### PR TITLE
Added KubeRay docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 [Volcano](https://volcano.sh/) is a batch system built on Kubernetes. It provides a suite of mechanisms that are commonly required by
 many classes of batch & elastic workload including: machine learning/deep learning, bioinformatics/genomics and
 other "big data" applications. These types of applications typically run on generalized domain frameworks like
-TensorFlow, Spark, PyTorch, MPI, etc, which Volcano integrates with.
+TensorFlow, Spark, Ray, PyTorch, MPI, etc, which Volcano integrates with.
 
 Volcano builds upon a decade and a half of experience running a wide
 variety of high performance workloads at scale using several systems
@@ -56,6 +56,7 @@ Volcano is an incubating project of the [Cloud Native Computing Foundation](http
 - [Horovod/MPI](https://github.com/volcano-sh/volcano/tree/master/example/integrations/mpi)
 - [paddlepaddle](https://github.com/volcano-sh/volcano/tree/master/example/integrations/paddlepaddle)
 - [cromwell](https://github.com/broadinstitute/cromwell/blob/develop/docs/backends/Volcano.md)
+- [KubeRay](https://ray-project.github.io/kuberay/guidance/volcano-integration)
 
 ## Quick Start Guide
 

--- a/docs/community/adopters.md
+++ b/docs/community/adopters.md
@@ -28,3 +28,4 @@ please feel free to add yourself into the following list by a pull request. Ther
 | [GrandOmics](https://www.grandomics.com/) |[@alartin](https://github.com/alartin)| Evaluation | Infrastructure of Hanwell (Huawei Cloud backend of Cromwell which is a Broad Institute implementation of WDL) |
 | [kt NexR](https://www.ktnexr.com) |[@minyk](https://github.com/minyk), [@dieselnexr](https://github.com/dieselnexr)| Evaluation | spark scheduler of our next cloud native product. |
 | [QTT Bigdata Infra](https://ir.qutoutiao.net/) |[@yuzhaojing](https://github.com/yuzhaojing) | Evaluation | Spark and AI on K8S. |
+| [Predibase](https://predibase.com/) |[@tgaddair](https://github.com/tgaddair) | Staging | Ray on K8s. |

--- a/docs/getting-started/getting-started.md
+++ b/docs/getting-started/getting-started.md
@@ -8,7 +8,7 @@ Kubernetes that are commonly required by many classes of batch & elastic workloa
 3. other "big data" applications.
 
 These types of applications typically run on generalized domain
-frameworks like TensorFlow, Spark, PyTorch, MPI, etc, which Volcano integrates with.
+frameworks like TensorFlow, Spark, Ray, PyTorch, MPI, etc, which Volcano integrates with.
 
 ### Why Volcano?
 - // TODO better to add separate md file & Link


### PR DESCRIPTION
Closes #2429.

Native integration with Volcano in KubeRay was added in https://github.com/ray-project/kuberay/pull/755. This provides first-class support for launching Ray jobs on Kubernetes using Volcano as a batch scheduler.