### PR TITLE
Fix  #1218 CI

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -46,6 +46,12 @@ jobs:
         with:
           go-version: 1.14.x
 
+      - name: Install musl
+        run: |
+          wget http://musl.libc.org/releases/musl-1.2.1.tar.gz
+          tar -xf musl-1.2.1.tar.gz && cd musl-1.2.1
+          ./configure
+          make && sudo make install
       - uses: actions/cache@v2
         with:
           path: ~/go/pkg/mod
@@ -55,15 +61,13 @@ jobs:
         run: |
           GO111MODULE="on" go get sigs.k8s.io/kind@v0.6.1
           curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.16.6/bin/linux/amd64/kubectl && sudo install kubectl /usr/local/bin/kubectl
-
-
       - name: Checkout code
         uses: actions/checkout@v2
 
       - run: |
-         make vcctl
-         make images
-         make e2e-test-jobp
+          make vcctl
+          make images CC=/usr/local/musl/bin/musl-gcc
+          make e2e-test-jobp
 
   e2e_sequence:
     runs-on: ubuntu-latest
@@ -74,6 +78,12 @@ jobs:
         with:
           go-version: 1.14.x
 
+      - name: Install musl
+        run: |
+          wget http://musl.libc.org/releases/musl-1.2.1.tar.gz
+          tar -xf musl-1.2.1.tar.gz && cd musl-1.2.1
+          ./configure
+          make && sudo make install
       - uses: actions/cache@v2
         with:
           path: ~/go/pkg/mod
@@ -84,14 +94,14 @@ jobs:
           GO111MODULE="on" go get sigs.k8s.io/kind@v0.6.1
           curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.16.6/bin/linux/amd64/kubectl && sudo install kubectl /usr/local/bin/kubectl
 
-
       - name: Checkout code
         uses: actions/checkout@v2
 
       - run: |
           make vcctl
-          make images
+          make images CC=/usr/local/musl/bin/musl-gcc
           make e2e-test-jobseq
+
   e2e_scheduling_basic:
     runs-on: ubuntu-latest
     name: E2E about Basic Scheduling
@@ -101,6 +111,13 @@ jobs:
         with:
           go-version: 1.14.x
 
+      - name: Install musl
+        run: |
+          wget http://musl.libc.org/releases/musl-1.2.1.tar.gz
+          tar -xf musl-1.2.1.tar.gz && cd musl-1.2.1
+          ./configure
+          make && sudo make install
+
       - uses: actions/cache@v2
         with:
           path: ~/go/pkg/mod
@@ -111,13 +128,12 @@ jobs:
           GO111MODULE="on" go get sigs.k8s.io/kind@v0.6.1
           curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.16.6/bin/linux/amd64/kubectl && sudo install kubectl /usr/local/bin/kubectl
 
-
       - name: Checkout code
         uses: actions/checkout@v2
 
       - run: |
           make vcctl
-          make images
+          make images CC=/usr/local/musl/bin/musl-gcc
           make e2e-test-schedulingbase
 
   e2e_scheduling_actions:
@@ -129,6 +145,13 @@ jobs:
         with:
           go-version: 1.14.x
 
+      - name: Install musl
+        run: |
+          wget http://musl.libc.org/releases/musl-1.2.1.tar.gz
+          tar -xf musl-1.2.1.tar.gz && cd musl-1.2.1
+          ./configure
+          make && sudo make install
+
       - uses: actions/cache@v2
         with:
           path: ~/go/pkg/mod
@@ -139,11 +162,10 @@ jobs:
           GO111MODULE="on" go get sigs.k8s.io/kind@v0.6.1
           curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.16.6/bin/linux/amd64/kubectl && sudo install kubectl /usr/local/bin/kubectl
 
-
       - name: Checkout code
         uses: actions/checkout@v2
 
       - run: |
           make vcctl
-          make images
+          make images CC=/usr/local/musl/bin/musl-gcc
           make e2e-test-schedulingaction


### PR DESCRIPTION
Use `musl-gcc` build image, because `vc-scheduler` default image is `alpine`, which only has `musl-libc`

Signed-off-by: Xu ZhengYu <zen-xu@outlook.com>