### PR TITLE
Inherit annotations from upper resources to k8s podgroup.

### DIFF
--- a/installer/helm/chart/volcano/templates/controllers.yaml
+++ b/installer/helm/chart/volcano/templates/controllers.yaml
@@ -52,7 +52,12 @@ rules:
   - apiGroups: ["networking.k8s.io"]
     resources: ["networkpolicies"]
     verbs: ["get", "create", "delete"]
-
+  - apiGroups: ["apps"]
+    resources: ["daemonsets", "replicasets", "statefulsets"]
+    verbs: ["get"]
+  - apiGroups: ["batch"]
+    resources: ["jobs"]
+    verbs: ["get"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/installer/volcano-development-arm64.yaml
+++ b/installer/volcano-development-arm64.yaml
@@ -8454,6 +8454,12 @@ rules:
   - apiGroups: ["networking.k8s.io"]
     resources: ["networkpolicies"]
     verbs: ["get", "create", "delete"]
+  - apiGroups: ["apps"]
+    resources: ["daemonsets", "replicasets", "statefulsets"]
+    verbs: ["get"]
+  - apiGroups: ["batch"]
+    resources: ["jobs"]
+    verbs: ["get"]
 ---
 # Source: volcano/templates/controllers.yaml
 kind: ClusterRoleBinding

--- a/installer/volcano-development.yaml
+++ b/installer/volcano-development.yaml
@@ -8454,6 +8454,12 @@ rules:
   - apiGroups: ["networking.k8s.io"]
     resources: ["networkpolicies"]
     verbs: ["get", "create", "delete"]
+  - apiGroups: ["apps"]
+    resources: ["daemonsets", "replicasets", "statefulsets"]
+    verbs: ["get"]
+  - apiGroups: ["batch"]
+    resources: ["jobs"]
+    verbs: ["get"]
 ---
 # Source: volcano/templates/controllers.yaml
 kind: ClusterRoleBinding

--- a/pkg/controllers/podgroup/pg_controller_handler.go
+++ b/pkg/controllers/podgroup/pg_controller_handler.go
@@ -18,6 +18,7 @@ package podgroup
 
 import (
 	"context"
+	"strings"
 
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -73,6 +74,41 @@ func (pg *pgcontroller) updatePodAnnotations(pod *v1.Pod, pgName string) error {
 	return nil
 }
 
+func (pg *pgcontroller) getAnnotationsFromUpperRes(kind string, name string, namespace string) map[string]string {
+	switch kind {
+	case "ReplicaSet":
+		rs, err := pg.kubeClient.AppsV1().ReplicaSets(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+		if err != nil {
+			klog.Errorf("Failed to get upper %s for Pod <%s/%s>: %v", kind, namespace, name, err)
+			return map[string]string{}
+		}
+		return rs.Annotations
+	case "DaemonSet":
+		ds, err := pg.kubeClient.AppsV1().DaemonSets(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+		if err != nil {
+			klog.Errorf("Failed to get upper %s for Pod <%s/%s>: %v", kind, namespace, name, err)
+			return map[string]string{}
+		}
+		return ds.Annotations
+	case "StatefulSet":
+		ss, err := pg.kubeClient.AppsV1().StatefulSets(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+		if err != nil {
+			klog.Errorf("Failed to get upper %s for Pod <%s/%s>: %v", kind, namespace, name, err)
+			return map[string]string{}
+		}
+		return ss.Annotations
+	case "Job":
+		job, err := pg.kubeClient.BatchV1().Jobs(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+		if err != nil {
+			klog.Errorf("Failed to get upper %s for Pod <%s/%s>: %v", kind, namespace, name, err)
+			return map[string]string{}
+		}
+		return job.Annotations
+	default:
+		return map[string]string{}
+	}
+}
+
 func (pg *pgcontroller) createNormalPodPGIfNotExist(pod *v1.Pod) error {
 	pgName := helpers.GeneratePodgroupName(pod)
 
@@ -100,6 +136,20 @@ func (pg *pgcontroller) createNormalPodPGIfNotExist(pod *v1.Pod) error {
 				Phase: scheduling.PodGroupPending,
 			},
 		}
+
+		// Inherit annotations from upper resources.
+		for _, reference := range pod.OwnerReferences {
+			if reference.Kind != "" && reference.Name != "" {
+				var upperAnnotations = pg.getAnnotationsFromUpperRes(reference.Kind, reference.Name, pod.Namespace)
+				for k, v := range upperAnnotations {
+					if strings.HasPrefix(k, scheduling.AnnotationPrefix) {
+						obj.Annotations[k] = v
+					}
+				}
+			}
+		}
+
+		// Individual annotations on pods would overwrite annotations inherited from upper resources.
 		if queueName, ok := pod.Annotations[scheduling.QueueNameAnnotationKey]; ok {
 			obj.Spec.Queue = queueName
 		}


### PR DESCRIPTION
When users applied k8s origin workloads like `daemonset`, `job`, etc., k8s created pods first, then volcano created podgroup from the pods, whose progress was different form volcano jobs. So podgroup created from k8s pods would miss annotations of origin workloads, causing configurations inserted in the form of annotations neglected, like #1901 .

So this pr fetched annotations from upper resources by searching pod `ownerReferences`, and filled in podgroups, so that some configurations in annotations were available for k8s workloads.