### PR TITLE
Register global options when start

### DIFF
--- a/cmd/scheduler/main.go
+++ b/cmd/scheduler/main.go
@@ -38,6 +38,7 @@ var logFlushFreq = pflag.Duration("log-flush-frequency", 5*time.Second, "Maximum
 func main() {
 	s := options.NewServerOption()
 	s.AddFlags(pflag.CommandLine)
+	s.RegisterOptions()
 
 	flag.InitFlags()
 	if err := s.CheckOptionOrDie(); err != nil {

--- a/hack/.golint_failures
+++ b/hack/.golint_failures
@@ -16,15 +16,4 @@ volcano.sh/volcano/pkg/controllers/job/plugins/env
 volcano.sh/volcano/pkg/controllers/job/plugins/interface
 volcano.sh/volcano/pkg/controllers/job/plugins/ssh
 volcano.sh/volcano/pkg/controllers/job/state
-volcano.sh/volcano/pkg/scheduler/actions/allocate
-volcano.sh/volcano/pkg/scheduler/actions/backfill
-volcano.sh/volcano/pkg/scheduler/actions/preempt
-volcano.sh/volcano/pkg/scheduler/actions/reclaim
-volcano.sh/volcano/pkg/scheduler/plugins/conformance
-volcano.sh/volcano/pkg/scheduler/plugins/drf
-volcano.sh/volcano/pkg/scheduler/plugins/gang
-volcano.sh/volcano/pkg/scheduler/plugins/predicates
-volcano.sh/volcano/pkg/scheduler/plugins/priority
-volcano.sh/volcano/pkg/scheduler/plugins/proportion
-volcano.sh/volcano/pkg/scheduler/util
 volcano.sh/volcano/test/e2e


### PR DESCRIPTION
Register a variable as a global one may not sounds a good fix.