### PR TITLE
move scheduler name out of common args

### DIFF
--- a/pkg/cli/job/common.go
+++ b/pkg/cli/job/common.go
@@ -22,13 +22,11 @@ import (
 )
 
 type commonFlags struct {
-	Master        string
-	Kubeconfig    string
-	SchedulerName string
+	Master     string
+	Kubeconfig string
 }
 
 func initFlags(cmd *cobra.Command, cf *commonFlags) {
-	cmd.Flags().StringVarP(&cf.SchedulerName, "scheduler", "S", "kube-batch", "the scheduler for this job")
 	cmd.Flags().StringVarP(&cf.Master, "master", "s", "", "the address of apiserver")
 
 	if home := homeDir(); home != "" {

--- a/pkg/cli/job/list.go
+++ b/pkg/cli/job/list.go
@@ -31,7 +31,8 @@ import (
 type listFlags struct {
 	commonFlags
 
-	Namespace string
+	Namespace     string
+	SchedulerName string
 }
 
 const (
@@ -54,6 +55,7 @@ func InitListFlags(cmd *cobra.Command) {
 	initFlags(cmd, &listJobFlags.commonFlags)
 
 	cmd.Flags().StringVarP(&listJobFlags.Namespace, "namespace", "N", "default", "the namespace of job")
+	cmd.Flags().StringVarP(&listJobFlags.SchedulerName, "scheduler", "S", "", "list job with specified scheduler name")
 }
 
 func ListJobs() error {
@@ -86,6 +88,9 @@ func PrintJobs(jobs *v1alpha1.JobList, writer io.Writer) {
 	}
 
 	for _, job := range jobs.Items {
+		if listJobFlags.SchedulerName != "" && listJobFlags.SchedulerName != job.Spec.SchedulerName {
+			continue
+		}
 		replicas := int32(0)
 		for _, ts := range job.Spec.Tasks {
 			replicas += ts.Replicas

--- a/pkg/cli/job/run.go
+++ b/pkg/cli/job/run.go
@@ -32,10 +32,11 @@ type runFlags struct {
 	Namespace string
 	Image     string
 
-	MinAvailable int
-	Replicas     int
-	Requests     string
-	Limits       string
+	MinAvailable  int
+	Replicas      int
+	Requests      string
+	Limits        string
+	SchedulerName string
 }
 
 var launchJobFlags = &runFlags{}
@@ -50,6 +51,7 @@ func InitRunFlags(cmd *cobra.Command) {
 	cmd.Flags().IntVarP(&launchJobFlags.Replicas, "replicas", "r", 1, "the total tasks of job")
 	cmd.Flags().StringVarP(&launchJobFlags.Requests, "requests", "R", "cpu=1000m,memory=100Mi", "the resource request of the task")
 	cmd.Flags().StringVarP(&launchJobFlags.Limits, "limits", "L", "cpu=1000m,memory=100Mi", "the resource limit of the task")
+	cmd.Flags().StringVarP(&listJobFlags.SchedulerName, "scheduler", "S", "kube-batch", "the scheduler for this job")
 }
 
 var jobName = "job.volcano.sh"


### PR DESCRIPTION
`--scheduler` is common argument now, so it can be parsed in any command ignoring that most of them do not use it at all.

So, this PR move this argument out of common argument and add it on demand for command which use it before.

And, add support for `vkctl job list` to list job with specified scheduler name.