### PR TITLE
Improve: preempt break out if intersection is null

### DIFF
--- a/pkg/scheduler/framework/session_plugins.go
+++ b/pkg/scheduler/framework/session_plugins.go
@@ -148,6 +148,11 @@ func (ssn *Session) Reclaimable(reclaimer *api.TaskInfo, reclaimees []*api.TaskI
 				continue
 			}
 			candidates := rf(reclaimer, reclaimees)
+			// intersection will be nil if length is 0, don't need to do any more check
+			if len(candidates) == 0 {
+				victims = nil
+				break
+			}
 			if !init {
 				victims = candidates
 				init = true
@@ -191,6 +196,12 @@ func (ssn *Session) Preemptable(preemptor *api.TaskInfo, preemptees []*api.TaskI
 				continue
 			}
 			candidates := pf(preemptor, preemptees)
+			// intersection will be nil if length is 0, don't need to do any more check
+			if len(candidates) == 0 {
+				victims = nil
+				break
+			}
+
 			if !init {
 				victims = candidates
 				init = true


### PR DESCRIPTION
when `candidates` is null in last plugin, there is no need to check any more due to `intersection` will be null.

return it directly to improve perfomance.