### PR TITLE
Feat/exclude unhealthy gpu devices

### DIFF
--- a/pkg/scheduler/api/node_info.go
+++ b/pkg/scheduler/api/node_info.go
@@ -330,6 +330,7 @@ func (ni *NodeInfo) setNodeGPUInfo(node *v1.Node) {
 	}
 	unhealthyGPUs := ni.getUnhealthyGPUs(node)
 	for id := range unhealthyGPUs {
+		klog.Info("delete unhealthy gpu id %d from GPUDevices", id)
 		delete(ni.GPUDevices, id)
 	}
 }

--- a/pkg/scheduler/api/node_info.go
+++ b/pkg/scheduler/api/node_info.go
@@ -329,9 +329,9 @@ func (ni *NodeInfo) setNodeGPUInfo(node *v1.Node) {
 		ni.GPUDevices[i] = NewGPUDevice(i, memoryPerCard)
 	}
 	unhealthyGPUs := ni.getUnhealthyGPUs(node)
-	for id := range unhealthyGPUs {
-		klog.V(4).Infof("delete unhealthy gpu id %d from GPUDevices", id)
-		delete(ni.GPUDevices, id)
+	for i := range unhealthyGPUs {
+		klog.V(4).Infof("delete unhealthy gpu id %d from GPUDevices", unhealthyGPUs[i])
+		delete(ni.GPUDevices, unhealthyGPUs[i])
 	}
 }
 
@@ -588,8 +588,8 @@ func (ni *NodeInfo) SubGPUResource(pod *v1.Pod) {
 }
 
 // getUnhealthyGPUs returns all the unhealthy GPU id.
-func (ni *NodeInfo) getUnhealthyGPUs(node *v1.Node) (unhealthyGPUs map[int]bool) {
-	unhealthyGPUs = map[int]bool{}
+func (ni *NodeInfo) getUnhealthyGPUs(node *v1.Node) (unhealthyGPUs []int) {
+	unhealthyGPUs = []int{}
 	devicesStr, ok := node.Annotations[UnhealthyGPUIDs]
 
 	if !ok {
@@ -602,7 +602,7 @@ func (ni *NodeInfo) getUnhealthyGPUs(node *v1.Node) (unhealthyGPUs map[int]bool)
 		if err != nil {
 			klog.Warningf("Failed to parse unhealthy gpu id %s due to %v", sid, err)
 		} else {
-			unhealthyGPUs[id] = true
+			unhealthyGPUs = append(unhealthyGPUs, id)
 		}
 	}
 	return

--- a/pkg/scheduler/api/node_info.go
+++ b/pkg/scheduler/api/node_info.go
@@ -330,7 +330,7 @@ func (ni *NodeInfo) setNodeGPUInfo(node *v1.Node) {
 	}
 	unhealthyGPUs := ni.getUnhealthyGPUs(node)
 	for id := range unhealthyGPUs {
-		klog.Info("delete unhealthy gpu id %d from GPUDevices", id)
+		klog.V(4).Infof("delete unhealthy gpu id %d from GPUDevices", id)
 		delete(ni.GPUDevices, id)
 	}
 }

--- a/pkg/scheduler/api/node_info.go
+++ b/pkg/scheduler/api/node_info.go
@@ -19,6 +19,7 @@ package api
 import (
 	"fmt"
 	"strconv"
+	"strings"
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/klog"
@@ -327,6 +328,10 @@ func (ni *NodeInfo) setNodeGPUInfo(node *v1.Node) {
 	for i := 0; i < int(gpuNumber); i++ {
 		ni.GPUDevices[i] = NewGPUDevice(i, memoryPerCard)
 	}
+	unhealthyGPUs := ni.getUnhealthyGPUs(node)
+	for id := range unhealthyGPUs {
+		delete(ni.GPUDevices, id)
+	}
 }
 
 // SetNode sets kubernetes node object to nodeInfo object
@@ -579,4 +584,25 @@ func (ni *NodeInfo) SubGPUResource(pod *v1.Pod) {
 			delete(dev.PodMap, string(pod.UID))
 		}
 	}
+}
+
+// getUnhealthyGPUs returns all the unhealthy GPU id.
+func (ni *NodeInfo) getUnhealthyGPUs(node *v1.Node) (unhealthyGPUs map[int]bool) {
+	unhealthyGPUs = map[int]bool{}
+	devicesStr, ok := node.Annotations[UnhealthyGPUIDs]
+
+	if !ok {
+		return
+	}
+
+	idsStr := strings.Split(devicesStr, ",")
+	for _, sid := range idsStr {
+		id, err := strconv.Atoi(sid)
+		if err != nil {
+			klog.Warningf("Failed to parse unhealthy gpu id %s due to %v", sid, err)
+		} else {
+			unhealthyGPUs[id] = true
+		}
+	}
+	return
 }

--- a/pkg/scheduler/api/well_known_labels.go
+++ b/pkg/scheduler/api/well_known_labels.go
@@ -28,7 +28,7 @@ const (
 	// GPUIndex is the key of gpu index
 	GPUIndex = "volcano.sh/gpu-index"
 
-	// UnhealthyGPUIds list of unhealthy gpu ids
+	// UnhealthyGPUIDs list of unhealthy gpu ids
 	UnhealthyGPUIDs = "volcano.sh/gpu-unhealthy-ids"
 
 	// OversubscriptionNode is the key of node oversubscription

--- a/pkg/scheduler/api/well_known_labels.go
+++ b/pkg/scheduler/api/well_known_labels.go
@@ -28,6 +28,9 @@ const (
 	// GPUIndex is the key of gpu index
 	GPUIndex = "volcano.sh/gpu-index"
 
+	// UnhealthyGPUIndexes list of unhealthy gpu ids
+	UnhealthyGPUIDs = "volcano.sh/gpu-unhealthy-ids"
+
 	// OversubscriptionNode is the key of node oversubscription
 	OversubscriptionNode = "volcano.sh/oversubscription"
 	// OversubscriptionCPU is the key of cpu oversubscription

--- a/pkg/scheduler/api/well_known_labels.go
+++ b/pkg/scheduler/api/well_known_labels.go
@@ -28,7 +28,7 @@ const (
 	// GPUIndex is the key of gpu index
 	GPUIndex = "volcano.sh/gpu-index"
 
-	// UnhealthyGPUIndexes list of unhealthy gpu ids
+	// UnhealthyGPUIds list of unhealthy gpu ids
 	UnhealthyGPUIDs = "volcano.sh/gpu-unhealthy-ids"
 
 	// OversubscriptionNode is the key of node oversubscription


### PR DESCRIPTION
Exclude unhealhy gpu device by list of node annotations `volcano.sh/gpu-unhealthy-ids`, which patch by volcano device plugin

https://github.com/volcano-sh/devices/pull/24