### PR TITLE
[controller] Set `Queue` field when pod has queue name annotation

### DIFF
--- a/pkg/apis/scheduling/v1beta1/labels.go
+++ b/pkg/apis/scheduling/v1beta1/labels.go
@@ -22,4 +22,8 @@ const KubeGroupNameAnnotationKey = "scheduling.k8s.io/group-name"
 
 // VolcanoGroupNameAnnotationKey is the annotation key of Pod to identify
 // which PodGroup it belongs to.
-const VolcanoGroupNameAnnotationKey = "scheduling.volcano.sh/group-name"
+const VolcanoGroupNameAnnotationKey = GroupName + "/group-name"
+
+// QueueNameAnnotationKey is the annotation key of Pod to identify
+// which queue it belongs to.
+const QueueNameAnnotationKey = GroupName + "/queue-name"

--- a/pkg/controllers/podgroup/pg_controller_handler.go
+++ b/pkg/controllers/podgroup/pg_controller_handler.go
@@ -89,6 +89,9 @@ func (cc *Controller) createNormalPodPGIfNotExist(pod *v1.Pod) error {
 				PriorityClassName: pod.Spec.PriorityClassName,
 			},
 		}
+		if queueName, ok := pod.Annotations[scheduling.QueueNameAnnotationKey]; ok {
+			pg.Spec.Queue = queueName
+		}
 
 		if _, err := cc.vcClient.SchedulingV1beta1().PodGroups(pod.Namespace).Create(pg); err != nil {
 			klog.Errorf("Failed to create normal PodGroup for Pod <%s/%s>: %v",


### PR DESCRIPTION
Fix #753

Add `scheduling.volcano.sh/queue-name` annotation key to identify which queue belong to. The controller will check if this annotation exists and set the `Queue` field.