### PR TITLE
Simplify job pvc create process

### DIFF
--- a/pkg/admission/admit_job.go
+++ b/pkg/admission/admit_job.go
@@ -147,8 +147,8 @@ func validateJob(job v1alpha1.Job, reviewResponse *v1beta1.AdmissionResponse) st
 		}
 	}
 
-	if validateInfo, ok := ValidateIO(job.Spec.Volumes); ok {
-		msg = msg + validateInfo
+	if err := validateIO(job.Spec.Volumes); err != nil {
+		msg = msg + err.Error()
 	}
 
 	// Check whether Queue already present or not

--- a/pkg/admission/admit_job_test.go
+++ b/pkg/admission/admit_job_test.go
@@ -850,6 +850,57 @@ func TestValidateExecution(t *testing.T) {
 					},
 					Volumes: []v1alpha1.VolumeSpec{
 						{
+							MountPath:       "/var",
+							VolumeClaimName: "pvc1",
+						},
+						{
+							MountPath:       "/var",
+							VolumeClaimName: "pvc2",
+						},
+					},
+				},
+			},
+			reviewResponse: v1beta1.AdmissionResponse{Allowed: true},
+			ret:            " duplicated mountPath: /var;",
+			ExpectErr:      true,
+		},
+		{
+			Name: "volume without VolumeClaimName and VolumeClaim",
+			Job: v1alpha1.Job{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "invalid-volume",
+					Namespace: namespace,
+				},
+				Spec: v1alpha1.JobSpec{
+					MinAvailable: 1,
+					Queue:        "default",
+					Tasks: []v1alpha1.TaskSpec{
+						{
+							Name:     "task-1",
+							Replicas: 1,
+							Template: v1.PodTemplateSpec{
+								ObjectMeta: metav1.ObjectMeta{
+									Labels: map[string]string{"name": "test"},
+								},
+								Spec: v1.PodSpec{
+									Containers: []v1.Container{
+										{
+											Name:  "fake-name",
+											Image: "busybox:1.24",
+										},
+									},
+								},
+							},
+						},
+					},
+					Policies: []v1alpha1.LifecyclePolicy{
+						{
+							Event:  v1alpha1.AnyEvent,
+							Action: v1alpha1.AbortJobAction,
+						},
+					},
+					Volumes: []v1alpha1.VolumeSpec{
+						{
 							MountPath: "/var",
 						},
 						{
@@ -859,7 +910,7 @@ func TestValidateExecution(t *testing.T) {
 				},
 			},
 			reviewResponse: v1beta1.AdmissionResponse{Allowed: true},
-			ret:            " duplicated mountPath: /var;",
+			ret:            " either VolumeClaim or VolumeClaimName must be specified;",
 			ExpectErr:      true,
 		},
 		// task Policy with any event and other events

--- a/pkg/controllers/job/helpers/helpers.go
+++ b/pkg/controllers/job/helpers/helpers.go
@@ -30,8 +30,8 @@ import (
 const (
 	// PodNameFmt pod name format
 	PodNameFmt = "%s-%s-%d"
-	// VolumeClaimFmt  volume claim name format
-	VolumeClaimFmt = "%s-volume-%s"
+	// persistentVolumeClaimFmt represents persistent volume claim name format
+	persistentVolumeClaimFmt = "%s-pvc-%s"
 )
 
 // GetTaskIndex   returns task Index
@@ -61,9 +61,9 @@ func GenRandomStr(l int) string {
 	return string(result)
 }
 
-// MakeVolumeClaimName creates volume claim name
-func MakeVolumeClaimName(jobName string) string {
-	return fmt.Sprintf(VolumeClaimFmt, jobName, GenRandomStr(12))
+// GenPVCName generates pvc name with job name
+func GenPVCName(jobName string) string {
+	return fmt.Sprintf(persistentVolumeClaimFmt, jobName, GenRandomStr(12))
 }
 
 // GetJobKeyByReq gets the key for the job request

--- a/pkg/controllers/job/job_controller_util.go
+++ b/pkg/controllers/job/job_controller_util.go
@@ -63,24 +63,19 @@ func createJobPod(job *batch.Job, template *v1.PodTemplateSpec, ix int) *v1.Pod 
 		vcName := volume.VolumeClaimName
 		name := fmt.Sprintf("%s-%s", job.Name, jobhelpers.GenRandomStr(12))
 		if _, ok := volumeMap[vcName]; !ok {
-			if _, ok := job.Status.ControlledResources["volume-emptyDir-"+vcName]; ok {
-				volume := v1.Volume{
-					Name: name,
-				}
-				volume.EmptyDir = &v1.EmptyDirVolumeSource{}
-				pod.Spec.Volumes = append(pod.Spec.Volumes, volume)
-			} else {
-				volume := v1.Volume{
-					Name: name,
-				}
-				volume.PersistentVolumeClaim = &v1.PersistentVolumeClaimVolumeSource{
-					ClaimName: vcName,
-				}
-				pod.Spec.Volumes = append(pod.Spec.Volumes, volume)
+			volume := v1.Volume{
+				Name: name,
+				VolumeSource: v1.VolumeSource{
+					PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
+						ClaimName: vcName,
+					},
+				},
 			}
+			pod.Spec.Volumes = append(pod.Spec.Volumes, volume)
 			volumeMap[vcName] = name
 		} else {
-			name = volumeMap[vcName]
+			// duplicate volumes, should be prevented
+			continue
 		}
 
 		for i, c := range pod.Spec.Containers {

--- a/pkg/controllers/job/job_controller_util_test.go
+++ b/pkg/controllers/job/job_controller_util_test.go
@@ -213,11 +213,6 @@ func TestCreateJobPod(t *testing.T) {
 						},
 					},
 				},
-				Status: v1alpha1.JobStatus{
-					ControlledResources: map[string]string{
-						"volume-emptyDir-vc1": "vc1",
-					},
-				},
 			},
 			PodTemplate: &v1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
@@ -292,11 +287,6 @@ func TestApplyPolicies(t *testing.T) {
 						},
 					},
 				},
