### PR TITLE
fix scheduler cache waitforcachesync

### DIFF
--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -85,7 +85,7 @@ func (pc *Scheduler) Run(stopCh <-chan struct{}) {
 	go pc.watchSchedulerConf(stopCh)
 	// Start cache for policy.
 	pc.cache.SetMetricsConf(pc.metricsConf)
-	go pc.cache.Run(stopCh)
+	pc.cache.Run(stopCh)
 	pc.cache.WaitForCacheSync(stopCh)
 	klog.V(2).Infof("scheduler completes Initialization and start to run")
 	go wait.Until(pc.runOnce, pc.schedulePeriod, stopCh)


### PR DESCRIPTION
`informerFactory.Start ` should be called before `informerFactory.WaitForCacheSync` ,and we can not make sure this  in goroutine

> I0621 11:02:51.566519       1 leaderelection.go:258] successfully acquired lease volcano-system/volcano
I0621 11:02:51.566961       1 scheduler.go:90] scheduler completes Initialization and start to run
I0621 11:02:51.567071       1 cache.go:1069] There are <0> Jobs, <0> Queues and <0> Nodes in total for scheduling.
I0621 11:02:51.567087       1 session.go:174] Open Session d9993fe3-f803-4865-a3bf-0e3423126f77 with <0> Job and <0> Queues
I0621 11:02:51.567322       1 enqueue.go:44] Enter Enqueue ...
I0621 11:02:51.567335       1 enqueue.go:78] Try to enqueue PodGroup to 0 Queues
I0621 11:02:51.567342       1 enqueue.go:103] Leaving Enqueue ...