### PR TITLE
Inherit kube-batch owners

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -2,7 +2,13 @@ reviewers:
   - k82cn
   - kevin-wangzefeng
   - quinton-hoole
+  - animeshsingh
+  - hex108
+  - hzxuzhonghu
 approvers:
   - k82cn
   - kevin-wangzefeng
   - quinton-hoole
+  - animeshsingh
+  - hex108
+  - hzxuzhonghu


### PR DESCRIPTION
Scheduler is an import part of Volcano, so inherit kube-batch owners. If any comments/suggestions, please let me know :)