### PR TITLE
fix some problems of golangci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,3 +1,26 @@
+# options for analysis running
+run:
+  # default concurrency is a available CPU number
+  concurrency: 4
+
+  # timeout for analysis, e.g. 30s, 5m, default is 1m
+  timeout: 10m
+
+  # exit code when at least one issue was found, default is 1
+  issues-exit-code: 1
+
+  # which dirs to skip: issues from them won't be reported;
+  # can use regexp here: generated.*, regexp is applied on full path;
+  # default value is empty list, but default dirs are skipped independently
+  # from this option's value (see skip-dirs-use-default).
+  # "/" will be replaced by current OS file path separator to properly work
+  # on Windows.
+  skip-dirs:
+    - vendor
+    - test
+  skip-files:
+    - .*_test.go
+
 # output configuration options
 output:
   # colored-line-number|line-number|json|tab|checkstyle|code-climate, default is "colored-line-number"
@@ -9,80 +32,35 @@ output:
   # print linter name in the end of issue text, default is true
   print-linter-name: true
 
+  # make issues output unique by line, default is true
+  uniq-by-line: true
+
 linters:
   # please, do not use `enable-all`: it's deprecated and will be removed soon.
   # inverted configuration with `enable-all` and `disable` is not scalable during updates of golangci-lint
   disable-all: true
   enable:
-    - deadcode
-    - errcheck
-    - gocritic
+    # linters maintained by golang.org
     - gofmt
-    - goimports 
-    - golint 
-    - gosimple
+    - goimports
+    - golint
     - govet
-    - ineffassign
-    - interfacer
-    - lll
-    - misspell
-    - staticcheck 
-    - structcheck 
-    - typecheck 
-    - unconvert 
-    - unparam 
-    - varcheck 
+    # linters default enabled by golangci-lint .
+    #- deadcode
+    #- errcheck
+    #- gosimple
+    #- ineffassign
+    #- staticcheck
+    #- structcheck
+    #- typecheck
+    #- unused
+    #- varcheck
+    # other linters supported by golangci-lint.
+    #- gosec
+    #- whitespace
 
-issues:
-  # Excluding configuration per-path, per-linter, per-text and per-source
-  exclude-rules:
-    - path: _test\.go
-      linters:
-        - gomnd
-    - path: test
-      linters:
-        - gomnd
-        - dupl
-    # TODO: unknownState is totally same with closingState
-    - path: pkg/controllers/queue/state/unknown.go
-      linters:
-        - dupl
-    - path: v1beta1
-      linters:
-        - golint
-        - dupl
-    - path: pkg/scheduler
-      linters:
-        - godot
-    - path: clientset
-      linters:
-        - godot
-    - path: informers
-      linters:
-        - godot
-    - path: pkg/cli/queue/operate.go
-      linters:
-        - godot
-    - path: pkg/controllers/job/plugins/ssh/ssh.go
-      linters:
-        - godot
-    - path: v1alpha1
-      linters:
-        - godot
-    - path: generated
-      linters:
-        - golint
-        - deadcode
-    - path: fake
-      linters:
-        - golint
-        - deadcode
-        - godot
-    # TODO: fix lint issue
-    - path: pkg/api
-      linters:
-        - errcheck
-        - lll
-        - unparam
-        - unconvert
-        - goimports
+linters-settings:
+  goimports:
+    local-prefixes: volcano.sh
+
+

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -43,7 +43,6 @@ linters:
     # linters maintained by golang.org
     - gofmt
     - goimports
-    - golint
     - govet
     # linters default enabled by golangci-lint .
     #- deadcode

--- a/Makefile
+++ b/Makefile
@@ -164,7 +164,7 @@ verify:
 
 lint: ## Lint the files
 	golangci-lint version
-	golangci-lint run pkg/kube pkg/version pkg/apis/...
+	golangci-lint run -v
 
 verify-generated-yaml:
 	./hack/check-generated-yaml.sh

