### PR TITLE
calc PGMinResources for Resources.Limits

### DIFF
--- a/pkg/controllers/job/job_controller_actions.go
+++ b/pkg/controllers/job/job_controller_actions.go
@@ -513,7 +513,7 @@ func (cc *Controller) calcPGMinResources(job *vkv1.Job) *v1.ResourceList {
 			}
 			podCnt++
 			for _, c := range task.Template.Spec.Containers {
-				addResourceList(minAvailableTasksRes, c.Resources.Requests)
+				addResourceList(minAvailableTasksRes, c.Resources.Requests, c.Resources.Limits)
 			}
 		}
 	}

--- a/pkg/controllers/job/job_controller_util.go
+++ b/pkg/controllers/job/job_controller_util.go
@@ -176,13 +176,21 @@ func applyPolicies(job *vkv1.Job, req *apis.Request) vkv1.Action {
 	return vkv1.SyncJobAction
 }
 
-func addResourceList(list, new v1.ResourceList) {
-	for name, quantity := range new {
+func addResourceList(list, req, limit v1.ResourceList) {
+	for name, quantity := range req {
 		if value, ok := list[name]; !ok {
 			list[name] = *quantity.Copy()
 		} else {
 			value.Add(quantity)
 			list[name] = value
+		}
+	}
+
+	// If Requests is omitted for a container,
+	// it defaults to Limits if that is explicitly specified.
+	for name, quantity := range limit {
+		if _, ok := list[name]; !ok {
+			list[name] = *quantity.Copy()
 		}
 	}
 }

--- a/pkg/controllers/job/job_controller_util_test.go
+++ b/pkg/controllers/job/job_controller_util_test.go
@@ -642,7 +642,7 @@ func TestAddResourceList(t *testing.T) {
 	}
 
 	for _, testcase := range testcases {
-		addResourceList(testcase.List, testcase.New)
+		addResourceList(testcase.List, testcase.New, nil)
 	}
 }
 


### PR DESCRIPTION
user can only set Containers.Resources.Limits， e.g. nvidia.com/gpu, we should add minResources.

https://kubernetes.io/docs/tasks/administer-cluster/manage-resources/cpu-default-namespace/#what-if-you-specify-a-container-s-limit-but-not-its-request