### PR TITLE
make update pod more descriptive

### DIFF
--- a/pkg/scheduler/cache/cache.go
+++ b/pkg/scheduler/cache/cache.go
@@ -353,7 +353,7 @@ func (pgb *podgroupBinder) Bind(job *schedulingapi.JobInfo, cluster string) (*sc
 		pod := task.Pod
 		pod.Annotations[batch.ForwardClusterKey] = cluster
 		pod.ResourceVersion = ""
-		_, err := pgb.kubeclient.CoreV1().Pods(pod.Namespace).UpdateStatus(context.TODO(), pod, metav1.UpdateOptions{})
+		_, err := pgb.kubeclient.CoreV1().Pods(pod.Namespace).Update(context.TODO(), pod, metav1.UpdateOptions{})
 		if err != nil {
 			klog.Errorf("Error while update pod annotation with error: %v", err)
 			return nil, err


### PR DESCRIPTION
`UpdateStatus` is usually used to update Status Spec, here is not this case,  `UpdateStatus` need more RBAC setting because it's a sub resource, `Update` method is more descriptive here.

ref: 

- https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
- https://github.com/kubernetes/kubernetes/issues/60845#issuecomment-370871217