### PR TITLE
Simple Issue Fixes in vkctl

### DIFF
--- a/pkg/cli/job/common.go
+++ b/pkg/cli/job/common.go
@@ -28,7 +28,7 @@ type commonFlags struct {
 }
 
 func initFlags(cmd *cobra.Command, cf *commonFlags) {
-	cmd.Flags().StringVarP(&cf.SchedulerName, "scheduler", "S", "vn-scheduler", "the scheduler for this job")
+	cmd.Flags().StringVarP(&cf.SchedulerName, "scheduler", "S", "kube-batch", "the scheduler for this job")
 	cmd.Flags().StringVarP(&cf.Master, "master", "s", "", "the address of apiserver")
 
 	if home := homeDir(); home != "" {

--- a/pkg/cli/job/delete.go
+++ b/pkg/cli/job/delete.go
@@ -47,6 +47,11 @@ func DeleteJob() error {
 		return err
 	}
 
+	if deleteJobFlags.JobName == "" {
+		err := fmt.Errorf("job name is mandaorty to delete a particular job")
+		return err
+	}
+
 	jobClient := versioned.NewForConfigOrDie(config)
 	err = jobClient.BatchV1alpha1().Jobs(deleteJobFlags.Namespace).Delete(deleteJobFlags.JobName, &metav1.DeleteOptions{})
 	if err != nil {

--- a/pkg/cli/job/resume.go
+++ b/pkg/cli/job/resume.go
@@ -16,6 +16,7 @@ limitations under the License.
 package job
 
 import (
+	"fmt"
 	"github.com/spf13/cobra"
 
 	"volcano.sh/volcano/pkg/apis/batch/v1alpha1"
@@ -40,6 +41,10 @@ func InitResumeFlags(cmd *cobra.Command) {
 func ResumeJob() error {
 	config, err := buildConfig(resumeJobFlags.Master, resumeJobFlags.Kubeconfig)
 	if err != nil {
+		return err
+	}
+	if resumeJobFlags.JobName == "" {
+		err := fmt.Errorf("job name is mandaorty to resume a particular job")
 		return err
 	}
 

--- a/pkg/cli/job/suspend.go
+++ b/pkg/cli/job/suspend.go
@@ -16,6 +16,7 @@ limitations under the License.
 package job
 
 import (
+	"fmt"
 	"github.com/spf13/cobra"
 
 	"volcano.sh/volcano/pkg/apis/batch/v1alpha1"
@@ -40,6 +41,11 @@ func InitSuspendFlags(cmd *cobra.Command) {
 func SuspendJob() error {
 	config, err := buildConfig(suspendJobFlags.Master, suspendJobFlags.Kubeconfig)
 	if err != nil {
+		return err
+	}
+
+	if suspendJobFlags.JobName == "" {
+		err := fmt.Errorf("job name is mandaorty to suspend a particular job")
 		return err
 	}
 

--- a/pkg/cli/queue/get.go
+++ b/pkg/cli/queue/get.go
@@ -52,7 +52,7 @@ func GetQueue() error {
 	}
 
 	if getQueueFlags.Name == "" {
-		err := fmt.Errorf("name is mandaorty to get the partiular queue details")
+		err := fmt.Errorf("name is mandaorty to get the particular queue details")
 		return err
 	}
 


### PR DESCRIPTION
Added validations for mandatory parameters in cli at client side it self
changed the default scheduler name from vn-scheduler to kube-batch

![PR_2019-05-17 11-39-12](https://user-images.githubusercontent.com/9107906/57906757-b8111480-7898-11e9-9769-c092e6211b3e.png)
