### PR TITLE
fix defaultMetricsInternal variable

### DIFF
--- a/pkg/scheduler/cache/cache.go
+++ b/pkg/scheduler/cache/cache.go
@@ -71,7 +71,7 @@ const (
 	// record name of mem average usage defined in prometheus rules
 	memUsageAvg = "mem_usage_avg"
 	// default interval for sync data from metrics server, the value is 5s
-	defaultMetricsInternal = 5
+	defaultMetricsInternal = 5000000000
 )
 
 func init() {


### PR DESCRIPTION
defaultMetricsInternal `5` means 5 nanoseconds, not 5 seconds

Signed-off-by: Tian Qiu <329508111@qq.com>