### PR TITLE
Update CA insert method in webhooks.

### DIFF
--- a/installer/helm/chart/volcano/templates/admission.yaml
+++ b/installer/helm/chart/volcano/templates/admission.yaml
@@ -84,6 +84,7 @@ spec:
       {{- end }}
       containers:
         - args:
+            - --enabled-admission={{ .Values.custom.enabled_admissions }}
             - --tls-cert-file=/admission.local.config/certificates/tls.crt
             - --tls-private-key-file=/admission.local.config/certificates/tls.key
             - --ca-cert-file=/admission.local.config/certificates/ca.crt

--- a/installer/helm/chart/volcano/templates/webhooks.yaml
+++ b/installer/helm/chart/volcano/templates/webhooks.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.custom.admission_enable }}
 
-{{- if .Values.custom.pods_mutatingwebhook_enable }}
+{{- if .Values.custom.enabled_admissions | regexMatch "/pods/mutate" }}
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
@@ -42,7 +42,7 @@ webhooks:
 
 ---
 
-{{- if .Values.custom.queues_mutatingwebhook_enable }}
+{{- if .Values.custom.enabled_admissions | regexMatch "/queues/mutate" }}
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
@@ -84,7 +84,7 @@ webhooks:
 
 ---
 
-{{- if .Values.custom.podgroups_mutatingwebhook_enable }}
+{{- if .Values.custom.enabled_admissions | regexMatch "/podgroups/mutate" }}
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
@@ -126,7 +126,7 @@ webhooks:
 
 ---
 
-{{- if .Values.custom.jobs_mutatingwebhook_enable }}
+{{- if .Values.custom.enabled_admissions | regexMatch "/jobs/mutate" }}
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
@@ -168,7 +168,7 @@ webhooks:
 
 ---
 
-{{- if .Values.custom.jobs_validatingwebhook_enable }}
+{{- if .Values.custom.enabled_admissions | regexMatch "/jobs/validate" }}
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
@@ -210,7 +210,7 @@ webhooks:
 
 ---
 
-{{- if .Values.custom.pods_validatingwebhook_enable }}
+{{- if .Values.custom.enabled_admissions | regexMatch "/pods/validate" }}
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
@@ -251,7 +251,7 @@ webhooks:
 
 ---
 
-{{- if .Values.custom.queues_validatingwebhook_enable }}
+{{- if .Values.custom.enabled_admissions | regexMatch "/queues/validate" }}
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:

--- a/installer/helm/chart/volcano/values.yaml
+++ b/installer/helm/chart/volcano/values.yaml
@@ -13,10 +13,4 @@ custom:
   admission_enable: true
   controller_enable: true
   scheduler_enable: true
-  pods_mutatingwebhook_enable: true
-  queues_mutatingwebhook_enable: true
-  podgroups_mutatingwebhook_enable: true
-  jobs_mutatingwebhook_enable: true
-  jobs_validatingwebhook_enable: true
-  pods_validatingwebhook_enable: true
-  queues_validatingwebhook_enable: true
+  enabled_admissions: "/jobs/mutate,/jobs/validate,/podgroups/mutate,/pods/validate,/pods/mutate,/queues/mutate,/queues/validate"

--- a/installer/volcano-development.yaml
+++ b/installer/volcano-development.yaml
@@ -134,6 +134,7 @@ spec:
       priorityClassName: system-cluster-critical
       containers:
         - args:
+            - --enabled-admission=/jobs/mutate,/jobs/validate,/podgroups/mutate,/pods/validate,/pods/mutate,/queues/mutate,/queues/validate
             - --tls-cert-file=/admission.local.config/certificates/tls.crt
             - --tls-private-key-file=/admission.local.config/certificates/tls.key
             - --ca-cert-file=/admission.local.config/certificates/ca.crt

--- a/pkg/webhooks/router/admission.go
+++ b/pkg/webhooks/router/admission.go
@@ -22,6 +22,8 @@ import (
 	"strings"
 	"sync"
 
+	"k8s.io/klog"
+
 	"volcano.sh/volcano/cmd/webhook-manager/app/options"
 )
 
@@ -48,11 +50,15 @@ func RegisterAdmission(service *AdmissionService) error {
 	return nil
 }
 
-func ForEachAdmission(config *options.Config, handler func(*AdmissionService)) {
+func ForEachAdmission(config *options.Config, handler func(*AdmissionService) error) error {
 	admissions := strings.Split(strings.TrimSpace(config.EnabledAdmission), ",")
+	klog.V(3).Infof("Enabled admissions are: %v, registered map are: %v", admissions, admissionMap)
 	for _, admission := range admissions {
 		if service, found := admissionMap[admission]; found {
-			handler(service)
+			if err := handler(service); err != nil {
+				return err
+			}
 		}
 	}
+	return nil
 }


### PR DESCRIPTION
Current method `addCaCertForWebhook()` only added CA cert for webhooks listed in `validatingWebhooksName` and `mutatingWebhooksName`
https://github.com/volcano-sh/volcano/blob/74b211451dbc16618bfd2d51a7288f0c0268551f/cmd/webhook-manager/app/util.go#L39-L51
Which is inconvenient for new webhook registration. For example, when user registered new webhook by arg `--enabled-admission`, new webhook would not get certs since the original method only go through slices above.
So this pr make `addCaCertForWebhook()` to go through all webhooks registered in volcano admission by arg `--enabled-admission`.

#2464 

Signed-off-by: jiangkaihua <jiangkaihua1@huawei.com>
