### PR TITLE
Only enable merge check for spark IT

### DIFF
--- a/.github/workflows/e2e_spark.yaml
+++ b/.github/workflows/e2e_spark.yaml
@@ -5,8 +5,6 @@ on:
   push:
     branches:
       - master
-  # PR triggered job
-  pull_request:
 jobs:
   k8s-integration-tests:
     name: "E2E about Spark Integration test"


### PR DESCRIPTION
Due to flaky error of spark it, we need to disable pr triggered job before we solve all flaky error.

Related: https://github.com/volcano-sh/volcano/issues/2165