### PR TITLE
fix(e2e): replace removed command of kind when getting kube config

### DIFF
--- a/hack/run-e2e-kind.sh
+++ b/hack/run-e2e-kind.sh
@@ -96,7 +96,9 @@ source "${VK_ROOT}/hack/lib/install.sh"
 check-prerequisites
 kind-up-cluster
 
-export KUBECONFIG="$(kind get kubeconfig-path ${CLUSTER_CONTEXT})"
+if [[ -z ${KUBECONFIG+x} ]]; then
+    export KUBECONFIG="${HOME}/.kube/config"
+fi
 
 install-volcano
 


### PR DESCRIPTION
Since `kind get kubeconfig-path` is removed after v0.7.0, the script may
fail with kind of higher version.

Signed-off-by: rudeigerc <rudeigerc@gmail.com>