### PR TITLE
Add maxRetry in job controller to prevent endless loop

### DIFF
--- a/pkg/controllers/job/job_controller.go
+++ b/pkg/controllers/job/job_controller.go
@@ -328,8 +328,9 @@ func (cc *Controller) processNextReq(count uint32) bool {
 			queue.AddRateLimited(req)
 			return true
 		}
-
-		glog.V(2).Infof("Dropping job<%s/%s> out of the queue: %v", jobInfo.Job.Namespace, jobInfo.Job.Name, err)
+		cc.recordJobEvent(jobInfo.Job.Namespace, jobInfo.Job.Name, vkbatchv1.ExecuteAction, fmt.Sprintf(
+			"Job failed on action %s for retry limit reached", action))
+		glog.Warningf("Dropping job<%s/%s> out of the queue: %v because max retries has reached", jobInfo.Job.Namespace, jobInfo.Job.Name, err)
 	}
 
 	// If no error, forget it.


### PR DESCRIPTION
In case there is invalid job container template(like stated https://github.com/volcano-sh/volcano/issues/409#issuecomment-520295818), that cannot be rejected at volcano admission. The job controller can get into an endless loop error retrying. 