### PR TITLE
Support hierarchical dominant resource fairness

### DIFF
--- a/example/hierarchical-jobs/jobs.yaml
+++ b/example/hierarchical-jobs/jobs.yaml
@@ -1,10 +1,9 @@
+
+---
 apiVersion: batch.volcano.sh/v1alpha1
 kind: Job
 metadata:
   name: eng-prod-job
-  annotations:
-    "scheduling.k8s.io/group-hierarchy": "root/eng/prod"
-    "scheduling.k8s.io/group-hierarchy-weight": "1/2/8"
 spec:
   minAvailable: 1
   schedulerName: volcano
@@ -16,7 +15,7 @@ spec:
     env: []
     svc: []
   maxRetry: 5
-  queue: default
+  queue: root-eng-prod
   tasks:
     - replicas: 6
       name: "default-nginx"
@@ -38,9 +37,6 @@ apiVersion: batch.volcano.sh/v1alpha1
 kind: Job
 metadata:
   name: eng-dev-job
-  annotations:
-    "scheduling.k8s.io/group-hierarchy": "root/eng/dev"
-    "scheduling.k8s.io/group-hierarchy-weight": "1/2/2"
 spec:
   minAvailable: 1
   schedulerName: volcano
@@ -52,7 +48,7 @@ spec:
     env: []
     svc: []
   maxRetry: 5
-  queue: default
+  queue: root-eng-dev
   tasks:
     - replicas: 6
       name: "default-nginx"
@@ -76,9 +72,6 @@ apiVersion: batch.volcano.sh/v1alpha1
 kind: Job
 metadata:
   name: sci-prod-job
-  annotations:
-    "scheduling.k8s.io/group-hierarchy": "root/sci/prod"
-    "scheduling.k8s.io/group-hierarchy-weight": "1/8/8"
 spec:
   minAvailable: 1
   schedulerName: volcano
@@ -90,7 +83,7 @@ spec:
     env: []
     svc: []
   maxRetry: 5
-  queue: default
+  queue: root-sci-prod
   tasks:
     - replicas: 6
       name: "default-nginx"
@@ -112,9 +105,6 @@ apiVersion: batch.volcano.sh/v1alpha1
 kind: Job
 metadata:
   name: sci-dev-job
-  annotations:
-    "scheduling.k8s.io/group-hierarchy": "root/sci/dev"
-    "scheduling.k8s.io/group-hierarchy-weight": "1/8/2"
 spec:
   minAvailable: 1
   schedulerName: volcano
@@ -126,7 +116,7 @@ spec:
     env: []
     svc: []
   maxRetry: 5
-  queue: default
+  queue: root-sci-dev
   tasks:
     - replicas: 6
       name: "default-nginx"

--- a/example/hierarchical-jobs/jobs.yaml
+++ b/example/hierarchical-jobs/jobs.yaml
@@ -1,0 +1,145 @@
+apiVersion: batch.volcano.sh/v1alpha1
+kind: Job
+metadata:
+  name: eng-prod-job
+  annotations:
+    "scheduling.k8s.io/group-hierarchy": "root/eng/prod"
+    "scheduling.k8s.io/group-hierarchy-weight": "1/2/8"
+spec:
+  minAvailable: 1
+  schedulerName: volcano
+  policies:
+    - event: PodEvicted
+      action: RestartJob
+  plugins:
+    ssh: []
+    env: []
+    svc: []
+  maxRetry: 5
+  queue: default
+  tasks:
+    - replicas: 6
+      name: "default-nginx"
+      template:
+        metadata:
+          name: web
+        spec:
+          schedulerName: volcano
+          containers:
+            - image: nginx
+              imagePullPolicy: IfNotPresent
+              name: nginx
+              resources:
+                requests:
+                  cpu: "0.5"
+          restartPolicy: OnFailure
+---
+apiVersion: batch.volcano.sh/v1alpha1
+kind: Job
+metadata:
+  name: eng-dev-job
+  annotations:
+    "scheduling.k8s.io/group-hierarchy": "root/eng/dev"
+    "scheduling.k8s.io/group-hierarchy-weight": "1/2/2"
+spec:
+  minAvailable: 1
+  schedulerName: volcano
+  policies:
+    - event: PodEvicted
+      action: RestartJob
+  plugins:
+    ssh: []
+    env: []
+    svc: []
+  maxRetry: 5
+  queue: default
+  tasks:
+    - replicas: 6
+      name: "default-nginx"
+      template:
+        metadata:
+          name: web
+        spec:
+          schedulerName: volcano
+          containers:
+            - image: nginx
+              imagePullPolicy: IfNotPresent
+              name: nginx
+              resources:
+                requests:
+                  cpu: "0.5"
+          restartPolicy: OnFailure
+
+
+---
+apiVersion: batch.volcano.sh/v1alpha1
+kind: Job
+metadata:
+  name: sci-prod-job
+  annotations:
+    "scheduling.k8s.io/group-hierarchy": "root/sci/prod"
+    "scheduling.k8s.io/group-hierarchy-weight": "1/8/8"
+spec:
+  minAvailable: 1
+  schedulerName: volcano
+  policies:
+    - event: PodEvicted
+      action: RestartJob
+  plugins:
+    ssh: []
+    env: []
+    svc: []
+  maxRetry: 5
+  queue: default
+  tasks:
+    - replicas: 6
+      name: "default-nginx"
+      template:
+        metadata:
+          name: web
+        spec:
+          schedulerName: volcano
+          containers:
+            - image: nginx
+              imagePullPolicy: IfNotPresent
+              name: nginx
+              resources:
+                requests:
+                  cpu: "0.5"
+          restartPolicy: OnFailure
+---
+apiVersion: batch.volcano.sh/v1alpha1
+kind: Job
+metadata:
+  name: sci-dev-job
+  annotations:
+    "scheduling.k8s.io/group-hierarchy": "root/sci/dev"
+    "scheduling.k8s.io/group-hierarchy-weight": "1/8/2"
+spec:
+  minAvailable: 1
+  schedulerName: volcano
+  policies:
+    - event: PodEvicted
+      action: RestartJob
+  plugins:
+    ssh: []
+    env: []
+    svc: []
+  maxRetry: 5
+  queue: default
+  tasks:
+    - replicas: 6
+      name: "default-nginx"
+      template:
+        metadata:
+          name: web
+        spec:
+          schedulerName: volcano
+          containers:
+            - image: nginx
+              imagePullPolicy: IfNotPresent
+              name: nginx
+              resources:
+                requests:
+                  cpu: "0.5"
+          restartPolicy: OnFailure

