### PR TITLE
pod could be preempted by default

### DIFF
--- a/pkg/scheduler/api/pod_info.go
+++ b/pkg/scheduler/api/pod_info.go
@@ -98,7 +98,7 @@ func GetPodPreemptable(pod *v1.Pod) bool {
 		}
 	}
 
-	return false
+	return true
 }
 
 // GetPodRevocableZone return volcano.sh/revocable-zone value for pod/podgroup

--- a/pkg/scheduler/plugins/tdm/tdm_test.go
+++ b/pkg/scheduler/plugins/tdm/tdm_test.go
@@ -330,6 +330,9 @@ func Test_TDM_victimsFn(t *testing.T) {
 	p2.Annotations[schedulingv2.PodPreemptable] = "true"
 	p3.Annotations[schedulingv2.PodPreemptable] = "true"
 
+	p4.Annotations[schedulingv2.PodPreemptable] = "false"
+	p5.Annotations[schedulingv2.PodPreemptable] = "false"
+
 	p6.Annotations[schedulingv2.PodPreemptable] = "true"
 	p7.Annotations[schedulingv2.PodPreemptable] = "true"
 	p8.Annotations[schedulingv2.PodPreemptable] = "true"


### PR DESCRIPTION
Signed-off-by: Zhe Jin <jinzhe.hit@gmail.com>

After PR https://github.com/volcano-sh/volcano/pull/2105, Pod could not be preempted by default and the behavior is different than before (Pod could be preempted by default).

In this PR, change the default value of `volcano.sh/preemptable` to `true` in function `GetPodPreemptable()` to make pod preemptable by default.
The `TDM` plugin use `JobInfo.extractPreemptable()` to check if a job is preemptable, this PR will not change it.