### PR TITLE
fix: node state will not be ready once it become unready(OutOfSync)

### DIFF
--- a/pkg/scheduler/api/node_info.go
+++ b/pkg/scheduler/api/node_info.go
@@ -305,17 +305,13 @@ func (ni *NodeInfo) setNodeGPUInfo(node *v1.Node) {
 
 // SetNode sets kubernetes node object to nodeInfo object
 func (ni *NodeInfo) SetNode(node *v1.Node) {
-	ni.setNodeState(node)
-	if !ni.Ready() {
-		klog.Warningf("Failed to set node info for %s, phase: %s, reason: %s",
-			ni.Name, ni.State.Phase, ni.State.Reason)
+	if node == nil {
 		return
 	}
 
 	// Dry run, make sure all fields other than `State` are in the original state.
 	copy := ni.Clone()
 	copy.setNode(node)
-	copy.setNodeState(node)
 	if !copy.Ready() {
 		klog.Warningf("SetNode makes node %s not ready, phase: %s, reason: %s",
 			copy.Name, copy.State.Phase, copy.State.Reason)
@@ -358,6 +354,8 @@ func (ni *NodeInfo) setNode(node *v1.Node) {
 			ni.AddGPUResource(ti.Pod)
 		}
 	}
+
+	ni.setNodeState(node)
 }
 
 func (ni *NodeInfo) allocateIdleResource(ti *TaskInfo) error {


### PR DESCRIPTION
Signed-off-by: Xinjian Yu <blink@blink.moe>
Fix: node state will not be ready again once it become unready because of out of sync.

An example: I have a node with some running pods which requested nvidia.com/gpu. If I delete the nvidia device plugin pod at this time, the allocatable of nvidia.com/gpu will be 0 for a short time, the node will be unready(reason: OutOfSync). the nvidia device plugin pod recreated, the allocatable of nvidia.com/gpu will be 8, but the node state will not be ready again.