### PR TITLE
Distinguish different pod-delete scenario

### DIFF
--- a/pkg/controllers/cache/cache.go
+++ b/pkg/controllers/cache/cache.go
@@ -59,7 +59,15 @@ func JobKey(job *v1alpha1.Job) string {
 }
 
 func jobTerminated(job *apis.JobInfo) bool {
-	return job.Job == nil && len(job.Pods) == 0
+	for _, pods := range job.Pods {
+		for _, pod := range pods {
+			if pod.Status.Phase != v1.PodSucceeded {
+				return false
+			}
+		}
+	}
+
+	return job.Job == nil
 }
 
 func jobKeyOfPod(pod *v1.Pod) (string, error) {

--- a/pkg/controllers/job/job_controller_actions_test.go
+++ b/pkg/controllers/job/job_controller_actions_test.go
@@ -24,7 +24,6 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	"volcano.sh/volcano/pkg/apis/batch/v1alpha1"
 	schedulingv1alpha2 "volcano.sh/volcano/pkg/apis/scheduling/v1beta1"
 	"volcano.sh/volcano/pkg/controllers/apis"
@@ -462,7 +461,7 @@ func TestDeleteJobPod(t *testing.T) {
 				}
 			}
 
-			err := fakeController.deleteJobPod(testcase.Job.Name, testcase.DeletePod)
+			_, err := fakeController.deleteJobPod(testcase.Job.Name, testcase.DeletePod)
 			if err != testcase.ExpextVal {
 				t.Errorf("Expected return value to be equal to expected: %s, but got: %s", testcase.ExpextVal, err)
 			}

--- a/pkg/controllers/job/job_controller_handler.go
+++ b/pkg/controllers/job/job_controller_handler.go
@@ -332,18 +332,21 @@ func (cc *Controller) deletePod(obj interface{}) {
 		return
 	}
 
-	req := apis.Request{
-		Namespace: pod.Namespace,
-		JobName:   jobName,
-		TaskName:  taskName,
-
-		Event:      bus.PodEvictedEvent,
-		JobVersion: int32(dVersion),
+	if pod.Status.Phase == v1.PodSucceeded {
+		return
 	}
 
 	if err := cc.cache.DeletePod(pod); err != nil {
 		klog.Errorf("Failed to delete Pod <%s/%s>: %v in cache",
 			pod.Namespace, pod.Name, err)
+	}
+
+	req := apis.Request{
+		Namespace:  pod.Namespace,
+		JobName:    jobName,
+		TaskName:   taskName,
+		Event:      bus.PodEvictedEvent,
+		JobVersion: int32(dVersion),
 	}
 
 	key := jobhelpers.GetJobKeyByReq(&req)

--- a/pkg/controllers/job/job_state_test.go
+++ b/pkg/controllers/job/job_state_test.go
@@ -231,7 +231,7 @@ func TestAbortingState_Execute(t *testing.T) {
 					t.Error("Error while retrieving value from Cache")
 				}
 
-				if testcase.JobInfo.Job.Status.Pending == 0 && testcase.JobInfo.Job.Status.Running == 0 && testcase.JobInfo.Job.Status.Terminating == 0 {
+				if jobInfo.Job.Status.Pending == 0 && jobInfo.Job.Status.Running == 0 && jobInfo.Job.Status.Terminating == 0 {
 					if jobInfo.Job.Status.State.Phase != v1alpha1.Aborted {
 						t.Error("Phase Should be aborted")
 					}
@@ -331,7 +331,7 @@ func TestCompletingState_Execute(t *testing.T) {
 				t.Error("Error while retrieving value from Cache")
 			}
 
-			if testcase.JobInfo.Job.Status.Running == 0 && testcase.JobInfo.Job.Status.Pending == 0 && testcase.JobInfo.Job.Status.Terminating == 0 {
+			if jobInfo.Job.Status.Running == 0 && jobInfo.Job.Status.Pending == 0 && jobInfo.Job.Status.Terminating == 0 {
 				if jobInfo.Job.Status.State.Phase != v1alpha1.Completed {
 					fmt.Println(jobInfo.Job.Status.State.Phase)
 					t.Errorf("Expected Phase to be Completed State in test case: %d", i)
@@ -1235,7 +1235,7 @@ func TestTerminatingState_Execute(t *testing.T) {
 			Name: "TerminatingState- With pod count not equal to zero",
 			JobInfo: &apis.JobInfo{
 				Namespace: namespace,
-				Name:      "jobinfo1",
+				Name:      "jobinfo2",
 				Job: &v1alpha1.Job{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "Job1",
@@ -1280,7 +1280,7 @@ func TestTerminatingState_Execute(t *testing.T) {
 				t.Error("Error while retrieving value from Cache")
 			}
 
-			if testcase.JobInfo.Job.Status.Running == 0 && testcase.JobInfo.Job.Status.Pending == 0 && testcase.JobInfo.Job.Status.Terminating == 0 {
+			if jobInfo.Job.Status.Running == 0 && jobInfo.Job.Status.Pending == 0 && jobInfo.Job.Status.Terminating == 0 {
 
 				if jobInfo.Job.Status.State.Phase != v1alpha1.Terminated {
 					fmt.Println(jobInfo.Job.Status.State.Phase)


### PR DESCRIPTION
Try to address issue #791
It's a draft solution, need further discussion.

In my ENV, seems it could work, but the `pg` status not correct, after delete(after success) the original pod will gone and not recreate but the status of `pg` is:
```
status:
  phase: Running
  running: 2
```
not what expect to:
```
status:
  phase: Running
  running: 2
  success: 1
```
