### PR TITLE
support task dag with gang

### DIFF
--- a/pkg/scheduler/api/job_info.go
+++ b/pkg/scheduler/api/job_info.go
@@ -59,9 +59,14 @@ func (db *DisruptionBudget) Clone() *DisruptionBudget {
 	}
 }
 
-// JobWaitingTime is maximum waiting time that a job could stay Pending in service level agreement
-// when job waits longer than waiting time, it should be inqueue at once, and cluster should reserve resources for it
-const JobWaitingTime = "sla-waiting-time"
+const (
+	// JobWaitingTime is maximum waiting time that a job could stay Pending in service level agreement
+	// when job waits longer than waiting time, it should be inqueue at once, and cluster should reserve resources for it
+	JobWaitingTime = "sla-waiting-time"
+	// CustomLaunch represents whether the job needs a custom launch
+	// true indicates that there is a dependency between tasks
+	CustomLaunch = "volcano.sh/custom-launch"
+)
 
 // TaskID is UID type for Task
 type TaskID types.UID
@@ -309,6 +314,7 @@ type JobInfo struct {
 
 	// All tasks of the Job.
 	TaskStatusIndex       map[TaskStatus]tasksMap
+	TaskStatusCount       map[TaskID]map[TaskStatus]int32
 	Tasks                 tasksMap
 	TaskMinAvailable      map[TaskID]int32
 	TaskMinAvailableTotal int32
@@ -321,7 +327,8 @@ type JobInfo struct {
 
 	ScheduleStartTimestamp metav1.Time
 
-	Preemptable bool
+	Preemptable  bool
+	CustomLaunch bool
 
 	// RevocableZone support set volcano.sh/revocable-zone annotaion or label for pod/podgroup
 	// we only support empty value or * value for this version and we will support specify revocable zone name for futrue release
@@ -340,6 +347,7 @@ func NewJobInfo(uid JobID, tasks ...*TaskInfo) *JobInfo {
 		Allocated:        EmptyResource(),
 		TotalRequest:     EmptyResource(),
 		TaskStatusIndex:  map[TaskStatus]tasksMap{},
+		TaskStatusCount:  map[TaskID]map[TaskStatus]int32{},
 		Tasks:            tasksMap{},
 		TaskMinAvailable: map[TaskID]int32{},
 	}
@@ -383,6 +391,7 @@ func (ji *JobInfo) SetPodGroup(pg *PodGroup) {
 	ji.Preemptable = ji.extractPreemptable(pg)
 	ji.RevocableZone = ji.extractRevocableZone(pg)
 	ji.Budget = ji.extractBudget(pg)
+	ji.CustomLaunch = ji.extractCustomLaunch(pg)
 
 	taskMinAvailableTotal := int32(0)
 	for task, member := range pg.Spec.MinTaskMember {
@@ -476,6 +485,16 @@ func (ji *JobInfo) extractBudget(pg *PodGroup) *DisruptionBudget {
 	return NewDisruptionBudget("", "")
 }
 
+// extractCustomLaunch return whether job has dependencies between tasks
+func (ji *JobInfo) extractCustomLaunch(pg *PodGroup) bool {
+	if sequential, found := pg.Annotations[CustomLaunch]; found {
+		if b, err := strconv.ParseBool(sequential); err == nil {
+			return b
+		}
+	}
+	return false
+}
+
 // GetMinResources return the min resources of podgroup.
 func (ji *JobInfo) GetMinResources() *Resource {
 	if ji.PodGroup.Spec.MinResources == nil {
@@ -497,6 +516,10 @@ func (ji *JobInfo) addTaskIndex(ti *TaskInfo) {
 		ji.TaskStatusIndex[ti.Status] = tasksMap{}
 	}
 	ji.TaskStatusIndex[ti.Status][ti.UID] = ti
+	if _, found := ji.TaskStatusCount[ti.GetTaskSpecKey()]; !found {
+		ji.TaskStatusCount[ti.GetTaskSpecKey()] = make(map[TaskStatus]int32)
+	}
+	ji.TaskStatusCount[ti.GetTaskSpecKey()][ti.Status]++
 }
 
 // AddTaskInfo is used to add a task to a job
@@ -533,6 +556,12 @@ func (ji *JobInfo) UpdateTaskStatus(task *TaskInfo, status TaskStatus) error {
 func (ji *JobInfo) deleteTaskIndex(ti *TaskInfo) {
 	if tasks, found := ji.TaskStatusIndex[ti.Status]; found {
 		delete(tasks, ti.UID)
+		if statusCount, found := ji.TaskStatusCount[ti.GetTaskSpecKey()]; found {
+			statusCount[ti.Status]--
+			if statusCount[ti.Status] == 0 {
+				delete(statusCount, ti.Status)
+			}
+		}
 
 		if len(tasks) == 0 {
 			delete(ji.TaskStatusIndex, ti.Status)
@@ -575,12 +604,14 @@ func (ji *JobInfo) Clone() *JobInfo {
 		PodGroup: ji.PodGroup.Clone(),
 
 		TaskStatusIndex:       map[TaskStatus]tasksMap{},
+		TaskStatusCount:       map[TaskID]map[TaskStatus]int32{},
 		TaskMinAvailable:      ji.TaskMinAvailable,
 		TaskMinAvailableTotal: ji.TaskMinAvailableTotal,
 		Tasks:                 tasksMap{},
 		Preemptable:           ji.Preemptable,
 		RevocableZone:         ji.RevocableZone,
 		Budget:                ji.Budget.Clone(),
+		CustomLaunch:          ji.CustomLaunch,
 	}
 
 	ji.CreationTimestamp.DeepCopyInto(&info.CreationTimestamp)
@@ -695,6 +726,15 @@ func (ji *JobInfo) ReadyTaskNum() int32 {
 
 // WaitingTaskNum returns the number of tasks that are pipelined.
 func (ji *JobInfo) WaitingTaskNum() int32 {
+	if ji.CustomLaunch {
+		var waitingTaskPodNum int32
+		for taskID, minAvailable := range ji.TaskMinAvailable {
+			if _, found := ji.TaskStatusCount[taskID]; !found {
+				waitingTaskPodNum += minAvailable
+			}
+		}
+		return int32(len(ji.TaskStatusIndex[Pipelined])) + waitingTaskPodNum
+	}
 	return int32(len(ji.TaskStatusIndex[Pipelined]))
 }
 
@@ -722,7 +762,11 @@ func (ji *JobInfo) CheckTaskValid() bool {
 		if minAvailable == 0 {
 			continue
 		}
-		if act, ok := actual[task]; !ok || act < minAvailable {
+		act, ok := actual[task]
+		if ji.CustomLaunch && !ok {
+			continue
+		}
+		if !ok || act < minAvailable {
 			return false
 		}
 	}
@@ -754,6 +798,11 @@ func (ji *JobInfo) CheckTaskReady() bool {
 		}
 	}
 	for taskID, minNum := range ji.TaskMinAvailable {
+		_, found := occupiedMap[taskID]
+		// skip check for those waiting task in dag
+		if ji.CustomLaunch && !found {
+			continue
+		}
 		if occupiedMap[taskID] < minNum {
 			klog.V(4).Infof("Job %s/%s Task %s occupied %v less than task min avaliable", ji.Namespace, ji.Name, taskID, occupiedMap[taskID])
 			return false
@@ -788,7 +837,7 @@ func (ji *JobInfo) CheckTaskPipelined() bool {
 	}
 	for taskID, minNum := range ji.TaskMinAvailable {
 		if occupiedMap[taskID] < minNum {
-			klog.V(4).Infof("Job %s/%s Task %s occupied %v less than task min avaliable", ji.Namespace, ji.Name, taskID, occupiedMap[taskID])
+			klog.V(4).Infof("Job %s/%s Task %s occupied %v less than task min available", ji.Namespace, ji.Name, taskID, occupiedMap[taskID])
 			return false
 		}
 	}
@@ -830,6 +879,9 @@ func (ji *JobInfo) CheckTaskStarving() bool {
 
 // ValidTaskNum returns the number of tasks that are valid.
 func (ji *JobInfo) ValidTaskNum() int32 {
+	if ji.CustomLaunch {
+		return ji.MinAvailable
+	}
 	occupied := 0
 	for status, tasks := range ji.TaskStatusIndex {
 		if AllocatedStatus(status) ||
@@ -845,6 +897,9 @@ func (ji *JobInfo) ValidTaskNum() int32 {
 
 // Ready returns whether job is ready for run
 func (ji *JobInfo) Ready() bool {
+	if ji.CustomLaunch {
+		return ji.CheckTaskReady()
+	}
 	occupied := ji.ReadyTaskNum()
 
 	return occupied >= ji.MinAvailable
@@ -857,4 +912,29 @@ func (ji *JobInfo) IsPending() bool {
 	}
 
 	return false
+}
+
+// GetWaitingTaskMinResources return the min resources of waiting tasks within dag.
+func (ji *JobInfo) GetWaitingTaskMinResources() *Resource {
+	taskMinAvailable := make(map[TaskID]int32)
+	for k, v := range ji.TaskMinAvailable {
+		taskMinAvailable[k] = v
+	}
+	minResources := ji.GetMinResources()
+
+	for status, tasks := range ji.TaskStatusIndex {
+		if AllocatedStatus(status) ||
+			status == Succeeded {
+			for _, task := range tasks {
+				if minNum, found := taskMinAvailable[getTaskID(task.Pod)]; !found || minNum <= 0 {
+					continue
+				}
+				taskMinAvailable[getTaskID(task.Pod)]--
+				minResources.sub(GetPodResourceWithoutInitContainers(task.Pod))
+			}
+			break
+		}
+	}
+
+	return minResources
 }

--- a/pkg/scheduler/api/job_info_test.go
+++ b/pkg/scheduler/api/job_info_test.go
@@ -79,6 +79,13 @@ func TestAddTaskInfo(t *testing.T) {
 						case01Task4.UID: case01Task4,
 					},
 				},
+				TaskStatusCount: map[TaskID]map[TaskStatus]int32{
+					TaskID(""): {
+						Running: 1,
+						Pending: 1,
+						Bound:   2,
+					},
+				},
 				NodesFitErrors:   make(map[TaskID]*FitErrors),
 				TaskMinAvailable: make(map[TaskID]int32),
 			},
@@ -145,6 +152,12 @@ func TestDeleteTaskInfo(t *testing.T) {
 					Pending: {case01Task1.UID: case01Task1},
 					Running: {case01Task3.UID: case01Task3},
 				},
+				TaskStatusCount: map[TaskID]map[TaskStatus]int32{
+					TaskID(""): {
+						Pending: 1,
+						Running: 1,
+					},
+				},
 				NodesFitErrors:   make(map[TaskID]*FitErrors),
 				TaskMinAvailable: make(map[TaskID]int32),
 			},
@@ -168,6 +181,12 @@ func TestDeleteTaskInfo(t *testing.T) {
 					},
 					Running: {
 						case02Task3.UID: case02Task3,
+					},
+				},
+				TaskStatusCount: map[TaskID]map[TaskStatus]int32{
+					TaskID(""): {
+						Pending: 1,
+						Running: 1,
 					},
 				},
 				NodesFitErrors:   make(map[TaskID]*FitErrors),

--- a/pkg/scheduler/framework/session.go
+++ b/pkg/scheduler/framework/session.go
@@ -212,6 +212,9 @@ func jobStatus(ssn *Session, jobInfo *api.JobInfo) scheduling.PodGroupStatus {
 	// If running tasks && unschedulable, unknown phase
 	if len(jobInfo.TaskStatusIndex[api.Running]) != 0 && unschedulable {
 		status.Phase = scheduling.PodGroupUnknown
+		if jobInfo.CustomLaunch {
+			status.Phase = scheduling.PodGroupInqueue
+		}
 	} else {
 		allocated := 0
 		for status, tasks := range jobInfo.TaskStatusIndex {
@@ -223,6 +226,9 @@ func jobStatus(ssn *Session, jobInfo *api.JobInfo) scheduling.PodGroupStatus {
 		// If there're enough allocated resource, it's running
 		if int32(allocated) >= jobInfo.PodGroup.Spec.MinMember {
 			status.Phase = scheduling.PodGroupRunning
+			if jobInfo.CustomLaunch && int32(allocated) < jobInfo.TaskMinAvailableTotal {
+				status.Phase = scheduling.PodGroupInqueue
+			}
 		} else if jobInfo.PodGroup.Status.Phase != scheduling.PodGroupInqueue {
 			status.Phase = scheduling.PodGroupPending
 		}

--- a/pkg/scheduler/plugins/overcommit/overcommit.go
+++ b/pkg/scheduler/plugins/overcommit/overcommit.go
@@ -92,7 +92,11 @@ func (op *overcommitPlugin) OnSessionOpen(ssn *framework.Session) {
 	for _, job := range ssn.Jobs {
 		// calculate inqueue job resources
 		if job.PodGroup.Status.Phase == scheduling.PodGroupInqueue && job.PodGroup.Spec.MinResources != nil {
-			op.inqueueResource.Add(api.NewResource(*job.PodGroup.Spec.MinResources))
+			if !job.CustomLaunch {
+				op.inqueueResource.Add(api.NewResource(*job.PodGroup.Spec.MinResources))
+			} else {
+				op.inqueueResource.Add(job.GetWaitingTaskMinResources())
+			}
 			continue
 		}
 		// calculate inqueue resource for running jobs

--- a/pkg/scheduler/plugins/proportion/proportion.go
+++ b/pkg/scheduler/plugins/proportion/proportion.go
@@ -142,7 +142,11 @@ func (pp *proportionPlugin) OnSessionOpen(ssn *framework.Session) {
 		}
 
 		if job.PodGroup.Status.Phase == scheduling.PodGroupInqueue {
-			attr.inqueue.Add(job.GetMinResources())
+			if !job.CustomLaunch {
+				attr.inqueue.Add(job.GetMinResources())
+			} else {
+				attr.inqueue.Add(job.GetWaitingTaskMinResources())
+			}
 		}
 
 		// calculate inqueue resource for running jobs

--- a/pkg/webhooks/admission/jobs/validate/admit_job.go
+++ b/pkg/webhooks/admission/jobs/validate/admit_job.go
@@ -122,6 +122,7 @@ func validateJobCreate(job *v1alpha1.Job, reviewResponse *admissionv1.AdmissionR
 	var msg string
 	taskNames := map[string]string{}
 	var totalReplicas int32
+	var taskMinAvailableTotal int32
 
 	if job.Spec.MinAvailable < 0 {
 		reviewResponse.Allowed = false
@@ -177,6 +178,13 @@ func validateJobCreate(job *v1alpha1.Job, reviewResponse *admissionv1.AdmissionR
 
 		// count replicas
 		totalReplicas += task.Replicas
+
+		// count taskMinAvailableTotal
+		if task.MinAvailable != nil {
+			taskMinAvailableTotal += *task.MinAvailable
+		} else {
+			taskMinAvailableTotal += task.Replicas
+		}
 
 		// validate task name
 		if errMsgs := validation.IsDNS1123Label(task.Name); len(errMsgs) > 0 {
@@ -236,6 +244,9 @@ func validateJobCreate(job *v1alpha1.Job, reviewResponse *admissionv1.AdmissionR
 		_, isDag := topoSort(job)
 		if !isDag {
 			msg += " job has dependencies between tasks, but doesn't form a directed acyclic graph(DAG);"
+		}
+		if taskMinAvailableTotal > job.Spec.MinAvailable {
+			msg += fmt.Sprintf("in order to finish task dag, job 'minAvailable' cannot be less than taskMinAvailableTotal: %v", taskMinAvailableTotal)
 		}
 	}
 

--- a/pkg/webhooks/admission/jobs/validate/admit_job_test.go
+++ b/pkg/webhooks/admission/jobs/validate/admit_job_test.go
@@ -1124,7 +1124,7 @@ func TestValidateJobCreate(t *testing.T) {
 					Namespace: namespace,
 				},
 				Spec: v1alpha1.JobSpec{
-					MinAvailable: 1,
+					MinAvailable: 2,
 					Queue:        "default",
 					Tasks: []v1alpha1.TaskSpec{
 						{
@@ -1174,7 +1174,7 @@ func TestValidateJobCreate(t *testing.T) {
 					Namespace: namespace,
 				},
 				Spec: v1alpha1.JobSpec{
-					MinAvailable: 1,
+					MinAvailable: 2,
 					Queue:        "default",
 					Tasks: []v1alpha1.TaskSpec{
 						{


### PR DESCRIPTION
[Task dependency in job](https://github.com/volcano-sh/volcano/blob/master/docs/design/task-launch-order-within-job.md) is supported in Volcano. 
However, the task depends function must remove the gang plugin to run normally.
I'm trying to get the task dag and gang plugin to work together. So I made some simple modifications.
- Special handling for Jobs with task dependencies when check  job valid. 
- keep pg inqueue when task dag is not finished.

Just a simple try, I want to discuss if it is possible.

Signed-off-by: HaoJie Liu <1187851227@qq.com>