### PR TITLE
support only specify preemptable=true for revocable workload

### DIFF
--- a/pkg/scheduler/api/job_info.go
+++ b/pkg/scheduler/api/job_info.go
@@ -270,8 +270,17 @@ func GetJobPreemptable(pg *PodGroup) bool {
 func GetJobRevocableZone(pg *PodGroup) string {
 	// check annotaion first
 	if len(pg.Annotations) > 0 {
-		if value, found := pg.Annotations[v1beta1.RevocableZone]; found && value == "*" {
+		if value, found := pg.Annotations[v1beta1.RevocableZone]; found {
+			if value != "*" {
+				return ""
+			}
 			return value
+		}
+
+		if value, found := pg.Annotations[v1beta1.PodPreemptable]; found {
+			if b, err := strconv.ParseBool(value); err == nil && b {
+				return "*"
+			}
 		}
 	}
 
@@ -280,7 +289,6 @@ func GetJobRevocableZone(pg *PodGroup) string {
 
 // GetBudget return budget value for job
 func GetBudget(pg *PodGroup) *DisruptionBudget {
-	// check annotaion first
 	if len(pg.Annotations) > 0 {
 		if value, found := pg.Annotations[v1beta1.JDBMinAvailable]; found {
 			return NewDisruptionBudget(value, "")

--- a/pkg/scheduler/api/pod_info.go
+++ b/pkg/scheduler/api/pod_info.go
@@ -99,13 +99,20 @@ func GetPodPreemptable(pod *v1.Pod) bool {
 
 // GetPodRevocableZone return volcano.sh/revocable-zone value for pod/podgroup
 func GetPodRevocableZone(pod *v1.Pod) string {
-	// check annotaion first
 	if len(pod.Annotations) > 0 {
-		if value, found := pod.Annotations[v1beta1.RevocableZone]; found && value == "*" {
+		if value, found := pod.Annotations[v1beta1.RevocableZone]; found {
+			if value != "*" {
+				return ""
+			}
 			return value
 		}
-	}
 
+		if value, found := pod.Annotations[v1beta1.PodPreemptable]; found {
+			if b, err := strconv.ParseBool(value); err == nil && b {
+				return "*"
+			}
+		}
+	}
 	return ""
 }
 


### PR DESCRIPTION
Signed-off-by: wpeng102 <wpeng102@126.com>

Before this PR, if customer only set `volcano.sh/preemptable: true`, the `volcano.sh/revocable-zone` will use default value (empty string). This means workload can not use revocable nodes.
This hehavior is not convenience to use.  After this PR, if user only set  `volcano.sh/preemptable: true`, we will consider the workload as `volcano.sh/revocable-zone: *`
So the co-located workload only need set `volcano.sh/preemptable: true`
