### PR TITLE
fix: high priority task cannot preemt low priority task

### DIFF
--- a/installer/helm/chart/volcano/config/volcano-scheduler-ci.conf
+++ b/installer/helm/chart/volcano/config/volcano-scheduler-ci.conf
@@ -3,7 +3,6 @@ tiers:
 - plugins:
   - name: priority
   - name: gang
-    enablePreemptable: false
   - name: conformance
   - name: sla
 - plugins:

--- a/installer/helm/chart/volcano/config/volcano-scheduler.conf
+++ b/installer/helm/chart/volcano/config/volcano-scheduler.conf
@@ -3,7 +3,6 @@ tiers:
 - plugins:
   - name: priority
   - name: gang
-    enablePreemptable: false
   - name: conformance
 - plugins:
   - name: overcommit

--- a/installer/volcano-development.yaml
+++ b/installer/volcano-development.yaml
@@ -8630,7 +8630,6 @@ data:
     - plugins:
       - name: priority
       - name: gang
-        enablePreemptable: false
       - name: conformance
     - plugins:
       - name: overcommit


### PR DESCRIPTION
fix: [#2547](https://github.com/volcano-sh/volcano/issues/2547)

When the queue resource usage exceeds the upper limit, the proportion does not allow new jobs in the queue to be scheduled. If the rejected jobs are high-priority jobs, the preemption function cannot be performed.

To solve the preceding problem, modify the configuration as follows and set it to the default configuration:
- If enableJobEnqueued of proportion is set to false, jobs are allowed to enter the queue. In the allocate phase, the upper limit of resources used by each queue is controlled.

- The default preemption switch of the gang plug-in is modified. The minAvailable resource of a job can be preempted and the resource of a high-priority job is preferentially guaranteed.

Signed-off-by: wangyang <wangyang289@huawei.com>