### PR TITLE
support scheduler cache dump

### DIFF
--- a/cmd/scheduler/app/options/options.go
+++ b/cmd/scheduler/app/options/options.go
@@ -72,7 +72,8 @@ type ServerOption struct {
 	MinPercentageOfNodesToFind int32
 	PercentageOfNodesToFind    int32
 
-	NodeSelector []string
+	NodeSelector      []string
+	EnableCacheDumper bool
 }
 
 type DecryptFunc func(c *ServerOption) error
@@ -125,6 +126,7 @@ func (s *ServerOption) AddFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&s.EnableHealthz, "enable-healthz", false, "Enable the health check; it is false by default")
 	fs.BoolVar(&s.EnableMetrics, "enable-metrics", false, "Enable the metrics function; it is false by default")
 	fs.StringSliceVar(&s.NodeSelector, "node-selector", nil, "volcano only work with the labeled node, like: --node-selector=volcano.sh/role:train --node-selector=volcano.sh/role:serving")
+	fs.BoolVar(&s.EnableCacheDumper, "cache-dumper", true, "Enable the cache dumper, it's true by default")
 }
 
 // CheckOptionOrDie check lock-object-namespace when LeaderElection is enabled.

--- a/cmd/scheduler/app/options/options_test.go
+++ b/cmd/scheduler/app/options/options_test.go
@@ -34,6 +34,7 @@ func TestAddFlags(t *testing.T) {
 	args := []string{
 		"--schedule-period=5m",
 		"--priority-class=false",
+		"--cache-dumper=false",
 	}
 	fs.Parse(args)
 

--- a/pkg/scheduler/api/job_info.go
+++ b/pkg/scheduler/api/job_info.go
@@ -268,7 +268,7 @@ func (ti *TaskInfo) GetTaskSpecKey() TaskID {
 
 // String returns the taskInfo details in a string
 func (ti TaskInfo) String() string {
-	res := fmt.Sprintf("Task (%v:%v/%v): job %v, status %v, pri %v"+
+	res := fmt.Sprintf("Task (%v:%v/%v): job %v, status %v, pri %v, "+
 		"resreq %v, preemptable %v, revocableZone %v",
 		ti.UID, ti.Namespace, ti.Name, ti.Job, ti.Status, ti.Priority,
 		ti.Resreq, ti.Preemptable, ti.RevocableZone)

--- a/pkg/scheduler/api/node_info.go
+++ b/pkg/scheduler/api/node_info.go
@@ -60,7 +60,7 @@ type NodeInfo struct {
 	Used *Resource
 
 	Allocatable   *Resource
-	Capability    *Resource
+	Capacity      *Resource
 	ResourceUsage *NodeUsage
 
 	Tasks             map[TaskID]*TaskInfo
@@ -134,7 +134,7 @@ func NewNodeInfo(node *v1.Node) *NodeInfo {
 		Used:      EmptyResource(),
 
 		Allocatable:   EmptyResource(),
-		Capability:    EmptyResource(),
+		Capacity:      EmptyResource(),
 		ResourceUsage: &NodeUsage{},
 
 		OversubscriptionResource: EmptyResource(),
@@ -151,7 +151,7 @@ func NewNodeInfo(node *v1.Node) *NodeInfo {
 		nodeInfo.Node = node
 		nodeInfo.Idle = NewResource(node.Status.Allocatable).Add(nodeInfo.OversubscriptionResource)
 		nodeInfo.Allocatable = NewResource(node.Status.Allocatable).Add(nodeInfo.OversubscriptionResource)
-		nodeInfo.Capability = NewResource(node.Status.Capacity).Add(nodeInfo.OversubscriptionResource)
+		nodeInfo.Capacity = NewResource(node.Status.Capacity).Add(nodeInfo.OversubscriptionResource)
 	}
 	nodeInfo.setNodeGPUInfo(node)
 	nodeInfo.setNodeState(node)
@@ -383,7 +383,7 @@ func (ni *NodeInfo) setNode(node *v1.Node) {
 	ni.Node = node
 
 	ni.Allocatable = NewResource(node.Status.Allocatable).Add(ni.OversubscriptionResource)
-	ni.Capability = NewResource(node.Status.Capacity).Add(ni.OversubscriptionResource)
+	ni.Capacity = NewResource(node.Status.Capacity).Add(ni.OversubscriptionResource)
 	ni.Releasing = EmptyResource()
 	ni.Pipelined = EmptyResource()
 	ni.Idle = NewResource(node.Status.Allocatable).Add(ni.OversubscriptionResource)

--- a/pkg/scheduler/api/node_info_test.go
+++ b/pkg/scheduler/api/node_info_test.go
@@ -58,7 +58,7 @@ func TestNodeInfo_AddPod(t *testing.T) {
 				Pipelined:                EmptyResource(),
 				OversubscriptionResource: EmptyResource(),
 				Allocatable:              buildResource("8000m", "10G"),
-				Capability:               buildResource("8000m", "10G"),
+				Capacity:                 buildResource("8000m", "10G"),
 				ResourceUsage:            &NodeUsage{},
 				State:                    NodeState{Phase: Ready},
 				Tasks: map[TaskID]*TaskInfo{
@@ -82,7 +82,7 @@ func TestNodeInfo_AddPod(t *testing.T) {
 				Pipelined:                EmptyResource(),
 				OversubscriptionResource: EmptyResource(),
 				Allocatable:              buildResource("2000m", "1G"),
-				Capability:               buildResource("2000m", "1G"),
+				Capacity:                 buildResource("2000m", "1G"),
 				ResourceUsage:            &NodeUsage{},
 				State:                    NodeState{Phase: Ready},
 				Tasks:                    map[TaskID]*TaskInfo{},
@@ -142,7 +142,7 @@ func TestNodeInfo_RemovePod(t *testing.T) {
 				Releasing:                EmptyResource(),
 				Pipelined:                EmptyResource(),
 				Allocatable:              buildResource("8000m", "10G"),
-				Capability:               buildResource("8000m", "10G"),
+				Capacity:                 buildResource("8000m", "10G"),
 				ResourceUsage:            &NodeUsage{},
 				State:                    NodeState{Phase: Ready},
 				Tasks: map[TaskID]*TaskInfo{
@@ -204,7 +204,7 @@ func TestNodeInfo_SetNode(t *testing.T) {
 				Releasing:                EmptyResource(),
 				Pipelined:                EmptyResource(),
 				Allocatable:              buildResource("10", "10G"),
-				Capability:               buildResource("10", "10G"),
+				Capacity:                 buildResource("10", "10G"),
 				ResourceUsage:            &NodeUsage{},
 				State:                    NodeState{Phase: NotReady, Reason: "OutOfSync"},
 				Tasks: map[TaskID]*TaskInfo{

--- a/pkg/scheduler/cache/dumper.go
+++ b/pkg/scheduler/cache/dumper.go
@@ -1,0 +1,80 @@
+/*
+ Copyright 2023 The Volcano Authors.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package cache
+
+import (
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+
+	"k8s.io/klog/v2"
+	"volcano.sh/volcano/pkg/scheduler/api"
+)
+
+// Dumper writes some information from the scheduler cache to the scheduler logs
+// for debugging purposes. Usage: run `kill -s USR2 <pid>` in the shell, where <pid>
+// is the process id of the scheduler process.
+type Dumper struct {
+	Cache Cache
+}
+
+func (d *Dumper) dumpAll() {
+	snapshot := d.Cache.Snapshot()
+	klog.Info("Dump of nodes info in scheduler cache")
+	for _, nodeInfo := range snapshot.Nodes {
+		klog.Info(d.printNodeInfo(nodeInfo))
+	}
+
+	klog.Info("Dump of jobs info in scheduler cache")
+	for _, jobInfo := range snapshot.Jobs {
+		klog.Info(d.printJobInfo(jobInfo))
+	}
+}
+
+func (d *Dumper) printNodeInfo(node *api.NodeInfo) string {
+	var data strings.Builder
+	data.WriteString("\n")
+	data.WriteString(node.String())
+	data.WriteString("\n")
+	return data.String()
+}
+
+func (d *Dumper) printJobInfo(jobInfo *api.JobInfo) string {
+	var data strings.Builder
+	data.WriteString("\n")
+	data.WriteString(jobInfo.String())
+	data.WriteString("\n")
+	return data.String()
+}
+
+// ListenForSignal starts a goroutine that will respond when process
+// receives SIGUSER2 signal.
+func (d *Dumper) ListenForSignal(stopCh <-chan struct{}) {
+	ch := make(chan os.Signal, 1)
+	signal.Notify(ch, syscall.SIGUSR2)
+	go func() {
+		for {
+			select {
+			case <-stopCh:
+				return
+			case <-ch:
+				d.dumpAll()
+			}
+		}
+	}()
+}

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/klog"
 
+	"volcano.sh/volcano/cmd/scheduler/app/options"
 	"volcano.sh/volcano/pkg/filewatcher"
 	schedcache "volcano.sh/volcano/pkg/scheduler/cache"
 	"volcano.sh/volcano/pkg/scheduler/conf"
@@ -48,6 +49,7 @@ type Scheduler struct {
 	plugins        []conf.Tier
 	configurations []conf.Configuration
 	metricsConf    map[string]string
+	dumper         schedcache.Dumper
 }
 
 // NewScheduler returns a scheduler
@@ -69,11 +71,13 @@ func NewScheduler(
 		}
 	}
 
+	cache := schedcache.New(config, schedulerNames, defaultQueue, nodeSelectors)
 	scheduler := &Scheduler{
 		schedulerConf:  schedulerConf,
 		fileWatcher:    watcher,
-		cache:          schedcache.New(config, schedulerNames, defaultQueue, nodeSelectors),
+		cache:          cache,
 		schedulePeriod: period,
+		dumper:         schedcache.Dumper{Cache: cache},
 	}
 
 	return scheduler, nil
@@ -89,6 +93,9 @@ func (pc *Scheduler) Run(stopCh <-chan struct{}) {
 	pc.cache.WaitForCacheSync(stopCh)
 	klog.V(2).Infof("scheduler completes Initialization and start to run")
 	go wait.Until(pc.runOnce, pc.schedulePeriod, stopCh)
+	if options.ServerOpts.EnableCacheDumper {
+		pc.dumper.ListenForSignal(stopCh)
+	}
 }
 
 func (pc *Scheduler) runOnce() {


### PR DESCRIPTION
This pr adds a cache dumper for the volcano scheduler(resolve #2517), it might be useful for debugging when some glitches happen online. 

In the old times if some scheduler error happened online, we can't get cache information from the log, because the log level is 2 by default, most of the time the log level may be needed to adjust to a high level to get more information. But this operation will restart the volcano process, then we may lose a chance to investigate the root cause of the error can't be easily reproduced. 

I tried to add a module to dynamically change the log level without restarting the scheduler process, but it seems like changing klog is more complicated than I thought, see #2322.

After this pr, when an error happens, people don't need to restart the volcano to get the cache information but by simply running a `kill -s USR2 <scheduler pid>`  command in the shell, and the dumper will print the snapshot information of the scheduler cache to the scheduler log, just like the following format:
```
Node (192.168.2.6): allocatable<cpu 3920.00, memory 6953406464.00, hugepages-2Mi 0.00, cce/eni 11000.00, hugepages-1Gi 0.00> idle <cpu 1870.00, memory 3899953152.00, hugepages-1Gi 0.00, hugepages-2Mi 0.00, cce/eni 11000.00>, used <cpu 2050.00, memory 3053453312.00>, releasing <cpu 0.00, memory 0.00>, oversubscribution <cpu 0.00, memory 0.00>, state <phase Ready, reaseon >, oversubscributionNode <false>, offlineJobEvicting <false>,taints <[]>
         0: Task (679c8fad-45da-44df-beb0-0b1dec88c045:kube-system/xxxxx): job , status Running, pri 0resreq cpu 0.00, memory 0.00, preemptable false, revocableZone , numaInfo { map[]}
         1: Task (f711618d-1e40-44f7-a115-0aead9cf8145:kube-system/volcano-scheduler-0): job , status Running, pri 0resreq cpu 500.00, memory 524288000.00, preemptable false, revocableZone , numaInfo { map[]}
         2: Task (48c86fa5-46d1-4353-94b1-567c8a646bec:kube-system/coredns-56d6f68cf9-tdzc2): job , status Running, pri 2000000000resreq cpu 500.00, memory 536870912.00, preemptable false, revocableZone , numaInfo { map[]}
         3: Task (ac1dad4b-683f-475d-9ab2-1f1c9dd67a0f:kube-system/yyyyyyy): job , status Running, pri 2000001000resreq cpu 100.00, memory 314572800.00, preemptable false, revocableZone , numaInfo { map[]}
         4: Task (7e14c2c2-4e01-462b-a1a8-7cc9ed67eb1a:kube-system/volcano-controller-68c95d6669-nn4gw): job , status Running, pri 0resreq cpu 500.00, memory 524288000.00, preemptable false, revocableZone , numaInfo { map[]}
         5: Task (0779548b-e9cc-43b4-a0f4-68ed85229322:kube-system/volcano-admission-bcf94c76c-pkrl9): job , status Running, pri 0resreq cpu 200.00, memory 524288000.00, preemptable false, revocableZone , numaInfo { map[]}
         6: Task (5cd06fe6-4b3f-498e-be38-473ba9b383e0:kube-system/zzzzzz-666db7bd48-bkrkr): job , status Running, pri 2000000000resreq cpu 250.00, memory 629145600.00, preemptable false, revocableZone , numaInfo { map[]}

Job (default/job-b-7af12912-c3ea-4d74-bd7c-73c6e5bd4969): namespace default (default), name job-b-7af12912-c3ea-4d74-bd7c-73c6e5bd4969, minAvailable 2, podGroup &{PodGroup:{TypeMeta:{Kind: APIVersion:} ObjectMeta:{Name:job-b-7af12912-c3ea-4d74-bd7c-73c6e5bd4969 GenerateName: Namespace:default SelfLink:/apis/scheduling.volcano.sh/v1beta1/namespaces/default/podgroups/job-b-7af12912-c3ea-4d74-bd7c-73c6e5bd4969 UID:6f22d035-9173-4aa0-aa99-57c7f51fe4b2 ResourceVersion:7128030 Generation:7 CreationTimestamp:2022-11-03 15:30:55 +0800 CST DeletionTimestamp:<nil> DeletionGracePeriodSeconds:<nil> Labels:map[] Annotations:map[kubectl.kubernetes.io/last-applied-configuration:{"apiVersion":"batch.volcano.sh/v1alpha1","kind":"Job","metadata":{"annotations":{},"name":"job-b","namespace":"default"},"spec":{"minAvailable":2,"priorityClassName":"low-priority","schedulerName":"volcano","tasks":[{"name":"test","replicas":8,"template":{"spec":{"containers":[{"command":["/bin/sh","-c","sleep 1000"],"image":"alpine","imagePullPolicy":"IfNotPresent","name":"running","resources":{"requests":{"cpu":"400m"}}}],"restartPolicy":"OnFailure"}}}]}}
] OwnerReferences:[{APIVersion:batch.volcano.sh/v1alpha1 Kind:Job Name:job-b UID:7af12912-c3ea-4d74-bd7c-73c6e5bd4969 Controller:0xc0009dd7c8 BlockOwnerDeletion:0xc0009dd7c9}] Finalizers:[] ClusterName: ManagedFields:[{Manager:Go-http-client Operation:Update APIVersion:scheduling.volcano.sh/v1beta1 Time:2022-11-03 15:31:26 +0800 CST FieldsType:FieldsV1 FieldsV1:{"f:metadata":{"f:annotations":{".":{},"f:kubectl.kubernetes.io/last-applied-configuration":{}},"f:ownerReferences":{}},"f:spec":{".":{},"f:minMember":{},"f:minResources":{".":{},"f:count/pods":{},"f:cpu":{},"f:pods":{},"f:requests.cpu":{}},"f:minTaskMember":{".":{},"f:test":{}},"f:priorityClassName":{},"f:queue":{}},"f:status":{".":{},"f:conditions":{},"f:phase":{},"f:running":{}}} Subresource:}]} Spec:{MinMember:2 MinTaskMember:map[test:8] Queue:default PriorityClassName:low-priority MinResources:0xc000bbc380} Status:{Phase:Running Conditions:[{Type:Unschedulable Status:True TransitionID:1b873ef4-308b-4325-be76-3474a0fdec5f LastTransitionTime:2022-11-03 15:31:14 +0800 CST Reason:NotEnoughResources Message:1/2 tasks in gang unschedulable: pod group is not ready, 1 Allocated, 1 Pipelined, 2 minAvailable} {Type:Scheduled Status:True TransitionID:548d0454-0eaa-43bb-92bf-8c064860895e LastTransitionTime:2022-11-03 15:31:27 +0800 CST Reason:tasks in gang are ready to be scheduled Message:}] Running:4 Succeeded:0 Failed:0}} Version:v1beta1}, preemptable false, revocableZone , minAvailable , maxAvailable
         0: Task (b0d97087-640c-4915-84df-629c945d6dd9:default/job-b-test-4): job default/job-b-7af12912-c3ea-4d74-bd7c-73c6e5bd4969, status Pending, pri 0resreq cpu 400.00, memory 0.00, preemptable false, revocableZone , numaInfo { map[]}
         1: Task (9cce188c-689a-441c-afa0-c7d456b75b75:default/job-b-test-0): job default/job-b-7af12912-c3ea-4d74-bd7c-73c6e5bd4969, status Running, pri 0resreq cpu 400.00, memory 0.00, preemptable false, revocableZone , numaInfo { map[]}
         2: Task (68968f6d-8773-4680-ad73-1c8b0e2801c5:default/job-b-test-2): job default/job-b-7af12912-c3ea-4d74-bd7c-73c6e5bd4969, status Running, pri 0resreq cpu 400.00, memory 0.00, preemptable false, revocableZone , numaInfo { map[]}
         3: Task (82fa6b4e-297f-4515-9e91-dbb4636ab3d5:default/job-b-test-5): job default/job-b-7af12912-c3ea-4d74-bd7c-73c6e5bd4969, status Pending, pri 0resreq cpu 400.00, memory 0.00, preemptable false, revocableZone , numaInfo { map[]}
         4: Task (1f32fb13-727a-494d-a0f4-b5dac88efc68:default/job-b-test-7): job default/job-b-7af12912-c3ea-4d74-bd7c-73c6e5bd4969, status Pending, pri 0resreq cpu 400.00, memory 0.00, preemptable false, revocableZone , numaInfo { map[]}
         5: Task (ea1745d0-9d16-49bd-a1d1-53119a92c382:default/job-b-test-1): job default/job-b-7af12912-c3ea-4d74-bd7c-73c6e5bd4969, status Running, pri 0resreq cpu 400.00, memory 0.00, preemptable false, revocableZone , numaInfo { map[]}
         6: Task (2e2bf69b-8600-4b2c-ab25-90b8a0b4e098:default/job-b-test-3): job default/job-b-7af12912-c3ea-4d74-bd7c-73c6e5bd4969, status Running, pri 0resreq cpu 400.00, memory 0.00, preemptable false, revocableZone , numaInfo { map[]}
         7: Task (e55aaa1a-2c36-4a21-bd22-6eb52bf8bf78:default/job-b-test-6): job default/job-b-7af12912-c3ea-4d74-bd7c-73c6e5bd4969, status Pending, pri 0resreq cpu 400.00, memory 0.00, preemptable false, revocableZone , numaInfo { map[]}
```
Note that this dumping operation may be expensive in large clusters, please only use it for debugging purposes.

Signed-off-by: xilinxing <xilinxing@huawei.com>