### PR TITLE
fix github action bug and set the release of checkout to be fixed v2.3.5

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,7 +11,7 @@ jobs:
       GOPATH: /home/runner/work/${{ github.repository }}
     steps:
       - name: Install Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v2.4.2
         with:
           go-version: 1.17.x
 


### PR DESCRIPTION
fix: https://github.com/volcano-sh/volcano/issues/2273
According to the [workaround](https://github.com/actions/checkout/issues/672#issuecomment-1010571414), set the release of checkout to be v2.3.5.
Signed-off-by: Thor-wl <13164644535@163.com>