### PR TITLE
Fix error resync logic

### DIFF
--- a/pkg/controllers/job/job_controller_actions.go
+++ b/pkg/controllers/job/job_controller_actions.go
@@ -265,10 +265,6 @@ func (cc *Controller) syncJob(jobInfo *apis.JobInfo, updateStatus state.UpdateSt
 					pod.Name, job.Name, err)
 				creationErrs = append(creationErrs, fmt.Errorf("failed to create pod %s, err: %#v", pod.Name, err))
 			} else {
-				if err != nil && apierrors.IsAlreadyExists(err) {
-					cc.resyncTask(pod)
-				}
-
 				classifyAndAddUpPodBaseOnPhase(newPod, &pending, &running, &succeeded, &failed, &unknown)
 				glog.V(3).Infof("Created Task <%s> of Job <%s/%s>",
 					pod.Name, job.Namespace, job.Name)


### PR DESCRIPTION
fixes: #384

There is time latency between `Controller.syncJob` creating a pod and the k8s informer get the notification. So there are cases job controller calling  `Controller.syncJob`  creating same pod twice, 