### PR TITLE
add hwdef as approver in controller and webhook submodule

### DIFF
--- a/pkg/controllers/OWNERS
+++ b/pkg/controllers/OWNERS
@@ -1,7 +1,9 @@
 reviewers:
   - hzxuzhonghu
   - TommyLike
+  - hwdef
 approvers:
   - hzxuzhonghu
   - TommyLike
   - shinytang6
+  - hwdef

--- a/pkg/webhooks/OWNERS
+++ b/pkg/webhooks/OWNERS
@@ -19,3 +19,4 @@ approvers:
   - Thor-wl
   - shinytang6
   - wpeng102
+  - hwdef


### PR DESCRIPTION
Signed-off-by: hwdef <hwdefcom@outlook.com>

ref: https://github.com/volcano-sh/community/issues/31