### PR TITLE
The preemption logic is only controlled by jobMinavailable in the gang plugin

### DIFF
--- a/pkg/scheduler/plugins/gang/gang.go
+++ b/pkg/scheduler/plugins/gang/gang.go
@@ -155,7 +155,8 @@ func (gp *gangPlugin) OnSessionOpen(ssn *framework.Session) {
 	jobStarvingFn := func(obj interface{}) bool {
 		ji := obj.(*api.JobInfo)
 		occupied := ji.WaitingTaskNum() + ji.ReadyTaskNum()
-		if ji.CheckTaskStarving() || occupied < ji.MinAvailable {
+		// In the preemption scenario, the taskMinAvailble configuration is not concerned, only the jobMinAvailble is concerned
+		if occupied < ji.MinAvailable {
 			return true
 		}
 		return false


### PR DESCRIPTION
Signed-off-by: wangyang <wangyang289@huawei.com>

fix：[#2629](https://github.com/volcano-sh/volcano/issues/2629)

In the preemption scenario, the gang plugin does not pay attention to the taskMinAvailble configuration for the time being, but only pays attention to the jobMinAvailble

