### PR TITLE
Fix enqueue conflicts with preempt and reclaim

### DIFF
--- a/cmd/webhook-manager/app/options/options.go
+++ b/cmd/webhook-manager/app/options/options.go
@@ -41,6 +41,7 @@ type Config struct {
 	WebhookName       string
 	WebhookNamespace  string
 	SchedulerName     string
+	EnqueueEnabled    bool
 	WebhookURL        string
 }
 
@@ -69,6 +70,7 @@ func (c *Config) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&c.WebhookURL, "webhook-url", "", "The url of this webhook")
 
 	fs.StringVar(&c.SchedulerName, "scheduler-name", defaultSchedulerName, "Volcano will handle pods whose .spec.SchedulerName is same as scheduler-name")
+	fs.BoolVar(&c.EnqueueEnabled, "enqueue-enabled", true, "Whether enqueue is enabled in volcano scheduler")
 }
 
 // CheckPortOrDie check valid port range.

--- a/cmd/webhook-manager/app/server.go
+++ b/cmd/webhook-manager/app/server.go
@@ -60,6 +60,7 @@ func Run(config *options.Config) error {
 		if service.Config != nil {
 			service.Config.VolcanoClient = vClient
 			service.Config.SchedulerName = config.SchedulerName
+			service.Config.EnqueueEnabled = config.EnqueueEnabled
 		}
 
 		klog.V(3).Infof("Registered '%s' as webhook.", service.Path)

--- a/pkg/webhooks/router/interface.go
+++ b/pkg/webhooks/router/interface.go
@@ -28,9 +28,10 @@ import (
 type AdmitFunc func(v1beta1.AdmissionReview) *v1beta1.AdmissionResponse
 
 type AdmissionServiceConfig struct {
-	SchedulerName string
-	KubeClient    kubernetes.Interface
-	VolcanoClient versioned.Interface
+	SchedulerName  string
+	EnqueueEnabled bool
+	KubeClient     kubernetes.Interface
+	VolcanoClient  versioned.Interface
 }
 
 type AdmissionService struct {


### PR DESCRIPTION
Fix: #991 

This makes admission controller allow creating pods when podgroup is pending if the `enqueue` action is not enabled.