### PR TITLE
support descheduler for volcano

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,10 +110,32 @@ job.batch/volcano-admission-init   1/1           48s        96s
 
 ```
 
+### Install descheduler with YAML files(optional)
+If you want to run descheduler with Volcano, just run the following command.
+
+```bash
+kubectl apply -f https://raw.githubusercontent.com/volcano-sh/volcano/master/installer/descheduler.yaml
+```
+
+Then you will get the outputs as follows:
+
+```bash
+[root@volcano] kubectl get configmap -n kube-system
+NAME                                 DATA   AGE
+descheduler-policy-configmap         1      1m
+
+[root@volcano] kubectl get deployment -n kube-system
+NAME                        READY   UP-TO-DATE   AVAILABLE   AGE
+descheduler                 1/1     1            1           1m
+```
+
+More details for descheduler can be referred to [kubernetes-sigs/descheduler](https://github.com/kubernetes-sigs/descheduler) 
+
+Note: this feature is **beta** version for Volcano. Suggest to just make use in non-production environments temporarily.
+
 ### Install from code
 
 If you don't have a kubernetes cluster, try one-click install from code base:
-
 ```bash
 ./hack/local-up-volcano.sh
 ```

--- a/installer/descheduler.yaml
+++ b/installer/descheduler.yaml
@@ -1,0 +1,129 @@
+# fork from kubernetes-sigs/descheduler/kubernetes/base/rbac.yaml
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: descheduler-cluster-role
+rules:
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create", "update"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "watch", "list"]
+  - apiGroups: [""]
+    resources: ["namespaces"]
+    verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "watch", "list", "delete"]
+  - apiGroups: [""]
+    resources: ["pods/eviction"]
+    verbs: ["create"]
+  - apiGroups: ["scheduling.k8s.io"]
+    resources: ["priorityclasses"]
+    verbs: ["get", "watch", "list"]
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: descheduler-sa
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: descheduler-cluster-role-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: descheduler-cluster-role
+subjects:
+  - name: descheduler-sa
+    kind: ServiceAccount
+    namespace: kube-system
+---
+# fork from kubernetes-sigs/descheduler/kubernetes/base/rbac.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: descheduler-policy-configmap
+  namespace: kube-system
+data:
+  policy.yaml: |
+    apiVersion: "descheduler/v1alpha1"
+    kind: "DeschedulerPolicy"
+    strategies:
+      "RemoveDuplicates":
+         enabled: true
+      "RemovePodsViolatingInterPodAntiAffinity":
+         enabled: true
+      "LowNodeUtilization":
+         enabled: true
+         params:
+           nodeResourceUtilizationThresholds:
+             thresholds:
+               "cpu" : 20
+               "memory": 20
+               "pods": 20
+             targetThresholds:
+               "cpu" : 50
+               "memory": 50
+               "pods": 50
+---
+# fork from kubernetes-sigs/descheduler/kubernetes/deployment/deployment.yaml
+# allow container run as root by default
+# change the image to be v0.19.0 to match the k8s version master branch depends on
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: descheduler
+  namespace: kube-system
+  labels:
+    app: descheduler
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: descheduler
+  template:
+    metadata:
+      labels:
+        app: descheduler
+    spec:
+      priorityClassName: system-cluster-critical
+      serviceAccountName: descheduler-sa
+      containers:
+        - name: descheduler
+          image: k8s.gcr.io/descheduler/descheduler:v0.19.0
+          imagePullPolicy: IfNotPresent
+          command:
+            - "/bin/descheduler"
+          args:
+            - "--policy-config-file"
+            - "/policy-dir/policy.yaml"
+            - "--descheduling-interval"
+            - "5m"
+            - "--v"
+            - "3"
+          ports:
+            - containerPort: 10258
+              protocol: TCP
+          resources:
+            requests:
+              cpu: 500m
+              memory: 256Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: false
+          volumeMounts:
+            - mountPath: /policy-dir
+              name: policy-volume
+      volumes:
+        - name: policy-volume
+          configMap:
+            name: descheduler-policy-configmap


### PR DESCRIPTION
ref: https://github.com/volcano-sh/volcano/issues/1777
This is just fork from https://github.com/kubernetes-sigs/descheduler. Will give specified support for Volcano such as group scheduling consideration when evict pods.
Signed-off-by: Thor-wl <13164644535@163.com>