### PR TITLE
Add enable overusedfn and allocatablefn switch

### DIFF
--- a/pkg/scheduler/conf/scheduler_conf.go
+++ b/pkg/scheduler/conf/scheduler_conf.go
@@ -83,6 +83,10 @@ type PluginOption struct {
 	EnabledVictim *bool `yaml:"enabledVictim"`
 	// EnabledJobStarving defines whether jobStarvingFn is enabled
 	EnabledJobStarving *bool `yaml:"enableJobStarving"`
+	// EnabledOverused defines whether overusedFn is enabled
+	EnabledOverused *bool `yaml:"enabledOverused"`
+	// EnabledAllocatable defines whether allocatable is enabled
+	EnabledAllocatable *bool `yaml:"enabledAllocatable"`
 	// Arguments defines the different arguments that can be given to different plugins
 	Arguments map[string]interface{} `yaml:"arguments"`
 }

--- a/pkg/scheduler/framework/session_plugins.go
+++ b/pkg/scheduler/framework/session_plugins.go
@@ -250,6 +250,9 @@ func (ssn *Session) Preemptable(preemptor *api.TaskInfo, preemptees []*api.TaskI
 func (ssn *Session) Overused(queue *api.QueueInfo) bool {
 	for _, tier := range ssn.Tiers {
 		for _, plugin := range tier.Plugins {
+			if !isEnabled(plugin.EnabledOverused) {
+				continue
+			}
 			of, found := ssn.overusedFns[plugin.Name]
 			if !found {
 				continue
@@ -267,6 +270,9 @@ func (ssn *Session) Overused(queue *api.QueueInfo) bool {
 func (ssn *Session) Allocatable(queue *api.QueueInfo, candidate *api.TaskInfo) bool {
 	for _, tier := range ssn.Tiers {
 		for _, plugin := range tier.Plugins {
+			if !isEnabled(plugin.EnabledAllocatable) {
+				continue
+			}
 			af, found := ssn.allocatableFns[plugin.Name]
 			if !found {
 				continue

--- a/pkg/scheduler/plugins/defaults.go
+++ b/pkg/scheduler/plugins/defaults.go
@@ -70,4 +70,10 @@ func ApplyPluginConfDefaults(option *conf.PluginOption) {
 	if option.EnabledJobStarving == nil {
 		option.EnabledJobStarving = &t
 	}
+	if option.EnabledOverused == nil {
+		option.EnabledOverused = &t
+	}
+	if option.EnabledAllocatable == nil {
+		option.EnabledAllocatable = &t
+	}
 }

--- a/pkg/scheduler/util_test.go
+++ b/pkg/scheduler/util_test.go
@@ -61,6 +61,8 @@ tiers:
 					EnabledJobEnqueued:    &trueValue,
 					EnabledVictim:         &trueValue,
 					EnabledJobStarving:    &trueValue,
+					EnabledOverused:       &trueValue,
+					EnabledAllocatable:    &trueValue,
 				},
 				{
 					Name:                  "gang",
@@ -80,6 +82,8 @@ tiers:
 					EnabledJobEnqueued:    &trueValue,
 					EnabledVictim:         &trueValue,
 					EnabledJobStarving:    &trueValue,
+					EnabledOverused:       &trueValue,
+					EnabledAllocatable:    &trueValue,
 				},
 				{
 					Name:                  "conformance",
@@ -99,6 +103,8 @@ tiers:
 					EnabledJobEnqueued:    &trueValue,
 					EnabledVictim:         &trueValue,
 					EnabledJobStarving:    &trueValue,
+					EnabledOverused:       &trueValue,
+					EnabledAllocatable:    &trueValue,
 				},
 			},
 		},
@@ -122,6 +128,8 @@ tiers:
 					EnabledJobEnqueued:    &trueValue,
 					EnabledVictim:         &trueValue,
 					EnabledJobStarving:    &trueValue,
+					EnabledOverused:       &trueValue,
+					EnabledAllocatable:    &trueValue,
 				},
 				{
 					Name:                  "predicates",
@@ -141,6 +149,8 @@ tiers:
 					EnabledJobEnqueued:    &trueValue,
 					EnabledVictim:         &trueValue,
 					EnabledJobStarving:    &trueValue,
+					EnabledOverused:       &trueValue,
+					EnabledAllocatable:    &trueValue,
 				},
 				{
 					Name:                  "proportion",
@@ -160,6 +170,8 @@ tiers:
 					EnabledJobEnqueued:    &trueValue,
 					EnabledVictim:         &trueValue,
 					EnabledJobStarving:    &trueValue,
+					EnabledOverused:       &trueValue,
+					EnabledAllocatable:    &trueValue,
 				},
 				{
 					Name:                  "nodeorder",
@@ -179,6 +191,8 @@ tiers:
 					EnabledJobEnqueued:    &trueValue,
 					EnabledVictim:         &trueValue,
 					EnabledJobStarving:    &trueValue,
+					EnabledOverused:       &trueValue,
+					EnabledAllocatable:    &trueValue,
 				},
 			},
 		},


### PR DESCRIPTION
This PR is my implementation of [issue2566](https://github.com/volcano-sh/volcano/issues/2566).  I have seen the [PR2572](https://github.com/volcano-sh/volcano/pull/2572), but the `allocatablefn` switch is omitted.

What's more, I think the naming of the plugin config should be consistent-- all of `abled` or `able`.