### PR TITLE
Fix: prepare-for-development dead link

### DIFF
--- a/docs/development/prepare-for-development.md
+++ b/docs/development/prepare-for-development.md
@@ -7,7 +7,6 @@ need to set up before being able to build and run the code.
 
 - [Setting up Go](#setting-up-go)
 - [Setting up Docker](#setting-up-docker)
-- [Other dependencies](#other-dependencies)
 - [Setting up Kubernetes](#setting-up-kubernetes)
 - [Setting up personal access token](#setting-up-a-personal-access-token)
 


### PR DESCRIPTION
The `prepare-for-development.d` had a dead link that wasn't pointing to anything. It was confusing to have a link that wasn't doing anything.