### PR TITLE
fix(deploy): add helm pre delete hook to delete orphan resources

### DIFF
--- a/installer/README.md
+++ b/installer/README.md
@@ -79,6 +79,7 @@ The following are the list configurable parameters of Volcano Chart and their de
 |`basic.admission_app_name`|Admission Controller App Name|`volcano-admission`|
 |`basic.controller_app_name`|Controller App Name|`volcano-controller`|
 |`basic.scheduler_app_name`|Scheduler App Name|`volcano-scheduler`|
+|`basic.pre_delete_hook_image_name`|Pre Delete Hook Image Name|`bitnami/kubectl:latest`|
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/installer/helm/chart/volcano/templates/admission.yaml
+++ b/installer/helm/chart/volcano/templates/admission.yaml
@@ -22,7 +22,7 @@ rules:
     verbs: ["get", "list", "watch"]
   - apiGroups: ["admissionregistration.k8s.io"]
     resources: ["mutatingwebhookconfigurations", "validatingwebhookconfigurations"]
-    verbs: ["get", "list", "watch", "create", "update"]
+    verbs: ["get", "list", "watch", "create", "update", "delete"]
   # Rules below is used generate admission service secret
   - apiGroups: ["certificates.k8s.io"]
     resources: ["certificatesigningrequests"]
@@ -42,6 +42,9 @@ rules:
   - apiGroups: ["scheduling.incubator.k8s.io", "scheduling.volcano.sh"]
     resources: ["podgroups"]
     verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["delete"]
 
 ---
 kind: ClusterRoleBinding

--- a/installer/helm/chart/volcano/templates/pre_delete_hook.yaml
+++ b/installer/helm/chart/volcano/templates/pre_delete_hook.yaml
@@ -1,0 +1,37 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ .Release.Name }}-pre-delete-hook
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: volcano-pre-delete-hook
+  annotations:
+    "helm.sh/hook": pre-delete
+    "helm.sh/hook-delete-policy": hook-succeeded,hook-failed
+spec:
+  backoffLimit: 3
+  template:
+    spec:
+      serviceAccount: {{ .Release.Name }}-admission
+      priorityClassName: system-cluster-critical
+      {{- if .Values.basic.image_pull_secret }}
+      imagePullSecrets:
+        - name: {{ .Values.basic.image_pull_secret }}
+      {{- end }}
+      containers:
+        - name: pre-delete-hook
+          image: {{ .Values.basic.pre_delete_hook_image_name }}
+          imagePullPolicy: "IfNotPresent"
+          command:
+            - /bin/sh
+            - -c
+            - |
+              kubectl delete mutatingwebhookconfiguration {{ .Release.Name }}-admission-service-jobs-mutate;
+              kubectl delete mutatingwebhookconfiguration {{ .Release.Name }}-admission-service-podgroups-mutate;
+              kubectl delete mutatingwebhookconfiguration {{ .Release.Name }}-admission-service-pods-mutate;
+              kubectl delete mutatingwebhookconfiguration {{ .Release.Name }}-admission-service-queues-mutate;
+              kubectl delete validatingwebhookconfiguration {{ .Release.Name }}-admission-service-jobs-validate;
+              kubectl delete validatingwebhookconfiguration {{ .Release.Name }}-admission-service-pods-validate;
+              kubectl delete validatingwebhookconfiguration {{ .Release.Name }}-admission-service-queues-validate;
+              kubectl delete secret {{.Values.basic.admission_secret_name}} -n {{ .Release.Namespace }};
+      restartPolicy: Never

--- a/installer/helm/chart/volcano/values.yaml
+++ b/installer/helm/chart/volcano/values.yaml
@@ -6,6 +6,7 @@ basic:
   admission_secret_name: "volcano-admission-secret"
   admission_config_file: "config/volcano-admission.conf"
   scheduler_config_file: "config/volcano-scheduler.conf"
+  pre_delete_hook_image_name: "bitnami/kubectl:latest"
 
   image_pull_secret: ""
   admission_port: 8443

--- a/installer/volcano-development.yaml
+++ b/installer/volcano-development.yaml
@@ -60,7 +60,7 @@ rules:
     verbs: ["get", "list", "watch"]
   - apiGroups: ["admissionregistration.k8s.io"]
     resources: ["mutatingwebhookconfigurations", "validatingwebhookconfigurations"]
-    verbs: ["get", "list", "watch", "create", "update"]
+    verbs: ["get", "list", "watch", "create", "update", "delete"]
   # Rules below is used generate admission service secret
   - apiGroups: ["certificates.k8s.io"]
     resources: ["certificatesigningrequests"]
@@ -80,6 +80,9 @@ rules:
   - apiGroups: ["scheduling.incubator.k8s.io", "scheduling.volcano.sh"]
     resources: ["podgroups"]
     verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["delete"]
 ---
 # Source: volcano/templates/admission.yaml
 kind: ClusterRoleBinding


### PR DESCRIPTION
This PR is trying to resolve https://github.com/volcano-sh/volcano/issues/2191, it uses helm hooks to uninstall orphan resources before uninstalling the helm package.

It can perfectly solve the above issue when using helm to deploy, but there still exists two problems:
1. A third-party kubectl dependency will be introduced
2. Installing volcano through `installer/volcano-deployment.yaml` will not take effect, which means issue https://github.com/volcano-sh/volcano/issues/2079, https://github.com/volcano-sh/volcano/issues/2102 still exists
(Though I do think we should not encourage users to deploy in this way)