### PR TITLE
[code refine] if only one candidate node, no need do scoring for it

### DIFF
--- a/pkg/scheduler/actions/allocate/allocate.go
+++ b/pkg/scheduler/actions/allocate/allocate.go
@@ -225,10 +225,8 @@ func (alloc *Action) Execute(ssn *framework.Session) {
 			var node *api.NodeInfo
 			switch {
 			case len(candidateNodes) == 0: // If not candidate nodes for this task, skip it.
-				// If not candidate nodes for this task, skip it.
 				continue
 			case len(candidateNodes) == 1: // If only one node after predicate, just use it.
-				// When only one node after predicate, just use it.
 				node = candidateNodes[0]
 			case len(candidateNodes) > 1: // If more than one node after predicate, using "the best" one
 				nodeScores := util.PrioritizeNodes(task, candidateNodes, ssn.BatchNodeOrderFn, ssn.NodeOrderMapFn, ssn.NodeOrderReduceFn)

--- a/pkg/scheduler/actions/allocate/allocate.go
+++ b/pkg/scheduler/actions/allocate/allocate.go
@@ -230,7 +230,6 @@ func (alloc *Action) Execute(ssn *framework.Session) {
 			case len(candidateNodes) == 1: // If only one node after predicate, just use it.
 				// When only one node after predicate, just use it.
 				node = candidateNodes[0]
-				klog.Infof("only one node")
 			case len(candidateNodes) > 1: // If more than one node after predicate, using "the best" one
 				nodeScores := util.PrioritizeNodes(task, candidateNodes, ssn.BatchNodeOrderFn, ssn.NodeOrderMapFn, ssn.NodeOrderReduceFn)
 

--- a/pkg/scheduler/actions/allocate/allocate.go
+++ b/pkg/scheduler/actions/allocate/allocate.go
@@ -222,16 +222,22 @@ func (alloc *Action) Execute(ssn *framework.Session) {
 				}
 			}
 
-			// If not candidate nodes for this task, skip it.
-			if len(candidateNodes) == 0 {
+			var node *api.NodeInfo
+			switch {
+			case len(candidateNodes) == 0: // If not candidate nodes for this task, skip it.
+				// If not candidate nodes for this task, skip it.
 				continue
-			}
+			case len(candidateNodes) == 1: // If only one node after predicate, just use it.
+				// When only one node after predicate, just use it.
+				node = candidateNodes[0]
+				klog.Infof("only one node")
+			case len(candidateNodes) > 1: // If more than one node after predicate, using "the best" one
+				nodeScores := util.PrioritizeNodes(task, candidateNodes, ssn.BatchNodeOrderFn, ssn.NodeOrderMapFn, ssn.NodeOrderReduceFn)
 
-			nodeScores := util.PrioritizeNodes(task, candidateNodes, ssn.BatchNodeOrderFn, ssn.NodeOrderMapFn, ssn.NodeOrderReduceFn)
-
-			node := ssn.BestNodeFn(task, nodeScores)
-			if node == nil {
-				node = util.SelectBestNode(nodeScores)
+				node = ssn.BestNodeFn(task, nodeScores)
+				if node == nil {
+					node = util.SelectBestNode(nodeScores)
+				}
 			}
 
 			// Allocate idle resource to the task.


### PR DESCRIPTION
In `allocate` action, if only get one  candidate node after PredicateNodes, no need to socreing for that node. scheduler can use this node derectly. 

Just like following kubernetest scheduler logic:
https://github.com/kubernetes/kubernetes/blob/2cb3c7f706dbf266820fbde2e1b23a320e5d3de7/pkg/scheduler/schedule_one.go#L338-L347
![image](https://user-images.githubusercontent.com/10152842/160318432-8ff03ebe-8f9d-4199-9134-1be26c9fc044.png)
