### PR TITLE
fix default Qeue e and webhook startup sequence

### DIFF
--- a/pkg/apis/scheduling/v1beta1/types.go
+++ b/pkg/apis/scheduling/v1beta1/types.go
@@ -261,6 +261,7 @@ type QueueStatus struct {
 type QueueSpec struct {
 	Weight     int32           `json:"weight,omitempty" protobuf:"bytes,1,opt,name=weight"`
 	Capability v1.ResourceList `json:"capability,omitempty" protobuf:"bytes,2,opt,name=capability"`
+	State QueueState `json:"state,omitempty" protobuf:"bytes,1,opt,name=state"`
 
 	// Reclaimable indicate whether the queue can be reclaimed by other queue
 	Reclaimable *bool `json:"reclaimable,omitempty" protobuf:"bytes,3,opt,name=reclaimable"`

--- a/pkg/scheduler/cache/cache.go
+++ b/pkg/scheduler/cache/cache.go
@@ -267,11 +267,14 @@ func newSchedulerCache(config *rest.Config, schedulerName string, defaultQueue s
 	}
 
 	// create default queue
+	reclaimable := true
 	defaultQue := vcv1beta1.Queue{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: defaultQueue,
 		},
 		Spec: vcv1beta1.QueueSpec{
+			Reclaimable: &reclaimable,
+			State: "Open",
 			Weight: 1,
 		},
 	}


### PR DESCRIPTION
fix default Qeue e and webhook startup sequence
Step·：
change pkg/apis/scheduling/v1beta1/types.go, add ”state“ field

Step2：
change pkg/scheduler/cache/cache.go