### PR TITLE
update cooldown protection plugin and supports the protection of the maximum number of cooldown. 

### DIFF
--- a/docs/user-guide/how_to_use_cdp_plugin.md
+++ b/docs/user-guide/how_to_use_cdp_plugin.md
@@ -4,6 +4,8 @@
 When we need to enable elastic training or serving, preemptible job's pods can be preempted or back to running repeatedly, if no cooldown protection set, these pods can be preempted again after they just started for a short time, this may cause service stability dropped.
 So we add "cdp" plugin to ensure preemptible job's pods can run for at least some time set by user.
 
+In another case, we do not want some tasks always be evicted, which makes it be starved to death, we need a way to protect them.
+
 ## Environment setup
 
 ### Install volcano
@@ -114,10 +116,11 @@ spec:
 1. add annotations in volcano job in format below.
    1. `volcano.sh/preemptable` annotation indicates that job or task is preemptable
    2. `volcano.sh/cooldown-time` annotation indicates cooldown time for the entire job or dedicated task. Value for the annotation indicates cooldown time, valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h". 
-
+   3. `volcano.sh/max-cooldown-times` annotation indicates max number of cooldown(eviction times) for entire job or dedicated task. if the task cooldown times are greater than this value, the task cannot be evicted.
         ```yaml
             volcano.sh/preemptable: "true"
             volcano.sh/cooldown-time: "600s"
+            volcano.sh/max-cooldown-times: "2"
         ```
 
 **Example 1**
@@ -198,4 +201,104 @@ spec:
                   cpu: "1"
           restartPolicy: OnFailure
 
