### PR TITLE
feat(scheduler): support resource quota consideration during pod group enqueue procedure

### DIFF
--- a/cmd/scheduler/app/options/options.go
+++ b/cmd/scheduler/app/options/options.go
@@ -57,9 +57,10 @@ type ServerOption struct {
 	HealthzBindAddress string
 
 	// Parameters for scheduling tuning: the number of feasible nodes to find and score
-	MinNodesToFind             int32
-	MinPercentageOfNodesToFind int32
-	PercentageOfNodesToFind    int32
+	MinNodesToFind                     int32
+	MinPercentageOfNodesToFind         int32
+	PercentageOfNodesToFind            int32
+	ConsiderResourceQuotaDuringEnqueue bool
 }
 
 // ServerOpts server options.
@@ -101,6 +102,8 @@ func (s *ServerOption) AddFlags(fs *pflag.FlagSet) {
 
 	// The percentage of nodes that would be scored in each scheduling cycle; if <= 0, an adpative percentage will be calcuated
 	fs.Int32Var(&s.PercentageOfNodesToFind, "percentage-nodes-to-find", defaultPercentageOfNodesToFind, "The percentage of nodes to find and score, if <=0 will be calcuated based on the cluster size")
+	fs.BoolVar(&s.ConsiderResourceQuotaDuringEnqueue, "consider-resource-quota-during-enqueue", false,
+		"Take resourceQuotas of the namespace into consideration during podgroup enqueue procedure; to enable it, set it true")
 }
 
 // CheckOptionOrDie check lock-object-namespace when LeaderElection is enabled.

--- a/pkg/scheduler/api/namespace_info.go
+++ b/pkg/scheduler/api/namespace_info.go
@@ -20,6 +20,9 @@ import (
 	"fmt"
 
 	v1 "k8s.io/api/core/v1"
+	v1helper "k8s.io/kubernetes/pkg/apis/core/v1/helper"
+	"strings"
+
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog"
 )
@@ -40,6 +43,10 @@ type NamespaceInfo struct {
 	Name NamespaceName
 	// Weight is the highest weight among many ResourceQuota.
 	Weight int64
+	// RQStatus stores the ResourceQuotaStatus of all ResourceQuotas in this namespace
+	RQStatus map[string]v1.ResourceQuotaStatus
+
+	RQToResource *Resource
 }
 
 // GetWeight returns weight of a namespace, any invalid case would get default value
@@ -48,6 +55,14 @@ func (n *NamespaceInfo) GetWeight() int64 {
 		return DefaultNamespaceWeight
 	}
 	return n.Weight
