### PR TITLE
correct podgroup creating bug for single pod without ownerreference

### DIFF
--- a/pkg/controllers/podgroup/pg_controller_handler.go
+++ b/pkg/controllers/podgroup/pg_controller_handler.go
@@ -112,8 +112,10 @@ func newPGOwnerReferences(pod *v1.Pod) []metav1.OwnerReference {
 
 	isController := true
 	return []metav1.OwnerReference{{
-		APIVersion: helpers.JobKind.GroupVersion().String(),
+		APIVersion: v1.SchemeGroupVersion.Version,
+		Kind:       "Pod",
 		Controller: &isController,
+		Name:       pod.Name,
 		UID:        pod.UID,
 	}}
 }


### PR DESCRIPTION
#496
* set pod itself as `ownerReference` of `podgroup` for pod who does not have `ownerReference` when creating `podgroup` for single pod

* since `kind` and `apiVersion` of pod in cache are empty, when merging `ownerReference` struct of `podgroup`, use hardcode instead of getting from pod
