### PR TITLE
fix scheduling failed when different role in tfjob has empty taskID

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/fsnotify/fsnotify v1.4.9
 	github.com/golang/mock v1.6.0
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
+	github.com/google/uuid v1.1.2
 	github.com/hashicorp/go-multierror v1.0.0
 	github.com/imdario/mergo v0.3.5
 	github.com/onsi/ginkgo/v2 v2.0.0
@@ -56,7 +57,6 @@ require (
 	github.com/google/cadvisor v0.43.0 // indirect
 	github.com/google/go-cmp v0.5.5 // indirect
 	github.com/google/gofuzz v1.1.0 // indirect
-	github.com/google/uuid v1.1.2 // indirect
 	github.com/googleapis/gnostic v0.5.5 // indirect
 	github.com/hashicorp/errwrap v1.0.0 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect

--- a/pkg/scheduler/api/job_info.go
+++ b/pkg/scheduler/api/job_info.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/uuid"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -147,7 +148,17 @@ func getTaskID(pod *v1.Pod) TaskID {
 		return TaskID(ts)
 	}
 
-	return ""
+	return TaskID(GetDefaultTaskSpec(pod))
+}
+
+// GetDefaultTaskSpec return the pod generate name without pod index
+// if pod name is "tfjob-worker-9", return "worker".
+func GetDefaultTaskSpec(pod *v1.Pod) string {
+	specs := strings.Split(pod.Name, "-")
+	if len(specs) < 3 {
+		return pod.Name
+	}
+	return specs[len(specs)-2]
 }
 
 const TaskPriorityAnnotation = "volcano.sh/task-priority"
@@ -261,7 +272,7 @@ func (ti *TaskInfo) Clone() *TaskInfo {
 
 func (ti *TaskInfo) GetTaskSpecKey() TaskID {
 	if ti.Pod == nil {
-		return ""
+		return TaskID(uuid.New().String())
 	}
 	return getTaskID(ti.Pod)
 }

--- a/pkg/scheduler/api/job_info_test.go
+++ b/pkg/scheduler/api/job_info_test.go
@@ -288,3 +288,36 @@ func TestTaskSchedulingReason(t *testing.T) {
 		}
 	}
 }
+
+func TestGetDefaultTaskSpec(t *testing.T) {
+	tests := []struct {
+		pod      *v1.Pod
+		expected string
+	}{
+		{
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "tfjob-ps-1"},
+			},
+			expected: "ps",
+		},
+		{
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "tfjob-prod-worker-2"},
+			},
+			expected: "worker",
+		},
+		{
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "randompod-123"},
+			},
+			expected: "randompod-123",
+		},
+	}
+
+	for i, test := range tests {
+		spec := GetDefaultTaskSpec(test.pod)
+		if spec != test.expected {
+			t.Errorf("case #%d, task %v, expected: %s, got: %s", i, test.pod.Name, test.expected, spec)
+		}
+	}
+}


### PR DESCRIPTION
Tfjob has different role with different NodeSelector and NodeAffinity.
such as  `PS` will choose nodes  with LabelA
`Worker` will choose nodes LabelB
`Chief` will choose nodes with LabelC

Current schedule rule will generate empty `TaskID` for tasks belonging to one job
It's ok for jobs with same NodeSelector rules, but not for  `ps`, `worker`, `chief` of tfjob with different NodeSelectors

/priority-high