### PR TITLE
Allow setting user name in ssh plugin

### DIFF
--- a/test/e2e/job_plugins.go
+++ b/test/e2e/job_plugins.go
@@ -130,7 +130,7 @@ var _ = Describe("Job E2E Test: Test Job Plugins", func() {
 			namespace: namespace,
 			name:      jobName,
 			plugins: map[string][]string{
-				"ssh": {"--no-root"},
+				"ssh": {"--user=volcano"},
 			},
 			tasks: []taskSpec{
 				{
@@ -188,7 +188,7 @@ var _ = Describe("Job E2E Test: Test Job Plugins", func() {
 			namespace: namespace,
 			name:      jobName,
 			plugins: map[string][]string{
-				"ssh": {"--no-root"},
+				"ssh": {"--user=volcano"},
 				"env": {},
 				"svc": {},
 			},


### PR DESCRIPTION
Fixes： #403


To support specifying ssh user when running volcano job.

```
apiVersion: batch.volcano.sh/v1alpha1
kind: Job
metadata:
  name: lm-mpi-job
spec:
  minAvailable: 3
  schedulerName: volcano
  plugins:
    ssh: ["--user=volcano"]    # specify volcano username
    svc: []
  tasks:
    ...

```
