### PR TITLE
BUG FIX: Fix too long ssh secret name

### DIFF
--- a/pkg/controllers/job/job_controller_plugins_test.go
+++ b/pkg/controllers/job/job_controller_plugins_test.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"testing"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/informers"
 	kubeclient "k8s.io/client-go/kubernetes/fake"
@@ -126,7 +126,7 @@ func TestPluginOnPodCreate(t *testing.T) {
 						}
 						exist := false
 						for _, volume := range container.VolumeMounts {
-							if volume.Name == fmt.Sprintf("%s-%s-%s", testcase.Job.Name, testcase.Job.UID, "ssh") {
+							if volume.Name == fmt.Sprintf("%s-%s", testcase.Job.Name, "ssh") {
 								exist = true
 							}
 						}
@@ -207,7 +207,7 @@ func TestPluginOnJobAdd(t *testing.T) {
 
 				if plugin == "ssh" {
 					_, err := fakeController.kubeClient.CoreV1().Secrets(namespace).Get(
-						fmt.Sprintf("%s-%s-%s", testcase.Job.Name, testcase.Job.UID, "ssh"), metav1.GetOptions{})
+						fmt.Sprintf("%s-%s", testcase.Job.Name, "ssh"), metav1.GetOptions{})
 					if err != nil {
 						t.Errorf("Case %d (%s): expected: Secret to be created, but not created because of error %s", i, testcase.Name, err.Error())
 					}

--- a/test/e2e/job_plugins.go
+++ b/test/e2e/job_plugins.go
@@ -24,9 +24,10 @@ import (
 	. "github.com/onsi/gomega"
 
 	cv1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kubernetes/pkg/scheduler/api"
 
+	batch "volcano.sh/volcano/pkg/apis/batch/v1alpha1"
 	"volcano.sh/volcano/pkg/controllers/job/helpers"
 	"volcano.sh/volcano/pkg/controllers/job/plugins/env"
 	"volcano.sh/volcano/pkg/controllers/job/plugins/svc"
@@ -153,16 +154,16 @@ var _ = Describe("Job E2E Test: Test Job Plugins", func() {
 		err := waitJobReady(context, job)
 		Expect(err).NotTo(HaveOccurred())
 
-		pluginName := fmt.Sprintf("%s-%s-ssh", jobName, job.UID)
+		secretName := genSSHSecretName(job)
 		_, err = context.kubeclient.CoreV1().Secrets(namespace).Get(
-			pluginName, v1.GetOptions{})
+			secretName, v1.GetOptions{})
 		Expect(err).NotTo(HaveOccurred())
 
 		pod, err := context.kubeclient.CoreV1().Pods(namespace).Get(
 			fmt.Sprintf(helpers.PodNameFmt, jobName, taskName, 0), v1.GetOptions{})
 		Expect(err).NotTo(HaveOccurred())
 		for _, volume := range pod.Spec.Volumes {
-			if volume.Name == pluginName {
+			if volume.Name == secretName {
 				foundVolume = true
 				break
 			}
@@ -211,16 +212,16 @@ var _ = Describe("Job E2E Test: Test Job Plugins", func() {
 		err := waitJobReady(context, job)
 		Expect(err).NotTo(HaveOccurred())
 
-		pluginName := fmt.Sprintf("%s-%s-ssh", jobName, job.UID)
+		secretName := genSSHSecretName(job)
 		_, err = context.kubeclient.CoreV1().Secrets(namespace).Get(
-			pluginName, v1.GetOptions{})
+			secretName, v1.GetOptions{})
 		Expect(err).NotTo(HaveOccurred())
 
 		pod, err := context.kubeclient.CoreV1().Pods(namespace).Get(
 			fmt.Sprintf(helpers.PodNameFmt, jobName, taskName, 0), v1.GetOptions{})
 		Expect(err).NotTo(HaveOccurred())
 		for _, volume := range pod.Spec.Volumes {
-			if volume.Name == pluginName {
+			if volume.Name == secretName {
 				foundVolume = true
 				break
 			}
@@ -257,3 +258,7 @@ var _ = Describe("Job E2E Test: Test Job Plugins", func() {
 		Expect(err).NotTo(HaveOccurred())
 	})
 })
+
+func genSSHSecretName(job *batch.Job) string {
+	return job.Name + "-ssh"
+}


### PR DESCRIPTION
ssh plugin we generate ssh secret with job uid, it increases the risk that the secret name can exceed the k8s length limit.

In the long run, we should check the k8s api return error. For invalid configs, we should mark job failed and donot retry. This should cover many places.

FYI: the invalid object error is of fixed type.
```
// BeforeCreate ensures that common operations for all resources are performed on creation. It only returns
// errors that can be converted to api.Status. It invokes PrepareForCreate, then GenerateName, then Validate.
// It returns nil if the object should be created.
func BeforeCreate(strategy RESTCreateStrategy, ctx context.Context, obj runtime.Object) error {
	objectMeta, kind, kerr := objectMetaAndKind(strategy, obj)
	if kerr != nil {
		return kerr
	}

	if strategy.NamespaceScoped() {
		if !ValidNamespace(ctx, objectMeta) {
			return errors.NewBadRequest("the namespace of the provided object does not match the namespace sent on the request")
		}
	} else if len(objectMeta.GetNamespace()) > 0 {
		objectMeta.SetNamespace(metav1.NamespaceNone)
	}
	objectMeta.SetDeletionTimestamp(nil)
	objectMeta.SetDeletionGracePeriodSeconds(nil)
	strategy.PrepareForCreate(ctx, obj)
	FillObjectMetaSystemFields(objectMeta)
	if len(objectMeta.GetGenerateName()) > 0 && len(objectMeta.GetName()) == 0 {
		objectMeta.SetName(strategy.GenerateName(objectMeta.GetGenerateName()))
	}

	// Ensure managedFields is not set unless the feature is enabled
	if !utilfeature.DefaultFeatureGate.Enabled(features.ServerSideApply) {
		objectMeta.SetManagedFields(nil)
	}
```

