### PR TITLE
fix proportion can not reclaim issue

### DIFF
--- a/pkg/scheduler/api/resource_info.go
+++ b/pkg/scheduler/api/resource_info.go
@@ -412,3 +412,34 @@ func (r *Resource) SetScalar(name v1.ResourceName, quantity float64) {
 	}
 	r.ScalarResources[name] = quantity
 }
+
+// MinDimensionResource is used to reset the r resource dimension which is less than rr
+// e.g r resource is <cpu 2000.00, memory 4047845376.00, hugepages-2Mi 0.00, hugepages-1Gi 0.00>
+// rr resource is <cpu 3000.00, memory 1000.00>
+// return r resource is <cpu 2000.00, memory 1000.00, hugepages-2Mi 0.00, hugepages-1Gi 0.00>
+func (r *Resource) MinDimensionResource(rr *Resource) *Resource {
+
+	if rr.MilliCPU < r.MilliCPU {
+		r.MilliCPU = rr.MilliCPU
+	}
+	if rr.Memory < r.Memory {
+		r.Memory = rr.Memory
+	}
+
+	if rr.ScalarResources == nil {
+		if r.ScalarResources != nil {
+			for name := range r.ScalarResources {
+				r.ScalarResources[name] = 0
+			}
+		}
+	} else {
+		if r.ScalarResources != nil {
+			for name, quant := range rr.ScalarResources {
+				if quant < r.ScalarResources[name] {
+					r.ScalarResources[name] = quant
+				}
+			}
+		}
+	}
+	return r
+}

--- a/pkg/scheduler/api/resource_info_test.go
+++ b/pkg/scheduler/api/resource_info_test.go
@@ -580,3 +580,53 @@ func TestLessEqualStrict(t *testing.T) {
 		}
 	}
 }
