### PR TITLE
Remove creationTimestamp comparation in jobOrderFn of gang plugin

### DIFF
--- a/pkg/scheduler/plugins/gang/gang.go
+++ b/pkg/scheduler/plugins/gang/gang.go
@@ -119,17 +119,6 @@ func (gp *gangPlugin) OnSessionOpen(ssn *framework.Session) {
 			return -1
 		}
 
-		if !lReady && !rReady {
-			if lv.CreationTimestamp.Equal(&rv.CreationTimestamp) {
-				if lv.UID < rv.UID {
-					return -1
-				}
-			} else if lv.CreationTimestamp.Before(&rv.CreationTimestamp) {
-				return -1
-			}
-			return 1
-		}
-
 		return 0
 	}
 


### PR DESCRIPTION
The creationTimestamp comparation in jobOrderFn of gang plugin should be removed, otherwise, the scheduler will ignore the jobOrderFn of other plugins.  The creationTimestamp comparation should be the last approach to use if all jobOrderFn return 0.