### PR TITLE
plugins/binpack: fix typo of BinpackMemory

### DIFF
--- a/pkg/scheduler/plugins/binpack/binpack.go
+++ b/pkg/scheduler/plugins/binpack/binpack.go
@@ -38,7 +38,7 @@ const (
 	BinpackWeight = "binpack.weight"
 	// BinpackCPU is the key for weight of cpu
 	BinpackCPU = "binpack.cpu"
-	// BinpackMemory is the key for memory of cpu
+	// BinpackMemory is the key for weight of memory
 	BinpackMemory = "binpack.memory"
 
 	// BinpackResources is the key for additional resource key name


### PR DESCRIPTION
There was inconsistent comment in plugins/binpack/binpack.go file. Fix the typo.