### PR TITLE
fix bug: capability validation failed when some running jobs finished or deleted

### DIFF
--- a/pkg/scheduler/plugins/proportion/proportion.go
+++ b/pkg/scheduler/plugins/proportion/proportion.go
@@ -18,7 +18,6 @@ package proportion
 
 import (
 	"k8s.io/klog"
-
 	"volcano.sh/volcano/pkg/scheduler/api"
 	"volcano.sh/volcano/pkg/scheduler/api/helpers"
 	"volcano.sh/volcano/pkg/scheduler/framework"
@@ -226,24 +225,6 @@ func (pp *proportionPlugin) OnSessionOpen(ssn *framework.Session) {
 		}
 
 		return overused
-	})
-
-	ssn.AddJobEnqueueableFn(pp.Name(), func(obj interface{}) bool {
-		job := obj.(*api.JobInfo)
-		queueID := job.Queue
-		attr := pp.queueOpts[queueID]
-		queue := ssn.Queues[queueID]
-
-		// If no capability is set, always enqueue the job.
-		if len(queue.Queue.Spec.Capability) == 0 {
-			klog.V(4).Infof("Capability of queue <%s> was not set, allow job <%s/%s> to Inqueue.",
-				queue.Name, job.Namespace, job.Name)
-			return true
-		}
-
-		minReq := api.NewResource(*job.PodGroup.Spec.MinResources)
-		// The queue resource quota limit has not reached
-		return minReq.Add(attr.allocated).LessEqual(api.NewResource(queue.Queue.Spec.Capability))
 	})
 
 	// Register event handlers.


### PR DESCRIPTION
bug fix point:
1.  the right time of capability validation is in enqueue action(required validation), not the jobEqueueableFn of plugins
2.  allocated resource for queue calculated incorrectly. Considering this cenario that some jobs are in the same queue, while parts are running but parts are pending because of capability limit. When one of running job finished or deleted, next scheduler cycle will choose some pending jobs (actually podgroups) inqueue by go through all pending jobs in the queue. In each inspect period for one job, scheduler will attempt to compare the sum of allocated reource and this job request resource with capability. If the inqueue jobs request resource are not added to allocated, every check round will get a same allocate resource. In fact, ahead inqueue jobs has already locked in some resource quota in capability. 

Signed-off-by: Thor <1187526662@qq.com>