### PR TITLE
feat(outOfSync): tracks and re-synchronizes node when it becomes 'OutOfSync'

### DIFF
--- a/pkg/scheduler/api/job_info.go
+++ b/pkg/scheduler/api/job_info.go
@@ -269,7 +269,7 @@ func (ti *TaskInfo) GetTaskSpecKey() TaskID {
 // String returns the taskInfo details in a string
 func (ti TaskInfo) String() string {
 	res := fmt.Sprintf("Task (%v:%v/%v): job %v, status %v, pri %v"+
-		"resreq %v, preemptable %v, revocableZone %v",
+		"resreq<%v>, preemptable %v, revocableZone %v",
 		ti.UID, ti.Namespace, ti.Name, ti.Job, ti.Status, ti.Priority,
 		ti.Resreq, ti.Preemptable, ti.RevocableZone)
 

--- a/pkg/scheduler/api/types.go
+++ b/pkg/scheduler/api/types.go
@@ -103,6 +103,15 @@ func (np NodePhase) String() string {
 	return "Unknown"
 }
 
+// NodePhaseReason defines the reason why node is in this phase
+type NodePhaseReason string
+
+const (
+	ReasonUnInitialized NodePhaseReason = "UnInitialized" // node is uninitialized
+	ReasonOutOfSync     NodePhaseReason = "OutOfSync"     // e.g.: lost of GPU
+	ReasonNotReady      NodePhaseReason = "NotReady"      // e.g.: power off
+)
+
 // validateStatusUpdate validates whether the status transfer is valid.
 func validateStatusUpdate(oldStatus, newStatus TaskStatus) error {
 	return nil

--- a/pkg/scheduler/cache/index.go
+++ b/pkg/scheduler/cache/index.go
@@ -1,0 +1,36 @@
+/*
+ Copyright 2022 The Volcano Authors.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package cache
+
+import (
+	v1 "k8s.io/api/core/v1"
+)
+
+// IndexNameNodeName is the index name for node name of pod
+const IndexNameNodeName = ".spec.nodeName"
+
+// IndexNodeName indices pod by its field `.spec.nodeName`
+func IndexNodeName(obj interface{}) ([]string, error) {
+	pod, ok := obj.(*v1.Pod)
+	if !ok {
+		return nil, nil
+	}
+	if nodeName := pod.Spec.NodeName; len(nodeName) > 0 {
+		return []string{nodeName}, nil
+	}
+	return nil, nil
+}


### PR DESCRIPTION
+ fix #1818.
+ A possible fix to the above issue:
    -  Add a `RateLimitingQueue` to holds the not ready nodes and start a asynchronous thread to synchronize  them.
    -  The events of `updateNode` and `removeTask` will trigger the re-synchronization of the related nodes.
    - The synchronization of node will use the latest `v1.Node` and `v1.Pod` list( a list of pods located on the former node) from the informer cache to:
        + updates node;
        + removes unwanted tasks(unlikely) and adds missing tasks;