### PR TITLE
fix scheduling process starts even if resource synchronization is not complete

### DIFF
--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -83,7 +83,7 @@ func (pc *Scheduler) Run(stopCh <-chan struct{}) {
 	pc.loadSchedulerConf()
 	go pc.watchSchedulerConf(stopCh)
 	// Start cache for policy.
-	go pc.cache.Run(stopCh)
+	pc.cache.Run(stopCh)
 	pc.cache.WaitForCacheSync(stopCh)
 	klog.V(2).Infof("scheduler completes Initialization and start to run")
 	go wait.Until(pc.runOnce, pc.schedulePeriod, stopCh)


### PR DESCRIPTION
Signed-off-by: huone1 <huwanxing@huawei.com>
in current version,  scheduling process starts even if resource synchronization is not complete.

```
// Run runs the Scheduler
func (pc *Scheduler) Run(stopCh <-chan struct{}) {
	pc.loadSchedulerConf()
	go pc.watchSchedulerConf(stopCh)
	// Start cache for policy.
	go pc.cache.Run(stopCh)                // it is wrong that informer.Start is asynchronous
	pc.cache.WaitForCacheSync(stopCh)   // nothing is waited and sharedInformerFactory.startedInformers is empty because the informer.Start is asynchronous
	klog.V(2).Infof("scheduler completes Initialization and start to run")
	go wait.Until(pc.runOnce, pc.schedulePeriod, stopCh)
}
```

 **cache.WaitForCacheSync just wait the resourcesynchronization  which the Informer started**

```
// WaitForCacheSync waits for all started informers' cache were synced.
func (f *sharedInformerFactory) WaitForCacheSync(stopCh <-chan struct{}) map[reflect.Type]bool {
	informers := func() map[reflect.Type]cache.SharedIndexInformer {
		f.lock.Lock()
		defer f.lock.Unlock()

		informers := map[reflect.Type]cache.SharedIndexInformer{}
		for informerType, informer := range f.informers {
                        //  f.startedInformers is  empty because the informer.Start is asynchronous  
			if f.startedInformers[informerType] {  
				informers[informerType] = informer
			}
		}
		return informers
	}()

	res := map[reflect.Type]bool{}
	for informType, informer := range informers {
		res[informType] = cache.WaitForCacheSync(stopCh, informer.HasSynced)
	}
	return res
}
```