### PR TITLE
Fix typo in version.go

### DIFF
--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -25,7 +25,7 @@ import (
 var (
 	// Version shows the version of volcano.
 	Version = "Not provided."
-	// GitSHA shoows the git commit id of volcano.
+	// GitSHA shows the git commit id of volcano.
 	GitSHA = "Not provided."
 	// Built shows the built time of the binary.
 	Built      = "Not provided."


### PR DESCRIPTION
Fix typo in version.go,

`shoows` should be `shows`