### PR TITLE
fix(predicates/predicateGPUbyMemory): traversal key of map are not sequence 

### DIFF
--- a/pkg/scheduler/plugins/predicates/gpu.go
+++ b/pkg/scheduler/plugins/predicates/gpu.go
@@ -18,6 +18,7 @@ package predicates
 
 import (
 	"fmt"
+	"sort"
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/klog"
@@ -62,6 +63,7 @@ func predicateGPUbyMemory(pod *v1.Pod, node *api.NodeInfo) []int {
 			devIDs = append(devIDs, devID)
 		}
 	}
+	sort.Ints(devIDs)
 	return devIDs
 }
 


### PR DESCRIPTION
Signed-off-by: yougjiahe <yongjiahe@tuputech.com>

Traversal key of allocatableGPUs, devIDs are not in sequence. So it will make fragment gpu use.  https://github.com/volcano-sh/volcano/pull/2476

Rebase the fix to the latest master code.

@Thor-wl  