### PR TITLE
🌈 optimize(victim task):remove unused copy

### DIFF
--- a/docs/design/scheduling-reason.md
+++ b/docs/design/scheduling-reason.md
@@ -1,6 +1,7 @@
 # Scheduling Reason
 
 [@eggiter](https://github.com/eggiter); Aug 13, 2021
+[@tgaddair](https://github.com/tgaddair); Dec 12, 2022
 
 ## Table of Contents
 
@@ -12,11 +13,14 @@
 
 - Currently, the reason and message in `pod.status.conditions["PodScheduled"]` and `podgroup.status.conditions["Unschedulable"]` is **NOT** informative, for example `x/x tasks in gang unschedulable: pod group is not ready, x Pending, x minAvailable`.
 - Users want to know which one breaks the scheduling cycle and why is that.
+- (@tgaddair): However, cluster autoscaling systems like [Karpenter](https://github.com/aws/karpenter) explicitly check for the `Unschedulable` reason on the pod to trigger scale-up (see [here](https://github.com/aws/karpenter-core/blob/fedb036e598fb51cda28bd5ae150743df009312f/pkg/utils/pod/scheduling.go#L25)). As such, we need to keep the `Reason` field consistent with default scheduler behavior.
 
 ## Solution
 
-- Introducing two extra scheduling reasons in PodScheduled PodCondition:
+- Introducing an extra scheduling reasons in PodScheduled PodCondition:
   + `Schedulable`: means that the scheduler can schedule the pod right now, but not bind yet.
+
+An additional reason was originally considered that conflicts with cluster autoscaler. Instead, this reason only appears in the detailed `Message` field, and shows up with `Reason: Unschedulable` in the pod:
   + `Undetermined`: means that the scheduler skips scheduling the pod which left the pod `Undetermined`, for example due to unschedulable pod already occurred.
 
 - Case:
@@ -35,12 +39,12 @@
   + |Tasks|Reason|Message|
     |-|-|-|
     |PodGroup |(same)| **3/6** tasks in gang unschedulable: pod group is not ready, 6 Pending, 6 minAvailable; **Pending: 1 Unschedulable, 2 Undetermined, 3 Schedulable** |
-    |Task1 ~ 2|**Undetermined**| **3/6** tasks in gang unschedulable: pod group is not ready, 6 Pending, 6 minAvailable; **Pending: 1 Unschedulable, 2 Undetermined, 3 Schedulable**  |
+    |Task1 ~ 2|**Unschedulable**| **3/6** tasks in gang unschedulable: pod group is not ready, 6 Pending, 6 minAvailable; **Pending: 1 Unschedulable, 2 Undetermined, 3 Schedulable**  |
     |Task3|**Schedulable**| **Pod ns1/task-1 can possibly be assgined to node1** |
     |Task4|**Schedulable**| **Pod ns1/task-2 can possibly be assgined to node2** |
     |Task5|**Schedulable**| **Pod ns1/task-3 can possibly be assgined to node3** |
     |Task6|Unschedulable| all nodes are unavailable: 1 plugin InterPodAffinity predicates failed node(s) didn't match pod affinity/anti-affinity, node(s) didn't match pod affinity rules, 2 node(s) resource fit failed.|
 
-    - Note: Task1 & 2 are `Undetermined` maybe because that this two locate after task6 by `TaskOrderFn`;
+    - Note: Task1 & 2 are `Unschedulable` maybe because that this two locate after task6 by `TaskOrderFn`;
 
 - In improved information, we can easily find the one that breaks the whole scheduling cycle and why dose that happen. Additionally,  we can find the histogram of reason why there are some tasks whose status is pending.

--- a/installer/helm/chart/volcano/config/volcano-scheduler-ci.conf
+++ b/installer/helm/chart/volcano/config/volcano-scheduler-ci.conf
@@ -3,11 +3,13 @@ tiers:
 - plugins:
   - name: priority
   - name: gang
+    enablePreemptable: false
   - name: conformance
   - name: sla
 - plugins:
   - name: overcommit
   - name: drf
+    enablePreemptable: false
   - name: predicates
   - name: proportion
   - name: nodeorder

--- a/installer/helm/chart/volcano/config/volcano-scheduler.conf
+++ b/installer/helm/chart/volcano/config/volcano-scheduler.conf
@@ -3,10 +3,12 @@ tiers:
 - plugins:
   - name: priority
   - name: gang
+    enablePreemptable: false
   - name: conformance
 - plugins:
   - name: overcommit
   - name: drf
+    enablePreemptable: false
   - name: predicates
   - name: proportion
   - name: nodeorder

--- a/installer/volcano-development.yaml
+++ b/installer/volcano-development.yaml
@@ -8630,10 +8630,12 @@ data:
     - plugins:
       - name: priority
       - name: gang
+        enablePreemptable: false
       - name: conformance
     - plugins:
       - name: overcommit
       - name: drf
+        enablePreemptable: false
       - name: predicates
       - name: proportion
       - name: nodeorder

--- a/pkg/controllers/job/job_controller_actions.go
+++ b/pkg/controllers/job/job_controller_actions.go
@@ -31,15 +31,14 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	quotav1 "k8s.io/apiserver/pkg/quota/v1"
 	"k8s.io/klog"
-	quotacore "k8s.io/kubernetes/pkg/quota/v1/evaluator/core"
-	"k8s.io/utils/clock"
-
 	batch "volcano.sh/apis/pkg/apis/batch/v1alpha1"
 	"volcano.sh/apis/pkg/apis/helpers"
 	scheduling "volcano.sh/apis/pkg/apis/scheduling/v1beta1"
+
 	"volcano.sh/volcano/pkg/controllers/apis"
 	jobhelpers "volcano.sh/volcano/pkg/controllers/job/helpers"
 	"volcano.sh/volcano/pkg/controllers/job/state"
+	"volcano.sh/volcano/pkg/controllers/util"
 )
 
 var calMutex sync.Mutex
@@ -671,7 +670,7 @@ func (cc *jobcontroller) createOrUpdatePodGroup(job *batch.Job) error {
 			pg := &scheduling.PodGroup{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: job.Namespace,
-					//add job.UID into its name when create new PodGroup
+					// add job.UID into its name when create new PodGroup
 					Name:        pgName,
 					Annotations: job.Annotations,
 					Labels:      job.Labels,
@@ -791,8 +790,7 @@ func (cc *jobcontroller) calcPGMinResources(job *batch.Job) *v1.ResourceList {
 			pod := &v1.Pod{
 				Spec: task.Template.Spec,
 			}
-			res, _ := quotacore.PodUsageFunc(pod, clock.RealClock{})
-			minReq = quotav1.Add(minReq, res)
+			minReq = quotav1.Add(minReq, *util.GetPodQuotaUsage(pod))
 		}
 	}
 

--- a/pkg/controllers/util/util.go
+++ b/pkg/controllers/util/util.go
@@ -1,0 +1,20 @@
+package util
+
+import (
+	"strings"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/kubernetes/pkg/apis/core/v1/helper"
+	quotacore "k8s.io/kubernetes/pkg/quota/v1/evaluator/core"
+	"k8s.io/utils/clock"
+)
+
+func GetPodQuotaUsage(pod *v1.Pod) *v1.ResourceList {
+	res, _ := quotacore.PodUsageFunc(pod, clock.RealClock{})
+	for name, quantity := range res {
+		if !helper.IsNativeResource(name) && strings.HasPrefix(string(name), v1.DefaultResourceRequestsPrefix) {
+			res[v1.ResourceName(strings.TrimPrefix(string(name), v1.DefaultResourceRequestsPrefix))] = quantity
+		}
+	}
+	return &res
+}

--- a/pkg/controllers/util/util_test.go
+++ b/pkg/controllers/util/util_test.go
@@ -1,0 +1,55 @@
+package util
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+func TestGetPodQuotaUsage(t *testing.T) {
+	resList := corev1.ResourceList{
+		corev1.ResourceCPU:    resource.MustParse("1000m"),
+		corev1.ResourceMemory: resource.MustParse("1000Mi"),
+		"nvidia.com/gpu":      resource.MustParse("1"),
+		"hugepages-test":      resource.MustParse("2000"),
+	}
+
+	container := corev1.Container{
+		Resources: corev1.ResourceRequirements{
+			Requests: resList,
+			Limits:   resList,
+		},
+	}
+
+	pod := &corev1.Pod{
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{container, container},
+		},
+	}
+
+	expected := map[string]int64{
+		"count/pods":              1,
+		"cpu":                     2,
+		"memory":                  1024 * 1024 * 2000,
+		"nvidia.com/gpu":          2,
+		"hugepages-test":          4000,
+		"limits.cpu":              2,
+		"limits.memory":           1024 * 1024 * 2000,
+		"requests.memory":         1024 * 1024 * 2000,
+		"requests.nvidia.com/gpu": 2,
+		"requests.hugepages-test": 4000,
+		"pods":                    1,
+		"requests.cpu":            2,
+	}
+
+	res := *GetPodQuotaUsage(pod)
+	for name, quantity := range expected {
+		value, ok := res[corev1.ResourceName(name)]
+		if !ok {
+			t.Errorf("Resource %s should exists in pod resources", name)
+		} else if quantity != value.Value() {
+			t.Errorf("Resource %s 's value %d should equal to %d", name, quantity, value.Value())
+		}
+	}
+}

--- a/pkg/scheduler/api/job_info.go
+++ b/pkg/scheduler/api/job_info.go
@@ -665,8 +665,8 @@ func (ji *JobInfo) TaskSchedulingReason(tid TaskID) (reason string, msg string) 
 			// Pod is not schedulable
 			return PodReasonUnschedulable, fe.Error()
 		}
-		// Pod is not scheduled yet
-		return PodReasonUndetermined, msg
+		// Pod is not scheduled yet, keep UNSCHEDULABLE as the reason to support cluster autoscaler
+		return PodReasonUnschedulable, msg
 	default:
 		return status.String(), msg
 	}

