### PR TITLE
add cooldown protection plugin

### DIFF
--- a/docs/user-guide/how_to_use_cdp_plugin.md
+++ b/docs/user-guide/how_to_use_cdp_plugin.md
@@ -1,0 +1,201 @@
+# Cooldown Protection Plugin User Guide
+
+## Background
+When we need to enable elastic training or serving, preemptible job's pods can be preempted or back to running repeatedly, if no cooldown protection set, these pods can be preempted again after they just started for a short time, this may cause service stability dropped.
+So we add "cdp" plugin to ensure preemptible job's pods can run for at least some time set by user.
+
+## Environment setup
+
+### Install volcano
+
+Refer to [Install Guide](../../installer/README.md) to install volcano.
+
+### Update scheduler configmap
+
+After installed, update the scheduler configuration:
+
+```shell
+kubectl edit configmap -n volcano-system volcano-scheduler-configmap
+```
+
+Register `cdp` plugin in configmap while enable `preempt` action
+
+```yaml
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: volcano-scheduler-configmap
+  namespace: volcano-system
+data:
+  volcano-scheduler.conf: |
+    actions: "enqueue, allocate, preempt, backfill"
+    tiers:
+    - plugins:
+      - name: priority
+      - name: gang
+      - name: conformance
+      - name: cdp
+    - plugins:
+      - name: drf
+      - name: predicates
+      - name: task-topology
+        arguments:
+          task-topology.weight: 10
+      - name: proportion
+      - name: nodeorder
+      - name: binpack
+```
+
+### Running Jobs
+
+Take a simple volcano job as sample.
+
+original job yaml is as below, which has "ps" and "worker" task
+
+```yaml
+apiVersion: batch.volcano.sh/v1alpha1
+kind: Job
+metadata:
+  name: test-job
+spec:
+  minAvailable: 3
+  schedulerName: volcano
+  priorityClassName: high-priority
+  plugins:
+    ssh: []
+    env: []
+    svc: []
+  maxRetry: 5
+  queue: default
+  volumes:
+    - mountPath: "/myinput"
+    - mountPath: "/myoutput"
+      volumeClaimName: "testvolumeclaimname"
+      volumeClaim:
+        accessModes: [ "ReadWriteOnce" ]
+        storageClassName: "my-storage-class"
+        resources:
+          requests:
+            storage: 1Gi
+  tasks:
+    - replicas: 6
+      name: "worker"
+      template:
+        metadata:
+          name: worker
+        spec:
+          containers:
+            - image: nginx
+              imagePullPolicy: IfNotPresent
+              name: nginx
+              resources:
+                requests:
+                  cpu: "1"
+          restartPolicy: OnFailure
+    - replicas: 2
+      name: "ps"
+      template:
+        metadata:
+          name: ps
+        spec:
+          containers:
+            - image: nginx
+              imagePullPolicy: IfNotPresent
+              name: nginx
+              resources:
+                requests:
+                  cpu: "1"
+          restartPolicy: OnFailure
+
+```
+
+#### Edit yaml of vcjob
+
+1. add annotations in volcano job in format below.
+   1. `volcano.sh/preemptable` annotation indicates that job or task is preemptable
+   2. `volcano.sh/cooldown-time` annotation indicates cooldown time for the entire job or dedicated task. Value for the annotation indicates cooldown time, valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h". 
+
+        ```yaml
+            volcano.sh/preemptable: "true"
+            volcano.sh/cooldown-time: "600s"
+        ```
+
+**Example 1**
+
+Add annotation to entire job, then "ps" and "worker" task can be preempted and all have cooldown time support.
+
+```yaml
+apiVersion: batch.volcano.sh/v1alpha1
+kind: Job
+metadata:
+  name: test-job
+  annotations:
+    volcano.sh/preemptable: "true"
+    volcano.sh/cooldown-time: "600s"
+spec:
+  ... # below keep the same
+```
+
+**Example 2**
+
+Add annotation to dedicated task, as shown below, only "worker" can be preempted and have cooldown time support.
+
+```yaml
+apiVersion: batch.volcano.sh/v1alpha1
+kind: Job
+metadata:
+  name: test-job
+spec:
+  minAvailable: 3
+  schedulerName: volcano
+  priorityClassName: high-priority
+  plugins:
+    ssh: []
+    env: []
+    svc: []
+  maxRetry: 5
+  queue: default
+  volumes:
+    - mountPath: "/myinput"
+    - mountPath: "/myoutput"
+      volumeClaimName: "testvolumeclaimname"
+      volumeClaim:
+        accessModes: [ "ReadWriteOnce" ]
+        storageClassName: "my-storage-class"
+        resources:
+          requests:
+            storage: 1Gi
+  tasks:
+    - replicas: 6
+      name: "worker"
+      template:
+        metadata:
+          name: worker
+          annotations:     # add annotation in tasks
+            volcano.sh/preemptable: "true"
+            volcano.sh/cooldown-time: "600s"
+        spec:
+          containers:
+            - image: nginx
+              imagePullPolicy: IfNotPresent
+              name: nginx
+              resources:
+                requests:
+                  cpu: "1"
+          restartPolicy: OnFailure
+    - replicas: 2
+      name: "ps"
+      template:
+        metadata:
+          name: ps
+        spec:
+          containers:
+            - image: nginx
+              imagePullPolicy: IfNotPresent
+              name: nginx
+              resources:
+                requests:
+                  cpu: "1"
+          restartPolicy: OnFailure
+
+```