--- a/example/hierarchical-jobs/queues.yaml
+++ b/example/hierarchical-jobs/queues.yaml
@@ -1,0 +1,39 @@
+apiVersion: scheduling.volcano.sh/v1beta1
+kind: Queue
+metadata:
+  name: root-eng-prod
+  annotations:
+    "volcano.sh/hierarchy": "root/eng/prod"
+    "volcano.sh/hierarchy-weights": "1/2/8"
+spec:
+  weight: 1
+---
+apiVersion: scheduling.volcano.sh/v1beta1
+kind: Queue
+metadata:
+  name: root-eng-dev
+  annotations:
+    "volcano.sh/hierarchy": "root/eng/dev"
+    "volcano.sh/hierarchy-weights": "1/2/2"
+spec:
+  weight: 1
+---
+apiVersion: scheduling.volcano.sh/v1beta1
+kind: Queue
+metadata:
+  name: root-sci-prod
+  annotations:
+    "volcano.sh/hierarchy": "root/sci/prod"
+    "volcano.sh/hierarchy-weights": "1/8/8"
+spec:
+  weight: 1
+---
+apiVersion: scheduling.volcano.sh/v1beta1
+kind: Queue
+metadata:
+  name: root-sci-dev
+  annotations:
+    "volcano.sh/hierarchy": "root/sci/dev"
+    "volcano.sh/hierarchy-weights": "1/8/2"
+spec:
+  weight: 1

--- a/pkg/apis/scheduling/v1beta1/labels.go
+++ b/pkg/apis/scheduling/v1beta1/labels.go
@@ -16,6 +16,10 @@ limitations under the License.
 
 package v1beta1
 
+const KubeGroupHierarchyAnnotationKey = "scheduling.k8s.io/group-hierarchy"
+
+const KubeGroupHierarchyWeightAnnotationKey = "scheduling.k8s.io/group-hierarchy-weight"
+
 // KubeGroupNameAnnotationKey is the annotation key of Pod to identify
 // which PodGroup it belongs to.
 const KubeGroupNameAnnotationKey = "scheduling.k8s.io/group-name"

--- a/pkg/apis/scheduling/v1beta1/labels.go
+++ b/pkg/apis/scheduling/v1beta1/labels.go
@@ -16,9 +16,9 @@ limitations under the License.
 
 package v1beta1
 
-const KubeGroupHierarchyAnnotationKey = "scheduling.k8s.io/group-hierarchy"
+const KubeHierarchyAnnotationKey = "volcano.sh/hierarchy"
 
-const KubeGroupHierarchyWeightAnnotationKey = "scheduling.k8s.io/group-hierarchy-weight"
+const KubeHierarchyWeightAnnotationKey = "volcano.sh/hierarchy-weights"
 
 // KubeGroupNameAnnotationKey is the annotation key of Pod to identify
 // which PodGroup it belongs to.

