### PR TITLE
enable eight golangci-lint linters and fix lint errors

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -45,18 +45,18 @@ linters:
     - goimports
     - govet
     # linters default enabled by golangci-lint .
-    #- deadcode
+    - deadcode
     #- errcheck
     #- gosimple
-    #- ineffassign
-    #- staticcheck
-    #- structcheck
-    #- typecheck
-    #- unused
-    #- varcheck
+    - ineffassign
+    - staticcheck
+    - structcheck
+    - typecheck
+    - unused
+    - varcheck
     # other linters supported by golangci-lint.
     #- gosec
-    #- whitespace
+    - whitespace
 
 linters-settings:
   goimports:

--- a/cmd/cli/vcctl.go
+++ b/cmd/cli/vcctl.go
@@ -71,7 +71,6 @@ func checkError(cmd *cobra.Command, err error) {
 var versionExample = `vcctl version`
 
 func versionCommand() *cobra.Command {
-
 	var command = &cobra.Command{
 		Use:     "version",
 		Short:   "Print the version information",

--- a/cmd/webhook-manager/app/server.go
+++ b/cmd/webhook-manager/app/server.go
@@ -115,5 +115,4 @@ func Run(config *options.Config) error {
 	case <-webhookServeError:
 		return fmt.Errorf("unknown webhook server error")
 	}
-
 }

--- a/pkg/cli/job/delete.go
+++ b/pkg/cli/job/delete.go
@@ -64,5 +64,4 @@ func DeleteJob() error {
 	}
 	fmt.Printf("delete job %v successfully\n", deleteJobFlags.JobName)
 	return nil
-
 }

--- a/pkg/cli/job/view.go
+++ b/pkg/cli/job/view.go
@@ -226,7 +226,6 @@ func PrintEvents(events []coreV1.Event, writer io.Writer) {
 	} else {
 		WriteLine(writer, Level0, "Events: \t<none>\n")
 	}
-
 }
 
 // GetEvents get the job event by config.

--- a/pkg/cli/queue/get.go
+++ b/pkg/cli/queue/get.go
@@ -43,7 +43,6 @@ func InitGetFlags(cmd *cobra.Command) {
 	initFlags(cmd, &getQueueFlags.commonFlags)
 
 	cmd.Flags().StringVarP(&getQueueFlags.Name, "name", "n", "", "the name of queue")
-
 }
 
 // GetQueue gets a queue.

--- a/pkg/cli/queue/list.go
+++ b/pkg/cli/queue/list.go
@@ -101,5 +101,4 @@ func PrintQueues(queues *v1beta1.QueueList, writer io.Writer) {
 			fmt.Printf("Failed to print queue command result: %s.\n", err)
 		}
 	}
-
 }

--- a/pkg/cli/vjobs/view.go
+++ b/pkg/cli/vjobs/view.go
@@ -267,7 +267,6 @@ func PrintEvents(events []coreV1.Event, writer io.Writer) {
 	} else {
 		WriteLine(writer, Level0, "Events: \t<none>\n")
 	}
-
 }
 
 // GetEvents get the job event by config.

--- a/pkg/cli/vqueues/get.go
+++ b/pkg/cli/vqueues/get.go
@@ -67,7 +67,6 @@ func InitGetFlags(cmd *cobra.Command) {
 	util.InitFlags(cmd, &getQueueFlags.CommonFlags)
 
 	cmd.Flags().StringVarP(&getQueueFlags.Name, "name", "n", "", "the name of queue")
-
 }
 
 // ListQueue lists all the queue.
@@ -107,7 +106,6 @@ func PrintQueues(queues *v1beta1.QueueList, writer io.Writer) {
 			fmt.Printf("Failed to print queue command result: %s.\n", err)
 		}
 	}
-
 }
 
 // GetQueue gets a queue.

--- a/pkg/cli/vsub/run.go
+++ b/pkg/cli/vsub/run.go
@@ -117,7 +117,6 @@ func setDefaultArgs() {
 			launchJobFlags.Namespace = defaultJobNamespace
 		}
 	}
