### PR TITLE
fix controller warning message

### DIFF
--- a/pkg/controllers/job/job_controller_actions.go
+++ b/pkg/controllers/job/job_controller_actions.go
@@ -739,11 +739,13 @@ func (cc *jobcontroller) calcPGMinResources(job *batch.Job) *v1.ResourceList {
 		tp := TaskPriority{0, task}
 		pc := task.Template.Spec.PriorityClassName
 
-		priorityClass, err := cc.pcLister.Get(pc)
-		if err != nil || priorityClass == nil {
-			klog.Warningf("Ignore task %s priority class %s: %v", task.Name, pc, err)
-		} else {
-			tp.priority = priorityClass.Value
+		if pc != "" {
+			priorityClass, err := cc.pcLister.Get(pc)
+			if err != nil || priorityClass == nil {
+				klog.Warningf("Ignore task %s priority class %s: %v", task.Name, pc, err)
+			} else {
+				tp.priority = priorityClass.Value
+			}
 		}
 
 		tasksPriority = append(tasksPriority, tp)


### PR DESCRIPTION
Signed-off-by: wpeng102 <wpeng102@126.com>

User not set PriorityClass in most cases, but controller will log the following warning message:
```
job_controller_actions.go:747] Ignore task default-nginx priority class : priorityclass.scheduling.k8s.io "" not found
```

That is because PriorityClass lister get a empty PriorityClass.