### PR TITLE
introduce elasticsearch index name config

### DIFF
--- a/docs/design/usage-based-scheduling.md
+++ b/docs/design/usage-based-scheduling.md
@@ -60,6 +60,8 @@ metrics:                             # metrics server related configuration
   type: prometheus                   # Optional, The metrics source type, prometheus by default, support prometheus and elasticsearch
   address: http://192.168.0.10:9090  # mandatory, The metrics source address
   interval: 30s                      # Optional, The scheduler pull metrics from Prometheus with this interval, 5s by default
+  elasticsearch:                     # Optional, The elasticsearch configuration
+    index: "custom-index-name"       # Optional, The elasticsearch index name, "metricbeat-*" by default
   ```
 
 ### How to predicate node

--- a/pkg/scheduler/metrics/source/metrics_client.go
+++ b/pkg/scheduler/metrics/source/metrics_client.go
@@ -37,7 +37,7 @@ func NewMetricsClient(metricsConf map[string]string) (MetricsClient, error) {
 	}
 	metricsType := metricsConf["type"]
 	if metricsType == "elasticsearch" {
-		return NewElasticsearchMetricsClient(address)
+		return NewElasticsearchMetricsClient(address, metricsConf)
 	}
 	return &PrometheusMetricsClient{address: address}, nil
 }

--- a/pkg/scheduler/metrics/source/metrics_client_elasticsearch.go
+++ b/pkg/scheduler/metrics/source/metrics_client_elasticsearch.go
@@ -33,12 +33,19 @@ const (
 )
 
 type ElasticsearchMetricsClient struct {
-	address string
-	es      *elasticsearch.Client
+	address   string
+	indexName string
+	es        *elasticsearch.Client
 }
 
-func NewElasticsearchMetricsClient(address string) (*ElasticsearchMetricsClient, error) {
+func NewElasticsearchMetricsClient(address string, conf map[string]string) (*ElasticsearchMetricsClient, error) {
 	e := &ElasticsearchMetricsClient{address: address}
+	indexConf := conf["elasticsearch.index"]
+	if len(indexConf) == 0 {
+		e.indexName = "metricbeat-*"
+	} else {
+		e.indexName = indexConf
+	}
 	var err error
 	e.es, err = elasticsearch.NewDefaultClient()
 	if err != nil {

--- a/pkg/scheduler/metrics/source/metrics_client_elasticsearch_test.go
+++ b/pkg/scheduler/metrics/source/metrics_client_elasticsearch_test.go
@@ -1,0 +1,39 @@
+/*
+ Copyright 2023 The Volcano Authors.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package source
+
+import "testing"
+
+func TestElasticsearchMetricsClientDefaultIndexName(t *testing.T) {
+	client, err := NewElasticsearchMetricsClient("http://localhost:9200", map[string]string{})
+	if err != nil {
+		t.Errorf("Failed to create client: %v", err)
+	}
+	if client.indexName != "metricbeat-*" {
+		t.Errorf("Default index name should be metricbeat-*")
+	}
+}
+
+func TestElasticsearchMetricsClientCustomIndexName(t *testing.T) {
+	client, err := NewElasticsearchMetricsClient("http://localhost:9200", map[string]string{"elasticsearch.index": "custom-index"})
+	if err != nil {
+		t.Errorf("Failed to create client: %v", err)
+	}
+	if client.indexName != "custom-index" {
+		t.Errorf("Custom index name should be custom-index")
+	}
+}


### PR DESCRIPTION
This code adds the elasticsearch.index configuration to allow users to specify their preferred index. If left unconfigured, the default index will be metricbeat-*.