### PR TITLE
[cherry-pick 1.7] Disable the preemption switch of gang and drf in the default configuration

### DIFF
--- a/installer/helm/chart/volcano/config/volcano-scheduler-ci.conf
+++ b/installer/helm/chart/volcano/config/volcano-scheduler-ci.conf
@@ -3,11 +3,13 @@ tiers:
 - plugins:
   - name: priority
   - name: gang
+    enablePreemptable: false
   - name: conformance
   - name: sla
 - plugins:
   - name: overcommit
   - name: drf
+    enablePreemptable: false
   - name: predicates
   - name: proportion
   - name: nodeorder

--- a/installer/helm/chart/volcano/config/volcano-scheduler.conf
+++ b/installer/helm/chart/volcano/config/volcano-scheduler.conf
@@ -3,10 +3,12 @@ tiers:
 - plugins:
   - name: priority
   - name: gang
+    enablePreemptable: false
   - name: conformance
 - plugins:
   - name: overcommit
   - name: drf
+    enablePreemptable: false
   - name: predicates
   - name: proportion
   - name: nodeorder

--- a/installer/volcano-development.yaml
+++ b/installer/volcano-development.yaml
@@ -8630,10 +8630,12 @@ data:
     - plugins:
       - name: priority
       - name: gang
+        enablePreemptable: false
       - name: conformance
     - plugins:
       - name: overcommit
       - name: drf
+        enablePreemptable: false
       - name: predicates
       - name: proportion
       - name: nodeorder


### PR DESCRIPTION
Signed-off-by: wangyang <wangyang289@huawei.com>

cherry pick： [#2613](https://github.com/volcano-sh/volcano/pull/2613)