### PR TITLE
add priorityClassName for rescheduler

### DIFF
--- a/installer/volcano-development.yaml
+++ b/installer/volcano-development.yaml
@@ -131,6 +131,7 @@ spec:
         app: volcano-admission
     spec:
       serviceAccount: volcano-admission
+      priorityClassName: system-cluster-critical
       containers:
         - args:
             - --tls-cert-file=/admission.local.config/certificates/tls.crt
@@ -174,6 +175,7 @@ spec:
   template:
     spec:
       serviceAccountName: volcano-admission
+      priorityClassName: system-cluster-critical
       restartPolicy: Never
       containers:
         - name: main
@@ -8473,6 +8475,7 @@ spec:
         app: volcano-controller
     spec:
       serviceAccount: volcano-controllers
+      priorityClassName: system-cluster-critical
       containers:
           - name: volcano-controllers
             image: volcanosh/vc-controller-manager:latest
@@ -8625,6 +8628,7 @@ spec:
         app: volcano-scheduler
     spec:
       serviceAccount: volcano-scheduler
+      priorityClassName: system-cluster-critical
       containers:
         - name: volcano-scheduler
           image: volcanosh/vc-scheduler:latest


### PR DESCRIPTION
Signed-off-by: jiangxiaobin96 <401236678@qq.com>

Add priorityClassName for rescheduler to avoid evicting volcano pod due to rescheduler will identify critical pods.