--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	k8s.io/utils v0.0.0-20210930125809-cb0fa318a74b
 	sigs.k8s.io/yaml v1.3.0
 	stathat.com/c/consistent v1.0.0
-	volcano.sh/apis v0.0.0-20220705062437-edd428c7d2fd
+	volcano.sh/apis v1.6.0-alpha.0.0.20220712043845-8d8aa5aecbd2
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -1204,5 +1204,5 @@ sigs.k8s.io/yaml v1.3.0 h1:a2VclLzOGrwOHDiV8EfBGhvjHvP46CtW5j6POvhYGGo=
 sigs.k8s.io/yaml v1.3.0/go.mod h1:GeOyir5tyXNByN85N/dRIT9es5UQNerPYEKK56eTBm8=
 stathat.com/c/consistent v1.0.0 h1:ezyc51EGcRPJUxfHGSgJjWzJdj3NiMU9pNfLNGiXV0c=
 stathat.com/c/consistent v1.0.0/go.mod h1:QkzMWzcbB+yQBL2AttO6sgsQS/JSTapcDISJalmCDS0=
-volcano.sh/apis v0.0.0-20220705062437-edd428c7d2fd h1:b48P7vnI1FHyw2ZaAwtgH8D2vCNyxWJxFU15PqSFmn8=
-volcano.sh/apis v0.0.0-20220705062437-edd428c7d2fd/go.mod h1:drNMGuHPn1ew7oBSDQb5KRey6tXOQksbUtw3gPxF3Vo=
+volcano.sh/apis v1.6.0-alpha.0.0.20220712043845-8d8aa5aecbd2 h1:8p4FIUbVepYoyxMKxnb6W8PohzweIrIh06YvCHklq78=
+volcano.sh/apis v1.6.0-alpha.0.0.20220712043845-8d8aa5aecbd2/go.mod h1:drNMGuHPn1ew7oBSDQb5KRey6tXOQksbUtw3gPxF3Vo=

