### PR TITLE
Use the namespace configuration in kubeconfig

### DIFF
--- a/pkg/cli/job/delete.go
+++ b/pkg/cli/job/delete.go
@@ -35,13 +35,30 @@ type deleteFlags struct {
 	JobName   string
 }
 
+func (dflags *deleteFlags) GetMasterUrl() string {
+	return dflags.Master
+}
+
+func (dflags *deleteFlags) GetKubeconfigPath() string {
+	return dflags.Kubeconfig
+}
+
+func (dflags *deleteFlags) GetNamespace() string {
+	return dflags.Namespace
+}
+
+func (dflags *deleteFlags) SetNamespace(ns string) error {
+	dflags.Namespace = ns
+	return nil
+}
+
 var deleteJobFlags = &deleteFlags{}
 
 // InitDeleteFlags init the delete command flags.
 func InitDeleteFlags(cmd *cobra.Command) {
 	initFlags(cmd, &deleteJobFlags.commonFlags)
 
-	cmd.Flags().StringVarP(&deleteJobFlags.Namespace, "namespace", "n", "default", "the namespace of job")
+	cmd.Flags().StringVarP(&deleteJobFlags.Namespace, "namespace", "n", "", "the namespace of job")
 	cmd.Flags().StringVarP(&deleteJobFlags.JobName, "name", "N", "", "the name of job")
 }
 
