### PR TITLE
refresh volumes logic

### DIFF
--- a/pkg/controllers/job/helpers/helpers.go
+++ b/pkg/controllers/job/helpers/helpers.go
@@ -49,7 +49,7 @@ func MakePodName(jobName string, taskName string, index int) string {
 	return fmt.Sprintf(PodNameFmt, jobName, taskName, index)
 }
 
-func genRandomStr(l int) string {
+func GenRandomStr(l int) string {
 	str := "0123456789abcdefghijklmnopqrstuvwxyz"
 	bytes := []byte(str)
 	var result []byte
@@ -62,7 +62,7 @@ func genRandomStr(l int) string {
 
 // MakeVolumeClaimName creates volume claim name
 func MakeVolumeClaimName(jobName string) string {
-	return fmt.Sprintf(VolumeClaimFmt, jobName, genRandomStr(12))
+	return fmt.Sprintf(VolumeClaimFmt, jobName, GenRandomStr(12))
 }
 
 // GetJobKeyByReq gets the key for the job request

--- a/pkg/controllers/job/helpers/helpers.go
+++ b/pkg/controllers/job/helpers/helpers.go
@@ -49,6 +49,7 @@ func MakePodName(jobName string, taskName string, index int) string {
 	return fmt.Sprintf(PodNameFmt, jobName, taskName, index)
 }
 
+// GenRandomStr generate random str with specified length l
 func GenRandomStr(l int) string {
 	str := "0123456789abcdefghijklmnopqrstuvwxyz"
 	bytes := []byte(str)

--- a/pkg/controllers/job/job_controller_actions.go
+++ b/pkg/controllers/job/job_controller_actions.go
@@ -17,6 +17,7 @@ limitations under the License.
 package job
 
 import (
+	"errors"
 	"fmt"
 	"sort"
 	"sync"
@@ -157,16 +158,16 @@ func (cc *Controller) createJob(job *vkv1.Job) (*vkv1.Job, error) {
 		return nil, err
 	}
 
-	if err := cc.createPodGroupIfNotExist(job); err != nil {
-		cc.recorder.Event(job, v1.EventTypeWarning, string(vkv1.PodGroupError),
-			fmt.Sprintf("Failed to create PodGroup, err: %v", err))
-		return nil, err
-	}
-
 	newJob, err := cc.createJobIOIfNotExist(job)
 	if err != nil {
 		cc.recorder.Event(job, v1.EventTypeWarning, string(vkv1.PVCError),
 			fmt.Sprintf("Failed to create PVC, err: %v", err))
+		return nil, err
+	}
+
+	if err := cc.createPodGroupIfNotExist(newJob); err != nil {
+		cc.recorder.Event(job, v1.EventTypeWarning, string(vkv1.PodGroupError),
+			fmt.Sprintf("Failed to create PodGroup, err: %v", err))
 		return nil, err
 	}
 
@@ -336,10 +337,9 @@ func (cc *Controller) syncJob(jobInfo *apis.JobInfo, updateStatus state.UpdateSt
 
 func (cc *Controller) createJobIOIfNotExist(job *vkv1.Job) (*vkv1.Job, error) {
 	// If PVC does not exist, create them for Job.
-	var needUpdate, nameExist bool
+	var needUpdate bool
 	volumes := job.Spec.Volumes
 	for index, volume := range volumes {
-		nameExist = false
 		vcName := volume.VolumeClaimName
 		if len(vcName) == 0 {
 			//NOTE(k82cn): Ensure never have duplicated generated names.
@@ -347,7 +347,7 @@ func (cc *Controller) createJobIOIfNotExist(job *vkv1.Job) (*vkv1.Job, error) {
 				vcName = vkjobhelpers.MakeVolumeClaimName(job.Name)
 				exist, err := cc.checkPVCExist(job, vcName)
 				if err != nil {
-					return nil, err
+					return job, err
 				}
 				if exist {
 					continue
@@ -356,25 +356,28 @@ func (cc *Controller) createJobIOIfNotExist(job *vkv1.Job) (*vkv1.Job, error) {
 				needUpdate = true
 				break
 			}
-		} else {
-			exist, err := cc.checkPVCExist(job, vcName)
-			if err != nil {
-				return nil, err
-			}
-			nameExist = exist
-		}
-
-		if !nameExist {
-			if job.Status.ControlledResources == nil {
-				job.Status.ControlledResources = make(map[string]string)
-			}
 			if volume.VolumeClaim != nil {
 				if err := cc.createPVC(job, vcName, volume.VolumeClaim); err != nil {
-					return nil, err
+					return job, err
 				}
 				job.Status.ControlledResources["volume-pvc-"+vcName] = vcName
 			} else {
 				job.Status.ControlledResources["volume-emptyDir-"+vcName] = vcName
+			}
+		} else {
+			if job.Status.ControlledResources["volume-emptyDir-"+vcName] == vcName || job.Status.ControlledResources["volume-pvc-"+vcName] == vcName {
+				continue
+			}
+			exist, err := cc.checkPVCExist(job, vcName)
+			if err != nil {
+				return job, err
+			}
+			if exist {
+				job.Status.ControlledResources["volume-pvc-"+vcName] = vcName
+			} else {
+				msg := fmt.Sprintf("PVC %s is not found, the job will be in the Pending state until the PVC is created.", vcName)
+				glog.Error(msg)
+				return job, errors.New(msg)
 			}
 		}
 	}
@@ -383,7 +386,10 @@ func (cc *Controller) createJobIOIfNotExist(job *vkv1.Job) (*vkv1.Job, error) {
 		if err != nil {
 			glog.Errorf("Failed to update Job %v/%v for volume claim name: %v ",
 				job.Namespace, job.Name, err)
-			return nil, err
+			return job, err
+		} else {
+			newJob.Status = job.Status
+			return newJob, err
 		}
 		newJob.Status = job.Status
 

--- a/pkg/controllers/job/job_controller_actions_test.go
+++ b/pkg/controllers/job/job_controller_actions_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package job
 
 import (
+	"errors"
 	"fmt"
 	"testing"
 
@@ -295,7 +296,7 @@ func TestCreateJobIOIfNotExistFunc(t *testing.T) {
 		ExpextVal error
 	}{
 		{
-			Name: "Create Job IO success case",
+			Name: "Create Job IO case",
 			Job: &v1alpha1.Job{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "job1",
@@ -309,7 +310,7 @@ func TestCreateJobIOIfNotExistFunc(t *testing.T) {
 					},
 				},
 			},
-			ExpextVal: nil,
+			ExpextVal: errors.New("pvc pvc1 is not found, the job will be in the Pending state until the PVC is created"),
 		},
 	}
 
@@ -319,8 +320,14 @@ func TestCreateJobIOIfNotExistFunc(t *testing.T) {
 			fakeController := newFakeController()
 
 			job, err := fakeController.createJobIOIfNotExist(testcase.Job)
-			if err != testcase.ExpextVal {
-				t.Errorf("Expected Return value to be : %s, but got: %s in testcase %d", testcase.ExpextVal, err, i)
+			if testcase.ExpextVal == nil {
+				if err != nil {
+					t.Errorf("Expected Return value to be : %v, but got: %v in testcase %d", testcase.ExpextVal, err, i)
+				}
+			} else {
+				if err == nil || err.Error() != testcase.ExpextVal.Error() {
+					t.Errorf("Expected Return value to be : %v, but got: %v in testcase %d", testcase.ExpextVal.Error(), err.Error(), i)
+				}
 			}
 
 			if len(job.Spec.Volumes) == 0 {


### PR DESCRIPTION
After this PR merged, the volume behavior would change to this.

-----

Before all, we have a job like this:
```
metadata:
  generateName: lm-volume-
  name: lm-volume-drhwm
spec:
  volumes:
  - mountPath: /mnt11
  - mountPath: /mnt21
    volumeClaimName: lm-pvc
  - mountPath: /mnt31
    volumeClaim:
      accessModes:
        - ReadWriteOnce
      resources:
        requests:
          storage: 1Gi
```
- The first volume would be an emptyDir for all container at /mnt11.
- The second volume would mount lm-pvc to /mnt21.
- The third volume would create a pvc following volumeClaim with name format `{jobname}-volume-{randomStr}` and mount it to /mnt31. 

-----

So the info recorded in controlledResources would be like this
```
status:
  controlledResources:
    volume-emptyDir-lm-volume-drhwm-volume-7hmf0d7qfonv: lm-volume-drhwm-volume-7hmf0d7qfonv
    volume-pvc-lm-pvc: lm-pvc
    volume-pvc-lm-volume-drhwm-volume-4t5agfb78vfj: lm-volume-drhwm-volume-4t5agfb78vfj
```