### PR TITLE
add task-spec in pod label

### DIFF
--- a/pkg/controllers/job/job_controller_util.go
+++ b/pkg/controllers/job/job_controller_util.go
@@ -124,6 +124,7 @@ func createJobPod(job *batch.Job, template *v1.PodTemplateSpec, ix int) *v1.Pod 
 
 	// Set pod labels for Service.
 	pod.Labels[batch.JobNameKey] = job.Name
+	pod.Labels[batch.TaskSpecKey] = tsKey
 	pod.Labels[batch.JobNamespaceKey] = job.Namespace
 	pod.Labels[batch.QueueNameKey] = job.Spec.Queue
 	if len(job.Labels) > 0 {


### PR DESCRIPTION
add task-spec in pod label since we want to add service to select the specific task spec pod. like the notebook app, we only want to expose the 22 (sshd) port of the master task pod.