### PR TITLE
ssh plugin support specifying private/public keys path

### DIFF
--- a/pkg/controllers/job/plugins/ssh/ssh.go
+++ b/pkg/controllers/job/plugins/ssh/ssh.go
@@ -23,8 +23,6 @@ import (
 	"encoding/pem"
 	"flag"
 	"fmt"
-	"strings"
-
 	"github.com/golang/glog"
 	"golang.org/x/crypto/ssh"
 
@@ -143,7 +141,7 @@ func (sp *sshPlugin) mountRsaKey(pod *v1.Pod, job *batch.Job) {
 
 	for i, c := range pod.Spec.Containers {
 		vm := v1.VolumeMount{
-			MountPath: strings.TrimSuffix(sp.sshKeyFilePath, "/"+SSHRelativePath),
+			MountPath: sp.sshKeyFilePath,
 			SubPath:   SSHRelativePath,
 			Name:      cmName,
 		}

--- a/pkg/controllers/job/plugins/ssh/ssh.go
+++ b/pkg/controllers/job/plugins/ssh/ssh.go
@@ -23,10 +23,10 @@ import (
 	"encoding/pem"
 	"flag"
 	"fmt"
-
-	"golang.org/x/crypto/ssh"
+	"strings"
 
 	"github.com/golang/glog"
+	"golang.org/x/crypto/ssh"
 
 	"k8s.io/api/core/v1"
 
@@ -44,14 +44,23 @@ type sshPlugin struct {
 	Clientset pluginsinterface.PluginClientset
 
 	// flag parse args
-	noRoot bool
+	noRoot         bool
+	sshKeyFilePath string
 }
 
 // New creates ssh plugin
 func New(client pluginsinterface.PluginClientset, arguments []string) pluginsinterface.PluginInterface {
-	sshPlugin := sshPlugin{pluginArguments: arguments, Clientset: client}
+	sshPlugin := sshPlugin{
+		pluginArguments: arguments,
+		Clientset:       client,
+		sshKeyFilePath:  SSHAbsolutePath,
+	}
 
 	sshPlugin.addFlags()
+	// if not set ssh key files path, use the default.
+	if sshPlugin.noRoot && sshPlugin.sshKeyFilePath == SSHAbsolutePath {
+		sshPlugin.sshKeyFilePath = env.ConfigMapMountPath + "/" + SSHRelativePath
+	}
 
 	return &sshPlugin
 }
@@ -94,10 +103,6 @@ func (sp *sshPlugin) OnJobDelete(job *batch.Job) error {
 }
 
 func (sp *sshPlugin) mountRsaKey(pod *v1.Pod, job *batch.Job) {
-	sshPath := SSHAbsolutePath
-	if sp.noRoot {
-		sshPath = env.ConfigMapMountPath + "/" + SSHRelativePath
-	}
 
 	cmName := sp.cmName(job)
 	sshVolume := v1.Volume{
@@ -129,7 +134,7 @@ func (sp *sshPlugin) mountRsaKey(pod *v1.Pod, job *batch.Job) {
 		DefaultMode: &mode,
 	}
 
-	if sshPath != SSHAbsolutePath {
+	if sp.sshKeyFilePath != SSHAbsolutePath {
 		var noRootMode int32 = 0755
 		sshVolume.ConfigMap.DefaultMode = &noRootMode
 	}
@@ -138,7 +143,7 @@ func (sp *sshPlugin) mountRsaKey(pod *v1.Pod, job *batch.Job) {
 
 	for i, c := range pod.Spec.Containers {
 		vm := v1.VolumeMount{
-			MountPath: sshPath,
+			MountPath: strings.TrimSuffix(sp.sshKeyFilePath, "/"+SSHRelativePath),
 			SubPath:   SSHRelativePath,
 			Name:      cmName,
 		}
@@ -187,7 +192,10 @@ func (sp *sshPlugin) cmName(job *batch.Job) string {
 
 func (sp *sshPlugin) addFlags() {
 	flagSet := flag.NewFlagSet(sp.Name(), flag.ContinueOnError)
+	// TODO: deprecate no-root
 	flagSet.BoolVar(&sp.noRoot, "no-root", sp.noRoot, "The ssh user, --no-root is common user")
+	flagSet.StringVar(&sp.sshKeyFilePath, "ssh-key-file-path", sp.sshKeyFilePath, "The path used to store "+
+		"ssh private and public keys, it is `/root/.ssh` by default.")
 
 	if err := flagSet.Parse(sp.pluginArguments); err != nil {
 		glog.Errorf("plugin %s flagset parse failed, err: %v", sp.Name(), err)

--- a/pkg/controllers/job/plugins/ssh/ssh_test.go
+++ b/pkg/controllers/job/plugins/ssh/ssh_test.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2019 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ssh
+
+import (
+	"testing"
+
+	"volcano.sh/volcano/pkg/controllers/job/plugins/env"
+	"volcano.sh/volcano/pkg/controllers/job/plugins/interface"
+)
+
+func TestSSHPlugin(t *testing.T) {
+
+	tests := []struct {
+		name           string
+		params         []string
+		noRoot         bool
+		sshKeyFilePath string
+	}{
+		{
+			name:           "no params specified",
+			noRoot:         false,
+			sshKeyFilePath: SSHAbsolutePath,
+		},
+		{
+			name:           "--no-root=true, ssh-key-file-path empty",
+			params:         []string{"--no-root=true"},
+			noRoot:         true,
+			sshKeyFilePath: env.ConfigMapMountPath + "/" + SSHRelativePath,
+		},
+		{
+			name:           "--no-root=true, --ssh-key-file-path=/a/b",
+			params:         []string{"--no-root=true", "--ssh-key-file-path=/a/b"},
+			noRoot:         true,
+			sshKeyFilePath: "/a/b",
+		},
+		{
+			name:           "--ssh-key-file-path=/a/b",
+			params:         []string{"--ssh-key-file-path=/a/b"},
+			noRoot:         false,
+			sshKeyFilePath: "/a/b",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			pluginInterface := New(pluginsinterface.PluginClientset{}, test.params)
+			plugin := pluginInterface.(*sshPlugin)
+			if plugin.noRoot != test.noRoot {
+				t.Errorf("Expected noRoot=%v, got %v", test.noRoot, plugin.noRoot)
+			}
+
+			if plugin.sshKeyFilePath != test.sshKeyFilePath {
+				t.Errorf("Expected sshKeyFilePath=%s, got %s", test.sshKeyFilePath, plugin.sshKeyFilePath)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Added `ssh-key-file-path` to allow users to specify the path of ssh keys. For example if you want to store the keys in `/a/b`, the blowing config can work.

```
apiVersion: batch.volcano.sh/v1alpha1
kind: Job
metadata:
  name: lm-horovod-job
  labels:
    "volcano.sh/job-type": Horovod
spec:
  minAvailable: 4
  schedulerName: volcano
  plugins:
    ssh: ["--ssh-key-file-path=/a/b"]    # or ["--ssh-key-file-path", "/a/b"]
```