### PR TITLE
Rename ClusterRole from prometheus to prometheus-volcano

### DIFF
--- a/installer/helm/chart/volcano/templates/prometheus.yaml
+++ b/installer/helm/chart/volcano/templates/prometheus.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: prometheus
+  name: prometheus-volcano
 rules:
 - apiGroups: [""]
   resources:
@@ -23,11 +23,11 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: prometheus
+  name: prometheus-volcano
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: prometheus
+  name: prometheus-volcano
 subjects:
 - kind: ServiceAccount
   name: default


### PR DESCRIPTION
If ClusterRole prometheus exists in the Kubernetes cluster, we can't install volcano using helm.

rendered manifests contain a resource that already exists. Unable to continue with install: ClusterRole "prometheus" in namespace "" exists and cannot be imported into the current release
