### PR TITLE
add `bindingTasks` to judge whether adding node to the snapshot.

### DIFF
--- a/pkg/scheduler/api/node_info.go
+++ b/pkg/scheduler/api/node_info.go
@@ -417,8 +417,8 @@ func (ni *NodeInfo) SubGPUResource(pod *v1.Pod) {
 func (ni *NodeInfo) GetBindingTasks() []TaskID {
 	var tasks []TaskID
 
-	for taskId := range ni.bindingTasks {
-		tasks = append(tasks, taskId)
+	for taskID := range ni.bindingTasks {
+		tasks = append(tasks, taskID)
 	}
 
 	return tasks

--- a/pkg/scheduler/api/node_info.go
+++ b/pkg/scheduler/api/node_info.go
@@ -1,17 +1,17 @@
 /*
-Copyright 2017 The Kubernetes Authors.
+ Copyright 2021 The Volcano Authors.
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+     http://www.apache.org/licenses/LICENSE-2.0
 
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
 */
 
 package api
@@ -52,6 +52,8 @@ type NodeInfo struct {
 	// Used to store custom information
 	Others     map[string]interface{}
 	GPUDevices map[int]*GPUDevice
+
+	bindingTasks map[TaskID]string
 }
 
 // FutureIdle returns resources that will be idle in the future:
@@ -81,6 +83,8 @@ func NewNodeInfo(node *v1.Node) *NodeInfo {
 		Tasks: make(map[TaskID]*TaskInfo),
 
 		GPUDevices: make(map[int]*GPUDevice),
+
+		bindingTasks: make(map[TaskID]string),
 	}
 
 	if node != nil {
@@ -104,6 +108,11 @@ func (ni *NodeInfo) Clone() *NodeInfo {
 	for _, p := range ni.Tasks {
 		res.AddTask(p)
 	}
+
+	for taskID, _ := range ni.bindingTasks {
+		res.AddBindingTask(taskID)
+	}
+
 	return res
 }
 
@@ -401,5 +410,28 @@ func (ni *NodeInfo) SubGPUResource(pod *v1.Pod) {
 		if dev := ni.GPUDevices[id]; dev != nil {
 			delete(dev.PodMap, string(pod.UID))
 		}
+	}
+}
+
+// GetBindingTasks return binding task ids
+func (ni *NodeInfo) GetBindingTasks() []TaskID {
+	var tasks []TaskID
+
+	for taskId, _ := range ni.bindingTasks {
+		tasks = append(tasks, taskId)
+	}
+
+	return tasks
+}
+
+// AddBindingTask add binding taskId to node
+func (ni *NodeInfo) AddBindingTask(task TaskID) {
+	ni.bindingTasks[task] = ""
+}
+
+// RemoveBindingTask remove binding taskId from node
+func (ni *NodeInfo) RemoveBindingTask(task TaskID) {
+	if _, found := ni.bindingTasks[task]; found {
+		delete(ni.bindingTasks, task)
 	}
 }

--- a/pkg/scheduler/api/node_info.go
+++ b/pkg/scheduler/api/node_info.go
@@ -109,7 +109,7 @@ func (ni *NodeInfo) Clone() *NodeInfo {
 		res.AddTask(p)
 	}
 
-	for taskID, _ := range ni.bindingTasks {
+	for taskID := range ni.bindingTasks {
 		res.AddBindingTask(taskID)
 	}
 
@@ -417,7 +417,7 @@ func (ni *NodeInfo) SubGPUResource(pod *v1.Pod) {
 func (ni *NodeInfo) GetBindingTasks() []TaskID {
 	var tasks []TaskID
 
-	for taskId, _ := range ni.bindingTasks {
+	for taskId := range ni.bindingTasks {
 		tasks = append(tasks, taskId)
 	}
 

--- a/pkg/scheduler/api/node_info_test.go
+++ b/pkg/scheduler/api/node_info_test.go
@@ -1,17 +1,17 @@
 /*
-Copyright 2017 The Kubernetes Authors.
+ Copyright 2021 The Volcano Authors.
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+     http://www.apache.org/licenses/LICENSE-2.0
 
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
 */
 
 package api
@@ -62,7 +62,8 @@ func TestNodeInfo_AddPod(t *testing.T) {
 					"c1/p1": NewTaskInfo(case01Pod1),
 					"c1/p2": NewTaskInfo(case01Pod2),
 				},
-				GPUDevices: make(map[int]*GPUDevice),
+				GPUDevices:   make(map[int]*GPUDevice),
+				bindingTasks: make(map[TaskID]string),
 			},
 		},
 		{
@@ -70,17 +71,18 @@ func TestNodeInfo_AddPod(t *testing.T) {
 			node: case02Node,
 			pods: []*v1.Pod{case02Pod1},
 			expected: &NodeInfo{
-				Name:        "n2",
-				Node:        case02Node,
-				Idle:        buildResource("2000m", "1G"),
-				Used:        EmptyResource(),
-				Releasing:   EmptyResource(),
-				Pipelined:   EmptyResource(),
-				Allocatable: buildResource("2000m", "1G"),
-				Capability:  buildResource("2000m", "1G"),
-				State:       NodeState{Phase: Ready},
-				Tasks:       map[TaskID]*TaskInfo{},
-				GPUDevices:  make(map[int]*GPUDevice),
+				Name:         "n2",
+				Node:         case02Node,
+				Idle:         buildResource("2000m", "1G"),
+				Used:         EmptyResource(),
+				Releasing:    EmptyResource(),
+				Pipelined:    EmptyResource(),
+				Allocatable:  buildResource("2000m", "1G"),
+				Capability:   buildResource("2000m", "1G"),
+				State:        NodeState{Phase: Ready},
+				Tasks:        map[TaskID]*TaskInfo{},
+				GPUDevices:   make(map[int]*GPUDevice),
+				bindingTasks: make(map[TaskID]string),
 			},
 			expectedFailure: true,
 		},
@@ -140,7 +142,8 @@ func TestNodeInfo_RemovePod(t *testing.T) {
 					"c1/p1": NewTaskInfo(case01Pod1),
 					"c1/p3": NewTaskInfo(case01Pod3),
 				},
-				GPUDevices: make(map[int]*GPUDevice),
+				GPUDevices:   make(map[int]*GPUDevice),
+				bindingTasks: make(map[TaskID]string),
 			},
 		},
 	}

--- a/pkg/scheduler/cache/cache.go
+++ b/pkg/scheduler/cache/cache.go
@@ -1,17 +1,17 @@
 /*
-Copyright 2017 The Kubernetes Authors.
+ Copyright 2021 The Volcano Authors.
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+     http://www.apache.org/licenses/LICENSE-2.0
 
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
 */
 
 package cache
@@ -557,6 +557,19 @@ func (sc *SchedulerCache) Bind(taskInfo *schedulingapi.TaskInfo, hostname string
 
 	p := task.Pod
 	go func() {
+		node := sc.Nodes[hostname]
+		taskId := schedulingapi.PodKey(p)
+
+		sc.Lock()
+		node.AddBindingTask(taskId)
+		sc.Unlock()
+
+		defer func() {
+			sc.Lock()
+			node.RemoveBindingTask(taskId)
+			sc.Unlock()
+		}()
+
 		if err := sc.Binder.Bind(p, hostname); err != nil {
 			sc.resyncTask(task)
 		} else {
@@ -681,6 +694,12 @@ func (sc *SchedulerCache) Snapshot() *schedulingapi.ClusterInfo {
 
 	for _, value := range sc.Nodes {
 		if !value.Ready() {
+			continue
+		}
+
+		bindingTasks := value.GetBindingTasks()
+		if len(bindingTasks) > 0 {
+			klog.V(4).Infof("There are %d binding tasks, skip node %s", len(bindingTasks), value.Name)
 			continue
 		}
 

--- a/pkg/scheduler/cache/cache.go
+++ b/pkg/scheduler/cache/cache.go
@@ -557,16 +557,15 @@ func (sc *SchedulerCache) Bind(taskInfo *schedulingapi.TaskInfo, hostname string
 
 	p := task.Pod
 	go func() {
-		node := sc.Nodes[hostname]
-		taskId := schedulingapi.PodKey(p)
+		taskID := schedulingapi.PodKey(p)
 
 		sc.Lock()
-		node.AddBindingTask(taskId)
+		node.AddBindingTask(taskID)
 		sc.Unlock()
 
 		defer func() {
 			sc.Lock()
-			node.RemoveBindingTask(taskId)
+			node.RemoveBindingTask(taskID)
 			sc.Unlock()
 		}()
 


### PR DESCRIPTION
If the node has some binding tasks, current session skip this node.

fix #1383

Signed-off-by: ZhengYu, Xu <zen-xu@outlook.com>