### PR TITLE
feat: mutate default of job spec

### DIFF
--- a/pkg/apis/batch/v1alpha1/job.go
+++ b/pkg/apis/batch/v1alpha1/job.go
@@ -52,6 +52,7 @@ type JobSpec struct {
 	SchedulerName string `json:"schedulerName,omitempty" protobuf:"bytes,1,opt,name=schedulerName"`
 
 	// The minimal available pods to run for this Job
+	// Defaults to the summary of tasks' replicas
 	// +optional
 	MinAvailable int32 `json:"minAvailable,omitempty" protobuf:"bytes,2,opt,name=minAvailable"`
 

--- a/pkg/controllers/job/state/restarting.go
+++ b/pkg/controllers/job/state/restarting.go
@@ -29,10 +29,7 @@ type restartingState struct {
 func (ps *restartingState) Execute(action v1alpha1.Action) error {
 	return KillJob(ps.job, PodRetainPhaseNone, func(status *vcbatch.JobStatus) bool {
 		// Get the maximum number of retries.
-		maxRetry := DefaultMaxRetry
-		if ps.job.Job.Spec.MaxRetry != 0 {
-			maxRetry = ps.job.Job.Spec.MaxRetry
-		}
+		maxRetry := ps.job.Job.Spec.MaxRetry
 
 		if status.RetryCount >= maxRetry {
 			// Failed is the phase that the job is restarted failed reached the maximum number of retries.

--- a/pkg/controllers/job/state/util.go
+++ b/pkg/controllers/job/state/util.go
@@ -20,9 +20,6 @@ import (
 	vcbatch "volcano.sh/volcano/pkg/apis/batch/v1alpha1"
 )
 
-// DefaultMaxRetry is the default number of retries.
-const DefaultMaxRetry int32 = 3
-
 // TotalTasks returns number of tasks in a given volcano job.
 func TotalTasks(job *vcbatch.Job) int32 {
 	var rep int32

--- a/pkg/webhooks/admission/jobs/mutate/mutate_job.go
+++ b/pkg/webhooks/admission/jobs/mutate/mutate_job.go
@@ -35,6 +35,8 @@ import (
 const (
 	// DefaultQueue constant stores the name of the queue as "default"
 	DefaultQueue = "default"
+	// DefaultMaxRetry is the default number of retries.
+	DefaultMaxRetry = 3
 
 	defaultSchedulerName = "volcano"
 )
@@ -110,6 +112,14 @@ func createPatch(job *v1alpha1.Job) ([]byte, error) {
 	if pathScheduler != nil {
 		patch = append(patch, *pathScheduler)
 	}
+	pathMaxRetry := patchDefaultMaxRetry(job)
+	if pathMaxRetry != nil {
+		patch = append(patch, *pathMaxRetry)
+	}
+	pathMinAvailable := patchDefaultMinAvailable(job)
+	if pathMinAvailable != nil {
+		patch = append(patch, *pathMinAvailable)
+	}
 	pathSpec := mutateSpec(job.Spec.Tasks, "/spec/tasks")
 	if pathSpec != nil {
 		patch = append(patch, *pathSpec)
@@ -129,6 +139,27 @@ func patchDefaultScheduler(job *v1alpha1.Job) *patchOperation {
 	// Add default scheduler name if not specified.
 	if job.Spec.SchedulerName == "" {
 		return &patchOperation{Op: "add", Path: "/spec/schedulerName", Value: defaultSchedulerName}
+	}
+	return nil
+}
+
+func patchDefaultMaxRetry(job *v1alpha1.Job) *patchOperation {
+	// Add default maxRetry if maxRetry is zero.
+	if job.Spec.MaxRetry == 0 {
+		return &patchOperation{Op: "add", Path: "/spec/maxRetry", Value: DefaultMaxRetry}
+	}
+	return nil
+}
+
+func patchDefaultMinAvailable(job *v1alpha1.Job) *patchOperation {
+	// Add default minAvailable if minAvailable is zero.
+	if job.Spec.MinAvailable == 0 {
+		var totalReplicas int32
+		for _, task := range job.Spec.Tasks {
+			totalReplicas += task.Replicas
+		}
+
+		return &patchOperation{Op: "add", Path: "/spec/minAvailable", Value: totalReplicas}
 	}
 	return nil
 }


### PR DESCRIPTION
Since #1131 needed to modify the API level, some compromises were made. The disadvantage of this is that if the user set the specified field as 0, we will still set the default value, but this will at least not affect the user’s original behavior.