### PR TITLE
Fair Scheduling For Jobs Of Same Priority And Different Queue

### DIFF
--- a/pkg/scheduler/actions/allocate/allocate.go
+++ b/pkg/scheduler/actions/allocate/allocate.go
@@ -146,7 +146,7 @@ func (alloc *Action) Execute(ssn *framework.Session) {
 				continue
 			}
 
-			if queue == nil || ssn.QueueOrderFn(currentQueue, queue) {
+			if queue == nil || ssn.JobPriorityQueueOrderFn(queueInNamespace[currentQueue.UID], queueInNamespace[queue.UID]) {
 				queue = currentQueue
 			}
 		}

--- a/pkg/scheduler/util/priority_queue.go
+++ b/pkg/scheduler/util/priority_queue.go
@@ -47,6 +47,11 @@ func (q *PriorityQueue) Push(it interface{}) {
 	heap.Push(&q.queue, it)
 }
 
+// Top get first element in the priority Queue
+func (q *PriorityQueue) Top() interface{} {
+	return q.queue.Top()
+}
+
 // Pop pops element in the priority Queue
 func (q *PriorityQueue) Pop() interface{} {
 	if q.Len() == 0 {
@@ -90,5 +95,11 @@ func (pq *priorityQueue) Pop() interface{} {
 	n := len(old)
 	item := old[n-1]
 	(*pq).items = old[0 : n-1]
+	return item
+}
+
+func (pq *priorityQueue) Top() interface{} {
+	n := len((*pq).items)
+	item := (*pq).items[n-1]
 	return item
 }


### PR DESCRIPTION
fair scheduling for jobs of same priority and different queue, add top() to priority queue and add compare job create timestamp towards different queue.
