### PR TITLE
Add JobType in CLI

### DIFF
--- a/pkg/apis/batch/v1alpha1/labels.go
+++ b/pkg/apis/batch/v1alpha1/labels.go
@@ -22,4 +22,5 @@ const (
 	JobNamespaceKey = "volcano.sh/job-namespace"
 	DefaultTaskSpec = "default"
 	JobVersion      = "volcano.sh/job-version"
+	JobTypeKey      = "volcano.sh/job-type"
 )

--- a/pkg/cli/job/list.go
+++ b/pkg/cli/job/list.go
@@ -45,6 +45,7 @@ const (
 	Succeeded  string = "Succeeded"
 	Failed     string = "Failed"
 	RetryCount string = "RetryCount"
+	JobType    string = "JobType"
 )
 
 var listJobFlags = &listFlags{}
@@ -78,8 +79,8 @@ func ListJobs() error {
 
 func PrintJobs(jobs *v1alpha1.JobList, writer io.Writer) {
 	maxNameLen := getMaxNameLen(jobs)
-	_, err := fmt.Fprintf(writer, fmt.Sprintf("%%-%ds%%-25s%%-12s%%-12s%%-6s%%-10s%%-10s%%-12s%%-10s%%-12s\n", maxNameLen),
-		Name, Creation, Phase, Replicas, Min, Pending, Running, Succeeded, Failed, RetryCount)
+	_, err := fmt.Fprintf(writer, fmt.Sprintf("%%-%ds%%-25s%%-12s%%-12s%%-12s%%-6s%%-10s%%-10s%%-12s%%-10s%%-12s\n", maxNameLen),
+		Name, Creation, Phase, JobType, Replicas, Min, Pending, Running, Succeeded, Failed, RetryCount)
 	if err != nil {
 		fmt.Printf("Failed to print list command result: %s.\n", err)
 	}
@@ -89,8 +90,12 @@ func PrintJobs(jobs *v1alpha1.JobList, writer io.Writer) {
 		for _, ts := range job.Spec.Tasks {
 			replicas += ts.Replicas
 		}
-		_, err = fmt.Fprintf(writer, fmt.Sprintf("%%-%ds%%-25s%%-12s%%-12d%%-6d%%-10d%%-10d%%-12d%%-10d%%-12d\n", maxNameLen),
-			job.Name, job.CreationTimestamp.Format("2006-01-02 15:04:05"), job.Status.State.Phase, replicas,
+		jobType := job.ObjectMeta.Labels[v1alpha1.JobTypeKey]
+		if jobType == "" {
+			jobType = "Batch"
+		}
+		_, err = fmt.Fprintf(writer, fmt.Sprintf("%%-%ds%%-25s%%-12s%%-12s%%-12d%%-6d%%-10d%%-10d%%-12d%%-10d%%-12d\n", maxNameLen),
+			job.Name, job.CreationTimestamp.Format("2006-01-02 15:04:05"), job.Status.State.Phase, jobType, replicas,
 			job.Status.MinAvailable, job.Status.Pending, job.Status.Running, job.Status.Succeeded, job.Status.Failed, job.Status.RetryCount)
 		if err != nil {
 			fmt.Printf("Failed to print list command result: %s.\n", err)


### PR DESCRIPTION
Display Job Type in job list in CLI command.  Label to be added in JobSpec should be of Format 
```
metadata:
  name: test-job
  labels:
    volcano.sh/job-type: Tensorflow
```
And CLI command output is 
![Screenshot from 2019-05-13 18-08-16](https://user-images.githubusercontent.com/34565833/57621886-23fa3100-75aa-11e9-9d04-574bfca0ab52.png)

Fixes https://github.com/volcano-sh/volcano/issues/142