### PR TITLE
:art: optimize the  job-topology code and  avoid the potential panic

### DIFF
--- a/pkg/scheduler/plugins/task-topology/topology.go
+++ b/pkg/scheduler/plugins/task-topology/topology.go
@@ -88,7 +88,6 @@ func (p *taskTopologyPlugin) TaskOrderFn(l interface{}, r interface{}) int {
 		return 0
 	}
 
-
 	lvBucket := lvJobManager.GetBucket(lv)
 	rvBucket := rvJobManager.GetBucket(rv)
 	// the one have bucket would always prior to another

--- a/pkg/scheduler/plugins/task-topology/topology.go
+++ b/pkg/scheduler/plugins/task-topology/topology.go
@@ -69,29 +69,28 @@ func (p *taskTopologyPlugin) TaskOrderFn(l interface{}, r interface{}) int {
 	lv, ok := l.(*api.TaskInfo)
 	if !ok {
 		klog.Errorf("Object is not a taskinfo")
+		return 0
 	}
 	rv, ok := r.(*api.TaskInfo)
 	if !ok {
 		klog.Errorf("Object is not a taskinfo")
+		return 0
 	}
 
 	lvJobManager := p.managers[lv.Job]
 	rvJobManager := p.managers[rv.Job]
-
-	var lvBucket, rvBucket *Bucket
-	if lvJobManager != nil {
-		lvBucket = lvJobManager.GetBucket(lv)
-	} else {
+	if lvJobManager == nil {
 		klog.V(4).Infof("No job manager for job <ID: %s>, do not return task order.", lv.Job)
 		return 0
 	}
-	if rvJobManager != nil {
-		rvBucket = rvJobManager.GetBucket(rv)
-	} else {
+	if rvJobManager == nil {
 		klog.V(4).Infof("No job manager for job <ID: %s>, do not return task order.", rv.Job)
 		return 0
 	}
 
+
+	lvBucket := lvJobManager.GetBucket(lv)
+	rvBucket := rvJobManager.GetBucket(rv)
 	// the one have bucket would always prior to another
 	lvInBucket := lvBucket != nil
 	rvInBucket := rvBucket != nil


### PR DESCRIPTION
Signed-off-by: kingeasternsun <kingeasternsun@gmail.com>

1. If ok equal false, the code `lv.Job ` or `rv.Job` may be panic
2. We could move the `== nil` judgement ahead to make code more clear