### PR TITLE
doc: add schedulerName in gpu sharing user guide

### DIFF
--- a/docs/user-guide/how_to_use_gpu_sharing.md
+++ b/docs/user-guide/how_to_use_gpu_sharing.md
@@ -90,6 +90,7 @@ kind: Pod
 metadata:
   name: gpu-pod1
 spec:
+  schedulerName: volcano
   containers:
     - name: cuda-container
       image: nvidia/cuda:9.0-devel
@@ -106,6 +107,7 @@ kind: Pod
 metadata:
   name: gpu-pod2
 spec:
+  schedulerName: volcano
   containers:
     - name: cuda-container
       image: nvidia/cuda:9.0-devel


### PR DESCRIPTION
User should specify pod's `spec.schedulerName` to be `volcano`, otherwise the pod will be scheduled by default k8s scheduler.

Signed-off-by: ChAnYaNG97 <790194334@qq.com>