### PR TITLE
optimize: reuse predicate error on same task group

### DIFF
--- a/pkg/controllers/apis/job_info.go
+++ b/pkg/controllers/apis/job_info.go
@@ -65,7 +65,7 @@ func (ji *JobInfo) SetJob(job *batch.Job) {
 func (ji *JobInfo) AddPod(pod *v1.Pod) error {
 	taskName, found := pod.Annotations[batch.TaskSpecKey]
 	if !found {
-		return fmt.Errorf("failed to taskName of Pod <%s/%s>",
+		return fmt.Errorf("failed to find taskName of Pod <%s/%s>",
 			pod.Namespace, pod.Name)
 	}
 

--- a/pkg/scheduler/actions/allocate/allocate.go
+++ b/pkg/scheduler/actions/allocate/allocate.go
@@ -198,7 +198,7 @@ func (alloc *Action) Execute(ssn *framework.Session) {
 			tasks.Len(), job.Namespace, job.Name)
 
 		stmt := framework.NewStatement(ssn)
-
+		ph := util.NewPredicateHelper()
 		for !tasks.Empty() {
 			task := tasks.Pop().(*api.TaskInfo)
 
@@ -211,7 +211,7 @@ func (alloc *Action) Execute(ssn *framework.Session) {
 
 			klog.V(3).Infof("There are <%d> nodes for Job <%v/%v>", len(nodes), job.Namespace, job.Name)
 
-			predicateNodes, fitErrors := util.PredicateNodes(task, nodes, predicateFn)
+			predicateNodes, fitErrors := ph.PredicateNodes(task, nodes, predicateFn)
 			if len(predicateNodes) == 0 {
 				job.NodesFitErrors[task.UID] = fitErrors
 				break

--- a/pkg/scheduler/api/job_info.go
+++ b/pkg/scheduler/api/job_info.go
@@ -219,6 +219,13 @@ func (ti *TaskInfo) Clone() *TaskInfo {
 	}
 }
 
+func (ti *TaskInfo) GetTaskSpecKey() TaskID {
+	if ti.Pod == nil {
+		return ""
+	}
+	return getTaskID(ti.Pod)
+}
+
 // String returns the taskInfo details in a string
 func (ti TaskInfo) String() string {
 	return fmt.Sprintf("Task (%v:%v/%v): job %v, status %v, pri %v"+
@@ -382,7 +389,7 @@ func (ji *JobInfo) extractPreemptable(pg *PodGroup) bool {
 
 // extractRevocableZone return volcano.sh/revocable-zone value for pod/podgroup
 func (ji *JobInfo) extractRevocableZone(pg *PodGroup) string {
-	// check annotaion first
+	// check annotation first
 	if len(pg.Annotations) > 0 {
 		if value, found := pg.Annotations[v1beta1.RevocableZone]; found {
 			if value != "*" {

--- a/pkg/scheduler/util/predicate_helper.go
+++ b/pkg/scheduler/util/predicate_helper.go
@@ -1,0 +1,108 @@
+package util
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"sync/atomic"
+
+	"k8s.io/client-go/util/workqueue"
+	"k8s.io/klog"
+	"volcano.sh/volcano/pkg/scheduler/api"
+)
+
+type PredicateHelper interface {
+	PredicateNodes(task *api.TaskInfo, nodes []*api.NodeInfo, fn api.PredicateFn) ([]*api.NodeInfo, *api.FitErrors)
+}
+
+type predicateHelper struct {
+	taskPredicateErrorCache map[string]map[string]error
+}
+
+// PredicateNodes returns the specified number of nodes that fit a task
+func (ph *predicateHelper) PredicateNodes(task *api.TaskInfo, nodes []*api.NodeInfo, fn api.PredicateFn) ([]*api.NodeInfo, *api.FitErrors) {
+	var errorLock sync.RWMutex
+	fe := api.NewFitErrors()
+
+	allNodes := len(nodes)
+	if allNodes == 0 {
+		return make([]*api.NodeInfo, 0), fe
+	}
+	numNodesToFind := CalculateNumOfFeasibleNodesToFind(int32(allNodes))
+
+	//allocate enough space to avoid growing it
+	predicateNodes := make([]*api.NodeInfo, numNodesToFind)
+
+	numFoundNodes := int32(0)
+	processedNodes := int32(0)
+
+	taskGroupid := taskGroupID(task)
+	nodeErrorCache, taskFailedBefore := ph.taskPredicateErrorCache[taskGroupid]
+	if nodeErrorCache == nil {
+		nodeErrorCache = map[string]error{}
+	}
+
+	//create a context with cancellation
+	ctx, cancel := context.WithCancel(context.Background())
+
+	checkNode := func(index int) {
+		// Check the nodes starting from where is left off in the previous scheduling cycle,
+		// to make sure all nodes have the same chance of being examined across pods.
+		node := nodes[(lastProcessedNodeIndex+index)%allNodes]
+		atomic.AddInt32(&processedNodes, 1)
+		klog.V(4).Infof("Considering Task <%v/%v> on node <%v>: <%v> vs. <%v>",
+			task.Namespace, task.Name, node.Name, task.Resreq, node.Idle)
+
+		// Check if the task had "predicate" failure before.
+		// And then check if the task failed to predict on this node before.
+		if taskFailedBefore {
+			errorLock.RLock()
+			errC, ok := nodeErrorCache[node.Name]
+			errorLock.RUnlock()
+
+			if ok {
+				errorLock.Lock()
+				fe.SetNodeError(node.Name, errC)
+				errorLock.Unlock()
+				return
+			}
+		}
+
+		// TODO (k82cn): Enable eCache for performance improvement.
+		if err := fn(task, node); err != nil {
+			klog.V(3).Infof("Predicates failed for task <%s/%s> on node <%s>: %v",
+				task.Namespace, task.Name, node.Name, err)
+			errorLock.Lock()
+			nodeErrorCache[node.Name] = err
+			ph.taskPredicateErrorCache[taskGroupid] = nodeErrorCache
+			fe.SetNodeError(node.Name, err)
+			errorLock.Unlock()
+			return
+		}
+
+		//check if the number of found nodes is more than the numNodesTofind
+		length := atomic.AddInt32(&numFoundNodes, 1)
+		if length > numNodesToFind {
+			cancel()
+			atomic.AddInt32(&numFoundNodes, -1)
+		} else {
+			predicateNodes[length-1] = node
+		}
+	}
+
+	//workqueue.ParallelizeUntil(context.TODO(), 16, len(nodes), checkNode)
+	workqueue.ParallelizeUntil(ctx, 16, allNodes, checkNode)
+
+	//processedNodes := int(numFoundNodes) + len(filteredNodesStatuses) + len(failedPredicateMap)
+	lastProcessedNodeIndex = (lastProcessedNodeIndex + int(processedNodes)) % allNodes
+	predicateNodes = predicateNodes[:numFoundNodes]
+	return predicateNodes, fe
+}
+
+func taskGroupID(task *api.TaskInfo) string {
+	return fmt.Sprintf("%s/%s", task.Job, task.GetTaskSpecKey())
+}
+
+func NewPredicateHelper() PredicateHelper {
+	return &predicateHelper{taskPredicateErrorCache: map[string]map[string]error{}}
+}

--- a/pkg/scheduler/util/scheduler_helper.go
+++ b/pkg/scheduler/util/scheduler_helper.go
@@ -23,7 +23,6 @@ import (
 	"math/rand"
 	"sort"
 	"sync"
-	"sync/atomic"
 
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog"
@@ -65,65 +64,6 @@ func CalculateNumOfFeasibleNodesToFind(numAllNodes int32) (numNodes int32) {
 		numNodes = opts.MinNodesToFind
 	}
 	return numNodes
-}
-
-// PredicateNodes returns the specified number of nodes that fit a task
-func PredicateNodes(task *api.TaskInfo, nodes []*api.NodeInfo, fn api.PredicateFn) ([]*api.NodeInfo, *api.FitErrors) {
-	//var workerLock sync.Mutex
-
-	var errorLock sync.Mutex
-	fe := api.NewFitErrors()
-
-	allNodes := len(nodes)
-	if allNodes == 0 {
-		return make([]*api.NodeInfo, 0), fe
-	}
-	numNodesToFind := CalculateNumOfFeasibleNodesToFind(int32(allNodes))
-
-	//allocate enough space to avoid growing it
-	predicateNodes := make([]*api.NodeInfo, numNodesToFind)
-
-	numFoundNodes := int32(0)
-	processedNodes := int32(0)
-
-	//create a context with cancellation
-	ctx, cancel := context.WithCancel(context.Background())
-
-	checkNode := func(index int) {
-		// Check the nodes starting from where is left off in the previous scheduling cycle,
-		// to make sure all nodes have the same chance of being examined across pods.
-		node := nodes[(lastProcessedNodeIndex+index)%allNodes]
-		atomic.AddInt32(&processedNodes, 1)
-		klog.V(4).Infof("Considering Task <%v/%v> on node <%v>: <%v> vs. <%v>",
-			task.Namespace, task.Name, node.Name, task.Resreq, node.Idle)
-
-		// TODO (k82cn): Enable eCache for performance improvement.
-		if err := fn(task, node); err != nil {
-			klog.V(3).Infof("Predicates failed for task <%s/%s> on node <%s>: %v",
-				task.Namespace, task.Name, node.Name, err)
-			errorLock.Lock()
-			fe.SetNodeError(node.Name, err)
-			errorLock.Unlock()
-			return
-		}
-
-		//check if the number of found nodes is more than the numNodesTofind
-		length := atomic.AddInt32(&numFoundNodes, 1)
-		if length > numNodesToFind {
-			cancel()
-			atomic.AddInt32(&numFoundNodes, -1)
-		} else {
-			predicateNodes[length-1] = node
-		}
-	}
-
-	//workqueue.ParallelizeUntil(context.TODO(), 16, len(nodes), checkNode)
-	workqueue.ParallelizeUntil(ctx, 16, allNodes, checkNode)
-
-	//processedNodes := int(numFoundNodes) + len(filteredNodesStatuses) + len(failedPredicateMap)
-	lastProcessedNodeIndex = (lastProcessedNodeIndex + int(processedNodes)) % allNodes
-	predicateNodes = predicateNodes[:numFoundNodes]
-	return predicateNodes, fe
 }
 
 // PrioritizeNodes returns a map whose key is node's score and value are corresponding nodes


### PR DESCRIPTION
### Background
I found that there is a logic in "PredicateNodes" could be improved. 
In current logic, every replica(TaskInfo wrapping pod) of same task will do the same predicate operations at every scheduling action. But those replicas has same resource requirements in common. 
So I guess there is no need to predicate on the node again for another replicas if the "predicate" failure happend for one of the replicas.

```
  tasks:
    - replicas: 6
      name: "default-nginx"
      template:
        metadata:
          name: web
```

### Solution
saving `taskPredicateErrorCache map[string]map[string]error` in PredicateHelper. The map is like `map[TaskGroupID]map[Node.Name]error`.
And `TaskGroupID` is "$JobID/$TaskSpecKey". Could this identify a task group?

ref: #1740 (Optimize the throughput of scheduler) 