### PR TITLE
fix: avoid chan block within taintTolerationScore

### DIFF
--- a/pkg/scheduler/plugins/nodeorder/nodeorder.go
+++ b/pkg/scheduler/plugins/nodeorder/nodeorder.go
@@ -316,7 +316,7 @@ func interPodAffinityScore(
 	}
 
 	nodescoreList := make(k8sframework.NodeScoreList, len(nodes))
-	errCh := make(chan error, 1)
+	errCh := make(chan error, len(nodes))
 	workqueue.ParallelizeUntil(context.TODO(), 16, len(nodes), func(index int) {
 		nodeName := nodes[index].Name
 		ctx, cancel := context.WithCancel(context.Background())
@@ -368,7 +368,7 @@ func taintTolerationScore(
 	}
 
 	nodescoreList := make(k8sframework.NodeScoreList, len(nodes))
-	errCh := make(chan error, 1)
+	errCh := make(chan error, len(nodes))
 	workqueue.ParallelizeUntil(context.TODO(), 16, len(nodes), func(index int) {
 		nodeName := nodes[index].Name
 		ctx, cancel := context.WithCancel(context.Background())


### PR DESCRIPTION
While learning the scheduling process, I found that there maybe a problem which could block the progress of scheduling. The easiest way to fix this problem is scale the size of errch up to len(nodes).