### PR TITLE
fix printing volcano-scheduler-configmap loading log;

### DIFF
--- a/pkg/scheduler/framework/plugins.go
+++ b/pkg/scheduler/framework/plugins.go
@@ -40,7 +40,6 @@ func RegisterPluginBuilder(name string, pc PluginBuilder) {
 	defer pluginMutex.Unlock()
 
 	pluginBuilders[name] = pc
-	klog.V(2).Infof("Successfully registered plugin: %s", name)
 }
 
 // CleanupPluginBuilders cleans up all the plugin
@@ -108,7 +107,6 @@ func RegisterAction(act Action) {
 	defer pluginMutex.Unlock()
 
 	actionMap[act.Name()] = act
-	klog.V(2).Infof("Successfully registered action: %s", act.Name())
 }
 
 // GetAction get the action by name

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -123,7 +123,7 @@ func (pc *Scheduler) loadSchedulerConf() {
 	klog.V(4).Infof("Start loadSchedulerConf ...")
 	defer func() {
 		actions, plugins := pc.getSchedulerConf()
-		klog.V(4).Infof("Successfully loaded scheduler conf, actions: %v, plugins: %v", actions, plugins)
+		klog.V(2).Infof("Successfully loaded scheduler conf, actions: %v, plugins: %v", actions, plugins)
 	}()
 
 	var err error


### PR DESCRIPTION
action/plugin register log printing won't work because initializing klog is after it is called at register plugin/action, so add more detail print at successfully loaded scheduler configuration.