### PR TITLE
support random-minimal-cost

### DIFF
--- a/pkg/scheduler/framework/arguments.go
+++ b/pkg/scheduler/framework/arguments.go
@@ -89,6 +89,26 @@ func (a Arguments) GetBool(ptr *bool, key string) {
 	*ptr = value
 }
 
+// GetString get the string value from string
+func (a Arguments) GetString(ptr *string, key string) {
+	if ptr == nil {
+		return
+	}
+
+	argv, ok := a[key]
+	if !ok {
+		return
+	}
+
+	value, ok := argv.(string)
+	if !ok {
+		klog.Warningf("Could not parse argument: %v for key %s to string", argv, key)
+		return
+	}
+
+	*ptr = value
+}
+
 // GetArgOfActionFromConf return argument of action reading from configuration of schedule
 func GetArgOfActionFromConf(configurations []conf.Configuration, actionName string) Arguments {
 	for _, c := range configurations {

--- a/pkg/scheduler/plugins/factory.go
+++ b/pkg/scheduler/plugins/factory.go
@@ -30,6 +30,7 @@ import (
 	"volcano.sh/volcano/pkg/scheduler/plugins/predicates"
 	"volcano.sh/volcano/pkg/scheduler/plugins/priority"
 	"volcano.sh/volcano/pkg/scheduler/plugins/proportion"
+	"volcano.sh/volcano/pkg/scheduler/plugins/random"
 	"volcano.sh/volcano/pkg/scheduler/plugins/rescheduling"
 	"volcano.sh/volcano/pkg/scheduler/plugins/resourcequota"
 	"volcano.sh/volcano/pkg/scheduler/plugins/sla"
@@ -57,6 +58,7 @@ func init() {
 	framework.RegisterPluginBuilder(usage.PluginName, usage.New)
 
 	// Plugins for Queues
+	framework.RegisterPluginBuilder(random.PluginName, random.New)
 	framework.RegisterPluginBuilder(proportion.PluginName, proportion.New)
 
 	// Plugins for Extender

--- a/pkg/scheduler/plugins/random/calculate.go
+++ b/pkg/scheduler/plugins/random/calculate.go
@@ -1,0 +1,116 @@
+package random
+
+import (
+	v1 "k8s.io/api/core/v1"
+	"math"
+	"volcano.sh/volcano/pkg/scheduler/api"
+)
+
+func (rp *randomPlugin) Calculate() {
+	guarantees := make([]*api.Resource, 0)
+	capacities := make([]*api.Resource, 0)
+	requests := make([]*api.Resource, 0)
+	weights := make([]int32, 0)
+	queueMap := make(map[int]api.QueueID)
+	queueIndex := 0
+	var totalWeight int32
+	for queueId, attr := range rp.queueOpts {
+		guarantees = append(guarantees, attr.guarantee)
+		capacities = append(capacities, attr.realCapability)
+		requests = append(requests, attr.request)
+		weights = append(weights, attr.weight)
+		totalWeight += attr.weight
+		queueMap[queueIndex] = queueId
+		queueIndex++
+	}
+	totalResource := rp.totalResource.Clone()
+	weightResources := make([]*api.Resource, 0)
+	for _, w := range weights {
+		weightResources = append(weightResources, totalResource.Multi(float64(w)/float64(totalWeight)))
+	}
+
+	deserves := rp.calculate(rp.totalResource, rp.totalGuarantee, guarantees, capacities, requests, weightResources,
+		len(rp.queueOpts), rp.tryNum, rp.weightCostWeight, rp.requestCostWeight)
+	for i, d := range deserves {
+		queueId := queueMap[i]
+		rp.queueOpts[queueId].deserved = d
+	}
+}
+
+func (rp *randomPlugin) calculate(total, totalGuarantees *api.Resource, guarantees, capacities, requests, weightResources []*api.Resource,
+	queueNum, tryNum, weightCostWeight, requestCostWeight int) []*api.Resource {
+
+	remaining := total.Clone().Sub(totalGuarantees)
+	min := math.MaxFloat64
+	var d []*api.Resource
+	// find the smallest cost in tryNum tries
+	for i := 0; i < tryNum; i++ {
+		// try with random split
+		deserves := try(remaining.Clone(), guarantees, capacities, queueNum)
+		// calculate cost
+		costw := costs(deserves, weightResources, rp.costFunction)
+		costr := costs(deserves, requests, rp.costFunction)
+		cost := float64(weightCostWeight)*costw + float64(requestCostWeight)*costr
+		if min > cost {
+			min = cost
+			d = deserves
+		}
+	}
+	return d
+}
+
+// calculate the queue's deserved, and make sure that a queue's deserved is in [guarantee,capacity]
+func try(remaining *api.Resource, guarantees, capacities []*api.Resource, queueNum int) []*api.Resource {
+	deserves := make([]*api.Resource, 0)
+	divides := divide(remaining, queueNum)
+	deserve := api.EmptyResource()
+	extra := api.EmptyResource()
+	for i := 0; i < queueNum; i++ {
+		deserve, extra = mix(extra, divides[i], guarantees[i], capacities[i])
+		deserves = append(deserves, deserve)
+	}
+	return deserves
+}
+
+// divide remaining into queueNum parts
+func divide(remaining *api.Resource, queueNum int) []*api.Resource {
+	result := make([]*api.Resource, 0)
+	// can only be 123.0/345.0.0 etc
+	cpuSplit := randomNumFloat64(remaining.MilliCPU, queueNum, 0)
+	memSplit := randomNumFloat64(remaining.Memory, queueNum, 0)
+	scalarSplit := make(map[v1.ResourceName][]float64)
+	if len(remaining.ScalarResources) > 0 {
+		for r, v := range remaining.ScalarResources {
+			// can only be 1000.0/2000.0 etc
+			rSplit := randomNumFloat64(v, queueNum, -3)
+			scalarSplit[r] = rSplit
+		}
+	}
+
+	for i := 0; i < queueNum; i++ {
+		q := &api.Resource{
+			MilliCPU:        cpuSplit[i],
+			Memory:          memSplit[i],
+			ScalarResources: make(map[v1.ResourceName]float64),
+		}
+		result = append(result, q)
+		if len(remaining.ScalarResources) == 0 {
+			continue
+		}
+		for r, v := range scalarSplit {
+			q.ScalarResources[r] = v[i]
+		}
+	}
+	return result
+}
+
+// shaving peaks and filling valleys
+// make sure that deserve is in [guarantee,capacity], if extra + divide > deserve, return new extra
+func mix(extra, divide, guarantee, capacity *api.Resource) (*api.Resource, *api.Resource) {
+	deserve := extra.Add(divide).Add(guarantee)
+	if deserve.LessEqual(capacity, api.Zero) {
+		return deserve, api.EmptyResource()
+	}
+	d := deserve.MinDimensionResource(capacity, api.Zero)
+	return d, deserve.Sub(d)
+}

--- a/pkg/scheduler/plugins/random/cost.go
+++ b/pkg/scheduler/plugins/random/cost.go
@@ -1,0 +1,41 @@
+package random
+
+import (
+	"fmt"
+	v1 "k8s.io/api/core/v1"
+	"math"
+	"volcano.sh/volcano/pkg/scheduler/api"
+)
+
+type costFunction func(r *api.Resource, rr *api.Resource) float64
+
+var costFunctions = map[string]costFunction{}
+
+func init() {
+	costFunctions[DefaultCostFunction] = eulerDistance
+}
+
+func costs(l, r []*api.Resource, costFunction string) float64 {
+	cost, ok := costFunctions[costFunction]
+	if !ok {
+		panic(fmt.Sprintf("illegal costFunction for %s", costFunction))
+	}
+	sum := 0.0
+	for i := 0; i < len(l); i++ {
+		sum += cost(l[i], r[i])
+	}
+	return sum
+}
+
+func eulerDistance(r *api.Resource, rr *api.Resource) float64 {
+	costCpu := math.Pow(r.MilliCPU-rr.MilliCPU, 2)
+	costMem := math.Pow(r.Memory-rr.Memory, 2)
+	cost := costCpu + costMem
+	for rName, rQuant := range rr.ScalarResources {
+		if r.ScalarResources == nil {
+			r.ScalarResources = map[v1.ResourceName]float64{}
+		}
+		cost += math.Pow(r.ScalarResources[rName]-rQuant, 2)
+	}
+	return cost
+}

--- a/pkg/scheduler/plugins/random/math.go
+++ b/pkg/scheduler/plugins/random/math.go
@@ -1,0 +1,52 @@
+package random
+
+import (
+	"math"
+	"math/rand"
+	"sort"
+	"time"
+)
+
+// generate a random float64
+// if decimal = 2, the result is accurate to two decimal places, such as 1.23/2.34 etc
+// if decimal = 0, the result is an integer
+// if decimal = -2, the result is an integer multiple of 100, such as 100/1200 etc
+func randomFloat64(max float64, decimal int) float64 {
+	rand.Seed(time.Now().UnixNano())
+	random := rand.Float64()
+	random = random * max
+	pow := math.Pow10(decimal)
+	randomInt64 := int64(random * pow)
+	randomFloat64 := float64(randomInt64) / pow
+	return randomFloat64
+}
+
+// 截绳法, generate num random float64 whose sum is sum
+func randomNumFloat64(sum float64, num int, decimal int) []float64 {
+	if num <= 0 {
+		return nil
+	}
+	if num == 1 {
+		return []float64{randomFloat64(sum, decimal)}
+	}
+	nodes := make([]float64, 0)
+	nodes = append(nodes, 0.0)
+	for i := 0; i < num-1; i++ {
+		node := randomFloat64(sum, decimal)
+		nodes = append(nodes, node)
+	}
+	nodes = append(nodes, sum)
+	sort.Float64s(nodes)
+	result := make([]float64, 0)
+	for i := 1; i < len(nodes); i++ {
+		result = append(result, sub(nodes[i], nodes[i-1], decimal))
+	}
+	return result
+}
+
+func sub(l, r float64, decimal int) float64 {
+	pow := math.Pow10(decimal)
+	subInt64 := int64(l*pow) - int64(r*pow)
+	subFloat64 := float64(subInt64) / pow
+	return subFloat64
+}

--- a/pkg/scheduler/plugins/random/random_minimal_cost.go
+++ b/pkg/scheduler/plugins/random/random_minimal_cost.go
@@ -1,0 +1,348 @@
+package random
+
+import (
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/klog"
+	"math"
+
+	"volcano.sh/apis/pkg/apis/scheduling"
+	"volcano.sh/volcano/pkg/scheduler/api"
+	"volcano.sh/volcano/pkg/scheduler/api/helpers"
+	"volcano.sh/volcano/pkg/scheduler/framework"
+	"volcano.sh/volcano/pkg/scheduler/metrics"
+	"volcano.sh/volcano/pkg/scheduler/plugins/util"
+)
+
+// PluginName indicates name of volcano scheduler plugin.
+const (
+	PluginName               = "random"
+	TryNum                   = "try-num"
+	DefaultTryNum            = 1000
+	WeightCostWeight         = "weight-cost-weight"
+	DefaultWeightCostWeight  = 1
+	RequestCostWeight        = "request-cost-weight"
+	DefaultRequestCostWeight = 1
+	CostFunction             = "cost-function"
+	DefaultCostFunction      = "eulerDistance"
+)
+
+type randomPlugin struct {
+	totalResource  *api.Resource
+	totalGuarantee *api.Resource
+	queueOpts      map[api.QueueID]*queueAttr
+	// Arguments given for the plugin
+	pluginArguments framework.Arguments
+
+	tryNum            int
+	weightCostWeight  int
+	requestCostWeight int
+	costFunction      string
+}
+
+type queueAttr struct {
+	queueID api.QueueID
+	name    string
+	weight  int32
+	share   float64
+
+	deserved  *api.Resource
+	allocated *api.Resource
+	request   *api.Resource
+	// elastic represents the sum of job's elastic resource, job's elastic = job.allocated - job.minAvailable
+	elastic *api.Resource
+	// inqueue represents the resource request of the inqueue job
+	inqueue    *api.Resource
+	capability *api.Resource
+	// realCapability represents the resource limit of the queue, LessEqual capability
+	realCapability *api.Resource
+	guarantee      *api.Resource
+}
+
+// New return proportion action
+func New(arguments framework.Arguments) framework.Plugin {
+	return &randomPlugin{
+		totalResource:   api.EmptyResource(),
+		totalGuarantee:  api.EmptyResource(),
+		queueOpts:       map[api.QueueID]*queueAttr{},
+		pluginArguments: arguments,
+	}
+}
+
+func (rp *randomPlugin) Name() string {
+	return PluginName
+}
+
+func (rp *randomPlugin) OnSessionOpen(ssn *framework.Session) {
+
+	rp.pluginArguments.GetInt(&rp.tryNum, TryNum)
+	if rp.tryNum == 0 {
+		rp.tryNum = DefaultTryNum
+	}
+	rp.pluginArguments.GetInt(&rp.tryNum, WeightCostWeight)
+	if rp.weightCostWeight == 0 {
+		rp.weightCostWeight = DefaultWeightCostWeight
+	}
+	rp.pluginArguments.GetInt(&rp.tryNum, RequestCostWeight)
+	if rp.requestCostWeight == 0 {
+		rp.requestCostWeight = DefaultRequestCostWeight
+	}
+	rp.pluginArguments.GetString(&rp.costFunction, CostFunction)
+	if len(rp.costFunction) == 0 {
+		rp.costFunction = DefaultCostFunction
+	}
+
+	// Prepare scheduling data for this session.
+	rp.totalResource.Add(ssn.TotalResource)
+
+	klog.V(4).Infof("The total resource is <%v>", rp.totalResource)
+	for _, queue := range ssn.Queues {
+		if len(queue.Queue.Spec.Guarantee.Resource) == 0 {
+			continue
+		}
+		guarantee := api.NewResource(queue.Queue.Spec.Guarantee.Resource)
+		rp.totalGuarantee.Add(guarantee)
+	}
+	klog.V(4).Infof("The total guarantee resource is <%v>", rp.totalGuarantee)
+	// Build attributes for Queues.
+	for _, job := range ssn.Jobs {
+		klog.V(4).Infof("Considering Job <%s/%s>.", job.Namespace, job.Name)
+		if _, found := rp.queueOpts[job.Queue]; !found {
+			queue := ssn.Queues[job.Queue]
+			attr := &queueAttr{
+				queueID: queue.UID,
+				name:    queue.Name,
+				weight:  queue.Weight,
+
+				deserved:  api.EmptyResource(),
+				allocated: api.EmptyResource(),
+				request:   api.EmptyResource(),
+				elastic:   api.EmptyResource(),
+				inqueue:   api.EmptyResource(),
+				guarantee: api.EmptyResource(),
+			}
+			if len(queue.Queue.Spec.Capability) != 0 {
+				attr.capability = api.NewResource(queue.Queue.Spec.Capability)
+				if attr.capability.MilliCPU <= 0 {
+					attr.capability.MilliCPU = math.MaxFloat64
+				}
+				if attr.capability.Memory <= 0 {
+					attr.capability.Memory = math.MaxFloat64
+				}
+			}
+			if len(queue.Queue.Spec.Guarantee.Resource) != 0 {
+				attr.guarantee = api.NewResource(queue.Queue.Spec.Guarantee.Resource)
+			}
+			realCapability := rp.totalResource.Clone().Sub(rp.totalGuarantee).Add(attr.guarantee)
+			if attr.capability == nil {
+				attr.realCapability = realCapability
+			} else {
+				attr.realCapability = helpers.Min(realCapability, attr.capability)
+			}
+			rp.queueOpts[job.Queue] = attr
+			klog.V(4).Infof("Added Queue <%s> attributes.", job.Queue)
+		}
+
+		attr := rp.queueOpts[job.Queue]
+		for status, tasks := range job.TaskStatusIndex {
+			if api.AllocatedStatus(status) {
+				for _, t := range tasks {
+					attr.allocated.Add(t.Resreq)
+					attr.request.Add(t.Resreq)
+				}
+			} else if status == api.Pending {
+				for _, t := range tasks {
+					attr.request.Add(t.Resreq)
+				}
+			}
+		}
+
+		if job.PodGroup.Status.Phase == scheduling.PodGroupInqueue {
+			attr.inqueue.Add(job.GetMinResources())
+		}
+
+		// calculate inqueue resource for running jobs
+		// the judgement 'job.PodGroup.Status.Running >= job.PodGroup.Spec.MinMember' will work on cases such as the following condition:
+		// Considering a Spark job is completed(driver pod is completed) while the podgroup keeps running, the allocated resource will be reserved again if without the judgement.
+		if job.PodGroup.Status.Phase == scheduling.PodGroupRunning &&
+			job.PodGroup.Spec.MinResources != nil &&
+			int32(util.CalculateAllocatedTaskNum(job)) >= job.PodGroup.Spec.MinMember {
+			allocated := util.GetAllocatedResource(job)
+			inqueued := util.GetInqueueResource(job, allocated)
+			attr.inqueue.Add(inqueued)
+		}
+		attr.elastic.Add(job.GetElasticResources())
+		klog.V(5).Infof("Queue %s allocated <%s> request <%s> inqueue <%s> elastic <%s>",
+			attr.name, attr.allocated.String(), attr.request.String(), attr.inqueue.String(), attr.elastic.String())
+	}
+
+	for queueID, queueInfo := range ssn.Queues {
+		if _, ok := rp.queueOpts[queueID]; !ok {
+			metrics.UpdateQueueAllocated(queueInfo.Name, 0, 0)
+		}
+	}
+
+	// Record metrics
+	for _, attr := range rp.queueOpts {
+		metrics.UpdateQueueAllocated(attr.name, attr.allocated.MilliCPU, attr.allocated.Memory)
+		metrics.UpdateQueueRequest(attr.name, attr.request.MilliCPU, attr.request.Memory)
+		metrics.UpdateQueueWeight(attr.name, attr.weight)
+		queue := ssn.Queues[attr.queueID]
+		metrics.UpdateQueuePodGroupInqueueCount(attr.name, queue.Queue.Status.Inqueue)
+		metrics.UpdateQueuePodGroupPendingCount(attr.name, queue.Queue.Status.Pending)
+		metrics.UpdateQueuePodGroupRunningCount(attr.name, queue.Queue.Status.Running)
+		metrics.UpdateQueuePodGroupUnknownCount(attr.name, queue.Queue.Status.Unknown)
+	}
+
+	rp.Calculate()
+	for _, attr := range rp.queueOpts {
+		klog.V(4).Infof("The attributes of queue <%s> in proportion: deserved <%v>, realCapability <%v>, allocate <%v>, request <%v>, elastic <%v>, share <%0.2f>",
+			attr.name, attr.deserved, attr.realCapability, attr.allocated, attr.request, attr.elastic, attr.share)
+	}
+
+	ssn.AddQueueOrderFn(rp.Name(), func(l, r interface{}) int {
+		lv := l.(*api.QueueInfo)
+		rv := r.(*api.QueueInfo)
+
+		if rp.queueOpts[lv.UID].share == rp.queueOpts[rv.UID].share {
+			return 0
+		}
+
+		if rp.queueOpts[lv.UID].share < rp.queueOpts[rv.UID].share {
+			return -1
+		}
+
+		return 1
+	})
+
+	ssn.AddReclaimableFn(rp.Name(), func(reclaimer *api.TaskInfo, reclaimees []*api.TaskInfo) ([]*api.TaskInfo, int) {
+		var victims []*api.TaskInfo
+		allocations := map[api.QueueID]*api.Resource{}
+
+		for _, reclaimee := range reclaimees {
+			job := ssn.Jobs[reclaimee.Job]
+			attr := rp.queueOpts[job.Queue]
+
+			if _, found := allocations[job.Queue]; !found {
+				allocations[job.Queue] = attr.allocated.Clone()
+			}
+			allocated := allocations[job.Queue]
+			if allocated.LessPartly(reclaimer.Resreq, api.Zero) {
+				klog.V(3).Infof("Failed to allocate resource for Task <%s/%s> in Queue <%s>, not enough resource.",
+					reclaimee.Namespace, reclaimee.Name, job.Queue)
+				continue
+			}
+
+			if !allocated.LessEqual(attr.deserved, api.Zero) {
+				allocated.Sub(reclaimee.Resreq)
+				victims = append(victims, reclaimee)
+			}
+		}
+		klog.V(4).Infof("Victims from proportion plugins are %+v", victims)
+		return victims, util.Permit
+	})
+
+	ssn.AddOverusedFn(rp.Name(), func(obj interface{}) bool {
+		queue := obj.(*api.QueueInfo)
+		attr := rp.queueOpts[queue.UID]
+
+		overused := attr.deserved.LessEqual(attr.allocated, api.Zero)
+		metrics.UpdateQueueOverused(attr.name, overused)
+		if overused {
+			klog.V(3).Infof("Queue <%v>: deserved <%v>, allocated <%v>, share <%v>",
+				queue.Name, attr.deserved, attr.allocated, attr.share)
+		}
+
+		return overused
+	})
+
+	ssn.AddAllocatableFn(rp.Name(), func(queue *api.QueueInfo, candidate *api.TaskInfo) bool {
+		attr := rp.queueOpts[queue.UID]
+
+		free, _ := attr.deserved.Diff(attr.allocated, api.Zero)
+		allocatable := candidate.Resreq.LessEqual(free, api.Zero)
+		if !allocatable {
+			klog.V(3).Infof("Queue <%v>: deserved <%v>, allocated <%v>; Candidate <%v>: resource request <%v>",
+				queue.Name, attr.deserved, attr.allocated, candidate.Name, candidate.Resreq)
+		}
+
+		return allocatable
+	})
+
+	ssn.AddJobEnqueueableFn(rp.Name(), func(obj interface{}) int {
+		job := obj.(*api.JobInfo)
+		queueID := job.Queue
+		attr := rp.queueOpts[queueID]
+		queue := ssn.Queues[queueID]
+		// If no capability is set, always enqueue the job.
+		if attr.realCapability == nil {
+			klog.V(4).Infof("Capability of queue <%s> was not set, allow job <%s/%s> to Inqueue.",
+				queue.Name, job.Namespace, job.Name)
+			return util.Permit
+		}
+
+		if job.PodGroup.Spec.MinResources == nil {
+			klog.V(4).Infof("job %s MinResources is null.", job.Name)
+			return util.Permit
+		}
+		minReq := job.GetMinResources()
+
+		klog.V(5).Infof("job %s min resource <%s>, queue %s capability <%s> allocated <%s> inqueue <%s> elastic <%s>",
+			job.Name, minReq.String(), queue.Name, attr.realCapability.String(), attr.allocated.String(), attr.inqueue.String(), attr.elastic.String())
+		// The queue resource quota limit has not reached
+		inqueue := minReq.Add(attr.allocated).Add(attr.inqueue).Sub(attr.elastic).LessEqual(attr.realCapability, api.Infinity)
+		klog.V(5).Infof("job %s inqueue %v", job.Name, inqueue)
+		if inqueue {
+			attr.inqueue.Add(job.GetMinResources())
+			return util.Permit
+		}
+		ssn.RecordPodGroupEvent(job.PodGroup, v1.EventTypeNormal, string(scheduling.PodGroupUnschedulableType), "queue resource quota insufficient")
+		return util.Reject
+	})
+
+	// Register event handlers.
+	ssn.AddEventHandler(&framework.EventHandler{
+		AllocateFunc: func(event *framework.Event) {
+			job := ssn.Jobs[event.Task.Job]
+			attr := rp.queueOpts[job.Queue]
+			attr.allocated.Add(event.Task.Resreq)
+			metrics.UpdateQueueAllocated(attr.name, attr.allocated.MilliCPU, attr.allocated.Memory)
+
+			rp.updateShare(attr)
+
+			klog.V(4).Infof("Random AllocateFunc: task <%v/%v>, resreq <%v>,  share <%v>",
+				event.Task.Namespace, event.Task.Name, event.Task.Resreq, attr.share)
+		},
+		DeallocateFunc: func(event *framework.Event) {
+			job := ssn.Jobs[event.Task.Job]
+			attr := rp.queueOpts[job.Queue]
+			attr.allocated.Sub(event.Task.Resreq)
+			metrics.UpdateQueueAllocated(attr.name, attr.allocated.MilliCPU, attr.allocated.Memory)
+
+			rp.updateShare(attr)
+
+			klog.V(4).Infof("Random EvictFunc: task <%v/%v>, resreq <%v>,  share <%v>",
+				event.Task.Namespace, event.Task.Name, event.Task.Resreq, attr.share)
+		},
+	})
+}
+
+func (rp *randomPlugin) OnSessionClose(ssn *framework.Session) {
+	rp.totalResource = nil
+	rp.totalGuarantee = nil
+	rp.queueOpts = nil
+}
+
+func (rp *randomPlugin) updateShare(attr *queueAttr) {
+	res := float64(0)
+
+	// TODO(k82cn): how to handle fragment issues?
+	for _, rn := range attr.deserved.ResourceNames() {
+		share := helpers.Share(attr.allocated.Get(rn), attr.deserved.Get(rn))
+		if share > res {
+			res = share
+		}
+	}
+
+	attr.share = res
+	metrics.UpdateQueueShare(attr.name, attr.share)
+}


### PR DESCRIPTION
related issue #2364 

随着queue的配置越来越多，包括guarantee/capacity/weight 以及queue的资源请求request，根据这些配置计算queue.deserved 的逻辑越来越复杂，且可能出现一个queue guarantee很大但weight 这类相互矛盾的情况，queue.deserved  很难通过一个简单的规则来计算了，因此需要提出新的计算逻辑来计算queue.deserved。

guarantee和capacity是硬约束，在满足硬约束的前提下，尽量使得queue.deserved 满足weight比例 和 queue的实际需要/request。一个思路是：queue的deserved 不是由计算得到，而是随机产生（当然要限定在`[guarantee,capacity]` 范围内），将一个计算queue'deserved 的问题转换为 在1k次/1w次随机产生的 queue'deserved 中选择最优的问题。如何判断 deserved1 比deserved2 更好呢？可以借用机器学习中“损失函数值最小”的思路，假设有3个queue 且只考虑cpu 和内存资源，对于一个随机候选 `(queue1_deserved,queue2_deserved,queue3_deserved)`（在机器学习的概念上，实际上一个3*2 tensor），如果能够尽可能贴合 queue的weight `(queue1_weight,queue2_weight,queue3_weight)`，又能尽可能贴合 queue
的request`(queue1_request,queue2_request,queue3_request)`，即可以认为这个候选是最优的。

具体流程
1. 计算各个queue的weightResources，一个queue的weightResource 计算公式`weightResources = queue.weight / totalWeight`
2. 先确保 各个queue 可以得到guarantee，剩下的remaining (`remaining= total - totalGuarantee` )用于在各个queue 二次分配
3. 将 remaining 随机分为 queueNum 份分给每个queue，并保证 每个queue的resource 在 [guarantee,capacity] 范围内
	1. 将remaining 随机分成 queueNum 份 分给每个queue，每个queue 分到divide
	2. 每个queue 此时的资源 =  divide + guarantee，divide + guarantee可能超过queue的capacity
	3. 如果超过，则将多出来的部分 extra = divide + guarantee - capacity，匀给下一个queue，直到最后一个queue
4. 计算本次随机分配的cost，cost 由 costw 和 costr 组成
	1. costw 表示 本次分配与 weightResources 的距离，数学上为 两个张量的距离，有多种计算策略，示例中使用欧拉距离
	2. costr 表示 本次分配与 request 的距离
	3. cost = weight_weight * costw + request_weight * costr， 通过weight_weight 和 request_weight 的值，可以控制更希望 贴合weight 还是request
5. 重复第3,4 步 tryNum次，记录最小成本时的分配方案，即为最终分配方案。tryNum 次数越多，效果越好。

可选参数
1. tryNum，随机产生候选deserved 的个数
2. weight_weight，计算cost 时 weight_weight 的比重，值越大，最后的deserved 越贴合weight比例
3. request_weight，计算cost 时 request_weight 的比重，值越大，最后的deserved 越贴合request

部署时 使用random（暂定名）代替proportion plugin
```
apiVersion: v1
kind: ConfigMap
metadata:
  name: volcano-scheduler-configmap
  namespace: volcano-system
data:
  volcano-scheduler.conf: |
    actions: "enqueue,allocate,preempt,reclaim,backfill"
    tiers:
    - plugins:
      - name: priority
      - name: gang
      - name: conformance
    - plugins:
      - name: drf
      - name: predicates
      - name: random       // replace proportion
      - name: nodeorder
      - name: binpack
```
