### PR TITLE
use patch to replace update pod operator

### DIFF
--- a/installer/helm/chart/volcano/templates/controllers.yaml
+++ b/installer/helm/chart/volcano/templates/controllers.yaml
@@ -28,7 +28,7 @@ rules:
     verbs: ["create", "list", "watch", "update", "patch"]
   - apiGroups: [""]
     resources: ["pods"]
-    verbs: ["create", "get", "list", "watch", "update", "bind", "delete"]
+    verbs: ["create", "get", "list", "watch", "update", "bind", "delete", "patch"]
   - apiGroups: [""]
     resources: ["pods/finalizers"]
     verbs: ["update", "patch"]

--- a/installer/volcano-development-arm64.yaml
+++ b/installer/volcano-development-arm64.yaml
@@ -8433,7 +8433,7 @@ rules:
     verbs: ["create", "list", "watch", "update", "patch"]
   - apiGroups: [""]
     resources: ["pods"]
-    verbs: ["create", "get", "list", "watch", "update", "bind", "delete"]
+    verbs: ["create", "get", "list", "watch", "update", "bind", "delete", "patch"]
   - apiGroups: [""]
     resources: ["pods/finalizers"]
     verbs: ["update", "patch"]

--- a/installer/volcano-development.yaml
+++ b/installer/volcano-development.yaml
@@ -8433,7 +8433,7 @@ rules:
     verbs: ["create", "list", "watch", "update", "patch"]
   - apiGroups: [""]
     resources: ["pods"]
-    verbs: ["create", "get", "list", "watch", "update", "bind", "delete"]
+    verbs: ["create", "get", "list", "watch", "update", "bind", "delete", "patch"]
   - apiGroups: [""]
     resources: ["pods/finalizers"]
     verbs: ["update", "patch"]

--- a/pkg/controllers/podgroup/pg_controller_test.go
+++ b/pkg/controllers/podgroup/pg_controller_test.go
@@ -170,7 +170,12 @@ func TestAddPodGroup(t *testing.T) {
 			t.Errorf("Case %s failed, expect %v, got %v", testCase.name, testCase.expectedPodGroup, pg)
 		}
 
-		podAnnotation := pod.Annotations[scheduling.KubeGroupNameAnnotationKey]
+		newpod, err := c.kubeClient.CoreV1().Pods(testCase.pod.Namespace).Get(context.TODO(), pod.Name, metav1.GetOptions{})
+		if err != nil {
+			t.Errorf("Case %s failed when creating pod for %v", testCase.name, err)
+		}
+
+		podAnnotation := newpod.Annotations[scheduling.KubeGroupNameAnnotationKey]
 		if testCase.expectedPodGroup.Name != podAnnotation {
 			t.Errorf("Case %s failed, expect %v, got %v", testCase.name,
 				testCase.expectedPodGroup.Name, podAnnotation)


### PR DESCRIPTION
Signed-off-by: wpeng102 <wpeng102@126.com>

Sometimes pg controller update pod annotation will failed due to pod resource version check.  We can use `path` operator to replace `Update ` operator. 