### PR TITLE
update golang version to 1.19.5

### DIFF
--- a/installer/dockerfile/controller-manager/Dockerfile
+++ b/installer/dockerfile/controller-manager/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.19.4 AS builder
+FROM golang:1.19.5 AS builder
 WORKDIR /go/src/volcano.sh/
 ADD . volcano
 RUN cd volcano && make vc-controller-manager

--- a/installer/dockerfile/scheduler/Dockerfile
+++ b/installer/dockerfile/scheduler/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.19.4 AS builder
+FROM golang:1.19.5 AS builder
 WORKDIR /go/src/volcano.sh/
 ADD . volcano
 RUN cd volcano && make vc-scheduler

--- a/installer/dockerfile/webhook-manager/Dockerfile
+++ b/installer/dockerfile/webhook-manager/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.19.4 AS builder
+FROM golang:1.19.5 AS builder
 WORKDIR /go/src/volcano.sh/
 ADD . volcano
 RUN cd volcano && make vc-webhook-manager


### PR DESCRIPTION
Signed-off-by: yanggang <gang.yang@daocloud.io>

go1.19.5 have releaed for a time. Update to follow it..
Also go1.20 is released. maybe we should wait for a several versions after ,and follow it.

[go release](https://github.com/golang/go/tags)