### PR TITLE
not set owner reference for pod group to improve delete performance 

### DIFF
--- a/cmd/controller-manager/app/options/options.go
+++ b/cmd/controller-manager/app/options/options.go
@@ -64,6 +64,8 @@ type ServerOption struct {
 	DetectionPeriodOfDependsOntask time.Duration
 	// To determine whether inherit owner's annotations for pods when create podgroup
 	InheritOwnerAnnotations bool
+	// Associate owner reference for podgroup
+	AssociatedOwnerReference bool
 }
 
 type DecryptFunc func(c *ServerOption) error
@@ -96,6 +98,7 @@ func (s *ServerOption) AddFlags(fs *pflag.FlagSet) {
 	fs.DurationVar(&s.DetectionPeriodOfDependsOntask, "detection-period-of-dependson-task", defaultDetectionPeriodOfDependsOntask, "It indicates how often to detect the status of dependent tasks."+
 		"e.g. --detection-period-of-dependson-task=1s")
 	fs.BoolVar(&s.InheritOwnerAnnotations, "inherit-owner-annotations", true, "Enable inherit owner annotations for pods when create podgroup; it is enabled by default")
+	fs.BoolVar(&s.AssociatedOwnerReference, "associate-owner-reference", true, "Associate owner reference for podgroup; it is enabled by default")
 }
 
 // CheckOptionOrDie checks the LockObjectNamespace.

