### PR TITLE
[tdm plugin] separate JobPipelined into two semantics for preempt action

### DIFF
--- a/pkg/scheduler/actions/preempt/preempt.go
+++ b/pkg/scheduler/actions/preempt/preempt.go
@@ -128,8 +128,8 @@ func (alloc *Action) Execute(ssn *framework.Session) {
 				}
 			}
 
-			// Commit changes only if job is pipelined, otherwise try next job.
-			if ssn.JobPipelined(preemptorJob) {
+			// Commit changes only if plugin PreemptCommit fn allow, otherwise try next job.
+			if ssn.PreemptCommit(preemptorJob) {
 				stmt.Commit()
 			} else {
 				stmt.Discard()

--- a/pkg/scheduler/actions/preempt/preempt_test.go
+++ b/pkg/scheduler/actions/preempt/preempt_test.go
@@ -291,6 +291,7 @@ func TestPreempt(t *testing.T) {
 							Name:                "gang",
 							EnabledPreemptable:  &trueValue,
 							EnabledJobPipelined: &trueValue,
+							EnabledJobStarving:  &trueValue,
 						},
 					},
 				},

--- a/pkg/scheduler/conf/scheduler_conf.go
+++ b/pkg/scheduler/conf/scheduler_conf.go
@@ -73,6 +73,8 @@ type PluginOption struct {
 	EnabledReservedNodes *bool `yaml:"enableReservedNodes"`
 	// EnabledVictim defines whether victimsFn is enabled
 	EnabledVictim *bool `yaml:"enabledVictim"`
+	// EnabledPreemptCommit defines whether preemptCommitFn is enabled
+	EnabledPreemptCommit *bool `yaml:"enablePreemptCommit"`
 	// Arguments defines the different arguments that can be given to different plugins
 	Arguments map[string]string `yaml:"arguments"`
 }

--- a/pkg/scheduler/conf/scheduler_conf.go
+++ b/pkg/scheduler/conf/scheduler_conf.go
@@ -73,8 +73,8 @@ type PluginOption struct {
 	EnabledReservedNodes *bool `yaml:"enableReservedNodes"`
 	// EnabledVictim defines whether victimsFn is enabled
 	EnabledVictim *bool `yaml:"enabledVictim"`
-	// EnabledPreemptCommit defines whether preemptCommitFn is enabled
-	EnabledPreemptCommit *bool `yaml:"enablePreemptCommit"`
+	// EnabledJobStarving defines whether jobStarvingFn is enabled
+	EnabledJobStarving *bool `yaml:"enableJobStarving"`
 	// Arguments defines the different arguments that can be given to different plugins
 	Arguments map[string]string `yaml:"arguments"`
 }

