### PR TITLE
Adds the missing field to the Webhook

### DIFF
--- a/pkg/webhooks/admission/jobs/validate/util.go
+++ b/pkg/webhooks/admission/jobs/validate/util.go
@@ -37,6 +37,8 @@ var policyEventMap = map[busv1alpha1.Event]bool{
 	busv1alpha1.TaskCompletedEvent: true,
 	busv1alpha1.OutOfSyncEvent:     false,
 	busv1alpha1.CommandIssuedEvent: false,
+	busv1alpha1.JobUpdatedEvent:    true,
+	busv1alpha1.TaskFailedEvent:    true,
 }
 
 // policyActionMap defines all policy actions and whether to allow external use.
@@ -49,6 +51,9 @@ var policyActionMap = map[busv1alpha1.Action]bool{
 	busv1alpha1.ResumeJobAction:    true,
 	busv1alpha1.SyncJobAction:      false,
 	busv1alpha1.EnqueueAction:      false,
+	busv1alpha1.SyncQueueAction:    false,
+	busv1alpha1.OpenQueueAction:    false,
+	busv1alpha1.CloseQueueAction:   false,
 }
 
 func validatePolicies(policies []batchv1alpha1.LifecyclePolicy, fldPath *field.Path) error {


### PR DESCRIPTION
Ref: #1567

I'm not sure I'm right about whether these fields are permissible for external use.

Also, about adding aliases, does that mean that some events are the same? For example `podFailed` and `taskFailed`, I am not sure if this is correct,  If only 10% of pods fail, is taskfailed? or only 1% of pod fail?