### PR TITLE
switch the order of patch and existence check

### DIFF
--- a/pkg/scheduler/plugins/predicates/predicates.go
+++ b/pkg/scheduler/plugins/predicates/predicates.go
@@ -184,15 +184,15 @@ func (pp *predicatesPlugin) OnSessionOpen(ssn *framework.Session) {
 					klog.Errorf("The node %s can't place the pod %s in ns %s", pod.Spec.NodeName, pod.Name, pod.Namespace)
 					return
 				}
+				dev, ok := nodeInfo.GPUDevices[id]
+				if !ok {
+					klog.Errorf("Failed to get GPU %d from node %s", id, nodeName)
+					return
+				}
 				patch := api.AddGPUIndexPatch(id)
 				pod, err := kubeClient.CoreV1().Pods(pod.Namespace).Patch(context.TODO(), pod.Name, types.JSONPatchType, []byte(patch), metav1.PatchOptions{})
 				if err != nil {
 					klog.Errorf("Patch pod %s failed with patch %s: %v", pod.Name, patch, err)
-					return
-				}
-				dev, ok := nodeInfo.GPUDevices[id]
-				if !ok {
-					klog.Errorf("Failed to get GPU %d from node %s", id, nodeName)
 					return
 				}
 				dev.PodMap[string(pod.UID)] = pod


### PR DESCRIPTION
1. The existence check of GPU device id seems unnecessary since id was just generated using the same struct, but we can save it as a double check.
2. However, current order of patch and existence check can lead to a situation where the patch succeed but the check failed. In this case, a pod in PodMap will be missed.