### PR TITLE
support elastic annotation in preempt/reclaim plugin

### DIFF
--- a/pkg/scheduler/actions/preempt/preempt.go
+++ b/pkg/scheduler/actions/preempt/preempt.go
@@ -119,6 +119,9 @@ func (alloc *Action) Execute(ssn *framework.Session) {
 					if task.Resreq.IsEmpty() {
 						return false
 					}
+					if !task.Preemptable {
+						return false
+					}
 					job, found := ssn.Jobs[task.Job]
 					if !found {
 						return false

--- a/pkg/scheduler/actions/preempt/preempt_test.go
+++ b/pkg/scheduler/actions/preempt/preempt_test.go
@@ -177,9 +177,8 @@ func TestPreempt(t *testing.T) {
 					},
 				},
 			},
-
 			pods: []*v1.Pod{
-				util.BuildPod("c1", "preemptee1", "n1", v1.PodRunning, util.BuildResourceList("1", "1G"), "pg1", make(map[string]string), make(map[string]string)),
+				util.BuildPod("c1", "preemptee1", "n1", v1.PodRunning, util.BuildResourceList("1", "1G"), "pg1", map[string]string{schedulingv1beta1.PodPreemptable: "true"}, make(map[string]string)),
 				util.BuildPod("c1", "preemptee2", "n1", v1.PodRunning, util.BuildResourceList("1", "1G"), "pg1", make(map[string]string), make(map[string]string)),
 				util.BuildPod("c1", "preemptor1", "", v1.PodPending, util.BuildResourceList("1", "1G"), "pg2", make(map[string]string), make(map[string]string)),
 				util.BuildPod("c1", "preemptor2", "", v1.PodPending, util.BuildResourceList("1", "1G"), "pg2", make(map[string]string), make(map[string]string)),
@@ -234,9 +233,9 @@ func TestPreempt(t *testing.T) {
 			// There are 3 cpus and 3G of memory idle and 3 tasks running each consuming 1 cpu and 1G of memory.
 			// Big task requiring 5 cpus and 5G of memory should preempt 2 of 3 running tasks to fit into the node.
 			pods: []*v1.Pod{
-				util.BuildPod("c1", "preemptee1", "n1", v1.PodRunning, util.BuildResourceList("1", "1G"), "pg1", make(map[string]string), make(map[string]string)),
-				util.BuildPod("c1", "preemptee2", "n1", v1.PodRunning, util.BuildResourceList("1", "1G"), "pg1", make(map[string]string), make(map[string]string)),
-				util.BuildPod("c1", "preemptee3", "n1", v1.PodRunning, util.BuildResourceList("1", "1G"), "pg1", make(map[string]string), make(map[string]string)),
+				util.BuildPod("c1", "preemptee1", "n1", v1.PodRunning, util.BuildResourceList("1", "1G"), "pg1", map[string]string{schedulingv1beta1.PodPreemptable: "true"}, make(map[string]string)),
+				util.BuildPod("c1", "preemptee2", "n1", v1.PodRunning, util.BuildResourceList("1", "1G"), "pg1", map[string]string{schedulingv1beta1.PodPreemptable: "true"}, make(map[string]string)),
+				util.BuildPod("c1", "preemptee3", "n1", v1.PodRunning, util.BuildResourceList("1", "1G"), "pg1", map[string]string{schedulingv1beta1.PodPreemptable: "true"}, make(map[string]string)),
 				util.BuildPod("c1", "preemptor1", "", v1.PodPending, util.BuildResourceList("5", "5G"), "pg2", make(map[string]string), make(map[string]string)),
 			},
 			nodes: []*v1.Node{

--- a/pkg/scheduler/actions/reclaim/reclaim.go
+++ b/pkg/scheduler/actions/reclaim/reclaim.go
@@ -134,6 +134,9 @@ func (ra *Action) Execute(ssn *framework.Session) {
 				if task.Status != api.Running {
 					continue
 				}
+				if !task.Preemptable {
+					continue
+				}
 
 				if j, found := ssn.Jobs[task.Job]; !found {
 					continue

--- a/pkg/scheduler/actions/reclaim/reclaim_test.go
+++ b/pkg/scheduler/actions/reclaim/reclaim_test.go
@@ -81,7 +81,7 @@ func TestReclaim(t *testing.T) {
 				},
 			},
 			pods: []*v1.Pod{
-				util.BuildPod("c1", "preemptee1", "n1", v1.PodRunning, util.BuildResourceList("1", "1G"), "pg1", make(map[string]string), make(map[string]string)),
+				util.BuildPod("c1", "preemptee1", "n1", v1.PodRunning, util.BuildResourceList("1", "1G"), "pg1", map[string]string{schedulingv1beta1.PodPreemptable: "true"}, make(map[string]string)),
 				util.BuildPod("c1", "preemptee2", "n1", v1.PodRunning, util.BuildResourceList("1", "1G"), "pg1", make(map[string]string), make(map[string]string)),
 				util.BuildPod("c1", "preemptee3", "n1", v1.PodRunning, util.BuildResourceList("1", "1G"), "pg1", make(map[string]string), make(map[string]string)),
 				util.BuildPod("c1", "preemptor1", "", v1.PodPending, util.BuildResourceList("1", "1G"), "pg2", make(map[string]string), make(map[string]string)),

--- a/test/e2e/schedulingaction/preempt.go
+++ b/test/e2e/schedulingaction/preempt.go
@@ -54,10 +54,11 @@ var _ = Describe("Job E2E Test", func() {
 		job := &e2eutil.JobSpec{
 			Tasks: []e2eutil.TaskSpec{
 				{
-					Img: e2eutil.DefaultNginxImage,
-					Req: slot,
-					Min: 1,
-					Rep: 1,
+					Img:    e2eutil.DefaultNginxImage,
+					Req:    slot,
+					Min:    1,
+					Rep:    1,
+					Labels: map[string]string{schedulingv1beta1.PodPreemptable: "true"},
 				},
 			},
 		}
@@ -93,10 +94,11 @@ var _ = Describe("Job E2E Test", func() {
 		job := &e2eutil.JobSpec{
 			Tasks: []e2eutil.TaskSpec{
 				{
-					Img: e2eutil.DefaultNginxImage,
-					Req: slot,
-					Min: 1,
-					Rep: rep,
+					Img:    e2eutil.DefaultNginxImage,
+					Req:    slot,
+					Min:    1,
+					Rep:    rep,
+					Labels: map[string]string{schedulingv1beta1.PodPreemptable: "true"},
 				},
 			},
 		}
@@ -194,10 +196,11 @@ var _ = Describe("Job E2E Test", func() {
 		job := &e2eutil.JobSpec{
 			Tasks: []e2eutil.TaskSpec{
 				{
-					Img: e2eutil.DefaultNginxImage,
-					Req: slot,
-					Min: 1,
-					Rep: rep / 2,
+					Img:    e2eutil.DefaultNginxImage,
+					Req:    slot,
+					Min:    1,
+					Rep:    rep / 2,
+					Labels: map[string]string{schedulingv1beta1.PodPreemptable: "true"},
 				},
 			},
 		}
@@ -242,10 +245,11 @@ var _ = Describe("Job E2E Test", func() {
 		job := &e2eutil.JobSpec{
 			Tasks: []e2eutil.TaskSpec{
 				{
-					Img: e2eutil.DefaultNginxImage,
-					Req: slot,
-					Min: 1,
-					Rep: 1,
+					Img:    e2eutil.DefaultNginxImage,
+					Req:    slot,
+					Min:    1,
+					Rep:    1,
+					Labels: map[string]string{schedulingv1beta1.PodPreemptable: "true"},
 				},
 			},
 		}
@@ -297,10 +301,11 @@ var _ = Describe("Job E2E Test", func() {
 		job := &e2eutil.JobSpec{
 			Tasks: []e2eutil.TaskSpec{
 				{
-					Img: e2eutil.DefaultNginxImage,
-					Req: slot,
-					Min: 1,
-					Rep: rep,
+					Img:    e2eutil.DefaultNginxImage,
+					Req:    slot,
+					Min:    1,
+					Rep:    rep,
+					Labels: map[string]string{schedulingv1beta1.PodPreemptable: "true"},
 				},
 			},
 		}

--- a/test/e2e/schedulingaction/reclaim.go
+++ b/test/e2e/schedulingaction/reclaim.go
@@ -39,10 +39,11 @@ var _ = Describe("Reclaim E2E Test", func() {
 		job := &e2eutil.JobSpec{
 			Tasks: []e2eutil.TaskSpec{
 				{
-					Img: e2eutil.DefaultNginxImage,
-					Req: req,
-					Min: 1,
-					Rep: 1,
+					Img:    e2eutil.DefaultNginxImage,
+					Req:    req,
+					Min:    1,
+					Rep:    1,
+					Labels: map[string]string{schedulingv1beta1.PodPreemptable: "true"},
 				},
 			},
 			Name:     name,
@@ -488,10 +489,11 @@ var _ = Describe("Reclaim E2E Test", func() {
 		spec := &e2eutil.JobSpec{
 			Tasks: []e2eutil.TaskSpec{
 				{
-					Img: e2eutil.DefaultNginxImage,
-					Req: e2eutil.CPU1Mem1,
-					Min: 1,
-					Rep: 2,
+					Img:    e2eutil.DefaultNginxImage,
+					Req:    e2eutil.CPU1Mem1,
+					Min:    1,
+					Rep:    2,
+					Labels: map[string]string{schedulingv1beta1.PodPreemptable: "true"},
 				},
 			},
 		}
@@ -552,10 +554,11 @@ var _ = Describe("Reclaim E2E Test", func() {
 		spec := &e2eutil.JobSpec{
 			Tasks: []e2eutil.TaskSpec{
 				{
-					Img: e2eutil.DefaultNginxImage,
-					Req: slot,
-					Min: 1,
-					Rep: rep,
+					Img:    e2eutil.DefaultNginxImage,
+					Req:    slot,
+					Min:    1,
+					Rep:    rep,
+					Labels: map[string]string{schedulingv1beta1.PodPreemptable: "true"},
 				},
 			},
 		}


### PR DESCRIPTION
support a new annotation `volcano.sh/elastic` in pod, if `volcano.sh/elastic` = "false" (default value is true), preempt and reclaim plugin will not evict the pod.
in AI/spark case, there are always two role of pod: master/worker or driver/executor,  if master pod is evicted, the worker pod will be fail too, so it may be necessary to make sure the master pod can not to be evicted.