### PR TITLE
cmd: add --managed-namespaces flag to vc-webhook-manager

### DIFF
--- a/cmd/webhook-manager/main.go
+++ b/cmd/webhook-manager/main.go
@@ -54,6 +54,10 @@ func main() {
 	go wait.Until(klog.Flush, *logFlushFreq, wait.NeverStop)
 	defer klog.Flush()
 
+	if err := config.MutualExclusiveNSOpt(); err != nil {
+		klog.Fatalf("Only one of --ignored-namespaces and --managed-namespaces may be specified", err)
+	}
+
 	if err := config.CheckPortOrDie(); err != nil {
 		klog.Fatalf("Configured port is invalid: %v", err)
 	}


### PR DESCRIPTION
As described in #2286 this adds the `--managed-namespaces` flag to the vc-webhook-manager binary. The flag is mutually exclusive with the `--ingored-namespaces` flag.

As a note, I personally think that `--ignored-namespaces` is a dangerous idea. It essentially leans towards "most privileged" rather than "least privileged".

### Important notes

#### Syntax question
I'm not really a Go programmer (mostly Python) but am learning. I struggled with one thing. On line 61 of `cmd/webhook-manager/app/util.go` I used `var selectorOperator metav1.LabelSelectorOperator`. I'm not sure if this is the preferred syntax for this project but struggled to get any other syntax to work here.

#### Removal of default ingored namespaces
In adding this flag, it was significantly simpler to remove the `defaultIgnoredNamespaces`. I also think that setting the list of ignored/managed namespaces should be explicit. 

This became an issue for me while working on putting together a Helm chart for Volcano and found that having a default set of ignored namespaces made developing a functional Helm chart difficult. For example, Helm has the convention of specifying which namespace a chart will be deployed do using `helm install --namespace`. With `defaultIgnoredNamespaces` set, it was non-obvious why the chart was managing the wrong namespace.

#### RBAC
While #2286 mentions the issue of over-broad RBAC, in order to keep this PR small, I haven't done anything to address the RBAC issues. I will, however, attempt to address those issues in the helm chart mentioned above. I can open a new issue for the RBAC issues if needed.

Fixes #2286