+
+func TestMinDimensionResource(t *testing.T) {
+	tests := []struct {
+		resource1 *Resource
+		resource2 *Resource
+		expected  *Resource
+	}{
+		{
+			resource1: &Resource{
+				MilliCPU:        4000,
+				Memory:          2000,
+				ScalarResources: map[v1.ResourceName]float64{"scalar.test/scalar1": 1, "hugepages-test": 2},
+			},
+			resource2: &Resource{
+				MilliCPU:        3000,
+				Memory:          2000,
+				ScalarResources: map[v1.ResourceName]float64{"scalar.test/scalar1": 0, "hugepages-test": 0},
+			},
+			expected: &Resource{
+				MilliCPU:        3000,
+				Memory:          2000,
+				ScalarResources: map[v1.ResourceName]float64{"scalar.test/scalar1": 0, "hugepages-test": 0},
+			},
+		},
+		{
+			resource1: &Resource{
+				MilliCPU:        4000,
+				Memory:          4000,
+				ScalarResources: map[v1.ResourceName]float64{"scalar.test/scalar1": 1000, "hugepages-test": 2000},
+			},
+			resource2: &Resource{
+				MilliCPU:        5000,
+				Memory:          2000,
+				ScalarResources: map[v1.ResourceName]float64{"scalar.test/scalar1": 0, "hugepages-test": 3000},
+			},
+			expected: &Resource{
+				MilliCPU:        4000,
+				Memory:          2000,
+				ScalarResources: map[v1.ResourceName]float64{"scalar.test/scalar1": 0, "hugepages-test": 2000},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		test.resource1.MinDimensionResource(test.resource2)
+		if !reflect.DeepEqual(test.expected, test.resource1) {
+			t.Errorf("expected: %#v, got: %#v", test.expected, test.resource1)
+		}
+	}
+}

--- a/pkg/scheduler/plugins/proportion/proportion.go
+++ b/pkg/scheduler/plugins/proportion/proportion.go
@@ -17,6 +17,8 @@ limitations under the License.
 package proportion
 
 import (
+	"reflect"
+
 	"k8s.io/klog"
 
 	"volcano.sh/volcano/pkg/apis/scheduling"
@@ -151,6 +153,7 @@ func (pp *proportionPlugin) OnSessionOpen(ssn *framework.Session) {
 			break
 		}
 
+		oldRemaining := remaining.Clone()
 		// Calculates the deserved of each Queue.
 		// increasedDeserved is the increased value for attr.deserved of processed queues
 		// decreasedDeserved is the decreased value for attr.deserved of processed queues
@@ -175,6 +178,9 @@ func (pp *proportionPlugin) OnSessionOpen(ssn *framework.Session) {
 				attr.deserved = helpers.Min(attr.deserved, attr.request)
 				meet[attr.queueID] = struct{}{}
 				klog.V(4).Infof("queue <%s> is meet", attr.name)
+			} else {
+				attr.deserved.MinDimensionResource(attr.request)
+				klog.V(4).Infof("Format queue <%s> deserved resource to <%v>", attr.name, attr.deserved)
 			}
 			pp.updateShare(attr)
 
@@ -190,7 +196,8 @@ func (pp *proportionPlugin) OnSessionOpen(ssn *framework.Session) {
 		}
 
 		remaining.Sub(increasedDeserved).Add(decreasedDeserved)
-		if remaining.IsEmpty() {
+		klog.V(4).Infof("Remaining resource is  <%s>", remaining)
+		if remaining.IsEmpty() || reflect.DeepEqual(remaining, oldRemaining) {
 			klog.V(4).Infof("Exiting when remaining is empty:  <%v>", remaining)
 			break
 		}

--- a/pkg/scheduler/plugins/proportion/proportion.go
+++ b/pkg/scheduler/plugins/proportion/proportion.go
@@ -198,7 +198,7 @@ func (pp *proportionPlugin) OnSessionOpen(ssn *framework.Session) {
 		remaining.Sub(increasedDeserved).Add(decreasedDeserved)
 		klog.V(4).Infof("Remaining resource is  <%s>", remaining)
 		if remaining.IsEmpty() || reflect.DeepEqual(remaining, oldRemaining) {
-			klog.V(4).Infof("Exiting when remaining is empty:  <%v>", remaining)
+			klog.V(4).Infof("Exiting when remaining is empty or no queue has more reosurce request:  <%v>", remaining)
 			break
 		}
 	}


### PR DESCRIPTION
## Root cause:
In proportion.go, it will calculate `deserved`  value for each queue. If queue's `request` is larger than  `deserved`,  we also need format each dimension value of  `deserved`.
For example:
we submit jobs in queue1 first, then submit jobs in queue2.
Cluster total resource is `<cpu 4000.00, memory 8095690752.00, hugepages-1Gi 0.00, hugepages-2Mi 0.00>`. 
Queue1 weight is 1 and requests `<cpu 3000.00, memory 0.00>` 
Queue2 weight is 1 and requests `<cpu 3000.00, memory 0.00>`
For the current logic, after proportion calculate,  we got:
Queue1's deserved value is `<cpu 2000.00, memory 4047845376.00, hugepages-1Gi 0.00, hugepages-2Mi 0.00>`
Queue2's deserved value is `<cpu 2000.00, memory 4047845376.00, hugepages-1Gi 0.00, hugepages-2Mi 0.00>`

The above logic have two logic mistakes:
1）queue1 and queue2 does not request any memory resource, but `deserved` value has. If other queue request memory resource, this will lead that queue can not get all the free memory reosurce
2)  In `ReclaimableFn` it checks if tasks can be added into victims
```
if attr.deserved.LessEqualStrict(allocated) {
    victims = append(victims, reclaimee)
}
```
For the current logic Queue1  deserved  `<cpu 2000.00, memory 4047845376.00, hugepages-1Gi 0.00, hugepages-2Mi 0.00>` is not Less than Queue1 allocate `<cpu 3000.00, memory 0.00>` So, Queue2 can not reclaim any resource from Queue1.

Actually, the correct deserved value should be:
Queue1 `<cpu 2000.00, memory 0.000, hugepages-1Gi 0.00, hugepages-2Mi 0.00>`
Queue2 `<cpu 2000.00, memory 0.00, hugepages-1Gi 0.00, hugepages-2Mi 0.00>`

## Solution:
1) For unmeet queue case, we should re-format each dimension value of  `deserved` value.
For example, if the deserved is `<cpu 2000.00, memory 4047845376.00, hugepages-1Gi 0.00, hugepages-2Mi 0.00>` and request is `<cpu 3000.00, memory 0.00>`, after format, the final deserved value should be `<cpu 2000.00, memory 0, hugepages-1Gi 0.00, hugepages-2Mi 0.00>`

2) If no queue require the remaining resource, then we can break the `deserved` calculate process.