### PR TITLE
support to set healthz address and metrics address

### DIFF
--- a/cmd/controller-manager/app/options/options.go
+++ b/cmd/controller-manager/app/options/options.go
@@ -25,11 +25,12 @@ import (
 )
 
 const (
-	defaultQPS           = 50.0
-	defaultBurst         = 100
-	defaultWorkers       = 3
-	defaultMaxRequeueNum = 15
-	defaultSchedulerName = "volcano"
+	defaultQPS            = 50.0
+	defaultBurst          = 100
+	defaultWorkers        = 3
+	defaultMaxRequeueNum  = 15
+	defaultSchedulerName  = "volcano"
+	defaultHealthzAddress = ":11251"
 )
 
 // ServerOption is the main context object for the controllers.
@@ -54,10 +55,7 @@ type ServerOption struct {
 
 // NewServerOption creates a new CMServer with a default config.
 func NewServerOption() *ServerOption {
-	s := ServerOption{
-		HealthzBindAddress: ":11252",
-	}
-	return &s
+	return &ServerOption{}
 }
 
 // AddFlags adds flags for a specific CMServer to the specified FlagSet.
@@ -74,6 +72,7 @@ func (s *ServerOption) AddFlags(fs *pflag.FlagSet) {
 		"Larger number = faster job updating, but more CPU load")
 	fs.StringArrayVar(&s.SchedulerNames, "scheduler-name", []string{defaultSchedulerName}, "Volcano will handle pods whose .spec.SchedulerName is same as scheduler-name")
 	fs.IntVar(&s.MaxRequeueNum, "max-requeue-num", defaultMaxRequeueNum, "The number of times a job, queue or command will be requeued before it is dropped out of the queue")
+	fs.StringVar(&s.HealthzBindAddress, "healthz-address", defaultHealthzAddress, "The address to listen on for the health check server.")
 }
 
 // CheckOptionOrDie checks the LockObjectNamespace.

--- a/cmd/scheduler/app/options/options.go
+++ b/cmd/scheduler/app/options/options.go
@@ -30,6 +30,7 @@ const (
 	defaultSchedulerPeriod = time.Second
 	defaultQueue           = "default"
 	defaultListenAddress   = ":8080"
+	defaultHealthzAddress  = ":11251"
 	defaultPluginsDir      = ""
 
 	defaultQPS   = 2000.0
@@ -70,10 +71,7 @@ var ServerOpts *ServerOption
 
 // NewServerOption creates a new CMServer with a default config.
 func NewServerOption() *ServerOption {
-	s := ServerOption{
-		HealthzBindAddress: ":11251",
-	}
-	return &s
+	return &ServerOption{}
 }
 
 // AddFlags adds flags for a specific CMServer to the specified FlagSet.
@@ -91,6 +89,7 @@ func (s *ServerOption) AddFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&s.PrintVersion, "version", false, "Show version and quit")
 	fs.StringVar(&s.LockObjectNamespace, "lock-object-namespace", s.LockObjectNamespace, "Define the namespace of the lock object that is used for leader election")
 	fs.StringVar(&s.ListenAddress, "listen-address", defaultListenAddress, "The address to listen on for HTTP requests.")
+	fs.StringVar(&s.HealthzBindAddress, "healthz-address", defaultHealthzAddress, "The address to listen on for the health check server.")
 	fs.BoolVar(&s.EnablePriorityClass, "priority-class", true,
 		"Enable PriorityClass to provide the capacity of preemption at pod group level; to disable it, set it false")
 	fs.Float32Var(&s.KubeClientOptions.QPS, "kube-api-qps", defaultQPS, "QPS to use while talking with kubernetes apiserver")

--- a/cmd/webhook-manager/app/options/options.go
+++ b/cmd/webhook-manager/app/options/options.go
@@ -37,6 +37,7 @@ type Config struct {
 	CertFile          string
 	KeyFile           string
 	CaCertFile        string
+	ListenAddress     string
 	Port              int
 	PrintVersion      bool
 	WebhookName       string
@@ -61,6 +62,7 @@ func (c *Config) AddFlags(fs *pflag.FlagSet) {
 		"File containing the default x509 Certificate for HTTPS. (CA cert, if any, concatenated "+
 		"after server cert).")
 	fs.StringVar(&c.KeyFile, "tls-private-key-file", c.KeyFile, "File containing the default x509 private key matching --tls-cert-file.")
+	fs.StringVar(&c.ListenAddress, "listen-address", "", "The address to listen on for the admission-controller-server.")
 	fs.IntVar(&c.Port, "port", 8443, "the port used by admission-controller-server.")
 	fs.BoolVar(&c.PrintVersion, "version", false, "Show version and quit")
 	fs.Float32Var(&c.KubeClientOptions.QPS, "kube-api-qps", defaultQPS, "QPS to use while talking with kubernetes apiserver")

--- a/cmd/webhook-manager/app/server.go
+++ b/cmd/webhook-manager/app/server.go
@@ -93,7 +93,7 @@ func Run(config *options.Config) error {
 	signal.Notify(stopChannel, syscall.SIGTERM, syscall.SIGINT)
 
 	server := &http.Server{
-		Addr:      ":" + strconv.Itoa(config.Port),
+		Addr:      config.ListenAddress + ":" + strconv.Itoa(config.Port),
 		TLSConfig: configTLS(config, restConfig),
 	}
 	go func() {


### PR DESCRIPTION
Signed-off-by: huone1 <huwanxing@huawei.com>

it is  insecure to bind address 0.0.0.0， so it is better to support to set the listen address 
it is also supported to set them in k8s arguments

for example
kubectl edit deploy volcano-controllers -n volcano-system
set the pod ip as the listen IP
> spec:
      containers:
      - args:
        - --logtostderr
        - --healthz-address=$(MY_POD_IP):11251
        - -v=4
        - 2>&1
        env:
        - name: MY_POD_IP
          valueFrom:
            fieldRef:
              apiVersion: v1
              fieldPath: status.podIP


![image](https://user-images.githubusercontent.com/71266853/143192331-01da85d8-0264-47c1-a36f-7b65ce0ac701.png)
