### PR TITLE
Managed and scheduled multiple single pods with podgroup

### DIFF
--- a/docs/user-guide/how_to_schedule_multipe_single_pods_with_podgroup.md
+++ b/docs/user-guide/how_to_schedule_multipe_single_pods_with_podgroup.md
@@ -1,0 +1,103 @@
+# Manage & Schedule multiple single pods with podgroup
+
+## Background
+Volcano can manage single pod when the scheduler of pod is volcano, volcano controller will help to create a podgroup for this pod.
+But it can not manage and schedule multiple single pods in one pg now. And this missing ability is very useful in spark client mode and so on.
+It will also play a role in some scenarios that require multiple single pods to work together (vj cannot be used).
+
+## Key Points
+* Single pods need add two annotations, one is "scheduling.k8s.io/group-name", another is "scheduling.volcano.sh/group-min-resources". Please see the following example.
+* The controller will select the largest  minresource among single pods of the same "scheduling.k8s.io/group-name" annotation to add or update pg.
+* All single pods will be pg's OwnerReference.
+
+## Examples
+1. Create three single pods.
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: busybox1
+  annotations:
+    "scheduling.k8s.io/group-name": "busybox-pg"
+    "scheduling.volcano.sh/group-min-resources": "{\"cpu\":\"100m\",\"memory\":\"128Mi\"}"
+spec:
+  schedulerName: volcano
+  containers:
+    - name: busybox
+      image: busybox:1.28
+      command: ['sh', '-c', 'echo "Hello, busybox1!" && sleep 3600']
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: busybox2
+  annotations:
+    "scheduling.k8s.io/group-name": "busybox-pg"
+    "scheduling.volcano.sh/group-min-resources": "{\"cpu\":\"200m\",\"memory\":\"256Mi\"}"
+spec:
+  schedulerName: volcano
+  containers:
+    - name: busybox
+      image: busybox:1.28
+      command: ['sh', '-c', 'echo "Hello, busybox2!" && sleep 3600']
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: busybox3
+  annotations:
+    "scheduling.k8s.io/group-name": "busybox-pg"
+spec:
+  schedulerName: volcano
+  containers:
+    - name: busybox
+      image: busybox:1.28
+      command: ['sh', '-c', 'echo "Hello, busybox3!" && sleep 3600']
+```
+2. Kubectl describe pg.
+```
+Name:         busybox-pg
+Namespace:    default
+Labels:       <none>
+Annotations:  <none>
+API Version:  scheduling.volcano.sh/v1beta1
+Kind:         PodGroup
+Metadata:
+....
+  Owner References:
+    API Version:           v1
+    Block Owner Deletion:  true
+    Controller:            true
+    Kind:                  Pod
+    Name:                  busybox1
+    UID:                   aebfe6ed-3a4c-48f0-a38b-bc542ed262b4
+    API Version:           v1
+    Block Owner Deletion:  true
+    Controller:            false
+    Kind:                  Pod
+    Name:                  busybox2
+    UID:                   6262515d-1885-442a-b6e1-3878aa26f96a
+    API Version:           v1
+    Block Owner Deletion:  true
+    Controller:            false
+    Kind:                  Pod
+    Name:                  busybox3
+    UID:                   26c217d6-2d30-4282-8959-df0bfca9e07f
+....
+Spec:
+  Min Member:  1
+  Min Resources:
+    Cpu:     200m
+    Memory:  256Mi
+  Queue:     default
+Status:
+....
+Events:
+  Type    Reason     Age                 From     Message
+  ----    ------     ----                ----     -------
+  Normal  Scheduled  25s (x25 over 49s)  volcano  pod group is ready
+```
+
+## Limitations
+* Currently only "scheduling.k8s.io/group-name", "scheduling.volcano.sh/group-min-resources" and "scheduling.volcano.sh/queue-name" are supported.
+* Other properties under PodGroup's Spec cannot be injected through pod annotations.

--- a/pkg/webhooks/admission/pods/validate/admit_pod.go
+++ b/pkg/webhooks/admission/pods/validate/admit_pod.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/klog/v2"
 
 	"volcano.sh/apis/pkg/apis/helpers"
+
 	vcv1beta1 "volcano.sh/apis/pkg/apis/scheduling/v1beta1"
 	commonutil "volcano.sh/volcano/pkg/util"
 	"volcano.sh/volcano/pkg/webhooks/router"
@@ -112,7 +113,7 @@ func validatePod(pod *v1.Pod, reviewResponse *admissionv1.AdmissionResponse) str
 		pgName = pod.Annotations[vcv1beta1.KubeGroupNameAnnotationKey]
 	}
 	if pgName != "" {
-		if err := checkPG(pod, pgName, true); err != nil {
+		if err := checkPG(pod, pgName, util.BelongToVcJob(pod)); err != nil {
 			msg = err.Error()
 			reviewResponse.Allowed = false
 		} else if err := checkPGQueueState(pod, pgName); err != nil {

--- a/pkg/webhooks/admission/pods/validate/admit_pod_test.go
+++ b/pkg/webhooks/admission/pods/validate/admit_pod_test.go
@@ -21,6 +21,8 @@ import (
 	"strings"
 	"testing"
 
+	"volcano.sh/apis/pkg/apis/scheduling"
+
 	admissionv1 "k8s.io/api/admission/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -33,6 +35,7 @@ func TestValidatePod(t *testing.T) {
 
 	namespace := "test"
 	pgName := "podgroup-p1"
+	ownerReferenceController := true
 
 	testCases := []struct {
 		Name           string
@@ -77,6 +80,13 @@ func TestValidatePod(t *testing.T) {
 					Namespace:   namespace,
 					Name:        "volcano-pod-2",
 					Annotations: map[string]string{vcschedulingv1.KubeGroupNameAnnotationKey: pgName},
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion: scheduling.GroupName + "/v1beta1",
+							Kind:       "Job",
+							Controller: &ownerReferenceController,
+						},
+					},
 				},
 				Spec: v1.PodSpec{
 					SchedulerName: "volcano",
@@ -228,6 +238,32 @@ func TestValidatePod(t *testing.T) {
 			ret:            "",
 			ExpectErr:      false,
 			queueName:      "",
+		},
+		// validate volcano pod when pg is assigned manually
+		{
+			Name: "validate volcano pod when pg is assigned manually",
+			Pod: v1.Pod{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "v1",
+					Kind:       "Pod",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: namespace,
+					Name:      "volcano-pod-2",
+					Annotations: map[string]string{
+						vcschedulingv1.KubeGroupNameAnnotationKey:            pgName,
+						vcschedulingv1.VolcanoGroupMinResourcesAnnotationKey: "{\"cpu\":\"200m\",\"memory\":\"128Mi\"}",
+					},
+				},
+				Spec: v1.PodSpec{
+					SchedulerName: "volcano",
+				},
+			},
+
+			reviewResponse: admissionv1.AdmissionResponse{Allowed: true},
+			ret:            "",
+			ExpectErr:      false,
+			disabledPG:     true,
 		},
 	}
 

--- a/pkg/webhooks/util/util.go
+++ b/pkg/webhooks/util/util.go
@@ -17,9 +17,13 @@ limitations under the License.
 package util
 
 import (
+	"strings"
+
 	admissionv1 "k8s.io/api/admission/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog/v2"
+	"volcano.sh/apis/pkg/apis/scheduling"
 )
 
 // ToAdmissionResponse updates the admission response with the input error.
@@ -31,4 +35,14 @@ func ToAdmissionResponse(err error) *admissionv1.AdmissionResponse {
 			Message: err.Error(),
 		},
 	}
+}
+
+// BelongToVcJob Check if pod belongs to vcjob
+func BelongToVcJob(pod *v1.Pod) bool {
+	for _, ownerReference := range pod.OwnerReferences {
+		if *ownerReference.Controller && strings.HasPrefix(ownerReference.APIVersion, scheduling.GroupName) && ownerReference.Kind == "Job" {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
For solve this situation

- When we use spark client model to submit spark job in k8s with volcano scheduler. hope all executors can be managed and scheduled through podgroup.

- hope some single pods can be managed and scheduled through podgroup with volcano.
