### PR TITLE
Optimize the way to build images in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@
 BIN_DIR=_output/bin
 RELEASE_DIR=_output/release
 REPO_PATH=volcano.sh/volcano
-IMAGE_PREFIX=volcanosh/vc
+IMAGE_PREFIX=volcanosh
 CRD_OPTIONS ?= "crd:crdVersions=v1,generateEmbeddedObjectMeta=true"
 CC ?= "gcc"
 SUPPORT_PLUGINS ?= "no"
@@ -53,7 +53,7 @@ else
 REL_OSARCH=linux/$(OSARCH)
 endif
 
-# Run `make images DOCKER_PLATFORMS="linux/amd64,linux/arm64" BUILDX_OUTPUT_TYPE=registry IMAGE_PREFIX=[yourregistry]/vc` to push multi-platform
+# Run `make images DOCKER_PLATFORMS="linux/amd64,linux/arm64" BUILDX_OUTPUT_TYPE=registry IMAGE_PREFIX=[yourregistry]` to push multi-platform
 DOCKER_PLATFORMS ?= "${REL_OSARCH}"
 
 include Makefile.def
@@ -101,7 +101,7 @@ image_bins: init
 
 images:
 	for name in controller-manager scheduler webhook-manager; do\
-		docker buildx build -t "${IMAGE_PREFIX}-$$name:$(TAG)" . -f ./installer/dockerfile/$$name/Dockerfile --output=type="${BUILDX_OUTPUT_TYPE}" --platform "${DOCKER_PLATFORMS}"; \
+		docker buildx build -t "${IMAGE_PREFIX}/vc-$$name:$(TAG)" . -f ./installer/dockerfile/$$name/Dockerfile --output=type="${BUILDX_OUTPUT_TYPE}" --platform "${DOCKER_PLATFORMS}"; \
 	done
 
 generate-code:

--- a/hack/lib/install.sh
+++ b/hack/lib/install.sh
@@ -26,27 +26,27 @@ function kind-up-cluster {
 
   echo
   echo "Loading docker images into kind cluster"
-  kind load docker-image ${IMAGE_PREFIX}-controller-manager:${TAG} ${CLUSTER_CONTEXT}
-  kind load docker-image ${IMAGE_PREFIX}-scheduler:${TAG} ${CLUSTER_CONTEXT}
-  kind load docker-image ${IMAGE_PREFIX}-webhook-manager:${TAG} ${CLUSTER_CONTEXT}
+  kind load docker-image ${IMAGE_PREFIX}/vc-controller-manager:${TAG} ${CLUSTER_CONTEXT}
+  kind load docker-image ${IMAGE_PREFIX}/vc-scheduler:${TAG} ${CLUSTER_CONTEXT}
+  kind load docker-image ${IMAGE_PREFIX}/vc-webhook-manager:${TAG} ${CLUSTER_CONTEXT}
 }
 
 # check if the required images exist
 function check-images {
   echo "Checking whether the required images exist"
-  docker image inspect "${IMAGE_PREFIX}-controller-manager:${TAG}" > /dev/null
+  docker image inspect "${IMAGE_PREFIX}/vc-controller-manager:${TAG}" > /dev/null
   if [[ $? -ne 0 ]]; then
-    echo -e "\033[31mERROR\033[0m: ${IMAGE_PREFIX}-controller-manager:${TAG} does not exist"
+    echo -e "\033[31mERROR\033[0m: ${IMAGE_PREFIX}/vc-controller-manager:${TAG} does not exist"
     exit 1
   fi
-  docker image inspect "${IMAGE_PREFIX}-scheduler:${TAG}" > /dev/null
+  docker image inspect "${IMAGE_PREFIX}/vc-scheduler:${TAG}" > /dev/null
   if [[ $? -ne 0 ]]; then
-    echo -e "\033[31mERROR\033[0m: ${IMAGE_PREFIX}-scheduler:${TAG} does not exist"
+    echo -e "\033[31mERROR\033[0m: ${IMAGE_PREFIX}/vc-scheduler:${TAG} does not exist"
     exit 1
   fi
-  docker image inspect "${IMAGE_PREFIX}-webhook-manager:${TAG}" > /dev/null
+  docker image inspect "${IMAGE_PREFIX}/vc-webhook-manager:${TAG}" > /dev/null
   if [[ $? -ne 0 ]]; then
-    echo -e "\033[31mERROR\033[0m: ${IMAGE_PREFIX}-webhook-manager:${TAG} does not exist"
+    echo -e "\033[31mERROR\033[0m: ${IMAGE_PREFIX}/vc-webhook-manager:${TAG} does not exist"
     exit 1
   fi
 }

