### PR TITLE
change ssh key file's permission to 644 when is not root mode

### DIFF
--- a/pkg/controllers/job/plugins/ssh/ssh.go
+++ b/pkg/controllers/job/plugins/ssh/ssh.go
@@ -160,7 +160,7 @@ func (sp *sshPlugin) mountRsaKey(pod *v1.Pod, job *batch.Job) {
 	}
 
 	if sp.sshKeyFilePath != SSHAbsolutePath {
-		var noRootMode int32 = 0600
+		var noRootMode int32 = 0644
 		sshVolume.Secret.DefaultMode = &noRootMode
 	}
 


### PR DESCRIPTION
login with ssh key will fail when users is not root and `noRootMode` set to 0600, then mpi job can not run correctly