### PR TITLE
add shinytang6 to volcano maintainer

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -9,6 +9,7 @@
 | Zhonghu Xu           | [hzxuzhonghu](https://github.com/hzxuzhonghu)           | Huawei      |
 | Thor-wl              | [Thor-wl](https://github.com/Thor-wl)                   | Huawei      |
 | William-wang         | [william-wang](https://github.com/william-wang)         | Huawei      |
+| Liang Tang           | [shinytang6](https://github.com/shinytang6)             | Baidu       |
 
 ## Emeritus
 


### PR DESCRIPTION
Some of my latest contributions related to volcano:

1. support minAvailable at task level #1459
2. use nodeMap to fix anti-affinity problem #1430
3. fix ssh missing when job update #1429
4. add podgroup admission #1375
5. help downstream communities better integrate volcano https://github.com/kubeflow/common/pull/116 

Totally, i've contributed around 20 merged PRs and actively participated in community meetings, community issue responses, code reviews. Hope to become a maintainer and help volcano better~