### PR TITLE
fix issue queue is not met even if oldDeserved and deserved are the same

### DIFF
--- a/pkg/scheduler/plugins/proportion/proportion.go
+++ b/pkg/scheduler/plugins/proportion/proportion.go
@@ -210,6 +210,8 @@ func (pp *proportionPlugin) OnSessionOpen(ssn *framework.Session) {
 			}
 			attr.deserved.MinDimensionResource(attr.request, api.Zero)
 
+			attr.deserved = helpers.Max(attr.deserved, attr.guarantee)
+			pp.updateShare(attr)
 			klog.V(4).Infof("Format queue <%s> deserved resource to <%v>", attr.name, attr.deserved)
 
 			if attr.request.LessEqual(attr.deserved, api.Zero) {
@@ -219,8 +221,6 @@ func (pp *proportionPlugin) OnSessionOpen(ssn *framework.Session) {
 				meet[attr.queueID] = struct{}{}
 				klog.V(4).Infof("queue <%s> is meet cause of the capability", attr.name)
 			}
-			attr.deserved = helpers.Max(attr.deserved, attr.guarantee)
-			pp.updateShare(attr)
 
 			klog.V(4).Infof("The attributes of queue <%s> in proportion: deserved <%v>, realCapability <%v>, allocate <%v>, request <%v>, elastic <%v>, share <%0.2f>",
 				attr.name, attr.deserved, attr.realCapability, attr.allocated, attr.request, attr.elastic, attr.share)


### PR DESCRIPTION
Signed-off-by: Zhe Jin <jinzhe.hit@gmail.com>

Fix https://github.com/volcano-sh/volcano/issues/2549

**How to reproduce (refer to https://github.com/volcano-sh/volcano/issues/2549)**
1. there is one node in cluster and the allocatable of node
```
Allocatable:
  cpu:                6
  ephemeral-storage:  48294789041
  hugepages-2Mi:      0
  memory:             13484824Ki
  pods:               110
...
Allocated resources:
  (Total limits may be over 100 percent, i.e., overcommitted.)
  Resource           Requests    Limits
  --------           --------    ------
  cpu                1 (16%)     0 (0%)
  memory             170Mi (1%)  170Mi (1%)
  ephemeral-storage  100Mi (0%)  0 (0%)
  hugepages-2Mi      0 (0%)      0 (0%)
Events:              <none>
```

2. create two queues
```
$ kubectl get queue high-queue -o yaml
apiVersion: scheduling.volcano.sh/v1beta1
kind: Queue
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"scheduling.volcano.sh/v1beta1","kind":"Queue","metadata":{"annotations":{},"name":"high-queue"},"spec":{"capability":{"cpu":"1","memory":"359Gi"},"reclaimable":true,"weight":10000000}}
  creationTimestamp: "2022-10-26T09:04:50Z"
  generation: 3
  name: high-queue
  resourceVersion: "38613721"
  uid: 7de29005-b105-46ea-a1cd-2772cf20256f
spec:
  capability:
    cpu: "1"
    memory: 359Gi
  reclaimable: true
  weight: 10000000
status:
  reservation: {}
  state: Open

$ kubectl get queue low-queue -o yaml
apiVersion: scheduling.volcano.sh/v1beta1
kind: Queue
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"scheduling.volcano.sh/v1beta1","kind":"Queue","metadata":{"annotations":{},"name":"low-queue"},"spec":{"capability":{"cpu":"960","memory":"900Gi"},"reclaimable":true,"weight":1}}
  creationTimestamp: "2022-10-26T09:04:54Z"
  generation: 1
  name: low-queue
  resourceVersion: "38613720"
  uid: b1117f86-0fe4-4cf2-8c44-e01f59ecfdf5
spec:
  capability:
    cpu: "960"
    memory: 900Gi
  reclaimable: true
  weight: 1
status:
  reservation: {}
  state: Open
```

3. submit a job to low-queue and wait for all pods to run
```
$ cat low-queue-job.yaml 
apiVersion: batch.volcano.sh/v1alpha1
kind: Job
metadata:
  name: low-queue-job1
spec:
  minAvailable: 1
  schedulerName: volcano
  policies:
    - event: PodEvicted
      action: RestartJob
  plugins:
    ssh: []
    env: []
    svc: []
  maxRetry: 5
  queue: low-queue
  tasks:
    - replicas: 4
      name: "mork1"
      template:
        metadata:
          name: mork1
        spec:
          schedulerName: volcano
          containers:
            - image: busybox
              imagePullPolicy: IfNotPresent
              command:
                - /bin/sh
                - -c
                - sleep 360000
              name: sleeptask
              resources:
                requests:
                  cpu: "1000m"
                  memory: "500M"
                limits:
                  cpu: "1000m"
                  memory: "500M"
``` 

4. submit a job to high-queue
```
$ cat high-queue-job.yaml 
apiVersion: batch.volcano.sh/v1alpha1
kind: Job
metadata:
  name: high-queue-job1
spec:
  minAvailable: 1
  schedulerName: volcano
  policies:
    - event: PodEvicted
      action: RestartJob
  plugins:
    ssh: []
    env: []
    svc: []
  maxRetry: 5
  queue: high-queue
  tasks:
    - replicas: 1
      name: "mork1"
      template:
        metadata:
          name: mork1
        spec:
          schedulerName: volcano
          containers:
            - image: busybox
              imagePullPolicy: IfNotPresent
              command:
                - /bin/sh
                - -c
                - sleep 360000
              name: sleeptask
              resources:
                requests:
                  cpu: "2000m"
                  memory: "500M"
                limits:
                  cpu: "2000m"
                  memory: "500M"
```

5. check volcano scheduler log and we can find that high-queue is not in met status even if its reserved dose not change
```
I1027 03:13:28.595984       1 proportion.go:199] Considering Queue <high-queue>: weight <10000000>, total weight <10000001>.
I1027 03:13:28.595990       1 proportion.go:213] Format queue <high-queue> deserved resource to <cpu 1000.00, memory 500000000.00, hugepages-2Mi 0.00>
I1027 03:13:28.595998       1 proportion.go:225] The attributes of queue <high-queue> in proportion: deserved <cpu 1000.00, memory 500000000.00>, realCapability <cpu 1000.00, memory 13808459776.00>, allocate <cpu 0.00, memory 0.00>, request <cpu 2000.00, memory 500000000.00>, elastic <cpu 0.00, memory 0.00>, share <0.00>
I1027 03:13:28.596008       1 proportion.go:199] Considering Queue <low-queue>: weight <1>, total weight <10000001>.
I1027 03:13:28.596014       1 proportion.go:213] Format queue <low-queue> deserved resource to <cpu 3.75, memory 9969673.14, hugepages-2Mi 0.00>
I1027 03:13:28.596023       1 proportion.go:225] The attributes of queue <low-queue> in proportion: deserved <cpu 3.75, memory 9969673.14>, realCapability <cpu 6000.00, memory 13808459776.00>, allocate <cpu 4000.00, memory 2000000000.00>, request <cpu 4000.00, memory 2000000000.00>, elastic <cpu 3000.00, memory 1500000000.00>, share <1067.89>
I1027 03:13:28.596033       1 proportion.go:237] Remaining resource is  <cpu 4996.25, memory 13298490102.86, hugepages-2Mi 0.00>
I1027 03:13:28.596041       1 proportion.go:199] Considering Queue <low-queue>: weight <1>, total weight <10000001>.
I1027 03:13:28.596047       1 proportion.go:213] Format queue <low-queue> deserved resource to <cpu 3.75, memory 9971002.98, hugepages-2Mi 0.00>
I1027 03:13:28.596055       1 proportion.go:225] The attributes of queue <low-queue> in proportion: deserved <cpu 3.75, memory 9971002.98>, realCapability <cpu 6000.00, memory 13808459776.00>, allocate <cpu 4000.00, memory 2000000000.00>, request <cpu 4000.00, memory 2000000000.00>, elastic <cpu 3000.00, memory 1500000000.00>, share <1067.75>
I1027 03:13:28.596065       1 proportion.go:199] Considering Queue <high-queue>: weight <10000000>, total weight <10000001>.
I1027 03:13:28.596073       1 proportion.go:213] Format queue <high-queue> deserved resource to <cpu 1000.00, memory 500000000.00, hugepages-2Mi 0.00>
I1027 03:13:28.596081       1 proportion.go:225] The attributes of queue <high-queue> in proportion: deserved <cpu 1000.00, memory 500000000.00>, realCapability <cpu 1000.00, memory 13808459776.00>, allocate <cpu 0.00, memory 0.00>, request <cpu 2000.00, memory 500000000.00>, elastic <cpu 0.00, memory 0.00>, share <0.00>
I1027 03:13:28.596090       1 proportion.go:237] Remaining resource is  <cpu 4996.25, memory 13298488773.02, hugepages-2Mi 0.00>
I1027 03:13:28.596097       1 proportion.go:199] Considering Queue <high-queue>: weight <10000000>, total weight <10000001>.
I1027 03:13:28.596104       1 proportion.go:213] Format queue <high-queue> deserved resource to <cpu 1000.00, memory 500000000.00, hugepages-2Mi 0.00>
I1027 03:13:28.596112       1 proportion.go:225] The attributes of queue <high-queue> in proportion: deserved <cpu 1000.00, memory 500000000.00>, realCapability <cpu 1000.00, memory 13808459776.00>, allocate <cpu 0.00, memory 0.00>, request <cpu 2000.00, memory 500000000.00>, elastic <cpu 0.00, memory 0.00>, share <0.00>
I1027 03:13:28.596122       1 proportion.go:199] Considering Queue <low-queue>: weight <1>, total weight <10000001>.
I1027 03:13:28.596129       1 proportion.go:213] Format queue <low-queue> deserved resource to <cpu 3.75, memory 9972332.83, hugepages-2Mi 0.00>
I1027 03:13:28.596138       1 proportion.go:225] The attributes of queue <low-queue> in proportion: deserved <cpu 3.75, memory 9972332.83>, realCapability <cpu 6000.00, memory 13808459776.00>, allocate <cpu 4000.00, memory 2000000000.00>, request <cpu 4000.00, memory 2000000000.00>, elastic <cpu 3000.00, memory 1500000000.00>, share <1067.61>
I1027 03:13:28.596148       1 proportion.go:237] Remaining resource is  <cpu 4996.25, memory 13298487443.17, hugepages-2Mi 0.00>
```

**Root Cause**
```go
			if attr.request.LessEqual(attr.deserved, api.Zero) {
				meet[attr.queueID] = struct{}{}
				klog.V(4).Infof("queue <%s> is meet", attr.name)
			} else if reflect.DeepEqual(attr.deserved, oldDeserved) {  // queue is not met due to oldDeserved(<cpu 2.40, memory 6375935.80>) and deserved(<cpu 2.40, memory 6377266.01, hugepages-2Mi 0.00>) are different
				meet[attr.queueID] = struct{}{}
				klog.V(4).Infof("queue <%s> is meet cause of the capability", attr.name)
			}
			attr.deserved = helpers.Max(attr.deserved, attr.guarantee)  // deserved is changed from <cpu 2.40, memory 6377266.01, hugepages-2Mi 0.00> to <cpu 2.40, memory 6375935.80>
			pp.updateShare(attr)
```

scheduler should use `deserved` after adjust it according to `guarantee`, otherwise it will cause queue in wrong status.