### PR TITLE
fix(underused): Do not check overused when there is no UnderUsedResourceFn added

### DIFF
--- a/pkg/scheduler/actions/allocate/allocate.go
+++ b/pkg/scheduler/actions/allocate/allocate.go
@@ -204,8 +204,7 @@ func (alloc *Action) Execute(ssn *framework.Session) {
 
 			// Check whether the queue is overused on dimension that the task requested
 			taskRequest := task.Resreq.ResourceNames()
-
-			if !ssn.UnderusedResources(queue).Contains(taskRequest) {
+			if underusedResources := ssn.UnderusedResources(queue); underusedResources != nil && !underusedResources.Contains(taskRequest) {
 				klog.V(3).Infof("Queue <%s> is overused when considering task <%s>, ignore it.", queue.Name, task.Name)
 				continue
 			}

--- a/pkg/scheduler/actions/reclaim/reclaim.go
+++ b/pkg/scheduler/actions/reclaim/reclaim.go
@@ -113,7 +113,7 @@ func (ra *Action) Execute(ssn *framework.Session) {
 
 		// Check whether the queue is overused on dimension that the task requested
 		taskRequest := task.Resreq.ResourceNames()
-		if !ssn.UnderusedResources(queue).Contains(taskRequest) {
+		if underusedResources := ssn.UnderusedResources(queue); underusedResources != nil && !underusedResources.Contains(taskRequest) {
 			klog.V(3).Infof("Queue <%s> is overused when considering task <%s>, ignore it.", queue.Name, task.Name)
 			continue
 		}

--- a/pkg/scheduler/framework/session_plugins.go
+++ b/pkg/scheduler/framework/session_plugins.go
@@ -263,7 +263,13 @@ func (ssn *Session) Overused(queue *api.QueueInfo) bool {
 }
 
 // UnderusedResources invoke underused function of the plugins
+// Returns:
+//  * nil if no `UnderUsedResourceFn` is registered
+//  * [] if no under-used resources
 func (ssn *Session) UnderusedResources(queue *api.QueueInfo) api.ResourceNameList {
+	if len(ssn.underUsedFns) == 0 {
+		return nil
+	}
 	for _, tier := range ssn.Tiers {
 		for _, plugin := range tier.Plugins {
 			of, found := ssn.underUsedFns[plugin.Name]


### PR DESCRIPTION
- fix #1724 .
- Do not check overused when there is no `UnderUsedResourceFn` added.