### PR TITLE
fix controller job cache not sync latest version issue

### DIFF
--- a/pkg/controllers/cache/cache.go
+++ b/pkg/controllers/cache/cache.go
@@ -18,6 +18,7 @@ package cache
 
 import (
 	"fmt"
+	"strconv"
 	"sync"
 	"time"
 
@@ -152,8 +153,20 @@ func (jc *jobCache) Update(obj *v1alpha1.Job) error {
 	if !found {
 		return fmt.Errorf("failed to find job <%v>", key)
 	}
-	job.Job = obj
 
+	var oldResourceversion, newResourceversion uint64
+	var err error
+	if oldResourceversion, err = strconv.ParseUint(job.Job.ResourceVersion, 10, 64); err != nil {
+		return fmt.Errorf("failed to parase job <%v> resource version <%s>", key, job.Job.ResourceVersion)
+	}
+
+	if newResourceversion, err = strconv.ParseUint(obj.ResourceVersion, 10, 64); err != nil {
+		return fmt.Errorf("failed to parase job <%v> resource version <%s>", key, obj.ResourceVersion)
+	}
+	if newResourceversion < oldResourceversion {
+		return fmt.Errorf("job <%v> has too old resource version: %d (%d)", key, newResourceversion, oldResourceversion)
+	}
+	job.Job = obj
 	return nil
 }
 

--- a/pkg/controllers/cache/cache_test.go
+++ b/pkg/controllers/cache/cache_test.go
@@ -243,8 +243,9 @@ func TestJobCache_Update(t *testing.T) {
 			JobsInCache: map[string]*v1alpha1.Job{
 				"job1": {
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "job1",
-						Namespace: namespace,
+						Name:            "job1",
+						Namespace:       namespace,
+						ResourceVersion: "100",
 					},
 					Status: v1alpha1.JobStatus{
 						State: v1alpha1.JobState{
@@ -255,8 +256,9 @@ func TestJobCache_Update(t *testing.T) {
 			},
 			UpdatedJob: &v1alpha1.Job{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "job1",
-					Namespace: namespace,
+					Name:            "job1",
+					Namespace:       namespace,
+					ResourceVersion: "100",
 				},
 				Status: v1alpha1.JobStatus{
 					State: v1alpha1.JobState{
@@ -271,8 +273,9 @@ func TestJobCache_Update(t *testing.T) {
 			JobsInCache: nil,
 			UpdatedJob: &v1alpha1.Job{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "job1",
-					Namespace: namespace,
+					Name:            "job1",
+					Namespace:       namespace,
+					ResourceVersion: "100",
 				},
 				Status: v1alpha1.JobStatus{
 					State: v1alpha1.JobState{

--- a/pkg/controllers/job/job_controller_actions_test.go
+++ b/pkg/controllers/job/job_controller_actions_test.go
@@ -54,9 +54,10 @@ func TestKillJobFunc(t *testing.T) {
 			Name: "KillJob success Case",
 			Job: &v1alpha1.Job{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "job1",
-					Namespace: namespace,
-					UID:       "e7f18111-1cec-11ea-b688-fa163ec79500",
+					Name:            "job1",
+					Namespace:       namespace,
+					UID:             "e7f18111-1cec-11ea-b688-fa163ec79500",
+					ResourceVersion: "100",
 				},
 			},
 			PodGroup: &schedulingv1alpha2.PodGroup{
@@ -195,8 +196,9 @@ func TestSyncJobFunc(t *testing.T) {
 			Name: "SyncJob success Case",
 			Job: &v1alpha1.Job{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "job1",
-					Namespace: namespace,
+					Name:            "job1",
+					Namespace:       namespace,
+					ResourceVersion: "100",
 				},
 				Spec: v1alpha1.JobSpec{
 					Tasks: []v1alpha1.TaskSpec{
@@ -325,8 +327,9 @@ func TestCreateJobIOIfNotExistFunc(t *testing.T) {
 			Name: "Create Job IO case",
 			Job: &v1alpha1.Job{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "job1",
-					Namespace: namespace,
+					Name:            "job1",
+					Namespace:       namespace,
+					ResourceVersion: "100",
 				},
 				Spec: v1alpha1.JobSpec{
 					Volumes: []v1alpha1.VolumeSpec{
@@ -376,8 +379,9 @@ func TestCreatePVCFunc(t *testing.T) {
 			Name: "CreatePVC success Case",
 			Job: &v1alpha1.Job{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "job1",
-					Namespace: namespace,
+					Name:            "job1",
+					Namespace:       namespace,
+					ResourceVersion: "100",
 				},
 			},
 			VolumeClaim: &v1.PersistentVolumeClaimSpec{
@@ -415,8 +419,9 @@ func TestCreatePodGroupIfNotExistFunc(t *testing.T) {
 			Name: "CreatePodGroup success Case",
 			Job: &v1alpha1.Job{
 				ObjectMeta: metav1.ObjectMeta{
-					Namespace: namespace,
-					Name:      "job1",
+					Namespace:       namespace,
+					Name:            "job1",
+					ResourceVersion: "100",
 				},
 			},
 			ExpextVal: nil,
@@ -463,8 +468,9 @@ func TestUpdatePodGroupIfJobUpdateFunc(t *testing.T) {
 			},
 			Job: &v1alpha1.Job{
 				ObjectMeta: metav1.ObjectMeta{
-					Namespace: namespace,
-					Name:      "job1",
+					Namespace:       namespace,
+					Name:            "job1",
+					ResourceVersion: "100",
 				},
 				Spec: v1alpha1.JobSpec{
 					PriorityClassName: "new",
@@ -513,8 +519,9 @@ func TestDeleteJobPod(t *testing.T) {
 			Name: "DeleteJobPod success case",
 			Job: &v1alpha1.Job{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "job1",
-					Namespace: namespace,
+					Name:            "job1",
+					Namespace:       namespace,
+					ResourceVersion: "100",
 				},
 			},
 			Pods: map[string]*v1.Pod{

--- a/pkg/controllers/job/job_state_test.go
+++ b/pkg/controllers/job/job_state_test.go
@@ -49,8 +49,9 @@ func TestAbortedState_Execute(t *testing.T) {
 				Name:      "jobinfo1",
 				Job: &v1alpha1.Job{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "Job1",
-						Namespace: namespace,
+						Name:            "Job1",
+						Namespace:       namespace,
+						ResourceVersion: "100",
 					},
 					Status: v1alpha1.JobStatus{
 						State: v1alpha1.JobState{
@@ -69,8 +70,9 @@ func TestAbortedState_Execute(t *testing.T) {
 				Name:      "jobinfo1",
 				Job: &v1alpha1.Job{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "Job1",
-						Namespace: namespace,
+						Name:            "Job1",
+						Namespace:       namespace,
+						ResourceVersion: "100",
 					},
 					Status: v1alpha1.JobStatus{
 						State: v1alpha1.JobState{
@@ -135,8 +137,9 @@ func TestAbortingState_Execute(t *testing.T) {
 				Name:      "jobinfo1",
 				Job: &v1alpha1.Job{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "Job1",
-						Namespace: namespace,
+						Name:            "Job1",
+						Namespace:       namespace,
+						ResourceVersion: "100",
 					},
 					Status: v1alpha1.JobStatus{
 						State: v1alpha1.JobState{
@@ -155,8 +158,9 @@ func TestAbortingState_Execute(t *testing.T) {
 				Name:      "jobinfo1",
 				Job: &v1alpha1.Job{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "Job1",
-						Namespace: namespace,
+						Name:            "Job1",
+						Namespace:       namespace,
+						ResourceVersion: "100",
 					},
 					Status: v1alpha1.JobStatus{
 						State: v1alpha1.JobState{
@@ -175,8 +179,9 @@ func TestAbortingState_Execute(t *testing.T) {
 				Name:      "jobinfo1",
 				Job: &v1alpha1.Job{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "Job1",
-						Namespace: namespace,
+						Name:            "Job1",
+						Namespace:       namespace,
+						ResourceVersion: "100",
 					},
 					Status: v1alpha1.JobStatus{
 						Pending: 1,
@@ -265,8 +270,9 @@ func TestCompletingState_Execute(t *testing.T) {
 				Name:      "jobinfo1",
 				Job: &v1alpha1.Job{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "Job1",
-						Namespace: namespace,
+						Name:            "Job1",
+						Namespace:       namespace,
+						ResourceVersion: "100",
 					},
 					Status: v1alpha1.JobStatus{
 						Running: 2,
@@ -292,8 +298,9 @@ func TestCompletingState_Execute(t *testing.T) {
 				Name:      "jobinfo1",
 				Job: &v1alpha1.Job{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "Job1",
-						Namespace: namespace,
+						Name:            "Job1",
+						Namespace:       namespace,
+						ResourceVersion: "100",
 					},
 					Status: v1alpha1.JobStatus{
 						State: v1alpha1.JobState{
@@ -364,8 +371,9 @@ func TestFinishedState_Execute(t *testing.T) {
 				Name:      "jobinfo1",
 				Job: &v1alpha1.Job{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "Job1",
-						Namespace: namespace,
+						Name:            "Job1",
+						Namespace:       namespace,
+						ResourceVersion: "100",
 					},
 					Status: v1alpha1.JobStatus{
 						State: v1alpha1.JobState{
@@ -420,8 +428,9 @@ func TestPendingState_Execute(t *testing.T) {
 				Name:      "jobinfo1",
 				Job: &v1alpha1.Job{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "Job1",
-						Namespace: namespace,
+						Name:            "Job1",
+						Namespace:       namespace,
+						ResourceVersion: "100",
 					},
 					Status: v1alpha1.JobStatus{
 						State: v1alpha1.JobState{
@@ -440,8 +449,9 @@ func TestPendingState_Execute(t *testing.T) {
 				Name:      "jobinfo1",
 				Job: &v1alpha1.Job{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "Job1",
-						Namespace: namespace,
+						Name:            "Job1",
+						Namespace:       namespace,
+						ResourceVersion: "100",
 					},
 					Status: v1alpha1.JobStatus{
 						Terminating: 2,
@@ -467,8 +477,9 @@ func TestPendingState_Execute(t *testing.T) {
 				Name:      "jobinfo1",
 				Job: &v1alpha1.Job{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "Job1",
-						Namespace: namespace,
+						Name:            "Job1",
+						Namespace:       namespace,
+						ResourceVersion: "100",
 					},
 					Status: v1alpha1.JobStatus{
 						State: v1alpha1.JobState{
@@ -487,8 +498,9 @@ func TestPendingState_Execute(t *testing.T) {
 				Name:      "jobinfo1",
 				Job: &v1alpha1.Job{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "Job1",
-						Namespace: namespace,
+						Name:            "Job1",
+						Namespace:       namespace,
+						ResourceVersion: "100",
 					},
 					Status: v1alpha1.JobStatus{
 						Terminating: 2,
@@ -514,8 +526,9 @@ func TestPendingState_Execute(t *testing.T) {
 				Name:      "jobinfo1",
 				Job: &v1alpha1.Job{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "Job1",
-						Namespace: namespace,
+						Name:            "Job1",
+						Namespace:       namespace,
+						ResourceVersion: "100",
 					},
 					Status: v1alpha1.JobStatus{
 						Terminating: 2,
@@ -541,8 +554,9 @@ func TestPendingState_Execute(t *testing.T) {
 				Name:      "jobinfo1",
 				Job: &v1alpha1.Job{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "Job1",
-						Namespace: namespace,
+						Name:            "Job1",
+						Namespace:       namespace,
+						ResourceVersion: "100",
 					},
 					Status: v1alpha1.JobStatus{
 						State: v1alpha1.JobState{
@@ -561,8 +575,9 @@ func TestPendingState_Execute(t *testing.T) {
 				Name:      "jobinfo1",
 				Job: &v1alpha1.Job{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "Job1",
-						Namespace: namespace,
+						Name:            "Job1",
+						Namespace:       namespace,
+						ResourceVersion: "100",
 					},
 					Status: v1alpha1.JobStatus{
 						Terminating: 2,
@@ -588,8 +603,9 @@ func TestPendingState_Execute(t *testing.T) {
 				Name:      "jobinfo1",
 				Job: &v1alpha1.Job{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "Job1",
-						Namespace: namespace,
+						Name:            "Job1",
+						Namespace:       namespace,
+						ResourceVersion: "100",
 					},
 					Spec: v1alpha1.JobSpec{
 						MinAvailable: 3,
@@ -619,8 +635,9 @@ func TestPendingState_Execute(t *testing.T) {
 				Name:      "jobinfo1",
 				Job: &v1alpha1.Job{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "Job1",
-						Namespace: namespace,
+						Name:            "Job1",
+						Namespace:       namespace,
+						ResourceVersion: "100",
 					},
 					Spec: v1alpha1.JobSpec{
 						MinAvailable: 3,
@@ -649,8 +666,9 @@ func TestPendingState_Execute(t *testing.T) {
 				Name:      "jobinfo1",
 				Job: &v1alpha1.Job{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "Job1",
-						Namespace: namespace,
+						Name:            "Job1",
+						Namespace:       namespace,
+						ResourceVersion: "100",
 					},
 					Spec: v1alpha1.JobSpec{
 						MinAvailable: 3,
@@ -758,8 +776,9 @@ func TestRestartingState_Execute(t *testing.T) {
 				Name:      "jobinfo1",
 				Job: &v1alpha1.Job{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "Job1",
-						Namespace: namespace,
+						Name:            "Job1",
+						Namespace:       namespace,
+						ResourceVersion: "100",
 					},
 					Spec: v1alpha1.JobSpec{
 						MaxRetry: 3,
@@ -782,8 +801,9 @@ func TestRestartingState_Execute(t *testing.T) {
 				Name:      "jobinfo1",
 				Job: &v1alpha1.Job{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "Job1",
-						Namespace: namespace,
+						Name:            "Job1",
+						Namespace:       namespace,
+						ResourceVersion: "100",
 					},
 					Spec: v1alpha1.JobSpec{
 						MaxRetry: 3,
@@ -869,8 +889,9 @@ func TestRunningState_Execute(t *testing.T) {
 				Name:      "jobinfo1",
 				Job: &v1alpha1.Job{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "Job1",
-						Namespace: namespace,
+						Name:            "Job1",
+						Namespace:       namespace,
+						ResourceVersion: "100",
 					},
 					Spec: v1alpha1.JobSpec{},
 					Status: v1alpha1.JobStatus{
@@ -897,8 +918,9 @@ func TestRunningState_Execute(t *testing.T) {
 				Name:      "jobinfo1",
 				Job: &v1alpha1.Job{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "Job1",
-						Namespace: namespace,
+						Name:            "Job1",
+						Namespace:       namespace,
+						ResourceVersion: "100",
 					},
 					Spec: v1alpha1.JobSpec{},
 					Status: v1alpha1.JobStatus{
@@ -919,8 +941,9 @@ func TestRunningState_Execute(t *testing.T) {
 				Name:      "jobinfo1",
 				Job: &v1alpha1.Job{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "Job1",
-						Namespace: namespace,
+						Name:            "Job1",
+						Namespace:       namespace,
+						ResourceVersion: "100",
 					},
 					Spec: v1alpha1.JobSpec{},
 					Status: v1alpha1.JobStatus{
@@ -941,8 +964,9 @@ func TestRunningState_Execute(t *testing.T) {
 				Name:      "jobinfo1",
 				Job: &v1alpha1.Job{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "Job1",
-						Namespace: namespace,
+						Name:            "Job1",
+						Namespace:       namespace,
+						ResourceVersion: "100",
 					},
 					Spec: v1alpha1.JobSpec{},
 					Status: v1alpha1.JobStatus{
@@ -969,8 +993,9 @@ func TestRunningState_Execute(t *testing.T) {
 				Name:      "jobinfo1",
 				Job: &v1alpha1.Job{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "Job1",
-						Namespace: namespace,
+						Name:            "Job1",
+						Namespace:       namespace,
+						ResourceVersion: "100",
 					},
 					Spec: v1alpha1.JobSpec{},
 					Status: v1alpha1.JobStatus{
@@ -991,8 +1016,9 @@ func TestRunningState_Execute(t *testing.T) {
 				Name:      "jobinfo1",
 				Job: &v1alpha1.Job{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "Job1",
-						Namespace: namespace,
+						Name:            "Job1",
+						Namespace:       namespace,
+						ResourceVersion: "100",
 					},
 					Spec: v1alpha1.JobSpec{},
 					Status: v1alpha1.JobStatus{
@@ -1019,8 +1045,9 @@ func TestRunningState_Execute(t *testing.T) {
 				Name:      "jobinfo1",
 				Job: &v1alpha1.Job{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "Job1",
-						Namespace: namespace,
+						Name:            "Job1",
+						Namespace:       namespace,
+						ResourceVersion: "100",
 					},
 					Spec: v1alpha1.JobSpec{},
 					Status: v1alpha1.JobStatus{
@@ -1041,8 +1068,9 @@ func TestRunningState_Execute(t *testing.T) {
 				Name:      "jobinfo1",
 				Job: &v1alpha1.Job{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "Job1",
-						Namespace: namespace,
+						Name:            "Job1",
+						Namespace:       namespace,
+						ResourceVersion: "100",
 					},
 					Spec: v1alpha1.JobSpec{},
 					Status: v1alpha1.JobStatus{
@@ -1069,8 +1097,9 @@ func TestRunningState_Execute(t *testing.T) {
 				Name:      "jobinfo1",
 				Job: &v1alpha1.Job{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "job1",
-						Namespace: namespace,
+						Name:            "job1",
+						Namespace:       namespace,
+						ResourceVersion: "100",
 					},
 					Spec: v1alpha1.JobSpec{
 						Tasks: []v1alpha1.TaskSpec{
@@ -1109,8 +1138,9 @@ func TestRunningState_Execute(t *testing.T) {
 				Name:      "jobinfo1",
 				Job: &v1alpha1.Job{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "job1",
-						Namespace: namespace,
+						Name:            "job1",
+						Namespace:       namespace,
+						ResourceVersion: "100",
 					},
 					Spec: v1alpha1.JobSpec{
 						Tasks: []v1alpha1.TaskSpec{
@@ -1228,8 +1258,9 @@ func TestTerminatingState_Execute(t *testing.T) {
 				Name:      "jobinfo1",
 				Job: &v1alpha1.Job{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "Job1",
-						Namespace: namespace,
+						Name:            "Job1",
+						Namespace:       namespace,
+						ResourceVersion: "100",
 					},
 					Status: v1alpha1.JobStatus{
 						Running: 2,
@@ -1255,8 +1286,9 @@ func TestTerminatingState_Execute(t *testing.T) {
 				Name:      "jobinfo1",
 				Job: &v1alpha1.Job{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "Job1",
-						Namespace: namespace,
+						Name:            "Job1",
+						Namespace:       namespace,
+						ResourceVersion: "100",
 					},
 					Status: v1alpha1.JobStatus{
 						State: v1alpha1.JobState{


### PR DESCRIPTION
Signed-off-by: wpeng102 <wpeng102@126.com>

Resolve issue:  https://github.com/volcano-sh/volcano/issues/2160

#### What happened:
vcjob phase can get stuck in "Pending" or "Starting" even after all pods have completed.
Detail refer https://github.com/volcano-sh/volcano/issues/2160

#### Root Cause:
When controller update job status, `Kopf` add annotation for this job.  

Consider this situation: 
https://github.com/volcano-sh/volcano/blob/ccda7582e7df156ceddebeeb07fd83aacdf7d04a/pkg/controllers/job/job_controller_actions.go#L462-L468

https://github.com/volcano-sh/volcano/blob/ccda7582e7df156ceddebeeb07fd83aacdf7d04a/pkg/controllers/job/job_controller_handler.go#L93

thread1 at L462, get the job with `version_1`.
thread2 at L93, get `Kopf` add annotation event and put `version_2` job into cache.
thread1 at L468, put `version_1` job into cache again. 

When next call `UpdateStatus` will use the old `version_1` job, then meet [2160](https://github.com/volcano-sh/volcano/issues/2160) issue.

#### Manual  reproduce steps:
1) add `time.Sleep(time.Second*20)`  before https://github.com/volcano-sh/volcano/blob/ccda7582e7df156ceddebeeb07fd83aacdf7d04a/pkg/controllers/job/job_controller_actions.go#L468
2) submit vcjob
3) during controller sleep, add annotation for this job manually.

#### Solution:
In `cache.update` need check if the job resourceversion is bigger than the old one.

After this fix, when trigger the above case the controller log will print:
```
E0414 08:12:30.419699       1 job_controller_actions.go:307] SyncJob - Failed to update Job default/job-38 in cache:  job <default/job-38> has too old resource version: 6358346 (6358347)
```
Then controller will requeue this request. 