### PR TITLE
optimize: shorten sync context in Snapshot

### DIFF
--- a/pkg/scheduler/api/resource_info.go
+++ b/pkg/scheduler/api/resource_info.go
@@ -461,10 +461,10 @@ func (r *Resource) Diff(rr *Resource, defaultValue DimensionDefaultValue) (*Reso
 		decreasedVal.Memory = rightRes.Memory - leftRes.Memory
 	}
 
-	increasedVal.ScalarResources = make(map[v1.ResourceName]float64, 0)
-	decreasedVal.ScalarResources = make(map[v1.ResourceName]float64, 0)
+	increasedVal.ScalarResources = make(map[v1.ResourceName]float64)
+	decreasedVal.ScalarResources = make(map[v1.ResourceName]float64)
 	for lName, lQuant := range leftRes.ScalarResources {
-		rQuant, _ := rightRes.ScalarResources[lName]
+		rQuant := rightRes.ScalarResources[lName]
 		if lQuant == -1 {
 			increasedVal.ScalarResources[lName] = -1
 			continue

--- a/pkg/scheduler/plugins/priority/priority.go
+++ b/pkg/scheduler/plugins/priority/priority.go
@@ -18,6 +18,7 @@ package priority
 
 import (
 	"k8s.io/klog"
+
 	"volcano.sh/volcano/pkg/scheduler/api"
 	"volcano.sh/volcano/pkg/scheduler/framework"
 	"volcano.sh/volcano/pkg/scheduler/plugins/util"
@@ -117,7 +118,6 @@ func (pp *priorityPlugin) OnSessionOpen(ssn *framework.Session) {
 		return ji.ReadyTaskNum()+ji.WaitingTaskNum() < int32(len(ji.Tasks))
 	}
 	ssn.AddJobStarvingFns(pp.Name(), jobStarvingFn)
-
 }
 
 func (pp *priorityPlugin) OnSessionClose(ssn *framework.Session) {}


### PR DESCRIPTION
I guess the sync logic in the func "Snapshot" could be shorten, so I modify some code within the function. I think it may help to be more readable.
I don't konw if such kind of prs are meaningless. Please let me if such a pr can't improve anything.

And fix some conflicts from golangci-lint