### PR TITLE
don't return err message when the pod isn't in the nodeinfo cache

### DIFF
--- a/pkg/scheduler/api/node_info.go
+++ b/pkg/scheduler/api/node_info.go
@@ -296,8 +296,9 @@ func (ni *NodeInfo) RemoveTask(ti *TaskInfo) error {
 
 	task, found := ni.Tasks[key]
 	if !found {
-		return fmt.Errorf("failed to find task <%v/%v> on host <%v>",
+		klog.Warningf("failed to find task <%v/%v> on host <%v>",
 			ti.Namespace, ti.Name, ni.Name)
+		return nil
 	}
 
 	if ni.Node != nil {

--- a/pkg/scheduler/cache/event_handlers.go
+++ b/pkg/scheduler/cache/event_handlers.go
@@ -67,6 +67,8 @@ func (sc *SchedulerCache) addTask(pi *schedulingapi.TaskInfo) error {
 			if err := node.AddTask(pi); err != nil {
 				return err
 			}
+		} else {
+			klog.V(4).Infof("Pod <%v/%v> is in status %s.", pi.Namespace, pi.Name, pi.Status.String())
 		}
 	}
 


### PR DESCRIPTION
Signed-off-by: huone1 <huwanxing@huawei.com>

in function RemoveTask, just print the warning info; 
because
1. pod status changes running to completed ，don't add the pod to nodeinfo data 
   
![image](https://user-images.githubusercontent.com/71266853/118422059-09a54180-b6f5-11eb-8e11-62b0b345ab01.png)

2. node.RemoveTask returns err msg "failed to find task..." if scheduler deployment receives the updatePod event after the pod has been in status  completed
