### PR TITLE
fix that parse the scheduler configuration argument with blank error

### DIFF
--- a/pkg/scheduler/framework/arguments.go
+++ b/pkg/scheduler/framework/arguments.go
@@ -17,8 +17,6 @@ limitations under the License.
 package framework
 
 import (
-	"strconv"
-
 	"k8s.io/klog"
 
 	"volcano.sh/volcano/pkg/scheduler/conf"
@@ -38,10 +36,9 @@ func (a Arguments) GetInt(ptr *int, key string) {
 		return
 	}
 
-	valueStr, _ := argv.(string)
-	value, err := strconv.Atoi(valueStr)
-	if err != nil {
-		klog.Warningf("Could not parse argument: %s for key %s to int, with err %v", argv, key, err.Error())
+	value, ok := argv.(int)
+	if !ok {
+		klog.Warningf("Could not parse argument: %v for key %s to int", argv, key)
 		return
 	}
 
@@ -59,10 +56,9 @@ func (a Arguments) GetFloat64(ptr *float64, key string) {
 		return
 	}
 
-	valueStr, _ := argv.(string)
-	value, err := strconv.ParseFloat(valueStr, 64)
-	if err != nil {
-		klog.Warningf("Could not parse argument: %s for key %s to float64, with err %v", argv, key, err.Error())
+	value, ok := argv.(float64)
+	if !ok {
+		klog.Warningf("Could not parse argument: %v for key %s to float64", argv, key)
 		return
 	}
 
@@ -80,10 +76,9 @@ func (a Arguments) GetBool(ptr *bool, key string) {
 		return
 	}
 
-	valueStr, _ := argv.(string)
-	value, err := strconv.ParseBool(valueStr)
-	if err != nil {
-		klog.Warningf("Could not parse argument: %s for key %s to bool, with err %v", argv, key, err.Error())
+	value, ok := argv.(bool)
+	if !ok {
+		klog.Warningf("Could not parse argument: %v for key %s to bool", argv, key)
 		return
 	}
 

--- a/pkg/scheduler/framework/arguments_test.go
+++ b/pkg/scheduler/framework/arguments_test.go
@@ -36,15 +36,7 @@ func TestArgumentsGetInt(t *testing.T) {
 	cases := []GetIntTestCases{
 		{
 			arg: Arguments{
-				"anotherkey": "12",
-			},
-			key:         key1,
-			baseValue:   10,
-			expectValue: 10,
-		},
-		{
-			arg: Arguments{
-				key1: "15",
+				key1: 15,
 			},
 			key:         key1,
 			baseValue:   10,
@@ -100,7 +92,7 @@ func TestArgumentsGetFloat64(t *testing.T) {
 		{
 			name: "key exist",
 			arg: Arguments{
-				key1: "1.5",
+				key1: 1.5,
 			},
 			key:         key1,
 			baseValue:   1.2,

--- a/pkg/scheduler/plugins/binpack/binpack_test.go
+++ b/pkg/scheduler/plugins/binpack/binpack_test.go
@@ -43,12 +43,12 @@ func TestArguments(t *testing.T) {
 	defer framework.CleanupPluginBuilders()
 
 	arguments := framework.Arguments{
-		"binpack.weight":                    "10",
-		"binpack.cpu":                       "5",
-		"binpack.memory":                    "2",
+		"binpack.weight":                    10,
+		"binpack.cpu":                       5,
+		"binpack.memory":                    2,
 		"binpack.resources":                 "nvidia.com/gpu, example.com/foo",
-		"binpack.resources.nvidia.com/gpu":  "7",
-		"binpack.resources.example.com/foo": "-3",
+		"binpack.resources.nvidia.com/gpu":  7,
+		"binpack.resources.example.com/foo": -3,
 	}
 
 	builder, ok := framework.GetPluginBuilder(PluginName)
@@ -154,12 +154,12 @@ func TestNode(t *testing.T) {
 				n1, n2, n3,
 			},
 			arguments: framework.Arguments{
-				"binpack.weight":                    "10",
-				"binpack.cpu":                       "2",
-				"binpack.memory":                    "3",
+				"binpack.weight":                    10,
+				"binpack.cpu":                       2,
+				"binpack.memory":                    3,
 				"binpack.resources":                 "nvidia.com/gpu, example.com/foo",
-				"binpack.resources.nvidia.com/gpu":  "7",
-				"binpack.resources.example.com/foo": "8",
+				"binpack.resources.nvidia.com/gpu":  7,
+				"binpack.resources.example.com/foo": 8,
 			},
 			expected: map[string]map[string]float64{
 				"c1/p1": {
@@ -199,11 +199,11 @@ func TestNode(t *testing.T) {
 				n1, n2, n3,
 			},
 			arguments: framework.Arguments{
-				"binpack.weight":                   "1",
-				"binpack.cpu":                      "1",
-				"binpack.memory":                   "1",
+				"binpack.weight":                   1,
+				"binpack.cpu":                      1,
+				"binpack.memory":                   1,
 				"binpack.resources":                "nvidia.com/gpu",
-				"binpack.resources.nvidia.com/gpu": "23",
+				"binpack.resources.nvidia.com/gpu": 23,
 			},
 			expected: map[string]map[string]float64{
 				"c1/p1": {


### PR DESCRIPTION
ref：https://github.com/volcano-sh/volcano/issues/2053
The root reason is that argument is collected with interface{} now and its value is valid type. Namely, it cannot be converted to string first or it will be error. Unfortunely, the original code ignore the error with `_` and the `value` gets the default value "".
Signed-off-by: Thor-wl <13164644535@163.com>