### PR TITLE
Improve: reduce calculation of total nodes' resource in stead of storing it when snapshot

### DIFF
--- a/pkg/scheduler/framework/session.go
+++ b/pkg/scheduler/framework/session.go
@@ -41,6 +41,8 @@ type Session struct {
 
 	kubeClient kubernetes.Interface
 	cache      cache.Cache
+
+	TotalResource *api.Resource
 	// podGroupStatus cache podgroup status during schedule
 	// This should not be mutated after initiated
 	podGroupStatus map[api.JobID]scheduling.PodGroupStatus
@@ -88,6 +90,7 @@ func openSession(cache cache.Cache) *Session {
 		kubeClient: cache.Client(),
 		cache:      cache,
 
+		TotalResource:  api.EmptyResource(),
 		podGroupStatus: map[api.JobID]scheduling.PodGroupStatus{},
 
 		Jobs:           map[api.JobID]*api.JobInfo{},
@@ -154,6 +157,11 @@ func openSession(cache cache.Cache) *Session {
 	ssn.RevocableNodes = snapshot.RevocableNodes
 	ssn.Queues = snapshot.Queues
 	ssn.NamespaceInfo = snapshot.NamespaceInfo
+	// calculate all nodes' resource only once in each schedule cycle, other plugins can clone it when need
+	for _, n := range ssn.Nodes {
+		ssn.TotalResource.Add(n.Allocatable)
+	}
+
 	klog.V(3).Infof("Open Session %v with <%d> Job and <%d> Queues",
 		ssn.UID, len(ssn.Jobs), len(ssn.Queues))
 
@@ -174,6 +182,7 @@ func closeSession(ssn *Session) {
 	ssn.queueOrderFns = nil
 	ssn.clusterOrderFns = nil
 	ssn.NodeList = nil
+	ssn.TotalResource = nil
 
 	klog.V(3).Infof("Close Session %v", ssn.UID)
 }

--- a/pkg/scheduler/plugins/drf/drf.go
+++ b/pkg/scheduler/plugins/drf/drf.go
@@ -201,9 +201,7 @@ func (drf *drfPlugin) compareQueues(root *hierarchicalNode, lqueue *api.QueueInf
 
 func (drf *drfPlugin) OnSessionOpen(ssn *framework.Session) {
 	// Prepare scheduling data for this session.
-	for _, n := range ssn.Nodes {
-		drf.totalResource.Add(n.Allocatable)
-	}
+	drf.totalResource.Add(ssn.TotalResource)
 
 	klog.V(4).Infof("Total Allocatable %s", drf.totalResource)
 

--- a/pkg/scheduler/plugins/proportion/proportion.go
+++ b/pkg/scheduler/plugins/proportion/proportion.go
@@ -68,9 +68,7 @@ func (pp *proportionPlugin) Name() string {
 
 func (pp *proportionPlugin) OnSessionOpen(ssn *framework.Session) {
 	// Prepare scheduling data for this session.
-	for _, n := range ssn.Nodes {
-		pp.totalResource.Add(n.Allocatable)
-	}
+	pp.totalResource.Add(ssn.TotalResource)
 
 	klog.V(4).Infof("The total resource is <%v>", pp.totalResource)
 


### PR DESCRIPTION
storing total nodes' resource when snapshot in case of each plugins calculate it 

Signed-off-by: lowang_bh <lhui_wang@163.com>