### PR TITLE
Added svc plugin name in ControlledResources of job status

### DIFF
--- a/pkg/controllers/job/plugins/svc/svc.go
+++ b/pkg/controllers/job/plugins/svc/svc.go
@@ -79,6 +79,8 @@ func (sp *servicePlugin) OnJobAdd(job *vkv1.Job) error {
 		return err
 	}
 
+	job.Status.ControlledResources["plugin-"+sp.Name()] = sp.Name()
+
 	return nil
 }
 


### PR DESCRIPTION
Added for svc pluging which was missing.

job.Status.ControlledResources["plugin-"+sp.Name()] = sp.Name()