### PR TITLE
try to fixed scheduler crash  fatal error: concurrent map writes

### DIFF
--- a/pkg/scheduler/plugins/numaaware/numaaware.go
+++ b/pkg/scheduler/plugins/numaaware/numaaware.go
@@ -19,6 +19,7 @@ package numaaware
 import (
 	"context"
 	"fmt"
+	"sync"
 
 	"volcano.sh/volcano/pkg/scheduler/plugins/util"
 
@@ -225,9 +226,12 @@ func filterNodeByPolicy(task *api.TaskInfo, node *api.NodeInfo, nodeResSets map[
 
 func getNodeNumaNumForTask(nodeInfo []*api.NodeInfo, resAssignMap map[string]api.ResNumaSets) map[string]int64 {
 	nodeNumaNumMap := make(map[string]int64)
+	var mx sync.RWMutex
 	workqueue.ParallelizeUntil(context.TODO(), 16, len(nodeInfo), func(index int) {
 		node := nodeInfo[index]
 		assignCpus := resAssignMap[node.Name][string(v1.ResourceCPU)]
+		mx.Lock()
+		defer mx.Unlock()
 		nodeNumaNumMap[node.Name] = int64(getNumaNodeCntForcpuID(assignCpus, node.NumaSchedulerInfo.CPUDetail))
 	})
 


### PR DESCRIPTION
when use numa aware plugin and set vcjob task replicas large 1, scheduler crash, and raise fatal error: concurrent map writes.