### PR TITLE
Add livenessProbe and readinessProbe in Grafana Container

### DIFF
--- a/installer/helm/chart/volcano/templates/grafana.yaml
+++ b/installer/helm/chart/volcano/templates/grafana.yaml
@@ -70,6 +70,16 @@ spec:
       containers:
       - name: grafana
         image: grafana/grafana:latest
+        readinessProbe:
+          httpGet:
+            path: /api/health
+            port: 3000
+        livenessProbe:
+          httpGet:
+            path: /api/health
+            port: 3000
+          initialDelaySeconds: 10
+          periodSeconds: 10
         ports:
         - name: grafana
           containerPort: 3000


### PR DESCRIPTION
Add livenessProbe and readinessProbe in Grafana container configuration. 

Without these settings, the load balancer on cloud platforms (such as GKE) do not redirect traffic to the container as the container are never considered healthy.