--- a/pkg/scheduler/framework/session.go
+++ b/pkg/scheduler/framework/session.go
@@ -74,7 +74,7 @@ type Session struct {
 	targetJobFns      map[string]api.TargetJobFn
 	reservedNodesFns  map[string]api.ReservedNodesFn
 	victimTasksFns    map[string]api.VictimTasksFn
-	preemptCommitFns  map[string]api.ValidateFn
+	jobStarvingFns    map[string]api.ValidateFn
 }
 
 func openSession(cache cache.Cache) *Session {
@@ -110,7 +110,7 @@ func openSession(cache cache.Cache) *Session {
 		targetJobFns:      map[string]api.TargetJobFn{},
 		reservedNodesFns:  map[string]api.ReservedNodesFn{},
 		victimTasksFns:    map[string]api.VictimTasksFn{},
-		preemptCommitFns:  map[string]api.ValidateFn{},
+		jobStarvingFns:    map[string]api.ValidateFn{},
 	}
 
 	snapshot := cache.Snapshot()

--- a/pkg/scheduler/framework/session.go
+++ b/pkg/scheduler/framework/session.go
@@ -74,6 +74,7 @@ type Session struct {
 	targetJobFns      map[string]api.TargetJobFn
 	reservedNodesFns  map[string]api.ReservedNodesFn
 	victimTasksFns    map[string]api.VictimTasksFn
+	preemptCommitFns  map[string]api.ValidateFn
 }
 
 func openSession(cache cache.Cache) *Session {
@@ -109,6 +110,7 @@ func openSession(cache cache.Cache) *Session {
 		targetJobFns:      map[string]api.TargetJobFn{},
 		reservedNodesFns:  map[string]api.ReservedNodesFn{},
 		victimTasksFns:    map[string]api.VictimTasksFn{},
+		preemptCommitFns:  map[string]api.ValidateFn{},
 	}
 
 	snapshot := cache.Snapshot()

--- a/pkg/scheduler/framework/session_plugins.go
+++ b/pkg/scheduler/framework/session_plugins.go
@@ -293,13 +293,13 @@ func (ssn *Session) JobStarving(obj interface{}) bool {
 			}
 			hasFound = true
 
-			if jrf(obj) {
-				return true
+			if !jrf(obj) {
+				return false
 			}
 		}
 		// this tier registed function
 		if hasFound {
-			return false
+			return true
 		}
 	}
 

--- a/pkg/scheduler/plugins/defaults.go
+++ b/pkg/scheduler/plugins/defaults.go
@@ -64,7 +64,7 @@ func ApplyPluginConfDefaults(option *conf.PluginOption) {
 	if option.EnabledVictim == nil {
 		option.EnabledVictim = &t
 	}
-	if option.EnabledPreemptCommit == nil {
-		option.EnabledPreemptCommit = &t
+	if option.EnabledJobStarving == nil {
+		option.EnabledJobStarving = &t
 	}
 }

--- a/pkg/scheduler/plugins/defaults.go
+++ b/pkg/scheduler/plugins/defaults.go
@@ -64,4 +64,7 @@ func ApplyPluginConfDefaults(option *conf.PluginOption) {
 	if option.EnabledVictim == nil {
 		option.EnabledVictim = &t
 	}
+	if option.EnabledPreemptCommit == nil {
+		option.EnabledPreemptCommit = &t
+	}
 }

--- a/pkg/scheduler/plugins/gang/gang.go
+++ b/pkg/scheduler/plugins/gang/gang.go
@@ -127,10 +127,13 @@ func (gp *gangPlugin) OnSessionOpen(ssn *framework.Session) {
 		ji := obj.(*api.JobInfo)
 		return ji.Ready()
 	})
-	ssn.AddJobPipelinedFn(gp.Name(), func(obj interface{}) bool {
+
+	pipelinedFn := func(obj interface{}) bool {
 		ji := obj.(*api.JobInfo)
 		return ji.Pipelined()
-	})
+	}
+	ssn.AddJobPipelinedFn(gp.Name(), pipelinedFn)
+	ssn.AddPreemptCommitFns(gp.Name(), pipelinedFn)
 }
 
 func (gp *gangPlugin) OnSessionClose(ssn *framework.Session) {

--- a/pkg/scheduler/plugins/gang/gang.go
+++ b/pkg/scheduler/plugins/gang/gang.go
@@ -133,7 +133,12 @@ func (gp *gangPlugin) OnSessionOpen(ssn *framework.Session) {
 		return ji.Pipelined()
 	}
 	ssn.AddJobPipelinedFn(gp.Name(), pipelinedFn)
-	ssn.AddPreemptCommitFns(gp.Name(), pipelinedFn)
+
+	jobStarvingFn := func(obj interface{}) bool {
+		ji := obj.(*api.JobInfo)
+		return !ji.Pipelined()
+	}
+	ssn.AddJobStarvingFns(gp.Name(), jobStarvingFn)
 }
 
 func (gp *gangPlugin) OnSessionClose(ssn *framework.Session) {

--- a/pkg/scheduler/plugins/tdm/tdm.go
+++ b/pkg/scheduler/plugins/tdm/tdm.go
@@ -272,23 +272,17 @@ func (bp *tdmPlugin) OnSessionOpen(ssn *framework.Session) {
 
 	jobPipelinedFn := func(obj interface{}) bool {
 		jobInfo := obj.(*api.JobInfo)
-		if jobInfo.Preemptable {
-			// ignore preemptable job
-			return true
-		}
-		// non preemptable job(high priority) try to feed all its tasks
 		occupied := jobInfo.WaitingTaskNum() + jobInfo.ReadyTaskNum()
-		return occupied >= (int32)(len(jobInfo.Tasks))
-
+		return occupied >= jobInfo.MinAvailable
 	}
 
-	preemptCommitFn := func(obj interface{}) bool {
+	jobStarvingFn := func(obj interface{}) bool {
 		jobInfo := obj.(*api.JobInfo)
 		// allow none preemptable elastic job (deployment) preempt task
-		if !jobInfo.Preemptable {
-			return true
+		if jobInfo.Preemptable {
+			return false
 		}
-		return false
+		return len(jobInfo.TaskStatusIndex[api.Pending]) > 0
 	}
 
 	ssn.AddPredicateFn(bp.Name(), predicateFn)
@@ -297,7 +291,7 @@ func (bp *tdmPlugin) OnSessionOpen(ssn *framework.Session) {
 	ssn.AddVictimTasksFns(bp.Name(), victimsFn)
 	ssn.AddJobOrderFn(bp.Name(), jobOrderFn)
 	ssn.AddJobPipelinedFn(bp.Name(), jobPipelinedFn)
-	ssn.AddPreemptCommitFns(bp.Name(), preemptCommitFn)
+	ssn.AddJobStarvingFns(bp.Name(), jobStarvingFn)
 }
 
 func (bp *tdmPlugin) maxVictims(victims []*api.TaskInfo) []*api.TaskInfo {

--- a/pkg/scheduler/plugins/tdm/tdm.go
+++ b/pkg/scheduler/plugins/tdm/tdm.go
@@ -282,12 +282,22 @@ func (bp *tdmPlugin) OnSessionOpen(ssn *framework.Session) {
 
 	}
 
+	preemptCommitFn := func(obj interface{}) bool {
+		jobInfo := obj.(*api.JobInfo)
+		// allow none preemptable elastic job (deployment) preempt task
+		if !jobInfo.Preemptable {
+			return true
+		}
+		return false
+	}
+
 	ssn.AddPredicateFn(bp.Name(), predicateFn)
 	ssn.AddNodeOrderFn(bp.Name(), nodeOrderFn)
 	ssn.AddPreemptableFn(bp.Name(), preemptableFn)
 	ssn.AddVictimTasksFns(bp.Name(), victimsFn)
 	ssn.AddJobOrderFn(bp.Name(), jobOrderFn)
 	ssn.AddJobPipelinedFn(bp.Name(), jobPipelinedFn)
+	ssn.AddPreemptCommitFns(bp.Name(), preemptCommitFn)
 }
 
 func (bp *tdmPlugin) maxVictims(victims []*api.TaskInfo) []*api.TaskInfo {

--- a/pkg/scheduler/util_test.go
+++ b/pkg/scheduler/util_test.go
@@ -63,6 +63,7 @@ tiers:
 					EnabledTargetJob:      &trueValue,
 					EnabledReservedNodes:  &trueValue,
 					EnabledVictim:         &trueValue,
+					EnabledPreemptCommit:  &trueValue,
 				},
 				{
 					Name:                  "gang",
@@ -80,6 +81,7 @@ tiers:
 					EnabledTargetJob:      &trueValue,
 					EnabledReservedNodes:  &trueValue,
 					EnabledVictim:         &trueValue,
+					EnabledPreemptCommit:  &trueValue,
 				},
 				{
 					Name:                  "conformance",
@@ -97,6 +99,7 @@ tiers:
 					EnabledTargetJob:      &trueValue,
 					EnabledReservedNodes:  &trueValue,
 					EnabledVictim:         &trueValue,
+					EnabledPreemptCommit:  &trueValue,
 				},
 			},
 		},
@@ -118,6 +121,7 @@ tiers:
 					EnabledTargetJob:      &trueValue,
 					EnabledReservedNodes:  &trueValue,
 					EnabledVictim:         &trueValue,
+					EnabledPreemptCommit:  &trueValue,
 				},
 				{
 					Name:                  "predicates",
@@ -135,6 +139,7 @@ tiers:
 					EnabledTargetJob:      &trueValue,
 					EnabledReservedNodes:  &trueValue,
 					EnabledVictim:         &trueValue,
+					EnabledPreemptCommit:  &trueValue,
 				},
 				{
 					Name:                  "proportion",
@@ -152,6 +157,7 @@ tiers:
 					EnabledTargetJob:      &trueValue,
 					EnabledReservedNodes:  &trueValue,
 					EnabledVictim:         &trueValue,
+					EnabledPreemptCommit:  &trueValue,
 				},
 				{
 					Name:                  "nodeorder",
@@ -169,6 +175,7 @@ tiers:
 					EnabledTargetJob:      &trueValue,
 					EnabledReservedNodes:  &trueValue,
 					EnabledVictim:         &trueValue,
+					EnabledPreemptCommit:  &trueValue,
 				},
 			},
 		},