--- a/cmd/controller-manager/app/server.go
+++ b/cmd/controller-manager/app/server.go
@@ -127,6 +127,7 @@ func startControllers(config *rest.Config, opt *options.ServerOption) func(ctx c
 	controllerOpt.VolcanoClient = vcclientset.NewForConfigOrDie(config)
 	controllerOpt.SharedInformerFactory = informers.NewSharedInformerFactory(controllerOpt.KubeClient, 0)
 	controllerOpt.InheritOwnerAnnotations = opt.InheritOwnerAnnotations
+	controllerOpt.AssociateOwnerReference = opt.AssociatedOwnerReference
 
 	return func(ctx context.Context) {
 		framework.ForeachController(func(c framework.Controller) {

--- a/pkg/controllers/framework/interface.go
+++ b/pkg/controllers/framework/interface.go
@@ -33,6 +33,7 @@ type ControllerOption struct {
 	MaxRequeueNum         int
 
 	InheritOwnerAnnotations bool
+	AssociateOwnerReference bool
 }
 
 // Controller is the interface of all controllers.

--- a/pkg/controllers/podgroup/pg_controller.go
+++ b/pkg/controllers/podgroup/pg_controller.go
@@ -19,12 +19,15 @@ package podgroup
 import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/informers"
+	appinformers "k8s.io/client-go/informers/apps/v1"
 	coreinformers "k8s.io/client-go/informers/core/v1"
 	"k8s.io/client-go/kubernetes"
+	applisters "k8s.io/client-go/listers/apps/v1"
 	corelisters "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog"
+	"sync"
 
 	scheduling "volcano.sh/apis/pkg/apis/scheduling/v1beta1"
 	vcclientset "volcano.sh/apis/pkg/client/clientset/versioned"
@@ -42,11 +45,14 @@ func init() {
 
 // pgcontroller the Podgroup pgcontroller type.
 type pgcontroller struct {
+	lock *sync.Mutex
+
 	kubeClient kubernetes.Interface
 	vcClient   vcclientset.Interface
 
 	podInformer coreinformers.PodInformer
 	pgInformer  schedulinginformer.PodGroupInformer
+	rsInformer  appinformers.ReplicaSetInformer
 
 	informerFactory   informers.SharedInformerFactory
 	vcInformerFactory vcinformer.SharedInformerFactory
@@ -59,12 +65,20 @@ type pgcontroller struct {
 	pgLister schedulinglister.PodGroupLister
 	pgSynced func() bool
 
+	// A store of replicasets
+	rsLister applisters.ReplicaSetLister
+	rsSynced func() bool
+
 	queue workqueue.RateLimitingInterface
 
 	schedulerNames []string
 
 	// To determine whether inherit owner's annotations for pods when create podgroup
 	inheritOwnerAnnotations bool
+
+	associateOwnerReference bool
+
+	podgroups map[string]*scheduling.PodGroup
 }
 
 func (pg *pgcontroller) Name() string {
@@ -81,6 +95,7 @@ func (pg *pgcontroller) Initialize(opt *framework.ControllerOption) error {
 	pg.schedulerNames = make([]string, len(opt.SchedulerNames))
 	copy(pg.schedulerNames, opt.SchedulerNames)
 	pg.inheritOwnerAnnotations = opt.InheritOwnerAnnotations
+	pg.associateOwnerReference = opt.AssociateOwnerReference
 
 	pg.informerFactory = opt.SharedInformerFactory
 	pg.podInformer = opt.SharedInformerFactory.Core().V1().Pods()
@@ -95,6 +110,20 @@ func (pg *pgcontroller) Initialize(opt *framework.ControllerOption) error {
 	pg.pgInformer = factory.Scheduling().V1beta1().PodGroups()
 	pg.pgLister = pg.pgInformer.Lister()
 	pg.pgSynced = pg.pgInformer.Informer().HasSynced
+	pg.pgInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    pg.addPodGroup,
+		DeleteFunc: pg.deletePodGroup,
+	})
+
+	pg.rsInformer = opt.SharedInformerFactory.Apps().V1().ReplicaSets()
+	pg.rsLister = pg.rsInformer.Lister()
+	pg.rsSynced = pg.pgInformer.Informer().HasSynced
+	pg.rsInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		DeleteFunc: pg.deleteReplicaSet,
+	})
+
+	pg.lock = new(sync.Mutex)
+	pg.podgroups = make(map[string]*scheduling.PodGroup)
 
 	return nil
 }

--- a/pkg/controllers/podgroup/pg_controller_handler.go
+++ b/pkg/controllers/podgroup/pg_controller_handler.go
@@ -19,8 +19,10 @@ package podgroup
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"strings"
 
+	appv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -60,6 +62,63 @@ func (pg *pgcontroller) addPod(obj interface{}) {
 	}
 
 	pg.queue.Add(req)
+}
+
+func (pg *pgcontroller) deleteReplicaSet(obj interface{}) {
+	rs, ok := obj.(*appv1.ReplicaSet)
+	if !ok {
+		klog.Errorf("Failed to convert %v to apps.ReplicaSet", obj)
+		return
+	}
+
+	pg.lock.Lock()
+	defer pg.lock.Unlock()
+	podGroupKey := fmt.Sprintf("ReplicaSet/%s/%s", rs.Name, string(rs.UID))
+	if group, ok := pg.podgroups[podGroupKey]; ok {
+		err := pg.vcClient.SchedulingV1beta1().PodGroups(group.Namespace).Delete(context.TODO(), group.Name, metav1.DeleteOptions{})
+		if err != nil {
+			klog.Errorf("Failed to delete PodGroup <%s/%s>: %v", group.Namespace, group.Name, err)
+		}
+	}
+}
+
+func (pg *pgcontroller) addPodGroup(obj interface{}) {
+	podGroup, ok := obj.(*scheduling.PodGroup)
+	if !ok {
+		klog.Errorf("Failed to convert %v to scheduling.PodGroup", obj)
+		return
+	}
+
+	pg.lock.Lock()
+	defer pg.lock.Unlock()
+	if _, ok := podGroup.Annotations["owner-reference-kind"]; !ok || len(podGroup.OwnerReferences) > 0 {
+		klog.V(4).Infof("PodGroup %s/%s is not created by pg_controller or has owner reference, ignore it", podGroup.Namespace, podGroup.Name)
+		return
+	}
+	podGroupKey := fmt.Sprintf("%s/%s/%s",
+		podGroup.Annotations["owner-reference-kind"], podGroup.Annotations["owner-reference-name"], podGroup.Annotations["owner-reference-uuid"])
+	if _, ok := pg.podgroups[podGroupKey]; ok {
+		return
+	}
+	pg.podgroups[podGroupKey] = podGroup
+}
+
+func (pg *pgcontroller) deletePodGroup(obj interface{}) {
+	podGroup, ok := obj.(*scheduling.PodGroup)
+	if !ok {
+		klog.Errorf("Failed to convert %v to scheduling.PodGroup", obj)
+		return
+	}
+
+	pg.lock.Lock()
+	defer pg.lock.Unlock()
+	if _, ok := podGroup.Annotations["owner-reference-kind"]; !ok {
+		klog.V(4).Infof("PodGroup %s/%s is not created by pg_controller or has owner reference, ignore it", podGroup.Namespace, podGroup.Name)
+		return
+	}
+	podGroupKey := fmt.Sprintf("%s/%s/%s",
+		podGroup.Annotations["owner-reference-kind"], podGroup.Annotations["owner-reference-name"], podGroup.Annotations["owner-reference-uuid"])
+	delete(pg.podgroups, podGroupKey)
 }
 
 func (pg *pgcontroller) updatePodAnnotations(pod *v1.Pod, pgName string) error {
@@ -157,11 +216,10 @@ func (pg *pgcontroller) createNormalPodPGIfNotExist(pod *v1.Pod) error {
 
 		obj := &scheduling.PodGroup{
 			ObjectMeta: metav1.ObjectMeta{
-				Namespace:       pod.Namespace,
-				Name:            pgName,
-				OwnerReferences: newPGOwnerReferences(pod),
-				Annotations:     map[string]string{},
-				Labels:          map[string]string{},
+				Namespace:   pod.Namespace,
+				Name:        pgName,
+				Annotations: map[string]string{},
+				Labels:      map[string]string{},
 			},
 			Spec: scheduling.PodGroupSpec{
 				MinMember:         1,
@@ -171,6 +229,25 @@ func (pg *pgcontroller) createNormalPodPGIfNotExist(pod *v1.Pod) error {
 			Status: scheduling.PodGroupStatus{
 				Phase: scheduling.PodGroupPending,
 			},
+		}
+
+		owners := newPGOwnerReferences(pod)
+		if pg.associateOwnerReference {
+			obj.OwnerReferences = owners
+		} else {
+			// only support one owner reference
+			if len(owners) > 0 {
+				owner := owners[0]
+				switch owner.Kind {
+				// TODO: should also support statefulset/daemonset/job
+				case "ReplicaSet":
+					obj.Annotations["owner-reference-kind"] = owner.Kind
+					obj.Annotations["owner-reference-name"] = owner.Name
+					obj.Annotations["owner-reference-uuid"] = string(owner.UID)
+				default:
+					obj.OwnerReferences = owners
+				}
+			}
 		}
 
 		pg.inheritUpperAnnotations(pod, obj)


### PR DESCRIPTION
Signed-off-by: Zhe Jin <jinzhe.hit@gmail.com>

Currently, pod group controller will set owner reference of pod to pod group and pod group will be deleted automatically when owner reference resource is deleted. This will cause performance downgrade when delete owner reference resource.

This pr introduce a new option `--associate-owner-reference` for volcano controller and its default value is true.
`--associate-owner-reference=true`  means the behavior is as same as before.
`--associate-owner-reference=false` means volcano controller will not set owner reference for pod group and pod group will be deleted by volcano controller after pod owner reference is deleted.

Only `ReplicaSet` is supported in this PR.