### PR TITLE
Make sure Open state queue can be deleted

### DIFF
--- a/pkg/webhooks/admission/queues/validate/validate_queue.go
+++ b/pkg/webhooks/admission/queues/validate/validate_queue.go
@@ -198,14 +198,9 @@ func validateQueueDeleting(queue string) error {
 		return fmt.Errorf("`%s` queue can not be deleted", "default")
 	}
 
-	q, err := config.VolcanoClient.SchedulingV1beta1().Queues().Get(context.TODO(), queue, metav1.GetOptions{})
+	_, err := config.VolcanoClient.SchedulingV1beta1().Queues().Get(context.TODO(), queue, metav1.GetOptions{})
 	if err != nil {
 		return err
-	}
-
-	if q.Status.State != schedulingv1beta1.QueueStateClosed {
-		return fmt.Errorf("only queue with state `%s` can be deleted, queue `%s` state is `%s`",
-			schedulingv1beta1.QueueStateClosed, q.Name, q.Status.State)
 	}
 
 	return nil

--- a/pkg/webhooks/admission/queues/validate/validate_queue_test.go
+++ b/pkg/webhooks/admission/queues/validate/validate_queue_test.go
@@ -564,7 +564,7 @@ func TestAdmitQueues(t *testing.T) {
 			},
 		},
 		{
-			Name: "Abnormal Case Queue With Open State Can Not Be Deleted",
+			Name: "Normal Case Queue With Open State Can Be Deleted (Until close queue in kubectl supported)",
 			AR: admissionv1.AdmissionReview{
 				TypeMeta: metav1.TypeMeta{
 					Kind:       "AdmissionReview",
@@ -589,11 +589,7 @@ func TestAdmitQueues(t *testing.T) {
 				},
 			},
 			reviewResponse: &admissionv1.AdmissionResponse{
-				Allowed: false,
-				Result: &metav1.Status{
-					Message: fmt.Sprintf("only queue with state `%s` can be deleted, queue `%s` state is `%s`",
-						schedulingv1beta1.QueueStateClosed, "open-state-for-delete", schedulingv1beta1.QueueStateOpen),
-				},
+				Allowed: true,
 			},
 		},
 		{

--- a/test/e2e/jobp/admission.go
+++ b/test/e2e/jobp/admission.go
@@ -1395,7 +1395,7 @@ var _ = ginkgo.Describe("Job E2E Test: Test Admission service", func() {
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	})
 
-	ginkgo.It("queue check: open queue can NOT be deleted", func() {
+	ginkgo.It("queue check: open queue can be deleted", func() {
 		queueName := "deleted-open-queue"
 		ctx := e2eutil.InitTestContext(e2eutil.Options{})
 		defer e2eutil.CleanupTestContext(ctx)
@@ -1421,6 +1421,6 @@ var _ = ginkgo.Describe("Job E2E Test: Test Admission service", func() {
 		})
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		err = ctx.Vcclient.SchedulingV1beta1().Queues().Delete(context.TODO(), queue.Name, metav1.DeleteOptions{})
-		gomega.Expect(err).To(gomega.HaveOccurred())
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	})
 })


### PR DESCRIPTION
Make sure `Open` state queue can't be deleted in kubectl, this is not very convenient for users. We'd better to make sure `Open` state queue can be deleted until we support queue operations in kubectl.

Signed-off-by: Yikun Jiang <yikunkero@gmail.com>

Closes: https://github.com/volcano-sh/volcano/issues/2068