### PR TITLE
modify the 'vcctl job run' function

### DIFF
--- a/pkg/cli/job/run_test.go
+++ b/pkg/cli/job/run_test.go
@@ -77,6 +77,7 @@ func TestCreateJob(t *testing.T) {
 			commonFlags: commonFlags{
 				Master: server.URL,
 			},
+			Name:      "test",
 			Namespace: "test",
 			Requests:  "cpu=1000m,memory=100Mi",
 		}
@@ -104,9 +105,6 @@ func TestInitRunFlags(t *testing.T) {
 	}
 	if cmd.Flag("replicas") == nil {
 		t.Errorf("Could not find the flag replicas")
-	}
-	if cmd.Flag("name") == nil {
-		t.Errorf("Could not find the flag name")
 	}
 	if cmd.Flag("min") == nil {
 		t.Errorf("Could not find the flag min")

--- a/test/e2e/vcctl.go
+++ b/test/e2e/vcctl.go
@@ -172,7 +172,7 @@ Flags:
   -L, --limits string       the resource limit of the task (default "cpu=1000m,memory=100Mi")
   -s, --master string       the address of apiserver
   -m, --min int             the minimal available tasks of job (default 1)
-  -N, --name string         the name of job (default "test")
+  -N, --name string         the name of job
   -n, --namespace string    the namespace of job (default "default")
   -r, --replicas int        the total tasks of job (default 1)
   -R, --requests string     the resource request of the task (default "cpu=1000m,memory=100Mi")


### PR DESCRIPTION
now `vcctl job run` can used as`vcctl job run -N <job name> -n <namespace> -i <image>`
and `vcctl job run` with no arguments will throw error