### PR TITLE
allow setting replicas in helm chart

### DIFF
--- a/installer/README.md
+++ b/installer/README.md
@@ -81,8 +81,11 @@ The following are the list configurable parameters of Volcano Chart and their de
 |`basic.scheduler_app_name`|Scheduler App Name|`volcano-scheduler`|
 |`custom.metrics_enable`|Whether to Enable Metrics|`false`|
 |`custom.admission_enable`|Whether to Enable Admission|`true`|
+|`custom.admission_replicas`|The number of Admission pods to run|`1`|
 |`custom.controller_enable`|Whether to Enable Controller|`true`|
+|`custom.controller_replicas`|The number of Controller pods to run|`1`|
 |`custom.scheduler_enable`|Whether to Enable Scheduler|`true`|
+|`custom.scheduler_replicas`|The number of Scheduler pods to run|`1`|
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/installer/helm/chart/volcano/templates/admission.yaml
+++ b/installer/helm/chart/volcano/templates/admission.yaml
@@ -67,7 +67,7 @@ metadata:
   name: {{ .Release.Name }}-admission
   namespace: {{ .Release.Namespace }}
 spec:
-  replicas: 1
+  replicas: {{ .Values.custom.admission_replicas }}
   selector:
     matchLabels:
       app: volcano-admission

--- a/installer/helm/chart/volcano/templates/controllers.yaml
+++ b/installer/helm/chart/volcano/templates/controllers.yaml
@@ -82,7 +82,7 @@ metadata:
   labels:
     app: volcano-controller
 spec:
-  replicas: 1
+  replicas: {{ .Values.custom.controller_replicas }}
   selector:
     matchLabels:
       app: volcano-controller

--- a/installer/helm/chart/volcano/templates/scheduler.yaml
+++ b/installer/helm/chart/volcano/templates/scheduler.yaml
@@ -102,7 +102,7 @@ metadata:
   labels:
     app: volcano-scheduler
 spec:
-  replicas: 1
+  replicas: {{ .Values.custom.scheduler_replicas }}
   selector:
     matchLabels:
       app: volcano-scheduler

--- a/installer/helm/chart/volcano/values.yaml
+++ b/installer/helm/chart/volcano/values.yaml
@@ -11,6 +11,9 @@ basic:
 custom:
   metrics_enable: false
   admission_enable: true
+  admission_replicas: 1
   controller_enable: true
+  controller_replicas: 1
   scheduler_enable: true
+  scheduler_replicas: 1
   enabled_admissions: "/jobs/mutate,/jobs/validate,/podgroups/mutate,/pods/validate,/pods/mutate,/queues/mutate,/queues/validate"


### PR DESCRIPTION
This PR adds possibility to specify the number of component replicas during volcano helm installation

resolves #2520