### PR TITLE
update PriorityClass from scheduling.k8s.io/v1beta1 to scheduling.k8s…

### DIFF
--- a/pkg/scheduler/actions/preempt/preempt_test.go
+++ b/pkg/scheduler/actions/preempt/preempt_test.go
@@ -21,11 +21,11 @@ import (
 	"time"
 
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/api/scheduling/v1beta1"
+	schedulingv1 "k8s.io/api/scheduling/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/record"
 
-	schedulingv1 "volcano.sh/apis/pkg/apis/scheduling/v1beta1"
+	schedulingv1beta1 "volcano.sh/apis/pkg/apis/scheduling/v1beta1"
 	"volcano.sh/volcano/cmd/scheduler/app/options"
 	"volcano.sh/volcano/pkg/scheduler/api"
 	"volcano.sh/volcano/pkg/scheduler/cache"
@@ -48,26 +48,26 @@ func TestPreempt(t *testing.T) {
 
 	tests := []struct {
 		name      string
-		podGroups []*schedulingv1.PodGroup
+		podGroups []*schedulingv1beta1.PodGroup
 		pods      []*v1.Pod
 		nodes     []*v1.Node
-		queues    []*schedulingv1.Queue
+		queues    []*schedulingv1beta1.Queue
 		expected  int
 	}{
 		{
 			name: "do not preempt if there are enough idle resources",
-			podGroups: []*schedulingv1.PodGroup{
+			podGroups: []*schedulingv1beta1.PodGroup{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "pg1",
 						Namespace: "c1",
 					},
-					Spec: schedulingv1.PodGroupSpec{
+					Spec: schedulingv1beta1.PodGroupSpec{
 						MinMember: 3,
 						Queue:     "q1",
 					},
-					Status: schedulingv1.PodGroupStatus{
-						Phase: schedulingv1.PodGroupInqueue,
+					Status: schedulingv1beta1.PodGroupStatus{
+						Phase: schedulingv1beta1.PodGroupInqueue,
 					},
 				},
 			},
@@ -80,12 +80,12 @@ func TestPreempt(t *testing.T) {
 			nodes: []*v1.Node{
 				util.BuildNode("n1", util.BuildResourceList("10", "10G"), make(map[string]string)),
 			},
-			queues: []*schedulingv1.Queue{
+			queues: []*schedulingv1beta1.Queue{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "q1",
 					},
-					Spec: schedulingv1.QueueSpec{
+					Spec: schedulingv1beta1.QueueSpec{
 						Weight: 1,
 					},
 				},
@@ -94,18 +94,18 @@ func TestPreempt(t *testing.T) {
 		},
 		{
 			name: "do not preempt if job is pipelined",
-			podGroups: []*schedulingv1.PodGroup{
+			podGroups: []*schedulingv1beta1.PodGroup{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "pg1",
 						Namespace: "c1",
 					},
-					Spec: schedulingv1.PodGroupSpec{
+					Spec: schedulingv1beta1.PodGroupSpec{
 						MinMember: 1,
 						Queue:     "q1",
 					},
-					Status: schedulingv1.PodGroupStatus{
-						Phase: schedulingv1.PodGroupInqueue,
+					Status: schedulingv1beta1.PodGroupStatus{
+						Phase: schedulingv1beta1.PodGroupInqueue,
 					},
 				},
 				{
@@ -113,12 +113,12 @@ func TestPreempt(t *testing.T) {
 						Name:      "pg2",
 						Namespace: "c1",
 					},
-					Spec: schedulingv1.PodGroupSpec{
+					Spec: schedulingv1beta1.PodGroupSpec{
 						MinMember: 1,
 						Queue:     "q1",
 					},
-					Status: schedulingv1.PodGroupStatus{
-						Phase: schedulingv1.PodGroupInqueue,
+					Status: schedulingv1beta1.PodGroupStatus{
+						Phase: schedulingv1beta1.PodGroupInqueue,
 					},
 				},
 			},
@@ -133,12 +133,12 @@ func TestPreempt(t *testing.T) {
 			nodes: []*v1.Node{
 				util.BuildNode("n1", util.BuildResourceList("3", "3G"), make(map[string]string)),
 			},
-			queues: []*schedulingv1.Queue{
+			queues: []*schedulingv1beta1.Queue{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "q1",
 					},
-					Spec: schedulingv1.QueueSpec{
+					Spec: schedulingv1beta1.QueueSpec{
 						Weight: 1,
 					},
 				},
@@ -147,19 +147,19 @@ func TestPreempt(t *testing.T) {
 		},
 		{
 			name: "preempt one task of different job to fit both jobs on one node",
-			podGroups: []*schedulingv1.PodGroup{
+			podGroups: []*schedulingv1beta1.PodGroup{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "pg1",
 						Namespace: "c1",
 					},
-					Spec: schedulingv1.PodGroupSpec{
+					Spec: schedulingv1beta1.PodGroupSpec{
 						MinMember:         1,
 						Queue:             "q1",
 						PriorityClassName: "low-priority",
 					},
-					Status: schedulingv1.PodGroupStatus{
-						Phase: schedulingv1.PodGroupInqueue,
+					Status: schedulingv1beta1.PodGroupStatus{
+						Phase: schedulingv1beta1.PodGroupInqueue,
 					},
 				},
 				{
@@ -167,13 +167,13 @@ func TestPreempt(t *testing.T) {
 						Name:      "pg2",
 						Namespace: "c1",
 					},
-					Spec: schedulingv1.PodGroupSpec{
+					Spec: schedulingv1beta1.PodGroupSpec{
 						MinMember:         1,
 						Queue:             "q1",
 						PriorityClassName: "high-priority",
 					},
-					Status: schedulingv1.PodGroupStatus{
-						Phase: schedulingv1.PodGroupInqueue,
+					Status: schedulingv1beta1.PodGroupStatus{
+						Phase: schedulingv1beta1.PodGroupInqueue,
 					},
 				},
 			},
@@ -187,12 +187,12 @@ func TestPreempt(t *testing.T) {
 			nodes: []*v1.Node{
 				util.BuildNode("n1", util.BuildResourceList("2", "2G"), make(map[string]string)),
 			},
-			queues: []*schedulingv1.Queue{
+			queues: []*schedulingv1beta1.Queue{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "q1",
 					},
-					Spec: schedulingv1.QueueSpec{
+					Spec: schedulingv1beta1.QueueSpec{
 						Weight: 1,
 					},
 				},
@@ -201,19 +201,19 @@ func TestPreempt(t *testing.T) {
 		},
 		{
 			name: "preempt enough tasks to fit large task of different job",
-			podGroups: []*schedulingv1.PodGroup{
+			podGroups: []*schedulingv1beta1.PodGroup{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "pg1",
 						Namespace: "c1",
 					},
-					Spec: schedulingv1.PodGroupSpec{
+					Spec: schedulingv1beta1.PodGroupSpec{
 						MinMember:         1,
 						Queue:             "q1",
 						PriorityClassName: "low-priority",
 					},
-					Status: schedulingv1.PodGroupStatus{
-						Phase: schedulingv1.PodGroupInqueue,
+					Status: schedulingv1beta1.PodGroupStatus{
+						Phase: schedulingv1beta1.PodGroupInqueue,
 					},
 				},
 				{
@@ -221,13 +221,13 @@ func TestPreempt(t *testing.T) {
 						Name:      "pg2",
 						Namespace: "c1",
 					},
-					Spec: schedulingv1.PodGroupSpec{
+					Spec: schedulingv1beta1.PodGroupSpec{
 						MinMember:         1,
 						Queue:             "q1",
 						PriorityClassName: "high-priority",
 					},
-					Status: schedulingv1.PodGroupStatus{
-						Phase: schedulingv1.PodGroupInqueue,
+					Status: schedulingv1beta1.PodGroupStatus{
+						Phase: schedulingv1beta1.PodGroupInqueue,
 					},
 				},
 			},
@@ -242,12 +242,12 @@ func TestPreempt(t *testing.T) {
 			nodes: []*v1.Node{
 				util.BuildNode("n1", util.BuildResourceList("6", "6G"), make(map[string]string)),
 			},
-			queues: []*schedulingv1.Queue{
+			queues: []*schedulingv1beta1.Queue{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "q1",
 					},
-					Spec: schedulingv1.QueueSpec{
+					Spec: schedulingv1beta1.QueueSpec{
 						Weight: 1,
 					},
 				},
@@ -275,14 +275,14 @@ func TestPreempt(t *testing.T) {
 				Evictor:         evictor,
 				StatusUpdater:   &util.FakeStatusUpdater{},
 				VolumeBinder:    &util.FakeVolumeBinder{},
-				PriorityClasses: make(map[string]*v1beta1.PriorityClass),
+				PriorityClasses: make(map[string]*schedulingv1.PriorityClass),
 
 				Recorder: record.NewFakeRecorder(100),
 			}
-			schedulerCache.PriorityClasses["high-priority"] = &v1beta1.PriorityClass{
+			schedulerCache.PriorityClasses["high-priority"] = &schedulingv1.PriorityClass{
 				Value: 100000,
 			}
-			schedulerCache.PriorityClasses["low-priority"] = &v1beta1.PriorityClass{
+			schedulerCache.PriorityClasses["low-priority"] = &schedulingv1.PriorityClass{
 				Value: 10,
 			}
 			for _, node := range test.nodes {

--- a/pkg/scheduler/actions/reclaim/reclaim_test.go
+++ b/pkg/scheduler/actions/reclaim/reclaim_test.go
@@ -21,11 +21,11 @@ import (
 	"time"
 
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/api/scheduling/v1beta1"
+	schedulingv1 "k8s.io/api/scheduling/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/record"
 
-	schedulingv1 "volcano.sh/apis/pkg/apis/scheduling/v1beta1"
+	schedulingv1beta1 "volcano.sh/apis/pkg/apis/scheduling/v1beta1"
 	"volcano.sh/volcano/pkg/scheduler/api"
 	"volcano.sh/volcano/pkg/scheduler/cache"
 	"volcano.sh/volcano/pkg/scheduler/conf"
@@ -44,26 +44,26 @@ func TestReclaim(t *testing.T) {
 
 	tests := []struct {
 		name      string
-		podGroups []*schedulingv1.PodGroup
+		podGroups []*schedulingv1beta1.PodGroup
 		pods      []*v1.Pod
 		nodes     []*v1.Node
-		queues    []*schedulingv1.Queue
+		queues    []*schedulingv1beta1.Queue
 		expected  int
 	}{
 		{
 			name: "Two Queue with one Queue overusing resource, should reclaim",
-			podGroups: []*schedulingv1.PodGroup{
+			podGroups: []*schedulingv1beta1.PodGroup{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "pg1",
 						Namespace: "c1",
 					},
-					Spec: schedulingv1.PodGroupSpec{
+					Spec: schedulingv1beta1.PodGroupSpec{
 						Queue:             "q1",
 						PriorityClassName: "low-priority",
 					},
-					Status: schedulingv1.PodGroupStatus{
-						Phase: schedulingv1.PodGroupInqueue,
+					Status: schedulingv1beta1.PodGroupStatus{
+						Phase: schedulingv1beta1.PodGroupInqueue,
 					},
 				},
 				{
@@ -71,12 +71,12 @@ func TestReclaim(t *testing.T) {
 						Name:      "pg2",
 						Namespace: "c1",
 					},
-					Spec: schedulingv1.PodGroupSpec{
+					Spec: schedulingv1beta1.PodGroupSpec{
 						Queue:             "q2",
 						PriorityClassName: "high-priority",
 					},
-					Status: schedulingv1.PodGroupStatus{
-						Phase: schedulingv1.PodGroupInqueue,
+					Status: schedulingv1beta1.PodGroupStatus{
+						Phase: schedulingv1beta1.PodGroupInqueue,
 					},
 				},
 			},
@@ -89,12 +89,12 @@ func TestReclaim(t *testing.T) {
 			nodes: []*v1.Node{
 				util.BuildNode("n1", util.BuildResourceList("3", "3Gi"), make(map[string]string)),
 			},
-			queues: []*schedulingv1.Queue{
+			queues: []*schedulingv1beta1.Queue{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "q1",
 					},
-					Spec: schedulingv1.QueueSpec{
+					Spec: schedulingv1beta1.QueueSpec{
 						Weight: 1,
 					},
 				},
@@ -102,7 +102,7 @@ func TestReclaim(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "q2",
 					},
-					Spec: schedulingv1.QueueSpec{
+					Spec: schedulingv1beta1.QueueSpec{
 						Weight: 1,
 					},
 				},
@@ -129,14 +129,14 @@ func TestReclaim(t *testing.T) {
 			Evictor:         evictor,
 			StatusUpdater:   &util.FakeStatusUpdater{},
 			VolumeBinder:    &util.FakeVolumeBinder{},
-			PriorityClasses: make(map[string]*v1beta1.PriorityClass),
+			PriorityClasses: make(map[string]*schedulingv1.PriorityClass),
 
 			Recorder: record.NewFakeRecorder(100),
 		}
-		schedulerCache.PriorityClasses["high-priority"] = &v1beta1.PriorityClass{
+		schedulerCache.PriorityClasses["high-priority"] = &schedulingv1.PriorityClass{
 			Value: 100000,
 		}
-		schedulerCache.PriorityClasses["low-priority"] = &v1beta1.PriorityClass{
+		schedulerCache.PriorityClasses["low-priority"] = &schedulingv1.PriorityClass{
 			Value: 10,
 		}
 		for _, node := range test.nodes {

--- a/pkg/scheduler/cache/cache.go
+++ b/pkg/scheduler/cache/cache.go
@@ -25,7 +25,7 @@ import (
 	"time"
 
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/api/scheduling/v1beta1"
+	schedulingv1 "k8s.io/api/scheduling/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -108,9 +108,9 @@ type SchedulerCache struct {
 	Jobs                 map[schedulingapi.JobID]*schedulingapi.JobInfo
 	Nodes                map[string]*schedulingapi.NodeInfo
 	Queues               map[schedulingapi.QueueID]*schedulingapi.QueueInfo
-	PriorityClasses      map[string]*v1beta1.PriorityClass
+	PriorityClasses      map[string]*schedulingv1.PriorityClass
 	NodeList             []string
-	defaultPriorityClass *v1beta1.PriorityClass
+	defaultPriorityClass *schedulingv1.PriorityClass
 	defaultPriority      int32
 
 	NamespaceCollection map[string]*schedulingapi.NamespaceCollection
@@ -367,7 +367,7 @@ func newSchedulerCache(config *rest.Config, schedulerName string, defaultQueue s
 		Jobs:            make(map[schedulingapi.JobID]*schedulingapi.JobInfo),
 		Nodes:           make(map[string]*schedulingapi.NodeInfo),
 		Queues:          make(map[schedulingapi.QueueID]*schedulingapi.QueueInfo),
-		PriorityClasses: make(map[string]*v1beta1.PriorityClass),
+		PriorityClasses: make(map[string]*schedulingv1.PriorityClass),
 		errTasks:        workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter()),
 		deletedJobs:     workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter()),
 		kubeClient:      kubeClient,

--- a/pkg/scheduler/cache/event_handlers.go
+++ b/pkg/scheduler/cache/event_handlers.go
@@ -22,7 +22,7 @@ import (
 	"strconv"
 
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/api/scheduling/v1beta1"
+	schedulingv1 "k8s.io/api/scheduling/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/cache"
@@ -33,7 +33,7 @@ import (
 	nodeinfov1alpha1 "volcano.sh/apis/pkg/apis/nodeinfo/v1alpha1"
 	"volcano.sh/apis/pkg/apis/scheduling"
 	"volcano.sh/apis/pkg/apis/scheduling/scheme"
-	schedulingv1 "volcano.sh/apis/pkg/apis/scheduling/v1beta1"
+	schedulingv1beta1 "volcano.sh/apis/pkg/apis/scheduling/v1beta1"
 	"volcano.sh/apis/pkg/apis/utils"
 	schedulingapi "volcano.sh/volcano/pkg/scheduler/api"
 )
@@ -444,9 +444,9 @@ func (sc *SchedulerCache) deletePodGroup(id schedulingapi.JobID) error {
 
 // AddPodGroupV1beta1 add podgroup to scheduler cache
 func (sc *SchedulerCache) AddPodGroupV1beta1(obj interface{}) {
-	ss, ok := obj.(*schedulingv1.PodGroup)
+	ss, ok := obj.(*schedulingv1beta1.PodGroup)
 	if !ok {
-		klog.Errorf("Cannot convert to *schedulingv1.PodGroup: %v", obj)
+		klog.Errorf("Cannot convert to *schedulingv1beta1.PodGroup: %v", obj)
 		return
 	}
 
@@ -470,14 +470,14 @@ func (sc *SchedulerCache) AddPodGroupV1beta1(obj interface{}) {
 
 // UpdatePodGroupV1beta1 add podgroup to scheduler cache
 func (sc *SchedulerCache) UpdatePodGroupV1beta1(oldObj, newObj interface{}) {
-	oldSS, ok := oldObj.(*schedulingv1.PodGroup)
+	oldSS, ok := oldObj.(*schedulingv1beta1.PodGroup)
 	if !ok {
-		klog.Errorf("Cannot convert oldObj to *schedulingv1.SchedulingSpec: %v", oldObj)
+		klog.Errorf("Cannot convert oldObj to *schedulingv1beta1.SchedulingSpec: %v", oldObj)
 		return
 	}
-	newSS, ok := newObj.(*schedulingv1.PodGroup)
+	newSS, ok := newObj.(*schedulingv1beta1.PodGroup)
 	if !ok {
-		klog.Errorf("Cannot convert newObj to *schedulingv1.SchedulingSpec: %v", newObj)
+		klog.Errorf("Cannot convert newObj to *schedulingv1beta1.SchedulingSpec: %v", newObj)
 		return
 	}
 
@@ -504,13 +504,13 @@ func (sc *SchedulerCache) UpdatePodGroupV1beta1(oldObj, newObj interface{}) {
 
 // DeletePodGroupV1beta1 delete podgroup from scheduler cache
 func (sc *SchedulerCache) DeletePodGroupV1beta1(obj interface{}) {
-	var ss *schedulingv1.PodGroup
+	var ss *schedulingv1beta1.PodGroup
 	switch t := obj.(type) {
-	case *schedulingv1.PodGroup:
+	case *schedulingv1beta1.PodGroup:
 		ss = t
 	case cache.DeletedFinalStateUnknown:
 		var ok bool
-		ss, ok = t.Obj.(*schedulingv1.PodGroup)
+		ss, ok = t.Obj.(*schedulingv1beta1.PodGroup)
 		if !ok {
 			klog.Errorf("Cannot convert to podgroup: %v", t.Obj)
 			return
@@ -533,9 +533,9 @@ func (sc *SchedulerCache) DeletePodGroupV1beta1(obj interface{}) {
 
 // AddQueueV1beta1 add queue to scheduler cache
 func (sc *SchedulerCache) AddQueueV1beta1(obj interface{}) {
-	ss, ok := obj.(*schedulingv1.Queue)
+	ss, ok := obj.(*schedulingv1beta1.Queue)
 	if !ok {
-		klog.Errorf("Cannot convert to *schedulingv1.Queue: %v", obj)
+		klog.Errorf("Cannot convert to *schedulingv1beta1.Queue: %v", obj)
 		return
 	}
 
@@ -554,14 +554,14 @@ func (sc *SchedulerCache) AddQueueV1beta1(obj interface{}) {
 
 // UpdateQueueV1beta1 update queue to scheduler cache
 func (sc *SchedulerCache) UpdateQueueV1beta1(oldObj, newObj interface{}) {
-	oldSS, ok := oldObj.(*schedulingv1.Queue)
+	oldSS, ok := oldObj.(*schedulingv1beta1.Queue)
 	if !ok {
-		klog.Errorf("Cannot convert oldObj to *schedulingv1.Queue: %v", oldObj)
+		klog.Errorf("Cannot convert oldObj to *schedulingv1beta1.Queue: %v", oldObj)
 		return
 	}
-	newSS, ok := newObj.(*schedulingv1.Queue)
+	newSS, ok := newObj.(*schedulingv1beta1.Queue)
 	if !ok {
-		klog.Errorf("Cannot convert newObj to *schedulingv1.Queue: %v", newObj)
+		klog.Errorf("Cannot convert newObj to *schedulingv1beta1.Queue: %v", newObj)
 		return
 	}
 
@@ -582,19 +582,19 @@ func (sc *SchedulerCache) UpdateQueueV1beta1(oldObj, newObj interface{}) {
 
 // DeleteQueueV1beta1 delete queue from the scheduler cache
 func (sc *SchedulerCache) DeleteQueueV1beta1(obj interface{}) {
-	var ss *schedulingv1.Queue
+	var ss *schedulingv1beta1.Queue
 	switch t := obj.(type) {
-	case *schedulingv1.Queue:
+	case *schedulingv1beta1.Queue:
 		ss = t
 	case cache.DeletedFinalStateUnknown:
 		var ok bool
-		ss, ok = t.Obj.(*schedulingv1.Queue)
+		ss, ok = t.Obj.(*schedulingv1beta1.Queue)
 		if !ok {
-			klog.Errorf("Cannot convert to *schedulingv1.Queue: %v", t.Obj)
+			klog.Errorf("Cannot convert to *schedulingv1beta1.Queue: %v", t.Obj)
 			return
 		}
 	default:
-		klog.Errorf("Cannot convert to *schedulingv1.Queue: %v", t)
+		klog.Errorf("Cannot convert to *schedulingv1beta1.Queue: %v", t)
 		return
 	}
 
@@ -618,19 +618,19 @@ func (sc *SchedulerCache) deleteQueue(id schedulingapi.QueueID) {
 
 //DeletePriorityClass delete priorityclass from the scheduler cache
 func (sc *SchedulerCache) DeletePriorityClass(obj interface{}) {
-	var ss *v1beta1.PriorityClass
+	var ss *schedulingv1.PriorityClass
 	switch t := obj.(type) {
-	case *v1beta1.PriorityClass:
+	case *schedulingv1.PriorityClass:
 		ss = t
 	case cache.DeletedFinalStateUnknown:
 		var ok bool
-		ss, ok = t.Obj.(*v1beta1.PriorityClass)
+		ss, ok = t.Obj.(*schedulingv1.PriorityClass)
 		if !ok {
-			klog.Errorf("Cannot convert to *v1beta1.PriorityClass: %v", t.Obj)
+			klog.Errorf("Cannot convert to *schedulingv1.PriorityClass: %v", t.Obj)
 			return
 		}
 	default:
-		klog.Errorf("Cannot convert to *v1beta1.PriorityClass: %v", t)
+		klog.Errorf("Cannot convert to *schedulingv1.PriorityClass: %v", t)
 		return
 	}
 
@@ -642,16 +642,16 @@ func (sc *SchedulerCache) DeletePriorityClass(obj interface{}) {
 
 //UpdatePriorityClass update priorityclass to scheduler cache
 func (sc *SchedulerCache) UpdatePriorityClass(oldObj, newObj interface{}) {
-	oldSS, ok := oldObj.(*v1beta1.PriorityClass)
+	oldSS, ok := oldObj.(*schedulingv1.PriorityClass)
 	if !ok {
-		klog.Errorf("Cannot convert oldObj to *v1beta1.PriorityClass: %v", oldObj)
+		klog.Errorf("Cannot convert oldObj to *schedulingv1.PriorityClass: %v", oldObj)
 
 		return
 	}
 
-	newSS, ok := newObj.(*v1beta1.PriorityClass)
+	newSS, ok := newObj.(*schedulingv1.PriorityClass)
 	if !ok {
-		klog.Errorf("Cannot convert newObj to *v1beta1.PriorityClass: %v", newObj)
+		klog.Errorf("Cannot convert newObj to *schedulingv1.PriorityClass: %v", newObj)
 		return
 	}
 
@@ -664,9 +664,9 @@ func (sc *SchedulerCache) UpdatePriorityClass(oldObj, newObj interface{}) {
 
 //AddPriorityClass add priorityclass to scheduler cache
 func (sc *SchedulerCache) AddPriorityClass(obj interface{}) {
-	ss, ok := obj.(*v1beta1.PriorityClass)
+	ss, ok := obj.(*schedulingv1.PriorityClass)
 	if !ok {
-		klog.Errorf("Cannot convert to *v1beta1.PriorityClass: %v", obj)
+		klog.Errorf("Cannot convert to *schedulingv1.PriorityClass: %v", obj)
 		return
 	}
 
@@ -676,7 +676,7 @@ func (sc *SchedulerCache) AddPriorityClass(obj interface{}) {
 	sc.addPriorityClass(ss)
 }
 
-func (sc *SchedulerCache) deletePriorityClass(pc *v1beta1.PriorityClass) {
+func (sc *SchedulerCache) deletePriorityClass(pc *schedulingv1.PriorityClass) {
 	if pc.GlobalDefault {
 		sc.defaultPriorityClass = nil
 		sc.defaultPriority = 0
@@ -685,7 +685,7 @@ func (sc *SchedulerCache) deletePriorityClass(pc *v1beta1.PriorityClass) {
 	delete(sc.PriorityClasses, pc.Name)
 }
 
-func (sc *SchedulerCache) addPriorityClass(pc *v1beta1.PriorityClass) {
+func (sc *SchedulerCache) addPriorityClass(pc *schedulingv1.PriorityClass) {
 	if pc.GlobalDefault {
 		if sc.defaultPriorityClass != nil {
 			klog.Errorf("Updated default priority class from <%s> to <%s> forcefully.",

--- a/pkg/scheduler/plugins/predicates/predicates_test.go
+++ b/pkg/scheduler/plugins/predicates/predicates_test.go
@@ -7,12 +7,12 @@ import (
 	"github.com/agiledragon/gomonkey/v2"
 
 	apiv1 "k8s.io/api/core/v1"
-	"k8s.io/api/scheduling/v1beta1"
+	schedulingv1 "k8s.io/api/scheduling/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/record"
 
-	schedulingv1 "volcano.sh/apis/pkg/apis/scheduling/v1beta1"
+	schedulingv1beta1 "volcano.sh/apis/pkg/apis/scheduling/v1beta1"
 	"volcano.sh/volcano/cmd/scheduler/app/options"
 	"volcano.sh/volcano/pkg/scheduler/actions/allocate"
 	"volcano.sh/volcano/pkg/scheduler/api"
@@ -76,33 +76,33 @@ func TestEventHandler(t *testing.T) {
 	n2.Labels["kubernetes.io/hostname"] = "node2"
 
 	// priority
-	p1 := &v1beta1.PriorityClass{ObjectMeta: metav1.ObjectMeta{Name: "p1"}, Value: 1}
-	p2 := &v1beta1.PriorityClass{ObjectMeta: metav1.ObjectMeta{Name: "p2"}, Value: 2}
+	p1 := &schedulingv1.PriorityClass{ObjectMeta: metav1.ObjectMeta{Name: "p1"}, Value: 1}
+	p2 := &schedulingv1.PriorityClass{ObjectMeta: metav1.ObjectMeta{Name: "p2"}, Value: 2}
 	// podgroup
-	pg1 := &schedulingv1.PodGroup{
+	pg1 := &schedulingv1beta1.PodGroup{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "ns1",
 			Name:      "pg1",
 		},
-		Spec: schedulingv1.PodGroupSpec{
+		Spec: schedulingv1beta1.PodGroupSpec{
 			Queue:             "q1",
 			MinMember:         int32(2),
 			PriorityClassName: p2.Name,
 		},
 	}
-	pg2 := &schedulingv1.PodGroup{
+	pg2 := &schedulingv1beta1.PodGroup{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "ns1",
 			Name:      "pg2",
 		},
-		Spec: schedulingv1.PodGroupSpec{
+		Spec: schedulingv1beta1.PodGroupSpec{
 			Queue:             "q1",
 			MinMember:         int32(1),
 			PriorityClassName: p1.Name,
 		},
 	}
 	// queue
-	queue1 := &schedulingv1.Queue{
+	queue1 := &schedulingv1beta1.Queue{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "q1",
 		},
@@ -113,16 +113,16 @@ func TestEventHandler(t *testing.T) {
 		name     string
 		pods     []*apiv1.Pod
 		nodes    []*apiv1.Node
-		pcs      []*v1beta1.PriorityClass
-		pgs      []*schedulingv1.PodGroup
+		pcs      []*schedulingv1.PriorityClass
+		pgs      []*schedulingv1beta1.PodGroup
 		expected map[string]string
 	}{
 		{
 			name:  "pod-deallocate",
 			pods:  []*apiv1.Pod{w1, w2, w3},
 			nodes: []*apiv1.Node{n1, n2},
-			pcs:   []*v1beta1.PriorityClass{p1, p2},
-			pgs:   []*schedulingv1.PodGroup{pg1, pg2},
+			pcs:   []*schedulingv1.PriorityClass{p1, p2},
+			pgs:   []*schedulingv1beta1.PodGroup{pg1, pg2},
 			expected: map[string]string{ // podKey -> node
 				"ns1/worker-3": "node1",
 			},
@@ -145,7 +145,7 @@ func TestEventHandler(t *testing.T) {
 		schedulerCache := &cache.SchedulerCache{
 			Nodes:           make(map[string]*api.NodeInfo),
 			Jobs:            make(map[api.JobID]*api.JobInfo),
-			PriorityClasses: make(map[string]*v1beta1.PriorityClass),
+			PriorityClasses: make(map[string]*schedulingv1.PriorityClass),
 			Queues:          make(map[api.QueueID]*api.QueueInfo),
 			Binder:          binder,
 			StatusUpdater:   &util.FakeStatusUpdater{},
@@ -162,8 +162,8 @@ func TestEventHandler(t *testing.T) {
 			schedulerCache.PriorityClasses[pc.Name] = pc
 		}
 		for _, pg := range test.pgs {
-			pg.Status = schedulingv1.PodGroupStatus{
-				Phase: schedulingv1.PodGroupInqueue,
+			pg.Status = schedulingv1beta1.PodGroupStatus{
+				Phase: schedulingv1beta1.PodGroupInqueue,
 			}
 			schedulerCache.AddPodGroupV1beta1(pg)
 		}

--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -30,7 +30,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
-	schedv1 "k8s.io/api/scheduling/v1beta1"
+	schedv1 "k8s.io/api/scheduling/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -213,7 +213,7 @@ func CleanupTestContext(ctx *TestContext) {
 
 func createPriorityClasses(cxt *TestContext) {
 	for name, value := range cxt.PriorityClasses {
-		_, err := cxt.Kubeclient.SchedulingV1beta1().PriorityClasses().Create(context.TODO(),
+		_, err := cxt.Kubeclient.SchedulingV1().PriorityClasses().Create(context.TODO(),
 			&schedv1.PriorityClass{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: name,
@@ -228,7 +228,7 @@ func createPriorityClasses(cxt *TestContext) {
 
 func deletePriorityClasses(cxt *TestContext) {
 	for name := range cxt.PriorityClasses {
-		err := cxt.Kubeclient.SchedulingV1beta1().PriorityClasses().Delete(context.TODO(), name, metav1.DeleteOptions{})
+		err := cxt.Kubeclient.SchedulingV1().PriorityClasses().Delete(context.TODO(), name, metav1.DeleteOptions{})
 		Expect(err).NotTo(HaveOccurred())
 	}
 }


### PR DESCRIPTION
The scheduling.k8s.io/v1beta1 API version of PriorityClass is no longer served as of v1.22，only scheduling.k8s.io/v1 is available which is added since v1.14. 

Signed-off-by: lc2705 <liuchang2705@163.com>