### PR TITLE
fix: demo missed queue default config

### DIFF
--- a/example/integrations/tensorflow/dist-mnist/tf-dist-mnist-example.yaml
+++ b/example/integrations/tensorflow/dist-mnist/tf-dist-mnist-example.yaml
@@ -11,6 +11,7 @@ spec:
   policies:
     - event: PodEvicted
       action: RestartJob
+  queue: default
   tasks:
     - replicas: 1
       name: ps


### PR DESCRIPTION
demo missed queue config , and will cause 
```
"I0215 07:29:14.571344       1 job_controller.go:334] Failed to handle Job <default/tensorflow-dist-mnist>: queue.scheduling.volcano.sh "" not found" 
```
