### PR TITLE
bugfix: api-server deny empty admission response with PatchType set

### DIFF
--- a/pkg/webhooks/admission/jobs/mutate/mutate_job.go
+++ b/pkg/webhooks/admission/jobs/mutate/mutate_job.go
@@ -97,8 +97,10 @@ func Jobs(ar admissionv1.AdmissionReview) *admissionv1.AdmissionResponse {
 		Allowed: true,
 		Patch:   patchBytes,
 	}
-	pt := admissionv1.PatchTypeJSONPatch
-	reviewResponse.PatchType = &pt
+	if len(patchBytes) > 0 {
+		pt := admissionv1.PatchTypeJSONPatch
+		reviewResponse.PatchType = &pt
+	}
 
 	return &reviewResponse
 }

--- a/pkg/webhooks/admission/podgroups/mutate/mutate_podgroup.go
+++ b/pkg/webhooks/admission/podgroups/mutate/mutate_podgroup.go
@@ -87,12 +87,15 @@ func PodGroups(ar admissionv1.AdmissionReview) *admissionv1.AdmissionResponse {
 		}
 	}
 
-	pt := admissionv1.PatchTypeJSONPatch
-	return &admissionv1.AdmissionResponse{
-		Allowed:   true,
-		Patch:     patchBytes,
-		PatchType: &pt,
+	reviewResponse := admissionv1.AdmissionResponse{
+		Allowed: true,
+		Patch:   patchBytes,
 	}
+	if len(patchBytes) > 0 {
+		pt := admissionv1.PatchTypeJSONPatch
+		reviewResponse.PatchType = &pt
+	}
+	return &reviewResponse
 }
 
 func createPodGroupPatch(podgroup *schedulingv1beta1.PodGroup) ([]byte, error) {

--- a/pkg/webhooks/admission/pods/mutate/mutate_pod.go
+++ b/pkg/webhooks/admission/pods/mutate/mutate_pod.go
@@ -19,6 +19,7 @@ package mutate
 import (
 	"encoding/json"
 	"fmt"
+
 	admissionv1 "k8s.io/api/admission/v1"
 	whv1 "k8s.io/api/admissionregistration/v1"
 	v1 "k8s.io/api/core/v1"
@@ -90,8 +91,10 @@ func Pods(ar admissionv1.AdmissionReview) *admissionv1.AdmissionResponse {
 		Allowed: true,
 		Patch:   patchBytes,
 	}
-	pt := admissionv1.PatchTypeJSONPatch
-	reviewResponse.PatchType = &pt
+	if len(patchBytes) > 0 {
+		pt := admissionv1.PatchTypeJSONPatch
+		reviewResponse.PatchType = &pt
+	}
 
 	return &reviewResponse
 }

--- a/pkg/webhooks/admission/queues/mutate/mutate_queue.go
+++ b/pkg/webhooks/admission/queues/mutate/mutate_queue.go
@@ -88,12 +88,15 @@ func Queues(ar admissionv1.AdmissionReview) *admissionv1.AdmissionResponse {
 		}
 	}
 
-	pt := admissionv1.PatchTypeJSONPatch
-	return &admissionv1.AdmissionResponse{
-		Allowed:   true,
-		Patch:     patchBytes,
-		PatchType: &pt,
+	reviewResponse := admissionv1.AdmissionResponse{
+		Allowed: true,
+		Patch:   patchBytes,
 	}
+	if len(patchBytes) > 0 {
+		pt := admissionv1.PatchTypeJSONPatch
+		reviewResponse.PatchType = &pt
+	}
+	return &reviewResponse
 }
 
 func createQueuePatch(queue *schedulingv1beta1.Queue) ([]byte, error) {


### PR DESCRIPTION
Happen to get an api-server error `webhook returned response.patchType but not response.patch` when using volcano then after some digging into the code, I figure out that api-server needs the `PatchType` and `Patch` pair-matched in the admission response:
https://github.com/kubernetes/apiserver/blob/a0fc11eb6ae0f06eb4fb1f158a1e43e0413adae3/pkg/admission/plugin/webhook/request/admissionreview.go#L66-L73
If an empty `Patch` body is generated and the current implementation always sets the `PatchType` to `JsonType` which will cause the error above. The reason why an empty `Patch` body is generated in my case is I'm not using the `admission-conf` flag of the admission command in my project which will not pass the verification check in the following code for your information:
https://github.com/volcano-sh/volcano/blob/2cfce7a1305e4ad6d3dcb1a11bf3dc528aee0701/pkg/webhooks/admission/pods/mutate/mutate_pod.go#L101-L104

