### PR TITLE
Remove default quota info in `NewNamespaceCollection`

### DIFF
--- a/pkg/scheduler/api/namespace_info.go
+++ b/pkg/scheduler/api/namespace_info.go
@@ -83,12 +83,6 @@ func NewNamespaceCollection(name string) *NamespaceCollection {
 		Name:        name,
 		quotaWeight: cache.NewHeap(quotaItemKeyFunc, quotaItemLessFunc),
 	}
-	// add at least one item into quotaWeight.
-	// Because cache.Heap.Pop would be blocked until queue is not empty
-	n.updateWeight(&quotaItem{
-		name:   NamespaceWeightKey,
-		weight: DefaultNamespaceWeight,
-	})
 	return n
 }
 

--- a/pkg/scheduler/api/namespace_info_test.go
+++ b/pkg/scheduler/api/namespace_info_test.go
@@ -60,15 +60,6 @@ func TestNamespaceCollection(t *testing.T) {
 	if info.Weight != 16 {
 		t.Errorf("weight of namespace should be %d, but not %d", 16, info.Weight)
 	}
-
-	c.Delete(newQuota("abc", 0))
-	c.Delete(newQuota("def", 15))
-	c.Delete(newQuota("ghi", -1))
-
-	info = c.Snapshot()
-	if info.Weight != DefaultNamespaceWeight {
-		t.Errorf("weight of namespace should be default weight %d, but not %d", DefaultNamespaceWeight, info.Weight)
-	}
 }
 
 func TestEmptyNamespaceCollection(t *testing.T) {

--- a/pkg/scheduler/api/namespace_info_test.go
+++ b/pkg/scheduler/api/namespace_info_test.go
@@ -61,34 +61,3 @@ func TestNamespaceCollection(t *testing.T) {
 		t.Errorf("weight of namespace should be %d, but not %d", 16, info.Weight)
 	}
 }
-
-func TestEmptyNamespaceCollection(t *testing.T) {
-	c := NewNamespaceCollection("testEmptyCollection")
-
-	info := c.Snapshot()
-	if info.Weight != DefaultNamespaceWeight {
-		t.Errorf("weight of namespace should be %d, but not %d", DefaultNamespaceWeight, info.Weight)
-	}
-
-	// snapshot can be called anytime
-	info = c.Snapshot()
-	if info.Weight != DefaultNamespaceWeight {
-		t.Errorf("weight of namespace should be %d, but not %d", DefaultNamespaceWeight, info.Weight)
-	}
-
-	c.Delete(newQuota("abc", 0))
-
-	info = c.Snapshot()
-	if info.Weight != DefaultNamespaceWeight {
-		t.Errorf("weight of namespace should be %d, but not %d", DefaultNamespaceWeight, info.Weight)
-	}
-
-	c.Delete(newQuota("abc", 0))
-	c.Delete(newQuota("def", 15))
-	c.Delete(newQuota("ghi", -1))
-
-	info = c.Snapshot()
-	if info.Weight != DefaultNamespaceWeight {
-		t.Errorf("weight of namespace should be default weight %d, but not %d", DefaultNamespaceWeight, info.Weight)
-	}
-}


### PR DESCRIPTION
Since `NewNamespaceCollection` only used in `updateResourceQuota`, add default quota info is unnecessary.

https://github.com/volcano-sh/volcano/blob/5ebe2d94de86c19d1c3368d7f6a2238519c36665/pkg/scheduler/cache/event_handlers.go#L692-L701

Signed-off-by: ZhengYu, Xu <zen-xu@outlook.com>