### PR TITLE
enable gosec and fix related errors

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -55,12 +55,14 @@ linters:
     - unused
     - varcheck
     # other linters supported by golangci-lint.
-    #- gosec
+    - gosec
     - revive
     - whitespace
 
 linters-settings:
   goimports:
     local-prefixes: volcano.sh
-
+  gosec:
+    includes:
+      - G601
 

--- a/example/kubecon-2019-china/scripts/node-info.go
+++ b/example/kubecon-2019-china/scripts/node-info.go
@@ -61,7 +61,8 @@ func main() {
 		if _, found := podMap[nodeName]; !found {
 			podMap[nodeName] = api.EmptyResource()
 		}
-		res := api.GetPodResourceWithoutInitContainers(&p)
+		pod := p
+		res := api.GetPodResourceWithoutInitContainers(&pod)
 		podMap[nodeName].Add(res)
 	}
 

--- a/pkg/scheduler/api/device_info.go
+++ b/pkg/scheduler/api/device_info.go
@@ -56,8 +56,8 @@ func (g *GPUDevice) getUsedGPUMemory() uint {
 // GetGPUResourceOfPod returns the GPU resource required by the pod.
 func GetGPUResourceOfPod(pod *v1.Pod) uint {
 	var mem uint
-	for _, container := range pod.Spec.Containers {
-		mem += getGPUResourceOfContainer(&container)
+	for index := range pod.Spec.Containers {
+		mem += getGPUResourceOfContainer(&pod.Spec.Containers[index])
 	}
 	return mem
 }

--- a/pkg/scheduler/framework/job_updater.go
+++ b/pkg/scheduler/framework/job_updater.go
@@ -72,7 +72,8 @@ func isPodGroupConditionsUpdated(newCondition, oldCondition []scheduling.PodGrou
 		newTransitionID := newCond.TransitionID
 		newCond.TransitionID = oldCond.TransitionID
 
-		shouldUpdate := !reflect.DeepEqual(&newCond, &oldCond)
+		tempNewCond := newCond
+		shouldUpdate := !reflect.DeepEqual(&tempNewCond, &oldCond)
 
 		newCond.LastTransitionTime = newTime
 		newCond.TransitionID = newTransitionID

--- a/pkg/scheduler/plugins/numaaware/numaaware.go
+++ b/pkg/scheduler/plugins/numaaware/numaaware.go
@@ -127,7 +127,8 @@ func (pp *numaPlugin) OnSessionOpen(ssn *framework.Session) {
 		taskPolicy := policy.GetPolicy(node, numaNodes[node.Name])
 		allResAssignMap := make(map[string]cpuset.CPUSet)
 		for _, container := range task.Pod.Spec.Containers {
-			providersHints := policy.AccumulateProvidersHints(&container, node.NumaSchedulerInfo, resNumaSets, pp.hintProviders)
+			con := container
+			providersHints := policy.AccumulateProvidersHints(&con, node.NumaSchedulerInfo, resNumaSets, pp.hintProviders)
 			hit, admit := taskPolicy.Predicate(providersHints)
 			if !admit {
 				return fmt.Errorf("plugin %s predicates failed for task %s container %s on node %s",
@@ -136,7 +137,7 @@ func (pp *numaPlugin) OnSessionOpen(ssn *framework.Session) {
 
 			klog.V(4).Infof("[numaaware] hits for task %s container '%v': %v on node %s, besthit: %v",
 				task.Name, container.Name, providersHints, node.Name, hit)
-			resAssignMap := policy.Allocate(&container, &hit, node.NumaSchedulerInfo, resNumaSets, pp.hintProviders)
+			resAssignMap := policy.Allocate(&con, &hit, node.NumaSchedulerInfo, resNumaSets, pp.hintProviders)
 			for resName, assign := range resAssignMap {
 				allResAssignMap[resName] = allResAssignMap[resName].Union(assign)
 				resNumaSets[resName] = resNumaSets[resName].Difference(assign)


### PR DESCRIPTION
Signed-off-by: gy95 <1015105054@qq.com>

enable gosec linter check
the error output is ` G601: Implicit memory aliasing in for loop. (gosec)`
in the `for range` loop, we should address the value directly, maybe the address points to the same address

ref: [using-reference-to-loop-iterator-variable](https://github.com/golang/go/wiki/CommonMistakes#using-reference-to-loop-iterator-variable)