--- a/pkg/controllers/job/job_controller_util.go
+++ b/pkg/controllers/job/job_controller_util.go
@@ -115,6 +115,9 @@ func createJobPod(job *batch.Job, template *v1.PodTemplateSpec, topologyPolicy b
 		if value, found := job.Annotations[schedulingv2.PodPreemptable]; found {
 			pod.Annotations[schedulingv2.PodPreemptable] = value
 		}
+		if value, found := job.Annotations[schedulingv2.CooldownTime]; found {
+			pod.Annotations[schedulingv2.CooldownTime] = value
+		}
 		if value, found := job.Annotations[schedulingv2.RevocableZone]; found {
 			pod.Annotations[schedulingv2.RevocableZone] = value
 		}
@@ -138,6 +141,9 @@ func createJobPod(job *batch.Job, template *v1.PodTemplateSpec, topologyPolicy b
 	if len(job.Labels) > 0 {
 		if value, found := job.Labels[schedulingv2.PodPreemptable]; found {
 			pod.Labels[schedulingv2.PodPreemptable] = value
+		}
+		if value, found := job.Labels[schedulingv2.CooldownTime]; found {
+			pod.Labels[schedulingv2.CooldownTime] = value
 		}
 	}
 

--- a/pkg/controllers/podgroup/pg_controller_handler.go
+++ b/pkg/controllers/podgroup/pg_controller_handler.go
@@ -157,11 +157,17 @@ func (pg *pgcontroller) createNormalPodPGIfNotExist(pod *v1.Pod) error {
 		if value, ok := pod.Annotations[scheduling.PodPreemptable]; ok {
 			obj.Annotations[scheduling.PodPreemptable] = value
 		}
+		if value, ok := pod.Annotations[scheduling.CooldownTime]; ok {
+			obj.Annotations[scheduling.CooldownTime] = value
+		}
 		if value, ok := pod.Annotations[scheduling.RevocableZone]; ok {
 			obj.Annotations[scheduling.RevocableZone] = value
 		}
 		if value, ok := pod.Labels[scheduling.PodPreemptable]; ok {
 			obj.Labels[scheduling.PodPreemptable] = value
+		}
+		if value, ok := pod.Labels[scheduling.CooldownTime]; ok {
+			obj.Labels[scheduling.CooldownTime] = value
 		}
 
 		if value, found := pod.Annotations[scheduling.JDBMinAvailable]; found {

--- a/pkg/scheduler/plugins/cdp/cdp.go
+++ b/pkg/scheduler/plugins/cdp/cdp.go
@@ -1,0 +1,112 @@
+/*
+Copyright 2022 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cdp
+
+import (
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/klog"
+
+	"volcano.sh/apis/pkg/apis/scheduling/v1beta1"
+	"volcano.sh/volcano/pkg/scheduler/api"
+	"volcano.sh/volcano/pkg/scheduler/framework"
+	"volcano.sh/volcano/pkg/scheduler/plugins/util"
+)
+
+const (
+	// refer to issue https://github.com/volcano-sh/volcano/issues/2075,
+	// plugin cdp means cooldown protection, related to elastic scheduler,
+	// when we need to enable elastic training or serving,
+	// preemptible job's pods can be preempted or back to running repeatedly,
+	// if no cooldown protection set, these pods can be preempted again after they just started for a short time,
+	// this may cause service stability dropped.
+	// cdp plugin here is to ensure vcjob's pods cannot be preempted within cooldown protection conditions.
+	// currently cdp plugin only support cooldown time protection.
+	PluginName = "cdp"
+)
+
+type CooldownProtectionPlugin struct {
+}
+
+// New return CooldownProtectionPlugin
+func New(arguments framework.Arguments) framework.Plugin {
+	return &CooldownProtectionPlugin{}
+}
+
+// Name implements framework.Plugin
+func (*CooldownProtectionPlugin) Name() string {
+	return PluginName
+}
+
+func (sp *CooldownProtectionPlugin) podCooldownTime(pod *v1.Pod) (value time.Duration, enabled bool) {
+	// check labels and annotations
+	v, ok := pod.Labels[v1beta1.CooldownTime]
+	if !ok {
+		v, ok = pod.Annotations[v1beta1.CooldownTime]
+		if !ok {
+			return 0, false
+		}
+	}
+	vi, err := time.ParseDuration(v)
+	if err != nil {
+		klog.Warningf("invalid time duration %s=%s", v1beta1.CooldownTime, v)
+		return 0, false
+	}
+	return vi, true
+}
+
+// OnSessionOpen implements framework.Plugin
+func (sp *CooldownProtectionPlugin) OnSessionOpen(ssn *framework.Session) {
+	preemptableFn := func(preemptor *api.TaskInfo, preemptees []*api.TaskInfo) ([]*api.TaskInfo, int) {
+		var victims []*api.TaskInfo
+		for _, preemptee := range preemptees {
+			cooldownTime, enabled := sp.podCooldownTime(preemptee.Pod)
+			if !enabled {
+				victims = append(victims, preemptee)
+				continue
+			}
+			pod := preemptee.Pod
+			// find the time of pod really transform to running
+			// only running pod check stable time, others all put into victims
+			stableFiltered := false
+			if pod.Status.Phase == v1.PodRunning {
+				// ensure pod is running and have ready state
+				for _, c := range pod.Status.Conditions {
+					if c.Type == v1.PodScheduled && c.Status == v1.ConditionTrue {
+						if c.LastTransitionTime.Add(cooldownTime).After(time.Now()) {
+							stableFiltered = true
+						}
+						break
+					}
+				}
+			}
+			if !stableFiltered {
+				victims = append(victims, preemptee)
+			}
+		}
+
+		klog.V(4).Infof("Victims from cdp plugins are %+v", victims)
+		return victims, util.Permit
+	}
+
+	klog.V(4).Info("plugin cdp session open")
+	ssn.AddPreemptableFn(sp.Name(), preemptableFn)
+}
+
+// OnSessionClose implements framework.Plugin
+func (*CooldownProtectionPlugin) OnSessionClose(ssn *framework.Session) {}

--- a/pkg/scheduler/plugins/cdp/cdp_test.go
+++ b/pkg/scheduler/plugins/cdp/cdp_test.go
@@ -1,0 +1,162 @@
+/*
+Copyright 2022 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cdp
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"volcano.sh/apis/pkg/apis/scheduling/v1beta1"
+	"volcano.sh/volcano/pkg/scheduler/api"
+	"volcano.sh/volcano/pkg/scheduler/cache"
+	"volcano.sh/volcano/pkg/scheduler/conf"
+	"volcano.sh/volcano/pkg/scheduler/framework"
+)
+
+func makePod(labels map[string]string, annotations map[string]string, podScheduledTime time.Time) *v1.Pod {
+	annotations[v1beta1.KubeGroupNameAnnotationKey] = "test-group"
+	phase := v1.PodPending
+	conditions := []v1.PodCondition{}
+	if !podScheduledTime.IsZero() {
+		phase = v1.PodRunning
+		conditions = append(conditions, v1.PodCondition{
+			Type:               v1.PodScheduled,
+			LastTransitionTime: metav1.NewTime(podScheduledTime),
+			Status:             v1.ConditionTrue,
+		})
+	}
+	return &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "test-pod",
+			Namespace:   "default",
+			Labels:      labels,
+			Annotations: annotations,
+		},
+		Status: v1.PodStatus{
+			Phase:      phase,
+			Conditions: conditions,
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				{},
+			},
+		},
+	}
+
+}
+
+func Test_CooldownTimePlugin_podPreemptStableTime(t *testing.T) {
+	type args struct {
+		pod *v1.Pod
+	}
+	plugin := &CooldownProtectionPlugin{}
+	tests := []struct {
+		name        string
+		sp          *CooldownProtectionPlugin
+		args        args
+		wantEnabled bool
+		wantValue   time.Duration
+	}{
+		{
+			name: "normal",
+			sp:   plugin,
+			args: args{
+				pod: makePod(map[string]string{},
+					map[string]string{v1beta1.CooldownTime: "600s"},
+					time.Now().Add(time.Second*-100)),
+			},
+			wantEnabled: true,
+			wantValue:   time.Second * 600,
+		},
+		{
+			name: "not-enabled",
+			sp:   plugin,
+			args: args{
+				pod: makePod(map[string]string{},
+					map[string]string{v1beta1.CooldownTime: "600abcde"},
+					time.Now().Add(time.Second*-100)),
+			},
+			wantEnabled: false,
+			wantValue:   0,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sp := &CooldownProtectionPlugin{}
+			gotValue, gotEnabled := sp.podCooldownTime(tt.args.pod)
+			if gotEnabled != tt.wantEnabled {
+				t.Errorf("CooldownTimePlugin.podPreemptStableTime() gotEnabled = %v, want %v", gotEnabled, tt.wantEnabled)
+			}
+			if gotValue != tt.wantValue {
+				t.Errorf("CooldownTimePlugin.podPreemptStableTime() gotValue = %v, want %v", gotValue, tt.wantValue)
+			}
+		})
+	}
+}
+
+func TestPreemptableFn(t *testing.T) {
+	plugin := &CooldownProtectionPlugin{}
+	enabledPreemptable := true
+	pluginOption := conf.PluginOption{
+		Name:               PluginName,
+		EnabledPreemptable: &enabledPreemptable,
+	}
+	schedulerCache := &cache.SchedulerCache{}
+	ssn := framework.OpenSession(schedulerCache, []conf.Tier{
+		{
+			Plugins: []conf.PluginOption{pluginOption},
+		},
+	},
+		[]conf.Configuration{
+			{
+				Name: "preempt",
+			},
+		},
+	)
+
+	plugin.OnSessionOpen(ssn) // register preempt fn
+
+	// prepare preemptor and preemptees
+	// task1: should be filtered
+	task1 := api.NewTaskInfo(
+		makePod(map[string]string{v1beta1.PodPreemptable: "true"},
+			map[string]string{v1beta1.CooldownTime: "600s"},
+			time.Now().Add(time.Second*-100)),
+	)
+	// task2: invalid label, not enabled
+	task2 := api.NewTaskInfo(
+		makePod(map[string]string{v1beta1.PodPreemptable: "true"},
+			map[string]string{v1beta1.CooldownTime: "600abcde"},
+			time.Now().Add(time.Second*-100)),
+	)
+	// task3: after stable time, can be preempted
+	task3 := api.NewTaskInfo(
+		makePod(map[string]string{v1beta1.PodPreemptable: "true"},
+			map[string]string{v1beta1.CooldownTime: "600s"},
+			time.Now().Add(time.Second*-800)),
+	)
+	preemptees := []*api.TaskInfo{task1, task2, task3}
+	victims := ssn.Preemptable(&api.TaskInfo{}, preemptees)
+
+	expectVictims := []*api.TaskInfo{task2, task3}
+	if !reflect.DeepEqual(victims, expectVictims) {
+		t.Errorf("stable preempt test not equal! expect victims %v, actual %v", expectVictims, victims)
+	}
+}

--- a/pkg/scheduler/plugins/factory.go
+++ b/pkg/scheduler/plugins/factory.go
@@ -19,6 +19,7 @@ package plugins
 import (
 	"volcano.sh/volcano/pkg/scheduler/framework"
 	"volcano.sh/volcano/pkg/scheduler/plugins/binpack"
+	"volcano.sh/volcano/pkg/scheduler/plugins/cdp"
 	"volcano.sh/volcano/pkg/scheduler/plugins/conformance"
 	"volcano.sh/volcano/pkg/scheduler/plugins/drf"
 	"volcano.sh/volcano/pkg/scheduler/plugins/extender"
@@ -51,6 +52,7 @@ func init() {
 	framework.RegisterPluginBuilder(sla.PluginName, sla.New)
 	framework.RegisterPluginBuilder(tasktopology.PluginName, tasktopology.New)
 	framework.RegisterPluginBuilder(numaaware.PluginName, numaaware.New)
+	framework.RegisterPluginBuilder(cdp.PluginName, cdp.New)
 	framework.RegisterPluginBuilder(rescheduling.PluginName, rescheduling.New)
 	framework.RegisterPluginBuilder(usage.PluginName, usage.New)
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1045,7 +1045,7 @@ sigs.k8s.io/yaml
 # stathat.com/c/consistent v1.0.0
 ## explicit
 stathat.com/c/consistent
-# volcano.sh/apis v0.0.0-20220705062437-edd428c7d2fd
+# volcano.sh/apis v1.6.0-alpha.0.0.20220712043845-8d8aa5aecbd2
 ## explicit; go 1.17
 volcano.sh/apis/pkg/apis/batch/v1alpha1
 volcano.sh/apis/pkg/apis/bus/v1alpha1

--- a/vendor/volcano.sh/apis/pkg/apis/scheduling/v1beta1/labels.go
+++ b/vendor/volcano.sh/apis/pkg/apis/scheduling/v1beta1/labels.go
@@ -42,9 +42,9 @@ const QueueNameAnnotationKey = GroupName + "/queue-name"
 // PodPreemptable is the key of preemptable
 const PodPreemptable = "volcano.sh/preemptable"
 
-// PodPreemptStableTime is the key of preempt-stable-time, value's format "600s","10m" 
-// Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h". 
-const PreemptStableTime = "volcano.sh/preempt-stable-time"
+// CooldownTime is the key of cooldown-time, value's format "600s","10m"
+// Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+const CooldownTime = "volcano.sh/cooldown-time"
 
 //RevocableZone is the key of revocable-zone
 const RevocableZone = "volcano.sh/revocable-zone"


### PR DESCRIPTION
resolve issue [#2075](https://github.com/volcano-sh/volcano/issues/2075)

Add cooldown time support for preempt action:
1. provide a new label/annotation named "volcano.sh/preempt-stable-time", whose value means the cool down time for preempt with unit second. This label/annotation can be set for entire vcjob or some dedicated tasks, if set to job, we'll transfer to all tasks' pods.
2. add a plugin to participate in preempt action, ensure pods whose scheduled time after `now - preempt-stable-time` will be not in the result victims list