### PR TITLE
Create base image for admission service

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,9 @@ images: image_bins
 		rm installer/dockerfile/$$name/vk-$$name; \
 	done
 
+admission-base-image:
+	docker build --no-cache -t $(IMAGE_PREFIX)-admission-base:$(TAG) ./installer/dockerfile/admission/ -f ./installer/dockerfile/admission/Dockerfile.base;
+
 generate-code:
 	./hack/update-gencode.sh
 

--- a/installer/dockerfile/admission/Dockerfile.base
+++ b/installer/dockerfile/admission/Dockerfile.base
@@ -13,10 +13,16 @@
 # limitations under the License.
 
 
-# The base image is created via `Dockerfile.base`, the base image is cached
-# since the required packages change very rarely.
-FROM volcanosh/vk-admission-base:latest
+FROM alpine:latest
 
-ADD vk-admission /vk-admission
-ADD gen-admission-secret.sh /gen-admission-secret.sh
-ENTRYPOINT ["/vk-admission"]
+# Install requirements for admission service
+# Install requirements
+ARG KUBE_VERSION="1.13.1"
+RUN apk add --update ca-certificates && \
+    apk add --update openssl && \
+    apk add --update -t deps curl && \
+    curl -L https://storage.googleapis.com/kubernetes-release/release/v$KUBE_VERSION/bin/linux/amd64/kubectl -o /usr/local/bin/kubectl && \
+    chmod +x /usr/local/bin/kubectl && \
+    apk del --purge deps && \
+    rm /var/cache/apk/*
+ENTRYPOINT []


### PR DESCRIPTION
Now we would build admission service image from ground in our CI workflow, this patch creates a base image which consists of the installation of required libraries for admission service. This can improve the performance when testing.

For #282 
 
image name: volcanosh/vk-admission-base

image content:
```
Sending build context to Docker daemon  9.216kB
Step 1/4 : FROM alpine:latest
 ---> 055936d39205
Step 2/4 : ARG KUBE_VERSION="1.13.1"
 ---> Running in 9a9a54338322
Removing intermediate container 9a9a54338322
 ---> 8e7e7a086e00
Step 3/4 : RUN apk add --update ca-certificates &&     apk add --update openssl &&     apk add --update -t deps curl &&     curl -L https://storage.googleapis.com/kubernetes-release/release/v$KUBE_VERSION/bin/linux/amd64/kubectl -o /usr/local/bin/kubectl &&     chmod +x /usr/local/bin/kubectl &&     apk del --purge deps &&     rm /var/cache/apk/*
 ---> Running in 00a41be6c337
fetch http://dl-cdn.alpinelinux.org/alpine/v3.9/main/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.9/community/x86_64/APKINDEX.tar.gz
(1/1) Installing ca-certificates (20190108-r0)
Executing busybox-1.29.3-r10.trigger
Executing ca-certificates-20190108-r0.trigger
OK: 6 MiB in 15 packages
(1/1) Installing openssl (1.1.1b-r1)
Executing busybox-1.29.3-r10.trigger
OK: 7 MiB in 16 packages
(1/5) Installing nghttp2-libs (1.35.1-r0)
(2/5) Installing libssh2 (1.8.2-r0)
(3/5) Installing libcurl (7.64.0-r2)
(4/5) Installing curl (7.64.0-r2)
(5/5) Installing deps (0)
Executing busybox-1.29.3-r10.trigger
OK: 8 MiB in 21 packages
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 37.4M  100 37.4M    0     0   550k      0  0:01:09  0:01:09 --:--:--  522k
(1/5) Purging deps (0)
(2/5) Purging curl (7.64.0-r2)
(3/5) Purging libcurl (7.64.0-r2)
(4/5) Purging nghttp2-libs (1.35.1-r0)
(5/5) Purging libssh2 (1.8.2-r0)
Executing busybox-1.29.3-r10.trigger
OK: 7 MiB in 16 packages
Removing intermediate container 00a41be6c337
 ---> 94ff3774735c
Step 4/4 : ENTRYPOINT []
 ---> Running in e460e1ac0f47
Removing intermediate container e460e1ac0f47
 ---> bbadada24a40
Successfully built bbadada24a40
Successfully tagged volcanosh/vk-admission-base:latest
```
