### PR TITLE
make sure non-preemptable and revocable workload not preempt other tasks

### DIFF
--- a/pkg/scheduler/plugins/tdm/tdm.go
+++ b/pkg/scheduler/plugins/tdm/tdm.go
@@ -190,7 +190,8 @@ func (tp *tdmPlugin) OnSessionOpen(ssn *framework.Session) {
 	}
 
 	preemptableFn := func(preemptor *api.TaskInfo, preemptees []*api.TaskInfo) []*api.TaskInfo {
-		if preemptor.Preemptable {
+		// for the preemptable or can use revocablezone workload, they can not preempt other tasks.
+		if preemptor.Preemptable || len(preemptor.RevocableZone) > 0 {
 			klog.V(4).Infof("TDM task %s/%s is preemptable, do nothing skip", preemptor.Namespace, preemptor.Name)
 			return nil
 		}


### PR DESCRIPTION
Signed-off-by: wpeng102 <wpeng102@126.com>

For the preemptable or use revocablezone workload, they can not preempt other tasks.