### PR TITLE
Dynamic loading comfigmap about action and plugins of scheduler, move loadSchedulerConf processing from run to runOnce 

### DIFF
--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -61,11 +61,33 @@ func NewScheduler(
 
 // Run runs the Scheduler
 func (pc *Scheduler) Run(stopCh <-chan struct{}) {
-	var err error
-
 	// Start cache for policy.
 	go pc.cache.Run(stopCh)
 	pc.cache.WaitForCacheSync(stopCh)
+
+	go wait.Until(pc.runOnce, pc.schedulePeriod, stopCh)
+}
+
+func (pc *Scheduler) runOnce() {
+	glog.V(4).Infof("Start scheduling ...")
+	scheduleStartTime := time.Now()
+	defer glog.V(4).Infof("End scheduling ...")
+	defer metrics.UpdateE2eDuration(metrics.Duration(scheduleStartTime))
+
+	pc.loadSchedulerConf()
+
+	ssn := framework.OpenSession(pc.cache, pc.plugins)
+	defer framework.CloseSession(ssn)
+
+	for _, action := range pc.actions {
+		actionStartTime := time.Now()
+		action.Execute(ssn)
+		metrics.UpdateActionDuration(action.Name(), metrics.Duration(actionStartTime))
+	}
+}
+
+func (pc *Scheduler) loadSchedulerConf() {
+	var err error
 
 	// Load configuration of scheduler
 	schedConf := defaultSchedulerConf
@@ -80,23 +102,5 @@ func (pc *Scheduler) Run(stopCh <-chan struct{}) {
 	pc.actions, pc.plugins, err = loadSchedulerConf(schedConf)
 	if err != nil {
 		panic(err)
-	}
-
-	go wait.Until(pc.runOnce, pc.schedulePeriod, stopCh)
-}
-
-func (pc *Scheduler) runOnce() {
-	glog.V(4).Infof("Start scheduling ...")
-	scheduleStartTime := time.Now()
-	defer glog.V(4).Infof("End scheduling ...")
-	defer metrics.UpdateE2eDuration(metrics.Duration(scheduleStartTime))
-
-	ssn := framework.OpenSession(pc.cache, pc.plugins)
-	defer framework.CloseSession(ssn)
-
-	for _, action := range pc.actions {
-		actionStartTime := time.Now()
-		action.Execute(ssn)
-		metrics.UpdateActionDuration(action.Name(), metrics.Duration(actionStartTime))
 	}
 }


### PR DESCRIPTION
The reason for this changes is to realize dynamically loading configuration of scheduler. When configuration about `action` or `plugins` of scheduler changes, the scheduler can load and use the new configuration without restarting.

For time of loading configuration is very shot, the changes has no effect on the scheduling performance

Time duration of `scheduler.loadSchedulerConf` function

| serial num   | time duration(us)    | 
| :----------: | :------------------: | 
| 1            | 226.97               |
| 2            | 179.438              |
| 3            | 181.991              |
| 4            | 326.252              |
| 5            | 331.443              |
| 6            | 256.802              |
| 7            | 325.434              |
| 8            | 254.457              |
| 9            | `504.386`              |
| 10           | 216.369              |
| 11           | 221.776              |
| 12           | 266.722              |
| 13           | 211.502              |
| 14           | 203.506              |
| 15           | 208.086              |
| 16           | 233.679              |
| 17           | 241.664              |
| 18           | 234.157              |             
| 19           | 200.129              |
| 20           | 198.543              |
