### PR TITLE
Added "enqueue" to the actions in defaultSchedulerConf to fix a bug

### DIFF
--- a/pkg/scheduler/util.go
+++ b/pkg/scheduler/util.go
@@ -29,7 +29,7 @@ import (
 )
 
 var defaultSchedulerConf = `
-actions: "allocate, backfill"
+actions: "allocate, backfill, enqueue"
 tiers:
 - plugins:
   - name: priority


### PR DESCRIPTION
With the addition of the new status "**enqueue**", a scheduler with the actions "a**llocate, backfill**" defined in the default configuration will not schedule a job with **PodGroupPending** status. For example, if a job cannot be scheduled at the submission time due to resource contention, it will never get scheduled even when resources are available later. Simply adding "**enqueue**" to the action list of _defaultSchedulerConf_ in _pkg/scheduler/util.go_ fixes the problem.

**actions: "allocate, backfill"**  ==> **actions: "allocate, backfill, enqueue"**