### PR TITLE
🦄 refactor(binpack):optimize the code to get resourceWeight

### DIFF
--- a/pkg/scheduler/plugins/binpack/binpack.go
+++ b/pkg/scheduler/plugins/binpack/binpack.go
@@ -151,6 +151,9 @@ func calculateWeight(args framework.Arguments) priorityWeight {
 		weight.BinPackingResources[v1.ResourceName(resource)] = resourceWeight
 	}
 
+	weight.BinPackingResources[v1.ResourceCPU] = weight.BinPackingCPU
+	weight.BinPackingResources[v1.ResourceMemory] = weight.BinPackingMemory
+
 	return weight
 }
 
@@ -216,18 +219,7 @@ func BinPackingScore(task *api.TaskInfo, node *api.NodeInfo, weight priorityWeig
 		allocate := allocatable.Get(resource)
 		nodeUsed := used.Get(resource)
 
-		resourceWeight := 0
-		found := false
-		switch resource {
-		case v1.ResourceCPU:
-			resourceWeight = weight.BinPackingCPU
-			found = true
-		case v1.ResourceMemory:
-			resourceWeight = weight.BinPackingMemory
-			found = true
-		default:
-			resourceWeight, found = weight.BinPackingResources[resource]
-		}
+		resourceWeight, found := weight.BinPackingResources[resource]
 		if !found {
 			continue
 		}

--- a/pkg/scheduler/plugins/binpack/binpack_test.go
+++ b/pkg/scheduler/plugins/binpack/binpack_test.go
@@ -21,7 +21,7 @@ import (
 	"math"
 	"testing"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/record"
@@ -81,6 +81,14 @@ func TestArguments(t *testing.T) {
 		case "example.com/foo":
 			if weight != 1 {
 				t.Errorf("example.com/foo should be 1, but not %v", weight)
+			}
+		case v1.ResourceCPU:
+			if weight != 5 {
+				t.Errorf("%v should be 5, but not %v", v1.ResourceCPU, weight)
+			}
+		case v1.ResourceMemory:
+			if weight != 2 {
+				t.Errorf("%v should be 2, but not %v", v1.ResourceMemory, weight)
 			}
 		default:
 			t.Errorf("resource %s with weight %d should not appear", name, weight)


### PR DESCRIPTION
Signed-off-by: kingeasternsun <kingeasternsun@gmail.com>

We could just put all resources including cpu or mem into `BinPackingResources`, Because in this plugin, the cpu or mem has no difference with other scalaResouces