### PR TITLE
Fix queue unknown state bug

### DIFF
--- a/pkg/controllers/queue/state/closing.go
+++ b/pkg/controllers/queue/state/closing.go
@@ -47,7 +47,7 @@ func (cs *closingState) Execute(action v1alpha1.Action) error {
 				return
 			}
 
-			if specState == v1beta1.QueueStateClosed {
+			if specState == v1beta1.QueueStateClosing {
 				if len(podGroupList) == 0 {
 					status.State = v1beta1.QueueStateClosed
 					return


### PR DESCRIPTION
When queue in `closing` state, delete a volcano job will trigger `SyncQueue`, we need check the current queue state if `QueueStateClosing`  instead of `QueueStateClosed `