### PR TITLE
Add kubeClient in scheduler framwork.Session

### DIFF
--- a/pkg/scheduler/cache/event_handlers.go
+++ b/pkg/scheduler/cache/event_handlers.go
@@ -84,7 +84,7 @@ func (sc *SchedulerCache) addPod(pod *v1.Pod) error {
 }
 
 func (sc *SchedulerCache) syncTask(oldTask *schedulingapi.TaskInfo) error {
-	newPod, err := sc.kubeclient.CoreV1().Pods(oldTask.Namespace).Get(context.TODO(), oldTask.Name, metav1.GetOptions{})
+	newPod, err := sc.kubeClient.CoreV1().Pods(oldTask.Namespace).Get(context.TODO(), oldTask.Name, metav1.GetOptions{})
 	if err != nil {
 		if errors.IsNotFound(err) {
 			err := sc.deleteTask(oldTask)

--- a/pkg/scheduler/cache/interface.go
+++ b/pkg/scheduler/cache/interface.go
@@ -18,6 +18,7 @@ package cache
 
 import (
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes"
 
 	"volcano.sh/volcano/pkg/scheduler/api"
 )
@@ -53,6 +54,9 @@ type Cache interface {
 
 	// BindVolumes binds volumes to the task
 	BindVolumes(task *api.TaskInfo) error
+
+	// Client returns the kubernetes clientSet, which can be used by plugins
+	Client() kubernetes.Interface
 }
 
 // VolumeBinder interface for allocate and bind volumes

--- a/pkg/scheduler/framework/session.go
+++ b/pkg/scheduler/framework/session.go
@@ -23,6 +23,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/uuid"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/klog"
 
 	"volcano.sh/volcano/pkg/apis/scheduling"
@@ -36,7 +37,8 @@ import (
 type Session struct {
 	UID types.UID
 
-	cache cache.Cache
+	kubeClient kubernetes.Interface
+	cache      cache.Cache
 
 	podGroupStatus map[api.JobID]*scheduling.PodGroupStatus
 
@@ -72,8 +74,9 @@ type Session struct {
 
 func openSession(cache cache.Cache) *Session {
 	ssn := &Session{
-		UID:   uuid.NewUUID(),
-		cache: cache,
+		UID:        uuid.NewUUID(),
+		kubeClient: cache.Client(),
+		cache:      cache,
 
 		podGroupStatus: map[api.JobID]*scheduling.PodGroupStatus{},
 

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -33,7 +33,6 @@ import (
 // nodes that they fit on and writes bindings back to the api server.
 type Scheduler struct {
 	cache          schedcache.Cache
-	config         *rest.Config
 	actions        []framework.Action
 	plugins        []conf.Tier
 	configurations []conf.Configuration
@@ -45,13 +44,12 @@ type Scheduler struct {
 func NewScheduler(
 	config *rest.Config,
 	schedulerName string,
-	conf string,
+	schedulerConf string,
 	period time.Duration,
 	defaultQueue string,
 ) (*Scheduler, error) {
 	scheduler := &Scheduler{
-		config:         config,
-		schedulerConf:  conf,
+		schedulerConf:  schedulerConf,
 		cache:          schedcache.New(config, schedulerName, defaultQueue),
 		schedulePeriod: period,
 	}


### PR DESCRIPTION
This is to allow each plugin to make use of existing kube client. 
Currently required by #852 

Alternative solution considered:  pass it as a param of plugins' initializing function.  There is a caveat for this, it will require all plugins to change their `New` function, which is not friendly to those who develop their own plugin based on volcano. 