### PR TITLE
Remove `Undetermined` reason to fix cluster autoscaler compatibility

### DIFF
--- a/docs/design/scheduling-reason.md
+++ b/docs/design/scheduling-reason.md
@@ -1,6 +1,7 @@
 # Scheduling Reason
 
 [@eggiter](https://github.com/eggiter); Aug 13, 2021
+[@tgaddair](https://github.com/tgaddair); Dec 12, 2022
 
 ## Table of Contents
 
@@ -12,11 +13,14 @@
 
 - Currently, the reason and message in `pod.status.conditions["PodScheduled"]` and `podgroup.status.conditions["Unschedulable"]` is **NOT** informative, for example `x/x tasks in gang unschedulable: pod group is not ready, x Pending, x minAvailable`.
 - Users want to know which one breaks the scheduling cycle and why is that.
+- (@tgaddair): However, cluster autoscaling systems like [Karpenter](https://github.com/aws/karpenter) explicitly check for the `Unschedulable` reason on the pod to trigger scale-up (see [here](https://github.com/aws/karpenter-core/blob/fedb036e598fb51cda28bd5ae150743df009312f/pkg/utils/pod/scheduling.go#L25)). As such, we need to keep the `Reason` field consistent with default scheduler behavior.
 
 ## Solution
 
-- Introducing two extra scheduling reasons in PodScheduled PodCondition:
+- Introducing an extra scheduling reasons in PodScheduled PodCondition:
   + `Schedulable`: means that the scheduler can schedule the pod right now, but not bind yet.
+
+An additional reason was originally considered that conflicts with cluster autoscaler. Instead, this reason only appears in the detailed `Message` field, and shows up with `Reason: Unschedulable` in the pod:
   + `Undetermined`: means that the scheduler skips scheduling the pod which left the pod `Undetermined`, for example due to unschedulable pod already occurred.
 
 - Case:
@@ -35,12 +39,12 @@
   + |Tasks|Reason|Message|
     |-|-|-|
     |PodGroup |(same)| **3/6** tasks in gang unschedulable: pod group is not ready, 6 Pending, 6 minAvailable; **Pending: 1 Unschedulable, 2 Undetermined, 3 Schedulable** |
-    |Task1 ~ 2|**Undetermined**| **3/6** tasks in gang unschedulable: pod group is not ready, 6 Pending, 6 minAvailable; **Pending: 1 Unschedulable, 2 Undetermined, 3 Schedulable**  |
+    |Task1 ~ 2|**Unschedulable**| **3/6** tasks in gang unschedulable: pod group is not ready, 6 Pending, 6 minAvailable; **Pending: 1 Unschedulable, 2 Undetermined, 3 Schedulable**  |
     |Task3|**Schedulable**| **Pod ns1/task-1 can possibly be assgined to node1** |
     |Task4|**Schedulable**| **Pod ns1/task-2 can possibly be assgined to node2** |
     |Task5|**Schedulable**| **Pod ns1/task-3 can possibly be assgined to node3** |
     |Task6|Unschedulable| all nodes are unavailable: 1 plugin InterPodAffinity predicates failed node(s) didn't match pod affinity/anti-affinity, node(s) didn't match pod affinity rules, 2 node(s) resource fit failed.|
 
-    - Note: Task1 & 2 are `Undetermined` maybe because that this two locate after task6 by `TaskOrderFn`;
+    - Note: Task1 & 2 are `Unschedulable` maybe because that this two locate after task6 by `TaskOrderFn`;
 
 - In improved information, we can easily find the one that breaks the whole scheduling cycle and why dose that happen. Additionally,  we can find the histogram of reason why there are some tasks whose status is pending.

--- a/pkg/scheduler/api/job_info.go
+++ b/pkg/scheduler/api/job_info.go
@@ -666,7 +666,7 @@ func (ji *JobInfo) TaskSchedulingReason(tid TaskID) (reason string, msg string) 
 			return PodReasonUnschedulable, fe.Error()
 		}
 		// Pod is not scheduled yet
-		return PodReasonUndetermined, msg
+		return PodReasonUnschedulable, msg
 	default:
 		return status.String(), msg
 	}

--- a/pkg/scheduler/api/job_info.go
+++ b/pkg/scheduler/api/job_info.go
@@ -665,7 +665,7 @@ func (ji *JobInfo) TaskSchedulingReason(tid TaskID) (reason string, msg string) 
 			// Pod is not schedulable
 			return PodReasonUnschedulable, fe.Error()
 		}
