### PR TITLE
fix: add jobUID into job's podgroup name ensure podgroup's unique, solve #2044

### DIFF
--- a/pkg/controllers/job/job_controller_actions.go
+++ b/pkg/controllers/job/job_controller_actions.go
@@ -648,7 +648,8 @@ func (cc *jobcontroller) createOrUpdatePodGroup(job *batch.Job) error {
 
 		pg := &scheduling.PodGroup{
 			ObjectMeta: metav1.ObjectMeta{
-				Namespace:   job.Namespace,
+				Namespace: job.Namespace,
+				//add job.UID into its name when create new PodGroup
 				Name:        pgName,
 				Annotations: job.Annotations,
 				Labels:      job.Labels,

--- a/pkg/controllers/job/job_controller_actions_test.go
+++ b/pkg/controllers/job/job_controller_actions_test.go
@@ -61,7 +61,7 @@ func TestKillJobFunc(t *testing.T) {
 			},
 			PodGroup: &schedulingv1alpha2.PodGroup{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "job1",
+					Name:      "job1-e7f18111-1cec-11ea-b688-fa163ec79500",
 					Namespace: namespace,
 				},
 			},
@@ -197,6 +197,7 @@ func TestSyncJobFunc(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "job1",
 					Namespace: namespace,
+					UID:       "e7f18111-1cec-11ea-b688-fa163ec79500",
 				},
 				Spec: v1alpha1.JobSpec{
 					Tasks: []v1alpha1.TaskSpec{
@@ -227,7 +228,7 @@ func TestSyncJobFunc(t *testing.T) {
 			},
 			PodGroup: &schedulingv1alpha2.PodGroup{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "job1",
+					Name:      "job1-e7f18111-1cec-11ea-b688-fa163ec79500",
 					Namespace: namespace,
 				},
 				Spec: schedulingv1alpha2.PodGroupSpec{
@@ -417,6 +418,7 @@ func TestCreatePodGroupIfNotExistFunc(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: namespace,
 					Name:      "job1",
+					UID:       "e7f18111-1cec-11ea-b688-fa163ec79500",
 				},
 			},
 			ExpextVal: nil,
@@ -432,7 +434,8 @@ func TestCreatePodGroupIfNotExistFunc(t *testing.T) {
 				t.Errorf("Expected return value to be equal to expected: %s, but got: %s", testcase.ExpextVal, err)
 			}
 
-			_, err = fakeController.vcClient.SchedulingV1beta1().PodGroups(namespace).Get(context.TODO(), testcase.Job.Name, metav1.GetOptions{})
+			pgName := testcase.Job.Name + "-" + string(testcase.Job.UID)
+			_, err = fakeController.vcClient.SchedulingV1beta1().PodGroups(namespace).Get(context.TODO(), pgName, metav1.GetOptions{})
 			if err != nil {
 				t.Error("Expected PodGroup to get created, but not created")
 			}
@@ -455,7 +458,7 @@ func TestUpdatePodGroupIfJobUpdateFunc(t *testing.T) {
 			PodGroup: &schedulingv1alpha2.PodGroup{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: namespace,
-					Name:      "job1",
+					Name:      "job1-e7f18111-1cec-11ea-b688-fa163ec79500",
 				},
 				Spec: schedulingv1alpha2.PodGroupSpec{
 					MinResources: &v1.ResourceList{},
@@ -465,6 +468,7 @@ func TestUpdatePodGroupIfJobUpdateFunc(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: namespace,
 					Name:      "job1",
+					UID:       "e7f18111-1cec-11ea-b688-fa163ec79500",
 				},
 				Spec: v1alpha1.JobSpec{
 					PriorityClassName: "new",
@@ -485,7 +489,8 @@ func TestUpdatePodGroupIfJobUpdateFunc(t *testing.T) {
 				t.Errorf("Expected return value to be equal to expected: %s, but got: %s", testcase.ExpectVal, err)
 			}
 
-			pg, err := fakeController.vcClient.SchedulingV1beta1().PodGroups(namespace).Get(context.TODO(), testcase.Job.Name, metav1.GetOptions{})
+			pgName := testcase.Job.Name + "-" + string(testcase.Job.UID)
+			pg, err := fakeController.vcClient.SchedulingV1beta1().PodGroups(namespace).Get(context.TODO(), pgName, metav1.GetOptions{})
 			if err != nil {
 				t.Error("Expected PodGroup to be created, but not created")
 			}


### PR DESCRIPTION
podgroup may carete failed when a job with same jobName exec a series of operations, such as create/delete/create, you can see it in #2044 