### PR TITLE
Improved log output so that successful pods do not exist on node

### DIFF
--- a/pkg/scheduler/api/node_info.go
+++ b/pkg/scheduler/api/node_info.go
@@ -214,8 +214,13 @@ func (ni *NodeInfo) RemoveTask(ti *TaskInfo) error {
 
 	task, found := ni.Tasks[key]
 	if !found {
-		return fmt.Errorf("failed to find task <%v/%v> on host <%v>",
-			ti.Namespace, ti.Name, ni.Name)
+		if ti.Pod.Status.Phase != v1.PodSucceeded {
+			return fmt.Errorf("failed to find task <%v/%v> on host <%v>",
+				ti.Namespace, ti.Name, ni.Name)
+		} else {
+			glog.V(5).Infof("Task <%v/%v> status[Succeeded] not on Node <%v> cancel RemoveTask", ti.Namespace, ti.Name, ni.Name)
+			return nil
+		}
 	}
 
 	if ni.Node != nil {

--- a/pkg/scheduler/api/node_info.go
+++ b/pkg/scheduler/api/node_info.go
@@ -215,7 +215,7 @@ func (ni *NodeInfo) RemoveTask(ti *TaskInfo) error {
 	task, found := ni.Tasks[key]
 	if !found {
 		if ti.Pod.Status.Phase == v1.PodSucceeded {
-			glog.V(5).Infof("Task <%v/%v> status[Succeeded] not on Node <%v> cancel RemoveTask", ti.Namespace, ti.Name, ni.Name)
+			glog.V(5).Infof("Task <%v/%v> status [Succeeded] not on Node <%v> cancel RemoveTask", ti.Namespace, ti.Name, ni.Name)
 			return nil
 		}
 		return fmt.Errorf("failed to find task <%v/%v> on host <%v>",

--- a/pkg/scheduler/api/node_info.go
+++ b/pkg/scheduler/api/node_info.go
@@ -214,13 +214,12 @@ func (ni *NodeInfo) RemoveTask(ti *TaskInfo) error {
 
 	task, found := ni.Tasks[key]
 	if !found {
-		if ti.Pod.Status.Phase != v1.PodSucceeded {
-			return fmt.Errorf("failed to find task <%v/%v> on host <%v>",
-				ti.Namespace, ti.Name, ni.Name)
-		} else {
+		if ti.Pod.Status.Phase == v1.PodSucceeded {
 			glog.V(5).Infof("Task <%v/%v> status[Succeeded] not on Node <%v> cancel RemoveTask", ti.Namespace, ti.Name, ni.Name)
 			return nil
 		}
+		return fmt.Errorf("failed to find task <%v/%v> on host <%v>",
+			ti.Namespace, ti.Name, ni.Name)
 	}
 
 	if ni.Node != nil {


### PR DESCRIPTION
A successful pod is not found on node and does not need to be printed with an error