### PR TITLE
chore: Remove outdated info

### DIFF
--- a/docs/community/adopters.md
+++ b/docs/community/adopters.md
@@ -12,7 +12,6 @@ please feel free to add yourself into the following list by a pull request. Ther
 | ------------ | ------- | ----------- | ------------------ |
 | [Unisound](https://www.unisound.com/) |[@xieydd](https://github.com/xieydd)| Evaluation | Evaluation in ATLAS AI Platform |
 | [BIBDR](http://www.bibdr.org/en/) |[@felix5572](https://github.com/felix5572)| Evaluation | Scientific calculations in physics, materials , biology and chemistry. molecular dynamics simulation. |
-| [caicloud](https://caicloud.io/) |[@gaocegege](https://github.com/gaocegege)| Evaluation | Scheduler for Distributed DL training Jobs |
 | [Baidu](https://baidu.com/) |[@tizhou86](https://github.com/tizhou86)| Testing | Scheduler for Deep Learning Platform to Optimize Performance |
 | [GrandOmics](https://www.grandomics.com/) |[@alartin](https://github.com/alartin)| Evaluation | Infrastructure of Hanwell (Huawei Cloud backend of Cromwell which is a Broad Institute implementation of WDL) |
 | [Huawei Cloud](https://huaweicloud.com/) |[@tsjsdbd](https://github.com/tsjsdbd)| **Production** | Scheduler & Job Management of AI Container Service and CCI  |


### PR DESCRIPTION
@gaocegege does not maintain infra at Caicloud now, thus remove it from adopters.

Signed-off-by: cegao <cegao@tencent.com>