--- a/cmd/webhook-manager/app/server.go
+++ b/cmd/webhook-manager/app/server.go
@@ -25,11 +25,11 @@ import (
 	"strconv"
 	"syscall"
 
-	"k8s.io/klog"
-
 	v1 "k8s.io/api/core/v1"
 	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/klog"
+
 	"volcano.sh/apis/pkg/apis/scheduling/scheme"
 	"volcano.sh/volcano/cmd/webhook-manager/app/options"
 	"volcano.sh/volcano/pkg/kube"

--- a/pkg/cli/queue/util.go
+++ b/pkg/cli/queue/util.go
@@ -22,15 +22,15 @@ import (
 	"os"
 	"strings"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	// Initialize client auth plugin.
+	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+
 	busv1alpha1 "volcano.sh/apis/pkg/apis/bus/v1alpha1"
 	"volcano.sh/apis/pkg/apis/helpers"
 	"volcano.sh/apis/pkg/client/clientset/versioned"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/clientcmd"
-	// Initialize client auth plugin.
-	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 )
 
 func homeDir() string {

--- a/pkg/controllers/apis/job_info.go
+++ b/pkg/controllers/apis/job_info.go
@@ -19,7 +19,7 @@ package apis
 import (
 	"fmt"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 
 	batch "volcano.sh/apis/pkg/apis/batch/v1alpha1"
 )

--- a/pkg/controllers/apis/request.go
+++ b/pkg/controllers/apis/request.go
@@ -18,6 +18,7 @@ package apis
 
 import (
 	"fmt"
+
 	"volcano.sh/apis/pkg/apis/bus/v1alpha1"
 )
 

--- a/pkg/controllers/cache/interface.go
+++ b/pkg/controllers/cache/interface.go
@@ -17,7 +17,7 @@ limitations under the License.
 package cache
 
 import (
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 
 	"volcano.sh/apis/pkg/apis/batch/v1alpha1"
 	"volcano.sh/volcano/pkg/controllers/apis"

--- a/pkg/controllers/framework/factory.go
+++ b/pkg/controllers/framework/factory.go
@@ -18,6 +18,7 @@ package framework
 
 import (
 	"fmt"
+
 	"k8s.io/klog"
 )
 

--- a/pkg/controllers/framework/interface.go
+++ b/pkg/controllers/framework/interface.go
@@ -19,6 +19,7 @@ package framework
 import (
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
+
 	vcclientset "volcano.sh/apis/pkg/client/clientset/versioned"
 )
 

--- a/pkg/controllers/job/helpers/helpers.go
+++ b/pkg/controllers/job/helpers/helpers.go
@@ -22,7 +22,7 @@ import (
 	"strings"
 	"time"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 
 	"volcano.sh/volcano/pkg/controllers/apis"
 )

--- a/pkg/controllers/job/job_controller_resync.go
+++ b/pkg/controllers/job/job_controller_resync.go
@@ -22,8 +22,7 @@ import (
 	"time"
 
 	"golang.org/x/time/rate"
-
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/util/workqueue"

--- a/pkg/controllers/job/plugins/factory.go
+++ b/pkg/controllers/job/plugins/factory.go
@@ -20,7 +20,7 @@ import (
 	"sync"
 
 	"volcano.sh/volcano/pkg/controllers/job/plugins/env"
-	"volcano.sh/volcano/pkg/controllers/job/plugins/interface"
+	pluginsinterface "volcano.sh/volcano/pkg/controllers/job/plugins/interface"
 	"volcano.sh/volcano/pkg/controllers/job/plugins/ssh"
 	"volcano.sh/volcano/pkg/controllers/job/plugins/svc"
 )

--- a/pkg/controllers/job/state/running.go
+++ b/pkg/controllers/job/state/running.go
@@ -18,6 +18,7 @@ package state
 
 import (
 	v1 "k8s.io/api/core/v1"
+
 	vcbatch "volcano.sh/apis/pkg/apis/batch/v1alpha1"
 	"volcano.sh/apis/pkg/apis/bus/v1alpha1"
 	"volcano.sh/volcano/pkg/controllers/apis"

--- a/pkg/scheduler/actions/allocate/allocate.go
+++ b/pkg/scheduler/actions/allocate/allocate.go
@@ -18,6 +18,7 @@ package allocate
 
 import (
 	"k8s.io/klog"
+
 	"volcano.sh/apis/pkg/apis/scheduling"
 	"volcano.sh/volcano/pkg/scheduler/api"
 	"volcano.sh/volcano/pkg/scheduler/framework"

--- a/pkg/scheduler/actions/elect/elect.go
+++ b/pkg/scheduler/actions/elect/elect.go
@@ -3,6 +3,7 @@ package elect
 
 import (
 	"k8s.io/klog"
+
 	"volcano.sh/apis/pkg/apis/scheduling"
 	"volcano.sh/volcano/pkg/scheduler/api"
 	"volcano.sh/volcano/pkg/scheduler/framework"

--- a/pkg/scheduler/api/node_info.go
+++ b/pkg/scheduler/api/node_info.go
@@ -22,6 +22,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/klog"
+
 	"volcano.sh/apis/pkg/apis/scheduling/v1beta1"
 )
 

--- a/pkg/scheduler/api/numa_info.go
+++ b/pkg/scheduler/api/numa_info.go
@@ -20,6 +20,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/kubernetes/pkg/kubelet/cm/cpumanager/topology"
 	"k8s.io/kubernetes/pkg/kubelet/cm/cpuset"
+
 	nodeinfov1alpha1 "volcano.sh/apis/pkg/apis/nodeinfo/v1alpha1"
 )
 

--- a/pkg/scheduler/api/pod_info.go
+++ b/pkg/scheduler/api/pod_info.go
@@ -24,6 +24,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/klog"
+
 	"volcano.sh/apis/pkg/apis/scheduling/v1beta1"
 )
 

--- a/pkg/scheduler/cache/util.go
+++ b/pkg/scheduler/cache/util.go
@@ -16,9 +16,7 @@ limitations under the License.
 
 package cache
 
-import (
-	"k8s.io/api/core/v1"
-)
+import v1 "k8s.io/api/core/v1"
 
 // responsibleForPod returns true if the pod has asked to be scheduled by the given scheduler.
 func responsibleForPod(pod *v1.Pod, schedulerName string) bool {

--- a/pkg/scheduler/framework/statement.go
+++ b/pkg/scheduler/framework/statement.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	"k8s.io/klog"
+
 	"volcano.sh/volcano/pkg/scheduler/api"
 	"volcano.sh/volcano/pkg/scheduler/metrics"
 )

--- a/pkg/scheduler/plugins/predicates/proportional.go
+++ b/pkg/scheduler/plugins/predicates/proportional.go
@@ -18,7 +18,9 @@ package predicates
 
 import (
 	"fmt"
+
 	v1 "k8s.io/api/core/v1"
+
 	"volcano.sh/volcano/pkg/scheduler/api"
 )
 

--- a/pkg/scheduler/plugins/reservation/reservation.go
+++ b/pkg/scheduler/plugins/reservation/reservation.go
@@ -17,8 +17,9 @@ limitations under the License.
 package reservation
 
 import (
-	"k8s.io/klog"
 	"time"
+
+	"k8s.io/klog"
 
 	"volcano.sh/volcano/pkg/scheduler/api"
 	"volcano.sh/volcano/pkg/scheduler/framework"

--- a/pkg/scheduler/plugins/task-topology/topology.go
+++ b/pkg/scheduler/plugins/task-topology/topology.go
@@ -18,10 +18,11 @@ package tasktopology
 
 import (
 	"fmt"
-	"k8s.io/klog"
-	"k8s.io/kubernetes/pkg/scheduler/framework/v1alpha1"
 	"strings"
 	"time"
+
+	"k8s.io/klog"
+	"k8s.io/kubernetes/pkg/scheduler/framework/v1alpha1"
 
 	"volcano.sh/volcano/pkg/scheduler/api"
 	"volcano.sh/volcano/pkg/scheduler/framework"

--- a/pkg/scheduler/plugins/util/k8s/framework.go
+++ b/pkg/scheduler/plugins/util/k8s/framework.go
@@ -61,20 +61,17 @@ func (f *Framework) RejectWaitingPod(uid types.UID) {
 // HasFilterPlugins returns true if at least one filter plugin is defined.
 func (f *Framework) HasFilterPlugins() bool {
 	panic("not implemented")
-	return false
 }
 
 // HasScorePlugins returns true if at least one score plugin is defined.
 func (f *Framework) HasScorePlugins() bool {
 	panic("not implemented")
-	return false
 }
 
 // ListPlugins returns a map of extension point name to plugin names configured at each extension
 // point. Returns nil if no plugins where configred.
 func (f *Framework) ListPlugins() map[string][]config.Plugin {
 	panic("not implemented")
-	return nil
 }
 
 // ClientSet returns a kubernetes clientset.
@@ -90,7 +87,6 @@ func (f *Framework) SharedInformerFactory() informers.SharedInformerFactory {
 // VolumeBinder returns the volume binder used by scheduler.
 func (f *Framework) VolumeBinder() scheduling.SchedulerVolumeBinder {
 	panic("not implemented")
-	return nil
 }
 
 // EventRecorder was introduced in k8s v1.19.6 and to be implemented

--- a/pkg/scheduler/plugins/util/k8s/snapshot.go
+++ b/pkg/scheduler/plugins/util/k8s/snapshot.go
@@ -25,6 +25,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/kubernetes/pkg/scheduler/framework/v1alpha1"
+
 	"volcano.sh/volcano/pkg/scheduler/plugins/util"
 )
 

--- a/pkg/scheduler/util/test_utils.go
+++ b/pkg/scheduler/util/test_utils.go
@@ -18,15 +18,14 @@ package util
 
 import (
 	"fmt"
-
 	"sync"
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-
 	volumescheduling "k8s.io/kubernetes/pkg/controller/volume/scheduling"
+
 	schedulingv2 "volcano.sh/apis/pkg/apis/scheduling/v1beta1"
 	"volcano.sh/volcano/pkg/scheduler/api"
 )

--- a/pkg/webhooks/config/config.go
+++ b/pkg/webhooks/config/config.go
@@ -17,16 +17,15 @@ limitations under the License.
 package config
 
 import (
-	"gopkg.in/yaml.v2"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sync"
 
+	"github.com/fsnotify/fsnotify"
+	"gopkg.in/yaml.v2"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/klog"
-
-	"github.com/fsnotify/fsnotify"
 
 	"volcano.sh/volcano/pkg/filewatcher"
 )

--- a/pkg/webhooks/router/interface.go
+++ b/pkg/webhooks/router/interface.go
@@ -21,6 +21,7 @@ import (
 	whv1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/record"
+
 	"volcano.sh/apis/pkg/client/clientset/versioned"
 	"volcano.sh/volcano/pkg/webhooks/config"
 )


### PR DESCRIPTION
Signed-off-by: gy95 <1015105054@qq.com>

modify some codes of golangci-lint
we can use `make lint` command to run golangci-lint tools to check codes.
And too much codes to run all linters, so I only choose `gofmt` `goimports` `golint` `govet` linters to check codes, `goimports` put imports beginning with `volcano.sh` (packages of volcano.sh)after 3rd-party packages;

We can enable more linters to check codes to make codes robuster.