### PR TITLE
Added helm hooks to fix `helm upgrade`

### DIFF
--- a/installer/helm/chart/volcano/templates/admission.yaml
+++ b/installer/helm/chart/volcano/templates/admission.yaml
@@ -12,11 +12,15 @@ kind: ServiceAccount
 metadata:
   name: {{ .Release.Name }}-admission
   namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ .Release.Name }}-admission
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
 rules:
   - apiGroups: [""]
     resources: ["configmaps"]
@@ -49,6 +53,8 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ .Release.Name }}-admission-role
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
 subjects:
   - kind: ServiceAccount
     name: {{ .Release.Name }}-admission
@@ -138,6 +144,10 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     app: volcano-admission-init
+  annotations:
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
   backoffLimit: 3
   template:


### PR DESCRIPTION
Currently, running `helm upgrade --namespace volcano-system volcano .` will fail because the `volcano-admission-init` will fail, as the secret it creates already exists. As this Job only needs to be run for install, we can add a hook to disable it on subsequent upgrades. Also, we add a hook to delete the job when it completes successfully.