### PR TITLE
Support to config multi extenders, bindTask verb and managedResources…

### DIFF
--- a/pkg/scheduler/api/pod_info.go
+++ b/pkg/scheduler/api/pod_info.go
@@ -155,3 +155,16 @@ func GetPodResourceWithoutInitContainers(pod *v1.Pod) *Resource {
 
 	return result
 }
+
+func MatchResource(pod *v1.Pod, resources []string) (map[string]int64, bool) {
+	resource := GetPodResourceRequest(pod)
+	for sr, v := range resource.ScalarResources {
+		for _, re := range resources {
+			if sr.String() == re {
+				klog.V(3).Infof("matched resource for pod %s, %s=%s", pod.Name, sr.String(), re)
+				return map[string]int64{sr.String(): int64(v / 1000)}, true
+			}
+		}
+	}
+	return nil, false
+}

--- a/pkg/scheduler/api/types.go
+++ b/pkg/scheduler/api/types.go
@@ -174,3 +174,6 @@ type VictimTasksFn func([]*TaskInfo) []*TaskInfo
 
 // AllocatableFn is the func declaration used to check whether the task can be allocated
 type AllocatableFn func(*QueueInfo, *TaskInfo) bool
+
+// BindTaskFn is the func declaration used to bind node for task.
+type BindTaskFn func(*TaskInfo) error

--- a/pkg/scheduler/conf/scheduler_conf.go
+++ b/pkg/scheduler/conf/scheduler_conf.go
@@ -87,6 +87,8 @@ type PluginOption struct {
 	EnabledOverused *bool `yaml:"enabledOverused"`
 	// EnabledAllocatable defines whether allocatable is enabled
 	EnabledAllocatable *bool `yaml:"enabledAllocatable"`
+	// EnabledBindTask defines whether bindTaskFn is enabled
+	EnabledBindTask *bool `yaml:"enabledBindTask"`
 	// Arguments defines the different arguments that can be given to different plugins
 	Arguments map[string]interface{} `yaml:"arguments"`
 }

