### PR TITLE
fix: fix scheduler deployment  warnning log 

### DIFF
--- a/pkg/scheduler/plugins/util/util.go
+++ b/pkg/scheduler/plugins/util/util.go
@@ -69,6 +69,10 @@ func NewPodLister(ssn *framework.Session) *PodLister {
 
 			for _, task := range tasks {
 				pl.Tasks[task.UID] = task
+
+				pod := pl.copyTaskPod(task)
+				pl.CachedPods[task.UID] = pod
+
 				if HaveAffinity(task.Pod) {
 					pl.TaskWithAffinity[task.UID] = task
 				}


### PR DESCRIPTION
for predicates plugin
OnSessionOpen 1. call util.NewPodLister(ssn) to get allocate pod info
2. pl.List(labels.NewSelector()) get pod info from PodLister that util.NewPodLister return, but util.NewPodLister  didn't fill  the member "CachedPods" which lead to  log "DeepCopy for pod %s/%s at PodLister.GetPod is unexpected"