+```
+
+**Example 3**
+
+Add annotation to dedicated task, as shown below, the only task in a job named "test-low-job" can be preempted and have the maximum number of times of cooldown support.
+
+In that case, if the cluster only has 6 CPU cores, the first step users apply a job named "test-low-job", then apply a job named "test-middle-job", after the job named "test-middle-job" is finished, the job named "test-low-job" running again.  At this moment, apply the task job named "test-high-job" can not preempted the task job named "test-low-job". because the cooldown is protected, the job named "test-low-job" can just be preempted one time when set annotation `volcano.sh/max-cooldown-times: "1"`
+```yaml
+apiVersion: batch.volcano.sh/v1alpha1
+kind: Job
+metadata:
+   name: test-low-job
+spec:
+   minAvailable: 3
+   schedulerName: volcano
+   priorityClassName: low-priority
+   maxRetry: 5
+   queue: default
+   tasks:
+      - replicas: 6
+        name: tasks
+        template:
+           metadata:
+              name: worker
+              annotations:
+                 volcano.sh/preemptable: 'true'
+                 volcano.sh/max-cooldown-times: '1'
+           spec:
+              containers:
+                 - image: alpine
+                   imagePullPolicy: IfNotPresent
+                   name: sleep
+                   command:
+                      - /bin/ash
+                      - '-c'
+                      - sleep 3600
+                   resources:
+                      requests:
+                         cpu: '1'
+              restartPolicy: OnFailure
+---
+apiVersion: batch.volcano.sh/v1alpha1
+kind: Job
+metadata:
+   name: test-middle-job
+spec:
+   minAvailable: 3
+   schedulerName: volcano
+   priorityClassName: middle-priority
+   maxRetry: 5
+   queue: default
+   tasks:
+      - replicas: 6
+        name: tasks
+        template:
+           metadata:
+              name: worker
+           spec:
+              containers:
+                 - image: alpine
+                   imagePullPolicy: IfNotPresent
+                   name: sleep
+                   command:
+                      - /bin/ash
+                      - '-c'
+                      - sleep 60
+                   resources:
+                      requests:
+                         cpu: '1'
+              restartPolicy: OnFailure
+---
+apiVersion: batch.volcano.sh/v1alpha1
+kind: Job
+metadata:
+   name: test-high-job
+spec:
+   minAvailable: 3
+   schedulerName: volcano
+   priorityClassName: high-priority
+   maxRetry: 5
+   queue: default
+   tasks:
+      - replicas: 6
+        name: tasks
+        template:
+           metadata:
+              name: worker
+           spec:
+              containers:
+                 - image: alpine
+                   imagePullPolicy: IfNotPresent
+                   name: sleep
+                   command:
+                      - /bin/ash
+                      - '-c'
+                      - sleep 3600
+                   resources:
+                      requests:
+                         cpu: '1'
+              restartPolicy: OnFailure
 ```

--- a/pkg/controllers/job/job_controller_util.go
+++ b/pkg/controllers/job/job_controller_util.go
@@ -118,6 +118,9 @@ func createJobPod(job *batch.Job, template *v1.PodTemplateSpec, topologyPolicy b
 		if value, found := job.Annotations[schedulingv2.CooldownTime]; found {
 			pod.Annotations[schedulingv2.CooldownTime] = value
 		}
+		if value, found := job.Annotations[schedulingv2.MaxCooldownTimes]; found {
+			pod.Annotations[schedulingv2.MaxCooldownTimes] = value
+		}
 		if value, found := job.Annotations[schedulingv2.RevocableZone]; found {
 			pod.Annotations[schedulingv2.RevocableZone] = value
 		}
@@ -144,6 +147,9 @@ func createJobPod(job *batch.Job, template *v1.PodTemplateSpec, topologyPolicy b
 		}
 		if value, found := job.Labels[schedulingv2.CooldownTime]; found {
 			pod.Labels[schedulingv2.CooldownTime] = value
+		}
+		if value, found := job.Labels[schedulingv2.MaxCooldownTimes]; found {
+			pod.Labels[schedulingv2.MaxCooldownTimes] = value
 		}
 	}
 

--- a/pkg/controllers/podgroup/pg_controller_handler.go
+++ b/pkg/controllers/podgroup/pg_controller_handler.go
@@ -160,6 +160,9 @@ func (pg *pgcontroller) createNormalPodPGIfNotExist(pod *v1.Pod) error {
 		if value, ok := pod.Annotations[scheduling.CooldownTime]; ok {
 			obj.Annotations[scheduling.CooldownTime] = value
 		}
+		if value, ok := pod.Annotations[scheduling.MaxCooldownTimes]; ok {
+			obj.Annotations[scheduling.MaxCooldownTimes] = value
+		}
 		if value, ok := pod.Annotations[scheduling.RevocableZone]; ok {
 			obj.Annotations[scheduling.RevocableZone] = value
 		}
@@ -168,6 +171,9 @@ func (pg *pgcontroller) createNormalPodPGIfNotExist(pod *v1.Pod) error {
 		}
 		if value, ok := pod.Labels[scheduling.CooldownTime]; ok {
 			obj.Labels[scheduling.CooldownTime] = value
+		}
+		if value, ok := pod.Labels[scheduling.MaxCooldownTimes]; ok {
+			obj.Labels[scheduling.MaxCooldownTimes] = value
 		}
 
 		if value, found := pod.Annotations[scheduling.JDBMinAvailable]; found {

--- a/pkg/scheduler/cache/cache.go
+++ b/pkg/scheduler/cache/cache.go
@@ -23,6 +23,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/prometheus/client_golang/api"
@@ -695,6 +696,13 @@ func (sc *SchedulerCache) Evict(taskInfo *schedulingapi.TaskInfo, reason string)
 			sc.resyncTask(task)
 		}
 		return err
+	}
+
+	// Update task eviction times recode in JobInfo
+	if job.Preemptable {
+		if times, ok := job.TaskCooldownTimesRecord[task.Name]; ok {
+			atomic.AddInt32(times, 1)
+		}
 	}
 
 	p := task.Pod

--- a/vendor/volcano.sh/apis/pkg/apis/scheduling/v1beta1/labels.go
+++ b/vendor/volcano.sh/apis/pkg/apis/scheduling/v1beta1/labels.go
@@ -46,6 +46,10 @@ const PodPreemptable = "volcano.sh/preemptable"
 // Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
 const CooldownTime = "volcano.sh/cooldown-time"
 
+// MaxCooldownTimes is the annotation key of Pod to set maximum number of cooldown(evictions),
+//value's format "0", 1. 0 means no limit.
+const MaxCooldownTimes = "volcano.sh/max-cooldown-times"
+
 //RevocableZone is the key of revocable-zone
 const RevocableZone = "volcano.sh/revocable-zone"
 

--- a/vendor/volcano.sh/apis/pkg/apis/scheduling/v1beta1/labels.go
+++ b/vendor/volcano.sh/apis/pkg/apis/scheduling/v1beta1/labels.go
@@ -46,10 +46,6 @@ const PodPreemptable = "volcano.sh/preemptable"
 // Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
 const CooldownTime = "volcano.sh/cooldown-time"
 
-// MaxCooldownTimes is the annotation key of Pod to set maximum number of cooldown(evictions),
-//value's format "0", 1. 0 means no limit.
-const MaxCooldownTimes = "volcano.sh/max-cooldown-times"
-
 //RevocableZone is the key of revocable-zone
 const RevocableZone = "volcano.sh/revocable-zone"
 


### PR DESCRIPTION
as issue https://github.com/volcano-sh/volcano/pull/2149 describes, now cdp plugin supports the protection of the maximum number of cooldown.

issue: #2362 provide a new label/annotation named "volcano.sh/max-cooldown-times", whose value means the  max number of cooldown(eviction times) for entire job or dedicated task. if the task cooldown times are greater than this value, the task cannot be evicted.

update `cdp` plugin to participate in preempting action, and ensure pods that belong to protected tasks will be not in the result victims list.