### PR TITLE
support multi scheduler name for scheduler and webhook

### DIFF
--- a/cmd/scheduler/app/options/options.go
+++ b/cmd/scheduler/app/options/options.go
@@ -45,7 +45,7 @@ const (
 // ServerOption is the main context object for the controller manager.
 type ServerOption struct {
 	KubeClientOptions    kube.ClientOptions
-	SchedulerName        string
+	SchedulerNames       []string
 	SchedulerConf        string
 	SchedulePeriod       time.Duration
 	EnableLeaderElection bool
@@ -83,7 +83,7 @@ func (s *ServerOption) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&s.KubeClientOptions.Master, "master", s.KubeClientOptions.Master, "The address of the Kubernetes API server (overrides any value in kubeconfig)")
 	fs.StringVar(&s.KubeClientOptions.KubeConfig, "kubeconfig", s.KubeClientOptions.KubeConfig, "Path to kubeconfig file with authorization and master location information")
 	// volcano scheduler will ignore pods with scheduler names other than specified with the option
-	fs.StringVar(&s.SchedulerName, "scheduler-name", defaultSchedulerName, "vc-scheduler will handle pods whose .spec.SchedulerName is same as scheduler-name")
+	fs.StringArrayVar(&s.SchedulerNames, "scheduler-name", []string{defaultSchedulerName}, "vc-scheduler will handle pods whose .spec.SchedulerName is same as scheduler-name")
 	fs.StringVar(&s.SchedulerConf, "scheduler-conf", "", "The absolute path of scheduler configuration file")
 	fs.DurationVar(&s.SchedulePeriod, "schedule-period", defaultSchedulerPeriod, "The period between each scheduling cycle")
 	fs.StringVar(&s.DefaultQueue, "default-queue", defaultQueue, "The default queue name of the job")

--- a/cmd/scheduler/app/options/options_test.go
+++ b/cmd/scheduler/app/options/options_test.go
@@ -39,7 +39,7 @@ func TestAddFlags(t *testing.T) {
 
 	// This is a snapshot of expected options parsed by args.
 	expected := &ServerOption{
-		SchedulerName:  defaultSchedulerName,
+		SchedulerNames: []string{defaultSchedulerName},
 		SchedulePeriod: 5 * time.Minute,
 		DefaultQueue:   defaultQueue,
 		ListenAddress:  defaultListenAddress,

--- a/cmd/scheduler/app/server.go
+++ b/cmd/scheduler/app/server.go
@@ -31,6 +31,7 @@ import (
 	"volcano.sh/volcano/pkg/scheduler"
 	"volcano.sh/volcano/pkg/scheduler/framework"
 	"volcano.sh/volcano/pkg/signals"
+	commonutil "volcano.sh/volcano/pkg/util"
 	"volcano.sh/volcano/pkg/version"
 
 	v1 "k8s.io/api/core/v1"
@@ -74,7 +75,7 @@ func Run(opt *options.ServerOption) error {
 	}
 
 	sched, err := scheduler.NewScheduler(config,
-		opt.SchedulerName,
+		opt.SchedulerNames,
 		opt.SchedulerConf,
 		opt.SchedulePeriod,
 		opt.DefaultQueue,
@@ -115,7 +116,7 @@ func Run(opt *options.ServerOption) error {
 	// Prepare event clients.
 	broadcaster := record.NewBroadcaster()
 	broadcaster.StartRecordingToSink(&corev1.EventSinkImpl{Interface: leaderElectionClient.CoreV1().Events(opt.LockObjectNamespace)})
-	eventRecorder := broadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: opt.SchedulerName})
+	eventRecorder := broadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: commonutil.GenerateComponentName(opt.SchedulerNames)})
 
 	hostname, err := os.Hostname()
 	if err != nil {
@@ -126,7 +127,7 @@ func Run(opt *options.ServerOption) error {
 
 	rl, err := resourcelock.New(resourcelock.ConfigMapsResourceLock,
 		opt.LockObjectNamespace,
-		opt.SchedulerName,
+		commonutil.GenerateComponentName(opt.SchedulerNames),
 		leaderElectionClient.CoreV1(),
 		leaderElectionClient.CoordinationV1(),
 		resourcelock.ResourceLockConfig{

--- a/cmd/webhook-manager/app/options/options.go
+++ b/cmd/webhook-manager/app/options/options.go
@@ -47,7 +47,7 @@ type Config struct {
 	PrintVersion      bool
 	WebhookName       string
 	WebhookNamespace  string
-	SchedulerName     string
+	SchedulerNames    []string
 	WebhookURL        string
 	ConfigPath        string
 	EnabledAdmission  string
@@ -80,7 +80,7 @@ func (c *Config) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&c.WebhookName, "webhook-service-name", "", "The name of this webhook")
 	fs.StringVar(&c.WebhookURL, "webhook-url", "", "The url of this webhook")
 	fs.StringVar(&c.EnabledAdmission, "enabled-admission", defaultEnabledAdmission, "enabled admission webhooks")
-	fs.StringVar(&c.SchedulerName, "scheduler-name", defaultSchedulerName, "Volcano will handle pods whose .spec.SchedulerName is same as scheduler-name")
+	fs.StringArrayVar(&c.SchedulerNames, "scheduler-name", []string{defaultSchedulerName}, "Volcano will handle pods whose .spec.SchedulerName is same as scheduler-name")
 	fs.StringVar(&c.ConfigPath, "admission-conf", "", "The configmap file of this webhook")
 	fs.StringVar(&c.IgnoredNamespaces, "ignored-namespaces", defaultIgnoredNamespaces, "Comma-separated list of namespaces to be ignored by admission webhooks")
 }

--- a/cmd/webhook-manager/app/server.go
+++ b/cmd/webhook-manager/app/server.go
@@ -32,6 +32,7 @@ import (
 	"volcano.sh/apis/pkg/apis/scheduling/scheme"
 	"volcano.sh/volcano/cmd/webhook-manager/app/options"
 	"volcano.sh/volcano/pkg/kube"
+	commonutil "volcano.sh/volcano/pkg/util"
 	"volcano.sh/volcano/pkg/version"
 	wkconfig "volcano.sh/volcano/pkg/webhooks/config"
 	"volcano.sh/volcano/pkg/webhooks/router"
@@ -65,12 +66,12 @@ func Run(config *options.Config) error {
 
 	broadcaster := record.NewBroadcaster()
 	broadcaster.StartRecordingToSink(&corev1.EventSinkImpl{Interface: kubeClient.CoreV1().Events("")})
-	recorder := broadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: config.SchedulerName})
+	recorder := broadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: commonutil.GenerateComponentName(config.SchedulerNames)})
 	router.ForEachAdmission(config, func(service *router.AdmissionService) {
 		if service.Config != nil {
 			service.Config.VolcanoClient = vClient
 			service.Config.KubeClient = kubeClient
-			service.Config.SchedulerName = config.SchedulerName
+			service.Config.SchedulerNames = config.SchedulerNames
 			service.Config.Recorder = recorder
 			service.Config.ConfigData = admissionConf
 		}

--- a/pkg/controllers/podgroup/pg_controller.go
+++ b/pkg/controllers/podgroup/pg_controller.go
@@ -33,6 +33,7 @@ import (
 	schedulinginformer "volcano.sh/apis/pkg/client/informers/externalversions/scheduling/v1beta1"
 	schedulinglister "volcano.sh/apis/pkg/client/listers/scheduling/v1beta1"
 	"volcano.sh/volcano/pkg/controllers/framework"
+	commonutil "volcano.sh/volcano/pkg/util"
 )
 
 func init() {
@@ -137,7 +138,7 @@ func (pg *pgcontroller) processNextReq() bool {
 		return true
 	}
 
-	if !contains(pg.schedulerNames, pod.Spec.SchedulerName) {
+	if !commonutil.Contains(pg.schedulerNames, pod.Spec.SchedulerName) {
 		klog.V(5).Infof("pod %v/%v field SchedulerName is not matched", pod.Namespace, pod.Name)
 		return true
 	}
@@ -158,13 +159,4 @@ func (pg *pgcontroller) processNextReq() bool {
 	pg.queue.Forget(req)
 
 	return true
-}
-
-func contains(slice []string, element string) bool {
-	for _, item := range slice {
-		if item == element {
-			return true
-		}
-	}
-	return false
 }

--- a/pkg/scheduler/cache/cache_test.go
+++ b/pkg/scheduler/cache/cache_test.go
@@ -105,9 +105,9 @@ func TestGetOrCreateJob(t *testing.T) {
 	pi3 := api.NewTaskInfo(pod3)
 
 	cache := &SchedulerCache{
-		Nodes:         make(map[string]*api.NodeInfo),
-		Jobs:          make(map[api.JobID]*api.JobInfo),
-		schedulerName: "volcano",
+		Nodes:          make(map[string]*api.NodeInfo),
+		Jobs:           make(map[api.JobID]*api.JobInfo),
+		schedulerNames: []string{"volcano"},
 	}
 
 	tests := []struct {

--- a/pkg/scheduler/cache/event_handlers.go
+++ b/pkg/scheduler/cache/event_handlers.go
@@ -39,6 +39,7 @@ import (
 	"volcano.sh/apis/pkg/apis/utils"
 	schedulingapi "volcano.sh/volcano/pkg/scheduler/api"
 	"volcano.sh/volcano/pkg/scheduler/metrics"
+	commonutil "volcano.sh/volcano/pkg/util"
 )
 
 func isTerminated(status schedulingapi.TaskStatus) bool {
@@ -49,9 +50,9 @@ func isTerminated(status schedulingapi.TaskStatus) bool {
 // pi.Pod.Spec.SchedulerName is same as volcano scheduler's name, otherwise it will return nil.
 func (sc *SchedulerCache) getOrCreateJob(pi *schedulingapi.TaskInfo) *schedulingapi.JobInfo {
 	if len(pi.Job) == 0 {
-		if pi.Pod.Spec.SchedulerName != sc.schedulerName {
-			klog.V(4).Infof("Pod %s/%s will not scheduled by %s, skip creating PodGroup and Job for it",
-				pi.Pod.Namespace, pi.Pod.Name, sc.schedulerName)
+		if !commonutil.Contains(sc.schedulerNames, pi.Pod.Spec.SchedulerName) {
+			klog.V(4).Infof("Pod %s/%s will not scheduled by %#v, skip creating PodGroup and Job for it",
+				pi.Pod.Namespace, pi.Pod.Name, sc.schedulerNames)
 		}
 		return nil
 	}

--- a/pkg/scheduler/cache/util.go
+++ b/pkg/scheduler/cache/util.go
@@ -27,13 +27,14 @@ import (
 	"stathat.com/c/consistent"
 
 	scheduling "volcano.sh/apis/pkg/apis/scheduling/v1beta1"
+	commonutil "volcano.sh/volcano/pkg/util"
 )
 
 // responsibleForPod returns false at following conditions:
 // 1. The current scheduler is not specified scheduler in Pod's spec.
 // 2. The Job which the Pod belongs is not assigned to current scheduler based on the hash algorithm in multi-schedulers scenario
-func responsibleForPod(pod *v1.Pod, schedulerName string, mySchedulerPodName string, c *consistent.Consistent) bool {
-	if schedulerName != pod.Spec.SchedulerName {
+func responsibleForPod(pod *v1.Pod, schedulerNames []string, mySchedulerPodName string, c *consistent.Consistent) bool {
+	if !commonutil.Contains(schedulerNames, pod.Spec.SchedulerName) {
 		return false
 	}
 	if c != nil {

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -53,7 +53,7 @@ type Scheduler struct {
 // NewScheduler returns a scheduler
 func NewScheduler(
 	config *rest.Config,
-	schedulerName string,
+	schedulerNames []string,
 	schedulerConf string,
 	period time.Duration,
 	defaultQueue string,
@@ -72,7 +72,7 @@ func NewScheduler(
 	scheduler := &Scheduler{
 		schedulerConf:  schedulerConf,
 		fileWatcher:    watcher,
-		cache:          schedcache.New(config, schedulerName, defaultQueue, nodeSelectors),
+		cache:          schedcache.New(config, schedulerNames, defaultQueue, nodeSelectors),
 		schedulePeriod: period,
 	}
 

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -1,0 +1,34 @@
+package util
+
+const (
+	defaultSchedulerName = "volcano"
+)
+
+// Contains check if slice contains element
+func Contains(slice []string, element string) bool {
+	for _, item := range slice {
+		if item == element {
+			return true
+		}
+	}
+	return false
+}
+
+// GenerateComponentName generate component name volcano
+func GenerateComponentName(schedulerNames []string) string {
+	if len(schedulerNames) == 1 {
+		return schedulerNames[0]
+	}
+
+	return defaultSchedulerName
+}
+
+// GenerateSchedulerName generate scheduler name for volcano job
+func GenerateSchedulerName(schedulerNames []string) string {
+	// choose the first scheduler name for volcano job if its schedulerName is empty
+	if len(schedulerNames) > 0 {
+		return schedulerNames[0]
+	}
+
+	return defaultSchedulerName
+}

--- a/pkg/webhooks/admission/jobs/mutate/mutate_job.go
+++ b/pkg/webhooks/admission/jobs/mutate/mutate_job.go
@@ -30,6 +30,7 @@ import (
 	"volcano.sh/volcano/pkg/controllers/job/plugins/distributed-framework/mpi"
 	"volcano.sh/volcano/pkg/controllers/job/plugins/distributed-framework/pytorch"
 	"volcano.sh/volcano/pkg/controllers/job/plugins/distributed-framework/tensorflow"
+	commonutil "volcano.sh/volcano/pkg/util"
 	"volcano.sh/volcano/pkg/webhooks/router"
 	"volcano.sh/volcano/pkg/webhooks/schema"
 	"volcano.sh/volcano/pkg/webhooks/util"
@@ -41,8 +42,6 @@ const (
 	// DefaultMaxRetry is the default number of retries.
 	DefaultMaxRetry = 3
 
-	defaultSchedulerName = "volcano"
-
 	defaultMaxRetry int32 = 3
 )
 
@@ -53,6 +52,8 @@ func init() {
 var service = &router.AdmissionService{
 	Path: "/jobs/mutate",
 	Func: Jobs,
+
+	Config: config,
 
 	MutatingConfig: &whv1.MutatingWebhookConfiguration{
 		Webhooks: []whv1.MutatingWebhook{{
@@ -70,6 +71,8 @@ var service = &router.AdmissionService{
 		}},
 	},
 }
+
+var config = &router.AdmissionServiceConfig{}
 
 type patchOperation struct {
 	Op    string      `json:"op"`
@@ -149,7 +152,7 @@ func patchDefaultQueue(job *v1alpha1.Job) *patchOperation {
 func patchDefaultScheduler(job *v1alpha1.Job) *patchOperation {
 	// Add default scheduler name if not specified.
 	if job.Spec.SchedulerName == "" {
-		return &patchOperation{Op: "add", Path: "/spec/schedulerName", Value: defaultSchedulerName}
+		return &patchOperation{Op: "add", Path: "/spec/schedulerName", Value: commonutil.GenerateSchedulerName(config.SchedulerNames)}
 	}
 	return nil
 }

--- a/pkg/webhooks/admission/pods/validate/admit_pod.go
+++ b/pkg/webhooks/admission/pods/validate/admit_pod.go
@@ -32,6 +32,7 @@ import (
 
 	"volcano.sh/apis/pkg/apis/helpers"
 	vcv1beta1 "volcano.sh/apis/pkg/apis/scheduling/v1beta1"
+	commonutil "volcano.sh/volcano/pkg/util"
 	"volcano.sh/volcano/pkg/webhooks/router"
 	"volcano.sh/volcano/pkg/webhooks/schema"
 	"volcano.sh/volcano/pkg/webhooks/util"
@@ -100,10 +101,9 @@ allow pods to create when
 3. check pod budget annotations configure
 */
 func validatePod(pod *v1.Pod, reviewResponse *admissionv1.AdmissionResponse) string {
-	if pod.Spec.SchedulerName != config.SchedulerName {
+	if !commonutil.Contains(config.SchedulerNames, pod.Spec.SchedulerName) {
 		return ""
 	}
-
 	pgName := ""
 	msg := ""
 

--- a/pkg/webhooks/admission/pods/validate/admit_pod_test.go
+++ b/pkg/webhooks/admission/pods/validate/admit_pod_test.go
@@ -260,7 +260,7 @@ func TestValidatePod(t *testing.T) {
 
 		// create fake volcano clientset
 		config.VolcanoClient = vcclient.NewSimpleClientset()
-		config.SchedulerName = "volcano"
+		config.SchedulerNames = []string{"volcano"}
 
 		if !testCase.disabledPG {
 			_, err := config.VolcanoClient.SchedulingV1beta1().PodGroups(namespace).Create(context.TODO(), pg, metav1.CreateOptions{})

--- a/pkg/webhooks/router/interface.go
+++ b/pkg/webhooks/router/interface.go
@@ -30,11 +30,11 @@ import (
 type AdmitFunc func(admissionv1.AdmissionReview) *admissionv1.AdmissionResponse
 
 type AdmissionServiceConfig struct {
-	SchedulerName string
-	KubeClient    kubernetes.Interface
-	VolcanoClient versioned.Interface
-	Recorder      record.EventRecorder
-	ConfigData    *config.AdmissionConfiguration
+	SchedulerNames []string
+	KubeClient     kubernetes.Interface
+	VolcanoClient  versioned.Interface
+	Recorder       record.EventRecorder
+	ConfigData     *config.AdmissionConfiguration
 }
 
 type AdmissionService struct {


### PR DESCRIPTION
#2394 
Signed-off-by: Zhe Jin <jinzhe.hit@gmail.com>

Currently, volcano support multiple scheduler name in controllers(https://github.com/volcano-sh/volcano/pull/1792). This pr is used to support multiple scheduler names for scheduler and webhook, include:
* support specify multiple scheduler names in command line
* filer schedulable pods by multiple scheduler names
* use `volcano` as default component name when specify multiple scheduler names
* choose one scheduler name for volcano job in webhook if the job's schedulerName is empty