-
 }
 
 var jobName = "job.volcano.sh"
@@ -165,7 +164,6 @@ func RunJob() error {
 }
 
 func constructLaunchJobFlagsJob(launchJobFlags *runFlags, req, limit v1.ResourceList) (*vcbatch.Job, error) {
-
 	var commands []string
 
 	if launchJobFlags.Command != "" {

--- a/pkg/controllers/job/job_controller.go
+++ b/pkg/controllers/job/job_controller.go
@@ -219,7 +219,6 @@ func (cc *jobcontroller) Initialize(opt *framework.ControllerOption) error {
 
 // Run start JobController.
 func (cc *jobcontroller) Run(stopCh <-chan struct{}) {
-
 	go cc.jobInformer.Informer().Run(stopCh)
 	go cc.podInformer.Informer().Run(stopCh)
 	go cc.pvcInformer.Informer().Run(stopCh)

--- a/pkg/controllers/job/job_controller_actions.go
+++ b/pkg/controllers/job/job_controller_actions.go
@@ -267,7 +267,6 @@ func (cc *jobcontroller) syncJob(jobInfo *apis.JobInfo, updateStatus state.Updat
 
 	var syncTask bool
 	if pg, _ := cc.pgLister.PodGroups(job.Namespace).Get(job.Name); pg != nil {
-
 		if pg.Status.Phase != "" && pg.Status.Phase != scheduling.PodGroupPending {
 			syncTask = true
 		}

--- a/pkg/controllers/job/job_controller_handler.go
+++ b/pkg/controllers/job/job_controller_handler.go
@@ -265,7 +265,6 @@ func (cc *jobcontroller) updatePod(oldObj, newObj interface{}) {
 		if oldPod.Status.Phase != v1.PodSucceeded &&
 			cc.cache.TaskCompleted(jobcache.JobKeyByName(newPod.Namespace, jobName), taskName) {
 			event = bus.TaskCompletedEvent
-
 		}
 	case v1.PodPending, v1.PodRunning:
 		if cc.cache.TaskFailed(jobcache.JobKeyByName(newPod.Namespace, jobName), taskName) {
@@ -364,7 +363,6 @@ func (cc *jobcontroller) recordJobEvent(namespace, name string, event batch.JobE
 		return
 	}
 	cc.recorder.Event(job.Job, v1.EventTypeNormal, string(event), message)
-
 }
 
 func (cc *jobcontroller) handleCommands() {

--- a/pkg/controllers/job/job_controller_plugins.go
+++ b/pkg/controllers/job/job_controller_plugins.go
@@ -41,7 +41,6 @@ func (cc *jobcontroller) pluginOnPodCreate(job *batch.Job, pod *v1.Pod) error {
 			klog.Errorf("Failed to process on pod create plugin %s, err %v.", name, err)
 			return err
 		}
-
 	}
 	return nil
 }
@@ -63,7 +62,6 @@ func (cc *jobcontroller) pluginOnJobAdd(job *batch.Job) error {
 			klog.Errorf("Failed to process on job add plugin %s, err %v.", name, err)
 			return err
 		}
-
 	}
 
 	return nil
@@ -86,7 +84,6 @@ func (cc *jobcontroller) pluginOnJobDelete(job *batch.Job) error {
 			klog.Errorf("failed to process on job delete plugin %s, err %v.", name, err)
 			return err
 		}
-
 	}
 
 	return nil
@@ -109,7 +106,6 @@ func (cc *jobcontroller) pluginOnJobUpdate(job *batch.Job) error {
 			klog.Errorf("Failed to process on job update plugin %s, err %v.", name, err)
 			return err
 		}
-
 	}
 
 	return nil

--- a/pkg/controllers/job/job_controller_util.go
+++ b/pkg/controllers/job/job_controller_util.go
@@ -218,12 +218,10 @@ func checkEventExist(policyEvents []v1alpha1.Event, reqEvent v1alpha1.Event) boo
 		}
 	}
 	return false
-
 }
 
 func addResourceList(list, req, limit v1.ResourceList) {
 	for name, quantity := range req {
-
 		if value, ok := list[name]; !ok {
 			list[name] = quantity.DeepCopy()
 		} else {

--- a/pkg/controllers/job/plugins/svc/svc.go
+++ b/pkg/controllers/job/plugins/svc/svc.go
@@ -256,7 +256,6 @@ func (sp *servicePlugin) createServiceIfNotExist(job *batch.Job) error {
 			return e
 		}
 		job.Status.ControlledResources["plugin-"+sp.Name()] = sp.Name()
-
 	}
 
 	return nil
@@ -306,7 +305,6 @@ func (sp *servicePlugin) createNetworkPolicyIfNotExist(job *batch.Job) error {
 			return e
 		}
 		job.Status.ControlledResources["plugin-"+sp.Name()] = sp.Name()
-
 	}
 
 	return nil

--- a/pkg/controllers/job/state/completing.go
+++ b/pkg/controllers/job/state/completing.go
@@ -34,6 +34,5 @@ func (ps *completingState) Execute(action v1alpha1.Action) error {
 		}
 		status.State.Phase = vcbatch.Completed
 		return true
-
 	})
 }

