### PR TITLE
unified volcano-controller name

### DIFF
--- a/installer/helm/chart/volcano/templates/controller.yaml
+++ b/installer/helm/chart/volcano/templates/controller.yaml
@@ -2,14 +2,14 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ .Release.Name }}-controllers
+  name: {{ .Release.Name }}-controller
   namespace: {{ .Release.Namespace }}
 
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ .Release.Name }}-controllers
+  name: {{ .Release.Name }}-controller
 rules:
   - apiGroups: ["apiextensions.k8s.io"]
     resources: ["customresourcedefinitions"]
@@ -63,21 +63,21 @@ rules:
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ .Release.Name }}-controllers-role
+  name: {{ .Release.Name }}-controller-role
 subjects:
   - kind: ServiceAccount
-    name: {{ .Release.Name }}-controllers
+    name: {{ .Release.Name }}-controller
     namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
-  name: {{ .Release.Name }}-controllers
+  name: {{ .Release.Name }}-controller
   apiGroup: rbac.authorization.k8s.io
 
 ---
 kind: Deployment
 apiVersion: apps/v1
 metadata:
-  name: {{ .Release.Name }}-controllers
+  name: {{ .Release.Name }}-controller
   namespace: {{ .Release.Namespace }}
   labels:
     app: volcano-controller
@@ -91,14 +91,14 @@ spec:
       labels:
         app: volcano-controller
     spec:
-      serviceAccount: {{ .Release.Name }}-controllers
+      serviceAccount: {{ .Release.Name }}-controller
       priorityClassName: system-cluster-critical
       {{- if .Values.basic.image_pull_secret }}
       imagePullSecrets:
           - name: {{ .Values.basic.image_pull_secret }}
       {{- end }}
       containers:
-          - name: {{ .Release.Name }}-controllers
+          - name: {{ .Release.Name }}-controller
             image: {{.Values.basic.controller_image_name}}:{{.Values.basic.image_tag_version}}
             args:
               - --logtostderr

--- a/installer/volcano-development.yaml
+++ b/installer/volcano-development.yaml
@@ -8408,14 +8408,14 @@ status:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: volcano-controllers
+  name: volcano-controller
   namespace: volcano-system
 ---
 # Source: volcano/templates/controllers.yaml
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: volcano-controllers
+  name: volcano-controller
 rules:
   - apiGroups: ["apiextensions.k8s.io"]
     resources: ["customresourcedefinitions"]
@@ -8470,21 +8470,21 @@ rules:
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: volcano-controllers-role
+  name: volcano-controller-role
 subjects:
   - kind: ServiceAccount
-    name: volcano-controllers
+    name: volcano-controller
     namespace: volcano-system
 roleRef:
   kind: ClusterRole
-  name: volcano-controllers
+  name: volcano-controller
   apiGroup: rbac.authorization.k8s.io
 ---
 # Source: volcano/templates/controllers.yaml
 kind: Deployment
 apiVersion: apps/v1
 metadata:
-  name: volcano-controllers
+  name: volcano-controller
   namespace: volcano-system
   labels:
     app: volcano-controller
@@ -8498,10 +8498,10 @@ spec:
       labels:
         app: volcano-controller
     spec:
-      serviceAccount: volcano-controllers
+      serviceAccount: volcano-controller
       priorityClassName: system-cluster-critical
       containers:
-          - name: volcano-controllers
+          - name: volcano-controller
             image: volcanosh/vc-controller-manager:latest
             args:
               - --logtostderr


### PR DESCRIPTION
volcano-controller has two name now. "volcano-controller" and "volcano-controllers". Inconsistent names are not suitable for maintenance.