### PR TITLE
Support JobReady for extender plugin

### DIFF
--- a/pkg/scheduler/plugins/extender/argument.go
+++ b/pkg/scheduler/plugins/extender/argument.go
@@ -62,3 +62,11 @@ type QueueOverusedRequest struct {
 type QueueOverusedResponse struct {
 	Overused bool `json:"overused"`
 }
+
+type JobReadyRequest struct {
+	Job *api.JobInfo `json:"job"`
+}
+
+type JobReadyResponse struct {
+	Status bool `json:"status"`
+}


### PR DESCRIPTION
#2335
Add JobReady verb for extender plugin to support extender scheduler do something like pod updates after node predicates.