### PR TITLE
Modify scheduling events for pod and podgroup

### DIFF
--- a/pkg/apis/scheduling/types.go
+++ b/pkg/apis/scheduling/types.go
@@ -57,7 +57,20 @@ const (
 type PodGroupConditionType string
 
 const (
+	// PodGroupUnschedulableType is Unschedulable event type
 	PodGroupUnschedulableType PodGroupConditionType = "Unschedulable"
+
+	// PodGroupScheduled is scheduled event type
+	PodGroupScheduled PodGroupConditionType = "Scheduled"
+)
+
+type PodGroupConditionDetail string
+
+const (
+	// PodGroupReady is that PodGroup has reached scheduling restriction
+	PodGroupReady PodGroupConditionDetail = "pod group is ready"
+	// PodGroupNotReady is that PodGroup has not yet reached the scheduling restriction
+	PodGroupNotReady PodGroupConditionDetail = "pod group is not ready"
 )
 
 // PodGroupCondition contains details for the current state of this pod group.

--- a/pkg/apis/scheduling/v1alpha1/types.go
+++ b/pkg/apis/scheduling/v1alpha1/types.go
@@ -45,7 +45,20 @@ const (
 type PodGroupConditionType string
 
 const (
+	// PodGroupUnschedulableType is Unschedulable event type
 	PodGroupUnschedulableType PodGroupConditionType = "Unschedulable"
+
+	// PodGroupScheduled is scheduled event type
+	PodGroupScheduled PodGroupConditionType = "Scheduled"
+)
+
+type PodGroupConditionDetail string
+
+const (
+	// PodGroupReady is that PodGroup has reached scheduling restriction
+	PodGroupReady PodGroupConditionDetail = "pod group is ready"
+	// PodGroupNotReady is that PodGroup has not yet reached the scheduling restriction
+	PodGroupNotReady PodGroupConditionDetail = "pod group is not ready"
 )
 
 // PodGroupCondition contains details for the current state of this pod group.

--- a/pkg/apis/scheduling/v1alpha2/types.go
+++ b/pkg/apis/scheduling/v1alpha2/types.go
@@ -57,7 +57,20 @@ const (
 type PodGroupConditionType string
 
 const (
+	// PodGroupUnschedulableType is Unschedulable event type
 	PodGroupUnschedulableType PodGroupConditionType = "Unschedulable"
+
+	// PodGroupScheduled is scheduled event type
+	PodGroupScheduled PodGroupConditionType = "Scheduled"
+)
+
+type PodGroupConditionDetail string
+
+const (
+	// PodGroupReady is that PodGroup has reached scheduling restriction
+	PodGroupReady PodGroupConditionDetail = "pod group is ready"
+	// PodGroupNotReady is that PodGroup has not yet reached the scheduling restriction
+	PodGroupNotReady PodGroupConditionDetail = "pod group is not ready"
 )
 
 // PodGroupCondition contains details for the current state of this pod group.

--- a/pkg/scheduler/api/job_info.go
+++ b/pkg/scheduler/api/job_info.go
@@ -26,6 +26,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
+	"volcano.sh/volcano/pkg/apis/scheduling"
 	"volcano.sh/volcano/pkg/apis/scheduling/v1alpha2"
 )
 
@@ -335,7 +336,7 @@ func (ji *JobInfo) FitError() string {
 		sort.Strings(reasonStrings)
 		return reasonStrings
 	}
-	reasonMsg := fmt.Sprintf("job is not ready, %v.", strings.Join(sortReasonsHistogram(), ", "))
+	reasonMsg := fmt.Sprintf("%v, %v.", scheduling.PodGroupNotReady, strings.Join(sortReasonsHistogram(), ", "))
 	return reasonMsg
 }
 


### PR DESCRIPTION
#519

* Change `job is not ready` to `pod group is not ready`

* If status of podgroup is inqueue, record unschedulable events for podgroup

* record scheduled events for podgroup during bind pod to node

events of pod will be like 

```
Events:
  Type     Reason            Age   From     Message
  ----     ------            ----  ----     -------
  Warning  FailedScheduling  45m   volcano  10/6 tasks in gang unschedulable: pod group is not ready, 10 minAvailable, 6 Pending.
  Warning  FailedScheduling  45m   volcano  10/10 tasks in gang unschedulable: pod group is not ready, 10 Pending, 10 minAvailable.
  Warning  FailedScheduling  45m   volcano  10/16 tasks in gang unschedulable: pod group is not ready, 10 minAvailable, 16 Pending.
  Warning  FailedScheduling  44m   volcano  10/22 tasks in gang unschedulable: pod group is not ready, 10 minAvailable, 22 Pending.
  Warning  FailedScheduling  44m   volcano  10/26 tasks in gang unschedulable: pod group is not ready, 10 minAvailable, 26 Pending.
  Warning  FailedScheduling  44m   volcano  10/30 tasks in gang unschedulable: pod group is not ready, 10 minAvailable, 30 Pending.
```

events for podgroup will be like:

```
Status:
  Phase:    Running
  Running:  12
Events:
  Type     Reason         Age                From     Message
  ----     ------         ----               ----     -------
  Warning  Unschedulable  53s (x3 over 55s)  volcano  0/0 tasks in gang unschedulable: pod group is not ready, 12 minAvailable.
  Warning  Unschedulable  46s (x7 over 52s)  volcano  6/6 tasks in gang unschedulable: pod group is not ready, 12 minAvailable, 6 Pending.
  Warning  Unschedulable  38s (x8 over 45s)  volcano  10/10 tasks in gang unschedulable: pod group is not ready, 10 Pending, 12 minAvailable.
  Normal   Scheduled      37s (x7 over 37s)  volcano  2/14 tasks in gang unschedulable: pod group is ready, 12 minAvailable, 2 Pending
```
