### PR TITLE
improve taintTolerationScore interPodAffinityScore throghput when failure occurs

### DIFF
--- a/pkg/scheduler/plugins/nodeorder/nodeorder.go
+++ b/pkg/scheduler/plugins/nodeorder/nodeorder.go
@@ -316,13 +316,24 @@ func interPodAffinityScore(
 	}
 
 	nodescoreList := make(k8sframework.NodeScoreList, len(nodes))
-	errCh := make(chan error, len(nodes))
-	workqueue.ParallelizeUntil(context.TODO(), 16, len(nodes), func(index int) {
+	// the default parallelization worker number is 16.
+	// the whole scoring will fail if one of the processes failed.
+	// so just create a parallelizeContext to control the whole ParallelizeUntil process.
+	// if the parallelizeCancel is invoked, the whole "ParallelizeUntil" goes to the end.
+	// this could avoid extra computation, especially in huge cluster.
+	// and the ParallelizeUntil guarantees only "workerNum" goroutines will be working simultaneously.
+	// so it's enough to allocate workerNum size for errCh.
+	// note that, in such case, size of errCh should be no less than parallelization number
+	workerNum := 16
+	errCh := make(chan error, workerNum)
+	parallelizeContext, parallelizeCancel := context.WithCancel(context.TODO())
+	workqueue.ParallelizeUntil(parallelizeContext, workerNum, len(nodes), func(index int) {
 		nodeName := nodes[index].Name
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		s, status := interPodAffinity.Score(ctx, state, pod, nodeName)
 		if !status.IsSuccess() {
+			parallelizeCancel()
 			errCh <- fmt.Errorf("calculate inter pod affinity priority failed %v", status.Message())
 			return
 		}
@@ -368,13 +379,17 @@ func taintTolerationScore(
 	}
 
 	nodescoreList := make(k8sframework.NodeScoreList, len(nodes))
-	errCh := make(chan error, len(nodes))
-	workqueue.ParallelizeUntil(context.TODO(), 16, len(nodes), func(index int) {
+	// size of errCh should be no less than parallelization number, see interPodAffinityScore.
+	workerNum := 16
+	errCh := make(chan error, workerNum)
+	parallelizeContext, parallelizeCancel := context.WithCancel(context.TODO())
+	workqueue.ParallelizeUntil(parallelizeContext, workerNum, len(nodes), func(index int) {
 		nodeName := nodes[index].Name
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		s, status := taintToleration.Score(ctx, cycleState, pod, nodeName)
 		if !status.IsSuccess() {
+			parallelizeCancel()
 			errCh <- fmt.Errorf("calculate taint toleration priority failed %v", status.Message())
 			return
 		}


### PR DESCRIPTION
I guess there is a work that could help improve taintTolerationScore & interPodAffinityScore throghput at failure cases.
This could avoid invalid computation when failure occurs, especially in huge cluster.
I think this could help enhance the scheduling throughput
refer to #1740 