### PR TITLE
fix: Add comments about the defaulting of queue

### DIFF
--- a/pkg/apis/scheduling/v1alpha1/types.go
+++ b/pkg/apis/scheduling/v1alpha1/types.go
@@ -116,7 +116,8 @@ type PodGroupSpec struct {
 	MinMember int32 `json:"minMember,omitempty" protobuf:"bytes,1,opt,name=minMember"`
 
 	// Queue defines the queue to allocate resource for PodGroup; if queue does not exist,
-	// the PodGroup will not be scheduled.
+	// the PodGroup will not be scheduled. Defaults to `default` Queue with the lowest weight.
+	// +optional
 	Queue string `json:"queue,omitempty" protobuf:"bytes,2,opt,name=queue"`
 
 	// If specified, indicates the PodGroup's priority. "system-node-critical" and

--- a/pkg/apis/scheduling/v1alpha2/types.go
+++ b/pkg/apis/scheduling/v1alpha2/types.go
@@ -116,7 +116,8 @@ type PodGroupSpec struct {
 	MinMember int32 `json:"minMember,omitempty" protobuf:"bytes,1,opt,name=minMember"`
 
 	// Queue defines the queue to allocate resource for PodGroup; if queue does not exist,
-	// the PodGroup will not be scheduled.
+	// the PodGroup will not be scheduled. Defaults to `default` Queue with the lowest weight.
+	// +optional
 	Queue string `json:"queue,omitempty" protobuf:"bytes,2,opt,name=queue"`
 
 	// If specified, indicates the PodGroup's priority. "system-node-critical" and


### PR DESCRIPTION
```go
	// TODO(k82cn): set default queue in admission.
	if len(ss.Spec.Queue) == 0 {
		sc.Jobs[job].Queue = kbapi.QueueID(sc.defaultQueue)
	}
```

Since we will set the default queue for the PodGroup, we should note it in the API.

Signed-off-by: Ce Gao <gaoce@caicloud.io>