### PR TITLE
add rest config into ssn

### DIFF
--- a/pkg/scheduler/cache/cache.go
+++ b/pkg/scheduler/cache/cache.go
@@ -92,6 +92,7 @@ type SchedulerCache struct {
 	sync.Mutex
 
 	kubeClient   *kubernetes.Clientset
+	restConfig   *rest.Config
 	vcClient     *vcclient.Clientset
 	defaultQueue string
 	// schedulerName is the name for volcano scheduler
@@ -412,6 +413,7 @@ func newSchedulerCache(config *rest.Config, schedulerName string, defaultQueue s
 		DeletedJobs:         workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter()),
 		kubeClient:          kubeClient,
 		vcClient:            vcClient,
+		restConfig:          config,
 		defaultQueue:        defaultQueue,
 		schedulerName:       schedulerName,
 		nodeSelectorLabels:  make(map[string]string),
@@ -778,6 +780,11 @@ func (sc *SchedulerCache) RevertVolumes(task *schedulingapi.TaskInfo, podVolumes
 // Client returns the kubernetes clientSet
 func (sc *SchedulerCache) Client() kubernetes.Interface {
 	return sc.kubeClient
+}
+
+// ClientConfig returns the rest config
+func (sc *SchedulerCache) ClientConfig() *rest.Config {
+	return sc.restConfig
 }
 
 // SharedInformerFactory returns the scheduler SharedInformerFactory

--- a/pkg/scheduler/cache/interface.go
+++ b/pkg/scheduler/cache/interface.go
@@ -20,6 +20,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/record"
 	scheduling "k8s.io/kubernetes/pkg/scheduler/framework/plugins/volumebinding"
 
@@ -69,6 +70,9 @@ type Cache interface {
 
 	// Client returns the kubernetes clientSet, which can be used by plugins
 	Client() kubernetes.Interface
+
+	// ClientConfig returns the rest config
+	ClientConfig() *rest.Config
 
 	UpdateSchedulerNumaInfo(sets map[string]api.ResNumaSets) error
 

--- a/pkg/scheduler/framework/session.go
+++ b/pkg/scheduler/framework/session.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/klog"
 	"volcano.sh/apis/pkg/apis/scheduling"
@@ -45,6 +46,7 @@ type Session struct {
 	kubeClient      kubernetes.Interface
 	recorder        record.EventRecorder
 	cache           cache.Cache
+	restConfig      *rest.Config
 	informerFactory informers.SharedInformerFactory
 
 	TotalResource *api.Resource
@@ -94,6 +96,7 @@ func openSession(cache cache.Cache) *Session {
 	ssn := &Session{
 		UID:             uuid.NewUUID(),
 		kubeClient:      cache.Client(),
+		restConfig:      cache.ClientConfig(),
 		recorder:        cache.EventRecorder(),
 		cache:           cache,
 		informerFactory: cache.SharedInformerFactory(),
@@ -464,6 +467,11 @@ func (ssn *Session) UpdateSchedulerNumaInfo(AllocatedSets map[string]api.ResNuma
 // KubeClient returns the kubernetes client
 func (ssn Session) KubeClient() kubernetes.Interface {
 	return ssn.kubeClient
+}
+
+// ClientConfig returns the rest client
+func (ssn Session) ClientConfig() *rest.Config {
+	return ssn.restConfig
 }
 
 // InformerFactory returns the scheduler ShareInformerFactory


### PR DESCRIPTION
Signed-off-by: wpeng102 <wpeng102@126.com>

Customer maybe introduce CRD resource for scheduling. So in scheduler plugin,  customer maybe need construct this CRD's informer. Currently ssn only provide kubeclient for plugin, we need provide restconfig for customer to init customer resource client. 