### PR TITLE
fix: deployment and pod, high priority cannot preempt low priority resources

### DIFF
--- a/pkg/scheduler/plugins/gang/gang.go
+++ b/pkg/scheduler/plugins/gang/gang.go
@@ -155,7 +155,7 @@ func (gp *gangPlugin) OnSessionOpen(ssn *framework.Session) {
 	jobStarvingFn := func(obj interface{}) bool {
 		ji := obj.(*api.JobInfo)
 		occupied := ji.WaitingTaskNum() + ji.ReadyTaskNum()
-		if ji.CheckTaskStarving() && occupied < ji.MinAvailable {
+		if ji.CheckTaskStarving() || occupied < ji.MinAvailable {
 			return true
 		}
 		return false


### PR DESCRIPTION
Signed-off-by: wangyang <wangyang289@huawei.com>

fix: [#2629](https://github.com/volcano-sh/volcano/issues/2629)

The test results are as follows:
```
[root@ecs-4b42-0002 volcano]# kubectl get pod 
NAME                           READY   STATUS    RESTARTS   AGE
deploy-high-587b867944-9qdvm   1/1     Running   0          40m
deploy-high-587b867944-dzfsr   0/1     Pending   0          40m
deploy-high-587b867944-msvxv   0/1     Pending   0          40m
deploy-high-587b867944-qtfbb   0/1     Pending   0          40m
deploy-low-67b97db94b-7wt2h    1/1     Running   0          40m
deploy-low-67b97db94b-scsx5    1/1     Running   0          40m
deploy-low-67b97db94b-vw8fv    1/1     Running   0          40m
deploy-low-67b97db94b-z44fq    0/1     Pending   0          40m
```
`deploy-high` can preempt the resources of `deploy-low`, but only one copy has preempted resources. 

Through code analysis, if the minavailable information is not set, the podGroup defaults to the minavailable value set by `deploy-high` 1. 

In this case, the default value is set to 1 or set to the value of replicas. I hope to open a new issue for discussion
