### PR TITLE
getOrCreateJob method's code logic is inconsistent with comment

### DIFF
--- a/pkg/scheduler/cache/event_handlers.go
+++ b/pkg/scheduler/cache/event_handlers.go
@@ -49,8 +49,8 @@ func (sc *SchedulerCache) getOrCreateJob(pi *schedulingapi.TaskInfo) *scheduling
 		if pi.Pod.Spec.SchedulerName != sc.schedulerName {
 			klog.V(4).Infof("Pod %s/%s will not scheduled by %s, skip creating PodGroup and Job for it",
 				pi.Pod.Namespace, pi.Pod.Name, sc.schedulerName)
+			return nil
 		}
-		return nil
 	}
 
 	if _, found := sc.Jobs[pi.Job]; !found {


### PR DESCRIPTION
If pi's Job does not exist, but the pi.Pod.Spec.SchedulerName is same as volcano scheduler's name.
According to the comment it will create a Job, but the original code logic will return nil