--- a/pkg/scheduler/framework/session.go
+++ b/pkg/scheduler/framework/session.go
@@ -35,7 +35,6 @@ import (
 	schedulingscheme "volcano.sh/apis/pkg/apis/scheduling/scheme"
 	vcv1beta1 "volcano.sh/apis/pkg/apis/scheduling/v1beta1"
 	"volcano.sh/volcano/pkg/scheduler/api"
-	schedulingapi "volcano.sh/volcano/pkg/scheduler/api"
 	"volcano.sh/volcano/pkg/scheduler/cache"
 	"volcano.sh/volcano/pkg/scheduler/conf"
 	"volcano.sh/volcano/pkg/scheduler/metrics"
@@ -100,6 +99,7 @@ type Session struct {
 	reservedNodesFns  map[string]api.ReservedNodesFn
 	victimTasksFns    map[string][]api.VictimTasksFn
 	jobStarvingFns    map[string]api.ValidateFn
+	bindTaskFns       map[string]api.BindTaskFn
 }
 
 func openSession(cache cache.Cache) *Session {
@@ -146,6 +146,7 @@ func openSession(cache cache.Cache) *Session {
 		reservedNodesFns:  map[string]api.ReservedNodesFn{},
 		victimTasksFns:    map[string][]api.VictimTasksFn{},
 		jobStarvingFns:    map[string]api.ValidateFn{},
+		bindTaskFns:       map[string]api.BindTaskFn{},
 	}
 
 	snapshot := cache.Snapshot()
@@ -530,7 +531,7 @@ func (ssn Session) InformerFactory() informers.SharedInformerFactory {
 }
 
 // RecordPodGroupEvent records podGroup events
-func (ssn Session) RecordPodGroupEvent(podGroup *schedulingapi.PodGroup, eventType, reason, msg string) {
+func (ssn Session) RecordPodGroupEvent(podGroup *api.PodGroup, eventType, reason, msg string) {
 	if podGroup == nil {
 		return
 	}

--- a/pkg/scheduler/framework/statement.go
+++ b/pkg/scheduler/framework/statement.go
@@ -293,6 +293,9 @@ func (s *Statement) Allocate(task *api.TaskInfo, nodeInfo *api.NodeInfo) (err er
 }
 
 func (s *Statement) allocate(task *api.TaskInfo) error {
+	if err := s.ssn.BindTaskFn(task); err != nil {
+		return err
+	}
 	if err := s.ssn.cache.AddBindTask(task); err != nil {
 		return err
 	}

--- a/pkg/scheduler/plugins/defaults.go
+++ b/pkg/scheduler/plugins/defaults.go
@@ -76,4 +76,7 @@ func ApplyPluginConfDefaults(option *conf.PluginOption) {
 	if option.EnabledAllocatable == nil {
 		option.EnabledAllocatable = &t
 	}
+	if option.EnabledBindTask == nil {
+		option.EnabledBindTask = &t
+	}
 }

--- a/pkg/scheduler/plugins/extender/argument.go
+++ b/pkg/scheduler/plugins/extender/argument.go
@@ -70,3 +70,11 @@ type JobReadyRequest struct {
 type JobReadyResponse struct {
 	Status bool `json:"status"`
 }
+
+type BindTaskRequest struct {
+	Task *api.TaskInfo `json:"task"`
+}
+
+type BindTaskResponse struct {
+	ErrorMessage string `json:"errorMessage"`
+}

--- a/pkg/scheduler/util_test.go
+++ b/pkg/scheduler/util_test.go
@@ -63,6 +63,7 @@ tiers:
 					EnabledJobStarving:    &trueValue,
 					EnabledOverused:       &trueValue,
 					EnabledAllocatable:    &trueValue,
+					EnabledBindTask:       &trueValue,
 				},
 				{
 					Name:                  "gang",
@@ -84,6 +85,7 @@ tiers:
 					EnabledJobStarving:    &trueValue,
 					EnabledOverused:       &trueValue,
 					EnabledAllocatable:    &trueValue,
+					EnabledBindTask:       &trueValue,
 				},
 				{
 					Name:                  "conformance",
@@ -105,6 +107,7 @@ tiers:
 					EnabledJobStarving:    &trueValue,
 					EnabledOverused:       &trueValue,
 					EnabledAllocatable:    &trueValue,
+					EnabledBindTask:       &trueValue,
 				},
 			},
 		},
@@ -130,6 +133,7 @@ tiers:
 					EnabledJobStarving:    &trueValue,
 					EnabledOverused:       &trueValue,
 					EnabledAllocatable:    &trueValue,
+					EnabledBindTask:       &trueValue,
 				},
 				{
 					Name:                  "predicates",
@@ -151,6 +155,7 @@ tiers:
 					EnabledJobStarving:    &trueValue,
 					EnabledOverused:       &trueValue,
 					EnabledAllocatable:    &trueValue,
+					EnabledBindTask:       &trueValue,
 				},
 				{
 					Name:                  "proportion",
@@ -172,6 +177,7 @@ tiers:
 					EnabledJobStarving:    &trueValue,
 					EnabledOverused:       &trueValue,
 					EnabledAllocatable:    &trueValue,
+					EnabledBindTask:       &trueValue,
 				},
 				{
 					Name:                  "nodeorder",
@@ -193,6 +199,7 @@ tiers:
 					EnabledJobStarving:    &trueValue,
 					EnabledOverused:       &trueValue,
 					EnabledAllocatable:    &trueValue,
+					EnabledBindTask:       &trueValue,
 				},
 			},
 		},


### PR DESCRIPTION
Implement: https://github.com/volcano-sh/volcano/issues/2681

1. Modify extender plugin config parse to support config multi extenders, and use urlPrefix as the unique key to identify each extender, like: https://github.com/kubernetes/kubernetes/blob/HEAD/pkg/scheduler/extender.go#L118-L119
2. Add managedResources as a list of extended resources that are managed by each extender, like: https://kubernetes.io/docs/reference/config-api/kube-scheduler-config.v1beta2/#kubescheduler-config-k8s-io-v1beta2-KubeSchedulerConfiguration
3. Add BindTask verb for extender plugin
4. Add multimachine config to indicates whether the extender can support multi machine

Signed-off-by: jinyuxi <jinyuxi@cambricon.com>