@@ -54,6 +71,9 @@ func DeleteJob() error {
 
 	if deleteJobFlags.JobName == "" {
 		err := fmt.Errorf("job name is mandatory to delete a particular job")
+		return err
+	}
+	if err := util.UpdateNamespace(deleteJobFlags); err != nil {
 		return err
 	}
 

--- a/pkg/cli/job/resume.go
+++ b/pkg/cli/job/resume.go
@@ -32,13 +32,30 @@ type resumeFlags struct {
 	JobName   string
 }
 
+func (reflags *resumeFlags) GetMasterUrl() string {
+	return reflags.Master
+}
+
+func (reflags *resumeFlags) GetKubeconfigPath() string {
+	return reflags.Kubeconfig
+}
+
+func (reflags *resumeFlags) GetNamespace() string {
+	return reflags.Namespace
+}
+
+func (reflags *resumeFlags) SetNamespace(ns string) error {
+	reflags.Namespace = ns
+	return nil
+}
+
 var resumeJobFlags = &resumeFlags{}
 
 // InitResumeFlags init resume command flags.
 func InitResumeFlags(cmd *cobra.Command) {
 	initFlags(cmd, &resumeJobFlags.commonFlags)
 
-	cmd.Flags().StringVarP(&resumeJobFlags.Namespace, "namespace", "n", "default", "the namespace of job")
+	cmd.Flags().StringVarP(&resumeJobFlags.Namespace, "namespace", "n", "", "the namespace of job")
 	cmd.Flags().StringVarP(&resumeJobFlags.JobName, "name", "N", "", "the name of job")
 }
 
@@ -50,6 +67,10 @@ func ResumeJob() error {
 	}
 	if resumeJobFlags.JobName == "" {
 		err := fmt.Errorf("job name is mandatory to resume a particular job")
+		return err
+	}
+
+	if util.UpdateNamespace(resumeJobFlags); err != nil {
 		return err
 	}
 

--- a/pkg/cli/job/run.go
+++ b/pkg/cli/job/run.go
@@ -48,6 +48,23 @@ type runFlags struct {
 	FileName      string
 }
 
+func (runflags *runFlags) GetMasterUrl() string {
+	return runflags.Master
+}
+
+func (runflags *runFlags) GetKubeconfigPath() string {
+	return runflags.Kubeconfig
+}
+
+func (runflags *runFlags) GetNamespace() string {
+	return runflags.Namespace
+}
+
+func (runflags *runFlags) SetNamespace(ns string) error {
+	runflags.Namespace = ns
+	return nil
+}
+
 var launchJobFlags = &runFlags{}
 
 // InitRunFlags init the run flags.
@@ -55,7 +72,7 @@ func InitRunFlags(cmd *cobra.Command) {
 	initFlags(cmd, &launchJobFlags.commonFlags)
 
 	cmd.Flags().StringVarP(&launchJobFlags.Image, "image", "i", "busybox", "the container image of job")
-	cmd.Flags().StringVarP(&launchJobFlags.Namespace, "namespace", "n", "default", "the namespace of job")
+	cmd.Flags().StringVarP(&launchJobFlags.Namespace, "namespace", "n", "", "the namespace of job")
 	cmd.Flags().StringVarP(&launchJobFlags.Name, "name", "N", "", "the name of job")
 	cmd.Flags().IntVarP(&launchJobFlags.MinAvailable, "min", "m", 1, "the minimal available tasks of job")
 	cmd.Flags().IntVarP(&launchJobFlags.Replicas, "replicas", "r", 1, "the total tasks of job")
@@ -76,6 +93,10 @@ func RunJob() error {
 
 	if launchJobFlags.Name == "" && launchJobFlags.FileName == "" {
 		err = fmt.Errorf("job name cannot be left blank")
+		return err
+	}
+
+	if err := util.UpdateNamespace(launchJobFlags); err != nil {
 		return err
 	}
 

--- a/pkg/cli/job/suspend.go
+++ b/pkg/cli/job/suspend.go
@@ -32,13 +32,30 @@ type suspendFlags struct {
 	JobName   string
 }
 
+func (sflags *suspendFlags) GetMasterUrl() string {
+	return sflags.Master
+}
+
+func (sflags *suspendFlags) GetKubeconfigPath() string {
+	return sflags.Kubeconfig
+}
+
+func (sflags *suspendFlags) GetNamespace() string {
+	return sflags.Namespace
+}
+
+func (sflags *suspendFlags) SetNamespace(ns string) error {
+	sflags.Namespace = ns
+	return nil
+}
+
 var suspendJobFlags = &suspendFlags{}
 
 // InitSuspendFlags init suspend related flags.
 func InitSuspendFlags(cmd *cobra.Command) {
 	initFlags(cmd, &suspendJobFlags.commonFlags)
 
-	cmd.Flags().StringVarP(&suspendJobFlags.Namespace, "namespace", "n", "default", "the namespace of job")
+	cmd.Flags().StringVarP(&suspendJobFlags.Namespace, "namespace", "n", "", "the namespace of job")
 	cmd.Flags().StringVarP(&suspendJobFlags.JobName, "name", "N", "", "the name of job")
 }
 
@@ -51,6 +68,10 @@ func SuspendJob() error {
 
 	if suspendJobFlags.JobName == "" {
 		err := fmt.Errorf("job name is mandatory to suspend a particular job")
+		return err
+	}
+
+	if err := util.UpdateNamespace(suspendJobFlags); err != nil {
 		return err
 	}
 

--- a/pkg/cli/job/view.go
+++ b/pkg/cli/job/view.go
@@ -43,6 +43,23 @@ type viewFlags struct {
 	JobName   string
 }
 
+func (vflags *viewFlags) GetMasterUrl() string {
+	return vflags.Master
+}
+
+func (vflags *viewFlags) GetKubeconfigPath() string {
+	return vflags.Kubeconfig
+}
+
+func (vflags *viewFlags) GetNamespace() string {
+	return vflags.Namespace
+}
+
+func (vflags *viewFlags) SetNamespace(ns string) error {
+	vflags.Namespace = ns
+	return nil
+}
+
 // level of print indent.
 const (
 	Level0 = iota
@@ -56,7 +73,7 @@ var viewJobFlags = &viewFlags{}
 func InitViewFlags(cmd *cobra.Command) {
 	initFlags(cmd, &viewJobFlags.commonFlags)
 
-	cmd.Flags().StringVarP(&viewJobFlags.Namespace, "namespace", "n", "default", "the namespace of job")
+	cmd.Flags().StringVarP(&viewJobFlags.Namespace, "namespace", "n", "", "the namespace of job")
 	cmd.Flags().StringVarP(&viewJobFlags.JobName, "name", "N", "", "the name of job")
 }
 
@@ -68,6 +85,10 @@ func ViewJob() error {
 	}
 	if viewJobFlags.JobName == "" {
 		err := fmt.Errorf("job name (specified by --name or -N) is mandatory to view a particular job")
+		return err
+	}
+
+	if err := util.UpdateNamespace(viewJobFlags); err != nil {
 		return err
 	}
 

--- a/pkg/cli/vcancel/cancel.go
+++ b/pkg/cli/vcancel/cancel.go
@@ -35,13 +35,30 @@ type cancelFlags struct {
 	JobName   string
 }
 
+func (cflags *cancelFlags) GetMasterUrl() string {
+	return cflags.Master
+}
+
+func (cflags *cancelFlags) GetKubeconfigPath() string {
+	return cflags.Kubeconfig
+}
+
+func (cflags *cancelFlags) GetNamespace() string {
+	return cflags.Namespace
+}
+
+func (cflags *cancelFlags) SetNamespace(ns string) error {
+	cflags.Namespace = ns
+	return nil
+}
+
 var cancelJobFlags = &cancelFlags{}
 
 // InitCancelFlags init the cancel command flags.
 func InitCancelFlags(cmd *cobra.Command) {
 	util.InitFlags(cmd, &cancelJobFlags.CommonFlags)
 
-	cmd.Flags().StringVarP(&cancelJobFlags.Namespace, "namespace", "N", "default", "the namespace of job")
+	cmd.Flags().StringVarP(&cancelJobFlags.Namespace, "namespace", "N", "", "the namespace of job")
 	cmd.Flags().StringVarP(&cancelJobFlags.JobName, "name", "n", "", "the name of job")
 }
 
@@ -54,6 +71,10 @@ func CancelJob() error {
 
 	if cancelJobFlags.JobName == "" {
 		err := fmt.Errorf("job name is mandatory to cancel a particular job")
+		return err
+	}
+
+	if err := util.UpdateNamespace(cancelJobFlags); err != nil {
 		return err
 	}
 

--- a/pkg/cli/vresume/resume.go
+++ b/pkg/cli/vresume/resume.go
@@ -32,13 +32,30 @@ type resumeFlags struct {
 	JobName   string
 }
 
+func (reflags *resumeFlags) GetMasterUrl() string {
+	return reflags.Master
+}
+
+func (reflags *resumeFlags) GetKubeconfigPath() string {
+	return reflags.Kubeconfig
+}
+
+func (reflags *resumeFlags) GetNamespace() string {
+	return reflags.Namespace
+}
+
+func (reflags *resumeFlags) SetNamespace(ns string) error {
+	reflags.Namespace = ns
+	return nil
+}
+
 var resumeJobFlags = &resumeFlags{}
 
 // InitResumeFlags init resume command flags.
 func InitResumeFlags(cmd *cobra.Command) {
 	util.InitFlags(cmd, &resumeJobFlags.CommonFlags)
 
-	cmd.Flags().StringVarP(&resumeJobFlags.Namespace, "namespace", "N", "default", "the namespace of job")
+	cmd.Flags().StringVarP(&resumeJobFlags.Namespace, "namespace", "N", "", "the namespace of job")
 	cmd.Flags().StringVarP(&resumeJobFlags.JobName, "name", "n", "", "the name of job")
 }
 
@@ -50,6 +67,9 @@ func ResumeJob() error {
 	}
 	if resumeJobFlags.JobName == "" {
 		err := fmt.Errorf("job name is mandatory to resume a particular job")
+		return err
+	}
+	if err := util.UpdateNamespace(resumeJobFlags); err != nil {
 		return err
 	}
 

--- a/pkg/cli/vsub/run.go
+++ b/pkg/cli/vsub/run.go
@@ -48,6 +48,23 @@ type runFlags struct {
 	Command       string
 }
 
+func (runflags *runFlags) GetMasterUrl() string {
+	return runflags.Master
+}
+
+func (runflags *runFlags) GetKubeconfigPath() string {
+	return runflags.Kubeconfig
+}
+
+func (runflags *runFlags) GetNamespace() string {
+	return runflags.Namespace
+}
+
+func (runflags *runFlags) SetNamespace(ns string) error {
+	runflags.Namespace = ns
+	return nil
+}
+
 var launchJobFlags = &runFlags{}
 
 const (
@@ -114,7 +131,7 @@ func setDefaultArgs() {
 		if namespace != "" {
 			launchJobFlags.Namespace = namespace
 		} else {
-			launchJobFlags.Namespace = defaultJobNamespace
+			util.UpdateNamespace(launchJobFlags)
 		}
 	}
 }

--- a/pkg/cli/vsuspend/suspend.go
+++ b/pkg/cli/vsuspend/suspend.go
@@ -32,13 +32,30 @@ type suspendFlags struct {
 	JobName   string
 }
 
+func (sflags *suspendFlags) GetMasterUrl() string {
+	return sflags.Master
+}
+
+func (sflags *suspendFlags) GetKubeconfigPath() string {
+	return sflags.Kubeconfig
+}
+
+func (sflags *suspendFlags) GetNamespace() string {
+	return sflags.Namespace
+}
+
+func (sflags *suspendFlags) SetNamespace(ns string) error {
+	sflags.Namespace = ns
+	return nil
+}
+
 var suspendJobFlags = &suspendFlags{}
 
 // InitSuspendFlags init suspend related flags.
 func InitSuspendFlags(cmd *cobra.Command) {
 	util.InitFlags(cmd, &suspendJobFlags.CommonFlags)
 
-	cmd.Flags().StringVarP(&suspendJobFlags.Namespace, "namespace", "N", "default", "the namespace of job")
+	cmd.Flags().StringVarP(&suspendJobFlags.Namespace, "namespace", "N", "", "the namespace of job")
 	cmd.Flags().StringVarP(&suspendJobFlags.JobName, "name", "n", "", "the name of job")
 }
 
@@ -51,6 +68,10 @@ func SuspendJob() error {
 
 	if suspendJobFlags.JobName == "" {
 		err := fmt.Errorf("job name is mandatory to suspend a particular job")
+		return err
+	}
+
+	if err := util.UpdateNamespace(suspendJobFlags); err != nil {
 		return err
 	}
 

--- a/test/e2e/vcctl/vcctl.go
+++ b/test/e2e/vcctl/vcctl.go
@@ -93,7 +93,7 @@ Flags:
   -h, --help                help for list
   -k, --kubeconfig string   (optional) absolute path to the kubeconfig file (default "` + kubeConfig + `")
   -s, --master string       the address of apiserver
-  -n, --namespace string    the namespace of job (default "default")
+  -n, --namespace string    the namespace of job
   -S, --scheduler string    list job with specified scheduler name
       --selector string     fuzzy matching jobName
 
@@ -120,7 +120,7 @@ Flags:
   -k, --kubeconfig string   (optional) absolute path to the kubeconfig file (default "` + kubeConfig + `")
   -s, --master string       the address of apiserver
   -N, --name string         the name of job
-  -n, --namespace string    the namespace of job (default "default")
+  -n, --namespace string    the namespace of job
 
 Global Flags:
       --log-flush-frequency duration   Maximum number of seconds between log flushes (default 5s)
@@ -145,7 +145,7 @@ Flags:
   -k, --kubeconfig string   (optional) absolute path to the kubeconfig file (default "` + kubeConfig + `")
   -s, --master string       the address of apiserver
   -N, --name string         the name of job
-  -n, --namespace string    the namespace of job (default "default")
+  -n, --namespace string    the namespace of job
 
 Global Flags:
       --log-flush-frequency duration   Maximum number of seconds between log flushes (default 5s)
@@ -174,7 +174,7 @@ Flags:
   -s, --master string       the address of apiserver
   -m, --min int             the minimal available tasks of job (default 1)
   -N, --name string         the name of job
-  -n, --namespace string    the namespace of job (default "default")
+  -n, --namespace string    the namespace of job
   -r, --replicas int        the total tasks of job (default 1)
   -R, --requests string     the resource request of the task (default "cpu=1000m,memory=100Mi")
   -S, --scheduler string    the scheduler for this job (default "volcano")


### PR DESCRIPTION
``Signed-off-by: wangyang <wangyang289@huawei.com>

fix: [#2594](https://github.com/volcano-sh/volcano/issues/2594)

- If ns is specified on the vcctl command line, the ns specified on the command line is used as the default value.
- If ns is not specified in the vcctl command but is specified in kubeconfig, ns in kubeconfig is used as the default value.
- If ns is not specified in the vcctl command line and kubeconfig, the default value default is used for ns.

**test**
The job information in the cluster is as follows:
```
[root@volcano-dev-wangyang bin]# kubectl get vcjob -A
NAMESPACE        NAME                      STATUS       MINAVAILABLE   RUNNINGS   AGE
default          vcjob-ns-default          Running      1              5          10m
test             vcjob-ns-test             Running      1              6          10m
volcano-system   vcjob-ns-volcano-system   Terminated                             9m28s
[root@volcano-dev-wangyang bin]# ./vcctl job list --all-namespaces
Namespace        Name                      Creation       Phase       JobType     Replicas    Min   Pending   Running   Succeeded   Failed    Unknown     RetryCount
default          vcjob-ns-default          2022-12-09     Running     Batch       8           1     3         5         0           0         0           0         
test             vcjob-ns-test             2022-12-09     Running     Batch       8           1     2         6         0           0         0           0         
volcano-system   vcjob-ns-volcano-system   2022-12-09     Terminated  Batch       8           0     0         0         0           0         0           0 
```
- If no namespace is specified for vcctl and kubeconfig, job information in default is queried by default.
```
[root@volcano-dev-wangyang bin]# kubectl get vcjob
NAME               STATUS    MINAVAILABLE   RUNNINGS   AGE
vcjob-ns-default   Running   1              3          23m
[root@volcano-dev-wangyang bin]# ./vcctl job list
Name               Creation       Phase       JobType     Replicas    Min   Pending   Running   Succeeded   Failed    Unknown     RetryCount
vcjob-ns-default   2022-12-09     Running     Batch       8           1     0         3         5           0         0           0 
```
- If namespace test is specified in kubeconfig, job information in test is queried by default.
```
- context:
    cluster: kind-my-test
    namespace: test
    user: kind-my-test
  name: kind-my-test
current-context: kind-my-test

[root@volcano-dev-wangyang bin]# kubectl get vcjob
NAME            STATUS    MINAVAILABLE   RUNNINGS   AGE
vcjob-ns-test   Running   1              6          15m
[root@volcano-dev-wangyang bin]# ./vcctl job list
Name            Creation       Phase       JobType     Replicas    Min   Pending   Running   Succeeded   Failed    Unknown     RetryCount
vcjob-ns-test   2022-12-09     Running     Batch       8           1     2         6         0           0         0           0     
```
- In kubeconfig, namespace test is specified, but namespace volcano-system is specified in the vcctl command. In this case, job information in volcano-system should be displayed.
```
[root@volcano-dev-wangyang bin]# kubectl get vcjob -n volcano-system
NAME                      STATUS       MINAVAILABLE   RUNNINGS   AGE
vcjob-ns-volcano-system   Terminated                             16m
[root@volcano-dev-wangyang bin]# ./vcctl job list -n volcano-system
Name                      Creation       Phase       JobType     Replicas    Min   Pending   Running   Succeeded   Failed    Unknown     RetryCount
vcjob-ns-volcano-system   2022-12-09     Terminated  Batch       8           0     0         0         0           0         0           0    
```