### PR TITLE
Implement mpi plugin

### DIFF
--- a/pkg/admission/admit_job.go
+++ b/pkg/admission/admit_job.go
@@ -146,6 +146,7 @@ func validateJob(job v1alpha1.Job, reviewResponse *v1beta1.AdmissionResponse) st
 			}
 		}
 
+		// TODO: find a way not to hardcode plugin name here
 		if _, found := job.Spec.Plugins["mpi"]; found {
 			if len(job.Spec.Plugins) > 1 {
 				msg = msg + " can not specify other plugins when `mpi` existed"

--- a/pkg/admission/admit_job.go
+++ b/pkg/admission/admit_job.go
@@ -141,8 +141,14 @@ func validateJob(job v1alpha1.Job, reviewResponse *v1beta1.AdmissionResponse) st
 	// invalid job plugins
 	if len(job.Spec.Plugins) != 0 {
 		for name := range job.Spec.Plugins {
-			if _, found := plugins.GetPluginBuilder(name); !found {
+			if P := plugins.GetPluginBuilder(name); P == nil {
 				msg = msg + fmt.Sprintf(" unable to find job plugin: %s", name)
+			}
+		}
+
+		if _, found := job.Spec.Plugins["mpi"]; found {
+			if len(job.Spec.Plugins) > 1 {
+				msg = msg + " can not specify other plugins when `mpi` existed"
 			}
 		}
 	}

--- a/pkg/controllers/job/helpers/helpers.go
+++ b/pkg/controllers/job/helpers/helpers.go
@@ -34,11 +34,11 @@ const (
 	VolumeClaimFmt = "%s-volume-%s"
 )
 
-// GetTaskIndex   returns task Index
+// GetTaskIndex returns task Index
 func GetTaskIndex(pod *v1.Pod) string {
-	num := strings.Split(pod.Name, "-")
-	if len(num) >= 3 {
-		return num[len(num)-1]
+	parts := strings.Split(pod.Name, "-")
+	if len(parts) == 3 {
+		return parts[2]
 	}
 
 	return ""

--- a/pkg/controllers/job/job_controller_plugins.go
+++ b/pkg/controllers/job/job_controller_plugins.go
@@ -31,8 +31,8 @@ import (
 func (cc *Controller) pluginOnPodCreate(job *batch.Job, pod *v1.Pod) error {
 	client := pluginsinterface.PluginClientset{KubeClients: cc.kubeClient}
 	for name, args := range job.Spec.Plugins {
-		pb, found := plugins.GetPluginBuilder(name)
-		if !found {
+		pb := plugins.GetPluginBuilder(name)
+		if pb == nil {
 			err := fmt.Errorf("failed to get plugin %s", name)
 			glog.Error(err)
 			return err
@@ -53,8 +53,8 @@ func (cc *Controller) pluginOnJobAdd(job *batch.Job) error {
 		job.Status.ControlledResources = make(map[string]string)
 	}
 	for name, args := range job.Spec.Plugins {
-		pb, found := plugins.GetPluginBuilder(name)
-		if !found {
+		pb := plugins.GetPluginBuilder(name)
+		if pb == nil {
 			err := fmt.Errorf("failed to get plugin %s", name)
 			glog.Error(err)
 			return err
@@ -73,8 +73,8 @@ func (cc *Controller) pluginOnJobAdd(job *batch.Job) error {
 func (cc *Controller) pluginOnJobDelete(job *batch.Job) error {
 	client := pluginsinterface.PluginClientset{KubeClients: cc.kubeClient}
 	for name, args := range job.Spec.Plugins {
-		pb, found := plugins.GetPluginBuilder(name)
-		if !found {
+		pb := plugins.GetPluginBuilder(name)
+		if pb == nil {
 			err := fmt.Errorf("failed to get plugin %s", name)
 			glog.Error(err)
 			return err

--- a/pkg/controllers/job/plugins/factory.go
+++ b/pkg/controllers/job/plugins/factory.go
@@ -17,7 +17,7 @@ limitations under the License.
 package plugins
 
 import (
-	"sync"
+	"volcano.sh/volcano/pkg/controllers/job/plugins/mpi"
 
 	"volcano.sh/volcano/pkg/controllers/job/plugins/env"
 	"volcano.sh/volcano/pkg/controllers/job/plugins/interface"
@@ -29,9 +29,8 @@ func init() {
 	RegisterPluginBuilder("ssh", ssh.New)
 	RegisterPluginBuilder("env", env.New)
 	RegisterPluginBuilder("svc", svc.New)
+	RegisterPluginBuilder("mpi", mpi.New)
 }
-
-var pluginMutex sync.Mutex
 
 // Plugin management
 var pluginBuilders = map[string]PluginBuilder{}
@@ -41,17 +40,10 @@ type PluginBuilder func(pluginsinterface.PluginClientset, []string) pluginsinter
 
 // RegisterPluginBuilder register plugin builders
 func RegisterPluginBuilder(name string, pc func(pluginsinterface.PluginClientset, []string) pluginsinterface.PluginInterface) {
-	pluginMutex.Lock()
-	defer pluginMutex.Unlock()
-
 	pluginBuilders[name] = pc
 }
 
 // GetPluginBuilder returns plugin builder for a given plugin name
-func GetPluginBuilder(name string) (PluginBuilder, bool) {
-	pluginMutex.Lock()
-	defer pluginMutex.Unlock()
-
-	pb, found := pluginBuilders[name]
-	return pb, found
+func GetPluginBuilder(name string) PluginBuilder {
+	return pluginBuilders[name]
 }

--- a/pkg/controllers/job/plugins/factory.go
+++ b/pkg/controllers/job/plugins/factory.go
@@ -17,10 +17,9 @@ limitations under the License.
 package plugins
 
 import (
-	"volcano.sh/volcano/pkg/controllers/job/plugins/mpi"
-
 	"volcano.sh/volcano/pkg/controllers/job/plugins/env"
 	"volcano.sh/volcano/pkg/controllers/job/plugins/interface"
+	"volcano.sh/volcano/pkg/controllers/job/plugins/mpi"
 	"volcano.sh/volcano/pkg/controllers/job/plugins/ssh"
 	"volcano.sh/volcano/pkg/controllers/job/plugins/svc"
 )

--- a/pkg/controllers/job/plugins/factory.go
+++ b/pkg/controllers/job/plugins/factory.go
@@ -17,6 +17,8 @@ limitations under the License.
 package plugins
 
 import (
+	"sync"
+
 	"volcano.sh/volcano/pkg/controllers/job/plugins/env"
 	"volcano.sh/volcano/pkg/controllers/job/plugins/interface"
 	"volcano.sh/volcano/pkg/controllers/job/plugins/mpi"
@@ -31,6 +33,8 @@ func init() {
 	RegisterPluginBuilder("mpi", mpi.New)
 }
 
+var pluginMutex sync.Mutex
+
 // Plugin management
 var pluginBuilders = map[string]PluginBuilder{}
 
@@ -39,10 +43,15 @@ type PluginBuilder func(pluginsinterface.PluginClientset, []string) pluginsinter
 
 // RegisterPluginBuilder register plugin builders
 func RegisterPluginBuilder(name string, pc func(pluginsinterface.PluginClientset, []string) pluginsinterface.PluginInterface) {
+	pluginMutex.Lock()
+	defer pluginMutex.Unlock()
 	pluginBuilders[name] = pc
 }
 
 // GetPluginBuilder returns plugin builder for a given plugin name
 func GetPluginBuilder(name string) PluginBuilder {
+	pluginMutex.Lock()
+	defer pluginMutex.Unlock()
+
 	return pluginBuilders[name]
 }

--- a/pkg/controllers/job/plugins/mpi/mpi.go
+++ b/pkg/controllers/job/plugins/mpi/mpi.go
@@ -54,7 +54,7 @@ type mpi struct {
 // New creates ssh plugin
 func New(client plugininterface.PluginClientset, arguments []string) plugininterface.PluginInterface {
 	mpi := mpi{pluginArguments: arguments, clientset: client}
-	mpi.ssh = ssh.New(client, arguments)
+	mpi.ssh = ssh.New(client, nil)
 	mpi.addFlags()
 
 	return &mpi

--- a/pkg/controllers/job/plugins/mpi/mpi.go
+++ b/pkg/controllers/job/plugins/mpi/mpi.go
@@ -1,0 +1,176 @@
+/*
+Copyright 2019 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mpi
+
+import (
+	"flag"
+	"fmt"
+	"strings"
+
+	"github.com/golang/glog"
+
+	"k8s.io/api/core/v1"
+
+	vkv1 "volcano.sh/volcano/pkg/apis/batch/v1alpha1"
+	"volcano.sh/volcano/pkg/apis/helpers"
+	plugininterface "volcano.sh/volcano/pkg/controllers/job/plugins/interface"
+	"volcano.sh/volcano/pkg/controllers/job/plugins/ssh"
+	"volcano.sh/volcano/pkg/controllers/job/plugins/svc"
+)
+
+type mpi struct {
+	// Arguments given for the plugin
+	pluginArguments []string
+
+	clientset plugininterface.PluginClientset
+
+	ssh plugininterface.PluginInterface
+
+	// mpi launcher index, by default it is 0.
+	launcher int
+	// mpi worker index, by default it is 1.
+	worker int
+	// slots per worker, by default it is 1.
+	slotsPerWorker int
+
+	// hosts specify which hosts to launcher MPI processes
+	hosts string
+}
+
+// New creates ssh plugin
+func New(client plugininterface.PluginClientset, arguments []string) plugininterface.PluginInterface {
+	mpi := mpi{pluginArguments: arguments, clientset: client}
+	mpi.ssh = ssh.New(client, arguments)
+	mpi.addFlags()
+
+	return &mpi
+}
+
+func (p *mpi) Name() string {
+	return "mpi"
+}
+
+func (p *mpi) OnPodCreate(pod *v1.Pod, job *vkv1.Job) error {
+	p.ssh.OnPodCreate(pod, job)
+
+	// only set `MPI_HOST` env and mount hostfile to launcher pod
+	if p.isLauncher(pod, job) {
+		cmName := p.cmName(job)
+		cmVolume := v1.Volume{
+			Name: cmName,
+		}
+		cmVolume.ConfigMap = &v1.ConfigMapVolumeSource{
+			LocalObjectReference: v1.LocalObjectReference{
+				Name: cmName,
+			},
+		}
+		pod.Spec.Volumes = append(pod.Spec.Volumes, cmVolume)
+
+		data := svc.GenerateHost(job)
+		key := fmt.Sprintf(svc.ConfigMapTaskHostFmt, job.Spec.Tasks[p.worker].Name)
+		mpiHosts := strings.ReplaceAll(data[key], "\n", ",")
+		for i, c := range pod.Spec.Containers {
+			vm := v1.VolumeMount{
+				MountPath: HOST_FILE_PATH,
+				Name:      cmName,
+			}
+
+			pod.Spec.Containers[i].VolumeMounts = append(c.VolumeMounts, vm)
+			pod.Spec.Containers[i].Env = append(pod.Spec.Containers[i].Env, v1.EnvVar{Name: MPI_HOST, Value: mpiHosts})
+		}
+
+	} else {
+		// use podName.serviceName as default pod DNS domain
+		if len(pod.Spec.Hostname) == 0 {
+			pod.Spec.Hostname = pod.Name
+		}
+		if len(pod.Spec.Subdomain) == 0 {
+			pod.Spec.Subdomain = job.Name
+		}
+	}
+	return nil
+}
+
+func (p *mpi) OnJobAdd(job *vkv1.Job) error {
+	p.ssh.OnJobAdd(job)
+
+	// Generate MPI_HOST
+	if len(job.Spec.Tasks) <= p.worker {
+		return fmt.Errorf("invalid MPI job, should contains at least launcher and worker")
+	}
+	data := svc.GenerateHost(job)
+	key := fmt.Sprintf(svc.ConfigMapTaskHostFmt, job.Spec.Tasks[p.worker].Name)
+
+	// create MPI hostfile configmap
+	hosts := strings.Split(data[key], "\n")
+	for i, host := range hosts {
+		hosts[i] = fmt.Sprintf("%s slots=%d", host, p.slotsPerWorker)
+	}
+
+	mpiHostFileData := map[string]string{HOST_FILE: strings.Join(hosts, "\n")}
+	if err := helpers.CreateConfigMapIfNotExist(job, p.clientset.KubeClients, mpiHostFileData, p.cmName(job)); err != nil {
+		return err
+	}
+
+	if err := svc.CreateServiceIfNotExist(p.clientset.KubeClients, job); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (p *mpi) OnJobDelete(job *vkv1.Job) error {
+	// resource clean up
+	p.ssh.OnJobDelete(job)
+
+	if err := helpers.DeleteConfigmap(job, p.clientset.KubeClients, p.cmName(job)); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (p *mpi) addFlags() {
+	flagSet := flag.NewFlagSet(p.Name(), flag.ContinueOnError)
+	flagSet.IntVar(&p.launcher, "launcher", 0, "The mpi launcher index of the job.spec.tasks, by default is 0.")
+	flagSet.IntVar(&p.worker, "worker", 1, "The mpi worker index of the job.spec.tasks, by default is 1.")
+	flagSet.IntVar(&p.slotsPerWorker, "slots-per-worker", 1, "Slots per worker, by default is 1.")
+
+	if err := flagSet.Parse(p.pluginArguments); err != nil {
+		glog.Errorf("plugin %s flagset parse failed, err: %v", p.Name(), err)
+	}
+	return
+}
+
+func (p *mpi) isLauncher(pod *v1.Pod, job *vkv1.Job) bool {
+	taskIndex := -1
+	for i := range job.Spec.Tasks {
+		if job.Spec.Tasks[i].Name == pod.Annotations[vkv1.TaskSpecKey] {
+			taskIndex = i
+		}
+	}
+
+	if taskIndex == p.launcher {
+		return true
+	}
+
+	return false
+}
+
+func (p *mpi) cmName(job *vkv1.Job) string {
+	return fmt.Sprintf("%s-%s", job.Name, p.Name())
+}

--- a/pkg/controllers/job/plugins/mpi/wellknown.go
+++ b/pkg/controllers/job/plugins/mpi/wellknown.go
@@ -22,7 +22,7 @@ const (
 
 	// HOST_FILE_PATH and HOST_FILE when used
 	// HOST_FILE_PATH represents mpi hostfile mount path
-	HOST_FILE_PATH = "/etc/mpi"
+	HOST_FILE_PATH = "/etc/volcano/mpi"
 
 	// MPI hostfile name
 	HOST_FILE = "hostfile"

--- a/pkg/controllers/job/plugins/mpi/wellknown.go
+++ b/pkg/controllers/job/plugins/mpi/wellknown.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2019 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mpi
+
+const (
+	// MPI_HOST env var
+	MPI_HOST = "MPI_HOST"
+
+	// HOST_FILE_PATH and HOST_FILE when used
+	// HOST_FILE_PATH represents mpi hostfile mount path
+	HOST_FILE_PATH = "/etc/mpi"
+
+	// MPI hostfile name
+	HOST_FILE = "hostfile"
+)

--- a/pkg/controllers/job/plugins/mpi/wellknown.go
+++ b/pkg/controllers/job/plugins/mpi/wellknown.go
@@ -17,13 +17,16 @@ limitations under the License.
 package mpi
 
 const (
-	// MPI_HOST env var
-	MPI_HOST = "MPI_HOST"
+	// HostFilePath and HostFile when used
+	// HostFilePath represents mpi hostfile mount path
+	HostFilePath = "/etc/volcano/mpi"
 
-	// HOST_FILE_PATH and HOST_FILE when used
-	// HOST_FILE_PATH represents mpi hostfile mount path
-	HOST_FILE_PATH = "/etc/volcano/mpi"
+	// HostFile represents MPI hostfile name
+	HostFile = "hostfile"
 
-	// MPI hostfile name
-	HOST_FILE = "hostfile"
+	// MPIHost env var
+	MPIHost = "MPI_HOST"
+
+	// MPIHostFile env var
+	MPIHostFile = "MPI_HOST_FILE"
 )

--- a/pkg/controllers/job/plugins/svc/svc.go
+++ b/pkg/controllers/job/plugins/svc/svc.go
@@ -123,6 +123,7 @@ func (sp *servicePlugin) mountConfigmap(pod *v1.Pod, job *batch.Job) {
 	}
 }
 
+// CreateServiceIfNotExist creates a placeholder service for the job.
 func CreateServiceIfNotExist(kubeClient kubernetes.Interface, job *batch.Job) error {
 	// If Service does not exist, create one for Job.
 	if _, err := kubeClient.CoreV1().Services(job.Namespace).Get(job.Name, metav1.GetOptions{}); err != nil {
@@ -171,6 +172,7 @@ func (sp *servicePlugin) cmName(job *batch.Job) string {
 	return fmt.Sprintf("%s-%s", job.Name, sp.Name())
 }
 
+// GenerateHost generates the hosts for all tasks.
 func GenerateHost(job *batch.Job) map[string]string {
 	data := make(map[string]string, len(job.Spec.Tasks))
 

--- a/test/e2e/mpi.go
+++ b/test/e2e/mpi.go
@@ -83,7 +83,7 @@ mpiexec --allow-run-as-root --hostfile /etc/volcano/mpiworker.host -np 2 mpi_hel
 		slot := oneCPU
 
 		spec := &jobSpec{
-			name: "mpi",
+			name: "mpi-plugin",
 			policies: []vkv1.LifecyclePolicy{
 				{
 					Action: vkv1.CompleteJobAction,
@@ -104,7 +104,7 @@ mpiexec --allow-run-as-root --hostfile /etc/volcano/mpiworker.host -np 2 mpi_hel
 					//Need sometime waiting for worker node ready
 					command: `sleep 5;
 mkdir -p /var/run/sshd; /usr/sbin/sshd;
-mpiexec --allow-run-as-root --hostfile /etc/volcano/mpiworker.host -np 2 mpi_hello_world > /home/re`,
+mpiexec --allow-run-as-root --hostfile ${MPI_HOST_FILE} -np 2 mpi_hello_world > /home/re`,
 				},
 				{
 					name:       "mpiworker",

--- a/test/e2e/mpi.go
+++ b/test/e2e/mpi.go
@@ -84,10 +84,10 @@ mpiexec --allow-run-as-root --hostfile /etc/volcano/mpiworker.host -np 2 mpi_hel
 
 		spec := &jobSpec{
 			name: "mpi-plugin",
-			policies: []vkv1.LifecyclePolicy{
+			policies: []vcbatch.LifecyclePolicy{
 				{
-					Action: vkv1.CompleteJobAction,
-					Event:  vkv1.TaskCompletedEvent,
+					Action: vcbatch.CompleteJobAction,
+					Event:  vcbatch.TaskCompletedEvent,
 				},
 			},
 			plugins: map[string][]string{
@@ -120,8 +120,8 @@ mpiexec --allow-run-as-root --hostfile ${MPI_HOST_FILE} -np 2 mpi_hello_world > 
 
 		job := createJob(context, spec)
 
-		err := waitJobPhases(context, job, []vkv1.JobPhase{
-			vkv1.Pending, vkv1.Running, vkv1.Completing, vkv1.Completed})
+		err := waitJobPhases(context, job, []vcbatch.JobPhase{
+			vcbatch.Pending, vcbatch.Running, vcbatch.Completing, vcbatch.Completed})
 		Expect(err).NotTo(HaveOccurred())
 	})
 


### PR DESCRIPTION
Add a new plugin `mpi`, with it users do not need to specify other plugins like `ssh` and `svc`, only one `mpi` is enough. 

Also, it add an env `MPI_HOST`, and mount a hostfile in ` /etc/volcano/mpi/hostfile` as  `MPI_HOST_FILE`,.

It will simplify MPI job greatly.