### PR TITLE
add csiNode cache for plugin

### DIFF
--- a/pkg/scheduler/api/cluster_info.go
+++ b/pkg/scheduler/api/cluster_info.go
@@ -28,6 +28,7 @@ type ClusterInfo struct {
 	NamespaceInfo  map[NamespaceName]*NamespaceInfo
 	RevocableNodes map[string]*NodeInfo
 	NodeList       []string
+	CSINodesStatus map[string]*CSINodeStatusInfo
 }
 
 func (ci ClusterInfo) String() string {

--- a/pkg/scheduler/api/node_info.go
+++ b/pkg/scheduler/api/node_info.go
@@ -35,6 +35,11 @@ func (o *AllocateFailError) Error() string {
 	return o.Reason
 }
 
+type CSINodeStatusInfo struct {
+	CSINodeName  string
+	DriverStatus map[string]bool
+}
+
 // NodeInfo is node level aggregated information.
 type NodeInfo struct {
 	Name string
@@ -606,4 +611,15 @@ func (ni *NodeInfo) getUnhealthyGPUs(node *v1.Node) (unhealthyGPUs []int) {
 		}
 	}
 	return
+}
+
+func (cs *CSINodeStatusInfo) Clone() *CSINodeStatusInfo {
+	newcs := &CSINodeStatusInfo{
+		CSINodeName:  cs.CSINodeName,
+		DriverStatus: make(map[string]bool),
+	}
+	for k, v := range cs.DriverStatus {
+		newcs.DriverStatus[k] = v
+	}
+	return newcs
 }

--- a/pkg/scheduler/cache/event_handlers.go
+++ b/pkg/scheduler/cache/event_handlers.go
@@ -19,6 +19,7 @@ package cache
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"strconv"
 
 	v1 "k8s.io/api/core/v1"
@@ -30,6 +31,7 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/cm/cpumanager/topology"
 	"k8s.io/kubernetes/pkg/kubelet/cm/cpuset"
 
+	sv1 "k8s.io/api/storage/v1"
 	nodeinfov1alpha1 "volcano.sh/apis/pkg/apis/nodeinfo/v1alpha1"
 	"volcano.sh/apis/pkg/apis/scheduling"
 	"volcano.sh/apis/pkg/apis/scheduling/scheme"
@@ -400,6 +402,69 @@ func (sc *SchedulerCache) DeleteNode(obj interface{}) {
 			break
 		}
 	}
+}
+
+func (sc *SchedulerCache) AddOrUpdateCSINode(obj interface{}) {
+	csiNode, ok := obj.(*sv1.CSINode)
+	if !ok {
+		return
+	}
+
+	var csiNodeStatus *schedulingapi.CSINodeStatusInfo
+	var found bool
+	sc.Mutex.Lock()
+	defer sc.Mutex.Unlock()
+	// update nodeVolumeCount
+
+	if csiNodeStatus, found = sc.CSINodesStatus[csiNode.Name]; !found {
+		csiNodeStatus = &schedulingapi.CSINodeStatusInfo{
+			CSINodeName:  csiNode.Name,
+			DriverStatus: make(map[string]bool),
+		}
+		sc.CSINodesStatus[csiNode.Name] = csiNodeStatus
+	}
+
+	for i := range csiNode.Spec.Drivers {
+		d := csiNode.Spec.Drivers[i]
+		csiNodeStatus.DriverStatus[d.Name] = d.Allocatable != nil && d.Allocatable.Count != nil
+	}
+}
+
+func (sc *SchedulerCache) UpdateCSINode(oldObj, newObj interface{}) {
+	oldCSINode, ok := oldObj.(*sv1.CSINode)
+	if !ok {
+		return
+	}
+	newCSINode, ok := newObj.(*sv1.CSINode)
+	if !ok {
+		return
+	}
+	if reflect.DeepEqual(oldCSINode.Spec, newCSINode.Spec) {
+		return
+	}
+	sc.AddOrUpdateCSINode(newObj)
+}
+
+func (sc *SchedulerCache) DeleteCSINode(obj interface{}) {
+	var csiNode *sv1.CSINode
+	switch t := obj.(type) {
+	case *sv1.CSINode:
+		csiNode = obj.(*sv1.CSINode)
+	case cache.DeletedFinalStateUnknown:
+		var ok bool
+		csiNode, ok = t.Obj.(*sv1.CSINode)
+		if !ok {
+			klog.Errorf("Cannot convert to *sv1.CSINode: %v", obj)
+			return
+		}
+	default:
+		klog.Errorf("Cannot convert to *sv1.CSINode: %v", obj)
+		return
+	}
+
+	sc.Mutex.Lock()
+	delete(sc.CSINodesStatus, csiNode.Name)
+	sc.Mutex.Unlock()
 }
 
 func getJobID(pg *schedulingapi.PodGroup) schedulingapi.JobID {


### PR DESCRIPTION
Signed-off-by: wpeng102 <wpeng102@126.com>

For internal CSI plugin, it requre scheduler cache maintains a `csiNodes` just like `Nodes` in cache.