### PR TITLE
default sort task by index

### DIFF
--- a/pkg/controllers/job/helpers/helpers.go
+++ b/pkg/controllers/job/helpers/helpers.go
@@ -19,6 +19,7 @@ package helpers
 import (
 	"fmt"
 	"math/rand"
+	"strconv"
 	"strings"
 	"time"
 
@@ -26,6 +27,7 @@ import (
 
 	batch "volcano.sh/apis/pkg/apis/batch/v1alpha1"
 	"volcano.sh/volcano/pkg/controllers/apis"
+	"volcano.sh/volcano/pkg/scheduler/api"
 )
 
 const (
@@ -43,6 +45,21 @@ func GetTaskIndex(pod *v1.Pod) string {
 	}
 
 	return ""
+}
+
+// ComparePodByIndex by pod index
+func CompareTask(lv, rv *api.TaskInfo) bool {
+	lStr := GetTaskIndex(lv.Pod)
+	rStr := GetTaskIndex(rv.Pod)
+	lIndex, lErr := strconv.Atoi(lStr)
+	rIndex, rErr := strconv.Atoi(rStr)
+	if lErr != nil || rErr != nil || lIndex == rIndex {
+		return lv.Pod.CreationTimestamp.Before(&rv.Pod.CreationTimestamp)
+	}
+	if lIndex > rIndex {
+		return false
+	}
+	return true
 }
 
 // GetTaskKey returns task key/name

--- a/pkg/controllers/job/helpers/helpers_test.go
+++ b/pkg/controllers/job/helpers/helpers_test.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2021 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package helpers
+
+import (
+	"testing"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"volcano.sh/volcano/pkg/scheduler/api"
+)
+
+func TestCompareTask(t *testing.T) {
+	createTime := time.Now()
+	items := []struct {
+		lv     *api.TaskInfo
+		rv     *api.TaskInfo
+		expect bool
+	}{
+		{
+			generateTaskInfo("prod-worker-21", createTime),
+			generateTaskInfo("prod-worker-1", createTime),
+			false,
+		},
+		{
+			generateTaskInfo("prod-worker-0", createTime),
+			generateTaskInfo("prod-worker-3", createTime),
+			true,
+		},
+		{
+			generateTaskInfo("prod-worker", createTime),
+			generateTaskInfo("prod-worker-3", createTime.Add(time.Hour)),
+			true,
+		},
+		{
+			generateTaskInfo("prod-worker", createTime),
+			generateTaskInfo("prod-worker-3", createTime.Add(-time.Hour)),
+			false,
+		},
+	}
+
+	for i, item := range items {
+		if value := CompareTask(item.lv, item.rv); value != item.expect {
+			t.Errorf("case %d: expected: %v, got %v", i, item.expect, value)
+		}
+	}
+}
+
+func generateTaskInfo(name string, createTime time.Time) *api.TaskInfo {
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              name,
+			CreationTimestamp: metav1.Time{Time: createTime},
+		},
+	}
+	return &api.TaskInfo{
+		Name: name,
+		Pod:  pod,
+	}
+}

--- a/pkg/scheduler/framework/session_plugins.go
+++ b/pkg/scheduler/framework/session_plugins.go
@@ -20,6 +20,7 @@ import (
 	k8sframework "k8s.io/kubernetes/pkg/scheduler/framework/v1alpha1"
 
 	"volcano.sh/apis/pkg/apis/scheduling"
+	"volcano.sh/volcano/pkg/controllers/job/helpers"
 	"volcano.sh/volcano/pkg/scheduler/api"
 )
 
@@ -633,13 +634,10 @@ func (ssn *Session) TaskOrderFn(l, r interface{}) bool {
 		return res < 0
 	}
 
-	// If no task order funcs, order task by CreationTimestamp first, then by UID.
+	// If no task order funcs, order task by default func.
 	lv := l.(*api.TaskInfo)
 	rv := r.(*api.TaskInfo)
-	if lv.Pod.CreationTimestamp.Equal(&rv.Pod.CreationTimestamp) {
-		return lv.UID < rv.UID
-	}
-	return lv.Pod.CreationTimestamp.Before(&rv.Pod.CreationTimestamp)
+	return helpers.CompareTask(lv, rv)
 }
 
 // PredicateFn invoke predicate function of the plugins


### PR DESCRIPTION
The tasks of vc-job is created in goroutine, and the `CreationTimestamp` of tasks is random.
 Sorting tasks by task index is a better choice 