### PR TITLE
By default, the preemption function of gang and drf is turned off

### DIFF
--- a/installer/helm/chart/volcano/config/volcano-scheduler-ci.conf
+++ b/installer/helm/chart/volcano/config/volcano-scheduler-ci.conf
@@ -3,11 +3,13 @@ tiers:
 - plugins:
   - name: priority
   - name: gang
+    enablePreemptable: false
   - name: conformance
   - name: sla
 - plugins:
   - name: overcommit
   - name: drf
+    enablePreemptable: false
   - name: predicates
   - name: proportion
   - name: nodeorder

--- a/installer/helm/chart/volcano/config/volcano-scheduler.conf
+++ b/installer/helm/chart/volcano/config/volcano-scheduler.conf
@@ -3,10 +3,12 @@ tiers:
 - plugins:
   - name: priority
   - name: gang
+    enablePreemptable: false
   - name: conformance
 - plugins:
   - name: overcommit
   - name: drf
+    enablePreemptable: false
   - name: predicates
   - name: proportion
   - name: nodeorder

--- a/installer/volcano-development.yaml
+++ b/installer/volcano-development.yaml
@@ -8630,10 +8630,12 @@ data:
     - plugins:
       - name: priority
       - name: gang
+        enablePreemptable: false
       - name: conformance
     - plugins:
       - name: overcommit
       - name: drf
+        enablePreemptable: false
       - name: predicates
       - name: proportion
       - name: nodeorder


### PR DESCRIPTION
Signed-off-by: wangyang <wangyang8126@gmail.com>

fix: [#2612](https://github.com/volcano-sh/volcano/issues/2612)

priority is a common priority preemption plug-in. By default, job preemption is performed based on the priority. If gang and drf preemption is required, you can manually enable it.