### PR TITLE
add fail event for annotation admission

### DIFF
--- a/cmd/webhook-manager/app/server.go
+++ b/cmd/webhook-manager/app/server.go
@@ -27,7 +27,11 @@ import (
 
 	"k8s.io/klog"
 
+	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/tools/record"
 	"volcano.sh/volcano/cmd/webhook-manager/app/options"
+	"volcano.sh/volcano/pkg/apis/scheduling/scheme"
 	"volcano.sh/volcano/pkg/kube"
 	"volcano.sh/volcano/pkg/version"
 	"volcano.sh/volcano/pkg/webhooks/router"
@@ -56,10 +60,15 @@ func Run(config *options.Config) error {
 
 	vClient := getVolcanoClient(restConfig)
 	kubeClient := getKubeClient(restConfig)
+
+	broadcaster := record.NewBroadcaster()
+	broadcaster.StartRecordingToSink(&corev1.EventSinkImpl{Interface: kubeClient.CoreV1().Events("")})
+	recorder := broadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: config.SchedulerName})
 	router.ForEachAdmission(func(service *router.AdmissionService) {
 		if service.Config != nil {
 			service.Config.VolcanoClient = vClient
 			service.Config.SchedulerName = config.SchedulerName
+			service.Config.Recorder = recorder
 		}
 
 		klog.V(3).Infof("Registered '%s' as webhook.", service.Path)

--- a/pkg/webhooks/admission/pods/admit_pod.go
+++ b/pkg/webhooks/admission/pods/admit_pod.go
@@ -19,15 +19,18 @@ package pods
 import (
 	"context"
 	"fmt"
+	"strconv"
+
 	"strings"
 
 	"k8s.io/api/admission/v1beta1"
 	whv1beta1 "k8s.io/api/admissionregistration/v1beta1"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog"
 
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"volcano.sh/volcano/pkg/apis/helpers"
 	vcv1beta1 "volcano.sh/volcano/pkg/apis/scheduling/v1beta1"
 	"volcano.sh/volcano/pkg/webhooks/router"
@@ -97,6 +100,7 @@ allow pods to create when
 1. schedulerName of pod isn't volcano
 2. pod has Podgroup whose phase isn't Pending
 3. normal pods whose schedulerName is volcano don't have podgroup.
+4. check pod budget annotations configure
 */
 func validatePod(pod *v1.Pod, reviewResponse *v1beta1.AdmissionResponse) string {
 	if pod.Spec.SchedulerName != config.SchedulerName {
@@ -125,6 +129,12 @@ func validatePod(pod *v1.Pod, reviewResponse *v1beta1.AdmissionResponse) string 
 		reviewResponse.Allowed = false
 	}
 
+	// check pod annotatations
+	if err := validateAnnotation(pod); err != nil {
+		msg = err.Error()
+		reviewResponse.Allowed = false
+	}
+
 	return msg
 }
 
@@ -141,4 +151,53 @@ func checkPGPhase(pod *v1.Pod, pgName string, isVCJob bool) error {
 	}
 	return fmt.Errorf("failed to create pod <%s/%s> as the podgroup phase is Pending",
 		pod.Namespace, pod.Name)
+}
+
+func validateAnnotation(pod *v1.Pod) error {
+	num := 0
+	if len(pod.Annotations) > 0 {
+		keys := []string{
+			vcv1beta1.JDBMinAvailable,
+			vcv1beta1.JDBMaxUnavailable,
+		}
+		for _, key := range keys {
+			if value, found := pod.Annotations[key]; found {
+				num++
+				if err := validateIntPercentageStr(key, value); err != nil {
+					recordEvent(err)
+					return err
+				}
+			}
+		}
+		if num > 1 {
+			return fmt.Errorf("not allow configure multiple annotations <%v> at same time", keys)
+		}
+	}
+	return nil
+}
+
+func recordEvent(err error) {
+	config.Recorder.Eventf(nil, v1.EventTypeWarning, "Admit", "Create pod failed due to %v", err)
+}
+
+func validateIntPercentageStr(key, value string) error {
+	tmp := intstr.Parse(value)
+	switch tmp.Type {
+	case intstr.Int:
+		if tmp.IntValue() <= 0 {
+			return fmt.Errorf("invalid value <%q> for %v, it must be a positive integer", value, key)
+		}
+		return nil
+	case intstr.String:
+		s := strings.Replace(tmp.StrVal, "%", "", -1)
+		v, err := strconv.Atoi(s)
+		if err != nil {
+			return fmt.Errorf("invalid value %v for %v", err, key)
+		}
+		if v <= 0 || v >= 100 {
+			return fmt.Errorf("invalid value <%q> for %v, it must be a valid percentage which between 1%% ~ 99%%", tmp.StrVal, key)
+		}
+		return nil
+	}
+	return fmt.Errorf("invalid type: neither int nor percentage for %v", key)
 }

--- a/pkg/webhooks/router/interface.go
+++ b/pkg/webhooks/router/interface.go
@@ -20,7 +20,7 @@ import (
 	"k8s.io/api/admission/v1beta1"
 	whv1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	"k8s.io/client-go/kubernetes"
-
+	"k8s.io/client-go/tools/record"
 	"volcano.sh/volcano/pkg/client/clientset/versioned"
 )
 
@@ -31,6 +31,7 @@ type AdmissionServiceConfig struct {
 	SchedulerName string
 	KubeClient    kubernetes.Interface
 	VolcanoClient versioned.Interface
+	Recorder      record.EventRecorder
 }
 
 type AdmissionService struct {


### PR DESCRIPTION
Signed-off-by: wpeng102 <wpeng102@126.com>

For `volcano.sh/jdb-min-available` and `volcano.sh/jdb-max-unavailable` annotaions, the value should be:
1. positive integer
2. percentage between 1% ~ 99%.
3. only allow set one of `volcano.sh/jdb-min-available` and `volcano.sh/jdb-max-unavailable`  annotations

We only create event for the pod admit failed case. In next version, we will mount this event to the corresponding resource.