### PR TITLE
change node not found errors 

### DIFF
--- a/pkg/scheduler/plugins/nodeorder/nodeorder.go
+++ b/pkg/scheduler/plugins/nodeorder/nodeorder.go
@@ -17,7 +17,7 @@ limitations under the License.
 package nodeorder
 
 import (
-	"fmt"
+	"k8s.io/apimachinery/pkg/api/errors"
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/klog"
@@ -237,7 +237,7 @@ func (c *cachedNodeInfo) GetNodeInfo(name string) (*v1.Node, error) {
 				}
 			}
 		}
-		return nil, fmt.Errorf("failed to find node <%s>", name)
+		return nil, errors.NewNotFound(v1.Resource("node"), name)
 	}
 
 	return node.Node, nil

--- a/pkg/scheduler/plugins/util/util.go
+++ b/pkg/scheduler/plugins/util/util.go
@@ -17,7 +17,7 @@ limitations under the License.
 package util
 
 import (
-	"fmt"
+	"k8s.io/apimachinery/pkg/api/errors"
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -204,7 +204,8 @@ type CachedNodeInfo struct {
 func (c *CachedNodeInfo) GetNodeInfo(name string) (*v1.Node, error) {
 	node, found := c.Session.Nodes[name]
 	if !found {
-		return nil, fmt.Errorf("failed to find node <%s>", name)
+
+		return nil, errors.NewNotFound(v1.Resource("node"), name)
 	}
 
 	return node.Node, nil


### PR DESCRIPTION
bugreport:
after remove one node from k8s cluster, when schedule new pod use kube-batch/volcano ,pod may be failed to scheule with this error

```
> I1203 02:43:04.686751       1 predicates.go:244] Pod Affinity/Anti-Affinity predicates Task <4e5f39da-cef3-43f5-b839-69dd52276555/2qac8qjsqsl09-0> on Node <node2>: fit false, err Failed to get all terms that pod 4e5f39da-cef3-43f5-b839-69dd52276555/2qac8qjsqsl09-0 matches, err: failed to find node <node3>
W1203 02:43:04.686772       1 scheduler_helper.go:80] Predicates failed for task <4e5f39da-cef3-43f5-b839-69dd52276555/2qac8qjsqsl09-0> on node <node2>: Failed to get all terms that pod 4e5f39da-cef3-43f5-b839-69dd52276555/2qac8qjsqsl09-0 matches, err: failed to find node <node3>
```


the GetNodeInfo in file /pkg/scheduler/plugins/util/util.go and pkg/scheduler/plugins/nodeorder/noderorder.go shoud change  node not found errors to kubernetes's node not found error,like this
`errors.NewNotFound(v1.Resource("node"), name)`

this function is called by k8s code (InterPodAffinityMatches function )when check pod Affinity. 
in k8s function getMatchingAntiAffinityTopologyPairsOfPods,it will ignore node that not exist.

```
if err != nil {
			if apierrors.IsNotFound(err) {
				klog.Errorf("Node not found, %v", existingPod.Spec.NodeName)
				continue
			}
			return nil, err
		}

```
