### PR TITLE
support elastic

### DIFF
--- a/pkg/scheduler/api/job_info.go
+++ b/pkg/scheduler/api/job_info.go
@@ -477,6 +477,13 @@ func (ji *JobInfo) GetMinResources() *Resource {
 	return NewResource(*ji.PodGroup.Spec.MinResources)
 }
 
+func (ji *JobInfo) GetElasticResources() *Resource {
+	if ji.Allocated.LessEqual(ji.GetMinResources(), Zero) {
+		return EmptyResource()
+	}
+	return ji.Allocated.Clone().Sub(ji.GetMinResources())
+}
+
 func (ji *JobInfo) addTaskIndex(ti *TaskInfo) {
 	if _, found := ji.TaskStatusIndex[ti.Status]; !found {
 		ji.TaskStatusIndex[ti.Status] = tasksMap{}


### PR DESCRIPTION
If the default queue is limited to 10 gpus, a job1 contains 10 pods (1 gpu per pod), and minAvailable = 5, we consider the remaining 5 pods to be elastic resources. At this point, if a new job2 (10 pods, minAvailable = 5, 1 gpu per pod) is submitted, job2 should also be able to run, but according to the current code, because job1 have occupied full of queue resources, so job2 can only be pending.

the pr fix it.