### PR TITLE
add revive linter as drop-in replacement of archived golint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -56,6 +56,7 @@ linters:
     - varcheck
     # other linters supported by golangci-lint.
     #- gosec
+    - revive
     - whitespace
 
 linters-settings:

--- a/pkg/controllers/job/plugins/svc/svc.go
+++ b/pkg/controllers/job/plugins/svc/svc.go
@@ -184,11 +184,7 @@ func (sp *servicePlugin) OnJobUpdate(job *batch.Job) error {
 	hostFile := GenerateHosts(job)
 
 	// updates ConfigMap of hosts for Pods to mount.
-	if err := helpers.CreateOrUpdateConfigMap(job, sp.Clientset.KubeClients, hostFile, sp.cmName(job)); err != nil {
-		return err
-	}
-
-	return nil
+	return helpers.CreateOrUpdateConfigMap(job, sp.Clientset.KubeClients, hostFile, sp.cmName(job))
 }
 
 func (sp *servicePlugin) mountConfigmap(pod *v1.Pod, job *batch.Job) {

--- a/pkg/controllers/podgroup/pg_controller_handler.go
+++ b/pkg/controllers/podgroup/pg_controller_handler.go
@@ -146,7 +146,6 @@ func newPGOwnerReferences(pod *v1.Pod) []metav1.OwnerReference {
 // addResourceList add list resource quantity
 func addResourceList(list, req, limit v1.ResourceList) {
 	for name, quantity := range req {
-
 		if value, ok := list[name]; !ok {
 			list[name] = quantity.DeepCopy()
 		} else {

--- a/pkg/scheduler/plugins/util/k8s/framework.go
+++ b/pkg/scheduler/plugins/util/k8s/framework.go
@@ -100,10 +100,10 @@ func (f *Framework) PreemptHandle() v1alpha1.PreemptHandle {
 }
 
 // NewFrameworkHandle creates a FrameworkHandle interface, which is used by k8s plugins.
-func NewFrameworkHandle(nodeMap map[string]*v1alpha1.NodeInfo, kClient kubernetes.Interface) v1alpha1.FrameworkHandle {
+func NewFrameworkHandle(nodeMap map[string]*v1alpha1.NodeInfo, client kubernetes.Interface) v1alpha1.FrameworkHandle {
 	snapshot := NewSnapshot(nodeMap)
 	return &Framework{
 		snapshot:   snapshot,
-		kubeClient: kClient,
+		kubeClient: client,
 	}
 }

--- a/pkg/scheduler/util/scheduler_helper.go
+++ b/pkg/scheduler/util/scheduler_helper.go
@@ -273,7 +273,7 @@ func GetMinInt(vals ...int) int {
 		return 0
 	}
 
-	var min int = vals[0]
+	min := vals[0]
 	for _, val := range vals {
 		if val <= min {
 			min = val

--- a/pkg/webhooks/admission/jobs/mutate/mutate_job.go
+++ b/pkg/webhooks/admission/jobs/mutate/mutate_job.go
@@ -74,7 +74,7 @@ type patchOperation struct {
 	Value interface{} `json:"value,omitempty"`
 }
 
-// MutateJobs mutate jobs.
+// Jobs mutate jobs.
 func Jobs(ar v1beta1.AdmissionReview) *v1beta1.AdmissionResponse {
 	klog.V(3).Infof("mutating jobs")
 


### PR DESCRIPTION
Signed-off-by: gy95 <1015105054@qq.com>

ref: https://golangci-lint.run/usage/linters/  , golint has been archived by the owner. Replaced by revive.
So add `revive` as drop-in replacement of archived `golint`