### PR TITLE
support label volcano.sh/task-priority

### DIFF
--- a/pkg/scheduler/api/job_info.go
+++ b/pkg/scheduler/api/job_info.go
@@ -162,6 +162,11 @@ func NewTaskInfo(pod *v1.Pod) *TaskInfo {
 		},
 	}
 
+	if taskPriority, ok := pod.Labels["volcano.sh/task-priority"]; ok {
+		if priority, err := strconv.ParseInt(taskPriority, 10, 32); err == nil {
+			ti.Priority = int32(priority)
+		}
+	}
 	if pod.Spec.Priority != nil {
 		ti.Priority = *pod.Spec.Priority
 	}

--- a/pkg/scheduler/api/job_info.go
+++ b/pkg/scheduler/api/job_info.go
@@ -131,6 +131,8 @@ func getTaskID(pod *v1.Pod) TaskID {
 	return ""
 }
 
+const TaskPriorityAnnotation = "volcano.sh/task-priority"
+
 // NewTaskInfo creates new taskInfo object for a Pod
 func NewTaskInfo(pod *v1.Pod) *TaskInfo {
 	initResReq := GetPodResourceRequest(pod)
@@ -166,7 +168,7 @@ func NewTaskInfo(pod *v1.Pod) *TaskInfo {
 		ti.Priority = *pod.Spec.Priority
 	}
 
-	if taskPriority, ok := pod.Labels["volcano.sh/task-priority"]; ok {
+	if taskPriority, ok := pod.Annotations[TaskPriorityAnnotation]; ok {
 		if priority, err := strconv.ParseInt(taskPriority, 10, 32); err == nil {
 			ti.Priority = int32(priority)
 		}

--- a/pkg/scheduler/api/job_info.go
+++ b/pkg/scheduler/api/job_info.go
@@ -162,13 +162,14 @@ func NewTaskInfo(pod *v1.Pod) *TaskInfo {
 		},
 	}
 
+	if pod.Spec.Priority != nil {
+		ti.Priority = *pod.Spec.Priority
+	}
+
 	if taskPriority, ok := pod.Labels["volcano.sh/task-priority"]; ok {
 		if priority, err := strconv.ParseInt(taskPriority, 10, 32); err == nil {
 			ti.Priority = int32(priority)
 		}
-	}
-	if pod.Spec.Priority != nil {
-		ti.Priority = *pod.Spec.Priority
 	}
 
 	return ti


### PR DESCRIPTION
a training job( such as tfjob/pytorchjob) always has many pods: one master and some workers. we need tell volcano that  the priority of  master pod is high than worker, so volcano can run master first and preempt master last.

we can set `pod.Priority` by create PriorityClass object in k8s, but it is troublesome for operator(such as tf-operator/pytorch-operator) to maintain the PriorityClass object. 

so it it simple to use pod Label `volcano.sh/task-priority` to mark the pod priority