### PR TITLE
replace queueMap with sets.String in enqueue action to improve readable

### DIFF
--- a/pkg/scheduler/actions/enqueue/enqueue.go
+++ b/pkg/scheduler/actions/enqueue/enqueue.go
@@ -46,7 +46,7 @@ func (enqueue *Action) Execute(ssn *framework.Session) {
 	defer klog.V(3).Infof("Leaving Enqueue ...")
 
 	queues := util.NewPriorityQueue(ssn.QueueOrderFn)
-	queueMap := sets.NewString()
+	queueSet := sets.NewString()
 	jobsMap := map[api.QueueID]*util.PriorityQueue{}
 
 	for _, job := range ssn.Jobs {
@@ -59,11 +59,11 @@ func (enqueue *Action) Execute(ssn *framework.Session) {
 			klog.Errorf("Failed to find Queue <%s> for Job <%s/%s>",
 				job.Queue, job.Namespace, job.Name)
 			continue
-		} else if queueMap.Has(string(queue.UID)) {
+		} else if queueSet.Has(string(queue.UID)) {
 			klog.V(5).Infof("Added Queue <%s> for Job <%s/%s>",
 				queue.Name, job.Namespace, job.Name)
 
-			queueMap.Insert(string(queue.UID))
+			queueSet.Insert(string(queue.UID))
 			queues.Push(queue)
 		}
 
@@ -90,7 +90,7 @@ func (enqueue *Action) Execute(ssn *framework.Session) {
 		if !found || jobs.Empty() {
 			continue
 		}
-		job := jobs.Pop().(*api.JobInfo)	
+		job := jobs.Pop().(*api.JobInfo)
 
 		if job.PodGroup.Spec.MinResources == nil || ssn.JobEnqueueable(job) {
 			ssn.JobEnqueued(job)

--- a/pkg/scheduler/actions/enqueue/enqueue.go
+++ b/pkg/scheduler/actions/enqueue/enqueue.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog"
 
 	"volcano.sh/apis/pkg/apis/scheduling"
@@ -45,7 +46,7 @@ func (enqueue *Action) Execute(ssn *framework.Session) {
 	defer klog.V(3).Infof("Leaving Enqueue ...")
 
 	queues := util.NewPriorityQueue(ssn.QueueOrderFn)
-	queueMap := map[api.QueueID]*api.QueueInfo{}
+	queueMap := sets.NewString()
 	jobsMap := map[api.QueueID]*util.PriorityQueue{}
 
 	for _, job := range ssn.Jobs {
@@ -58,11 +59,11 @@ func (enqueue *Action) Execute(ssn *framework.Session) {
 			klog.Errorf("Failed to find Queue <%s> for Job <%s/%s>",
 				job.Queue, job.Namespace, job.Name)
 			continue
-		} else if _, existed := queueMap[queue.UID]; !existed {
+		} else if queueMap.Has(string(queue.UID)) {
 			klog.V(5).Infof("Added Queue <%s> for Job <%s/%s>",
 				queue.Name, job.Namespace, job.Name)
 
-			queueMap[queue.UID] = queue
+			queueMap.Insert(string(queue.UID))
 			queues.Push(queue)
 		}
 
@@ -84,12 +85,12 @@ func (enqueue *Action) Execute(ssn *framework.Session) {
 
 		queue := queues.Pop().(*api.QueueInfo)
 
-		// Found "high" priority job
+		// skip the Queue that has no pending job
 		jobs, found := jobsMap[queue.UID]
 		if !found || jobs.Empty() {
 			continue
 		}
-		job := jobs.Pop().(*api.JobInfo)
+		job := jobs.Pop().(*api.JobInfo)	
 
 		if job.PodGroup.Spec.MinResources == nil || ssn.JobEnqueueable(job) {
 			ssn.JobEnqueued(job)

--- a/pkg/scheduler/actions/enqueue/enqueue.go
+++ b/pkg/scheduler/actions/enqueue/enqueue.go
@@ -59,7 +59,7 @@ func (enqueue *Action) Execute(ssn *framework.Session) {
 			klog.Errorf("Failed to find Queue <%s> for Job <%s/%s>",
 				job.Queue, job.Namespace, job.Name)
 			continue
-		} else if queueSet.Has(string(queue.UID)) {
+		} else if !queueSet.Has(string(queue.UID)) {
 			klog.V(5).Infof("Added Queue <%s> for Job <%s/%s>",
 				queue.Name, job.Namespace, job.Name)
 


### PR DESCRIPTION
the role of queueMap  in enqueue action is just to  dedup queue in queues,  and the value in `  map[api.QueueID]*api.QueueInfo{} ` has no use.