### PR TITLE
🐛  fix: fix logic when deal with resource dimension not defined in ScalarResources of r

### DIFF
--- a/pkg/scheduler/api/resource_info.go
+++ b/pkg/scheduler/api/resource_info.go
@@ -345,6 +345,14 @@ func (r *Resource) Less(rr *Resource, defaultValue DimensionDefaultValue) bool {
 		return false
 	}
 
+	if defaultValue == Infinity {
+		for name := range rr.ScalarResources {
+			if _, ok := r.ScalarResources[name]; !ok {
+				return false
+			}
+		}
+	}
+
 	for resourceName, leftValue := range r.ScalarResources {
 		rightValue, ok := rr.ScalarResources[resourceName]
 		if !ok && defaultValue == Infinity {
@@ -374,6 +382,14 @@ func (r *Resource) LessEqual(rr *Resource, defaultValue DimensionDefaultValue) b
 	}
 	if !lessEqualFunc(r.Memory, rr.Memory, minResource) {
 		return false
+	}
+
+	if defaultValue == Infinity {
+		for name := range rr.ScalarResources {
+			if _, ok := r.ScalarResources[name]; !ok {
+				return false
+			}
+		}
 	}
 
 	for resourceName, leftValue := range r.ScalarResources {
@@ -433,6 +449,14 @@ func (r *Resource) LessPartly(rr *Resource, defaultValue DimensionDefaultValue) 
 		return true
 	}
 
+	if defaultValue == Zero {
+		for name := range rr.ScalarResources {
+			if _, ok := r.ScalarResources[name]; !ok {
+				return true
+			}
+		}
+	}
+
 	for resourceName, leftValue := range r.ScalarResources {
 		rightValue, ok := rr.ScalarResources[resourceName]
 		if !ok && defaultValue == Infinity {
@@ -459,6 +483,14 @@ func (r *Resource) LessEqualPartly(rr *Resource, defaultValue DimensionDefaultVa
 
 	if lessEqualFunc(r.MilliCPU, rr.MilliCPU, minResource) || lessEqualFunc(r.Memory, rr.Memory, minResource) {
 		return true
+	}
+
+	if defaultValue == Zero {
+		for name := range rr.ScalarResources {
+			if _, ok := r.ScalarResources[name]; !ok {
+				return true
+			}
+		}
 	}
 
 	for resourceName, leftValue := range r.ScalarResources {

--- a/pkg/scheduler/api/resource_info_test.go
+++ b/pkg/scheduler/api/resource_info_test.go
@@ -557,7 +557,7 @@ func TestLess(t *testing.T) {
 				Memory:          2000,
 				ScalarResources: map[v1.ResourceName]float64{"scalar.test/scalar1": 1000, "hugepages-test": 2000},
 			},
-			expected: true,
+			expected: false,
 		},
 		{
 			resource1: &Resource{
@@ -701,7 +701,7 @@ func TestLessEqual(t *testing.T) {
 				Memory:          2000,
 				ScalarResources: map[v1.ResourceName]float64{"scalar.test/scalar1": 1000, "hugepages-test": 2000},
 			},
-			expected: true,
+			expected: false,
 		},
 		{
 			resource1: &Resource{
@@ -711,6 +711,30 @@ func TestLessEqual(t *testing.T) {
 			},
 			resource2: &Resource{},
 			expected:  false,
+		},
+		{
+			resource1: &Resource{
+				MilliCPU: 4000,
+				Memory:   2000,
+			},
+			resource2: &Resource{
+				MilliCPU:        4000,
+				Memory:          2000,
+				ScalarResources: map[v1.ResourceName]float64{"scalar.test/scalar1": 1000, "hugepages-test": 2000},
+			},
+			expected: false,
+		},
+		{
+			resource1: &Resource{
+				MilliCPU:        4000,
+				Memory:          2000,
+				ScalarResources: map[v1.ResourceName]float64{"scalar.test/scalar1": 1000, "hugepages-test": 2000},
+			},
+			resource2: &Resource{
+				MilliCPU: 4000,
+				Memory:   2000,
+			},
+			expected: true,
 		},
 	}
 
@@ -807,7 +831,7 @@ func TestLessPartly(t *testing.T) {
 				Memory:          2000,
 				ScalarResources: map[v1.ResourceName]float64{"scalar.test/scalar1": 1000, "hugepages-test": 2000},
 			},
-			expected: false,
+			expected: true,
 		},
 		{
 			resource1: &Resource{

--- a/pkg/scheduler/plugins/proportion/proportion.go
+++ b/pkg/scheduler/plugins/proportion/proportion.go
@@ -242,7 +242,7 @@ func (pp *proportionPlugin) OnSessionOpen(ssn *framework.Session) {
 		remaining.Sub(increasedDeserved).Add(decreasedDeserved)
 		klog.V(4).Infof("Remaining resource is  <%s>", remaining)
 		if remaining.IsEmpty() || reflect.DeepEqual(remaining, oldRemaining) {
-			klog.V(4).Infof("Exiting when remaining is empty or no queue has more reosurce request:  <%v>", remaining)
+			klog.V(4).Infof("Exiting when remaining is empty or no queue has more resource request:  <%v>", remaining)
 			break
 		}
 	}
@@ -337,7 +337,16 @@ func (pp *proportionPlugin) OnSessionOpen(ssn *framework.Session) {
 		klog.V(5).Infof("job %s min resource <%s>, queue %s capability <%s> allocated <%s> inqueue <%s> elastic <%s>",
 			job.Name, minReq.String(), queue.Name, attr.realCapability.String(), attr.allocated.String(), attr.inqueue.String(), attr.elastic.String())
 		// The queue resource quota limit has not reached
-		inqueue := minReq.Add(attr.allocated).Add(attr.inqueue).Sub(attr.elastic).LessEqual(attr.realCapability, api.Infinity)
+		r := minReq.Add(attr.allocated).Add(attr.inqueue).Sub(attr.elastic)
+		rr := attr.realCapability.Clone()
+
+		for name := range rr.ScalarResources {
+			if _, ok := r.ScalarResources[name]; !ok {
+				delete(rr.ScalarResources, name)
+			}
+		}
+
+		inqueue := r.LessEqual(rr, api.Infinity)
 		klog.V(5).Infof("job %s inqueue %v", job.Name, inqueue)
 		if inqueue {
 			attr.inqueue.Add(job.GetMinResources())


### PR DESCRIPTION
1. in `Less`, when `defaultValue` equals to `Infinity`, the resource dimension not defined in ScalarResources of `r` should be treated as Infinity Big.
2. in `LessEqual`, same like `Less` above.
3. in `LessPartly`, when `defaultValue` equals to `Zero`, the resource dimension not defined in ScalarResources of `r` should be treated as zero.
4. in `LessEqualPartly`, save like  `LessPartly` above.