### PR TITLE
Change e2e sequence tests timeout to 1 hour

### DIFF
--- a/.github/workflows/e2e_sequence.yaml
+++ b/.github/workflows/e2e_sequence.yaml
@@ -11,7 +11,7 @@ jobs:
   e2e_sequence:
     runs-on: ubuntu-18.04
     name: E2E about Sequence
-    timeout-minutes: 40
+    timeout-minutes: 60
     steps:
       - name: Install Go
         uses: actions/setup-go@v2


### PR DESCRIPTION
Since e2e sequence tests timeout frequently. We can consider change e2e sequence tests timeout to 1 hour