### PR TITLE
pdb bug 修复

### DIFF
--- a/pkg/scheduler/api/job_info.go
+++ b/pkg/scheduler/api/job_info.go
@@ -18,6 +18,7 @@ package api
 
 import (
 	"fmt"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"sort"
 	"strings"
 
@@ -196,7 +197,9 @@ func (ji *JobInfo) SetPodGroup(pg *PodGroup) {
 // SetPDB sets PDB to a job
 func (ji *JobInfo) SetPDB(pdb *policyv1.PodDisruptionBudget) {
 	ji.Name = pdb.Name
-	ji.MinAvailable = pdb.Spec.MinAvailable.IntVal
+	defaultMinAvailable := intstr.IntOrString{Type: intstr.Int, IntVal: int32(0)}
+	minAvailable := pdb.Spec.MinAvailable
+	ji.MinAvailable = int32(intstr.ValueOrDefault(minAvailable, defaultMinAvailable).IntValue())
 	ji.Namespace = pdb.Namespace
 
 	ji.CreationTimestamp = pdb.GetCreationTimestamp()

--- a/pkg/scheduler/api/job_info_test.go
+++ b/pkg/scheduler/api/job_info_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package api
 
 import (
+	policyv1 "k8s.io/api/policy/v1beta1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"reflect"
 	"testing"
 
@@ -197,4 +199,25 @@ func TestDeleteTaskInfo(t *testing.T) {
 				i, test.expected, ps)
 		}
 	}
+}
+
+func TestJobInfo_SetPDB(t *testing.T) {
+
+	info := &JobInfo{}
+	// case1
+	//intOrString := &intstr.IntOrString{Type:intstr.Int, IntVal:1}
+	//spec := policyv1.PodDisruptionBudgetSpec{MinAvailable:intOrString}
+	// case2
+	//spec := policyv1.PodDisruptionBudgetSpec{}
+	// case3
+	//intOrString := &intstr.IntOrString{}
+	//spec := policyv1.PodDisruptionBudgetSpec{MinAvailable:intOrString}
+	// case4
+	intOrString := &intstr.IntOrString{Type:intstr.String, StrVal:"1"}
+	spec := policyv1.PodDisruptionBudgetSpec{MinAvailable:intOrString}
+
+	pdb := &policyv1.PodDisruptionBudget{
+		Spec: spec,
+	}
+	info.SetPDB(pdb)
 }

--- a/pkg/scheduler/api/job_info_test.go
+++ b/pkg/scheduler/api/job_info_test.go
@@ -213,8 +213,8 @@ func TestJobInfo_SetPDB(t *testing.T) {
 	//intOrString := &intstr.IntOrString{}
 	//spec := policyv1.PodDisruptionBudgetSpec{MinAvailable:intOrString}
 	// case4
-	intOrString := &intstr.IntOrString{Type:intstr.String, StrVal:"1"}
-	spec := policyv1.PodDisruptionBudgetSpec{MinAvailable:intOrString}
+	intOrString := &intstr.IntOrString{Type: intstr.String, StrVal: "1"}
+	spec := policyv1.PodDisruptionBudgetSpec{MinAvailable: intOrString}
 
 	pdb := &policyv1.PodDisruptionBudget{
 		Spec: spec,


### PR DESCRIPTION
修复scheduler job_info.SetPDB(…) ，引发的：Panic： invalid memory address or nil pointer dereference