### PR TITLE
Fix issue in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ all: vc-scheduler vc-controllers vc-admission vkctl
 init:
 	mkdir -p ${BIN_DIR}
 
-scheduler: init
+vc-scheduler: init
 	go build -ldflags ${LD_FLAGS} -o=${BIN_DIR}/vc-scheduler ./cmd/scheduler
 
 vc-controllers: init


### PR DESCRIPTION
root@root1-HP-EliteBook-840-G2:/home/root1/SriniCH/workspace/src/volcano.sh/volcano# make
make: *** No rule to make target 'vc-scheduler', needed by 'all'.  Stop.

this issue is there on latest code with commit

commit c1cbbc1292e1adc4eae3a5f14062396a444960e0

make should  build the binaries properly, but its failing because of recent changes.
