### PR TITLE
fix podgroup phase

### DIFF
--- a/pkg/scheduler/framework/session.go
+++ b/pkg/scheduler/framework/session.go
@@ -174,7 +174,7 @@ func jobStatus(ssn *Session, jobInfo *api.JobInfo) scheduling.PodGroupStatus {
 	} else {
 		allocated := 0
 		for status, tasks := range jobInfo.TaskStatusIndex {
-			if api.AllocatedStatus(status) {
+			if api.AllocatedStatus(status) || status == api.Succeeded {
 				allocated += len(tasks)
 			}
 		}


### PR DESCRIPTION
when i use job.yaml

```
apiVersion: batch.volcano.sh/v1alpha1                                                                                                                                       
kind: Job 
metadata:
  generateName: job-xxx
spec:
  minAvailable: 4
  schedulerName: volcano
  plugins:
    ssh: []
    env: []
    svc: []
  policies:
  - event: PodFailed
    action: RestartJob
  tasks:
  - replicas: 1
    name: "mpimaster"
    template:
      spec:
        imagePullSecrets:
          - name: default-secret
        containers:
        - command:
            - /bin/sh
            - -c
            - | 
              mkdir -p /var/run/sshd; /usr/sbin/sshd; sleep 10;
          image: openmpi-hello:1.0
          imagePullPolicy: IfNotPresent
          name: mpimaster
          ports:
          - containerPort: 2222
            name: mpijob-port
          workingDir: /home
          resources:
            limits:
              cpu: 3750m
        restartPolicy: OnFailure
  - replicas: 3
    name: mpiworker
    template:
      spec:
        imagePullSecrets:
          - name: default-secret
        containers:
        - command:
            - /bin/sh
            - -c
            - |
              mkdir -p /var/run/sshd; /usr/sbin/sshd; sleep 5;
          image: openmpi-hello:1.0
          imagePullPolicy: IfNotPresent
          name: mpiworker
          ports:
          - containerPort: 2222
            name: mpijob-port
          workingDir: /home
          resources:
            limits:
              cpu: 3750m
        restartPolicy: OnFailure
```
i use kubectl create -f job.yaml, but phase of podgroup make me confused.

```
    | PG phase |        Pod             |
    | -------- | ---------------------- |
    | Pending  | none                   |
    | Inqueue  | 4 Pending              |
    | Running  | 4 Running              |
    | Pending  | 1 Running  3 Compeletd |
   
```

so i fix, when calc allocated num, include succeeded pod.
   
