### PR TITLE
fix the jobShare metric when job terminated

### DIFF
--- a/pkg/scheduler/cache/cache.go
+++ b/pkg/scheduler/cache/cache.go
@@ -828,6 +828,7 @@ func (sc *SchedulerCache) processCleanupJob() {
 
 	if schedulingapi.JobTerminated(job) {
 		delete(sc.Jobs, job.UID)
+		metrics.DeleteJobShare(job.Namespace, job.Name)
 		klog.V(3).Infof("Job <%v:%v/%v> was deleted.", job.UID, job.Namespace, job.Name)
 	} else {
 		// Retry

--- a/pkg/scheduler/metrics/job.go
+++ b/pkg/scheduler/metrics/job.go
@@ -44,6 +44,11 @@ func UpdateJobShare(jobNs, jobID string, share float64) {
 	jobShare.WithLabelValues(jobNs, jobID).Set(share)
 }
 
+// DeleteJobShare delete jobShare for one job
+func DeleteJobShare(jobNs, jobID string) {
+	jobShare.DeleteLabelValues(jobNs, jobID)
+}
+
 // RegisterJobRetries total number of job retries.
 func RegisterJobRetries(jobID string) {
 	jobRetryCount.WithLabelValues(jobID).Inc()


### PR DESCRIPTION
Add DeleteJobShare to remove the jobShare metrics for terminated job.