### PR TITLE
Move volcano-monitoring namespace creation

### DIFF
--- a/hack/generate-yaml.sh
+++ b/hack/generate-yaml.sh
@@ -107,7 +107,7 @@ if [[ -f ${MONITOR_DEPLOYMENT_YAML_FILENAME} ]];then
     rm ${MONITOR_DEPLOYMENT_YAML_FILENAME}
 fi
 
-cat ${VK_ROOT}/installer/namespace.yaml > ${DEPLOYMENT_FILE}
+cat ${VK_ROOT}/installer/volcano-system-namespace.yaml > ${DEPLOYMENT_FILE}
 ${HELM_BIN_DIR}/helm template ${VK_ROOT}/installer/helm/chart/volcano --namespace volcano-system \
       --name-template volcano --set basic.image_tag_version=${VOLCANO_IMAGE_TAG} --set basic.crd_version=${CRD_VERSION}\
       -s templates/admission.yaml \
@@ -120,6 +120,7 @@ ${HELM_BIN_DIR}/helm template ${VK_ROOT}/installer/helm/chart/volcano --namespac
       -s templates/nodeinfo_v1alpha1_numatopologies.yaml \
       >> ${DEPLOYMENT_FILE}
 
+cat ${VK_ROOT}/installer/volcano-monitoring-namespace.yaml > ${MONITOR_DEPLOYMENT_YAML_FILENAME}
 ${HELM_BIN_DIR}/helm template ${VK_ROOT}/installer/helm/chart/volcano --namespace volcano-monitoring \
       --name-template volcano --set basic.image_tag_version=${VOLCANO_IMAGE_TAG} --set custom.metrics_enable=true \
       -s templates/prometheus.yaml \

--- a/installer/volcano-development-arm64.yaml
+++ b/installer/volcano-development-arm64.yaml
@@ -3,11 +3,6 @@ kind: Namespace
 metadata:
   name: volcano-system
 ---
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: volcano-monitoring 
----
 # Source: volcano/templates/admission.yaml
 apiVersion: v1
 kind: ServiceAccount

--- a/installer/volcano-development.yaml
+++ b/installer/volcano-development.yaml
@@ -3,11 +3,6 @@ kind: Namespace
 metadata:
   name: volcano-system
 ---
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: volcano-monitoring 
----
 # Source: volcano/templates/admission.yaml
 apiVersion: v1
 kind: ServiceAccount

--- a/installer/volcano-monitoring-latest.yaml
+++ b/installer/volcano-monitoring-latest.yaml
@@ -1,3 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: volcano-monitoring
 ---
 # Source: volcano/templates/prometheus.yaml
 apiVersion: v1

--- a/installer/volcano-monitoring-namespace.yaml
+++ b/installer/volcano-monitoring-namespace.yaml
@@ -1,9 +1,4 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: volcano-system
----
-apiVersion: v1
-kind: Namespace
-metadata:
   name: volcano-monitoring 

--- a/installer/volcano-system-namespace.yaml
+++ b/installer/volcano-system-namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: volcano-system


### PR DESCRIPTION
Issue: #2373 
Move volcano-monitoring namespace creation in [volcano-monitoring-latest.yaml](https://github.com/volcano-sh/volcano/blob/master/installer/volcano-monitoring-latest.yaml) file.