### PR TITLE
Fix delete duplicate line.

### DIFF
--- a/pkg/controllers/job/job_controller_actions.go
+++ b/pkg/controllers/job/job_controller_actions.go
@@ -689,7 +689,6 @@ func (cc *jobcontroller) initJobStatus(job *batch.Job) (*batch.Job, error) {
 		return job, nil
 	}
 
-	job.Status.State.LastTransitionTime = metav1.Now()
 	job.Status.State.Phase = batch.Pending
 	job.Status.State.LastTransitionTime = metav1.Now()
 	job.Status.MinAvailable = job.Spec.MinAvailable


### PR DESCRIPTION
This commit fixes a bug in the volcano job initJobStatus that contains duplicate line for LastTransitionTime .