### PR TITLE
Fix calculating available gpu num error

### DIFF
--- a/pkg/scheduler/plugins/predicates/gpu.go
+++ b/pkg/scheduler/plugins/predicates/gpu.go
@@ -32,7 +32,7 @@ func checkNodeGPUSharingPredicate(pod *v1.Pod, nodeInfo *api.NodeInfo) (bool, er
 		return true, nil
 	}
 	ids := predicateGPUbyMemory(pod, nodeInfo)
-	if ids == nil {
+	if len(ids) == 0 {
 		return false, fmt.Errorf("no enough gpu memory on node %s", nodeInfo.Name)
 	}
 	return true, nil
@@ -44,7 +44,7 @@ func checkNodeGPUNumberPredicate(pod *v1.Pod, nodeInfo *api.NodeInfo) (bool, err
 		return true, nil
 	}
 	ids := predicateGPUbyNumber(pod, nodeInfo)
-	if ids == nil {
+	if len(ids) == 0 {
 		return false, fmt.Errorf("no enough gpu number on node %s", nodeInfo.Name)
 	}
 	return true, nil

--- a/pkg/scheduler/plugins/predicates/gpu.go
+++ b/pkg/scheduler/plugins/predicates/gpu.go
@@ -58,16 +58,11 @@ func predicateGPUbyMemory(pod *v1.Pod, node *api.NodeInfo) []int {
 	var devIDs []int
 
 	for devID := 0; devID < len(allocatableGPUs); devID++ {
-		availableGPU, ok := allocatableGPUs[devID]
-		if ok {
-			if availableGPU >= gpuRequest {
-				devIDs = append(devIDs, devID)
-				return devIDs
-			}
+		if availableGPU, ok := allocatableGPUs[devID]; ok && availableGPU >= gpuRequest {
+			devIDs = append(devIDs, devID)
 		}
 	}
-
-	return nil
+	return devIDs
 }
 
 // predicateGPU returns the available GPU IDs

--- a/pkg/scheduler/plugins/predicates/gpu.go
+++ b/pkg/scheduler/plugins/predicates/gpu.go
@@ -50,7 +50,7 @@ func checkNodeGPUNumberPredicate(pod *v1.Pod, nodeInfo *api.NodeInfo) (bool, err
 	return true, nil
 }
 
-// predicateGPU returns the available GPU ID
+// predicateGPUbyMemory returns the available GPU ID
 func predicateGPUbyMemory(pod *v1.Pod, node *api.NodeInfo) []int {
 	gpuRequest := api.GetGPUMemoryOfPod(pod)
 	allocatableGPUs := node.GetDevicesIdleGPUMemory()
@@ -75,19 +75,10 @@ func predicateGPUbyNumber(pod *v1.Pod, node *api.NodeInfo) []int {
 	gpuRequest := api.GetGPUNumberOfPod(pod)
 	allocatableGPUs := node.GetDevicesIdleGPUs()
 
-	var devIDs []int
-
 	if len(allocatableGPUs) < gpuRequest {
 		klog.Errorf("Not enough gpu cards")
 		return nil
 	}
 
-	for devID := 0; devID < len(allocatableGPUs); devID++ {
-		devIDs = append(devIDs, allocatableGPUs[devID])
-		if len(devIDs) == gpuRequest {
-			return devIDs
-		}
-	}
-
-	return nil
+	return allocatableGPUs[:gpuRequest]
 }

--- a/pkg/scheduler/plugins/predicates/predicates.go
+++ b/pkg/scheduler/plugins/predicates/predicates.go
@@ -193,7 +193,7 @@ func (pp *predicatesPlugin) OnSessionOpen(ssn *framework.Session) {
 					return
 				}
 				ids := predicateGPUbyMemory(pod, nodeInfo)
-				if ids == nil {
+				if len(ids) == 0 {
 					klog.Errorf("The node %s can't place the pod %s in ns %s", pod.Spec.NodeName, pod.Name, pod.Namespace)
 					return
 				}
@@ -222,7 +222,7 @@ func (pp *predicatesPlugin) OnSessionOpen(ssn *framework.Session) {
 					return
 				}
 				ids := predicateGPUbyNumber(pod, nodeInfo)
-				if ids == nil {
+				if len(ids) == 0 {
 					klog.Errorf("The node %s can't place the pod %s in ns %s", pod.Spec.NodeName, pod.Name, pod.Namespace)
 					return
 				}


### PR DESCRIPTION
/kind bug

The problem here is we'll always return devIDs with length equals to 1, but actually I think `predicateGPUbyMemory` wants to return all the available devIDs.
https://github.com/volcano-sh/volcano/blob/52a34f5ff10e3e37bd8c407ef9b559dd81dff3fb/pkg/scheduler/plugins/predicates/gpu.go#L63-L66