### PR TITLE
add shinytang6 to volcano approver

### DIFF
--- a/pkg/controllers/OWNERS
+++ b/pkg/controllers/OWNERS
@@ -1,7 +1,7 @@
 reviewers:
   - hzxuzhonghu
   - TommyLike
-  - shinytang6
 approvers:
   - hzxuzhonghu
   - TommyLike
+  - shinytang6

--- a/pkg/scheduler/OWNERS
+++ b/pkg/scheduler/OWNERS
@@ -1,8 +1,8 @@
-
 approvers:
   - k82cn
   - animeshsingh
   - Thor-wl
+  - shinytang6
 reviewers:
   - k82cn
   - animeshsingh
@@ -10,6 +10,5 @@ reviewers:
   - Thor-wl
   - alcorj-mizar
   - hudson741
-  - shinytang6
   - merryzhou
   - zen-xu


### PR DESCRIPTION
Some of my contributions:
1. add podgroup admission https://github.com/volcano-sh/volcano/pull/1375
2. add most allocated algo to nodeorder https://github.com/volcano-sh/volcano/pull/1307
3. fix resource calculation way https://github.com/volcano-sh/volcano/pull/1350
4. improve addResourceList func https://github.com/volcano-sh/volcano/pull/1332
5. update ssh secret when job updated https://github.com/volcano-sh/volcano/pull/1263
6. add job plugin example https://github.com/volcano-sh/volcano/pull/1254