### PR TITLE
all controller should share same informerFactory

### DIFF
--- a/pkg/controllers/framework/interface.go
+++ b/pkg/controllers/framework/interface.go
@@ -21,16 +21,18 @@ import (
 	"k8s.io/client-go/kubernetes"
 
 	vcclientset "volcano.sh/apis/pkg/client/clientset/versioned"
+	vcinformers "volcano.sh/apis/pkg/client/informers/externalversions"
 )
 
 // ControllerOption is the main context object for the controllers.
 type ControllerOption struct {
-	KubeClient            kubernetes.Interface
-	VolcanoClient         vcclientset.Interface
-	SharedInformerFactory informers.SharedInformerFactory
-	SchedulerNames        []string
-	WorkerNum             uint32
-	MaxRequeueNum         int
+	KubeClient             kubernetes.Interface
+	VolcanoClient          vcclientset.Interface
+	SharedInformerFactory  informers.SharedInformerFactory
+	VolcanoInformerFactory vcinformers.SharedInformerFactory
+	SchedulerNames         []string
+	WorkerNum              uint32
+	MaxRequeueNum          int
 }
 
 // Controller is the interface of all controllers.

--- a/pkg/controllers/garbagecollector/garbagecollector.go
+++ b/pkg/controllers/garbagecollector/garbagecollector.go
@@ -30,7 +30,6 @@ import (
 
 	"volcano.sh/apis/pkg/apis/batch/v1alpha1"
 	vcclientset "volcano.sh/apis/pkg/client/clientset/versioned"
-	informerfactory "volcano.sh/apis/pkg/client/informers/externalversions"
 	batchinformers "volcano.sh/apis/pkg/client/informers/externalversions/batch/v1alpha1"
 	batchlisters "volcano.sh/apis/pkg/client/listers/batch/v1alpha1"
 	"volcano.sh/volcano/pkg/controllers/framework"
@@ -69,7 +68,7 @@ func (gc *gccontroller) Name() string {
 // Initialize creates an instance of gccontroller.
 func (gc *gccontroller) Initialize(opt *framework.ControllerOption) error {
 	gc.vcClient = opt.VolcanoClient
-	jobInformer := informerfactory.NewSharedInformerFactory(gc.vcClient, 0).Batch().V1alpha1().Jobs()
+	jobInformer := opt.VolcanoInformerFactory.Batch().V1alpha1().Jobs()
 
 	gc.jobInformer = jobInformer
 	gc.jobLister = jobInformer.Lister()
@@ -91,7 +90,6 @@ func (gc *gccontroller) Run(stopCh <-chan struct{}) {
 	klog.Infof("Starting garbage collector")
 	defer klog.Infof("Shutting down garbage collector")
 
-	go gc.jobInformer.Informer().Run(stopCh)
 	if !cache.WaitForCacheSync(stopCh, gc.jobSynced) {
 		return
 	}

--- a/pkg/controllers/garbagecollector/garbagecollector_test.go
+++ b/pkg/controllers/garbagecollector/garbagecollector_test.go
@@ -25,6 +25,7 @@ import (
 
 	"volcano.sh/apis/pkg/apis/batch/v1alpha1"
 	volcanoclient "volcano.sh/apis/pkg/client/clientset/versioned/fake"
+	vcinformers "volcano.sh/apis/pkg/client/informers/externalversions"
 	"volcano.sh/volcano/pkg/controllers/framework"
 )
 
@@ -85,8 +86,11 @@ func TestGarbageCollector_ProcessTTL(t *testing.T) {
 	}
 	for i, testcase := range testcases {
 		gc := &gccontroller{}
+		vcClient := volcanoclient.NewSimpleClientset()
+		vcInformerFactory := vcinformers.NewSharedInformerFactory(vcClient, 0)
 		gc.Initialize(&framework.ControllerOption{
-			VolcanoClient: volcanoclient.NewSimpleClientset(),
+			VolcanoClient:          vcClient,
+			VolcanoInformerFactory: vcInformerFactory,
 		})
 
 		expired, err := gc.processTTL(testcase.Job)

--- a/pkg/controllers/job/job_controller_handler_test.go
+++ b/pkg/controllers/job/job_controller_handler_test.go
@@ -33,6 +33,7 @@ import (
 	"volcano.sh/apis/pkg/apis/helpers"
 	scheduling "volcano.sh/apis/pkg/apis/scheduling/v1beta1"
 	vcclientset "volcano.sh/apis/pkg/client/clientset/versioned"
+	vcinformers "volcano.sh/apis/pkg/client/informers/externalversions"
 	"volcano.sh/volcano/pkg/controllers/framework"
 )
 
@@ -53,13 +54,15 @@ func newController() *jobcontroller {
 	})
 
 	sharedInformers := informers.NewSharedInformerFactory(kubeClientSet, 0)
+	volcanoSharedInformers := vcinformers.NewSharedInformerFactory(vcclient, 0)
 
 	controller := &jobcontroller{}
 	opt := &framework.ControllerOption{
-		VolcanoClient:         vcclient,
-		KubeClient:            kubeClientSet,
-		SharedInformerFactory: sharedInformers,
-		WorkerNum:             3,
+		VolcanoClient:          vcclient,
+		KubeClient:             kubeClientSet,
+		SharedInformerFactory:  sharedInformers,
+		VolcanoInformerFactory: volcanoSharedInformers,
+		WorkerNum:              3,
 	}
 
 	controller.Initialize(opt)

--- a/pkg/controllers/job/job_controller_plugins_test.go
+++ b/pkg/controllers/job/job_controller_plugins_test.go
@@ -28,6 +28,7 @@ import (
 
 	batch "volcano.sh/apis/pkg/apis/batch/v1alpha1"
 	volcanoclient "volcano.sh/apis/pkg/client/clientset/versioned/fake"
+	vcinformers "volcano.sh/apis/pkg/client/informers/externalversions"
 	"volcano.sh/volcano/pkg/controllers/framework"
 )
 
@@ -36,13 +37,15 @@ func newFakeController() *jobcontroller {
 	kubeClientSet := kubeclient.NewSimpleClientset()
 
 	sharedInformers := informers.NewSharedInformerFactory(kubeClientSet, 0)
+	volcanoSharedInformers := vcinformers.NewSharedInformerFactory(volcanoClientSet, 0)
 
 	controller := &jobcontroller{}
 	opt := &framework.ControllerOption{
-		VolcanoClient:         volcanoClientSet,
-		KubeClient:            kubeClientSet,
-		SharedInformerFactory: sharedInformers,
-		WorkerNum:             3,
+		VolcanoClient:          volcanoClientSet,
+		KubeClient:             kubeClientSet,
+		SharedInformerFactory:  sharedInformers,
+		VolcanoInformerFactory: volcanoSharedInformers,
+		WorkerNum:              3,
 	}
 
 	controller.Initialize(opt)

--- a/pkg/controllers/podgroup/pg_controller.go
+++ b/pkg/controllers/podgroup/pg_controller.go
@@ -27,7 +27,6 @@ import (
 
 	scheduling "volcano.sh/apis/pkg/apis/scheduling/v1beta1"
 	vcclientset "volcano.sh/apis/pkg/client/clientset/versioned"
-	informerfactory "volcano.sh/apis/pkg/client/informers/externalversions"
 	schedulinginformer "volcano.sh/apis/pkg/client/informers/externalversions/scheduling/v1beta1"
 	schedulinglister "volcano.sh/apis/pkg/client/listers/scheduling/v1beta1"
 	"volcano.sh/volcano/pkg/controllers/framework"
@@ -79,7 +78,7 @@ func (pg *pgcontroller) Initialize(opt *framework.ControllerOption) error {
 		AddFunc: pg.addPod,
 	})
 
-	pg.pgInformer = informerfactory.NewSharedInformerFactory(pg.vcClient, 0).Scheduling().V1beta1().PodGroups()
+	pg.pgInformer = opt.VolcanoInformerFactory.Scheduling().V1beta1().PodGroups()
 	pg.pgLister = pg.pgInformer.Lister()
 	pg.pgSynced = pg.pgInformer.Informer().HasSynced
 
@@ -88,8 +87,6 @@ func (pg *pgcontroller) Initialize(opt *framework.ControllerOption) error {
 
 // Run start NewPodgroupController.
 func (pg *pgcontroller) Run(stopCh <-chan struct{}) {
-	go pg.podInformer.Informer().Run(stopCh)
-	go pg.pgInformer.Informer().Run(stopCh)
 
 	cache.WaitForCacheSync(stopCh, pg.podSynced, pg.pgSynced)
 

--- a/pkg/controllers/podgroup/pg_controller_test.go
+++ b/pkg/controllers/podgroup/pg_controller_test.go
@@ -29,6 +29,7 @@ import (
 
 	scheduling "volcano.sh/apis/pkg/apis/scheduling/v1beta1"
 	vcclient "volcano.sh/apis/pkg/client/clientset/versioned/fake"
+	vcinformers "volcano.sh/apis/pkg/client/informers/externalversions"
 	"volcano.sh/volcano/pkg/controllers/framework"
 )
 
@@ -36,13 +37,15 @@ func newFakeController() *pgcontroller {
 	kubeClient := kubeclient.NewSimpleClientset()
 	vcClient := vcclient.NewSimpleClientset()
 	sharedInformers := informers.NewSharedInformerFactory(kubeClient, 0)
+	vcSharedInformers := vcinformers.NewSharedInformerFactory(vcClient, 0)
 
 	controller := &pgcontroller{}
 	opt := &framework.ControllerOption{
-		KubeClient:            kubeClient,
-		VolcanoClient:         vcClient,
-		SharedInformerFactory: sharedInformers,
-		SchedulerNames:        []string{"volcano"},
+		KubeClient:             kubeClient,
+		VolcanoClient:          vcClient,
+		SharedInformerFactory:  sharedInformers,
+		VolcanoInformerFactory: vcSharedInformers,
+		SchedulerNames:         []string{"volcano"},
 	}
 
 	controller.Initialize(opt)

--- a/pkg/controllers/queue/queue_controller_test.go
+++ b/pkg/controllers/queue/queue_controller_test.go
@@ -22,22 +22,29 @@ import (
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/informers"
 	kubeclient "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/tools/cache"
 
 	schedulingv1beta1 "volcano.sh/apis/pkg/apis/scheduling/v1beta1"
 	vcclient "volcano.sh/apis/pkg/client/clientset/versioned/fake"
+	vcinformers "volcano.sh/apis/pkg/client/informers/externalversions"
 	"volcano.sh/volcano/pkg/controllers/framework"
 )
 
 func newFakeController() *queuecontroller {
-	KubeBatchClientSet := vcclient.NewSimpleClientset()
-	KubeClientSet := kubeclient.NewSimpleClientset()
+	kubeBatchClientSet := vcclient.NewSimpleClientset()
+	kubeClientSet := kubeclient.NewSimpleClientset()
+
+	sharedInformers := informers.NewSharedInformerFactory(kubeClientSet, 0)
+	volcanoSharedInformers := vcinformers.NewSharedInformerFactory(kubeBatchClientSet, 0)
 
 	controller := &queuecontroller{}
 	opt := framework.ControllerOption{
-		VolcanoClient: KubeBatchClientSet,
-		KubeClient:    KubeClientSet,
+		VolcanoClient:          kubeBatchClientSet,
+		KubeClient:             kubeClientSet,
+		SharedInformerFactory:  sharedInformers,
+		VolcanoInformerFactory: volcanoSharedInformers,
 	}
 
 	controller.Initialize(&opt)


### PR DESCRIPTION
If all  controllers created  their own `informerFactory`, there were many copies cache for one k8s object (such as volcano job or podgroup).  This would waste resource and memory 

all controller should share  one `informerFactory`

