### PR TITLE
Make Gang and Drf preemption work together

### DIFF
--- a/docs/design/hybird-preemption.md
+++ b/docs/design/hybird-preemption.md
@@ -1,0 +1,117 @@
+# Hybird preemption
+
+[@william-wang](http://github.com/william-wang); Aug 20, 2019
+
+## Table of Contents
+
+   * [Dynamic Plugins Configuration](#dynamic-plugins-configuration)
+      * [Table of Contents](#table-of-contents)
+      * [Motivation](#motivation)
+      * [Function Detail](#function-detail)
+     
+
+## Motivation
+
+Currently when Gang and Drf plugins are both configured and enable the preempt actions. The Drf and Gang preemption can not play together
+well. The following issues have been found.
+- When job’s `min.available` is configured to 1. This Job will be preempted endlessly.
+- When the `min.available` of multiple jobs are configured to 1. These jobs will preempt each other endless.
+- When most of tasks in job are completed, the jobs meet both preemptor and preemptee condition, so different jobs
+  will preempt each other endlessly.
+
+The PR404's target is to enhance the preemption to make make Gang and Drf work together more reasonable and resolve above problems.
+
+## Function Detail
+
+The enhancement complys with the tier design that if it fits plugins in high priority tier, the action will not go through the plugins
+in lower priority tiers And in each tier, it's considered passed when all the plugins are fitted.
+
+The basic preemption behavior is that the pending jobs preempt running jobs with Gang preemption. Once the preemptor jobs turn into 
+running, the Drf preemption will be used to balance resource among running jobs according to the Drf share.
+
+The detail is as below:
+
+When the job of preemptor task is not ready, it will only preempt running tasks from other jobs which occupy more resource than it’s min.Avaiable firstly
+and turns into running. Then the Drf preemption will be involved to preempt the resource among running jobs.
+And the Drf will not preempt `min.available` part resource of job forever.
+
+
+In `Preemptable(preemptor *api.TaskInfo, preemptees []*api.TaskInfo) []*api.TaskInfo {..}` function, The plugin function `pf` is redesigned.
+
+>candidates, unpreemptableList := pf(preemptor, preemptees)
+>
+>candidates: 
+```
+Tasks that can be preemptable. 
+If the preemptor job is not ready, it will get the candidates. 
+If the preemptor job is running, It will not find candidates. It need Drf plugin to preempt resource for this running job.
+```
+>unpreemptableList:
+```
+Tasks that should not be preemptable. 
+Gang plugin has the `min.Available` info. So it knows those tasks that should not be preemptable. The framework will filter
+out these tasks and pass the left tasks to Drf preemption function. The targe is to avoid Drf preempt `min.available` part resource.
+
+```
+
+```
+For example
+1. candidates: [task1, task2], unpreemptableList:[]
+
+Gang plugin will make decision and complete preemption on task1 and task2 alone.
+
+2. Candidates:[], unpreemptableList[task1]
+
+Gang plugin will not make decision, the Drf will complete preemption alone. The preemption will ignore the task1.
+```
+
+## Use Case
+The cluster has 4 CPUs totally, each task in job-01 and job-02 requests 1 CPU.
+- The Gang and Drf work together to complete preemption
+
+    | Actions        | Job Name  | Task Num  | Min.Available | Task status |  
+    | -------------- | --------- | --------- | --------------| ----------- |
+    | Submit 1st Job | job-01    | 4         | 2             | 4 Running   |
+    | Submit 2st Job | job-02    | 4         | 1             | 4 Pending   |
+    | Result         | job-01    | 4         | 2             | 2 Running   |
+    |                | job-02    | 4         | 1             | 2 Running   |
+    
+    The job-02 preempts one task from job-01 by Gang preemption. And preempts the second task from job-01 by Drf preemption. 
+    
+- The Drf preemption does not preempt `min.available` part resource of job
+
+    | Actions        | Job Name  | Task Num  | Min.Available | Task status |  
+    | -------------- | --------- | --------- | --------------| ----------- |
+    | Submit 1st Job | job-01    | 4         | 3             | 4 Running   |
+    | Submit 2st Job | job-02    | 4         | 1             | 4 Pending   |
+    | Result         | job-01    | 4         | 3             | 3 Running   |
+    |                | job-02    | 4         | 1             | 1 Running   |
+    
+    The job-02 preempts one task from job-01 by Gang preemption. And can not continue to preempt more tasks because all 
+    remaining 3 tasks in job-01 are added into the unpreemptableList. These tasks will be ignored by framework before pass to 
+    Drf preemption.
+
+- If high tier plugin(Gang) can make decision, it will complete preemption alone.
+
+    | Actions        | Job Name  | Task Num  | Min.Available | Task status |  
+    | -------------- | --------- | --------- | --------------| ----------- |
+    | Submit 1st Job | job-01    | 4         | 2             | 4 Running   |
+    | Submit 2st Job | job-02    | 4         | 2             | 4 Pending   |
+    | Result         | job-01    | 4         | 2             | 2 Running   |
+    |                | job-02    | 4         | 2             | 2 Running   |
+    
+   The job-02 preempts two tasks from job-01 by Gang preemption.
+  
+ - When most tasks of job are completed, the jobs does not preempt each other endless any more. 
+   The Drf will balance resource among jobs. 
+   
+    | Actions        | Job Name  | Task Num  | Min.Available | Task status                       |  
+    | -------------- | --------- | --------- | --------------| ----------------------------------|
+    | Submit 1st Job | job-01    | 10        | 3             | 4 Running  2 completed 4 Pending  |
+    | Submit 2st Job | job-02    | 10        | 2             | 10 Pending 2 completed 4 Pending  |
+    | Result         | job-01    | 10        | 3             | 2 Running  2 completed 6 Pending  |
+    |                | job-02    | 10        | 2             | 2 Pending  8 pending              |
+    
+    The job-02 preempts two tasks from job-01 by Gang preemption and turns into running. And then Drf balance 
+    resource between jobs according to the share.
+

--- a/pkg/scheduler/api/job_info.go
+++ b/pkg/scheduler/api/job_info.go
@@ -415,3 +415,9 @@ func (ji *JobInfo) Pipelined() bool {
 
 	return occupied >= ji.MinAvailable
 }
+
+func (ji *JobInfo) Preemptable() bool {
+	occupied := ji.ReadyTaskNum()
+
+	return ji.MinAvailable <= (occupied - 1)
+}

--- a/pkg/scheduler/api/node_info.go
+++ b/pkg/scheduler/api/node_info.go
@@ -94,10 +94,14 @@ func NewNodeInfo(node *v1.Node) *NodeInfo {
 // Clone used to clone nodeInfo Object
 func (ni *NodeInfo) Clone() *NodeInfo {
 	res := NewNodeInfo(ni.Node)
-
+	otherRes := EmptyResource()
 	for _, p := range ni.Tasks {
 		res.AddTask(p)
+		if p.pod.Spec.SchedulerName != 'volcano' {
+			otherRes.Add(p.Resreq)
+		}
 	}
+	res.Allocatable = res.Allocatable.Sub(otherRes)
 	res.Others = ni.Others
 	return res
 }

--- a/pkg/scheduler/api/node_info.go
+++ b/pkg/scheduler/api/node_info.go
@@ -97,7 +97,7 @@ func (ni *NodeInfo) Clone() *NodeInfo {
 	otherRes := EmptyResource()
 	for _, p := range ni.Tasks {
 		res.AddTask(p)
-		if p.pod.Spec.SchedulerName != 'volcano' {
+		if p.pod.Spec.SchedulerName != "volcano" {
 			otherRes.Add(p.Resreq)
 		}
 	}

--- a/pkg/scheduler/api/types.go
+++ b/pkg/scheduler/api/types.go
@@ -131,7 +131,7 @@ type ValidateExFn func(interface{}) *ValidateResult
 type PredicateFn func(*TaskInfo, *NodeInfo) error
 
 // EvictableFn is the func declaration used to evict tasks.
-type EvictableFn func(*TaskInfo, []*TaskInfo) []*TaskInfo
+type EvictableFn func(*TaskInfo, []*TaskInfo) ([]*TaskInfo, []*TaskInfo)
 
 // NodeOrderFn is the func declaration used to get priority score for a node for a particular task.
 type NodeOrderFn func(*TaskInfo, *NodeInfo) (float64, error)

--- a/pkg/scheduler/framework/session_plugins.go
+++ b/pkg/scheduler/framework/session_plugins.go
@@ -144,6 +144,7 @@ func (ssn *Session) Preemptable(preemptor *api.TaskInfo, preemptees []*api.TaskI
 	var init bool
 
 	for _, tier := range ssn.Tiers {
+		init = false
 		for _, plugin := range tier.Plugins {
 			if !isEnabled(plugin.EnabledPreemptable) {
 				continue
@@ -154,6 +155,9 @@ func (ssn *Session) Preemptable(preemptor *api.TaskInfo, preemptees []*api.TaskI
 				continue
 			}
 			candidates := pf(preemptor, preemptees)
+			if candidates == nil {
+				break
+			}
 			if !init {
 				victims = candidates
 				init = true

--- a/pkg/scheduler/plugins/conformance/conformance.go
+++ b/pkg/scheduler/plugins/conformance/conformance.go
@@ -42,7 +42,7 @@ func (pp *conformancePlugin) Name() string {
 }
 
 func (pp *conformancePlugin) OnSessionOpen(ssn *framework.Session) {
-	evictableFn := func(evictor *api.TaskInfo, evictees []*api.TaskInfo) []*api.TaskInfo {
+	evictableFn := func(evictor *api.TaskInfo, evictees []*api.TaskInfo) ([]*api.TaskInfo, []*api.TaskInfo) {
 		var victims []*api.TaskInfo
 
 		for _, evictee := range evictees {
@@ -58,7 +58,7 @@ func (pp *conformancePlugin) OnSessionOpen(ssn *framework.Session) {
 			victims = append(victims, evictee)
 		}
 
-		return victims
+		return victims, nil
 	}
 
 	ssn.AddPreemptableFn(pp.Name(), evictableFn)

--- a/pkg/scheduler/plugins/drf/drf.go
+++ b/pkg/scheduler/plugins/drf/drf.go
@@ -85,7 +85,7 @@ func (drf *drfPlugin) OnSessionOpen(ssn *framework.Session) {
 		drf.jobAttrs[job.UID] = attr
 	}
 
-	preemptableFn := func(preemptor *api.TaskInfo, preemptees []*api.TaskInfo) []*api.TaskInfo {
+	preemptableFn := func(preemptor *api.TaskInfo, preemptees []*api.TaskInfo) ([]*api.TaskInfo, []*api.TaskInfo) {
 		var victims []*api.TaskInfo
 
 		latt := drf.jobAttrs[preemptor.Job]
@@ -95,14 +95,6 @@ func (drf *drfPlugin) OnSessionOpen(ssn *framework.Session) {
 		allocations := map[api.JobID]*api.Resource{}
 
 		for _, preemptee := range preemptees {
-
-			// Min part tasks in job should not be preempted
-			preempteeJob := ssn.Jobs[preemptee.Job]
-			readyNum := preempteeJob.ReadyTaskNum()
-			preemptable := preempteeJob.MinAvailable <= readyNum-1 || preempteeJob.MinAvailable == 1
-			if !preemptable {
-				continue
-			}
 
 			if _, found := allocations[preemptee.Job]; !found {
 				ratt := drf.jobAttrs[preemptee.Job]
@@ -118,7 +110,7 @@ func (drf *drfPlugin) OnSessionOpen(ssn *framework.Session) {
 
 		glog.V(3).Infof("Victims from DRF plugins are %+v", victims)
 
-		return victims
+		return victims, nil
 	}
 
 	ssn.AddPreemptableFn(drf.Name(), preemptableFn)

--- a/pkg/scheduler/plugins/proportion/proportion.go
+++ b/pkg/scheduler/plugins/proportion/proportion.go
@@ -171,7 +171,7 @@ func (pp *proportionPlugin) OnSessionOpen(ssn *framework.Session) {
 		return 1
 	})
 
-	ssn.AddReclaimableFn(pp.Name(), func(reclaimer *api.TaskInfo, reclaimees []*api.TaskInfo) []*api.TaskInfo {
+	ssn.AddReclaimableFn(pp.Name(), func(reclaimer *api.TaskInfo, reclaimees []*api.TaskInfo) ([]*api.TaskInfo, []*api.TaskInfo) {
 		var victims []*api.TaskInfo
 		allocations := map[api.QueueID]*api.Resource{}
 
@@ -195,7 +195,7 @@ func (pp *proportionPlugin) OnSessionOpen(ssn *framework.Session) {
 			}
 		}
 
-		return victims
+		return victims, nil
 	})
 
 	ssn.AddOverusedFn(pp.Name(), func(obj interface{}) bool {


### PR DESCRIPTION
What this PR does / why we need it:
The PR is target to resolve the issue #390 to make drf and gang preemption work together well.

Which issue(s) this PR fixes (optional, in fixes #(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):
Fixes #390

Currently when I configure Gang, drf plguin and enable the preempt actions. The drf preemption has no chance to be called. This causes several problems. such as 

- Job(min>1) preempt job(min==1) forever
- Job(min==1) preempt job(min==1) each other forever
- When most of tasks in job are completed, the jobs meet both preemptor and preemptee condition, so the different jobs preempt each other endless.
drf preemption should be used to work together with Gang to resolve above issues.

Solution:
Without making any changes to current Tier design principal, the new solution is let Gang preemptFn to find the victims firstly, If all plugins preemptFn in Tier 1 find no victims, The drf preemptFn in Tier 2 is used to find victims.

**Solution Update:**
In previous solution, the DRF plguin need to take care of Job.MinAvailable. The reviewer suggested that DRF should not care the Job.MinAvaiable. So in the new solution.

Another return value is introduced to preemptableFns. 
**victims, unpreemptableList = pf(preemptor, preemptees)**
Each plugin can decide two values:
- victims:  the preemptable tasks
- upreeemptableList:  unpreemptable tasks. In some cases, Gang plugin can not find the victims from a set of tasks. However it can get a set of tasks that should not be preemptable(Min part tasks). This part of tasks can be useful for later preemption in other plugin. 

Here is an example.
There are two running jobs. DRF preemption might preempt MinAvailabe part tasks according to the share. In this solution, the Gang can detect the upreeemptableList and exclude these tasks from preemptees before later preemption in DRF.

The solution has been tested and works well.