--- a/pkg/controllers/cache/cache.go
+++ b/pkg/controllers/cache/cache.go
@@ -119,7 +119,6 @@ func (jc *jobCache) GetStatus(key string) (*v1alpha1.JobStatus, error) {
 func (jc *jobCache) Add(job *v1alpha1.Job) error {
 	jc.Lock()
 	defer jc.Unlock()
-
 	key := JobKey(job)
 	if jobInfo, found := jc.jobs[key]; found {
 		if jobInfo.Job == nil {

--- a/pkg/controllers/podgroup/pg_controller_handler.go
+++ b/pkg/controllers/podgroup/pg_controller_handler.go
@@ -97,16 +97,6 @@ func (pg *pgcontroller) createNormalPodPGIfNotExist(pod *v1.Pod) error {
 			obj.Spec.Queue = queueName
 		}
 
-		if hierarchy, ok := pod.Annotations[scheduling.KubeGroupHierarchyAnnotationKey]; ok {
-			obj.Annotations[scheduling.KubeGroupHierarchyAnnotationKey] = hierarchy
-		} else {
-			obj.Annotations[scheduling.KubeGroupHierarchyAnnotationKey] = "root"
-		}
-		if hierarchy, ok := pod.Annotations[scheduling.KubeGroupHierarchyWeightAnnotationKey]; ok {
-			obj.Annotations[scheduling.KubeGroupHierarchyWeightAnnotationKey] = hierarchy
-		} else {
-			obj.Annotations[scheduling.KubeGroupHierarchyWeightAnnotationKey] = "1"
-		}
 		if _, err := pg.vcClient.SchedulingV1beta1().PodGroups(pod.Namespace).Create(context.TODO(), obj, metav1.CreateOptions{}); err != nil {
 			klog.Errorf("Failed to create normal PodGroup for Pod <%s/%s>: %v",
 				pod.Namespace, pod.Name, err)

--- a/pkg/controllers/podgroup/pg_controller_handler.go
+++ b/pkg/controllers/podgroup/pg_controller_handler.go
@@ -86,6 +86,7 @@ func (pg *pgcontroller) createNormalPodPGIfNotExist(pod *v1.Pod) error {
 				Namespace:       pod.Namespace,
 				Name:            pgName,
 				OwnerReferences: newPGOwnerReferences(pod),
+				Annotations:     map[string]string{},
 			},
 			Spec: scheduling.PodGroupSpec{
 				MinMember:         1,
@@ -96,6 +97,16 @@ func (pg *pgcontroller) createNormalPodPGIfNotExist(pod *v1.Pod) error {
 			obj.Spec.Queue = queueName
 		}
 
+		if hierarchy, ok := pod.Annotations[scheduling.KubeGroupHierarchyAnnotationKey]; ok {
+			obj.Annotations[scheduling.KubeGroupHierarchyAnnotationKey] = hierarchy
+		} else {
+			obj.Annotations[scheduling.KubeGroupHierarchyAnnotationKey] = "root"
+		}
+		if hierarchy, ok := pod.Annotations[scheduling.KubeGroupHierarchyWeightAnnotationKey]; ok {
+			obj.Annotations[scheduling.KubeGroupHierarchyWeightAnnotationKey] = hierarchy
+		} else {
+			obj.Annotations[scheduling.KubeGroupHierarchyWeightAnnotationKey] = "1"
+		}
 		if _, err := pg.vcClient.SchedulingV1beta1().PodGroups(pod.Namespace).Create(context.TODO(), obj, metav1.CreateOptions{}); err != nil {
 			klog.Errorf("Failed to create normal PodGroup for Pod <%s/%s>: %v",
 				pod.Namespace, pod.Name, err)

--- a/pkg/scheduler/api/job_info.go
+++ b/pkg/scheduler/api/job_info.go
@@ -127,6 +127,8 @@ type JobInfo struct {
 
 	Name      string
 	Namespace string
+	Hierarchy string
+	Weights   string
 
 	Queue QueueID
 
@@ -174,6 +176,8 @@ func (ji *JobInfo) SetPodGroup(pg *PodGroup) {
 	ji.MinAvailable = pg.Spec.MinMember
 	ji.Queue = QueueID(pg.Spec.Queue)
 	ji.CreationTimestamp = pg.GetCreationTimestamp()
+	ji.Hierarchy = pg.Annotations[v1beta1.KubeGroupHierarchyAnnotationKey]
+	ji.Weights = pg.Annotations[v1beta1.KubeGroupHierarchyWeightAnnotationKey]
 
 	ji.PodGroup = pg
 }
@@ -241,6 +245,8 @@ func (ji *JobInfo) Clone() *JobInfo {
 		UID:       ji.UID,
 		Name:      ji.Name,
 		Namespace: ji.Namespace,
+		Hierarchy: ji.Hierarchy,
+		Weights:   ji.Weights,
 		Queue:     ji.Queue,
 		Priority:  ji.Priority,
 

--- a/pkg/scheduler/api/job_info.go
+++ b/pkg/scheduler/api/job_info.go
@@ -127,8 +127,6 @@ type JobInfo struct {
 
 	Name      string
 	Namespace string
-	Hierarchy string
-	Weights   string
 
 	Queue QueueID
 
@@ -176,8 +174,6 @@ func (ji *JobInfo) SetPodGroup(pg *PodGroup) {
 	ji.MinAvailable = pg.Spec.MinMember
 	ji.Queue = QueueID(pg.Spec.Queue)
 	ji.CreationTimestamp = pg.GetCreationTimestamp()
-	ji.Hierarchy = pg.Annotations[v1beta1.KubeGroupHierarchyAnnotationKey]
-	ji.Weights = pg.Annotations[v1beta1.KubeGroupHierarchyWeightAnnotationKey]
 
 	ji.PodGroup = pg
 }
@@ -245,8 +241,6 @@ func (ji *JobInfo) Clone() *JobInfo {
 		UID:       ji.UID,
 		Name:      ji.Name,
 		Namespace: ji.Namespace,
-		Hierarchy: ji.Hierarchy,
-		Weights:   ji.Weights,
 		Queue:     ji.Queue,
 		Priority:  ji.Priority,
 

--- a/pkg/scheduler/api/job_info.go
+++ b/pkg/scheduler/api/job_info.go
@@ -141,6 +141,9 @@ type JobInfo struct {
 	TaskStatusIndex map[TaskStatus]tasksMap
 	Tasks           tasksMap
 
+	Allocated    *Resource
+	TotalRequest *Resource
+
 	CreationTimestamp metav1.Time
 	PodGroup          *PodGroup
 }
@@ -151,6 +154,8 @@ func NewJobInfo(uid JobID, tasks ...*TaskInfo) *JobInfo {
 		UID:             uid,
 		MinAvailable:    0,
 		NodesFitErrors:  make(map[TaskID]*FitErrors),
+		Allocated:       EmptyResource(),
+		TotalRequest:    EmptyResource(),
 		TaskStatusIndex: map[TaskStatus]tasksMap{},
 		Tasks:           tasksMap{},
 	}
@@ -189,6 +194,10 @@ func (ji *JobInfo) addTaskIndex(ti *TaskInfo) {
 func (ji *JobInfo) AddTaskInfo(ti *TaskInfo) {
 	ji.Tasks[ti.UID] = ti
 	ji.addTaskIndex(ti)
+	ji.TotalRequest.Add(ti.Resreq)
+	if AllocatedStatus(ti.Status) {
+		ji.Allocated.Add(ti.Resreq)
+	}
 }
 
 // UpdateTaskStatus is used to update task's status in a job.
@@ -225,8 +234,11 @@ func (ji *JobInfo) deleteTaskIndex(ti *TaskInfo) {
 // DeleteTaskInfo is used to delete a task from a job
 func (ji *JobInfo) DeleteTaskInfo(ti *TaskInfo) error {
 	if task, found := ji.Tasks[ti.UID]; found {
+		ji.TotalRequest.Sub(task.Resreq)
+		if AllocatedStatus(task.Status) {
+			ji.Allocated.Sub(task.Resreq)
+		}
 		delete(ji.Tasks, task.UID)
-
 		ji.deleteTaskIndex(task)
 		return nil
 	}
@@ -246,6 +258,8 @@ func (ji *JobInfo) Clone() *JobInfo {
 
 		MinAvailable:   ji.MinAvailable,
 		NodesFitErrors: make(map[TaskID]*FitErrors),
+		Allocated:      EmptyResource(),
+		TotalRequest:   EmptyResource(),
 
 		PodGroup: ji.PodGroup,
 

--- a/pkg/scheduler/api/job_info_test.go
+++ b/pkg/scheduler/api/job_info_test.go
@@ -54,7 +54,9 @@ func TestAddTaskInfo(t *testing.T) {
 			uid:  case01UID,
 			pods: []*v1.Pod{case01Pod1, case01Pod2, case01Pod3, case01Pod4},
 			expected: &JobInfo{
-				UID: case01UID,
+				UID:          case01UID,
+				Allocated:    buildResource("4000m", "4G"),
+				TotalRequest: buildResource("5000m", "5G"),
 				Tasks: tasksMap{
 					case01Task1.UID: case01Task1,
 					case01Task2.UID: case01Task2,
@@ -127,7 +129,9 @@ func TestDeleteTaskInfo(t *testing.T) {
 			pods:   []*v1.Pod{case01Pod1, case01Pod2, case01Pod3},
 			rmPods: []*v1.Pod{case01Pod2},
 			expected: &JobInfo{
-				UID: case01UID,
+				Allocated:    buildResource("3000m", "3G"),
+				TotalRequest: buildResource("4000m", "4G"),
+				UID:          case01UID,
 				Tasks: tasksMap{
 					case01Task1.UID: case01Task1,
 					case01Task3.UID: case01Task3,
@@ -145,7 +149,9 @@ func TestDeleteTaskInfo(t *testing.T) {
 			pods:   []*v1.Pod{case02Pod1, case02Pod2, case02Pod3},
 			rmPods: []*v1.Pod{case02Pod2},
 			expected: &JobInfo{
-				UID: case02UID,
+				Allocated:    buildResource("3000m", "3G"),
+				TotalRequest: buildResource("4000m", "4G"),
+				UID:          case02UID,
 				Tasks: tasksMap{
 					case02Task1.UID: case02Task1,
 					case02Task3.UID: case02Task3,

--- a/pkg/scheduler/api/queue_info.go
+++ b/pkg/scheduler/api/queue_info.go
@@ -20,6 +20,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	"volcano.sh/volcano/pkg/apis/scheduling"
+	"volcano.sh/volcano/pkg/apis/scheduling/v1beta1"
 )
 
 // QueueID is UID type, serves as unique ID for each queue
@@ -32,6 +33,9 @@ type QueueInfo struct {
 
 	Weight int32
 
+	Weights   string
+	Hierarchy string
+
 	Queue *scheduling.Queue
 }
 
@@ -41,7 +45,9 @@ func NewQueueInfo(queue *scheduling.Queue) *QueueInfo {
 		UID:  QueueID(queue.Name),
 		Name: queue.Name,
 
-		Weight: queue.Spec.Weight,
+		Weight:    queue.Spec.Weight,
+		Hierarchy: queue.Annotations[v1beta1.KubeHierarchyAnnotationKey],
+		Weights:   queue.Annotations[v1beta1.KubeHierarchyWeightAnnotationKey],
 
 		Queue: queue,
 	}
@@ -50,10 +56,12 @@ func NewQueueInfo(queue *scheduling.Queue) *QueueInfo {
 // Clone is used to clone queueInfo object
 func (q *QueueInfo) Clone() *QueueInfo {
 	return &QueueInfo{
-		UID:    q.UID,
-		Name:   q.Name,
-		Weight: q.Weight,
-		Queue:  q.Queue,
+		UID:       q.UID,
+		Name:      q.Name,
+		Weight:    q.Weight,
+		Hierarchy: q.Hierarchy,
+		Weights:   q.Weights,
+		Queue:     q.Queue,
 	}
 }
 

--- a/pkg/scheduler/api/queue_info.go
+++ b/pkg/scheduler/api/queue_info.go
@@ -33,7 +33,12 @@ type QueueInfo struct {
 
 	Weight int32
 
-	Weights   string
+	// Weights is a list of slash sperated float numbers.
+	// Each of them is a weight corresponding the
+	// hierarchy level.
+	Weights string
+	// Hierarchy is a list of node name along the
+	// path from the root to the node itself.
 	Hierarchy string
 
 	Queue *scheduling.Queue

--- a/pkg/scheduler/api/resource_info.go
+++ b/pkg/scheduler/api/resource_info.go
@@ -141,6 +141,16 @@ func (r *Resource) Add(rr *Resource) *Resource {
 	return r
 }
 
+// Scale updates resource to the provided scale
+func (r *Resource) Scale(scale float64) *Resource {
+	r.MilliCPU *= scale
+	r.Memory *= scale
+	for rName, rQuant := range r.ScalarResources {
+		r.ScalarResources[rName] = rQuant * scale
+	}
+	return r
+}
+
 //Sub subtracts two Resource objects.
 func (r *Resource) Sub(rr *Resource) *Resource {
 	assert.Assertf(rr.LessEqual(r), "resource is not sufficient to do operation: <%v> sub <%v>", r, rr)

--- a/pkg/scheduler/cache/event_handlers.go
+++ b/pkg/scheduler/cache/event_handlers.go
@@ -370,8 +370,8 @@ func (sc *SchedulerCache) setPodGroup(ss *schedulingapi.PodGroup) error {
 }
 
 // Assumes that lock is already acquired.
-func (sc *SchedulerCache) updatePodGroup(newQueue *schedulingapi.PodGroup) error {
-	return sc.setPodGroup(newQueue)
+func (sc *SchedulerCache) updatePodGroup(newPodGroup *schedulingapi.PodGroup) error {
+	return sc.setPodGroup(newPodGroup)
 }
 
 // Assumes that lock is already acquired.

--- a/pkg/scheduler/conf/scheduler_conf.go
+++ b/pkg/scheduler/conf/scheduler_conf.go
@@ -47,8 +47,8 @@ type PluginOption struct {
 	EnabledJobOrder *bool `yaml:"enableJobOrder"`
 	// EnabledNamespaceOrder defines whether namespaceOrderFn is enabled
 	EnabledNamespaceOrder *bool `yaml:"enableNamespaceOrder"`
-	// EnableHierachy defines whether hierarchical sharing is enabled
-	EnableHierarchy *bool `yaml:"enableHierarchy"`
+	// EnabledHierachy defines whether hierarchical sharing is enabled
+	EnabledHierarchy *bool `yaml:"enableHierarchy"`
 	// EnabledJobReady defines whether jobReadyFn is enabled
 	EnabledJobReady *bool `yaml:"enableJobReady"`
 	// EnabledJobPipelined defines whether jobPipelinedFn is enabled

--- a/pkg/scheduler/conf/scheduler_conf.go
+++ b/pkg/scheduler/conf/scheduler_conf.go
@@ -47,6 +47,8 @@ type PluginOption struct {
 	EnabledJobOrder *bool `yaml:"enableJobOrder"`
 	// EnabledNamespaceOrder defines whether namespaceOrderFn is enabled
 	EnabledNamespaceOrder *bool `yaml:"enableNamespaceOrder"`
+	// EnableHierachy defines whether hierarchical sharing is enabled
+	EnableHierarchy *bool `yaml:"enableHierarchy"`
 	// EnabledJobReady defines whether jobReadyFn is enabled
 	EnabledJobReady *bool `yaml:"enableJobReady"`
 	// EnabledJobPipelined defines whether jobPipelinedFn is enabled

--- a/pkg/scheduler/plugins/drf/drf.go
+++ b/pkg/scheduler/plugins/drf/drf.go
@@ -47,7 +47,7 @@ type hierarchicalNode struct {
 	children  map[string]*hierarchicalNode
 }
 
-// resourceSaturated returns true if any resource is saturated or any resource of the job is non-demading
+// resourceSaturated returns true if any resource of the job is saturated or the job demands fully allocated resource
 func resourceSaturated(allocated *api.Resource, total *api.Resource, demandingResources map[v1.ResourceName]bool) bool {
 	for _, rn := range allocated.ResourceNames() {
 		if allocated.Get(rn) != 0 && total.Get(rn) != 0 &&
@@ -450,8 +450,7 @@ func (drf *drfPlugin) buildHierarchy(job *api.JobInfo, attr *drfAttr,
 				weight:    fweight,
 				hierarchy: paths[i],
 				attr: &drfAttr{
-					dominantResource: string(v1.ResourceCPU),
-					allocated:        api.EmptyResource(),
+					allocated: api.EmptyResource(),
 				},
 				children: make(map[string]*hierarchicalNode),
 			}
@@ -519,7 +518,7 @@ func (drf *drfPlugin) updateHierarchicalShare(node *hierarchicalNode,
 		}
 		// get dominant resource and share from demanding resources
 		res := 0.0
-		dominantResource := string(v1.ResourceCPU)
+		dominantResource := ""
 		for rn := range demandingResources {
 			share := helpers.Share(node.attr.allocated.Get(rn), drf.totalResource.Get(rn))
 			if share > res {

--- a/pkg/scheduler/plugins/drf/drf.go
+++ b/pkg/scheduler/plugins/drf/drf.go
@@ -489,7 +489,7 @@ func (drf *drfPlugin) updateHierarchicalShare(node *hierarchicalNode,
 			node.hierarchy, node.attr.share, node.attr.dominantResource, node.attr.allocated, node.saturated)
 	} else {
 		var mdr float64 = 1
-		// get minumun dominant resource share
+		// get minimun dominant resource share
 		for _, child := range node.children {
 			drf.updateHierarchicalShare(child, demandingResources)
 			// skip empty child and saturated child
@@ -501,7 +501,7 @@ func (drf *drfPlugin) updateHierarchicalShare(node *hierarchicalNode,
 			}
 		}
 
-		node.attr = &drfAttr{allocated: api.EmptyResource()}
+		node.attr.allocated = api.EmptyResource()
 		saturated := true
 		for _, child := range node.children {
 			if !child.saturated {
@@ -520,21 +520,9 @@ func (drf *drfPlugin) updateHierarchicalShare(node *hierarchicalNode,
 
 			}
 		}
-		// get dominant resource and share from demanding resources
-		res := 0.0
-		dominantResource := ""
-		for rn := range demandingResources {
-			share := helpers.Share(node.attr.allocated.Get(rn), drf.totalResource.Get(rn))
-			if share > res {
-				res = share
-				dominantResource = string(rn)
-			}
-
-		}
-		node.attr.share = res
-		node.attr.dominantResource = dominantResource
+		node.attr.dominantResource, node.attr.share = drf.calculateShare(
+			node.attr.allocated, drf.totalResource)
 		node.saturated = saturated
-
 		klog.V(4).Infof("Update hierarchical node %s, share %f, dominant resource %s, resource %v, saturated: %t",
 			node.hierarchy, node.attr.share, node.attr.dominantResource, node.attr.allocated, node.saturated)
 	}
@@ -549,9 +537,6 @@ func (drf *drfPlugin) UpdateHierarchicalShare(job *api.JobInfo, attr *drfAttr, h
 			demandingResources[rn] = true
 
 		}
-	}
-	if len(demandingResources) == 0 {
-		return
 	}
 	drf.buildHierarchy(job, attr, hierarchy, hierarchicalWeights)
 	drf.updateHierarchicalShare(drf.hierarchicalRoot, demandingResources)

--- a/pkg/scheduler/plugins/drf/hdrf_test.go
+++ b/pkg/scheduler/plugins/drf/hdrf_test.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"testing"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/klog"
@@ -22,18 +22,26 @@ import (
 func makePods(num int, cpu, mem, podGroupName string) []*v1.Pod {
 	pods := []*v1.Pod{}
 	for i := 0; i < num; i++ {
-		pods = append(pods, util.BuildPod("default", fmt.Sprintf("%s-p%d", podGroupName, i), "", v1.PodPending, util.BuildResourceList(cpu, mem), podGroupName, make(map[string]string), make(map[string]string)))
+		pods = append(pods, util.BuildPod("default",
+			fmt.Sprintf("%s-p%d", podGroupName, i), "",
+			v1.PodPending, util.BuildResourceList(cpu, mem),
+			podGroupName, make(map[string]string), make(map[string]string)))
 	}
 	return pods
 }
 
-type pgSpec struct {
-	taskNum   int
-	cpu       string
-	mem       string
-	pg        string
+type queueSpec struct {
+	name      string
 	hierarchy string
-	weight    string
+	weights   string
+}
+
+type pgSpec struct {
+	taskNum int
+	cpu     string
+	mem     string
+	pg      string
+	queue   string
 }
 
 func TestHDRF(t *testing.T) {
@@ -49,51 +57,58 @@ func TestHDRF(t *testing.T) {
 	defer framework.CleanupPluginBuilders()
 
 	tests := []struct {
-		name     string
-		pgSpecs  []pgSpec
-		nodes    []*v1.Node
-		queues   []*schedulingv1.Queue
-		expected map[string]string
+		name       string
+		pgSpecs    []pgSpec
+		nodes      []*v1.Node
+		queues     []*schedulingv1.Queue
+		queueSpecs []queueSpec
+		expected   map[string]string
 	}{
 		{
 			name: "rescaling test",
 			pgSpecs: []pgSpec{
 				{
-					taskNum:   10,
-					cpu:       "1",
-					mem:       "1G",
-					pg:        "pg1",
-					hierarchy: "root/sci",
-					weight:    "100/50",
+					taskNum: 10,
+					cpu:     "1",
+					mem:     "1G",
+					pg:      "pg1",
+					queue:   "root-sci",
 				},
 				{
-					taskNum:   10,
-					cpu:       "1",
-					mem:       "0G",
-					pg:        "pg21",
-					hierarchy: "root/eng/dev",
-					weight:    "100/50/50",
+					taskNum: 10,
+					cpu:     "1",
+					mem:     "0G",
+					pg:      "pg21",
+					queue:   "root-eng-dev",
 				},
 				{
-					taskNum:   10,
-					cpu:       "0",
-					mem:       "1G",
-					pg:        "pg22",
-					hierarchy: "root/eng/prod",
-					weight:    "100/50/50",
+					taskNum: 10,
+					cpu:     "0",
+					mem:     "1G",
+					pg:      "pg22",
+					queue:   "root-eng-prod",
 				},
 			},
 			nodes: []*v1.Node{util.BuildNode("n",
 				util.BuildResourceList("10", "10G"),
 				make(map[string]string))},
-			queues: []*schedulingv1.Queue{{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "default",
+			queueSpecs: []queueSpec{
+				{
+					name:      "root-sci",
+					hierarchy: "root/sci",
+					weights:   "100/50",
 				},
-				Spec: schedulingv1.QueueSpec{
-					Weight: 1,
+				{
+					name:      "root-eng-dev",
+					hierarchy: "root/eng/dev",
+					weights:   "100/50/50",
 				},
-			}},
+				{
+					name:      "root-eng-prod",
+					hierarchy: "root/eng/prod",
+					weights:   "100/50/50",
+				},
+			},
 			expected: map[string]string{
 				"pg1":  "cpu 5000.00, memory 5000000000.00, nvidia.com/gpu 0.00",
 				"pg21": "cpu 5000.00, memory 0.00, nvidia.com/gpu 0.00",
@@ -104,57 +119,71 @@ func TestHDRF(t *testing.T) {
 			name: "blocking nodes test",
 			pgSpecs: []pgSpec{
 				{
-					taskNum:   30,
-					cpu:       "1",
-					mem:       "0G",
-					pg:        "pg1",
-					hierarchy: "root/pg1",
-					weight:    "100/25",
+					taskNum: 30,
+					cpu:     "1",
+					mem:     "0G",
+					pg:      "pg1",
+					queue:   "root-pg1",
 				},
 				{
-					taskNum:   30,
-					cpu:       "1",
-					mem:       "0G",
-					pg:        "pg2",
-					hierarchy: "root/pg2",
-					weight:    "100/25",
+					taskNum: 30,
+					cpu:     "1",
+					mem:     "0G",
+					pg:      "pg2",
+					queue:   "root-pg2",
 				},
 				{
-					taskNum:   30,
-					cpu:       "1",
-					mem:       "0G",
-					pg:        "pg31",
-					hierarchy: "root/pg3/pg31",
-					weight:    "100/25/50",
+					taskNum: 30,
+					cpu:     "1",
+					mem:     "0G",
+					pg:      "pg31",
+					queue:   "root-pg3-pg31",
 				},
 				{
-					taskNum:   30,
-					cpu:       "0",
-					mem:       "1G",
-					pg:        "pg32",
-					hierarchy: "root/pg3/pg32",
-					weight:    "100/25/50",
+					taskNum: 30,
+					cpu:     "0",
+					mem:     "1G",
+					pg:      "pg32",
+					queue:   "root-pg3-pg32",
 				},
 				{
-					taskNum:   30,
-					cpu:       "0",
-					mem:       "1G",
-					pg:        "pg4",
-					hierarchy: "root/pg4",
-					weight:    "100/25",
+					taskNum: 30,
+					cpu:     "0",
+					mem:     "1G",
+					pg:      "pg4",
+					queue:   "root-pg4",
 				},
 			},
 			nodes: []*v1.Node{util.BuildNode("n",
 				util.BuildResourceList("30", "30G"),
 				make(map[string]string))},
-			queues: []*schedulingv1.Queue{{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "default",
+			queueSpecs: []queueSpec{
+				{
+					name:      "root-pg1",
+					hierarchy: "root/pg1",
+					weights:   "100/25",
 				},
-				Spec: schedulingv1.QueueSpec{
-					Weight: 1,
+				{
+					name:      "root-pg2",
+					hierarchy: "root/pg2",
+					weights:   "100/25",
 				},
-			}},
+				{
+					name:      "root-pg3-pg31",
+					hierarchy: "root/pg3/pg31",
+					weights:   "100/25/50",
+				},
+				{
+					name:      "root-pg3-pg32",
+					hierarchy: "root/pg3/pg32",
+					weights:   "100/25/50",
+				},
+				{
+					name:      "root-pg4",
+					hierarchy: "root/pg4",
+					weights:   "100/25",
+				},
+			},
 			expected: map[string]string{
 				"pg1":  "cpu 10000.00, memory 0.00, nvidia.com/gpu 0.00",
 				"pg2":  "cpu 10000.00, memory 0.00, nvidia.com/gpu 0.00",
@@ -176,14 +205,25 @@ func TestHDRF(t *testing.T) {
 			Binder:        binder,
 			StatusUpdater: &util.FakeStatusUpdater{},
 			VolumeBinder:  &util.FakeVolumeBinder{},
-
-			Recorder: record.NewFakeRecorder(100),
+			Recorder:      record.NewFakeRecorder(100),
 		}
 		for _, node := range test.nodes {
 			schedulerCache.AddNode(node)
 		}
-		for _, q := range test.queues {
-			schedulerCache.AddQueueV1beta1(q)
+		for _, q := range test.queueSpecs {
+			schedulerCache.AddQueueV1beta1(
+				&schedulingv1.Queue{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: q.name,
+						Annotations: map[string]string{
+							schedulingv1.KubeHierarchyAnnotationKey:       q.hierarchy,
+							schedulingv1.KubeHierarchyWeightAnnotationKey: q.weights,
+						},
+					},
+					Spec: schedulingv1.QueueSpec{
+						Weight: 1,
+					},
+				})
 		}
 		for _, pgSpec := range test.pgSpecs {
 			pods := makePods(pgSpec.taskNum, pgSpec.cpu, pgSpec.mem, pgSpec.pg)
@@ -194,13 +234,9 @@ func TestHDRF(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      pgSpec.pg,
 					Namespace: "default",
-					Annotations: map[string]string{
-						schedulingv1.KubeGroupHierarchyAnnotationKey:       pgSpec.hierarchy,
-						schedulingv1.KubeGroupHierarchyWeightAnnotationKey: pgSpec.weight,
-					},
 				},
 				Spec: schedulingv1.PodGroupSpec{
-					Queue: "default",
+					Queue: pgSpec.queue,
 				},
 			})
 		}
@@ -209,22 +245,22 @@ func TestHDRF(t *testing.T) {
 			{
 				Plugins: []conf.PluginOption{
 					{
-						Name:             PluginName,
-						EnabledHierarchy: &trueValue,
-						EnabledJobOrder:  &trueValue,
+						Name:              PluginName,
+						EnabledHierarchy:  &trueValue,
+						EnabledQueueOrder: &trueValue,
+						EnabledJobOrder:   &trueValue,
 					},
 				},
 			},
 		}, nil)
 		defer framework.CloseSession(ssn)
-
 		allocateAction := allocate.New()
 
 		allocateAction.Execute(ssn)
 
 		for _, job := range ssn.Jobs {
 			if test.expected[job.Name] != job.Allocated.String() {
-				t.Fatalf("job %s expected resource %s, but got %s", job.Name, test.expected[job.Name], job.Allocated)
+				t.Fatalf("%s: job %s expected resource %s, but got %s", test.name, job.Name, test.expected[job.Name], job.Allocated)
 			}
 		}
 

--- a/pkg/scheduler/plugins/drf/hdrf_test.go
+++ b/pkg/scheduler/plugins/drf/hdrf_test.go
@@ -1,0 +1,232 @@
+package drf
+
+import (
+	"flag"
+	"fmt"
+	"testing"
+
+	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/klog"
+	"volcano.sh/volcano/cmd/scheduler/app/options"
+	schedulingv1 "volcano.sh/volcano/pkg/apis/scheduling/v1beta1"
+	"volcano.sh/volcano/pkg/scheduler/actions/allocate"
+	"volcano.sh/volcano/pkg/scheduler/api"
+	"volcano.sh/volcano/pkg/scheduler/cache"
+	"volcano.sh/volcano/pkg/scheduler/conf"
+	"volcano.sh/volcano/pkg/scheduler/framework"
+	"volcano.sh/volcano/pkg/scheduler/util"
+)
+
+func makePods(num int, cpu, mem, podGroupName string) []*v1.Pod {
+	pods := []*v1.Pod{}
+	for i := 0; i < num; i++ {
+		pods = append(pods, util.BuildPod("default", fmt.Sprintf("%s-p%d", podGroupName, i), "", v1.PodPending, util.BuildResourceList(cpu, mem), podGroupName, make(map[string]string), make(map[string]string)))
+	}
+	return pods
+}
+
+type pgSpec struct {
+	taskNum   int
+	cpu       string
+	mem       string
+	pg        string
+	hierarchy string
+	weight    string
+}
+
+func TestHDRF(t *testing.T) {
+	klog.InitFlags(nil)
+	flag.Set("v", "4")
+	flag.Set("alsologtostderr", "true")
+	s := options.NewServerOption()
+	s.MinNodesToFind = 100
+	s.PercentageOfNodesToFind = 100
+	s.RegisterOptions()
+
+	framework.RegisterPluginBuilder(PluginName, New)
+	defer framework.CleanupPluginBuilders()
+
+	tests := []struct {
+		name     string
+		pgSpecs  []pgSpec
+		nodes    []*v1.Node
+		queues   []*schedulingv1.Queue
+		expected map[string]string
+	}{
+		{
+			name: "rescaling test",
+			pgSpecs: []pgSpec{
+				{
+					taskNum:   10,
+					cpu:       "1",
+					mem:       "1G",
+					pg:        "pg1",
+					hierarchy: "root/sci",
+					weight:    "100/50",
+				},
+				{
+					taskNum:   10,
+					cpu:       "1",
+					mem:       "0G",
+					pg:        "pg21",
+					hierarchy: "root/eng/dev",
+					weight:    "100/50/50",
+				},
+				{
+					taskNum:   10,
+					cpu:       "0",
+					mem:       "1G",
+					pg:        "pg22",
+					hierarchy: "root/eng/prod",
+					weight:    "100/50/50",
+				},
+			},
+			nodes: []*v1.Node{util.BuildNode("n",
+				util.BuildResourceList("10", "10G"),
+				make(map[string]string))},
+			queues: []*schedulingv1.Queue{{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "default",
+				},
+				Spec: schedulingv1.QueueSpec{
+					Weight: 1,
+				},
+			}},
+			expected: map[string]string{
+				"pg1":  "cpu 5000.00, memory 5000000000.00, nvidia.com/gpu 0.00",
+				"pg21": "cpu 5000.00, memory 0.00, nvidia.com/gpu 0.00",
+				"pg22": "cpu 0.00, memory 5000000000.00, nvidia.com/gpu 0.00",
+			},
+		},
+		{
+			name: "blocking nodes test",
+			pgSpecs: []pgSpec{
+				{
+					taskNum:   30,
+					cpu:       "1",
+					mem:       "0G",
+					pg:        "pg1",
+					hierarchy: "root/pg1",
+					weight:    "100/25",
+				},
+				{
+					taskNum:   30,
+					cpu:       "1",
+					mem:       "0G",
+					pg:        "pg2",
+					hierarchy: "root/pg2",
+					weight:    "100/25",
+				},
+				{
+					taskNum:   30,
+					cpu:       "1",
+					mem:       "0G",
+					pg:        "pg31",
+					hierarchy: "root/pg3/pg31",
+					weight:    "100/25/50",
+				},
+				{
+					taskNum:   30,
+					cpu:       "0",
+					mem:       "1G",
+					pg:        "pg32",
+					hierarchy: "root/pg3/pg32",
+					weight:    "100/25/50",
+				},
+				{
+					taskNum:   30,
+					cpu:       "0",
+					mem:       "1G",
+					pg:        "pg4",
+					hierarchy: "root/pg4",
+					weight:    "100/25",
+				},
+			},
+			nodes: []*v1.Node{util.BuildNode("n",
+				util.BuildResourceList("30", "30G"),
+				make(map[string]string))},
+			queues: []*schedulingv1.Queue{{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "default",
+				},
+				Spec: schedulingv1.QueueSpec{
+					Weight: 1,
+				},
+			}},
+			expected: map[string]string{
+				"pg1":  "cpu 10000.00, memory 0.00, nvidia.com/gpu 0.00",
+				"pg2":  "cpu 10000.00, memory 0.00, nvidia.com/gpu 0.00",
+				"pg31": "cpu 10000.00, memory 0.00, nvidia.com/gpu 0.00",
+				"pg32": "cpu 0.00, memory 15000000000.00, nvidia.com/gpu 0.00",
+				"pg4":  "cpu 0.00, memory 15000000000.00, nvidia.com/gpu 0.00",
+			},
+		},
+	}
+	for _, test := range tests {
+		binder := &util.FakeBinder{
+			Binds:   map[string]string{},
+			Channel: make(chan string),
+		}
+		schedulerCache := &cache.SchedulerCache{
+			Nodes:         make(map[string]*api.NodeInfo),
+			Jobs:          make(map[api.JobID]*api.JobInfo),
+			Queues:        make(map[api.QueueID]*api.QueueInfo),
+			Binder:        binder,
+			StatusUpdater: &util.FakeStatusUpdater{},
+			VolumeBinder:  &util.FakeVolumeBinder{},
+
+			Recorder: record.NewFakeRecorder(100),
+		}
+		for _, node := range test.nodes {
+			schedulerCache.AddNode(node)
+		}
+		for _, q := range test.queues {
+			schedulerCache.AddQueueV1beta1(q)
+		}
+		for _, pgSpec := range test.pgSpecs {
+			pods := makePods(pgSpec.taskNum, pgSpec.cpu, pgSpec.mem, pgSpec.pg)
+			for _, pod := range pods {
+				schedulerCache.AddPod(pod)
+			}
+			schedulerCache.AddPodGroupV1beta1(&schedulingv1.PodGroup{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      pgSpec.pg,
+					Namespace: "default",
+					Annotations: map[string]string{
+						schedulingv1.KubeGroupHierarchyAnnotationKey:       pgSpec.hierarchy,
+						schedulingv1.KubeGroupHierarchyWeightAnnotationKey: pgSpec.weight,
+					},
+				},
+				Spec: schedulingv1.PodGroupSpec{
+					Queue: "default",
+				},
+			})
+		}
+		trueValue := true
+		ssn := framework.OpenSession(schedulerCache, []conf.Tier{
+			{
+				Plugins: []conf.PluginOption{
+					{
+						Name:             PluginName,
+						EnabledHierarchy: &trueValue,
+						EnabledJobOrder:  &trueValue,
+					},
+				},
+			},
+		}, nil)
+		defer framework.CloseSession(ssn)
+
+		allocateAction := allocate.New()
+
+		allocateAction.Execute(ssn)
+
+		for _, job := range ssn.Jobs {
+			if test.expected[job.Name] != job.Allocated.String() {
+				t.Fatalf("job %s expected resource %s, but got %s", job.Name, test.expected[job.Name], job.Allocated)
+			}
+		}
+
+	}
+}

--- a/pkg/scheduler/util.go
+++ b/pkg/scheduler/util.go
@@ -52,11 +52,25 @@ func unmarshalSchedulerConf(confStr string) ([]framework.Action, []conf.Tier, []
 	if err := yaml.Unmarshal(buf, schedulerConf); err != nil {
 		return nil, nil, nil, err
 	}
-
 	// Set default settings for each plugin if not set
 	for i, tier := range schedulerConf.Tiers {
+		// drf with hierarchy enabled
+		hdrf := false
+		// proportion enabled
+		proprotion := false
 		for j := range tier.Plugins {
+			if tier.Plugins[j].Name == "drf" &&
+				tier.Plugins[j].EnabledHierarchy != nil &&
+				*tier.Plugins[j].EnabledHierarchy == true {
+				hdrf = true
+			}
+			if tier.Plugins[j].Name == "proportion" {
+				proprotion = true
+			}
 			plugins.ApplyPluginConfDefaults(&schedulerConf.Tiers[i].Plugins[j])
+		}
+		if hdrf && proprotion {
+			return nil, nil, nil, fmt.Errorf("proportion and drf with hierarchy enabled conflicts")
 		}
 	}
 

--- a/pkg/webhooks/admission/queues/mutate/mutate_queue_test.go
+++ b/pkg/webhooks/admission/queues/mutate/mutate_queue_test.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
+	"strings"
 	"testing"
 
 	"k8s.io/api/admission/v1beta1"
@@ -76,6 +77,43 @@ func TestMutateQueues(t *testing.T) {
 	refreshPatchJSON, err := json.Marshal(refreshPatch)
 	if err != nil {
 		t.Errorf("Marshal queue patch failed for %v.", err)
+	}
+
+	hierarchyWithoutRoot := schedulingv1beta1.Queue{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "queue-without-root",
+			Annotations: map[string]string{
+				schedulingv1beta1.KubeHierarchyAnnotationKey:       "a/b/c",
+				schedulingv1beta1.KubeHierarchyWeightAnnotationKey: "2/3/4",
+			},
+		},
+		Spec: schedulingv1beta1.QueueSpec{
+			Reclaimable: &trueValue,
+			Weight:      1,
+		},
+		Status: schedulingv1beta1.QueueStatus{
+			State: schedulingv1beta1.QueueStateOpen,
+		},
+	}
+
+	hierarchyWithoutRootJSON, err := json.Marshal(hierarchyWithoutRoot)
+	if err != nil {
+		t.Errorf("Marshal hierarchy without root failed for %v.", err)
+	}
+	var appendRootPatch []patchOperation
+	appendRootPatch = append(appendRootPatch, patchOperation{
+		Op:    "add",
+		Path:  fmt.Sprintf("/metadata/annotations/%s", strings.ReplaceAll(schedulingv1beta1.KubeHierarchyAnnotationKey, "/", "~1")),
+		Value: fmt.Sprintf("root/%s", hierarchyWithoutRoot.Annotations[schedulingv1beta1.KubeHierarchyAnnotationKey]),
+	})
+	appendRootPatch = append(appendRootPatch, patchOperation{
+		Op:    "add",
+		Path:  fmt.Sprintf("/metadata/annotations/%s", strings.ReplaceAll(schedulingv1beta1.KubeHierarchyWeightAnnotationKey, "/", "~1")),
+		Value: fmt.Sprintf("1/%s", hierarchyWithoutRoot.Annotations[schedulingv1beta1.KubeHierarchyWeightAnnotationKey]),
+	})
+	appendRootPatchJSON, err := json.Marshal(appendRootPatch)
+	if err != nil {
+		t.Errorf("Marshal appendRootPatch failed for %v", err)
 	}
 
 	testCases := []struct {
@@ -142,6 +180,37 @@ func TestMutateQueues(t *testing.T) {
 			reviewResponse: util.ToAdmissionResponse(fmt.Errorf("invalid operation `%s`, "+
 				"expect operation to be `CREATE`", "Invalid")),
 		},
+		{
+			Name: "Normal Case Append Default Root to The HDRF Attributes",
+			AR: v1beta1.AdmissionReview{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "AdmissionReview",
+					APIVersion: "admission.k8s.io/v1beta1",
+				},
+				Request: &v1beta1.AdmissionRequest{
+					Kind: metav1.GroupVersionKind{
+						Group:   "scheduling.volcano.sh",
+						Version: "v1beta1",
+						Kind:    "Queue",
+					},
+					Resource: metav1.GroupVersionResource{
+						Group:    "scheduling.volcano.sh",
+						Version:  "v1beta1",
+						Resource: "queues",
+					},
+					Name:      "qeueu-hierarchy-without-root",
+					Operation: "CREATE",
+					Object: runtime.RawExtension{
+						Raw: hierarchyWithoutRootJSON,
+					},
+				},
+			},
+			reviewResponse: &v1beta1.AdmissionResponse{
+				Allowed:   true,
+				PatchType: &pt,
+				Patch:     appendRootPatchJSON,
+			},
+		},
 	}
 
 	for _, testCase := range testCases {
@@ -149,7 +218,7 @@ func TestMutateQueues(t *testing.T) {
 			reviewResponse := Queues(testCase.AR)
 			if !reflect.DeepEqual(reviewResponse, testCase.reviewResponse) {
 				t.Errorf("Test case '%s' failed, expect: %v, got: %v", testCase.Name,
-					reviewResponse, testCase.reviewResponse)
+					testCase.reviewResponse, reviewResponse)
 			}
 		})
 	}

--- a/pkg/webhooks/admission/queues/validate/validate_queue.go
+++ b/pkg/webhooks/admission/queues/validate/validate_queue.go
@@ -154,7 +154,8 @@ func validateHierarchicalAttributes(queue *schedulingv1beta1.Queue, fldPath *fie
 		}
 		for _, queueInTree := range queueList.Items {
 			hierarchyInTree := queueInTree.Annotations[schedulingv1beta1.KubeHierarchyAnnotationKey]
-			if hierarchyInTree != "" && strings.HasPrefix(hierarchyInTree, hierarchy) {
+			if hierarchyInTree != "" && queue.Name != queueInTree.Name &&
+				strings.HasPrefix(hierarchyInTree, hierarchy) {
 				return append(errs, field.Invalid(fldPath, hierarchy,
 					fmt.Sprintf("%s is not allowed to be in the sub path of %s of queue %s",
 						hierarchy, hierarchyInTree, queueInTree.Name)))

--- a/pkg/webhooks/admission/queues/validate/validate_queue.go
+++ b/pkg/webhooks/admission/queues/validate/validate_queue.go
@@ -19,6 +19,8 @@ package validate
 import (
 	"context"
 	"fmt"
+	"strconv"
+	"strings"
 
 	"k8s.io/api/admission/v1beta1"
 	whv1beta1 "k8s.io/api/admissionregistration/v1beta1"
@@ -98,12 +100,70 @@ func validateQueue(queue *schedulingv1beta1.Queue) error {
 
 	errs = append(errs, validateStateOfQueue(queue.Status.State, resourcePath.Child("spec").Child("state"))...)
 	errs = append(errs, validateWeightOfQueue(queue.Spec.Weight, resourcePath.Child("spec").Child("weight"))...)
+	errs = append(errs, validateHierarchicalAttributes(queue, resourcePath.Child("metadata").Child("annotations"))...)
 
 	if len(errs) > 0 {
 		return errs.ToAggregate()
 	}
 
 	return nil
+}
+func validateHierarchicalAttributes(queue *schedulingv1beta1.Queue, fldPath *field.Path) field.ErrorList {
+	errs := field.ErrorList{}
+	hierarchy := queue.Annotations[schedulingv1beta1.KubeHierarchyAnnotationKey]
+	hierarchicalWeights := queue.Annotations[schedulingv1beta1.KubeHierarchyWeightAnnotationKey]
+	if hierarchy != "" || hierarchicalWeights != "" {
+		paths := strings.Split(hierarchy, "/")
+		weights := strings.Split(hierarchicalWeights, "/")
+		// path length must be the same with weights length
+		if len(paths) != len(weights) {
+			return append(errs, field.Invalid(fldPath, hierarchy,
+				fmt.Sprintf("%s must have the same length with %s",
+					schedulingv1beta1.KubeHierarchyAnnotationKey,
+					schedulingv1beta1.KubeHierarchyWeightAnnotationKey,
+				)))
+		}
+
+		// check weights format
+		for _, weight := range weights {
+			weightFloat, err := strconv.ParseFloat(weight, 64)
+			if err != nil {
+				return append(errs, field.Invalid(fldPath, hierarchicalWeights,
+					fmt.Sprintf("%s in the %s is invalid number: %v",
+						weight, hierarchicalWeights, err,
+					)))
+			}
+			if weightFloat <= 0 {
+				return append(errs, field.Invalid(fldPath, hierarchicalWeights,
+					fmt.Sprintf("%s in the %s must be larger than 0",
+						weight, hierarchicalWeights,
+					)))
+			}
+		}
+
+		// The node is not allowed to be in the sub path of a node.
+		// For example, a queue with "root/sci" conflicts with a queue with "root/sci/dev"
+		queueList, err := config.VolcanoClient.SchedulingV1beta1().Queues().List(context.TODO(), metav1.ListOptions{})
+		if err != nil {
+			return append(errs, field.Invalid(fldPath, hierarchy,
+				fmt.Sprintf("checking %s, list queues failed: %v",
+					schedulingv1beta1.KubeHierarchyAnnotationKey,
+					err,
+				)))
+
+		}
+		for _, queueInTree := range queueList.Items {
+			hierarchyInTree := queueInTree.Annotations[schedulingv1beta1.KubeHierarchyAnnotationKey]
+			if hierarchyInTree != "" && strings.HasPrefix(hierarchyInTree, hierarchy) {
+				return append(errs, field.Invalid(fldPath, hierarchy,
+					fmt.Sprintf("%s is not allowed to be in the sub path of %s of queue %s",
+						hierarchy, hierarchyInTree, queueInTree.Name)))
+
+			}
+		}
+
+	}
+	return errs
 }
 
 func validateStateOfQueue(value schedulingv1beta1.QueueState, fldPath *field.Path) field.ErrorList {


### PR DESCRIPTION
Hierarchical dominant resource fairness is configured with
a weighted tree, such that each node in the tree has a positive weight value.
The weights denote relative importance and do not have to sum to 1. The leaves
in the tree denote the jobs that are ultimately to be allocated resources,
whereas the internal nodes represent organizational or hierarchical groups.

In the case that an internal node has a child with a higher dominant share
while other children with another type of resource to be allocated will starve,
HDRF scales the child to the minimum dominant share and sums them up as the share of itself.

The hierarchy and weights of interest are annotated in the PodGroup
or Job annotations.

Signed-off-by: Peng Gao <peng.gao.dut@gmail.com>