### PR TITLE
Make pod validating in admission service optional

### DIFF
--- a/cmd/admission/main.go
+++ b/cmd/admission/main.go
@@ -66,7 +66,9 @@ func main() {
 
 	admissioncontroller.VolcanoClientSet = app.GetVolcanoClient(restConfig)
 
-	servePods(config)
+	if config.ValidatePod {
+		servePods(config)
+	}
 
 	caBundle, err := ioutil.ReadFile(config.CaCertFile)
 	if err != nil {

--- a/installer/README.md
+++ b/installer/README.md
@@ -79,6 +79,7 @@ The following are the list configurable parameters of Volcano Chart and their de
 |`basic.admission_app_name`|Admission Controller App Name|`volcano-admission`|
 |`basic.controller_app_name`|Controller App Name|`volcano-controller`|
 |`basic.scheduler_app_name`|Scheduler App Name|`volcano-scheduler`|
+|`basic.pod_admission_enabled`| Whether enable pod validation|`true`|
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/installer/helm/chart/volcano/templates/admission.yaml
+++ b/installer/helm/chart/volcano/templates/admission.yaml
@@ -81,6 +81,9 @@ spec:
             - --webhook-service-name={{ .Release.Name }}-admission-service
             - --alsologtostderr
             - --port=443
+            {{ if eq .Values.basic.pod_admission_enabled false }}
+            - --validate-pod=false
+            {{ end }}
             - -v=4
             - 2>&1
           image: {{.Values.basic.admission_image_name}}:{{.Values.basic.image_tag_version}}

--- a/installer/helm/chart/volcano/values.yaml
+++ b/installer/helm/chart/volcano/values.yaml
@@ -6,3 +6,4 @@ basic:
   admission_secret_name: "volcano-admission-secret"
   scheduler_config_file: "config/volcano-scheduler.conf"
   image_pull_secret: ""
+  pod_admission_enabled: true

--- a/installer/volcano-development.yaml
+++ b/installer/volcano-development.yaml
@@ -221,6 +221,7 @@ spec:
             - --webhook-service-name=volcano-admission-service
             - --alsologtostderr
             - --port=443
+            
             - -v=4
             - 2>&1
           image: volcanosh/vc-admission:latest


### PR DESCRIPTION
Make pod validation optional in admission service, for the case of spark operator, when application's podgroup has been initially created, the status would be pending and admission service would block the creation of driver pod which doesn't fit the case.