### PR TITLE
[numa-aware]fix concurrent map read and map write

### DIFF
--- a/pkg/scheduler/plugins/numaaware/numaaware.go
+++ b/pkg/scheduler/plugins/numaaware/numaaware.go
@@ -45,6 +45,7 @@ const (
 )
 
 type numaPlugin struct {
+	sync.Mutex
 	// Arguments given for the plugin
 	pluginArguments framework.Arguments
 	hintProviders   []policy.HintProvider
@@ -142,6 +143,8 @@ func (pp *numaPlugin) OnSessionOpen(ssn *framework.Session) {
 			}
 		}
 
+		pp.Lock()
+		defer pp.Unlock()
 		if _, ok := pp.assignRes[task.UID]; !ok {
 			pp.assignRes[task.UID] = make(map[string]api.ResNumaSets)
 		}


### PR DESCRIPTION
Signed-off-by: huone1 <huwanxing@huawei.com>
predicate logic is a concurrent  operation， so map access must add Mutex lock in numa-aware PredicateFn