-		// Pod is not scheduled yet
+		// Pod is not scheduled yet, keep UNSCHEDULABLE as the reason to support cluster autoscaler
 		return PodReasonUnschedulable, msg
 	default:
 		return status.String(), msg

--- a/pkg/scheduler/api/job_info_test.go
+++ b/pkg/scheduler/api/job_info_test.go
@@ -225,9 +225,9 @@ func TestTaskSchedulingReason(t *testing.T) {
 				},
 			},
 			expected: map[types.UID]string{
-				"pg":   "pod group is not ready, 6 Pending, 6 minAvailable; Pending: 3 Unschedulable, 3 Schedulable",
-				t1.UID: "pod group is not ready, 6 Pending, 6 minAvailable; Pending: 3 Unschedulable, 3 Schedulable",
-				t2.UID: "pod group is not ready, 6 Pending, 6 minAvailable; Pending: 3 Unschedulable, 3 Schedulable",
+				"pg":   "pod group is not ready, 6 Pending, 6 minAvailable; Pending: 3 Schedulable, 3 Unschedulable",
+				t1.UID: "pod group is not ready, 6 Pending, 6 minAvailable; Pending: 3 Schedulable, 3 Unschedulable",
+				t2.UID: "pod group is not ready, 6 Pending, 6 minAvailable; Pending: 3 Schedulable, 3 Unschedulable",
 				t3.UID: "Pod ns1/task-3 can possibly be assigned to node1",
 				t4.UID: "Pod ns1/task-4 can possibly be assigned to node2",
 				t5.UID: "Pod ns1/task-5 can possibly be assigned to node3",

--- a/pkg/scheduler/api/job_info_test.go
+++ b/pkg/scheduler/api/job_info_test.go
@@ -225,9 +225,9 @@ func TestTaskSchedulingReason(t *testing.T) {
 				},
 			},
 			expected: map[types.UID]string{
-				"pg":   "pod group is not ready, 6 Pending, 6 minAvailable; Pending: 1 Unschedulable, 2 Undetermined, 3 Schedulable",
-				t1.UID: "pod group is not ready, 6 Pending, 6 minAvailable; Pending: 1 Unschedulable, 2 Undetermined, 3 Schedulable",
-				t2.UID: "pod group is not ready, 6 Pending, 6 minAvailable; Pending: 1 Unschedulable, 2 Undetermined, 3 Schedulable",
+				"pg":   "pod group is not ready, 6 Pending, 6 minAvailable; Pending: 3 Unschedulable, 3 Schedulable",
+				t1.UID: "pod group is not ready, 6 Pending, 6 minAvailable; Pending: 3 Unschedulable, 3 Schedulable",
+				t2.UID: "pod group is not ready, 6 Pending, 6 minAvailable; Pending: 3 Unschedulable, 3 Schedulable",
 				t3.UID: "Pod ns1/task-3 can possibly be assigned to node1",
 				t4.UID: "Pod ns1/task-4 can possibly be assigned to node2",
 				t5.UID: "Pod ns1/task-5 can possibly be assigned to node3",

--- a/pkg/scheduler/api/unschedule_info.go
+++ b/pkg/scheduler/api/unschedule_info.go
@@ -20,13 +20,12 @@ const (
 const (
 	// PodReasonUnschedulable reason in PodScheduled PodCondition means that the scheduler
 	// can't schedule the pod right now, for example due to insufficient resources in the cluster.
+	// It can also mean that the scheduler skips scheduling the pod which left the pod `Undetermined`,
+	// for example due to unschedulable pod already occurred.
 	PodReasonUnschedulable = "Unschedulable"
 	// PodReasonSchedulable reason in PodScheduled PodCondition means that the scheduler
 	// can schedule the pod right now, but not bind yet
 	PodReasonSchedulable = "Schedulable"
-	// PodReasonUndetermined reason in PodScheduled PodCondition means that the scheduler
-	// skips scheduling the pod which left the pod `Undetermined`, for example due to unschedulable pod already occurred.
-	PodReasonUndetermined = "Undetermined"
 )
 
 // FitErrors is set of FitError on many nodes


### PR DESCRIPTION
Fixes #1775.

#1672 introduced fine-grained Reasons to give users more context about why scheduling did not succeed. However, this breaks compatibility with cluster autoscalers like Karpenter, which rely on the reason being set to `Unschedulable` to trigger scale-up, and the more fine-grained reason `Undetermined` causes the autoscaler to skip the pod.

This PR removes this reason to fix support for cluster autoscalers.