### PR TITLE
modify the return value of 'vcctl'

### DIFF
--- a/cmd/cli/vkctl.go
+++ b/cmd/cli/vkctl.go
@@ -17,6 +17,7 @@ package main
 
 import (
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/golang/glog"
@@ -47,6 +48,7 @@ func main() {
 
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Printf("Failed to execute command: %v\n", err)
+		os.Exit(2)
 	}
 }
 
@@ -60,6 +62,7 @@ func checkError(cmd *cobra.Command, err error) {
 		}
 
 		fmt.Printf("%s: %v\n", msg, err)
+		os.Exit(2)
 	}
 }
 

--- a/pkg/cli/job/run.go
+++ b/pkg/cli/job/run.go
@@ -72,23 +72,14 @@ func RunJob() error {
 		return err
 	}
 
-	req, err := populateResourceListV1(launchJobFlags.Requests)
-	if err != nil {
-		return err
-	}
-
-	limit, err := populateResourceListV1(launchJobFlags.Limits)
-	if err != nil {
-		return err
-	}
-
 	job, err := readFile(launchJobFlags.FileName)
 	if err != nil {
 		return err
 	}
 
 	if job == nil {
-		job = constructLaunchJobFlagsJob(launchJobFlags, req, limit)
+		fmt.Printf("Error: job script (specified by --filename or -f) is mandatory to run a particular job")
+		return nil
 	}
 
 	jobClient := versioned.NewForConfigOrDie(config)

--- a/pkg/cli/job/view.go
+++ b/pkg/cli/job/view.go
@@ -65,7 +65,7 @@ func ViewJob() error {
 		return err
 	}
 	if viewJobFlags.JobName == "" {
-		err := fmt.Errorf("job name (specified by --name or -N) is mandaorty to view a particular job")
+		err := fmt.Errorf("job name (specified by --name or -N) is mandatory to view a particular job")
 		return err
 	}
 


### PR DESCRIPTION
Fixes #454 

in cmd/cli/vkctl.go, return error code '2' instead of '0' when error occurs in 'vcctl', so that cromwell can read the correct 'check-alive' which refers to 'vcctl job view -N <job-name>'.

in pkg/cli/job.go, when job is nil, do not run the default job 'test', print the error output and return nil.