### PR TITLE
Optimize e2e runtime: reduce pytorch-plugin image download time

### DIFF
--- a/hack/run-e2e-kind.sh
+++ b/hack/run-e2e-kind.sh
@@ -23,8 +23,8 @@ export SHOW_VOLCANO_LOGS=${SHOW_VOLCANO_LOGS:-1}
 export CLEANUP_CLUSTER=${CLEANUP_CLUSTER:-1}
 export MPI_EXAMPLE_IMAGE=${MPI_EXAMPLE_IMAGE:-"volcanosh/example-mpi:0.0.1"}
 export TF_EXAMPLE_IMAGE=${TF_EXAMPLE_IMAGE:-"volcanosh/dist-mnist-tf-example:0.0.1"}
-# "volcanosh/pytorch-mnist-v1beta1-45c5727-example:0.0.1" is from "docker.io/kubeflowkatib/pytorch-mnist:v1beta1-45c5727"
-export PYTORCH_EXAMPLE_IMAGE=${PYTORCH_EXAMPLE_IMAGE:-"volcanosh/pytorch-mnist-v1beta1-45c5727-example:0.0.1"}
+# "volcanosh/pytorch-mnist-v1beta1-9ee8fda-example:0.0.1" is from "docker.io/kubeflowkatib/pytorch-mnist:v1beta1-9ee8fda"
+export PYTORCH_EXAMPLE_IMAGE=${PYTORCH_EXAMPLE_IMAGE:-"volcanosh/pytorch-mnist-v1beta1-9ee8fda-example:0.0.1"}
 export E2E_TYPE=${E2E_TYPE:-"ALL"}
 
 if [[ "${CLUSTER_NAME}xxx" == "xxx" ]];then

--- a/hack/run-e2e-kind.sh
+++ b/hack/run-e2e-kind.sh
@@ -23,6 +23,8 @@ export SHOW_VOLCANO_LOGS=${SHOW_VOLCANO_LOGS:-1}
 export CLEANUP_CLUSTER=${CLEANUP_CLUSTER:-1}
 export MPI_EXAMPLE_IMAGE=${MPI_EXAMPLE_IMAGE:-"volcanosh/example-mpi:0.0.1"}
 export TF_EXAMPLE_IMAGE=${TF_EXAMPLE_IMAGE:-"volcanosh/dist-mnist-tf-example:0.0.1"}
+# "volcanosh/pytorch-mnist-v1beta1-45c5727-example:0.0.1" is from "docker.io/kubeflowkatib/pytorch-mnist:v1beta1-45c5727"
+export PYTORCH_EXAMPLE_IMAGE=${PYTORCH_EXAMPLE_IMAGE:-"volcanosh/pytorch-mnist-v1beta1-45c5727-example:0.0.1"}
 export E2E_TYPE=${E2E_TYPE:-"ALL"}
 
 if [[ "${CLUSTER_NAME}xxx" == "xxx" ]];then
