### PR TITLE
fix id of gpu devices never delete when number gpu decrease

### DIFF
--- a/pkg/scheduler/api/node_info.go
+++ b/pkg/scheduler/api/node_info.go
@@ -298,6 +298,7 @@ func (ni *NodeInfo) setNodeGPUInfo(node *v1.Node) {
 	}
 
 	memoryPerCard := uint(totalMemory / gpuNumber)
+	ni.GPUDevices = make(map[int]*GPUDevice)
 	for i := 0; i < int(gpuNumber); i++ {
 		ni.GPUDevices[i] = NewGPUDevice(i, memoryPerCard)
 	}


### PR DESCRIPTION
When some gpu drop on node, and restart volcano gpu share device-plugin，and scheduler never delete id of gpu 