### PR TITLE
Support PrintVersion for scheduler&controller binaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,13 @@ BIN_DIR=_output/bin
 BIN_OSARCH=linux/amd64
 IMAGE_PREFIX=volcanosh/vk
 TAG = latest
+GitSHA=`git rev-parse HEAD`
+Date=`date "+%Y-%m-%d %H:%M:%S"`
+REPO_PATH=volcano.sh/volcano
+LD_FLAGS=" \
+    -X '${REPO_PATH}/pkg/version.GitSHA=${GitSHA}' \
+    -X '${REPO_PATH}/pkg/version.Built=${Date}'   \
+    -X '${REPO_PATH}/pkg/version.Version=${TAG}'"
 
 .EXPORT_ALL_VARIABLES:
 
@@ -17,7 +24,7 @@ cli:
 image_bins:
 	go get github.com/mitchellh/gox
 	for name in controllers scheduler admission; do\
-		CGO_ENABLED=0 gox -osarch=${BIN_OSARCH} -output ${BIN_DIR}/${BIN_OSARCH}/vk-$$name ./cmd/$$name; \
+		CGO_ENABLED=0 gox -osarch=${BIN_OSARCH} -ldflags ${LD_FLAGS} -output ${BIN_DIR}/${BIN_OSARCH}/vk-$$name ./cmd/$$name; \
 	done
 
 images: image_bins

--- a/cmd/controllers/app/options/options.go
+++ b/cmd/controllers/app/options/options.go
@@ -28,6 +28,7 @@ type ServerOption struct {
 	Kubeconfig           string
 	EnableLeaderElection bool
 	LockObjectNamespace  string
+	PrintVersion         bool
 }
 
 // NewServerOption creates a new CMServer with a default config.
@@ -43,6 +44,7 @@ func (s *ServerOption) AddFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&s.EnableLeaderElection, "leader-elect", s.EnableLeaderElection, "Start a leader election client and gain leadership before "+
 		"executing the main loop. Enable this when running replicated kar-scheduler for high availability.")
 	fs.StringVar(&s.LockObjectNamespace, "lock-object-namespace", s.LockObjectNamespace, "Define the namespace of the lock object.")
+	fs.BoolVar(&s.PrintVersion, "version", false, "Show version and quit")
 }
 
 func (s *ServerOption) CheckOptionOrDie() error {

--- a/cmd/controllers/main.go
+++ b/cmd/controllers/main.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"os"
 	"time"
+	"volcano.sh/volcano/pkg/version"
 
 	"github.com/golang/glog"
 	"github.com/spf13/pflag"
@@ -37,6 +38,11 @@ func main() {
 	s.AddFlags(pflag.CommandLine)
 
 	flag.InitFlags()
+
+	if s.PrintVersion {
+		version.PrintVersionAndExit()
+		os.Exit(0)
+	}
 	if err := s.CheckOptionOrDie(); err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)
 		os.Exit(1)

--- a/cmd/scheduler/main.go
+++ b/cmd/scheduler/main.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"os"
 	"time"
+	"volcano.sh/volcano/pkg/version"
 
 	"github.com/golang/glog"
 	"github.com/spf13/pflag"
@@ -40,6 +41,12 @@ func main() {
 	s.AddFlags(pflag.CommandLine)
 
 	flag.InitFlags()
+
+	if s.PrintVersion {
+		version.PrintVersionAndExit()
+		os.Exit(0)
+	}
+
 	if err := s.CheckOptionOrDie(); err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)
 		os.Exit(1)

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2019 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package version
+
+import (
+	"fmt"
+	"os"
+	"runtime"
+)
+
+var (
+	// Version shows the version of volcano.
+	Version = "Not provided."
+	// GitSHA shows the git commit id of volcano.
+	GitSHA = "Not provided."
+	// Built shows the built time of the binary.
+	Built = "Not provided."
+)
+
+// PrintVersionAndExit prints versions from the array returned by Info() and exit
+func PrintVersionAndExit() {
+	for _, i := range Info() {
+		fmt.Printf("%v\n", i)
+	}
+	os.Exit(0)
+}
+
+// Info returns an array of various service versions
+func Info() []string {
+	return []string{
+		fmt.Sprintf("Version: %s", Version),
+		fmt.Sprintf("Git SHA: %s", GitSHA),
+		fmt.Sprintf("Built At: %s", Built),
+		fmt.Sprintf("Go Version: %s", runtime.Version()),
+		fmt.Sprintf("Go OS/Arch: %s/%s", runtime.GOOS, runtime.GOARCH),
+	}
+}


### PR DESCRIPTION
Support printing version in scheduler&controller binaries, output as below:
```
Version: latest
Git SHA: da1b7ceb66a34c0b153be976d6f0320459e92be7
Built At: 2019-04-09 14:34:01
Go Version: go1.11.4
Go OS/Arch: linux/amd64
```
For #77 
**NOTE**: Image **TAG** should be updated when releasing.