### PR TITLE
support get queue from namespace

### DIFF
--- a/pkg/scheduler/framework/framework.go
+++ b/pkg/scheduler/framework/framework.go
@@ -39,16 +39,12 @@ func OpenSession(cache cache.Cache, tiers []conf.Tier, configurations []conf.Con
 			} else {
 				plugin := pb(plugin.Arguments)
 				ssn.plugins[plugin.Name()] = plugin
+				onSessionOpenStart := time.Now()
+				plugin.OnSessionOpen(ssn)
+				metrics.UpdatePluginDuration(plugin.Name(), metrics.OnSessionOpen, metrics.Duration(onSessionOpenStart))
 			}
 		}
 	}
-
-	for _, plugin := range ssn.plugins {
-		onSessionOpenStart := time.Now()
-		plugin.OnSessionOpen(ssn)
-		metrics.UpdatePluginDuration(plugin.Name(), metrics.OnSessionOpen, metrics.Duration(onSessionOpenStart))
-	}
-
 	return ssn
 }
 


### PR DESCRIPTION
Signed-off-by: q00575201 <qianjianmin@huawei.com>

In some scenarios,  the namespace is associated with the user’s level (e.g., v1 namespace is created by v1 user). Therefore, when scheduling jobs with the queue, we  also want the queue associates with the user level and the namespace (e.g., v1-queue). This PR supports get queue information from the namespace. To avoid interfering with other scenes, we also add a switch to controll this function.