### PR TITLE
delete bindingTasks from NodeInfo structure

### DIFF
--- a/pkg/scheduler/api/node_info.go
+++ b/pkg/scheduler/api/node_info.go
@@ -56,8 +56,6 @@ type NodeInfo struct {
 	Others     map[string]interface{}
 	GPUDevices map[int]*GPUDevice
 
-	bindingTasks map[TaskID]string
-
 	// enable node resource oversubscription
 	OversubscriptionNode bool
 	// OfflineJobEvicting true means node resource usage too high then dispatched pod can not use oversubscription resource
@@ -100,8 +98,6 @@ func NewNodeInfo(node *v1.Node) *NodeInfo {
 		Tasks:                    make(map[TaskID]*TaskInfo),
 
 		GPUDevices: make(map[int]*GPUDevice),
-
-		bindingTasks: make(map[TaskID]string),
 	}
 
 	nodeInfo.setOversubscription(node)
@@ -161,10 +157,6 @@ func (ni *NodeInfo) Clone() *NodeInfo {
 		}
 
 		klog.V(5).Infof("current Policies : %v", res.NumaSchedulerInfo.Policies)
-	}
-
-	for taskID := range ni.bindingTasks {
-		res.AddBindingTask(taskID)
 	}
 
 	res.Others = ni.Others
@@ -514,25 +506,4 @@ func (ni *NodeInfo) SubGPUResource(pod *v1.Pod) {
 			delete(dev.PodMap, string(pod.UID))
 		}
 	}
-}
-
-// GetBindingTasks return binding task ids
-func (ni *NodeInfo) GetBindingTasks() []TaskID {
-	var tasks []TaskID
-
-	for taskID := range ni.bindingTasks {
-		tasks = append(tasks, taskID)
-	}
-
-	return tasks
-}
-
-// AddBindingTask add binding taskId to node
-func (ni *NodeInfo) AddBindingTask(task TaskID) {
-	ni.bindingTasks[task] = ""
-}
-
-// RemoveBindingTask remove binding taskId from node
-func (ni *NodeInfo) RemoveBindingTask(task TaskID) {
-	delete(ni.bindingTasks, task)
 }

--- a/pkg/scheduler/api/node_info_test.go
+++ b/pkg/scheduler/api/node_info_test.go
@@ -63,8 +63,7 @@ func TestNodeInfo_AddPod(t *testing.T) {
 					"c1/p1": NewTaskInfo(case01Pod1),
 					"c1/p2": NewTaskInfo(case01Pod2),
 				},
-				GPUDevices:   make(map[int]*GPUDevice),
-				bindingTasks: make(map[TaskID]string),
+				GPUDevices: make(map[int]*GPUDevice),
 			},
 		},
 		{
@@ -84,7 +83,6 @@ func TestNodeInfo_AddPod(t *testing.T) {
 				State:                    NodeState{Phase: Ready},
 				Tasks:                    map[TaskID]*TaskInfo{},
 				GPUDevices:               make(map[int]*GPUDevice),
-				bindingTasks:             make(map[TaskID]string),
 			},
 			expectedFailure: true,
 		},
@@ -145,8 +143,7 @@ func TestNodeInfo_RemovePod(t *testing.T) {
 					"c1/p1": NewTaskInfo(case01Pod1),
 					"c1/p3": NewTaskInfo(case01Pod3),
 				},
-				GPUDevices:   make(map[int]*GPUDevice),
-				bindingTasks: make(map[TaskID]string),
+				GPUDevices: make(map[int]*GPUDevice),
 			},
 		},
 	}

--- a/pkg/scheduler/cache/cache.go
+++ b/pkg/scheduler/cache/cache.go
@@ -645,18 +645,6 @@ func (sc *SchedulerCache) Bind(taskInfo *schedulingapi.TaskInfo, hostname string
 		}
 	} else {
 		go func() {
-			taskID := schedulingapi.PodKey(p)
-
-			sc.Lock()
-			node.AddBindingTask(taskID)
-			sc.Unlock()
-
-			defer func() {
-				sc.Lock()
-				node.RemoveBindingTask(taskID)
-				sc.Unlock()
-			}()
-
 			if err := sc.Binder.Bind(p, hostname); err != nil {
 				sc.resyncTask(task)
 			} else {
@@ -822,12 +810,6 @@ func (sc *SchedulerCache) Snapshot() *schedulingapi.ClusterInfo {
 
 	for _, value := range sc.Nodes {
 		if !value.Ready() {
-			continue
-		}
-
-		bindingTasks := value.GetBindingTasks()
-		if len(bindingTasks) > 0 {
-			klog.V(4).Infof("There are %d binding tasks, skip node %s", len(bindingTasks), value.Name)
 			continue
 		}
 


### PR DESCRIPTION
Signed-off-by: huone1 <huwanxing@huawei.com>
in  #1388 , the nodeinfo add  the member bindingTasks to avoid the resource overuse.
But  before bind action，schedulercache has reduced the pod request resource on the binding node. 
![image](https://user-images.githubusercontent.com/71266853/126450939-45b26185-bf5b-4e8d-84c4-4adb5f08bdc2.png)

So the adjustment whether the binding is still in progress is unnecessary and it has some impact on binding performance due to the need for locks.