### PR TITLE
change e2e dependencies of makefile

### DIFF
--- a/.github/workflows/e2e_parallel_jobs.yaml
+++ b/.github/workflows/e2e_parallel_jobs.yaml
@@ -38,5 +38,4 @@ jobs:
 
       - name: Run E2E Tests
         run: |
-          make images CC=/usr/local/musl/bin/musl-gcc
-          make e2e-test-jobp
+          make e2e-test-jobp CC=/usr/local/musl/bin/musl-gcc

--- a/.github/workflows/e2e_scheduling_actions.yaml
+++ b/.github/workflows/e2e_scheduling_actions.yaml
@@ -38,5 +38,4 @@ jobs:
 
       - name: Run E2E Tests
         run: |
-          make images CC=/usr/local/musl/bin/musl-gcc
-          make e2e-test-schedulingaction
+          make e2e-test-schedulingaction CC=/usr/local/musl/bin/musl-gcc

--- a/.github/workflows/e2e_scheduling_basic.yaml
+++ b/.github/workflows/e2e_scheduling_basic.yaml
@@ -38,5 +38,4 @@ jobs:
 
       - name: Run E2E Tests
         run: |
-          make images CC=/usr/local/musl/bin/musl-gcc
-          make e2e-test-schedulingbase
+          make e2e-test-schedulingbase CC=/usr/local/musl/bin/musl-gcc

--- a/.github/workflows/e2e_sequence.yaml
+++ b/.github/workflows/e2e_sequence.yaml
@@ -38,5 +38,4 @@ jobs:
 
       - name: Run E2E Tests
         run: |
-          make images CC=/usr/local/musl/bin/musl-gcc
-          make e2e-test-jobseq
+          make e2e-test-jobseq CC=/usr/local/musl/bin/musl-gcc

--- a/.github/workflows/e2e_vcctl.yaml
+++ b/.github/workflows/e2e_vcctl.yaml
@@ -38,6 +38,4 @@ jobs:
 
       - name: Run E2E Tests
         run: |
-          make vcctl
-          make images CC=/usr/local/musl/bin/musl-gcc
-          make e2e-test-vcctl
+          make e2e-test-vcctl CC=/usr/local/musl/bin/musl-gcc

--- a/Makefile
+++ b/Makefile
@@ -121,25 +121,25 @@ unit-test:
 	go clean -testcache
 	go test -p 8 -race $$(find pkg -type f -name '*_test.go' | sed -r 's|/[^/]+$$||' | sort | uniq | sed "s|^|volcano.sh/volcano/|")
 
-e2e:
+e2e: images
 	./hack/run-e2e-kind.sh
 
-e2e-test-schedulingbase:
+e2e-test-schedulingbase: images
 	E2E_TYPE=SCHEDULINGBASE ./hack/run-e2e-kind.sh
 
-e2e-test-schedulingaction:
+e2e-test-schedulingaction: images
 	E2E_TYPE=SCHEDULINGACTION ./hack/run-e2e-kind.sh
 
-e2e-test-jobp:
+e2e-test-jobp: images
 	E2E_TYPE=JOBP ./hack/run-e2e-kind.sh
 
-e2e-test-jobseq:
+e2e-test-jobseq: images
 	E2E_TYPE=JOBSEQ ./hack/run-e2e-kind.sh
 
-e2e-test-vcctl:
+e2e-test-vcctl: vcctl images
 	E2E_TYPE=VCCTL ./hack/run-e2e-kind.sh
 
-e2e-test-stress:
+e2e-test-stress: images
 	E2E_TYPE=STRESS ./hack/run-e2e-kind.sh
 
 generate-yaml: init manifests


### PR DESCRIPTION
before  we run  `make e2e*` should ensure images have aleady exists.