### PR TITLE
fix bug predicateGPUbyMemory when gpu id not continuous

### DIFF
--- a/pkg/scheduler/plugins/predicates/gpu.go
+++ b/pkg/scheduler/plugins/predicates/gpu.go
@@ -57,7 +57,7 @@ func predicateGPUbyMemory(pod *v1.Pod, node *api.NodeInfo) []int {
 
 	var devIDs []int
 
-	for devID := 0; devID < len(allocatableGPUs); devID++ {
+	for devID := range allocatableGPUs {
 		if availableGPU, ok := allocatableGPUs[devID]; ok && availableGPU >= gpuRequest {
 			devIDs = append(devIDs, devID)
 		}


### PR DESCRIPTION
Signed-off-by: yongjiahe <yongjiahe@tuputech.com>

Use key to traversal .allocatableGPUs. When gpu id is not continuous, it will unable to allocate some gpu id