--- a/pkg/scheduler/util_test.go
+++ b/pkg/scheduler/util_test.go
@@ -63,7 +63,7 @@ tiers:
 					EnabledTargetJob:      &trueValue,
 					EnabledReservedNodes:  &trueValue,
 					EnabledVictim:         &trueValue,
-					EnabledPreemptCommit:  &trueValue,
+					EnabledJobStarving:    &trueValue,
 				},
 				{
 					Name:                  "gang",
@@ -81,7 +81,7 @@ tiers:
 					EnabledTargetJob:      &trueValue,
 					EnabledReservedNodes:  &trueValue,
 					EnabledVictim:         &trueValue,
-					EnabledPreemptCommit:  &trueValue,
+					EnabledJobStarving:    &trueValue,
 				},
 				{
 					Name:                  "conformance",
@@ -99,7 +99,7 @@ tiers:
 					EnabledTargetJob:      &trueValue,
 					EnabledReservedNodes:  &trueValue,
 					EnabledVictim:         &trueValue,
-					EnabledPreemptCommit:  &trueValue,
+					EnabledJobStarving:    &trueValue,
 				},
 			},
 		},
@@ -121,7 +121,7 @@ tiers:
 					EnabledTargetJob:      &trueValue,
 					EnabledReservedNodes:  &trueValue,
 					EnabledVictim:         &trueValue,
