### PR TITLE
Add node image information to the cache of the scheduler.

### DIFF
--- a/pkg/scheduler/api/node_info_test.go
+++ b/pkg/scheduler/api/node_info_test.go
@@ -22,6 +22,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sframework "k8s.io/kubernetes/pkg/scheduler/framework"
 )
 
 func nodeInfoEqual(l, r *NodeInfo) bool {
@@ -64,7 +65,8 @@ func TestNodeInfo_AddPod(t *testing.T) {
 					"c1/p1": NewTaskInfo(case01Pod1),
 					"c1/p2": NewTaskInfo(case01Pod2),
 				},
-				GPUDevices: make(map[int]*GPUDevice),
+				GPUDevices:  make(map[int]*GPUDevice),
+				ImageStates: make(map[string]*k8sframework.ImageStateSummary),
 			},
 		},
 		{
@@ -85,6 +87,7 @@ func TestNodeInfo_AddPod(t *testing.T) {
 				State:                    NodeState{Phase: Ready},
 				Tasks:                    map[TaskID]*TaskInfo{},
 				GPUDevices:               make(map[int]*GPUDevice),
+				ImageStates:              make(map[string]*k8sframework.ImageStateSummary),
 			},
 			expectedFailure: true,
 		},
@@ -146,7 +149,8 @@ func TestNodeInfo_RemovePod(t *testing.T) {
 					"c1/p1": NewTaskInfo(case01Pod1),
 					"c1/p3": NewTaskInfo(case01Pod3),
 				},
-				GPUDevices: make(map[int]*GPUDevice),
+				GPUDevices:  make(map[int]*GPUDevice),
+				ImageStates: make(map[string]*k8sframework.ImageStateSummary),
 			},
 		},
 	}
@@ -208,7 +212,8 @@ func TestNodeInfo_SetNode(t *testing.T) {
 					"c1/p2": NewTaskInfo(case01Pod2),
 					"c1/p3": NewTaskInfo(case01Pod3),
 				},
-				GPUDevices: make(map[int]*GPUDevice),
+				GPUDevices:  make(map[int]*GPUDevice),
+				ImageStates: make(map[string]*k8sframework.ImageStateSummary),
 			},
 		},
 	}

