### PR TITLE
Return ER resource in JobInfo.GetMinResources()

### DIFF
--- a/pkg/scheduler/api/job_info.go
+++ b/pkg/scheduler/api/job_info.go
@@ -481,7 +481,17 @@ func (ji *JobInfo) GetMinResources() *Resource {
 		return EmptyResource()
 	}
 
-	return NewResource(*ji.PodGroup.Spec.MinResources)
+	resources := v1.ResourceList{}
+
+	for k, v := range *ji.PodGroup.Spec.MinResources {
+		if !strings.HasPrefix(string(k), v1.DefaultResourceRequestsPrefix) {
+			continue
+		}
+		k = v1.ResourceName(strings.TrimPrefix(string(k), v1.DefaultResourceRequestsPrefix))
+		resources[k] = v
+	}
+
+	return NewResource(resources)
 }
 
 func (ji *JobInfo) GetElasticResources() *Resource {

--- a/pkg/scheduler/api/resource_info.go
+++ b/pkg/scheduler/api/resource_info.go
@@ -432,8 +432,7 @@ func (r *Resource) LessEqualPartly(rr *Resource, defaultValue DimensionDefaultVa
 
 // Equal returns true only on condition that values in all dimension are equal with each other for r and rr
 // Otherwise returns false.
-// @param defaultValue "default value for resource dimension not defined in ScalarResources. Its value can only be one of 'Zero' and 'Infinity'"
-func (r *Resource) Equal(rr *Resource, defaultValue DimensionDefaultValue) bool {
+func (r *Resource) Equal(rr *Resource) bool {
 	equalFunc := func(l, r, diff float64) bool {
 		return l == r || math.Abs(l-r) < diff
 	}

--- a/pkg/scheduler/api/resource_info_test.go
+++ b/pkg/scheduler/api/resource_info_test.go
@@ -1089,7 +1089,7 @@ func TestEqual(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		flag := test.resource1.Equal(test.resource2, Zero)
+		flag := test.resource1.Equal(test.resource2)
 		if !reflect.DeepEqual(test.expected, flag) {
 			t.Errorf("expected: %#v, got: %#v", test.expected, flag)
 		}


### PR DESCRIPTION
Signed-off-by: stingshen <stingshen@126.com>

issue: #2615 

Currently, JobInfo.GetMinResources() only returns natively supported resources. It should also return extended resources.

The root cause is [podComputeUsageHelper](https://github.com/kubernetes/kubernetes/blob/master/pkg/quota/v1/evaluator/core/pods.go#L286) only sets requests.resourceName, not resourceName for ERs.