### PR TITLE
Fix podgroup minResources calculation error

### DIFF
--- a/pkg/controllers/job/job_controller_actions.go
+++ b/pkg/controllers/job/job_controller_actions.go
@@ -756,19 +756,15 @@ func (cc *jobcontroller) calcPGMinResources(job *batch.Job) *v1.ResourceList {
 	sort.Sort(tasksPriority)
 
 	minReq := v1.ResourceList{}
-	podCnt := int32(0)
-	for _, task := range tasksPriority {
-		for i := int32(0); i < task.Replicas; i++ {
-			if podCnt >= job.Spec.MinAvailable {
-				break
+	for j := int32(0); j < job.Spec.MinAvailable; j++ {
+		for _, task := range tasksPriority {
+			for i := int32(0); i < task.Replicas; i++ {
+				pod := &v1.Pod{
+					Spec: task.Template.Spec,
+				}
+				res, _ := quotacore.PodUsageFunc(pod, clock.RealClock{})
+				minReq = quotav1.Add(minReq, res)
 			}
-
-			podCnt++
-			pod := &v1.Pod{
-				Spec: task.Template.Spec,
-			}
-			res, _ := quotacore.PodUsageFunc(pod, clock.RealClock{})
-			minReq = quotav1.Add(minReq, res)
 		}
 	}
 

--- a/test/e2e/util/job.go
+++ b/test/e2e/util/job.go
@@ -105,7 +105,6 @@ func CreateJobWithPodGroup(ctx *TestContext, jobSpec *JobSpec,
 		},
 	}
 
-	var min int32
 	for i, task := range jobSpec.Tasks {
 		name := task.Name
 		if len(name) == 0 {
@@ -150,14 +149,12 @@ func CreateJobWithPodGroup(ctx *TestContext, jobSpec *JobSpec,
 		}
 
 		job.Spec.Tasks = append(job.Spec.Tasks, ts)
-
-		min += task.Min
 	}
 
 	if jobSpec.Min > 0 {
 		job.Spec.MinAvailable = jobSpec.Min
 	} else {
-		job.Spec.MinAvailable = min
+		job.Spec.MinAvailable = 1
 	}
 
 	if jobSpec.Pri != "" {
@@ -203,7 +200,6 @@ func CreateJobInner(ctx *TestContext, jobSpec *JobSpec) (*batchv1alpha1.Job, err
 		},
 	}
 
-	var min int32
 	for i, task := range jobSpec.Tasks {
 		name := task.Name
 		if len(name) == 0 {
@@ -252,14 +248,12 @@ func CreateJobInner(ctx *TestContext, jobSpec *JobSpec) (*batchv1alpha1.Job, err
 		}
 
 		job.Spec.Tasks = append(job.Spec.Tasks, ts)
-
-		min += task.Min
 	}
 
 	if jobSpec.Min > 0 {
 		job.Spec.MinAvailable = jobSpec.Min
 	} else {
-		job.Spec.MinAvailable = min
+		job.Spec.MinAvailable = 1
 	}
 
 	if jobSpec.Pri != "" {


### PR DESCRIPTION
Suppose a tensorflow job like the following code
```yaml
spec:
  minAvailable: # to be set
  tasks:
  - minAvailable: 1
    name: server
          resources:
            requests:
              cpu: 50m
              memory: 100Mi
  - minAvailable: 1
    name: worker
          resources:
            requests:
              cpu: 50m
              memory: 100Mi
              nvidia.com/gpu: "1"
```
If the `spec.minAvailable` set 1 for the job, the `minResources` of pg goes like the following, which misses GPU resources and loses half of the real CPU/Memory resources used which will **put `podgroup` in a false `Running` state** even no GPU on any node:
```yaml
spec:
  minMember: 1
  minResources:
    cpu: 50m
    memory: 100Mi
status:
  conditions:
  - reason: tasks in gang are ready to be scheduled
    status: "True"
    type: Scheduled
  phase: Running
```
I believe that the correct resources needed should be like the following where GPU resources are mandatory and take all server and worker resources needed into consideration thus **pg should be in the `Pending` state**:
```yaml
  minResources:
    cpu: 100m
    memory: 200Mi
    nvidia.com/gpu: "1"
status:
  conditions:
  - message: '1/0 tasks in gang unschedulable: pod group is not ready, 1 minAvailable'
    reason: NotEnoughResources
    type: Unschedulable
  phase: Pending

```
The same error happens if the `spec.minAvailable` set 2 or more but only with a fraction of resources used lost. 

Furthermore, this error happens because the `pod` and `task` are two different things in `volcano-controller` and `volcano-scheduler`,  maybe different terminology of `task`s could be used in `volcano-controller` and `volcano-scheduler`, like replacing `task` in `volcano-controller` with `subjob`.