--- a/hack/publish.sh
+++ b/hack/publish.sh
@@ -65,18 +65,18 @@ if [[ "${DOCKER_USERNAME}xxx" == "xxx" ]];then
 fi
 
 echo "${DOCKER_PASSWORD}" | docker login -u "${DOCKER_USERNAME}" --password-stdin
-echo "pushing ${IMAGE_PREFIX}-controller-manager:${VOLCANO_IMAGE_TAG}"
-docker tag ${IMAGE_PREFIX}-controller-manager:${VOLCANO_IMAGE_TAG} ${IMAGE_PREFIX}-controllers:${VOLCANO_IMAGE_TAG}
-docker push ${IMAGE_PREFIX}-controllers:${VOLCANO_IMAGE_TAG}
-docker push ${IMAGE_PREFIX}-controller-manager:${VOLCANO_IMAGE_TAG}
+echo "pushing ${IMAGE_PREFIX}/vc-controller-manager:${VOLCANO_IMAGE_TAG}"
+docker tag ${IMAGE_PREFIX}/vc-controller-manager:${VOLCANO_IMAGE_TAG} ${IMAGE_PREFIX}/vc-controllers:${VOLCANO_IMAGE_TAG}
+docker push ${IMAGE_PREFIX}/vc-controllers:${VOLCANO_IMAGE_TAG}
+docker push ${IMAGE_PREFIX}/vc-controller-manager:${VOLCANO_IMAGE_TAG}
 
-echo "pushing ${IMAGE_PREFIX}-scheduler:${VOLCANO_IMAGE_TAG}"
-docker push ${IMAGE_PREFIX}-scheduler:${VOLCANO_IMAGE_TAG}
+echo "pushing ${IMAGE_PREFIX}/vc-scheduler:${VOLCANO_IMAGE_TAG}"
+docker push ${IMAGE_PREFIX}/vc-scheduler:${VOLCANO_IMAGE_TAG}
 
-echo "pushing ${IMAGE_PREFIX}-webhook-manager:${VOLCANO_IMAGE_TAG}"
-docker tag ${IMAGE_PREFIX}-webhook-manager:${VOLCANO_IMAGE_TAG} ${IMAGE_PREFIX}-admission:${VOLCANO_IMAGE_TAG}
-docker push ${IMAGE_PREFIX}-admission:${VOLCANO_IMAGE_TAG}
-docker push ${IMAGE_PREFIX}-webhook-manager:${VOLCANO_IMAGE_TAG}
+echo "pushing ${IMAGE_PREFIX}/vc-webhook-manager:${VOLCANO_IMAGE_TAG}"
+docker tag ${IMAGE_PREFIX}/vc-webhook-manager:${VOLCANO_IMAGE_TAG} ${IMAGE_PREFIX}/vc-admission:${VOLCANO_IMAGE_TAG}
+docker push ${IMAGE_PREFIX}/vc-admission:${VOLCANO_IMAGE_TAG}
+docker push ${IMAGE_PREFIX}/vc-webhook-manager:${VOLCANO_IMAGE_TAG}
 
 echo "Generate release tar files"
 cd ${RELEASE_FOLDER}/


### PR DESCRIPTION
Signed-off-by: hwdef <hwdefcom@outlook.com>

make the makefile consistent with https://github.com/volcano-sh/volcano/blob/master/docs/development/development.md#building-docker-images

before:
```
make images DOCKER_PLATFORMS="linux/amd64,linux/arm64" BUILDX_OUTPUT_TYPE=registry IMAGE_PREFIX=hwdef
```
the image tag will be `hwdef-controller-manager`

after:

```
make images DOCKER_PLATFORMS="linux/amd64,linux/arm64" BUILDX_OUTPUT_TYPE=registry IMAGE_PREFIX=hwdef
```
the image tag will be `hwdef/vc-controller-manager`
