### PR TITLE
support revocable-zone annotaion for workload

### DIFF
--- a/pkg/apis/scheduling/v1beta1/labels.go
+++ b/pkg/apis/scheduling/v1beta1/labels.go
@@ -35,8 +35,8 @@ const QueueNameAnnotationKey = GroupName + "/queue-name"
 // PodPreemptable is the key of preemptable
 const PodPreemptable = "volcano.sh/preemptable"
 
-//NodeRevocableZone is the key of revocable-zone
-const NodeRevocableZone = "volcano.sh/revocable-zone"
+//RevocableZone is the key of revocable-zone
+const RevocableZone = "volcano.sh/revocable-zone"
 
 // JDBMinAvailable is the key of min available pod number
 const JDBMinAvailable = "volcano.sh/jdb-min-available"

--- a/pkg/controllers/job/job_controller_util.go
+++ b/pkg/controllers/job/job_controller_util.go
@@ -105,6 +105,9 @@ func createJobPod(job *batch.Job, template *v1.PodTemplateSpec, ix int) *v1.Pod 
 		if value, found := job.Annotations[schedulingv2.PodPreemptable]; found {
 			pod.Annotations[schedulingv2.PodPreemptable] = value
 		}
+		if value, found := job.Annotations[schedulingv2.RevocableZone]; found {
+			pod.Annotations[schedulingv2.RevocableZone] = value
+		}
 
 		if value, found := job.Annotations[schedulingv2.JDBMinAvailable]; found {
 			pod.Annotations[schedulingv2.JDBMinAvailable] = value

--- a/pkg/controllers/podgroup/pg_controller_handler.go
+++ b/pkg/controllers/podgroup/pg_controller_handler.go
@@ -101,6 +101,9 @@ func (pg *pgcontroller) createNormalPodPGIfNotExist(pod *v1.Pod) error {
 		if value, ok := pod.Annotations[scheduling.PodPreemptable]; ok {
 			obj.Annotations[scheduling.PodPreemptable] = value
 		}
+		if value, ok := pod.Annotations[scheduling.RevocableZone]; ok {
+			obj.Annotations[scheduling.RevocableZone] = value
+		}
 		if value, ok := pod.Labels[scheduling.PodPreemptable]; ok {
 			obj.Labels[scheduling.PodPreemptable] = value
 		}

--- a/pkg/scheduler/api/node_info.go
+++ b/pkg/scheduler/api/node_info.go
@@ -115,7 +115,7 @@ func (ni *NodeInfo) Ready() bool {
 func (ni *NodeInfo) setRevocableZone(node *v1.Node) {
 	revocableZone := ""
 	if len(node.Labels) > 0 {
-		if value, found := node.Labels[v1beta1.NodeRevocableZone]; found {
+		if value, found := node.Labels[v1beta1.RevocableZone]; found {
 			revocableZone = value
 		}
 	}

--- a/pkg/scheduler/api/pod_info.go
+++ b/pkg/scheduler/api/pod_info.go
@@ -97,6 +97,18 @@ func GetPodPreemptable(pod *v1.Pod) bool {
 	return false
 }
 
+// GetPodRevocableZone return volcano.sh/revocable-zone value for pod/podgroup
+func GetPodRevocableZone(pod *v1.Pod) string {
+	// check annotaion first
+	if len(pod.Annotations) > 0 {
+		if value, found := pod.Annotations[v1beta1.RevocableZone]; found && value == "*" {
+			return value
+		}
+	}
+
+	return ""
+}
+
 // GetPodResourceWithoutInitContainers returns Pod's resource request, it does not contain
 // init containers' resource request.
 func GetPodResourceWithoutInitContainers(pod *v1.Pod) *Resource {

--- a/pkg/scheduler/plugins/tdm/tdm.go
+++ b/pkg/scheduler/plugins/tdm/tdm.go
@@ -156,8 +156,8 @@ func (tp *tdmPlugin) OnSessionOpen(ssn *framework.Session) {
 
 		klog.V(4).Infof("TDM node %v revocable zone %v:%v is active", node.Name, node.RevocableZone, tp.revocableZone[node.RevocableZone])
 
-		if !task.Preemptable {
-			msg := fmt.Sprintf("task %s/%s is not preemptable task, skip to schedule to node %s", task.Namespace, task.Name, node.Name)
+		if len(task.RevocableZone) == 0 {
+			msg := fmt.Sprintf("task %s/%s is not allow to dispatch to revocable node %s", task.Namespace, task.Name, node.Name)
 			return fmt.Errorf("plugin %s predicates %s", tp.Name(), msg)
 		}
 
@@ -178,8 +178,8 @@ func (tp *tdmPlugin) OnSessionOpen(ssn *framework.Session) {
 			return score, err
 		}
 
-		if !task.Preemptable {
-			klog.V(4).Infof("TDM task %s/%s is not preemptable task, skip to schedule to node %s", task.Namespace, task.Name, node.Name)
+		if len(task.RevocableZone) == 0 {
+			klog.V(4).Infof("TDM task %s/%s is not allow to dispatch to revocable node %s", task.Namespace, task.Name, node.Name)
 			return score, nil
 		}
 
@@ -364,23 +364,4 @@ func (tp *tdmPlugin) revocableNodePreemptableTask(rz string, ssn *framework.Sess
 	return tasksMap
 }
 
-func (tp *tdmPlugin) noneRevocableNodePreemptableTask(ssn *framework.Session) []*api.TaskInfo {
-	tasks := make([]*api.TaskInfo, 0)
-
-	for _, node := range ssn.Nodes {
-		if node.RevocableZone != "" {
-			continue
-		}
-
-		for _, task := range node.Tasks {
-			if task.Preemptable {
-				if task.Status == api.Running {
-					tasks = append(tasks, task)
-				}
-			}
-		}
-	}
-
-	return tasks
-}
 func (tp *tdmPlugin) OnSessionClose(ssn *framework.Session) {}

--- a/pkg/scheduler/plugins/tdm/tdm_test.go
+++ b/pkg/scheduler/plugins/tdm/tdm_test.go
@@ -114,22 +114,22 @@ func Test_TDM(t *testing.T) {
 	p2 := util.BuildPod("c1", "p2", "", v1.PodPending, util.BuildResourceList("1", "1Gi"), "pg1", make(map[string]string), make(map[string]string))
 	p3 := util.BuildPod("c1", "p3", "", v1.PodPending, util.BuildResourceList("1", "1Gi"), "pg1", make(map[string]string), make(map[string]string))
 
-	p1.Annotations[schedulingv2.PodPreemptable] = "true"
-	p3.Annotations[schedulingv2.PodPreemptable] = "true"
+	p1.Annotations[schedulingv2.RevocableZone] = "*"
+	p3.Annotations[schedulingv2.RevocableZone] = "*"
 
 	n1 := util.BuildNode("n1", util.BuildResourceList("16", "64Gi"), map[string]string{
-		schedulingv2.NodeRevocableZone: "rz1",
+		schedulingv2.RevocableZone: "rz1",
 	})
 
 	n2 := util.BuildNode("n2", util.BuildResourceList("16", "64Gi"), map[string]string{
-		schedulingv2.NodeRevocableZone: "rz1",
+		schedulingv2.RevocableZone: "rz1",
 	})
 
 	n3 := util.BuildNode("n3", util.BuildResourceList("16", "64Gi"), map[string]string{})
 	n4 := util.BuildNode("n4", util.BuildResourceList("16", "64Gi"), map[string]string{})
 
 	n5 := util.BuildNode("n5", util.BuildResourceList("16", "64Gi"), map[string]string{
-		schedulingv2.NodeRevocableZone: "rz2",
+		schedulingv2.RevocableZone: "rz2",
 	})
 
 	pg1 := &schedulingv2.PodGroup{
@@ -337,11 +337,11 @@ func Test_TDM_victimsFn(t *testing.T) {
 	p10.Annotations[schedulingv2.PodPreemptable] = "true"
 
 	n1 := util.BuildNode("n1", util.BuildResourceList("16", "64Gi"), map[string]string{
-		schedulingv2.NodeRevocableZone: "rz1",
+		schedulingv2.RevocableZone: "rz1",
 	})
 
 	n2 := util.BuildNode("n2", util.BuildResourceList("16", "64Gi"), map[string]string{
-		schedulingv2.NodeRevocableZone: "rz1",
+		schedulingv2.RevocableZone: "rz1",
 	})
 
 	queue1 := &schedulingv2.Queue{


### PR DESCRIPTION
Signed-off-by: wpeng102 <wpeng102@126.com>

Add `volcano.sh/revocable-zone` annotation for workload.
Currently, workload has two annotations about TDM plugin.

`volcano.sh/preemptable` indicates if the workload can be preempted. default value is `false`, means can not be preempted. 
`volcano.sh/revocable-zone` indicates if the workload can be dispatched to revocable nodes.  default value is "", means workload can not be dispatched to revocable nodes.