@@ -56,6 +58,8 @@ function install-volcano {
     echo "Pulling required docker images"
     docker pull ${MPI_EXAMPLE_IMAGE}
     docker pull ${TF_EXAMPLE_IMAGE}
+    docker pull ${PYTORCH_EXAMPLE_IMAGE}
+    kind load docker-image ${MPI_EXAMPLE_IMAGE} ${TF_EXAMPLE_IMAGE} ${PYTORCH_EXAMPLE_IMAGE} ${CLUSTER_CONTEXT}
   fi
 
   echo "Ensure create namespace"

--- a/hack/run-e2e-kind.sh
+++ b/hack/run-e2e-kind.sh
@@ -21,10 +21,6 @@ export VC_BIN=${VK_ROOT}/${BIN_DIR}/${BIN_OSARCH}
 export LOG_LEVEL=3
 export SHOW_VOLCANO_LOGS=${SHOW_VOLCANO_LOGS:-1}
 export CLEANUP_CLUSTER=${CLEANUP_CLUSTER:-1}
-export MPI_EXAMPLE_IMAGE=${MPI_EXAMPLE_IMAGE:-"volcanosh/example-mpi:0.0.1"}
-export TF_EXAMPLE_IMAGE=${TF_EXAMPLE_IMAGE:-"volcanosh/dist-mnist-tf-example:0.0.1"}
-# "volcanosh/pytorch-mnist-v1beta1-9ee8fda-example:0.0.1" is from "docker.io/kubeflowkatib/pytorch-mnist:v1beta1-9ee8fda"
-export PYTORCH_EXAMPLE_IMAGE=${PYTORCH_EXAMPLE_IMAGE:-"volcanosh/pytorch-mnist-v1beta1-9ee8fda-example:0.0.1"}
 export E2E_TYPE=${E2E_TYPE:-"ALL"}
 
 if [[ "${CLUSTER_NAME}xxx" == "xxx" ]];then
@@ -52,14 +48,6 @@ function install-volcano {
     if [ "$minor" -lt "18" ]; then
       crd_version="v1beta1"
     fi
-  fi
-
-  if [[ ${E2E_TYPE} = "ALL" ]] || [[ ${E2E_TYPE} = "JOBSEQ" ]]; then
-    echo "Pulling required docker images"
-    docker pull ${MPI_EXAMPLE_IMAGE}
-    docker pull ${TF_EXAMPLE_IMAGE}
-    docker pull ${PYTORCH_EXAMPLE_IMAGE}
-    kind load docker-image ${MPI_EXAMPLE_IMAGE} ${TF_EXAMPLE_IMAGE} ${PYTORCH_EXAMPLE_IMAGE} ${CLUSTER_CONTEXT}
   fi
 
   echo "Ensure create namespace"

--- a/test/e2e/jobseq/pytorch_plugin.go
+++ b/test/e2e/jobseq/pytorch_plugin.go
@@ -30,7 +30,7 @@ var _ = Describe("Pytorch Plugin E2E Test", func() {
 			Tasks: []e2eutil.TaskSpec{
 				{
 					Name:       "master",
-					Img:        "docker.io/kubeflowkatib/pytorch-mnist:v1beta1-45c5727",
+					Img:        e2eutil.DefaultPytorchImage,
 					Req:        slot,
 					Min:        1,
 					Rep:        1,
@@ -40,7 +40,7 @@ var _ = Describe("Pytorch Plugin E2E Test", func() {
 				},
 				{
 					Name:       "worker",
-					Img:        "docker.io/kubeflowkatib/pytorch-mnist:v1beta1-45c5727",
+					Img:        e2eutil.DefaultPytorchImage,
 					Req:        slot,
 					Min:        2,
 					Rep:        2,

--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -76,7 +76,7 @@ const (
 	DefaultNginxImage   = "nginx:1.14"
 	DefaultMPIImage     = "volcanosh/example-mpi:0.0.1"
 	DefaultTFImage      = "volcanosh/dist-mnist-tf-example:0.0.1"
-	DefaultPytorchImage = "volcanosh/pytorch-mnist-v1beta1-45c5727-example:0.0.1"
+	DefaultPytorchImage = "volcanosh/pytorch-mnist-v1beta1-9ee8fda-example:0.0.1"
 )
 
 func CpuResource(request string) v1.ResourceList {

--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -76,6 +76,7 @@ const (
 	DefaultNginxImage   = "nginx:1.14"
 	DefaultMPIImage     = "volcanosh/example-mpi:0.0.1"
 	DefaultTFImage      = "volcanosh/dist-mnist-tf-example:0.0.1"
+	DefaultPytorchImage = "volcanosh/pytorch-mnist-v1beta1-45c5727-example:0.0.1"
 )
 
 func CpuResource(request string) v1.ResourceList {

--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -76,6 +76,7 @@ const (
 	DefaultNginxImage   = "nginx:1.14"
 	DefaultMPIImage     = "volcanosh/example-mpi:0.0.1"
 	DefaultTFImage      = "volcanosh/dist-mnist-tf-example:0.0.1"
+	// "volcanosh/pytorch-mnist-v1beta1-9ee8fda-example:0.0.1" is from "docker.io/kubeflowkatib/pytorch-mnist:v1beta1-9ee8fda"
 	DefaultPytorchImage = "volcanosh/pytorch-mnist-v1beta1-9ee8fda-example:0.0.1"
 )
 


### PR DESCRIPTION
It takes too long for e2e to run the pytorch plugin use case, basically between 300s and 600s, as follows:
  ```
  • [SLOW TEST] [458.017 seconds]
  Pytorch Plugin E2E Test will run and complete finally
  /home/runner/work/volcano/volcano/test/e2e/jobseq/pytorch_plugin.go:12
  ```

- The image `pytorch-mnist:v1beta1-45c5727` is changed to `pytorch-mnist:v1beta1-9ee8fda`, and the image size is reduced from 1.2 GB to 600 MB.
- Unnecessary image download operations on the host node are reduced. Images can be directly loaded on the kind virtual node.
- The running time of e2e test cases is reduced from 38 minutes to about 30 minutes.