### PR TITLE
fix crd to support job patch ops

### DIFF
--- a/installer/helm/chart/volcano/templates/batch_v1alpha1_job.yaml
+++ b/installer/helm/chart/volcano/templates/batch_v1alpha1_job.yaml
@@ -184,6 +184,10 @@ spec:
                   description: Unique, one-word, CamelCase reason for the condition's
                     last transition.
                   type: string
+                lastTransitionTime:
+                  description: The time of last state transition.
+                  format: date-time
+                  type: string
               type: object
           type: object
   version: v1alpha1

--- a/installer/volcano-development.yaml
+++ b/installer/volcano-development.yaml
@@ -556,6 +556,10 @@ spec:
                   description: Unique, one-word, CamelCase reason for the condition's
                     last transition.
                   type: string
+                lastTransitionTime:
+                  description: The time of last state transition.
+                  format: date-time
+                  type: string
               type: object
           type: object
   version: v1alpha1

--- a/pkg/controllers/job/job_controller_actions.go
+++ b/pkg/controllers/job/job_controller_actions.go
@@ -541,6 +541,7 @@ func (cc *Controller) initJobStatus(job *batch.Job) (*batch.Job, error) {
 	}
 
 	job.Status.State.Phase = batch.Pending
+	job.Status.State.LastTransitionTime = metav1.Now()
 	job.Status.MinAvailable = job.Spec.MinAvailable
 	newJob, err := cc.vcClient.BatchV1alpha1().Jobs(job.Namespace).UpdateStatus(job)
 	if err != nil {


### PR DESCRIPTION
Without this, when running `kubectl edit vcjob xxx` to update a job fails.