### PR TITLE
fix addmission parsing bug

### DIFF
--- a/cmd/webhook-manager/app/options/options.go
+++ b/cmd/webhook-manager/app/options/options.go
@@ -28,7 +28,7 @@ const (
 	defaultSchedulerName    = "volcano"
 	defaultQPS              = 50.0
 	defaultBurst            = 100
-	defaultEnabledAdmission = "/jobs/mutate;/jobs/validate;/podgroups/mutate;/pods/validate;/pods/mutate;/queues/mutate;/queues/validate"
+	defaultEnabledAdmission = "/jobs/mutate,/jobs/validate,/podgroups/mutate,/pods/validate,/pods/mutate,/queues/mutate,/queues/validate"
 )
 
 // Config admission-controller server config.

--- a/pkg/webhooks/router/admission.go
+++ b/pkg/webhooks/router/admission.go
@@ -49,7 +49,7 @@ func RegisterAdmission(service *AdmissionService) error {
 }
 
 func ForEachAdmission(config *options.Config, handler func(*AdmissionService)) {
-	admissions := strings.Split(config.EnabledAdmission, ";")
+	admissions := strings.Split(strings.TrimSpace(config.EnabledAdmission), ",")
 	for _, admission := range admissions {
 		if service, found := admissionMap[admission]; found {
 			handler(service)


### PR DESCRIPTION
Signed-off-by: jianmin qian

background: in bash scripts, ";" also used as a delimiter. Thus if we use ";" to split a string, such as "/jobs/mutate;/jobs/validate;/podgroups/mutate;/pods/validate", we will just get "/jobs/mutate" as a result. In there, we change ";" to ","