### PR TITLE
version related changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ REL_OSARCH=linux/amd64
 REPO_PATH=volcano.sh/volcano
 IMAGE_PREFIX=volcanosh/vk
 TAG=latest
+RELEASE_VER=v0.1
 GitSHA=`git rev-parse HEAD`
 Date=`date "+%Y-%m-%d %H:%M:%S"`
 LD_FLAGS=" \

--- a/cmd/admission/app/configure/configure.go
+++ b/cmd/admission/app/configure/configure.go
@@ -40,6 +40,7 @@ type Config struct {
 	MutateWebhookName         string
 	ValidateWebhookConfigName string
 	ValidateWebhookName       string
+	PrintVersion              bool
 }
 
 func NewConfig() *Config {
@@ -64,6 +65,7 @@ func (c *Config) AddFlags() {
 		"Name of the mutatingwebhookconfiguration resource in Kubernetes.")
 	flag.StringVar(&c.ValidateWebhookName, "validate-webhook-name", "validatejob.volcano.sh",
 		"Name of the webhook entry in the webhook config.")
+	flag.BoolVar(&c.PrintVersion, "version", false, "Show version and quit")
 }
 
 func (c *Config) CheckPortOrDie() error {

--- a/cmd/admission/main.go
+++ b/cmd/admission/main.go
@@ -26,6 +26,7 @@ import (
 	"volcano.sh/volcano/cmd/admission/app"
 	appConf "volcano.sh/volcano/cmd/admission/app/configure"
 	admissioncontroller "volcano.sh/volcano/pkg/admission"
+	"volcano.sh/volcano/pkg/version"
 )
 
 func serveJobs(w http.ResponseWriter, r *http.Request) {
@@ -40,6 +41,10 @@ func main() {
 	config := appConf.NewConfig()
 	config.AddFlags()
 	flag.Parse()
+
+	if config.PrintVersion {
+		version.PrintVersionAndExit()
+	}
 
 	http.HandleFunc(admissioncontroller.AdmitJobPath, serveJobs)
 	http.HandleFunc(admissioncontroller.MutateJobPath, serveMutateJobs)

--- a/cmd/cli/vkctl.go
+++ b/cmd/cli/vkctl.go
@@ -24,6 +24,7 @@ import (
 	"github.com/spf13/pflag"
 
 	"k8s.io/apimachinery/pkg/util/wait"
+	"volcano.sh/volcano/pkg/version"
 )
 
 var logFlushFreq = pflag.Duration("log-flush-frequency", 5*time.Second, "Maximum number of seconds between log flushes")
@@ -41,6 +42,7 @@ func main() {
 
 	rootCmd.AddCommand(buildJobCmd())
 	rootCmd.AddCommand(buildQueueCmd())
+	rootCmd.AddCommand(versionCommand())
 
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Printf("Failed to execute command: %v", err)
@@ -58,4 +60,20 @@ func checkError(cmd *cobra.Command, err error) {
 
 		fmt.Printf("%s: %v\n", msg, err)
 	}
+}
+
+var versionExample = `vkctl version`
+
+func versionCommand() *cobra.Command {
+
+	var command = &cobra.Command{
+		Use:     "version",
+		Short:   "Print the version information",
+		Long:    "Print the version information",
+		Example: versionExample,
+		Run: func(cmd *cobra.Command, args []string) {
+			version.PrintVersionAndExit()
+		},
+	}
+	return command
 }

--- a/cmd/controllers/app/options/options.go
+++ b/cmd/controllers/app/options/options.go
@@ -35,6 +35,7 @@ type ServerOption struct {
 	LockObjectNamespace  string
 	KubeAPIBurst         int
 	KubeAPIQPS           float32
+	PrintVersion         bool
 }
 
 // NewServerOption creates a new CMServer with a default config.
@@ -52,6 +53,7 @@ func (s *ServerOption) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&s.LockObjectNamespace, "lock-object-namespace", s.LockObjectNamespace, "Define the namespace of the lock object.")
 	fs.Float32Var(&s.KubeAPIQPS, "kube-api-qps", defaultQPS, "QPS to use while talking with kubernetes apiserver")
 	fs.IntVar(&s.KubeAPIBurst, "kube-api-burst", defaultBurst, "Burst to use while talking with kubernetes apiserver")
+	fs.BoolVar(&s.PrintVersion, "version", false, "Show version and quit")
 }
 
 func (s *ServerOption) CheckOptionOrDie() error {

--- a/cmd/controllers/main.go
+++ b/cmd/controllers/main.go
@@ -28,6 +28,7 @@ import (
 
 	"volcano.sh/volcano/cmd/controllers/app"
 	"volcano.sh/volcano/cmd/controllers/app/options"
+	"volcano.sh/volcano/pkg/version"
 )
 
 var logFlushFreq = pflag.Duration("log-flush-frequency", 5*time.Second, "Maximum number of seconds between log flushes")
@@ -37,6 +38,10 @@ func main() {
 	s.AddFlags(pflag.CommandLine)
 
 	flag.InitFlags()
+
+	if s.PrintVersion {
+		version.PrintVersionAndExit()
+	}
 	if err := s.CheckOptionOrDie(); err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)
 		os.Exit(1)

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2019 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package version
+
+import (
+	"fmt"
+	"os"
+	"runtime"
+)
+
+var (
+	// Version shows the version of kube batch.
+	Version = "Not provided."
+	// GitSHA shoows the git commit id of kube batch.
+	GitSHA = "Not provided."
+	// Built shows the built time of the binary.
+	Built = "Not provided."
+)
+
+// PrintVersionAndExit prints versions from the array returned by Info() and exit
+func PrintVersionAndExit() {
+	apiVersion := "v1alpha1"
+	for _, i := range Info(apiVersion) {
+		fmt.Printf("%v\n", i)
+	}
+	os.Exit(0)
+}
+
+// Info returns an array of various service versions
+func Info(apiVersion string) []string {
+	return []string{
+		fmt.Sprintf("API Version: %s", apiVersion),
+		fmt.Sprintf("Version: %s", Version),
+		fmt.Sprintf("Git SHA: %s", GitSHA),
+		fmt.Sprintf("Built At: %s", Built),
+		fmt.Sprintf("Go Version: %s", runtime.Version()),
+		fmt.Sprintf("Go OS/Arch: %s/%s", runtime.GOOS, runtime.GOARCH),
+	}
+}


### PR DESCRIPTION
added version in vkctl, vk-admission & vk-controller

For #77

sample output

root@root1-HP-EliteBook-840-G2:/home/root1/SriniCH/workspace/src/volcano.sh/volcano# ./_output/bin/vk-admission --version
API Version: v1alpha1
Version: v0.1
Git SHA: e08f5886dd24d3f9682b005bcc354195228a3186
Built At: 2019-05-08 13:57:25
Go Version: go1.11.5
Go OS/Arch: linux/amd64
root@root1-HP-EliteBook-840-G2:/home/root1/SriniCH/workspace/src/volcano.sh/volcano# ./_output/bin/vk-controllers --version
API Version: v1alpha1
Version: v0.1
Git SHA: e08f5886dd24d3f9682b005bcc354195228a3186
Built At: 2019-05-08 13:57:22
Go Version: go1.11.5
Go OS/Arch: linux/amd64
root@root1-HP-EliteBook-840-G2:/home/root1/SriniCH/workspace/src/volcano.sh/volcano# ./_output/bin/vkctl version
API Version: v1alpha1
Version: v0.1
Git SHA: e08f5886dd24d3f9682b005bcc354195228a3186
Built At: 2019-05-08 13:57:28
Go Version: go1.11.5
Go OS/Arch: linux/amd64
