### PR TITLE
Change Statement unevict method to call UpdateTask

### DIFF
--- a/pkg/scheduler/framework/statement.go
+++ b/pkg/scheduler/framework/statement.go
@@ -98,7 +98,7 @@ func (s *Statement) unevict(reclaimee *api.TaskInfo, reason string) error {
 
 	// Update task in node.
 	if node, found := s.ssn.Nodes[reclaimee.NodeName]; found {
-		node.AddTask(reclaimee)
+		node.UpdateTask(reclaimee)
 	}
 
 	for _, eh := range s.ssn.eventHandlers {


### PR DESCRIPTION
**What this PR does / why we need it:**
This change ensures that when `unevict` is called the value of `nodeInfo.Releasing` will be updated as if the task was evicted.

Before this fix, because the task exists on the current `nodeInfo`, every time `unevict` is called the `Releasing` value of the nodeInfo isn't updated and the value remains same as if the task was `evicted`

**Why does it happen:**
This happens because `unevict` calls `AddTask`:
```
// Update task in node.
if node, found := s.ssn.Nodes[reclaimee.NodeName]; found {
     node.AddTask(reclaimee)
} 
```
`AddTask` will throw an error because this task already exists under the current nodeInfo and therefore will not update the `Releasing` field as if the current task is `Running`

Issue:  [#907](https://github.com/kubernetes-sigs/kube-batch/issues/907)
**This fix was added to kube-batch: https://github.com/kubernetes-sigs/kube-batch/pull/912**