--- a/pkg/scheduler/api/job_info_test.go
+++ b/pkg/scheduler/api/job_info_test.go
@@ -225,9 +225,9 @@ func TestTaskSchedulingReason(t *testing.T) {
 				},
 			},
 			expected: map[types.UID]string{
-				"pg":   "pod group is not ready, 6 Pending, 6 minAvailable; Pending: 1 Unschedulable, 2 Undetermined, 3 Schedulable",
-				t1.UID: "pod group is not ready, 6 Pending, 6 minAvailable; Pending: 1 Unschedulable, 2 Undetermined, 3 Schedulable",
-				t2.UID: "pod group is not ready, 6 Pending, 6 minAvailable; Pending: 1 Unschedulable, 2 Undetermined, 3 Schedulable",
+				"pg":   "pod group is not ready, 6 Pending, 6 minAvailable; Pending: 3 Schedulable, 3 Unschedulable",
+				t1.UID: "pod group is not ready, 6 Pending, 6 minAvailable; Pending: 3 Schedulable, 3 Unschedulable",
+				t2.UID: "pod group is not ready, 6 Pending, 6 minAvailable; Pending: 3 Schedulable, 3 Unschedulable",
 				t3.UID: "Pod ns1/task-3 can possibly be assigned to node1",
 				t4.UID: "Pod ns1/task-4 can possibly be assigned to node2",
 				t5.UID: "Pod ns1/task-5 can possibly be assigned to node3",

--- a/pkg/scheduler/api/unschedule_info.go
+++ b/pkg/scheduler/api/unschedule_info.go
@@ -20,13 +20,12 @@ const (
 const (
 	// PodReasonUnschedulable reason in PodScheduled PodCondition means that the scheduler
 	// can't schedule the pod right now, for example due to insufficient resources in the cluster.
+	// It can also mean that the scheduler skips scheduling the pod which left the pod `Undetermined`,
+	// for example due to unschedulable pod already occurred.
 	PodReasonUnschedulable = "Unschedulable"
 	// PodReasonSchedulable reason in PodScheduled PodCondition means that the scheduler
 	// can schedule the pod right now, but not bind yet
 	PodReasonSchedulable = "Schedulable"
-	// PodReasonUndetermined reason in PodScheduled PodCondition means that the scheduler
-	// skips scheduling the pod which left the pod `Undetermined`, for example due to unschedulable pod already occurred.
-	PodReasonUndetermined = "Undetermined"
 )
 
 // FitErrors is set of FitError on many nodes

--- a/pkg/scheduler/plugins/gang/gang.go
+++ b/pkg/scheduler/plugins/gang/gang.go
@@ -155,7 +155,8 @@ func (gp *gangPlugin) OnSessionOpen(ssn *framework.Session) {
 	jobStarvingFn := func(obj interface{}) bool {
 		ji := obj.(*api.JobInfo)
 		occupied := ji.WaitingTaskNum() + ji.ReadyTaskNum()
-		if ji.CheckTaskStarving() && occupied < ji.MinAvailable {
+		// In the preemption scenario, the taskMinAvailble configuration is not concerned, only the jobMinAvailble is concerned
+		if occupied < ji.MinAvailable {
 			return true
 		}
 		return false

--- a/test/e2e/jobp/job_controlled_resource.go
+++ b/test/e2e/jobp/job_controlled_resource.go
@@ -189,11 +189,11 @@ var _ = Describe("Job E2E Test: Test Job PVCs", func() {
 		pGroup, err := ctx.Vcclient.SchedulingV1beta1().PodGroups(ctx.Namespace).Get(context.TODO(), pgName, metav1.GetOptions{})
 		Expect(err).NotTo(HaveOccurred())
 
-		for name, q := range *pGroup.Spec.MinResources {
-			value, ok := expected[string(name)]
+		minReq := *pGroup.Spec.MinResources
+		for name, q := range expected {
+			value, ok := minReq[v12.ResourceName(name)]
 			Expect(ok).To(Equal(true), "Resource %s should exists in PodGroup", name)
-			Expect(q.Value()).To(Equal(value), "Resource %s 's value should equal to %d", name, value)
+			Expect(q).To(Equal(value.Value()), "Resource %s 's value should equal to %d", name, value)
 		}
-
 	})
 })


### PR DESCRIPTION
Signed-off-by: kingeasternsun <kingeasternsun@gmail.com>

1. We Cloned the Task when pass it to `stmt.Evict`, so there is no need to convert `victimTasksMap` to Slice