### PR TITLE
Return immediately when failed to generate admission secret

### DIFF
--- a/hack/run-e2e-kind.sh
+++ b/hack/run-e2e-kind.sh
@@ -64,14 +64,20 @@ function install-volcano {
 
   echo "Install volcano plugin into cluster...."
   helm plugin install --kubeconfig ${KUBECONFIG} installer/chart/volcano/plugins/gen-admission-secret
-  helm gen-admission-secret --service integration-admission-service --namespace kube-system
+
+  #If failed to generate secret for admission service, return immediately
+  helm gen-admission-secret --service ${CLUSTER_NAME}-admission-service --namespace kube-system
+  if [[ $? != 0 ]]; then
+    echo "Failed to install secret for admission service, usually we need a retry."
+    exit 1
+  fi
 
   echo "Install volcano chart"
-  helm install installer/chart/volcano --namespace kube-system --name integration --kubeconfig ${KUBECONFIG} --set basic.image_tag_version=${TAG}
+  helm install installer/chart/volcano --namespace kube-system --name ${CLUSTER_NAME} --kubeconfig ${KUBECONFIG} --set basic.image_tag_version=${TAG} --wait
 }
 
 function uninstall-volcano {
-  helm delete integration --purge --kubeconfig ${KUBECONFIG}
+  helm delete ${CLUSTER_NAME} --purge --kubeconfig ${KUBECONFIG}
 }
 
 function generate-log {

--- a/installer/chart/volcano/plugins/gen-admission-secret/gen-admission-secret.sh
+++ b/installer/chart/volcano/plugins/gen-admission-secret/gen-admission-secret.sh
@@ -108,7 +108,7 @@ done
 # approve and fetch the signed certificate
 kubectl certificate approve ${csrName}
 # verify certificate has been signed
-for x in $(seq 15); do
+for x in $(seq 20); do
     serverCert=$(kubectl get csr ${csrName} -o jsonpath='{.status.certificate}')
     if [[ ${serverCert} != '' ]]; then
         break
@@ -116,7 +116,7 @@ for x in $(seq 15); do
     sleep 1
 done
 if [[ ${serverCert} == '' ]]; then
-    echo "ERROR: After approving csr ${csrName}, the signed certificate did not appear on the resource. Giving up after 15 attempts." >&2
+    echo "ERROR: After approving csr ${csrName}, the signed certificate did not appear on the resource. Giving up after 20 attempts." >&2
     exit 1
 fi
 echo ${serverCert} | openssl base64 -d -A -out ${tmpdir}/server-cert.pem


### PR DESCRIPTION
Do not run the whole testcases when failed to generate admission secrets.