### PR TITLE
Fix volcano chart RBAC issue

### DIFF
--- a/installer/chart/volcano/templates/controllers.yaml
+++ b/installer/chart/volcano/templates/controllers.yaml
@@ -31,7 +31,7 @@ rules:
     verbs: ["create", "list", "watch", "update", "patch"]
   - apiGroups: [""]
     resources: ["pods"]
-    verbs: ["create", "list", "watch", "update"]
+    verbs: ["create", "get", "list", "watch", "update", "bind", "delete"]
   - apiGroups: [""]
     resources: ["persistentvolumeclaims"]
     verbs: ["get", "list", "watch", "create"]

--- a/installer/chart/volcano/templates/scheduler.yaml
+++ b/installer/chart/volcano/templates/scheduler.yaml
@@ -24,7 +24,7 @@ rules:
     resources: ["events"]
     verbs: ["create", "list", "watch", "update", "patch"]
   - apiGroups: [""]
-    resources: ["pods"]
+    resources: ["pods", "pods/status"]
     verbs: ["create", "get", "list", "watch", "update", "bind", "updateStatus", "delete"]
   - apiGroups: [""]
     resources: ["pods/binding"]
@@ -50,6 +50,12 @@ rules:
   - apiGroups: ["policy"]
     resources: ["poddisruptionbudgets"]
     verbs: ["list", "watch"]
+  - apiGroups: ["scheduling.incubator.k8s.io"]
+    resources: ["queues"]
+    verbs: ["get", "list", "watch", "create", "delete"]
+  - apiGroups: ["scheduling.k8s.io"]
+    resources: ["priorityclasses"]
+    verbs: ["get", "list", "watch"]
 
 ---
 kind: ClusterRoleBinding

--- a/pkg/controllers/job/job_controller_actions.go
+++ b/pkg/controllers/job/job_controller_actions.go
@@ -68,6 +68,8 @@ func (cc *Controller) killJob(jobInfo *apis.JobInfo, nextState state.NextStateFn
 				err := cc.kubeClients.CoreV1().Pods(pod.Namespace).Delete(pod.Name, nil)
 				if err != nil {
 					running++
+					glog.Errorf("Failed to delete pod %s for Job %s, err %#v",
+						pod.Name, job.Name, err)
 					errs = append(errs, err)
 					continue
 				}
@@ -76,6 +78,8 @@ func (cc *Controller) killJob(jobInfo *apis.JobInfo, nextState state.NextStateFn
 				err := cc.kubeClients.CoreV1().Pods(pod.Namespace).Delete(pod.Name, nil)
 				if err != nil {
 					pending++
+					glog.Errorf("Failed to delete pod %s for Job %s, err %#v",
+						pod.Name, job.Name, err)
 					errs = append(errs, err)
 					continue
 				}
@@ -86,6 +90,8 @@ func (cc *Controller) killJob(jobInfo *apis.JobInfo, nextState state.NextStateFn
 				err := cc.kubeClients.CoreV1().Pods(pod.Namespace).Delete(pod.Name, nil)
 				if err != nil {
 					failed++
+					glog.Errorf("Failed to delete pod %s for Job %s, err %#v",
+						pod.Name, job.Name, err)
 					errs = append(errs, err)
 					continue
 				}


### PR DESCRIPTION
Adding enough permission for controller and scheduler serviceaccount,  Also add error output when pod failed to delete.