### PR TITLE
Improve performance: remove priorityclass

### DIFF
--- a/pkg/controllers/job/job_controller.go
+++ b/pkg/controllers/job/job_controller.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"hash"
 	"hash/fnv"
-	"sync"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
@@ -206,10 +205,6 @@ func (cc *jobcontroller) Initialize(opt *framework.ControllerOption) error {
 	cc.pgSynced = cc.pgInformer.Informer().HasSynced
 
 	cc.pcInformer = sharedInformers.Scheduling().V1beta1().PriorityClasses()
-	cc.pcInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc:    cc.addPriorityClass,
-		DeleteFunc: cc.deletePriorityClass,
-	})
 	cc.pcLister = cc.pcInformer.Lister()
 	cc.pcSynced = cc.pcInformer.Informer().HasSynced
 

--- a/pkg/controllers/job/job_controller.go
+++ b/pkg/controllers/job/job_controller.go
@@ -109,11 +109,10 @@ type jobcontroller struct {
 	queueList    []workqueue.RateLimitingInterface
 	commandQueue workqueue.RateLimitingInterface
 	cache        jobcache.Cache
-	//Job Event recorder
+	// Job Event recorder
 	recorder        record.EventRecorder
 	priorityClasses map[string]*v1beta1.PriorityClass
 
-	sync.Mutex
 	errTasks workqueue.RateLimitingInterface
 	workers  uint32
 }
@@ -140,7 +139,6 @@ func (cc *jobcontroller) Initialize(opt *framework.ControllerOption) error {
 	cc.cache = jobcache.New()
 	cc.errTasks = newRateLimitingQueue()
 	cc.recorder = recorder
-	cc.priorityClasses = make(map[string]*v1beta1.PriorityClass)
 	cc.workers = workers
 
 	var i uint32

--- a/pkg/controllers/job/job_controller_handler.go
+++ b/pkg/controllers/job/job_controller_handler.go
@@ -23,7 +23,6 @@ import (
 	"strconv"
 
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/api/scheduling/v1beta1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/cache"
@@ -435,47 +434,3 @@ func (cc *jobcontroller) updatePodGroup(oldObj, newObj interface{}) {
 }
 
 // TODO(k82cn): add handler for PodGroup unschedulable event.
-
-func (cc *jobcontroller) addPriorityClass(obj interface{}) {
-	pc := convert2PriorityClass(obj)
-	if pc == nil {
-		return
-	}
-
-	cc.Mutex.Lock()
-	defer cc.Mutex.Unlock()
-
-	cc.priorityClasses[pc.Name] = pc
-}
-
-func (cc *jobcontroller) deletePriorityClass(obj interface{}) {
-	pc := convert2PriorityClass(obj)
-	if pc == nil {
-		return
-	}
-
-	cc.Mutex.Lock()
-	defer cc.Mutex.Unlock()
-
-	delete(cc.priorityClasses, pc.Name)
-}
-
-func convert2PriorityClass(obj interface{}) *v1beta1.PriorityClass {
-	var pc *v1beta1.PriorityClass
-	switch t := obj.(type) {
-	case *v1beta1.PriorityClass:
-		pc = t
-	case cache.DeletedFinalStateUnknown:
-		var ok bool
-		pc, ok = t.Obj.(*v1beta1.PriorityClass)
-		if !ok {
-			klog.Errorf("Cannot convert to *v1beta1.PriorityClass: %v", t.Obj)
-			return nil
-		}
-	default:
-		klog.Errorf("Cannot convert to *v1beta1.PriorityClass: %v", t)
-		return nil
-	}
-
-	return pc
-}

--- a/pkg/controllers/job/job_controller_resync.go
+++ b/pkg/controllers/job/job_controller_resync.go
@@ -65,9 +65,6 @@ func (cc *jobcontroller) processResyncTask() {
 }
 
 func (cc *jobcontroller) syncTask(oldTask *v1.Pod) error {
-	cc.Mutex.Lock()
-	defer cc.Mutex.Unlock()
-
 	newPod, err := cc.kubeClient.CoreV1().Pods(oldTask.Namespace).Get(context.TODO(), oldTask.Name, metav1.GetOptions{})
 	if err != nil {
 		if errors.IsNotFound(err) {


### PR DESCRIPTION
Remove the mutex simultaneously, which is used to protect priorityclass 