-				Status: v1alpha1.JobStatus{
-					ControlledResources: map[string]string{
-						"volume-emptyDir-vc1": "vc1",
-					},
-				},
 			},
 			Request: &apis.Request{
 				Action: v1alpha1.EnqueueAction,
@@ -332,11 +322,6 @@ func TestApplyPolicies(t *testing.T) {
 						},
 					},
 				},
-				Status: v1alpha1.JobStatus{
-					ControlledResources: map[string]string{
-						"volume-emptyDir-vc1": "vc1",
-					},
-				},
 			},
 			Request: &apis.Request{
 				Event: v1alpha1.OutOfSyncEvent,
@@ -370,12 +355,6 @@ func TestApplyPolicies(t *testing.T) {
 								},
 							},
 						},
-					},
-				},
-				Status: v1alpha1.JobStatus{
-					Version: 2,
-					ControlledResources: map[string]string{
-						"volume-emptyDir-vc1": "vc1",
 					},
 				},
 			},
@@ -420,11 +399,6 @@ func TestApplyPolicies(t *testing.T) {
 						},
 					},
 				},
-				Status: v1alpha1.JobStatus{
-					ControlledResources: map[string]string{
-						"volume-emptyDir-vc1": "vc1",
-					},
-				},
 			},
 			Request: &apis.Request{
 				TaskName: "task1",
@@ -466,11 +440,6 @@ func TestApplyPolicies(t *testing.T) {
 						},
 					},
 				},
-				Status: v1alpha1.JobStatus{
-					ControlledResources: map[string]string{
-						"volume-emptyDir-vc1": "vc1",
-					},
-				},
 			},
 			Request: &apis.Request{
 				TaskName: "task1",
@@ -505,11 +474,6 @@ func TestApplyPolicies(t *testing.T) {
 								},
 							},
 						},
-					},
-				},
-				Status: v1alpha1.JobStatus{
-					ControlledResources: map[string]string{
-						"volume-emptyDir-vc1": "vc1",
 					},
 				},
 			},
@@ -554,11 +518,6 @@ func TestApplyPolicies(t *testing.T) {
 						},
 					},
 				},
-				Status: v1alpha1.JobStatus{
-					ControlledResources: map[string]string{
-						"volume-emptyDir-vc1": "vc1",
-					},
-				},
 			},
 			Request: &apis.Request{
 				Event: v1alpha1.CommandIssuedEvent,
@@ -599,11 +558,6 @@ func TestApplyPolicies(t *testing.T) {
 							Event:    v1alpha1.CommandIssuedEvent,
 							ExitCode: &errorCode0,
 						},
-					},
-				},
-				Status: v1alpha1.JobStatus{
-					ControlledResources: map[string]string{
-						"volume-emptyDir-vc1": "vc1",
 					},
 				},
 			},

--- a/test/e2e/job_controlled_resource.go
+++ b/test/e2e/job_controlled_resource.go
@@ -26,47 +26,6 @@ import (
 )
 
 var _ = Describe("Job E2E Test: Test Job PVCs", func() {
-	It("Generate PVC name if not specified", func() {
-		jobName := "job-pvc-name-empty"
-		namespace := "test"
-		taskName := "task"
-		pvcName := "specifiedpvcname"
-		context := initTestContext()
-		defer cleanupTestContext(context)
-
-		job := createJob(context, &jobSpec{
-			namespace: namespace,
-			name:      jobName,
-			tasks: []taskSpec{
-				{
-					img:  defaultNginxImage,
-					req:  oneCPU,
-					min:  1,
-					rep:  1,
-					name: taskName,
-				},
-			},
-			volumes: []v1alpha1.VolumeSpec{
-				{
-					MountPath: "/mounttwo",
-				},
-			},
-		})
-
-		err := waitJobReady(context, job)
-		Expect(err).NotTo(HaveOccurred())
-
-		job, err = context.vcclient.BatchV1alpha1().Jobs(namespace).Get(jobName, metav1.GetOptions{})
-		Expect(err).NotTo(HaveOccurred())
-
-		Expect(len(job.Spec.Volumes)).To(Equal(1),
-			"Two volumes should be created")
-		for _, volume := range job.Spec.Volumes {
-			Expect(volume.VolumeClaimName).Should(Or(ContainSubstring(jobName), Equal(pvcName)),
-				"PVC name should be generated for manually specified.")
-		}
-	})
-
 	It("use exisisting PVC  in job", func() {
 		jobName := "job-pvc-name-exist"
 		namespace := "test"


### PR DESCRIPTION
This is to simplify `createJobIOIfNotExist` and fix some unreasonable logic, like `job.Status.ControlledResources["volume-emptyDir-"+vcName] = vcName`.