### PR TITLE
[WIP] Fix spark podgroup block

### DIFF
--- a/pkg/scheduler/actions/enqueue/enqueue.go
+++ b/pkg/scheduler/actions/enqueue/enqueue.go
@@ -67,6 +67,12 @@ func (enqueue *Action) Execute(ssn *framework.Session) {
 			queues.Push(queue)
 		}
 
+		if job.IsDeferredScheduling() {
+			klog.Errorf("The podgroup of job <%s/%s> in queue <%s> has no ownerreference information, and the scheduling is postponed",
+				job.Namespace, job.Name, job.Queue)
+			continue
+		}
+
 		if job.IsPending() {
 			if _, found := jobsMap[job.Queue]; !found {
 				jobsMap[job.Queue] = util.NewPriorityQueue(ssn.JobOrderFn)

--- a/pkg/scheduler/api/job_info.go
+++ b/pkg/scheduler/api/job_info.go
@@ -860,3 +860,7 @@ func (ji *JobInfo) IsPending() bool {
 func (ji *JobInfo) HasPendingTasks() bool {
 	return len(ji.TaskStatusIndex[Pending]) != 0
 }
+
+func (ji *JobInfo) IsDeferredScheduling() bool {
+	return ji.PodGroup == nil || len(ji.PodGroup.OwnerReferences) == 0
+}

--- a/test/e2e/jobp/admission.go
+++ b/test/e2e/jobp/admission.go
@@ -245,7 +245,7 @@ var _ = ginkgo.Describe("Job E2E Test: Test Admission service", func() {
 
 		podGroup, err := ctx.Vcclient.SchedulingV1beta1().PodGroups(ctx.Namespace).Create(context.TODO(), pg, v1.CreateOptions{})
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		err = e2eutil.WaitPodGroupPhase(ctx, podGroup, schedulingv1beta1.PodGroupInqueue)
+		err = e2eutil.WaitPodGroupPhase(ctx, podGroup, schedulingv1beta1.PodGroupPending)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		_, err = ctx.Kubeclient.CoreV1().Pods(ctx.Namespace).Create(context.TODO(), pod, v1.CreateOptions{})
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())


### PR DESCRIPTION
## fix: [#2633](https://github.com/volcano-sh/volcano/issues/2633)

### Modify content
When scheduling the pending podgroup into the queue, first determine whether the podgroup has ownerreference information. If not, the podgroup will not be scheduled in this cycle until the ownerreference information is updated, and then the scheduling will be performed.

### Why submit this PR
Run the task through spark submit. If spark submit is abnormally killed when the podgroup is successfully created but the corresponding pod is not created or the ownerreference information in the podgroup cannot be updated, it will cause podgroup resource leaks. If the resource is allocated, it will cause the resource to be locked.