### PR TITLE
fix: prevent SelectBestNode func arise panic

### DIFF
--- a/pkg/scheduler/util/scheduler_helper.go
+++ b/pkg/scheduler/util/scheduler_helper.go
@@ -218,6 +218,10 @@ func SelectBestNode(nodeScores map[float64][]*api.NodeInfo) *api.NodeInfo {
 		}
 	}
 
+	if len(bestNodes) == 0 {
+		return nil
+	}
+
 	return bestNodes[rand.Intn(len(bestNodes))]
 }
 

--- a/pkg/scheduler/util/scheduler_helper_test.go
+++ b/pkg/scheduler/util/scheduler_helper_test.go
@@ -44,6 +44,10 @@ func TestSelectBestNode(t *testing.T) {
 			},
 			ExpectedNodes: []*api.NodeInfo{{Name: "node3"}},
 		},
+		{
+			NodeScores:    map[float64][]*api.NodeInfo{},
+			ExpectedNodes: []*api.NodeInfo{nil},
+		},
 	}
 
 	oneOf := func(node *api.NodeInfo, nodes []*api.NodeInfo) bool {


### PR DESCRIPTION
Prevent SelectBestNode func arise panic when the length of nodeScores is zero.