### PR TITLE
add healthz and metric switch for deploy controller and scheduler

### DIFF
--- a/cmd/controller-manager/app/options/options.go
+++ b/cmd/controller-manager/app/options/options.go
@@ -51,6 +51,7 @@ type ServerOption struct {
 	// HealthzBindAddress is the IP address and port for the health check server to serve on,
 	// defaulting to 0.0.0.0:11252
 	HealthzBindAddress string
+	EnableHealthz      bool
 }
 
 // NewServerOption creates a new CMServer with a default config.
@@ -73,6 +74,7 @@ func (s *ServerOption) AddFlags(fs *pflag.FlagSet) {
 	fs.StringArrayVar(&s.SchedulerNames, "scheduler-name", []string{defaultSchedulerName}, "Volcano will handle pods whose .spec.SchedulerName is same as scheduler-name")
 	fs.IntVar(&s.MaxRequeueNum, "max-requeue-num", defaultMaxRequeueNum, "The number of times a job, queue or command will be requeued before it is dropped out of the queue")
 	fs.StringVar(&s.HealthzBindAddress, "healthz-address", defaultHealthzAddress, "The address to listen on for the health check server.")
+	fs.BoolVar(&s.EnableHealthz, "enable-healthz", false, "Enable the health check; it is false by default")
 }
 
 // CheckOptionOrDie checks the LockObjectNamespace.

--- a/cmd/controller-manager/app/server.go
+++ b/cmd/controller-manager/app/server.go
@@ -54,8 +54,10 @@ func Run(opt *options.ServerOption) error {
 		return err
 	}
 
-	if err := helpers.StartHealthz(opt.HealthzBindAddress, "volcano-controller"); err != nil {
-		return err
+	if opt.EnableHealthz {
+		if err := helpers.StartHealthz(opt.HealthzBindAddress, "volcano-controller"); err != nil {
+			return err
+		}
 	}
 
 	run := startControllers(config, opt)

--- a/cmd/scheduler/app/options/options.go
+++ b/cmd/scheduler/app/options/options.go
@@ -52,15 +52,16 @@ type ServerOption struct {
 	LockObjectNamespace  string
 	DefaultQueue         string
 	PrintVersion         bool
+	EnableMetrics        bool
 	ListenAddress        string
 	EnablePriorityClass  bool
 	EnableCSIStorage     bool
 	// vc-scheduler will load (not activate) custom plugins which are in this directory
-	PluginsDir string
+	PluginsDir    string
+	EnableHealthz bool
 	// HealthzBindAddress is the IP address and port for the health check server to serve on
 	// defaulting to :11251
 	HealthzBindAddress string
-
 	// Parameters for scheduling tuning: the number of feasible nodes to find and score
 	MinNodesToFind             int32
 	MinPercentageOfNodesToFind int32
@@ -107,7 +108,9 @@ func (s *ServerOption) AddFlags(fs *pflag.FlagSet) {
 
 	fs.StringVar(&s.PluginsDir, "plugins-dir", defaultPluginsDir, "vc-scheduler will load custom plugins which are in this directory")
 	fs.BoolVar(&s.EnableCSIStorage, "csi-storage", false,
-		"Enables tracking of available storage capacity that CSI drivers provide; it is false by default")
+		"Enable tracking of available storage capacity that CSI drivers provide; it is false by default")
+	fs.BoolVar(&s.EnableHealthz, "enable-healthz", false, "Enable the health check; it is false by default")
+	fs.BoolVar(&s.EnableMetrics, "enable-metrics", false, "Enable the metrics function; it is false by default")
 }
 
 // CheckOptionOrDie check lock-object-namespace when LeaderElection is enabled.

--- a/cmd/scheduler/app/server.go
+++ b/cmd/scheduler/app/server.go
@@ -82,13 +82,17 @@ func Run(opt *options.ServerOption) error {
 		panic(err)
 	}
 
-	go func() {
-		http.Handle("/metrics", promhttp.Handler())
-		klog.Fatalf("Prometheus Http Server failed %s", http.ListenAndServe(opt.ListenAddress, nil))
-	}()
+	if opt.EnableMetrics {
+		go func() {
+			http.Handle("/metrics", promhttp.Handler())
+			klog.Fatalf("Prometheus Http Server failed %s", http.ListenAndServe(opt.ListenAddress, nil))
+		}()
+	}
 
-	if err := helpers.StartHealthz(opt.HealthzBindAddress, "volcano-scheduler"); err != nil {
-		return err
+	if opt.EnableHealthz {
+		if err := helpers.StartHealthz(opt.HealthzBindAddress, "volcano-scheduler"); err != nil {
+			return err
+		}
 	}
 
 	ctx := signals.SetupSignalContext()

--- a/installer/helm/chart/volcano/templates/controllers.yaml
+++ b/installer/helm/chart/volcano/templates/controllers.yaml
@@ -92,6 +92,7 @@ spec:
             image: {{.Values.basic.controller_image_name}}:{{.Values.basic.image_tag_version}}
             args:
               - --logtostderr
+              - --enable-healthz=true
               - -v=4
               - 2>&1
             imagePullPolicy: "IfNotPresent"

--- a/installer/helm/chart/volcano/templates/scheduler.yaml
+++ b/installer/helm/chart/volcano/templates/scheduler.yaml
@@ -115,6 +115,8 @@ spec:
           args:
             - --logtostderr
             - --scheduler-conf=/volcano.scheduler/{{base .Values.basic.scheduler_config_file}}
+            - --enable-healthz=true
+            - --enable-metrics=true
             - -v=3
             - 2>&1
           imagePullPolicy: "IfNotPresent"

--- a/installer/volcano-development-arm64.yaml
+++ b/installer/volcano-development-arm64.yaml
@@ -127,6 +127,8 @@ spec:
           args:
             - --logtostderr
             - --scheduler-conf=/volcano.scheduler/volcano-scheduler.conf
+            - --enable-healthz=true
+            - --enable-metrics=true
             - -v=3
             - 2>&1
           imagePullPolicy: "IfNotPresent"
@@ -369,6 +371,7 @@ spec:
           image: volcanosh/vc-controller-manager-arm64:latest
           args:
             - --logtostderr
+            - --enable-healthz=true
             - -v=4
             - 2>&1
           imagePullPolicy: "IfNotPresent"

--- a/installer/volcano-development.yaml
+++ b/installer/volcano-development.yaml
@@ -7537,6 +7537,7 @@ spec:
             image: volcanosh/vc-controller-manager:latest
             args:
               - --logtostderr
+              - --enable-healthz=true
               - -v=4
               - 2>&1
             imagePullPolicy: "IfNotPresent"
@@ -7689,6 +7690,8 @@ spec:
           args:
             - --logtostderr
             - --scheduler-conf=/volcano.scheduler/volcano-scheduler.conf
+            - --enable-healthz=true
+            - --enable-metrics=true
             - -v=3
             - 2>&1
           imagePullPolicy: "IfNotPresent"


### PR DESCRIPTION
#1889 
Signed-off-by: huone1 <huwanxing@huawei.com>
For some users,it is  unnecessary and insecure to enable the metrics  service if they needn't the metrics ; And the  healthz check is also so on.
