### PR TITLE
Add `Inqueue` status

### DIFF
--- a/pkg/apis/scheduling/v1alpha1/types.go
+++ b/pkg/apis/scheduling/v1alpha1/types.go
@@ -194,7 +194,7 @@ type Queue struct {
 
 // QueueStatus represents the status of Queue.
 type QueueStatus struct {
-	// The number of 'Unknonw' PodGroup in this queue.
+	// The number of 'Unknown' PodGroup in this queue.
 	Unknown int32 `json:"unknown,omitempty" protobuf:"bytes,1,opt,name=unknown"`
 	// The number of 'Pending' PodGroup in this queue.
 	Pending int32 `json:"pending,omitempty" protobuf:"bytes,2,opt,name=pending"`

--- a/pkg/apis/scheduling/v1alpha2/types.go
+++ b/pkg/apis/scheduling/v1alpha2/types.go
@@ -194,12 +194,14 @@ type Queue struct {
 
 // QueueStatus represents the status of Queue.
 type QueueStatus struct {
-	// The number of 'Unknonw' PodGroup in this queue.
+	// The number of 'Unknown' PodGroup in this queue.
 	Unknown int32 `json:"unknown,omitempty" protobuf:"bytes,1,opt,name=unknown"`
 	// The number of 'Pending' PodGroup in this queue.
 	Pending int32 `json:"pending,omitempty" protobuf:"bytes,2,opt,name=pending"`
 	// The number of 'Running' PodGroup in this queue.
 	Running int32 `json:"running,omitempty" protobuf:"bytes,3,opt,name=running"`
+	// The number of `Inqueue` PodGroup in this queue.
+	Inqueue int32 `json:"inqueue,omitempty" protobuf:"bytes,4,opt,name=inqueue"`
 }
 
 // QueueSpec represents the template of Queue.

--- a/pkg/scheduler/api/queue_info.go
+++ b/pkg/scheduler/api/queue_info.go
@@ -53,12 +53,14 @@ type Queue struct {
 
 // QueueStatus represents the status of Queue.
 type QueueStatus struct {
-	// The number of 'Unknonw' PodGroup in this queue.
+	// The number of 'Unknown' PodGroup in this queue.
 	Unknown int32 `json:"unknown,omitempty" protobuf:"bytes,1,opt,name=unknown"`
 	// The number of 'Pending' PodGroup in this queue.
 	Pending int32 `json:"pending,omitempty" protobuf:"bytes,2,opt,name=pending"`
 	// The number of 'Running' PodGroup in this queue.
 	Running int32 `json:"running,omitempty" protobuf:"bytes,3,opt,name=running"`
+	// The number of `Inqueue` PodGroup in this queue.
+	Inqueue int32 `json:"inqueue,omitempty" protobuf:"bytes,4,opt,name=inqueue"`
 }
 
 // QueueSpec represents the template of Queue.


### PR DESCRIPTION
Add `Inqueue` to queue status, which is used to record podgroups that are in `Inqueue` phase.