### PR TITLE
refine scheduler framework

### DIFF
--- a/pkg/scheduler/cache/cache.go
+++ b/pkg/scheduler/cache/cache.go
@@ -115,6 +115,8 @@ type SchedulerCache struct {
 
 	errTasks    workqueue.RateLimitingInterface
 	deletedJobs workqueue.RateLimitingInterface
+
+	informerFactory informers.SharedInformerFactory
 }
 
 type defaultBinder struct {
@@ -383,6 +385,7 @@ func newSchedulerCache(config *rest.Config, schedulerName string, defaultQueue s
 	}
 
 	informerFactory := informers.NewSharedInformerFactory(sc.kubeClient, 0)
+	sc.informerFactory = informerFactory
 
 	// create informer for node information
 	sc.nodeInformer = informerFactory.Core().V1().Nodes()
@@ -683,6 +686,11 @@ func (sc *SchedulerCache) BindVolumes(task *schedulingapi.TaskInfo, podVolumes *
 // Client returns the kubernetes clientSet
 func (sc *SchedulerCache) Client() kubernetes.Interface {
 	return sc.kubeClient
+}
+
+// SharedInformerFactory returns the scheduler SharedInformerFactory
+func (sc *SchedulerCache) SharedInformerFactory() informers.SharedInformerFactory {
+	return sc.informerFactory
 }
 
 // UpdateSchedulerNumaInfo used to update scheduler node cache NumaSchedulerInfo

--- a/pkg/scheduler/cache/interface.go
+++ b/pkg/scheduler/cache/interface.go
@@ -18,6 +18,7 @@ package cache
 
 import (
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/pkg/controller/volume/scheduling"
 
@@ -65,6 +66,9 @@ type Cache interface {
 	Client() kubernetes.Interface
 
 	UpdateSchedulerNumaInfo(sets map[string]api.ResNumaSets) error
+
+	// SharedInformerFactory return scheduler SharedInformerFactory
+	SharedInformerFactory() informers.SharedInformerFactory
 }
 
 // VolumeBinder interface for allocate and bind volumes

--- a/pkg/scheduler/plugins/nodeorder/nodeorder.go
+++ b/pkg/scheduler/plugins/nodeorder/nodeorder.go
@@ -174,7 +174,7 @@ func (pp *nodeOrderPlugin) OnSessionOpen(ssn *framework.Session) {
 	})
 
 	// Initialize k8s scheduling plugins
-	handle := k8s.NewFrameworkHandle(nodeMap, ssn.KubeClient())
+	handle := k8s.NewFrameworkHandle(nodeMap, ssn.KubeClient(), ssn.InformerFactory())
 	// 1. NodeResourcesLeastAllocated
 	laArgs := &config.NodeResourcesLeastAllocatedArgs{
 		Resources: []config.ResourceSpec{

--- a/pkg/scheduler/plugins/predicates/predicates.go
+++ b/pkg/scheduler/plugins/predicates/predicates.go
@@ -244,7 +244,7 @@ func (pp *predicatesPlugin) OnSessionOpen(ssn *framework.Session) {
 
 	// Initialize k8s plugins
 	// TODO: Add more predicates, k8s.io/kubernetes/pkg/scheduler/framework/plugins/legacy_registry.go
-	handle := k8s.NewFrameworkHandle(nodeMap, ssn.KubeClient())
+	handle := k8s.NewFrameworkHandle(nodeMap, ssn.KubeClient(), ssn.InformerFactory())
 	// 1. NodeUnschedulable
 	plugin, _ := nodeunschedulable.New(nil, handle)
 	nodeUnscheduleFilter := plugin.(*nodeunschedulable.NodeUnschedulable)

--- a/pkg/scheduler/plugins/util/k8s/framework.go
+++ b/pkg/scheduler/plugins/util/k8s/framework.go
@@ -29,8 +29,9 @@ import (
 // Framework is a K8S framework who mainly provides some methods
 // about snapshot and plugins such as predicates
 type Framework struct {
-	snapshot   v1alpha1.SharedLister
-	kubeClient kubernetes.Interface
+	snapshot        v1alpha1.SharedLister
+	kubeClient      kubernetes.Interface
+	informerFactory informers.SharedInformerFactory
 }
 
 var _ v1alpha1.FrameworkHandle = &Framework{}
@@ -81,7 +82,7 @@ func (f *Framework) ClientSet() kubernetes.Interface {
 
 // SharedInformerFactory returns a shared informer factory.
 func (f *Framework) SharedInformerFactory() informers.SharedInformerFactory {
-	return informers.NewSharedInformerFactory(f.kubeClient, 0)
+	return f.informerFactory
 }
 
 // VolumeBinder returns the volume binder used by scheduler.
@@ -100,10 +101,11 @@ func (f *Framework) PreemptHandle() v1alpha1.PreemptHandle {
 }
 
 // NewFrameworkHandle creates a FrameworkHandle interface, which is used by k8s plugins.
-func NewFrameworkHandle(nodeMap map[string]*v1alpha1.NodeInfo, client kubernetes.Interface) v1alpha1.FrameworkHandle {
+func NewFrameworkHandle(nodeMap map[string]*v1alpha1.NodeInfo, client kubernetes.Interface, informerFactory informers.SharedInformerFactory) v1alpha1.FrameworkHandle {
 	snapshot := NewSnapshot(nodeMap)
 	return &Framework{
-		snapshot:   snapshot,
-		kubeClient: client,
+		snapshot:        snapshot,
+		kubeClient:      client,
+		informerFactory: informerFactory,
 	}
 }


### PR DESCRIPTION
Signed-off-by: wpeng102 <wpeng102@126.com>

Customer uses volcano framework to create a handler by the following code:
```
	handle := k8s.NewFrameworkHandle(nodeMap)

	// 1. volumeBinding
	vbArgs := &config.VolumeBindingArgs{}
	plugin, _ := volumebinding.New(vbArgs, handle)
	volumeBindingFilter := plugin.(*volumebinding.VolumeBinding)
```
`volumebinding.New` will use handler `SharedInformerFactory` to create some informer. We should pass scheudler's share informer for this handler to avoid customer write start informer logic in plugin.