--- a/pkg/controllers/job/state/restarting.go
+++ b/pkg/controllers/job/state/restarting.go
@@ -48,5 +48,4 @@ func (ps *restartingState) Execute(action v1alpha1.Action) error {
 
 		return false
 	})
-
 }

--- a/pkg/controllers/job/state/terminating.go
+++ b/pkg/controllers/job/state/terminating.go
@@ -34,6 +34,5 @@ func (ps *terminatingState) Execute(action v1alpha1.Action) error {
 		}
 		status.State.Phase = vcbatch.Terminated
 		return true
-
 	})
 }

--- a/pkg/controllers/podgroup/pg_controller.go
+++ b/pkg/controllers/podgroup/pg_controller.go
@@ -63,7 +63,6 @@ func (pg *pgcontroller) Name() string {
 
 // Initialize create new Podgroup Controller.
 func (pg *pgcontroller) Initialize(opt *framework.ControllerOption) error {
-
 	pg.kubeClient = opt.KubeClient
 	pg.vcClient = opt.VolcanoClient
 

--- a/pkg/controllers/queue/queue_controller.go
+++ b/pkg/controllers/queue/queue_controller.go
@@ -95,7 +95,6 @@ func (c *queuecontroller) Name() string {
 
 // NewQueueController creates a QueueController.
 func (c *queuecontroller) Initialize(opt *framework.ControllerOption) error {
-
 	c.vcClient = opt.VolcanoClient
 	c.kubeClient = opt.KubeClient
 

--- a/pkg/filewatcher/filewatcher.go
+++ b/pkg/filewatcher/filewatcher.go
@@ -44,7 +44,6 @@ func NewFileWatcher(path string) (FileWatcher, error) {
 	return &fileWatcher{
 		watcher: watcher,
 	}, nil
-
 }
 
 // Events returns the event channel.

--- a/pkg/scheduler/actions/preempt/preempt.go
+++ b/pkg/scheduler/actions/preempt/preempt.go
@@ -210,7 +210,6 @@ func preempt(
 
 		var preemptees []*api.TaskInfo
 		for _, task := range node.Tasks {
-
 			if filter == nil {
 				preemptees = append(preemptees, task.Clone())
 			} else if filter(task) {

--- a/pkg/scheduler/api/cluster_info.go
+++ b/pkg/scheduler/api/cluster_info.go
@@ -31,7 +31,6 @@ type ClusterInfo struct {
 }
 
 func (ci ClusterInfo) String() string {
-
 	str := "Cache:\n"
 
 	if len(ci.Nodes) != 0 {

--- a/pkg/scheduler/api/job_info.go
+++ b/pkg/scheduler/api/job_info.go
@@ -43,7 +43,6 @@ type DisruptionBudget struct {
 
 // NewDisruptionBudget create disruption budget for job
 func NewDisruptionBudget(minAvailable, maxUnavilable string) *DisruptionBudget {
-
 	disruptionBudget := &DisruptionBudget{
 		MinAvailable:  minAvailable,
 		MaxUnavilable: maxUnavilable,
@@ -278,7 +277,6 @@ func (ji *JobInfo) SetPodGroup(pg *PodGroup) {
 	ji.TaskMinAvailableTotal = taskMinAvailableTotal
 
 	ji.PodGroup = pg
-
 }
 
 // extractWaitingTime reads sla waiting time for job from podgroup annotations

--- a/pkg/scheduler/api/node_info.go
+++ b/pkg/scheduler/api/node_info.go
@@ -454,7 +454,6 @@ func (ni NodeInfo) String() string {
 	return fmt.Sprintf("Node (%s): allocatable<%v> idle <%v>, used <%v>, releasing <%v>, oversubscribution <%v>, "+
 		"state <phase %s, reaseon %s>, oversubscributionNode <%v>, offlineJobEvicting <%v>,taints <%v>%s",
 		ni.Name, ni.Allocatable, ni.Idle, ni.Used, ni.Releasing, ni.OversubscriptionResource, ni.State.Phase, ni.State.Reason, ni.OversubscriptionNode, ni.OfflineJobEvicting, ni.Node.Spec.Taints, tasks)
-
 }
 
 // Pods returns all pods running in that node

--- a/pkg/scheduler/api/resource_info.go
+++ b/pkg/scheduler/api/resource_info.go
@@ -484,7 +484,6 @@ func (r *Resource) SetScalar(name v1.ResourceName, quantity float64) {
 // rr resource is <cpu 3000.00, memory 1000.00>
 // return r resource is <cpu 2000.00, memory 1000.00, hugepages-2Mi 0.00, hugepages-1Gi 0.00>
 func (r *Resource) MinDimensionResource(rr *Resource) *Resource {
-
 	if rr.MilliCPU < r.MilliCPU {
 		r.MilliCPU = rr.MilliCPU
 	}

--- a/pkg/scheduler/cache/event_handlers.go
+++ b/pkg/scheduler/cache/event_handlers.go
@@ -622,7 +622,6 @@ func (sc *SchedulerCache) UpdatePriorityClass(oldObj, newObj interface{}) {
 		klog.Errorf("Cannot convert oldObj to *v1beta1.PriorityClass: %v", oldObj)
 
 		return
-
 	}
 
 	newSS, ok := newObj.(*v1beta1.PriorityClass)
@@ -666,7 +665,6 @@ func (sc *SchedulerCache) deletePriorityClass(pc *v1beta1.PriorityClass) {
 	if pc.GlobalDefault {
 		sc.defaultPriorityClass = nil
 		sc.defaultPriority = 0
-
 	}
 
 	delete(sc.PriorityClasses, pc.Name)
@@ -677,7 +675,6 @@ func (sc *SchedulerCache) addPriorityClass(pc *v1beta1.PriorityClass) {
 		if sc.defaultPriorityClass != nil {
 			klog.Errorf("Updated default priority class from <%s> to <%s> forcefully.",
 				sc.defaultPriorityClass.Name, pc.Name)
-
 		}
 		sc.defaultPriorityClass = pc
 		sc.defaultPriority = pc.Value
@@ -808,7 +805,6 @@ func getNumaInfo(srcInfo *nodeinfov1alpha1.Numatopology) *schedulingapi.Numatopo
 
 // Assumes that lock is already acquired.
 func (sc *SchedulerCache) addNumaInfo(info *nodeinfov1alpha1.Numatopology) error {
-
 	if sc.Nodes[info.Name] == nil {
 		sc.Nodes[info.Name] = schedulingapi.NewNodeInfo(nil)
 		sc.Nodes[info.Name].Name = info.Name

--- a/pkg/scheduler/framework/session.go
+++ b/pkg/scheduler/framework/session.go
@@ -195,7 +195,6 @@ func jobStatus(ssn *Session, jobInfo *api.JobInfo) scheduling.PodGroupStatus {
 		if c.Type == scheduling.PodGroupUnschedulableType &&
 			c.Status == v1.ConditionTrue &&
 			c.TransitionID == string(ssn.UID) {
-
 			unschedulable = true
 			break
 		}
@@ -468,5 +467,4 @@ func (ssn Session) String() string {
 	}
 
 	return msg
-
 }

--- a/pkg/scheduler/framework/session_plugins.go
+++ b/pkg/scheduler/framework/session_plugins.go
@@ -350,7 +350,6 @@ func (ssn *Session) JobValid(obj interface{}) *api.ValidateResult {
 			if vr := jrf(obj); vr != nil && !vr.Pass {
 				return vr
 			}
-
 		}
 	}
 
@@ -403,7 +402,6 @@ func (ssn *Session) JobEnqueued(obj interface{}) {
 			fn(obj)
 		}
 	}
-
 }
 
 // TargetJob invoke targetJobFns function of the plugins
@@ -506,7 +504,6 @@ func (ssn *Session) JobOrderFn(l, r interface{}) bool {
 		return lv.UID < rv.UID
 	}
 	return lv.CreationTimestamp.Before(&rv.CreationTimestamp)
-
 }
 
 // NamespaceOrderFn invoke namespaceorder function of the plugins
@@ -571,7 +568,6 @@ func (ssn *Session) QueueOrderFn(l, r interface{}) bool {
 			if j := qof(l, r); j != 0 {
 				return j < 0
 			}
-
 		}
 	}
 
@@ -582,7 +578,6 @@ func (ssn *Session) QueueOrderFn(l, r interface{}) bool {
 		return lv.UID < rv.UID
 	}
 	return lv.Queue.CreationTimestamp.Before(&rv.Queue.CreationTimestamp)
-
 }
 
 // TaskCompareFns invoke taskorder function of the plugins
@@ -618,7 +613,6 @@ func (ssn *Session) TaskOrderFn(l, r interface{}) bool {
 		return lv.UID < rv.UID
 	}
 	return lv.Pod.CreationTimestamp.Before(&rv.Pod.CreationTimestamp)
-
 }
 
 // PredicateFn invoke predicate function of the plugins
@@ -678,7 +672,6 @@ func (ssn *Session) NodeOrderFn(task *api.TaskInfo, node *api.NodeInfo) (float64
 				return 0, err
 			}
 			priorityScore += score
-
 		}
 	}
 	return priorityScore, nil
@@ -735,7 +728,6 @@ func (ssn *Session) NodeOrderMapFn(task *api.TaskInfo, node *api.NodeInfo) (map[
 				}
 				nodeScoreMap[plugin.Name] = score
 			}
-
 		}
 	}
 	return nodeScoreMap, priorityScore, nil

--- a/pkg/scheduler/plugins/conformance/conformance.go
+++ b/pkg/scheduler/plugins/conformance/conformance.go
@@ -52,7 +52,6 @@ func (pp *conformancePlugin) OnSessionOpen(ssn *framework.Session) {
 			if className == scheduling.SystemClusterCritical ||
 				className == scheduling.SystemNodeCritical ||
 				evictee.Namespace == v1.NamespaceSystem {
-
 				continue
 			}
 

--- a/pkg/scheduler/plugins/drf/drf.go
+++ b/pkg/scheduler/plugins/drf/drf.go
@@ -70,7 +70,6 @@ func (node *hierarchicalNode) Clone(parent *hierarchicalNode) *hierarchicalNode 
 		for _, child := range node.children {
 			newNode.children[child.hierarchy] = child.Clone(newNode)
 		}
-
 	}
 	return newNode
 }
@@ -88,7 +87,6 @@ func resourceSaturated(allocated *api.Resource,
 		}
 	}
 	return false
-
 }
 
 type drfAttr struct {
@@ -394,16 +392,13 @@ func (drf *drfPlugin) OnSessionOpen(ssn *framework.Session) {
 				if ret > shareDelta {
 					continue
 				}
-
 			}
 
 			klog.V(4).Infof("Victims from HDRF plugins are %+v", victims)
 
 			return victims, util.Permit
-
 		}
 		ssn.AddReclaimableFn(drf.Name(), reclaimFn)
-
 	}
 
 	jobOrderFn := func(l interface{}, r interface{}) int {
@@ -420,8 +415,8 @@ func (drf *drfPlugin) OnSessionOpen(ssn *framework.Session) {
 		if drf.jobAttrs[lv.UID].share < drf.jobAttrs[rv.UID].share {
 			return -1
 		}
-		return 1
 
+		return 1
 	}
 
 	ssn.AddJobOrderFn(drf.Name(), jobOrderFn)
@@ -565,7 +560,6 @@ func (drf *drfPlugin) buildHierarchy(root *hierarchicalNode, job *api.JobInfo, a
 	// update drf attribute bottom up
 	klog.V(4).Infof("Job <%s/%s> added to %s, weights %s, attr %v, total request: %s",
 		job.Namespace, job.Name, inode.hierarchy, hierarchicalWeights, child.attr, job.TotalRequest)
-
 }
 
 // updateNamespaceShare updates the node attribute recursively
@@ -606,7 +600,6 @@ func (drf *drfPlugin) updateHierarchicalShare(node *hierarchicalNode,
 					t := child.attr.allocated.Clone().Multi(mdr / child.attr.share)
 					node.attr.allocated.Add(t)
 				}
-
 			}
 		}
 		node.attr.dominantResource, node.attr.share = drf.calculateShare(
@@ -615,7 +608,6 @@ func (drf *drfPlugin) updateHierarchicalShare(node *hierarchicalNode,
 		klog.V(4).Infof("Update hierarchical node %s, share %f, dominant resource %s, resource %v, saturated: %t",
 			node.hierarchy, node.attr.share, node.attr.dominantResource, node.attr.allocated, node.saturated)
 	}
-
 }
 
 func (drf *drfPlugin) UpdateHierarchicalShare(root *hierarchicalNode, totalAllocated *api.Resource, job *api.JobInfo, attr *drfAttr, hierarchy, hierarchicalWeights string) {
@@ -624,7 +616,6 @@ func (drf *drfPlugin) UpdateHierarchicalShare(root *hierarchicalNode, totalAlloc
 	for _, rn := range drf.totalResource.ResourceNames() {
 		if totalAllocated.Get(rn) < drf.totalResource.Get(rn) {
 			demandingResources[rn] = true
-
 		}
 	}
 	drf.buildHierarchy(root, job, attr, hierarchy, hierarchicalWeights)

--- a/pkg/scheduler/plugins/gang/gang.go
+++ b/pkg/scheduler/plugins/gang/gang.go
@@ -209,7 +209,6 @@ func (gp *gangPlugin) OnSessionClose(ssn *framework.Session) {
 				klog.Errorf("Failed to update job <%s/%s> condition: %v",
 					job.Namespace, job.Name, err)
 			}
-
 		}
 		metrics.UpdateUnscheduleTaskCount(job.Name, int(unreadyTaskCount))
 		unreadyTaskCount = 0

--- a/pkg/scheduler/plugins/nodeorder/nodeorder.go
+++ b/pkg/scheduler/plugins/nodeorder/nodeorder.go
@@ -103,7 +103,6 @@ type priorityWeight struct {
 //        balancedresource.weight: 2
 //        tainttoleration.weight: 2
 func calculateWeight(args framework.Arguments) priorityWeight {
-
 	// Initial values for weights.
 	// By default, for backward compatibility and for reasonable scores,
 	// least requested priority is enabled and most requested priority is disabled.

--- a/pkg/scheduler/plugins/predicates/predicates.go
+++ b/pkg/scheduler/plugins/predicates/predicates.go
@@ -85,7 +85,6 @@ type predicateEnable struct {
 }
 
 func enablePredicate(args framework.Arguments) predicateEnable {
-
 	/*
 	   User Should give predicatesEnable in this format(predicate.GPUSharingEnable).
 	   Currently supported only GPUSharing predicate checks.
@@ -240,7 +239,6 @@ func (pp *predicatesPlugin) OnSessionOpen(ssn *framework.Session) {
 				return
 			}
 			klog.V(4).Infof("predicates, update pod %s/%s deallocate from node [%s]", pod.Namespace, pod.Name, nodeName)
-
 		},
 	})
 

--- a/pkg/scheduler/plugins/tdm/tdm.go
+++ b/pkg/scheduler/plugins/tdm/tdm.go
@@ -38,7 +38,6 @@ const (
 	revocableZoneLayout      = "15:04"
 	revocableZoneLabelPrefix = "tdm.revocable-zone."
 	evictPeriodLabel         = "tdm.evict.period"
-	evictMaxStepLabel        = "tdm.evict.max-step"
 	defaultPodEvictNum       = 1
 )
 

--- a/pkg/scheduler/plugins/util/util.go
+++ b/pkg/scheduler/plugins/util/util.go
@@ -251,7 +251,6 @@ type CachedNodeInfo struct {
 func (c *CachedNodeInfo) GetNodeInfo(name string) (*v1.Node, error) {
 	node, found := c.Session.Nodes[name]
 	if !found {
-
 		return nil, errors.NewNotFound(v1.Resource("node"), name)
 	}
 

--- a/pkg/webhooks/admission/jobs/validate/util.go
+++ b/pkg/webhooks/admission/jobs/validate/util.go
@@ -98,7 +98,6 @@ func validatePolicies(policies []batchv1alpha1.LifecyclePolicy, fldPath *field.P
 			if bFlag {
 				break
 			}
-
 		} else {
 			if *policy.ExitCode == 0 {
 				err = multierror.Append(err, fmt.Errorf("0 is not a valid error code"))

--- a/pkg/webhooks/admission/pods/validate/admit_pod.go
+++ b/pkg/webhooks/admission/pods/validate/admit_pod.go
@@ -69,7 +69,6 @@ var config = &router.AdmissionServiceConfig{}
 
 // AdmitPods is to admit pods and return response.
 func AdmitPods(ar v1beta1.AdmissionReview) *v1beta1.AdmissionResponse {
-
 	klog.V(3).Infof("admitting pods -- %s", ar.Request.Operation)
 
 	pod, err := schema.DecodePod(ar.Request.Object, ar.Request.Resource)

--- a/pkg/webhooks/admission/queues/validate/validate_queue.go
+++ b/pkg/webhooks/admission/queues/validate/validate_queue.go
@@ -150,7 +150,6 @@ func validateHierarchicalAttributes(queue *schedulingv1beta1.Queue, fldPath *fie
 					schedulingv1beta1.KubeHierarchyAnnotationKey,
 					err,
 				)))
-
 		}
 		for _, queueInTree := range queueList.Items {
 			hierarchyInTree := queueInTree.Annotations[schedulingv1beta1.KubeHierarchyAnnotationKey]
@@ -159,10 +158,8 @@ func validateHierarchicalAttributes(queue *schedulingv1beta1.Queue, fldPath *fie
 				return append(errs, field.Invalid(fldPath, hierarchy,
 					fmt.Sprintf("%s is not allowed to be in the sub path of %s of queue %s",
 						hierarchy, hierarchyInTree, queueInTree.Name)))
-
 			}
 		}
-
 	}
 	return errs
 }


### PR DESCRIPTION
Signed-off-by: gy95 <1015105054@qq.com>

enable the following linters, and fix lint errors
    - ineffassign
    - staticcheck
    - structcheck
    - typecheck
    - unused
    - varcheck
    - whitespace
    - deadcode