### PR TITLE
Add tensorflow job plugin

### DIFF
--- a/pkg/controllers/job/helpers/helpers.go
+++ b/pkg/controllers/job/helpers/helpers.go
@@ -24,6 +24,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 
+	batch "volcano.sh/apis/pkg/apis/batch/v1alpha1"
 	"volcano.sh/volcano/pkg/controllers/apis"
 )
 
@@ -42,6 +43,37 @@ func GetTaskIndex(pod *v1.Pod) string {
 	}
 
 	return ""
+}
+
+// GetTaskKey returns task key/name
+func GetTaskKey(pod *v1.Pod) string {
+	if pod.Annotations == nil || pod.Annotations[batch.TaskSpecKey] == "" {
+		return batch.DefaultTaskSpec
+	}
+	return pod.Annotations[batch.TaskSpecKey]
+}
+
+// GetTaskSpec returns task spec
+func GetTaskSpec(job *batch.Job, taskName string) (batch.TaskSpec, bool) {
+	for _, ts := range job.Spec.Tasks {
+		if ts.Name == taskName {
+			return ts, true
+		}
+	}
+	return batch.TaskSpec{}, false
+}
+
+// MakeDomainName creates task domain name
+func MakeDomainName(ts batch.TaskSpec, job *batch.Job, index int) string {
+	hostName := ts.Template.Spec.Hostname
+	subdomain := ts.Template.Spec.Subdomain
+	if len(hostName) == 0 {
+		hostName = MakePodName(job.Name, ts.Name, index)
+	}
+	if len(subdomain) == 0 {
+		subdomain = job.Name
+	}
+	return hostName + "." + subdomain
 }
 
 // MakePodName creates pod name.

