### PR TITLE
move prefilter out of predicates to improve performance

### DIFF
--- a/pkg/scheduler/actions/backfill/backfill.go
+++ b/pkg/scheduler/actions/backfill/backfill.go
@@ -58,6 +58,15 @@ func (backfill *Action) Execute(ssn *framework.Session) {
 				allocated := false
 				fe := api.NewFitErrors()
 
+				if err := ssn.PrePredicateFn(task); err != nil {
+					klog.V(3).Infof("PrePredicate for task %s/%s failed for: %v", task.Namespace, task.Name, err)
+					for _, ni := range ssn.Nodes {
+						fe.SetNodeError(ni.Name, err)
+					}
+					job.NodesFitErrors[task.UID] = fe
+					break
+				}
+
 				// As task did not request resources, so it only need to meet predicates.
 				// TODO (k82cn): need to prioritize nodes to avoid pod hole.
 				for _, node := range ssn.Nodes {

--- a/pkg/scheduler/actions/preempt/preempt.go
+++ b/pkg/scheduler/actions/preempt/preempt.go
@@ -206,6 +206,9 @@ func preempt(
 
 	allNodes := ssn.NodeList
 
+	if err := ssn.PrePredicateFn(preemptor); err != nil {
+		return false, fmt.Errorf("PrePredicate for task %s/%s failed for: %v", preemptor.Namespace, preemptor.Name, err)
+	}
 	predicateNodes, _ := predicateHelper.PredicateNodes(preemptor, allNodes, ssn.PredicateFn)
 
 	nodeScores := util.PrioritizeNodes(preemptor, predicateNodes, ssn.BatchNodeOrderFn, ssn.NodeOrderMapFn, ssn.NodeOrderReduceFn)

--- a/pkg/scheduler/actions/reclaim/reclaim.go
+++ b/pkg/scheduler/actions/reclaim/reclaim.go
@@ -116,6 +116,11 @@ func (ra *Action) Execute(ssn *framework.Session) {
 			continue
 		}
 
+		if err := ssn.PrePredicateFn(task); err != nil {
+			klog.V(3).Infof("PrePredicate for task %s/%s failed for: %v", task.Namespace, task.Name, err)
+			continue
+		}
+
 		assigned := false
 		for _, n := range ssn.Nodes {
 			// If predicates failed, next node.

--- a/pkg/scheduler/api/types.go
+++ b/pkg/scheduler/api/types.go
@@ -136,6 +136,9 @@ type JobEnqueuedFn func(interface{})
 // PredicateFn is the func declaration used to predicate node for task.
 type PredicateFn func(*TaskInfo, *NodeInfo) error
 
+// PrePredicateFn is the func declaration used to pre-predicate node for task.
+type PrePredicateFn func(*TaskInfo) error
+
 // BestNodeFn is the func declaration used to return the nodeScores to plugins.
 type BestNodeFn func(*TaskInfo, map[float64][]*NodeInfo) *NodeInfo
 

--- a/pkg/scheduler/framework/session.go
+++ b/pkg/scheduler/framework/session.go
@@ -73,6 +73,7 @@ type Session struct {
 	namespaceOrderFns map[string]api.CompareFn
 	clusterOrderFns   map[string]api.CompareFn
 	predicateFns      map[string]api.PredicateFn
+	prePredicateFns   map[string]api.PrePredicateFn
 	bestNodeFns       map[string]api.BestNodeFn
 	nodeOrderFns      map[string]api.NodeOrderFn
 	batchNodeOrderFns map[string]api.BatchNodeOrderFn
@@ -118,6 +119,7 @@ func openSession(cache cache.Cache) *Session {
 		namespaceOrderFns: map[string]api.CompareFn{},
 		clusterOrderFns:   map[string]api.CompareFn{},
 		predicateFns:      map[string]api.PredicateFn{},
+		prePredicateFns:   map[string]api.PrePredicateFn{},
 		bestNodeFns:       map[string]api.BestNodeFn{},
 		nodeOrderFns:      map[string]api.NodeOrderFn{},
 		batchNodeOrderFns: map[string]api.BatchNodeOrderFn{},


### PR DESCRIPTION
- when porting kube-scheduler plugins, the current implementation put `PreFilter` together with `Filter` into `PredicateFn`, the `PredicateFn` process each pod-node pair like the following pseudo code:  
  ``` python
  for pod in pods:
    for nodes in nodes:
      predicateFn(pod, node) # prefilters & filters
  ```
- it's functioning well while `PreFilter` only needs the pod object(no node required), we don't need to put it in the innermost loop. So a promotion of `PreFilter` to the outer loop is made in this pr for performance's sake, as a plugin like `inter-pod-afftinity` is very time-consuming to prepare the pod interconnections in `PreFilter`.  After this pr:
  ``` python
  for pod in pods:
    prePredicateFn(pod) # prefilters
    for nodes in nodes:
      predicateFn(pod, node) # filters
  ```
- Implementation notes:  
	- Is it right to put `stat` in `OnSessionOpen` as previously put into the `PredicateFn`?  
	  yes, it's correct, just as the type of  `stat` suggested `CycleState` its lifecycle should be in the whole scheduling cycle, and the kube-scheduler creates it in the `ScheduleOnce` function  
	  ``` go
	  	  func (sched *Scheduler) scheduleOne(ctx context.Context) {
	  	  	// ...
	  	  	state := framework.NewCycleState()
	  	    	scheduleResult, err := 
	  	    		sched.Algorithm.Schedule(schedulingCycleCtx, prof, state, pod)
	  	      // ...
	  	  }
	  ```
	- is it thread-safe to separate write(in `PreFilter`) and read (in `Filter`)?  
	  yes, the underlining data structure is a thread-safe map for `CycleState` to access data

resolves #2583 