### PR TITLE
Disable monitoring in the chart by default

### DIFF
--- a/installer/helm/chart/volcano/templates/grafana.yaml
+++ b/installer/helm/chart/volcano/templates/grafana.yaml
@@ -1,8 +1,9 @@
+{{ if .Values.monitoring.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: grafana-datasources
-  namespace: volcano-monitoring
+  namespace: {{ .Values.monitoring.namespace }}
 data:
   prometheus.yaml: |-
     {
@@ -26,7 +27,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: grafana-volcano-dashboard-config
-  namespace: volcano-monitoring
+  namespace: {{ .Values.monitoring.namespace }}
 data:
   dashboard.yaml: |-
     apiVersion: 1
@@ -42,7 +43,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: grafana-volcano-dashboard
-  namespace: volcano-monitoring
+  namespace: {{ .Values.monitoring.namespace }}
 data:
   volcano-dashboard.json: |-
     {"annotations":{"list":[{"builtIn":1,"datasource":"prometheus","enable":true,"hide":true,"iconColor":"rgba(0, 211, 255, 1)","name":"Annotations & Alerts","type":"dashboard"}]},"editable":true,"gnetId":null,"graphTooltip":0,"id":10,"links":[],"panels":[{"collapsed":false,"gridPos":{"h":1,"w":24,"x":0,"y":0},"id":13,"panels":[],"title":"Volcano Fairness","type":"row"},{"aliasColors":{},"bars":false,"dashLength":10,"dashes":false,"fill":1,"gridPos":{"h":7,"w":15,"x":0,"y":1},"id":14,"legend":{"avg":false,"current":false,"max":false,"min":false,"show":true,"total":false,"values":false},"lines":true,"linewidth":1,"links":[],"nullPointMode":"null","paceLength":10,"percentage":false,"pointradius":2,"points":false,"renderer":"flot","seriesOverrides":[],"stack":false,"steppedLine":false,"targets":[{"expr":"stddev(volcano_e2e_job_scheduling_duration)/avg(volcano_e2e_job_scheduling_duration)","format":"time_series","intervalFactor":1,"legendFormat":"CV (Job Duration)","refId":"A"}],"thresholds":[],"timeFrom":null,"timeRegions":[],"timeShift":null,"title":"Job Duration Coefficient Of Variation","tooltip":{"shared":true,"sort":0,"value_type":"individual"},"transparent":true,"type":"graph","xaxis":{"buckets":null,"mode":"time","name":null,"show":true,"values":[]},"yaxes":[{"format":"percentunit","label":null,"logBase":1,"max":null,"min":null,"show":true},{"format":"short","label":null,"logBase":1,"max":null,"min":null,"show":true}],"yaxis":{"align":false,"alignLevel":null}},{"collapsed":false,"gridPos":{"h":1,"w":24,"x":0,"y":8},"id":11,"panels":[],"title":"Volcano Effectiveness","type":"row"},{"cacheTimeout":null,"colorBackground":false,"colorValue":false,"colors":["#299c46","rgba(237, 129, 40, 0.89)","#d44a3a"],"format":"percentunit","gauge":{"maxValue":1,"minValue":0,"show":true,"thresholdLabels":false,"thresholdMarkers":true},"gridPos":{"h":7,"w":3,"x":0,"y":9},"id":2,"interval":null,"links":[],"mappingType":1,"mappingTypes":[{"name":"value to text","value":1},{"name":"range to text","value":2}],"maxDataPoints":100,"nullPointMode":"connected","nullText":null,"postfix":"","postfixFontSize":"50%","prefix":"","prefixFontSize":"50%","rangeMaps":[{"from":"null","text":"N/A","to":"null"}],"sparkline":{"fillColor":"rgba(31, 118, 189, 0.18)","full":false,"lineColor":"rgb(31, 120, 193)","show":false},"tableColumn":"","targets":[{"expr":"sum(kube_pod_container_resource_requests{resource=\"cpu\"})/sum(kube_node_status_allocatable_cpu_cores)","format":"time_series","instant":false,"interval":"","intervalFactor":1,"legendFormat":"","refId":"A"}],"thresholds":"0.7,0.9","timeFrom":null,"timeShift":null,"title":"Volcano Cluster Average CPU Usage","transparent":true,"type":"singlestat","valueFontSize":"80%","valueMaps":[{"op":"=","text":"N/A","value":"null"}],"valueName":"current"},{"cacheTimeout":null,"colorBackground":false,"colorValue":false,"colors":["#299c46","rgba(237, 129, 40, 0.89)","#d44a3a"],"format":"percentunit","gauge":{"maxValue":1,"minValue":0,"show":true,"thresholdLabels":false,"thresholdMarkers":true},"gridPos":{"h":7,"w":3,"x":3,"y":9},"id":3,"interval":null,"links":[],"mappingType":1,"mappingTypes":[{"name":"value to text","value":1},{"name":"range to text","value":2}],"maxDataPoints":100,"nullPointMode":"connected","nullText":null,"postfix":"","postfixFontSize":"50%","prefix":"","prefixFontSize":"50%","rangeMaps":[{"from":"null","text":"N/A","to":"null"}],"sparkline":{"fillColor":"rgba(31, 118, 189, 0.18)","full":false,"lineColor":"rgb(31, 120, 193)","show":false},"tableColumn":"","targets":[{"expr":"sum(kube_pod_container_resource_requests{resource=\"memory\"})/sum(kube_node_status_allocatable_memory_bytes)","format":"time_series","instant":false,"interval":"","intervalFactor":1,"legendFormat":"","refId":"A"}],"thresholds":"0.7,0.9","timeFrom":null,"timeShift":null,"title":"Volcano Cluster Average Memory Usage","transparent":true,"type":"singlestat","valueFontSize":"80%","valueMaps":[{"op":"=","text":"N/A","value":"null"}],"valueName":"current"},{"cacheTimeout":null,"colorBackground":false,"colorValue":false,"colors":["#299c46","rgba(237, 129, 40, 0.89)","#d44a3a"],"format":"percentunit","gauge":{"maxValue":1,"minValue":0,"show":true,"thresholdLabels":false,"thresholdMarkers":true},"gridPos":{"h":7,"w":3,"x":6,"y":9},"id":4,"interval":null,"links":[],"mappingType":1,"mappingTypes":[{"name":"value to text","value":1},{"name":"range to text","value":2}],"maxDataPoints":100,"nullPointMode":"connected","nullText":null,"postfix":"","postfixFontSize":"50%","prefix":"","prefixFontSize":"50%","rangeMaps":[{"from":"null","text":"N/A","to":"null"}],"sparkline":{"fillColor":"rgba(31, 118, 189, 0.18)","full":false,"lineColor":"rgb(31, 120, 193)","show":false},"tableColumn":"","targets":[{"expr":"sum(kube_pod_container_resource_requests{resource=\"nvidia_com_gpu\"})/sum(kube_node_status_capacity{resource=\"nvidia_com_gpu\"})","format":"time_series","instant":false,"interval":"","intervalFactor":1,"legendFormat":"","refId":"A"}],"thresholds":"0.7,0.9","timeFrom":null,"timeShift":null,"title":"Volcano Cluster Average GPU Usage","transparent":true,"type":"singlestat","valueFontSize":"80%","valueMaps":[{"op":"=","text":"N/A","value":"null"}],"valueName":"current"},{"aliasColors":{},"bars":false,"dashLength":10,"dashes":false,"fill":1,"gridPos":{"h":7,"w":15,"x":0,"y":16},"id":6,"legend":{"avg":false,"current":false,"max":false,"min":false,"show":true,"total":false,"values":false},"lines":true,"linewidth":1,"links":[],"nullPointMode":"null","paceLength":10,"percentage":false,"pointradius":2,"points":false,"renderer":"flot","seriesOverrides":[],"stack":false,"steppedLine":false,"targets":[{"expr":"stddev(sum by (node) (kube_pod_container_resource_requests{resource=\"cpu\"}))/avg(sum by (node) (kube_pod_container_resource_requests{resource=\"cpu\"}))","format":"time_series","intervalFactor":1,"legendFormat":"CV (CPU)","refId":"A"},{"expr":"stddev(sum by (node) (kube_pod_container_resource_requests{resource=\"memory\"}))/avg(sum by (node) (kube_pod_container_resource_requests{resource=\"memory\"}))","format":"time_series","intervalFactor":1,"legendFormat":"CV (Memory)","refId":"B"},{"expr":"stddev(sum by (node) (kube_pod_container_resource_requests{resource=\"nvidia_com_gpu\"}))/avg(sum by (node) (kube_pod_container_resource_requests{resource=\"nvidia_com_gpu\"}))","format":"time_series","intervalFactor":1,"legendFormat":"CV (Nvidia GPU)","refId":"C"}],"thresholds":[],"timeFrom":null,"timeRegions":[],"timeShift":null,"title":"Node Resource Coefficient Of Variation","tooltip":{"shared":true,"sort":0,"value_type":"individual"},"transparent":true,"type":"graph","xaxis":{"buckets":null,"mode":"time","name":null,"show":true,"values":[]},"yaxes":[{"format":"percentunit","label":null,"logBase":1,"max":null,"min":null,"show":true},{"format":"short","label":null,"logBase":1,"max":null,"min":null,"show":true}],"yaxis":{"align":false,"alignLevel":null}}],"schemaVersion":18,"style":"dark","tags":[],"templating":{"list":[]},"time":{"from":"now-6h","to":"now"},"timepicker":{"refresh_intervals":["5s","10s","30s","1m","5m","15m","30m","1h","2h","1d"],"time_options":["5m","15m","1h","6h","12h","24h","2d","7d","30d"]},"timezone":"","title":"Volcano Overview Dashboard","uid":"nYn30KvMz","version":15}
@@ -51,7 +52,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: grafana
-  namespace: volcano-monitoring
+  namespace: {{ .Values.monitoring.namespace }}
 spec:
   replicas: 1
   selector:
@@ -108,7 +109,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: grafana
-  namespace: volcano-monitoring
+  namespace: {{ .Values.monitoring.namespace }}
   annotations:
       prometheus.io/scrape: 'true'
       prometheus.io/port:   '3000'
@@ -120,3 +121,4 @@ spec:
     - port: 3000
       targetPort: 3000
       nodePort: 30004
+{{ end }}

--- a/installer/helm/chart/volcano/templates/kubestatemetrics.yaml
+++ b/installer/helm/chart/volcano/templates/kubestatemetrics.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.monitoring.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -129,13 +130,13 @@ metadata:
   labels:
     app.kubernetes.io/name: kube-state-metrics
   name: kube-state-metrics
-  namespace: volcano-monitoring
+  namespace: {{ .Values.monitoring.namespace }}
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: kube-state-metrics 
-  namespace: volcano-monitoring
+  namespace: {{ .Values.monitoring.namespace }}
   labels:
     k8s-app: kube-state-metrics  
 spec:
@@ -178,7 +179,7 @@ metadata:
   labels:
     app.kubernetes.io/name: kube-state-metrics
   name: kube-state-metrics
-  namespace: volcano-monitoring
+  namespace: {{ .Values.monitoring.namespace }}
   annotations:
     prometheus.io/path: /metrics
     prometheus.io/port: "8080"
@@ -193,3 +194,4 @@ spec:
     targetPort: telemetry
   selector:
     k8s-app: kube-state-metrics
+{{ end }}

--- a/installer/helm/chart/volcano/templates/prometheus.yaml
+++ b/installer/helm/chart/volcano/templates/prometheus.yaml
@@ -1,4 +1,5 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+{{ if .Values.monitoring.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: prometheus
@@ -20,7 +21,7 @@ rules:
   verbs: ["get"]
 
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: prometheus
@@ -31,7 +32,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: default
-  namespace: volcano-monitoring
+  namespace: {{ .Values.monitoring.namespace }}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -39,7 +40,7 @@ metadata:
   name: prometheus-server-conf
   labels:
     name: prometheus-server-conf
-  namespace: volcano-monitoring
+  namespace: {{ .Values.monitoring.namespace }}
 data:
   prometheus.rules: |-
     groups:
@@ -132,7 +133,7 @@ data:
       
       - job_name: 'kube-state-metrics'
         static_configs:
-          - targets: ['kube-state-metrics.volcano-monitoring.svc.cluster.local:8080']
+          - targets: ['kube-state-metrics.{{ .Values.monitoring.namespace }}.svc.cluster.local:8080']
 
       - job_name: 'kubernetes-cadvisor'
 
@@ -190,7 +191,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: prometheus-deployment
-  namespace: volcano-monitoring
+  namespace: {{ .Values.monitoring.namespace }}
   labels:
     app: prometheus-server
 spec:
@@ -229,7 +230,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: prometheus-service
-  namespace: volcano-monitoring
+  namespace: {{ .Values.monitoring.namespace }}
   annotations:
       prometheus.io/scrape: 'true'
       prometheus.io/port:   '9090'
@@ -242,3 +243,4 @@ spec:
     - port: 8080
       targetPort: 9090 
       nodePort: 30003
+{{ end }}

--- a/installer/helm/chart/volcano/values.yaml
+++ b/installer/helm/chart/volcano/values.yaml
@@ -7,3 +7,7 @@ basic:
   scheduler_config_file: "config/volcano-scheduler.conf"
   image_pull_secret: ""
   admission_port: 8443
+
+monitoring:
+  enabled: false
+  namespace: volcano-monitoring


### PR DESCRIPTION
Hey all,

This is my first PR. I am reviewing Volcano for use by my company and I wanted to help by making PR's or issues for everything I am running into trouble with.
So while applying the helm chart I ran into trouble that the volcano-monitoring namespace did not exist, I am already running my own monitoring solution so I don't need an extra one. So I made a PR to disable it. 

Please feel give me feedback on this.

I am also running into trouble with the `volcano-system` namespace. Not sure what I can do with that resource though for now created the namespace manually.