### PR TITLE
fix(job_controller): Fix log

### DIFF
--- a/pkg/controllers/job/job_controller_actions.go
+++ b/pkg/controllers/job/job_controller_actions.go
@@ -484,7 +484,7 @@ func (cc *jobcontroller) createOrUpdatePodGroup(job *batch.Job) error {
 	pg, err := cc.pgLister.PodGroups(job.Namespace).Get(job.Name)
 	if err != nil {
 		if !apierrors.IsNotFound(err) {
-			klog.V(3).Infof("Failed to get PodGroup for Job <%s/%s>: %v",
+			klog.Errorf("Failed to get PodGroup for Job <%s/%s>: %v",
 				job.Namespace, job.Name, err)
 			return err
 		}
@@ -508,7 +508,7 @@ func (cc *jobcontroller) createOrUpdatePodGroup(job *batch.Job) error {
 
 		if _, err = cc.vcClient.SchedulingV1beta1().PodGroups(job.Namespace).Create(context.TODO(), pg, metav1.CreateOptions{}); err != nil {
 			if !apierrors.IsAlreadyExists(err) {
-				klog.V(3).Infof("Failed to create PodGroup for Job <%s/%s>: %v",
+				klog.Errorf("Failed to create PodGroup for Job <%s/%s>: %v",
 					job.Namespace, job.Name, err)
 				return err
 			}
@@ -521,7 +521,7 @@ func (cc *jobcontroller) createOrUpdatePodGroup(job *batch.Job) error {
 		pg.Spec.MinResources = cc.calcPGMinResources(job)
 		if _, err = cc.vcClient.SchedulingV1beta1().PodGroups(job.Namespace).Update(context.TODO(), pg, metav1.UpdateOptions{}); err != nil {
 			if !apierrors.IsAlreadyExists(err) {
-				klog.V(3).Infof("Failed to create PodGroup for Job <%s/%s>: %v",
+				klog.Errorf("Failed to update PodGroup for Job <%s/%s>: %v",
 					job.Namespace, job.Name, err)
 				return err
 			}


### PR DESCRIPTION
We are using both `klog.V(3).Infof` and `klog.Errorf` when checking the errors.

Like https://github.com/volcano-sh/volcano/compare/master...gaocegege:log#diff-28557d59525e85335ee0eacff9269dcc0dbc0ffcc7ef146ef4e0e59d713df788L537 and https://github.com/volcano-sh/volcano/compare/master...gaocegege:log#diff-28557d59525e85335ee0eacff9269dcc0dbc0ffcc7ef146ef4e0e59d713df788L487

I think it is better to keep using Errorf for errors.

Signed-off-by: cegao <cegao@tencent.com>