### PR TITLE
optimize the CA parse Process

### DIFF
--- a/cmd/webhook-manager/app/options/options.go
+++ b/cmd/webhook-manager/app/options/options.go
@@ -18,6 +18,7 @@ package options
 
 import (
 	"fmt"
+	"io/ioutil"
 
 	"github.com/spf13/pflag"
 
@@ -37,6 +38,9 @@ type Config struct {
 	CertFile          string
 	KeyFile           string
 	CaCertFile        string
+	CertData          []byte
+	KeyData           []byte
+	CaCertData        []byte
 	ListenAddress     string
 	Port              int
 	PrintVersion      bool
@@ -47,6 +51,8 @@ type Config struct {
 	ConfigPath        string
 	EnabledAdmission  string
 }
+
+type DecryptFunc func(c *Config) error
 
 // NewConfig create new config.
 func NewConfig() *Config {
@@ -84,5 +90,40 @@ func (c *Config) CheckPortOrDie() error {
 	if c.Port < 1 || c.Port > 65535 {
 		return fmt.Errorf("the port should be in the range of 1 and 65535")
 	}
+	return nil
+}
+
+// readCAFiles read data from ca file path
+func (c *Config) readCAFiles() error {
+	var err error
+	c.CaCertData, err = ioutil.ReadFile(c.CaCertFile)
+	if err != nil {
+		return fmt.Errorf("failed to read cacert file (%s): %v", c.CaCertFile, err)
+	}
+
+	c.CertData, err = ioutil.ReadFile(c.CertFile)
+	if err != nil {
+		return fmt.Errorf("failed to read cert file (%s): %v", c.CertFile, err)
+	}
+
+	c.KeyData, err = ioutil.ReadFile(c.KeyFile)
+	if err != nil {
+		return fmt.Errorf("failed to read key file (%s): %v", c.KeyFile, err)
+	}
+
+	return nil
+}
+
+// ParseCAFiles parse ca file by decryptFunc
+func (c *Config) ParseCAFiles(decryptFunc DecryptFunc) error {
+	if err := c.readCAFiles(); err != nil {
+		return err
+	}
+
+	// users can add one function to decrypt tha data by their own way if CA data is encrypted
+	if decryptFunc != nil {
+		return decryptFunc(c)
+	}
+
 	return nil
 }

--- a/cmd/webhook-manager/app/server.go
+++ b/cmd/webhook-manager/app/server.go
@@ -18,7 +18,6 @@ package app
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"os/signal"
@@ -61,11 +60,6 @@ func Run(config *options.Config) error {
 		klog.V(2).Infof("loadAdmissionConf:%v", admissionConf.ResGroupsConfig)
 	}
 
-	caBundle, err := ioutil.ReadFile(config.CaCertFile)
-	if err != nil {
-		return fmt.Errorf("unable to read cacert file (%s): %v", config.CaCertFile, err)
-	}
-
 	vClient := getVolcanoClient(restConfig)
 	kubeClient := getKubeClient(restConfig)
 
@@ -85,7 +79,7 @@ func Run(config *options.Config) error {
 		http.HandleFunc(service.Path, service.Handler)
 
 		klog.V(3).Infof("Registered configuration for webhook <%s>", service.Path)
-		registerWebhookConfig(kubeClient, config, service, caBundle)
+		registerWebhookConfig(kubeClient, config, service, config.CaCertData)
 	})
 
 	webhookServeError := make(chan struct{})

--- a/cmd/webhook-manager/app/util.go
+++ b/cmd/webhook-manager/app/util.go
@@ -104,8 +104,8 @@ func getVolcanoClient(restConfig *rest.Config) *versioned.Clientset {
 // These are passed in as command line for cluster certification. If tls config is passed in, we use the directly
 // defined tls config, else use that defined in kubeconfig.
 func configTLS(config *options.Config, restConfig *rest.Config) *tls.Config {
-	if len(config.CertFile) != 0 && len(config.KeyFile) != 0 {
-		sCert, err := tls.LoadX509KeyPair(config.CertFile, config.KeyFile)
+	if len(config.CertData) != 0 && len(config.KeyData) != 0 {
+		sCert, err := tls.X509KeyPair(config.CertData, config.KeyData)
 		if err != nil {
 			klog.Fatal(err)
 		}

--- a/cmd/webhook-manager/main.go
+++ b/cmd/webhook-manager/main.go
@@ -58,6 +58,10 @@ func main() {
 		klog.Fatalf("Configured port is invalid: %v", err)
 	}
 
+	if err := config.ParseCAFiles(nil); err != nil {
+		klog.Fatalf("Failed to parse CA file: %v", err)
+	}
+
 	if err := app.Run(config); err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)
 		os.Exit(1)


### PR DESCRIPTION
Signed-off-by: huone1 <huwanxing@huawei.com>
For some users, they Maybe use their own certification files with specific encryption for security in webhook‘s register.
So add one interface ParseCAFiles to parse CA data and the argument decryptFunc is for the decryption . 