--- a/pkg/controllers/job/plugins/distributed-framework/tensorflow/tensorflow.go
+++ b/pkg/controllers/job/plugins/distributed-framework/tensorflow/tensorflow.go
@@ -1,0 +1,203 @@
+/*
+Copyright 2021 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tensorflow
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"strconv"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/klog"
+
+	batch "volcano.sh/apis/pkg/apis/batch/v1alpha1"
+	jobhelpers "volcano.sh/volcano/pkg/controllers/job/helpers"
+	pluginsinterface "volcano.sh/volcano/pkg/controllers/job/plugins/interface"
+)
+
+const (
+	DefaultPort = 2222
+	TFConfig    = "TF_CONFIG"
+)
+
+type tensorflowPlugin struct {
+	tfArguments   []string
+	Clientset     pluginsinterface.PluginClientset
+	psName        string
+	workerName    string
+	chiefName     string
+	evaluatorName string
+	port          int
+}
+
+// New creates tensorflow plugin.
+func New(client pluginsinterface.PluginClientset, arguments []string) pluginsinterface.PluginInterface {
+	tp := tensorflowPlugin{tfArguments: arguments, Clientset: client}
+	tp.addFlags()
+	return &tp
+}
+
+func (tp *tensorflowPlugin) addFlags() {
+	flagSet := flag.NewFlagSet(tp.Name(), flag.ContinueOnError)
+	flagSet.StringVar(&tp.psName, "ps", "ps", "name of ps role task")
+	flagSet.StringVar(&tp.workerName, "worker", "worker", "name of ps role task")
+	flagSet.StringVar(&tp.chiefName, "chief", "chief", "name of chief role task")
+	flagSet.StringVar(&tp.evaluatorName, "evaluator", "evaluator", "name of evaluator role task")
+	flagSet.IntVar(&tp.port, "port", DefaultPort, "service port")
+	if err := flagSet.Parse(tp.tfArguments); err != nil {
+		klog.Errorf("plugin %s flagset parse failed, err: %v", tp.Name(), err)
+	}
+}
+
+func (tp *tensorflowPlugin) Name() string {
+	return "tensorflow"
+}
+
+func (tp *tensorflowPlugin) OnPodCreate(pod *v1.Pod, job *batch.Job) error {
+	// No need to generate TF_CONFIG for stand-alone tensorflow job
+	if len(job.Spec.Tasks) == 1 && job.Spec.Tasks[0].Replicas == 1 {
+		return nil
+	}
+	// Generate TF_CONFIG value
+	spec, err := tp.generateTFClusterSpec(pod, job)
+	if err != nil {
+		return err
+	}
+	raw, err := json.Marshal(spec)
+	if err != nil {
+		return err
+	}
+
+	// Add TF_CONFIG enviroment variables
+	for i := range pod.Spec.Containers {
+		pod.Spec.Containers[i].Env = append(pod.Spec.Containers[i].Env, v1.EnvVar{
+			Name:  TFConfig,
+			Value: string(raw),
+		})
+	}
+	return nil
+}
+
+func (tp *tensorflowPlugin) OnJobAdd(job *batch.Job) error {
+	if job.Status.ControlledResources["plugin-"+tp.Name()] == tp.Name() {
+		return nil
+	}
+
+	job.Status.ControlledResources["plugin-"+tp.Name()] = tp.Name()
+
+	return nil
+}
+
+func (tp *tensorflowPlugin) OnJobDelete(job *batch.Job) error {
+	if job.Status.ControlledResources["plugin-"+tp.Name()] != tp.Name() {
+		return nil
+	}
+	delete(job.Status.ControlledResources, "plugin-"+tp.Name())
+	return nil
+}
+
+func (tp *tensorflowPlugin) OnJobUpdate(job *batch.Job) error {
+	return nil
+}
+
+func (tp *tensorflowPlugin) generateTFClusterSpec(pod *v1.Pod, job *batch.Job) (tfClusterSpec, error) {
+	index, err := strconv.Atoi(jobhelpers.GetTaskIndex(pod))
+	if err != nil {
+		return tfClusterSpec{}, err
+	}
+
+	// Generate tensorflow task info
+	c := tfClusterSpec{
+		Task: taskInfo{
+			Type:  tp.getTaskType(jobhelpers.GetTaskKey(pod)),
+			Index: index,
+		},
+	}
+
+	// Generate tensorflow cluster info
+	for _, ts := range job.Spec.Tasks {
+		hosts := []string{}
+		for i := 0; i < int(ts.Replicas); i++ {
+			hosts = append(hosts, fmt.Sprintf("%s:%d", jobhelpers.MakeDomainName(ts, job, i), tp.port))
+		}
+		switch ts.Name {
+		case tp.psName:
+			c.Cluster.PS = hosts
+		case tp.workerName:
+			c.Cluster.Worker = hosts
+		case tp.chiefName:
+			c.Cluster.Chief = hosts
+		case tp.evaluatorName:
+			c.Cluster.Evaluator = hosts
+		}
+	}
+	return c, nil
+}
+
+func (tp *tensorflowPlugin) getTaskType(taskKey string) tfTaskType {
+	switch taskKey {
+	case tp.chiefName:
+		return tfChief
+	case tp.workerName:
+		return tfWorker
+	case tp.psName:
+		return tfPS
+	case tp.evaluatorName:
+		return tfEvaluator
+	}
+	return tfTaskType(taskKey)
+}
+
+// TfClusterSpec is the spec of a tensorflow cluster
+// It will be injected into container's environment variables, and be used by tensorflow framework.
+// e.g.
+// {
+//    "cluster": {
+//      "worker": ["worker-0:2222", "worker-1:2222"],
+//      "ps": ["ps-0:2222"]
+//    },
+//    "task": {
+//      "type": "worker",
+//      "index": 0
+//    }
+// }
+type tfClusterSpec struct {
+	Cluster clusterInfo `json:"cluster"`
+	Task    taskInfo    `json:"task"`
+}
+
+type clusterInfo struct {
+	PS        []string `json:"ps,omitempty"`
+	Worker    []string `json:"worker,omitempty"`
+	Chief     []string `json:"chief,omitempty"`
+	Evaluator []string `json:"evaluator,omitempty"`
+}
+
+type tfTaskType string
+
+const (
+	tfWorker    tfTaskType = "worker"
+	tfChief     tfTaskType = "chief"
+	tfPS        tfTaskType = "ps"
+	tfEvaluator tfTaskType = "evaluator"
+)
+
+type taskInfo struct {
+	Type  tfTaskType `json:"type"`
+	Index int        `json:"index"`
+}

--- a/pkg/controllers/job/plugins/distributed-framework/tensorflow/tensorflow_test.go
+++ b/pkg/controllers/job/plugins/distributed-framework/tensorflow/tensorflow_test.go
@@ -1,0 +1,143 @@
+/*
+Copyright 2021 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tensorflow
+
+import (
+	"strings"
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	batch "volcano.sh/apis/pkg/apis/batch/v1alpha1"
+	pluginsinterface "volcano.sh/volcano/pkg/controllers/job/plugins/interface"
+)
+
+func TestTensorflow(t *testing.T) {
+	testjob := &batch.Job{
+		ObjectMeta: metav1.ObjectMeta{Name: "train-123"},
+		Spec: batch.JobSpec{
+			Tasks: []batch.TaskSpec{
+				{
+					Name:     "ps",
+					Replicas: 2,
+					Template: v1.PodTemplateSpec{},
+				},
+				{
+					Name:     "worker",
+					Replicas: 2,
+					Template: v1.PodTemplateSpec{},
+				},
+				{
+					Name:     "chief",
+					Replicas: 1,
+					Template: v1.PodTemplateSpec{},
+				},
+			},
+		},
+	}
+	testcases := []struct {
+		Name string
+		Job  *batch.Job
+		Pod  *v1.Pod
+	}{
+		{
+			Name: "ps case",
+			Job:  testjob,
+			Pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "train-123-ps-0",
+					Annotations: map[string]string{
+						batch.TaskSpecKey: "ps",
+					},
+				},
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Name: "main",
+						},
+					},
+				},
+			},
+		},
+		{
+			Name: "worker case",
+			Job:  testjob,
+			Pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "train-123-worker-0",
+					Annotations: map[string]string{
+						batch.TaskSpecKey: "worker",
+					},
+				},
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Name: "main",
+						},
+					},
+				},
+			},
+		},
+		{
+			Name: "chief case",
+			Job:  testjob,
+			Pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "train-123-chief-0",
+					Annotations: map[string]string{
+						batch.TaskSpecKey: "chief",
+					},
+				},
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Name: "main",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for i, testcase := range testcases {
+		t.Run(testcase.Name, func(t *testing.T) {
+			tp := New(pluginsinterface.PluginClientset{}, []string{"--port=5000"})
+			if err := tp.OnPodCreate(testcase.Pod, testcase.Job); err != nil {
+				t.Errorf("Case %d (%s): expect no error, but got error %v", i, testcase.Name, err)
+			}
+			if testcase.Pod.Spec.Containers[0].Env[0].Name != "TF_CONFIG" {
+				t.Errorf("Case %d (%s): wrong env name, got %s", i, testcase.Name, testcase.Pod.Spec.Containers[0].Env[0].Name)
+			}
+
+			switch {
+			case strings.Contains(testcase.Pod.Name, "ps"):
+				if testcase.Pod.Spec.Containers[0].Env[0].Value != `{"cluster":{"ps":["train-123-ps-0.train-123:5000","train-123-ps-1.train-123:5000"],"worker":["train-123-worker-0.train-123:5000","train-123-worker-1.train-123:5000"],"chief":["train-123-chief-0.train-123:5000"]},"task":{"type":"ps","index":0}}` {
+					t.Errorf("Case %d (%s): wrong env value, got %s", i, testcase.Name, testcase.Pod.Spec.Containers[0].Env[0].Value)
+				}
+			case strings.Contains(testcase.Pod.Name, "worker"):
+				if testcase.Pod.Spec.Containers[0].Env[0].Value != `{"cluster":{"ps":["train-123-ps-0.train-123:5000","train-123-ps-1.train-123:5000"],"worker":["train-123-worker-0.train-123:5000","train-123-worker-1.train-123:5000"],"chief":["train-123-chief-0.train-123:5000"]},"task":{"type":"worker","index":0}}` {
+					t.Errorf("Case %d (%s): wrong env value, got %s", i, testcase.Name, testcase.Pod.Spec.Containers[0].Env[0].Value)
+				}
+			case strings.Contains(testcase.Pod.Name, "chief"):
+				if testcase.Pod.Spec.Containers[0].Env[0].Value != `{"cluster":{"ps":["train-123-ps-0.train-123:5000","train-123-ps-1.train-123:5000"],"worker":["train-123-worker-0.train-123:5000","train-123-worker-1.train-123:5000"],"chief":["train-123-chief-0.train-123:5000"]},"task":{"type":"chief","index":0}}` {
+					t.Errorf("Case %d (%s): wrong env value, got %s", i, testcase.Name, testcase.Pod.Spec.Containers[0].Env[0].Value)
+				}
+			}
+		})
+	}
+}

--- a/pkg/controllers/job/plugins/factory.go
+++ b/pkg/controllers/job/plugins/factory.go
@@ -19,6 +19,7 @@ package plugins
 import (
 	"sync"
 
+	"volcano.sh/volcano/pkg/controllers/job/plugins/distributed-framework/tensorflow"
 	"volcano.sh/volcano/pkg/controllers/job/plugins/env"
 	pluginsinterface "volcano.sh/volcano/pkg/controllers/job/plugins/interface"
 	"volcano.sh/volcano/pkg/controllers/job/plugins/ssh"
@@ -29,6 +30,7 @@ func init() {
 	RegisterPluginBuilder("ssh", ssh.New)
 	RegisterPluginBuilder("env", env.New)
 	RegisterPluginBuilder("svc", svc.New)
+	RegisterPluginBuilder("tensorflow", tensorflow.New)
 }
 
 var pluginMutex sync.Mutex

--- a/test/e2e/jobseq/tensorflow_plugin.go
+++ b/test/e2e/jobseq/tensorflow_plugin.go
@@ -1,0 +1,127 @@
+/*
+Copyright 2021 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package jobseq
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	vcbatch "volcano.sh/apis/pkg/apis/batch/v1alpha1"
+	vcbus "volcano.sh/apis/pkg/apis/bus/v1alpha1"
+
+	e2eutil "volcano.sh/volcano/test/e2e/util"
+)
+
+var _ = Describe("TensorFlow Plugin E2E Test", func() {
+	It("Will Start in pending state and goes through other phases to get complete phase", func() {
+		ctx := e2eutil.InitTestContext(e2eutil.Options{})
+		defer e2eutil.CleanupTestContext(ctx)
+
+		jobName := "tensorflow-dist-mnist"
+
+		job := &vcbatch.Job{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: jobName,
+			},
+			Spec: vcbatch.JobSpec{
+				MinAvailable:  int32(3),
+				SchedulerName: e2eutil.SchedulerName,
+				Plugins: map[string][]string{
+					"tensorflow": {"--ps=ps", "--worker=worker", "--port=2222"},
+				},
+				Policies: []vcbatch.LifecyclePolicy{
+					{
+						Event:  vcbus.PodEvictedEvent,
+						Action: vcbus.RestartJobAction,
+					},
+				},
+				Tasks: []vcbatch.TaskSpec{
+					{
+						Replicas: int32(1),
+						Name:     "ps",
+						Template: v1.PodTemplateSpec{
+							Spec: v1.PodSpec{
+								RestartPolicy: v1.RestartPolicyNever,
+								Containers: []v1.Container{
+									{
+										Command: []string{
+											"sh",
+											"-c",
+											"python /var/tf_dist_mnist/dist_mnist.py --train_steps 1000",
+										},
+										Image: e2eutil.DefaultTFImage,
+										Name:  "tensorflow",
+										Ports: []v1.ContainerPort{
+											{
+												Name:          "tfjob-port",
+												ContainerPort: int32(2222),
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+					{
+						Replicas: int32(2),
+						Name:     "worker",
+						Policies: []vcbatch.LifecyclePolicy{
+							{
+								Event:  vcbus.TaskCompletedEvent,
+								Action: vcbus.CompleteJobAction,
+							},
+						},
+						Template: v1.PodTemplateSpec{
+							Spec: v1.PodSpec{
+								RestartPolicy: v1.RestartPolicyNever,
+								Containers: []v1.Container{
+									{
+										Command: []string{
+											"sh",
+											"-c",
+											"python /var/tf_dist_mnist/dist_mnist.py --train_steps 1000",
+										},
+										Image: e2eutil.DefaultTFImage,
+										Name:  "tensorflow",
+										Ports: []v1.ContainerPort{
+											{
+												Name:          "tfjob-port",
+												ContainerPort: int32(2222),
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		created, err := ctx.Vcclient.BatchV1alpha1().Jobs(ctx.Namespace).Create(context.TODO(), job, metav1.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		err = e2eutil.WaitJobStates(ctx, created, []vcbatch.JobPhase{vcbatch.Pending, vcbatch.Running, vcbatch.Completed}, e2eutil.FiveMinute)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+})


### PR DESCRIPTION
Signed-off-by: lubingtan <lubingtan@126.com>

reference: https://github.com/volcano-sh/volcano/pull/1806

Hi all~ this PR is a part of implementation for the proposal **Machine Learning Framework Plugins** https://github.com/volcano-sh/volcano/pull/1806 (or distributed framework plugins)

Because there are multiple plugins to be implemented, which will bring large size of changes. I prefer to split this implementation into several phases:

- [ ] Add Tensorflow job plugin (i.e. this PR)
- [ ] Add MPI job plugin.
- [ ] Add PyTorch job plugin.
- [ ] Add MXNet job plugin
- [ ] Add default task dependency policy for framework plugins after this https://github.com/volcano-sh/volcano/pull/1833 merged

Moreover, there are more AI frameworks, such as [MindSpore](https://github.com/mindspore-ai/mindspore), [PaddlePaddle](https://github.com/PaddlePaddle/Paddle), etc.  Any contributions for various framework plugins are welcomed.