+}
+
+// GetResourceQuotaStatus returns ResourceQuotaStatus of a namespace
+func (n *NamespaceInfo) GetResource() *Resource {
+	if n == nil {
+		return EmptyResource()
+	}
+	return n.RQToResource
 }
 
 type quotaItem struct {
@@ -75,13 +90,19 @@ type NamespaceCollection struct {
 	Name string
 
 	quotaWeight *cache.Heap
+
+	RQStatus map[string]v1.ResourceQuotaStatus
+
+	RQToResource *Resource
 }
 
 // NewNamespaceCollection creates new NamespaceCollection object to record all information about a namespace
 func NewNamespaceCollection(name string) *NamespaceCollection {
 	n := &NamespaceCollection{
-		Name:        name,
-		quotaWeight: cache.NewHeap(quotaItemKeyFunc, quotaItemLessFunc),
+		Name:         name,
+		quotaWeight:  cache.NewHeap(quotaItemKeyFunc, quotaItemLessFunc),
+		RQStatus:     make(map[string]v1.ResourceQuotaStatus),
+		RQToResource: EmptyResource(),
 	}
 	// add at least one item into quotaWeight.
 	// Because cache.Heap.Pop would be blocked until queue is not empty
@@ -118,11 +139,19 @@ func itemFromQuota(quota *v1.ResourceQuota) *quotaItem {
 // Update modify the registered information according quota object
 func (n *NamespaceCollection) Update(quota *v1.ResourceQuota) {
 	n.updateWeight(itemFromQuota(quota))
+	n.RQStatus[quota.Name] = quota.Status
+	n.RQToResource = n.convertResourceQuotaToResource(n.RQStatus)
 }
 
 // Delete remove the registered information according quota object
 func (n *NamespaceCollection) Delete(quota *v1.ResourceQuota) {
 	n.deleteWeight(itemFromQuota(quota))
+	delete(n.RQStatus, quota.Name)
+	if len(n.RQStatus) == 0 {
+		n.RQToResource = EmptyResource()
+	} else {
+		n.RQToResource = n.convertResourceQuotaToResource(n.RQStatus)
+	}
 }
 
 // Snapshot will clone a NamespaceInfo without Heap according NamespaceCollection
@@ -139,7 +168,43 @@ func (n *NamespaceCollection) Snapshot() *NamespaceInfo {
 	}
 
 	return &NamespaceInfo{
-		Name:   NamespaceName(n.Name),
-		Weight: weight,
+		Name:         NamespaceName(n.Name),
+		Weight:       weight,
+		RQStatus:     n.RQStatus,
+		RQToResource: n.RQToResource,
 	}
+}
+
+func (n *NamespaceCollection) convertResourceQuotaToResource(rQstatus map[string]v1.ResourceQuotaStatus) *Resource {
+	resourceTarget := EmptyResource()
+	resourceTarget.ScalarResources = make(map[v1.ResourceName]float64)
+	notFirstTimeSet := make(map[v1.ResourceName]bool)
+
+	klog.V(3).Infof("Convert resourceQuotaStatus to api resource")
+	for _, rQValue := range rQstatus {
+		for rName, rValue := range rQValue.Hard {
+			rValue.Sub(rQValue.Used[rName])
+			sName := v1.ResourceName(strings.TrimPrefix(string(rName), v1.DefaultResourceRequestsPrefix))
+			switch sName {
+			case v1.ResourceCPU:
+				if resourceTarget.MilliCPU > float64(rValue.MilliValue()) || !notFirstTimeSet[sName] {
+					resourceTarget.MilliCPU = float64(rValue.MilliValue())
+					notFirstTimeSet[sName] = true
+				}
+			case v1.ResourceMemory:
+				if resourceTarget.Memory > float64(rValue.Value()) || !notFirstTimeSet[sName] {
+					resourceTarget.Memory = float64(rValue.Value())
+					notFirstTimeSet[sName] = true
+				}
+			default:
+				if v1helper.IsScalarResourceName(sName) {
+					if resourceTarget.ScalarResources[sName] > float64(rValue.MilliValue()) || !notFirstTimeSet[sName] {
+						resourceTarget.ScalarResources[sName] = float64(rValue.MilliValue())
+						notFirstTimeSet[sName] = true
+					}
+				}
+			}
+		}
+	}
+	return resourceTarget
 }

--- a/pkg/scheduler/api/namespace_info_test.go
+++ b/pkg/scheduler/api/namespace_info_test.go
@@ -16,11 +16,11 @@ limitations under the License.
 package api
 
 import (
-	"testing"
-
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"reflect"
+	"testing"
 )
 
 func newQuota(name string, weight int) *v1.ResourceQuota {
@@ -41,17 +41,64 @@ func newQuota(name string, weight int) *v1.ResourceQuota {
 	return q
 }
 
+func newQuotaWithResource(name string, weight int, quotaHard []string, quotaUsed []string) *v1.ResourceQuota {
+	q := &v1.ResourceQuota{
+		TypeMeta: metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Spec: v1.ResourceQuotaSpec{
+			Hard: v1.ResourceList{
+				v1.ResourceRequestsCPU:        resource.MustParse(quotaHard[0]),
+				v1.ResourceRequestsMemory:     resource.MustParse(quotaHard[1]),
+				"requests." + GPUResourceName: resource.MustParse(quotaHard[2]),
+			},
+		},
+		Status: v1.ResourceQuotaStatus{
+			Hard: v1.ResourceList{
+				v1.ResourceRequestsCPU:        resource.MustParse(quotaHard[0]),
+				v1.ResourceRequestsMemory:     resource.MustParse(quotaHard[1]),
+				"requests." + GPUResourceName: resource.MustParse(quotaHard[2]),
+			},
+			Used: v1.ResourceList{
+				v1.ResourceRequestsCPU:        resource.MustParse(quotaUsed[0]),
+				v1.ResourceRequestsMemory:     resource.MustParse(quotaUsed[1]),
+				"requests." + GPUResourceName: resource.MustParse(quotaUsed[2]),
+			},
+		},
+	}
+
+	if weight >= 0 {
+		q.Spec.Hard[v1.ResourceName(NamespaceWeightKey)] = *resource.NewQuantity(int64(weight), resource.DecimalSI)
+	}
+
+	return q
+}
+
+func expectResource(resource []float64) *Resource {
+	return &Resource{
+		MilliCPU: resource[0],
+		Memory:   resource[1],
+		ScalarResources: map[v1.ResourceName]float64{
+			GPUResourceName: resource[2],
+		},
+	}
+}
+
 func TestNamespaceCollection(t *testing.T) {
 	c := NewNamespaceCollection("testCollection")
-	c.Update(newQuota("abc", 123))
-	c.Update(newQuota("abc", 456))
-	c.Update(newQuota("def", -1))
-	c.Update(newQuota("def", 16))
+	c.Update(newQuotaWithResource("abc", 123, []string{"8", "80000000", "8"}, []string{"2", "30000000", "2"}))
+	c.Update(newQuotaWithResource("abc", 456, []string{"5", "70000000", "5"}, []string{"2", "30000000", "2"}))
+	c.Update(newQuotaWithResource("def", -1, []string{"9", "90000000", "6"}, []string{"2", "30000000", "2"}))
+	c.Update(newQuotaWithResource("def", 16, []string{"9", "60000000", "4"}, []string{"2", "30000000", "2"}))
 	c.Update(newQuota("ghi", 0))
 
 	info := c.Snapshot()
 	if info.Weight != 456 {
 		t.Errorf("weight of namespace should be %d, but not %d", 456, info.Weight)
+	}
+	if !reflect.DeepEqual(info.RQToResource, expectResource([]float64{float64(3000), float64(30000000), float64(2000)})) {
+		t.Errorf("Convert resource test failed, expected %+v, but got %+v", expectResource([]float64{float64(3000), float64(30000000), float64(2000)}), info.RQToResource)
 	}
 
 	c.Delete(newQuota("abc", 0))
@@ -59,6 +106,12 @@ func TestNamespaceCollection(t *testing.T) {
 	info = c.Snapshot()
 	if info.Weight != 16 {
 		t.Errorf("weight of namespace should be %d, but not %d", 16, info.Weight)
+	}
+	if _, ok := info.RQStatus["abc"]; ok {
+		t.Errorf("RQStatus abc of namespace should not exist")
+	}
+	if !reflect.DeepEqual(info.RQToResource, expectResource([]float64{float64(7000), float64(30000000), float64(2000)})) {
+		t.Errorf("Convert resource test failed, expected %+v, but got %+v", expectResource([]float64{float64(7000), float64(30000000), float64(2000)}), info.RQToResource)
 	}
 
 	c.Delete(newQuota("abc", 0))
@@ -68,6 +121,9 @@ func TestNamespaceCollection(t *testing.T) {
 	info = c.Snapshot()
 	if info.Weight != DefaultNamespaceWeight {
 		t.Errorf("weight of namespace should be default weight %d, but not %d", DefaultNamespaceWeight, info.Weight)
+	}
+	if !reflect.DeepEqual(info.RQToResource, EmptyResource()) {
+		t.Errorf("resource should be equal to EmptyResource()")
 	}
 }
 


### PR DESCRIPTION
Try to solve: https://github.com/volcano-sh/volcano/issues/1014

1. Take resourceQuota in the namespace into consideration during podGroup enqueue procedure

For example you can set your resource quota as follows, then your podGroup will stay in pending state if the resource request plus usage is more than quota  

```yaml
spec:
  hard:
    requests.cpu: "32"
    requests.memory: 32Gi
    requests.nvidia.com/gpu: "10"
```

2. Add a flag to control this feature, default is “false“, which means disable