### PR TITLE
when delete pod, a new shadowgroup will be created

### DIFF
--- a/pkg/scheduler/cache/event_handlers.go
+++ b/pkg/scheduler/cache/event_handlers.go
@@ -116,6 +116,10 @@ func (sc *SchedulerCache) updatePod(oldPod, newPod *v1.Pod) error {
 	if err := sc.deletePod(oldPod); err != nil {
 		return err
 	}
+	//when delete pod, the ownerreference of pod will be set nil,just as orphan pod
+	if len(utils.GetController(newPod)) == 0 {
+		newPod.OwnerReferences = oldPod.OwnerReferences
+	}
 	return sc.addPod(newPod)
 }
 


### PR DESCRIPTION
when create a Job/Deployment using volcano-sh as scheduler, volcano will create a shadowjob in memory, but when we delete the Job/Deployment, volcano will create a new shadowgroup.  when delete Job/Deploymeng , k8s will update the pod's ownerreference as nil, just as the orphan pod. so volcano will create a new shadowjob.