-					EnabledPreemptCommit:  &trueValue,
+					EnabledJobStarving:    &trueValue,
 				},
 				{
 					Name:                  "predicates",
@@ -139,7 +139,7 @@ tiers:
 					EnabledTargetJob:      &trueValue,
 					EnabledReservedNodes:  &trueValue,
 					EnabledVictim:         &trueValue,
-					EnabledPreemptCommit:  &trueValue,
+					EnabledJobStarving:    &trueValue,
 				},
 				{
 					Name:                  "proportion",
@@ -157,7 +157,7 @@ tiers:
 					EnabledTargetJob:      &trueValue,
 					EnabledReservedNodes:  &trueValue,
 					EnabledVictim:         &trueValue,
-					EnabledPreemptCommit:  &trueValue,
+					EnabledJobStarving:    &trueValue,
 				},
 				{
 					Name:                  "nodeorder",
@@ -175,7 +175,7 @@ tiers:
 					EnabledTargetJob:      &trueValue,
 					EnabledReservedNodes:  &trueValue,
 					EnabledVictim:         &trueValue,
-					EnabledPreemptCommit:  &trueValue,
+					EnabledJobStarving:    &trueValue,
 				},
 			},
 		},


### PR DESCRIPTION
In `preempt` action, `JobPipelined` has two semantics:

1. For the `preemptor` job, it use `JobPipelined` to check if need preempt resource. 
https://github.com/volcano-sh/volcano/blob/e356245f0d90793533af3ee7c838b26a71ed0731/pkg/scheduler/actions/preempt/preempt.go#L68

2. For the `preemptor` job, it also use  `JobPipelined` to check if the preempt action can be committed.
https://github.com/volcano-sh/volcano/blob/e356245f0d90793533af3ee7c838b26a71ed0731/pkg/scheduler/actions/preempt/preempt.go#L132

For the elastic job (deployment) use one function two describe the above two semantic is not enough. 
1) High priority elastic job need preempt resource when it has pending tasks. 
2) High priroty elastic job should can commit the preempt action if it has preempt any task(no need meet the pipelined reqirement)