### PR TITLE
update config args to map[string]interface{} to extend the configs

### DIFF
--- a/pkg/scheduler/conf/scheduler_conf.go
+++ b/pkg/scheduler/conf/scheduler_conf.go
@@ -36,7 +36,7 @@ type Configuration struct {
 	// Name is name of action
 	Name string `yaml:"name"`
 	// Arguments defines the different arguments that can be given to specified action
-	Arguments map[string]string `yaml:"arguments"`
+	Arguments map[string]interface{} `yaml:"arguments"`
 }
 
 // PluginOption defines the options of plugin
@@ -80,5 +80,5 @@ type PluginOption struct {
 	// EnabledJobStarving defines whether jobStarvingFn is enabled
 	EnabledJobStarving *bool `yaml:"enableJobStarving"`
 	// Arguments defines the different arguments that can be given to different plugins
-	Arguments map[string]string `yaml:"arguments"`
+	Arguments map[string]interface{} `yaml:"arguments"`
 }

--- a/pkg/scheduler/framework/arguments.go
+++ b/pkg/scheduler/framework/arguments.go
@@ -25,7 +25,7 @@ import (
 )
 
 // Arguments map
-type Arguments map[string]string
+type Arguments map[string]interface{}
 
 // GetInt get the integer value from string
 func (a Arguments) GetInt(ptr *int, key string) {
@@ -34,13 +34,14 @@ func (a Arguments) GetInt(ptr *int, key string) {
 	}
 
 	argv, ok := a[key]
-	if !ok || argv == "" {
+	if !ok {
 		return
 	}
 
-	value, err := strconv.Atoi(argv)
+	valueStr, _ := argv.(string)
+	value, err := strconv.Atoi(valueStr)
 	if err != nil {
-		klog.Warningf("Could not parse argument: %s for key %s, with err %v", argv, key, err)
+		klog.Warningf("Could not parse argument: %s for key %s to int, with err %v", argv, key, err.Error())
 		return
 	}
 
@@ -54,13 +55,14 @@ func (a Arguments) GetFloat64(ptr *float64, key string) {
 	}
 
 	argv, ok := a[key]
-	if !ok || len(argv) == 0 {
+	if !ok {
 		return
 	}
 
-	value, err := strconv.ParseFloat(argv, 64)
+	valueStr, _ := argv.(string)
+	value, err := strconv.ParseFloat(valueStr, 64)
 	if err != nil {
-		klog.Warningf("Could not parse argument: %s for key %s, with err %v", argv, key, err)
+		klog.Warningf("Could not parse argument: %s for key %s to float64, with err %v", argv, key, err.Error())
 		return
 	}
 
@@ -74,13 +76,14 @@ func (a Arguments) GetBool(ptr *bool, key string) {
 	}
 
 	argv, ok := a[key]
-	if !ok || argv == "" {
+	if !ok {
 		return
 	}
 
-	value, err := strconv.ParseBool(argv)
+	valueStr, _ := argv.(string)
+	value, err := strconv.ParseBool(valueStr)
 	if err != nil {
-		klog.Warningf("Could not parse argument: %s for key %s, with err %v", argv, key, err)
+		klog.Warningf("Could not parse argument: %s for key %s to bool, with err %v", argv, key, err.Error())
 		return
 	}
 

--- a/pkg/scheduler/framework/arguments_test.go
+++ b/pkg/scheduler/framework/arguments_test.go
@@ -147,19 +147,19 @@ func TestGetArgOfActionFromConf(t *testing.T) {
 			configurations: []conf.Configuration{
 				{
 					Name: "enqueue",
-					Arguments: map[string]string{
+					Arguments: map[string]interface{}{
 						"overCommitFactor": "1.5",
 					},
 				},
 				{
 					Name: "allocate",
-					Arguments: map[string]string{
+					Arguments: map[string]interface{}{
 						"placeholde": "placeholde",
 					},
 				},
 			},
 			action: "enqueue",
-			expectedArguments: map[string]string{
+			expectedArguments: map[string]interface{}{
 				"overCommitFactor": "1.5",
 			},
 		},
@@ -168,7 +168,7 @@ func TestGetArgOfActionFromConf(t *testing.T) {
 			configurations: []conf.Configuration{
 				{
 					Name: "enqueue",
-					Arguments: map[string]string{
+					Arguments: map[string]interface{}{
 						"overCommitFactor": "1.5",
 					},
 				},

--- a/pkg/scheduler/plugins/binpack/binpack.go
+++ b/pkg/scheduler/plugins/binpack/binpack.go
@@ -129,7 +129,11 @@ func calculateWeight(args framework.Arguments) priorityWeight {
 		weight.BinPackingMemory = 1
 	}
 
-	resourcesStr := args[BinpackResources]
+	resourcesStr, ok := args[BinpackResources].(string)
+	if !ok {
+		resourcesStr = ""
+	}
+
 	resources := strings.Split(resourcesStr, ",")
 	for _, resource := range resources {
 		resource = strings.TrimSpace(resource)

--- a/pkg/scheduler/plugins/predicates/predicates.go
+++ b/pkg/scheduler/plugins/predicates/predicates.go
@@ -121,7 +121,10 @@ func enablePredicate(args framework.Arguments) predicateEnable {
 	// Checks whether predicate.ProportionalEnable is provided or not, if given, modifies the value in predicateEnable struct.
 	args.GetBool(&predicate.proportionalEnable, ProportionalPredicate)
 	resourcesProportional := make(map[v1.ResourceName]baseResource)
-	resourcesStr := args[ProportionalResource]
+	resourcesStr, ok := args[ProportionalResource].(string)
+	if !ok {
+		resourcesStr = ""
+	}
 	resources := strings.Split(resourcesStr, ",")
 	for _, resource := range resources {
 		resource = strings.TrimSpace(resource)

--- a/pkg/scheduler/plugins/sla/sla.go
+++ b/pkg/scheduler/plugins/sla/sla.go
@@ -87,7 +87,11 @@ func (sp *slaPlugin) OnSessionOpen(ssn *framework.Session) {
 	// read in sla waiting time for global cluster from sla plugin arguments
 	// if not set, job waiting time still can set in job yaml separately, otherwise job have no sla limits
 	if _, exist := sp.pluginArguments[JobWaitingTime]; exist {
-		jwt, err := time.ParseDuration(sp.pluginArguments[JobWaitingTime])
+		waitTime, ok := sp.pluginArguments[JobWaitingTime].(string)
+		if !ok {
+			waitTime = ""
+		}
+		jwt, err := time.ParseDuration(waitTime)
 		if err != nil {
 			klog.Errorf("Error occurs in parsing global job waiting time in sla plugin, err: %s.", err.Error())
 		}

--- a/pkg/scheduler/plugins/tdm/tdm.go
+++ b/pkg/scheduler/plugins/tdm/tdm.go
@@ -68,12 +68,12 @@ func New(args framework.Arguments) framework.Plugin {
 
 	for k, v := range args {
 		if strings.Contains(k, revocableZoneLabelPrefix) {
-			revocableZone[strings.Replace(k, revocableZoneLabelPrefix, "", 1)] = v
+			revocableZone[strings.Replace(k, revocableZoneLabelPrefix, "", 1)] = v.(string)
 		}
 	}
 
 	if period, ok := args[evictPeriodLabel]; ok {
-		if d, err := time.ParseDuration(period); err == nil {
+		if d, err := time.ParseDuration(period.(string)); err == nil {
 			evictPeriod = d
 		}
 	}

--- a/pkg/scheduler/plugins/tdm/tdm_test.go
+++ b/pkg/scheduler/plugins/tdm/tdm_test.go
@@ -263,7 +263,7 @@ func Test_TDM(t *testing.T) {
 							Name:             PluginName,
 							EnabledNodeOrder: &trueValue,
 							EnabledPredicate: &trueValue,
-							Arguments: map[string]string{
+							Arguments: map[string]interface{}{
 								"tdm.revocable-zone.rz1": "0:00-0:00",
 								"tdm.revocable-zone.rz2": "0:00-0:01",
 							},
@@ -714,7 +714,7 @@ func Test_TDM_victimsFn(t *testing.T) {
 
 			defer framework.CloseSession(ssn)
 
-			d, _ := time.ParseDuration(test.args[evictPeriodLabel])
+			d, _ := time.ParseDuration(test.args[evictPeriodLabel].(string))
 			time.Sleep(d)
 			res := ssn.VictimTasks()
 			if len(res) != test.want {


### PR DESCRIPTION
This update will help extend the configurations for the furture. Besides, it will be used in the following PR for the rescheduling feature. The configuration example can be referred to https://github.com/volcano-sh/volcano/blob/3a7007f0e4bfb5b82c349409ecafc49bd09bda9e/docs/design/rescheduling.md
Signed-off-by: Thor-wl <13164644535@163.com>