### PR TITLE
Mark job failed when its pod restart count exceed a fixed number

### DIFF
--- a/pkg/apis/batch/v1alpha1/job.go
+++ b/pkg/apis/batch/v1alpha1/job.go
@@ -169,6 +169,8 @@ const (
 	SyncJobAction Action = "SyncJob"
 	// EnqueueAction is the action to sync Job inqueue status.
 	EnqueueAction Action = "EnqueueJob"
+	// FailJobAction marks the job failed and all the pods of the job will be evicted.
+	FailJobAction Action = "FailJob"
 )
 
 // LifecyclePolicy specifies the lifecycle and error handling of task and job.

--- a/pkg/controllers/job/state/finished.go
+++ b/pkg/controllers/job/state/finished.go
@@ -27,5 +27,6 @@ type finishedState struct {
 
 func (ps *finishedState) Execute(action vkv1.Action) error {
 	// In finished state, e.g. Completed, always kill the whole job.
+	// This is to maintain the job status.
 	return KillJob(ps.job, PodRetainPhaseSoft, nil)
 }

--- a/pkg/controllers/job/state/running.go
+++ b/pkg/controllers/job/state/running.go
@@ -48,6 +48,11 @@ func (ps *runningState) Execute(action vkv1.Action) error {
 			status.State.Phase = vkv1.Completing
 			return true
 		})
+	case vkv1.FailJobAction:
+		return KillJob(ps.job, PodRetainPhaseSoft, func(status *vkv1.JobStatus) bool {
+			status.State.Phase = vkv1.Failed
+			return true
+		})
 	default:
 		return SyncJob(ps.job, func(status *vkv1.JobStatus) bool {
 			if status.Succeeded+status.Failed == TotalTasks(ps.job.Job) {


### PR DESCRIPTION
This is to prevent pod container endless restart. By this when a pod in crashLoopBackOff restart status and its restart count exceeds 5, we mark the job failed. And kill the remaining tasks.

Todo: add an api field in volcano job.