--- a/pkg/scheduler/cache/cache.go
+++ b/pkg/scheduler/cache/cache.go
@@ -19,6 +19,7 @@ package cache
 import (
 	"context"
 	"fmt"
+	"k8s.io/kubernetes/pkg/scheduler/framework"
 	"os"
 	"strconv"
 	"strings"
@@ -35,6 +36,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/informers"
 	infov1 "k8s.io/client-go/informers/core/v1"
@@ -144,6 +146,16 @@ type SchedulerCache struct {
 	BindFlowChannel chan *schedulingapi.TaskInfo
 	bindCache       []*schedulingapi.TaskInfo
 	batchNum        int
+
+	// A map from image name to its imageState.
+	imageStates map[string]*imageState
+}
+
+type imageState struct {
+	// Size of the image
+	size int64
+	// A set of node names for nodes having this image present
+	nodes sets.String
 }
 
 type DefaultBinder struct {
@@ -434,6 +446,7 @@ func newSchedulerCache(config *rest.Config, schedulerNames []string, defaultQueu
 		nodeSelectorLabels:  make(map[string]string),
 		NamespaceCollection: make(map[string]*schedulingapi.NamespaceCollection),
 		CSINodesStatus:      make(map[string]*schedulingapi.CSINodeStatusInfo),
+		imageStates:         make(map[string]*imageState),
 
 		NodeList: []string{},
 	}
@@ -1055,6 +1068,7 @@ func (sc *SchedulerCache) Snapshot() *schedulingapi.ClusterInfo {
 		}
 
 		snapshot.Nodes[value.Name] = value.Clone()
+		snapshot.Nodes[value.Name].ImageStates = value.CloneImageSumary()
 
 		if value.RevocableZone != "" {
 			snapshot.RevocableNodes[value.Name] = snapshot.Nodes[value.Name]
@@ -1313,5 +1327,13 @@ func (sc *SchedulerCache) setMetricsData(usageInfo map[string]*schedulingapi.Nod
 			klog.V(3).Infof("node: %s, ResourceUsage: %+v => %+v", k, *nodeInfo.ResourceUsage, *usageInfo[k])
 			nodeInfo.ResourceUsage = usageInfo[k]
 		}
+	}
+}
+
+// createImageStateSummary returns a summarizing snapshot of the given image's state.
+func (sc *SchedulerCache) createImageStateSummary(state *imageState) *framework.ImageStateSummary {
+	return &framework.ImageStateSummary{
+		Size:     state.size,
+		NumNodes: len(state.nodes),
 	}
 }

--- a/pkg/scheduler/plugins/nodeorder/nodeorder.go
+++ b/pkg/scheduler/plugins/nodeorder/nodeorder.go
@@ -262,66 +262,66 @@ func (pp *nodeOrderPlugin) OnSessionOpen(ssn *framework.Session) {
 		if weight.imageLocalityWeight != 0 {
 			score, status := imageLocality.Score(context.TODO(), state, task.Pod, node.Name)
 			if !status.IsSuccess() {
-				klog.Warningf("Image Locality Priority Failed because of Error: %v", status.AsError())
+				klog.Warningf("Node: %s, Image Locality Priority Failed because of Error: %v", node.Name, status.AsError())
 				return 0, status.AsError()
 			}
 
 			// If imageLocalityWeight is provided, host.Score is multiplied with weight, if not, host.Score is added to total score.
 			nodeScore += float64(score) * float64(weight.imageLocalityWeight)
-			klog.V(4).Infof("Image Locality score: %f", nodeScore)
+			klog.V(4).Infof("Node: %s, Image Locality score: %f", node.Name, nodeScore)
 		}
 
 		// NodeResourcesLeastAllocated
 		if weight.leastReqWeight != 0 {
 			score, status := leastAllocated.Score(context.TODO(), state, task.Pod, node.Name)
 			if !status.IsSuccess() {
-				klog.Warningf("Least Allocated Priority Failed because of Error: %v", status.AsError())
+				klog.Warningf("Node: %s, Least Allocated Priority Failed because of Error: %v", node.Name, status.AsError())
 				return 0, status.AsError()
 			}
 
 			// If leastReqWeight is provided, host.Score is multiplied with weight, if not, host.Score is added to total score.
 			nodeScore += float64(score) * float64(weight.leastReqWeight)
-			klog.V(4).Infof("Least Request score: %f", nodeScore)
+			klog.V(4).Infof("Node: %s, Least Request score: %f", node.Name, nodeScore)
 		}
 
 		// NodeResourcesMostAllocated
 		if weight.mostReqWeight != 0 {
 			score, status := mostAllocation.Score(context.TODO(), state, task.Pod, node.Name)
 			if !status.IsSuccess() {
-				klog.Warningf("Most Allocated Priority Failed because of Error: %v", status.AsError())
+				klog.Warningf("Node: %s, Most Allocated Priority Failed because of Error: %v", node.Name, status.AsError())
 				return 0, status.AsError()
 			}
 
 			// If mostRequestedWeight is provided, host.Score is multiplied with weight, it's 0 by default
 			nodeScore += float64(score) * float64(weight.mostReqWeight)
-			klog.V(4).Infof("Most Request score: %f", nodeScore)
+			klog.V(4).Infof("Node: %s, Most Request score: %f", node.Name, nodeScore)
 		}
 
 		// NodeResourcesBalancedAllocation
 		if weight.balancedResourceWeight != 0 {
 			score, status := balancedAllocation.Score(context.TODO(), state, task.Pod, node.Name)
 			if !status.IsSuccess() {
-				klog.Warningf("Balanced Resource Allocation Priority Failed because of Error: %v", status.AsError())
+				klog.Warningf("Node: %s, Balanced Resource Allocation Priority Failed because of Error: %v", node.Name, status.AsError())
 				return 0, status.AsError()
 			}
 
 			// If balancedResourceWeight is provided, host.Score is multiplied with weight, if not, host.Score is added to total score.
 			nodeScore += float64(score) * float64(weight.balancedResourceWeight)
-			klog.V(4).Infof("Balanced Request score: %f", nodeScore)
+			klog.V(4).Infof("Node: %s, Balanced Request score: %f", node.Name, nodeScore)
 		}
 
 		// NodeAffinity
 		if weight.nodeAffinityWeight != 0 {
 			score, status := nodeAffinity.Score(context.TODO(), state, task.Pod, node.Name)
 			if !status.IsSuccess() {
-				klog.Warningf("Calculate Node Affinity Priority Failed because of Error: %v", status.AsError())
+				klog.Warningf("Node: %s, Calculate Node Affinity Priority Failed because of Error: %v", node.Name, status.AsError())
 				return 0, status.AsError()
 			}
 
 			// TODO: should we normalize the score
 			// If nodeAffinityWeight is provided, host.Score is multiplied with weight, if not, host.Score is added to total score.
 			nodeScore += float64(score) * float64(weight.nodeAffinityWeight)
-			klog.V(4).Infof("Node Affinity score: %f", nodeScore)
+			klog.V(4).Infof("Node: %s, Node Affinity score: %f", node.Name, nodeScore)
 		}
 
 		klog.V(4).Infof("Total Score for task %s/%s on node %s is: %f", task.Namespace, task.Name, node.Name, nodeScore)

--- a/pkg/scheduler/plugins/util/util.go
+++ b/pkg/scheduler/plugins/util/util.go
@@ -239,6 +239,8 @@ func GenerateNodeMapAndSlice(nodes map[string]*api.NodeInfo) map[string]*schedul
 		nodeInfo := schedulernodeinfo.NewNodeInfo(node.Pods()...)
 		nodeInfo.SetNode(node.Node)
 		nodeMap[node.Name] = nodeInfo
+		// add imagestate into nodeinfo
+		nodeMap[node.Name].ImageStates = node.CloneImageSumary()
 	}
 	return nodeMap
 }


### PR DESCRIPTION
Signed-off-by: wangyang <wangyang289@huawei.com>

fix: [#2496](https://github.com/volcano-sh/volcano/issues/2496)
Verify and update based on [#2543](https://github.com/volcano-sh/volcano/pull/2543) due to contributor project adjustment. Thanks @zhifanggao 

Add ImageStates information to the cache of Volcano for trial use of the imagelocality policy.

Note:
Kubernetes uses the Docker engine. When the image name is matched, the prefix name matching is incomplete. [#112699](https://github.com/kubernetes/kubernetes/issues/112699)

