### PR TITLE
support EAS service pod request

### DIFF
--- a/pkg/scheduler/api/pod_info.go
+++ b/pkg/scheduler/api/pod_info.go
@@ -141,6 +141,17 @@ func GetPodTopologyInfo(pod *v1.Pod) *TopologyInfo {
 	return &info
 }
 
+// GetPodEasAccelerator return volcano.sh/eas-accelerator value and
+// volcano.sh/eas-accelerator-flavor-id value for the pod
+func GetPodEasAcceleratorInfo(pod *v1.Pod) string {
+	if len(pod.Annotations) > 0 {
+		if flavorId, found := pod.Annotations[v1beta1.EasAcceleratorFlavorId]; found {
+			return flavorId
+		}
+	}
+	return ""
+}
+
 // GetPodResourceWithoutInitContainers returns Pod's resource request, it does not contain
 // init containers' resource request.
 func GetPodResourceWithoutInitContainers(pod *v1.Pod) *Resource {

--- a/vendor/volcano.sh/apis/pkg/apis/scheduling/v1beta1/labels.go
+++ b/vendor/volcano.sh/apis/pkg/apis/scheduling/v1beta1/labels.go
@@ -49,3 +49,7 @@ const NumaPolicyKey = "volcano.sh/numa-topology-policy"
 
 // TopologyDecisionAnnotation is the key of topology decision about pod request resource
 const TopologyDecisionAnnotation = "volcano.sh/topology-decision"
+
+// EasAcceleratorFlavorId is the key of pod to identify the flavor id of the
+// specific EAS accelerator it uses
+const EasAcceleratorFlavorId = "volcano.sh/eas-accelerator-flavor-id"


### PR DESCRIPTION
Add `EasAcceleratorFlavorId` field for `TaskInfo` to indicate whether EAS accelerator resource is used, also a special annotation tag `volcano.sh/eas-accelerator-flavor-id` is added accordingly for the pod request.