### PR TITLE
add volume binding plugin

### DIFF
--- a/installer/helm/chart/volcano/templates/scheduler.yaml
+++ b/installer/helm/chart/volcano/templates/scheduler.yaml
@@ -41,7 +41,7 @@ rules:
     verbs: ["list", "watch", "update"]
   - apiGroups: [""]
     resources: ["persistentvolumes"]
-    verbs: ["list", "watch"]
+    verbs: ["list", "watch", "update"]
   - apiGroups: [""]
     resources: ["namespaces", "services", "replicationcontrollers"]
     verbs: ["list", "watch", "get"]

--- a/installer/volcano-development-arm64.yaml
+++ b/installer/volcano-development-arm64.yaml
@@ -8564,7 +8564,7 @@ rules:
     verbs: ["list", "watch", "update"]
   - apiGroups: [""]
     resources: ["persistentvolumes"]
-    verbs: ["list", "watch"]
+    verbs: ["list", "watch", "update"]
   - apiGroups: [""]
     resources: ["namespaces", "services", "replicationcontrollers"]
     verbs: ["list", "watch", "get"]

--- a/installer/volcano-development.yaml
+++ b/installer/volcano-development.yaml
@@ -8564,7 +8564,7 @@ rules:
     verbs: ["list", "watch", "update"]
   - apiGroups: [""]
     resources: ["persistentvolumes"]
-    verbs: ["list", "watch"]
+    verbs: ["list", "watch", "update"]
   - apiGroups: [""]
     resources: ["namespaces", "services", "replicationcontrollers"]
     verbs: ["list", "watch", "get"]

--- a/pkg/scheduler/plugins/nodeorder/nodeorder.go
+++ b/pkg/scheduler/plugins/nodeorder/nodeorder.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 
 	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilFeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog"
@@ -34,6 +35,7 @@ import (
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/noderesources"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/selectorspread"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/tainttoleration"
+	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/volumebinding"
 
 	"volcano.sh/volcano/pkg/scheduler/api"
 	"volcano.sh/volcano/pkg/scheduler/framework"
@@ -61,6 +63,8 @@ const (
 	ImageLocalityWeight = "imagelocality.weight"
 	// SelectorSpreadWeight is the key for providing Selector Spread Priority Weight in YAML
 	selectorSpreadWeight = "selectorspread.weight"
+	// VolumeBinding is the key for providing Volume Binding Priority Weight in YAML
+	volumeBindingWeight = "volumebinding.weight"
 )
 
 type nodeOrderPlugin struct {
@@ -86,6 +90,7 @@ type priorityWeight struct {
 	taintTolerationWeight  int
 	imageLocalityWeight    int
 	selectorSpreadWeight   int
+	volumeBindingWeight    int
 }
 
 // calculateWeight from the provided arguments.
@@ -127,6 +132,7 @@ func calculateWeight(args framework.Arguments) priorityWeight {
 		taintTolerationWeight:  1,
 		imageLocalityWeight:    1,
 		selectorSpreadWeight:   0,
+		volumeBindingWeight:    1,
 	}
 
 	// Checks whether nodeaffinity.weight is provided or not, if given, modifies the value in weight struct.
@@ -152,6 +158,9 @@ func calculateWeight(args framework.Arguments) priorityWeight {
 
 	// Checks whether selectorspread.weight is provided or not, if given, modifies the value in weight struct.
 	args.GetInt(&weight.selectorSpreadWeight, selectorSpreadWeight)
+
+	// Checks whether volumebinding.weight is provided or not, if given, modifies the value in weight struct.
+	args.GetInt(&weight.volumeBindingWeight, volumeBindingWeight)
 
 	return weight
 }
@@ -247,6 +256,15 @@ func (pp *nodeOrderPlugin) OnSessionOpen(ssn *framework.Session) {
 	p, _ = imagelocality.New(nil, handle)
 	imageLocality := p.(*imagelocality.ImageLocality)
 
+	// 6. VolumeBinding
+	volumeBindingArgs := &config.VolumeBindingArgs{
+		TypeMeta:           metav1.TypeMeta{},
+		BindTimeoutSeconds: volumebinding.DefaultBindTimeoutSeconds,
+		Shape:              nil,
+	}
+	p, _ = volumebinding.New(volumeBindingArgs, handle, fts)
+	volumeBinding := p.(*volumebinding.VolumeBinding)
+
 	nodeOrderFn := func(task *api.TaskInfo, node *api.NodeInfo) (float64, error) {
 		var nodeScore = 0.0
 
@@ -314,6 +332,19 @@ func (pp *nodeOrderPlugin) OnSessionOpen(ssn *framework.Session) {
 			// If nodeAffinityWeight is provided, host.Score is multiplied with weight, if not, host.Score is added to total score.
 			nodeScore += float64(score) * float64(weight.nodeAffinityWeight)
 			klog.V(4).Infof("Node Affinity score: %f", nodeScore)
+		}
+
+		// VolumeBinding
+		if weight.volumeBindingWeight != 0 {
+			score, status := volumeBinding.Score(context.TODO(), state, task.Pod, node.Name)
+			if !status.IsSuccess() {
+				klog.Warningf("Volume Binding Priority Failed because of Error: %v", status.AsError())
+				return 0, status.AsError()
+			}
+
+			// If volumeBindingWeight is provided, host.Score is multiplied with weight, if not, host.Score is added to total score.
+			nodeScore += float64(score) * float64(weight.volumeBindingWeight)
+			klog.V(4).Infof("Volume Binding score: %f", nodeScore)
 		}
 
 		klog.V(4).Infof("Total Score for task %s/%s on node %s is: %f", task.Namespace, task.Name, node.Name, nodeScore)


### PR DESCRIPTION
1. `VolumeBinding` plugin should rank before `VolumeZone` like kube-scheduler do
2. `NodeOrder` is by default enabled
3. `update` permission of pv is required for late binding of pvc

test cases include:
1. Late pvc binding using `WaitForFirstConsumer` storage class
2. node order based on the utilization, request-capacity percentage: the larger of the node capactiy and the lower utilization, the high of the score.
3. scripts used:
```yaml
apiVersion: v1
kind: PersistentVolume
metadata:
  name: pv-local
spec:
  capacity:
    storage: 5Gi
  volumeMode: Filesystem
  accessModes:
  - ReadWriteOnce
  persistentVolumeReclaimPolicy: Delete
  storageClassName: local-storage
  local:
    path: /data/k8s/localpv
  nodeAffinity: 
    required:
      nodeSelectorTerms:
      - matchExpressions:
        - key: kubernetes.io/hostname
          operator: In
          values:
          - 192.168.2.64

---
apiVersion: storage.k8s.io/v1
kind: StorageClass
metadata:
  name: local-storage
provisioner: kubernetes.io/no-provisioner
volumeBindingMode: WaitForFirstConsumer

---
kind: PersistentVolumeClaim
apiVersion: v1
metadata:
  name: pvc-local
spec:
  accessModes:
  - ReadWriteOnce
  resources:
    requests:
      storage: 5Gi
  storageClassName: local-storage

---
apiVersion: v1
kind: Pod
metadata:
  name: pv-local-pod
spec:
  imagePullSecrets:
    - name: default-secret
  schedulerName: volcano
  volumes:
  - name: example-pv-local
    persistentVolumeClaim:
      claimName: pvc-local
  containers:
  - name: example-pv-local
    image: nginx:1.23
    ports:
    - containerPort: 80
    volumeMounts:
    - mountPath: /usr/share/nginx/html
      name: example-pv-local

```

resolve #2485 

Signed-off-by: xilinxing <xilinxing@huawei.com>