### PR TITLE
support vkctl job view

### DIFF
--- a/cmd/cli/job.go
+++ b/cmd/cli/job.go
@@ -32,6 +32,16 @@ func buildJobCmd() *cobra.Command {
 	job.InitListFlags(jobListCmd)
 	jobCmd.AddCommand(jobListCmd)
 
+	jobViewCmd := &cobra.Command{
+		Use:   "view",
+		Short: "show job information",
+		Run: func(cmd *cobra.Command, args []string) {
+			checkError(cmd, job.ViewJob())
+		},
+	}
+	job.InitViewFlags(jobViewCmd)
+	jobCmd.AddCommand(jobViewCmd)
+
 	jobSuspendCmd := &cobra.Command{
 		Use:   "suspend",
 		Short: "abort a job",

--- a/pkg/cli/job/list.go
+++ b/pkg/cli/job/list.go
@@ -35,17 +35,20 @@ type listFlags struct {
 }
 
 const (
-	Name       string = "Name"
-	Creation   string = "Creation"
-	Phase      string = "Phase"
-	Replicas   string = "Replicas"
-	Min        string = "Min"
-	Pending    string = "Pending"
-	Running    string = "Running"
-	Succeeded  string = "Succeeded"
-	Failed     string = "Failed"
-	RetryCount string = "RetryCount"
-	JobType    string = "JobType"
+	Name        string = "Name"
+	Creation    string = "Creation"
+	Phase       string = "Phase"
+	Replicas    string = "Replicas"
+	Min         string = "Min"
+	Scheduler   string = "Scheduler"
+	Pending     string = "Pending"
+	Running     string = "Running"
+	Succeeded   string = "Succeeded"
+	Terminating string = "Terminating"
+	Version     string = "Version"
+	Failed      string = "Failed"
+	RetryCount  string = "RetryCount"
+	JobType     string = "JobType"
 )
 
 var listJobFlags = &listFlags{}

--- a/pkg/cli/job/view.go
+++ b/pkg/cli/job/view.go
@@ -1,0 +1,82 @@
+package job
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"volcano.sh/volcano/pkg/apis/batch/v1alpha1"
+	"volcano.sh/volcano/pkg/client/clientset/versioned"
+)
+
+type viewFlags struct {
+	commonFlags
+
+	Namespace string
+	JobName   string
+}
+
+var viewJobFlags = &viewFlags{}
+
+func InitViewFlags(cmd *cobra.Command) {
+	initFlags(cmd, &viewJobFlags.commonFlags)
+
+	cmd.Flags().StringVarP(&viewJobFlags.Namespace, "namespace", "N", "default", "the namespace of job")
+	cmd.Flags().StringVarP(&viewJobFlags.JobName, "name", "n", "", "the name of job")
+}
+
+func ViewJob() error {
+	config, err := buildConfig(viewJobFlags.Master, viewJobFlags.Kubeconfig)
+	if err != nil {
+		return err
+	}
+	if viewJobFlags.JobName == "" {
+		err := fmt.Errorf("job name (specified by --name or -n) is mandaorty to view a particular job")
+		return err
+	}
+
+	jobClient := versioned.NewForConfigOrDie(config)
+	job, err := jobClient.BatchV1alpha1().Jobs(viewJobFlags.Namespace).Get(viewJobFlags.JobName, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+	if job == nil {
+		fmt.Printf("No resources found\n")
+		return nil
+	}
+	PrintJob(job, os.Stdout)
+
+	return nil
+}
+
+func PrintJob(job *v1alpha1.Job, writer io.Writer) {
+	replicas := int32(0)
+	for _, ts := range job.Spec.Tasks {
+		replicas += ts.Replicas
+	}
+	lines := []string{
+		fmt.Sprintf("%s:\t\t%s", Name, job.Name),
+		fmt.Sprintf("%s:\t%s", Creation, job.CreationTimestamp.Format("2006-01-02 15:04:05")),
+		fmt.Sprintf("%s:\t%d", Replicas, replicas),
+		fmt.Sprintf("%s:\t\t%d", Min, job.Status.MinAvailable),
+		fmt.Sprintf("%s:\t%s", Scheduler, job.Spec.SchedulerName),
+		"Status",
+		fmt.Sprintf("  %s:\t%s", Phase, job.Status.State.Phase),
+		fmt.Sprintf("  %s:\t%d", Version, job.Status.Version),
+		fmt.Sprintf("  %s:\t%d", RetryCount, job.Status.RetryCount),
+		fmt.Sprintf("  %s:\t%d", Pending, job.Status.Pending),
+		fmt.Sprintf("  %s:\t%d", Running, job.Status.Running),
+		fmt.Sprintf("  %s:\t%d", Succeeded, job.Status.Succeeded),
+		fmt.Sprintf("  %s:\t%d", Failed, job.Status.Failed),
+		fmt.Sprintf("  %s:\t%d", Terminating, job.Status.Terminating),
+	}
+	_, err := fmt.Fprint(writer, strings.Join(lines, "\n"), "\n")
+	if err != nil {
+		fmt.Printf("Failed to print view command result: %s.\n", err)
+	}
+}


### PR DESCRIPTION
Add command to view vkjob for more details.
```
% ./vkctl job view -n lm-success-mjxgf
Name:           lm-success-mjxgf
Creation:       2019-05-19 16:19:58
Replicas:       5
Min:            5
Scheduler:      kube-batch
Status
  Phase:        Running
  Version:      0
  RetryCount:   0
  Pending:      0
  Running:      1
  Succeeded:    4
  Failed:       0
  Terminating:  0
```