### PR TITLE
Decouple the scanning cycle from the processing cycle

### DIFF
--- a/docs/design/rescheduling.md
+++ b/docs/design/rescheduling.md
@@ -76,7 +76,8 @@ tiers:
       - name: conformance
       - name: rescheduling       ## rescheduling plugin
         arguments:
-          interval: 5m           ## optional, the strategies will be called in this duration periodcally. 5 minuters by default. 
+          interval: 5m           ## optional, the strategies will be called in this duration periodically. 5 minutes by default.
+          metricsPeriod: 5m      ## optional, the metrics will be used during this plugin. 5 minutes by default.
           strategies:            ## required, strategies working in order
             - name: offlineOnly
             - name: lowPriorityFirst

--- a/pkg/scheduler/plugins/rescheduling/node_utilization_util.go
+++ b/pkg/scheduler/plugins/rescheduling/node_utilization_util.go
@@ -61,8 +61,8 @@ func getNodeUtilization() []*NodeUtilization {
 		nodeUtilization := &NodeUtilization{
 			nodeInfo: nodeInfo.Node,
 			utilization: map[v1.ResourceName]float64{
-				v1.ResourceCPU:    nodeInfo.ResourceUsage.CPUUsageAvg[Interval],
-				v1.ResourceMemory: nodeInfo.ResourceUsage.MEMUsageAvg[Interval],
+				v1.ResourceCPU:    nodeInfo.ResourceUsage.CPUUsageAvg[MetricsPeriod],
+				v1.ResourceMemory: nodeInfo.ResourceUsage.MEMUsageAvg[MetricsPeriod],
 			},
 			pods: nodeInfo.Pods(),
 		}

--- a/pkg/scheduler/plugins/rescheduling/rescheduling.go
+++ b/pkg/scheduler/plugins/rescheduling/rescheduling.go
@@ -32,6 +32,8 @@ const (
 	PluginName = "rescheduling"
 	// DefaultInterval indicates the default interval rescheduling plugin works for
 	DefaultInterval = 5 * time.Minute
+	// DefaultMetricsPeriod indicates the default metrics period rescheduling plugin works for
+	DefaultMetricsPeriod = "5m"
 	// DefaultStrategy indicates the default strategy rescheduling plugin making use of
 	DefaultStrategy = "lowNodeUtilization"
 )
@@ -46,14 +48,14 @@ var (
 	// VictimFn contains all the VictimTasksFn for registered the strategies
 	VictimFn map[string]api.VictimTasksFn
 
-	// Interval indicates the interval to get metrics, "5m" by default.
-	Interval string
+	// MetricsPeriod indicates the metrics period will be used during this plugin. 5 minutes by default.
+	MetricsPeriod string
 )
 
 func init() {
 	RegisteredStrategyConfigs = make(map[string]interface{})
 	VictimFn = make(map[string]api.VictimTasksFn)
-	Interval = "5m"
+	MetricsPeriod = "5m"
 
 	// register victim functions for all strategies here
 	VictimFn["lowNodeUtilization"] = victimsFnForLnu
@@ -153,8 +155,12 @@ func (rc *Configs) parseArguments(arguments framework.Arguments) {
 	if err != nil {
 		klog.V(4).Infof("Parse rescheduling interval failed. Reset the interval to 5m by default.")
 		rc.interval = DefaultInterval
-	} else {
-		Interval = intervalStr
+	}
+	if metricsPeriodArg, ok := arguments["metricsPeriod"]; ok {
+		MetricsPeriod = metricsPeriodArg.(string)
+	}
+	if MetricsPeriod == "" {
+		MetricsPeriod = DefaultMetricsPeriod
 	}
 	strategies, ok := arguments["strategies"]
 	if ok {


### PR DESCRIPTION
Decoupling the scanning cycle from the processing cycle can provide several benefits, including:

- Increased efficiency: When the scanning and processing cycles are decoupled, the processing cycle can be performed on the results of the previous scanning cycle. This reduces idle time and allows the system to operate more efficiently.
- Improved scalability: Decoupling the scanning and processing cycles can also improve system scalability. By allowing the processing cycle to operate independently of the scanning cycle, the system can handle larger volumes of data without slowing down.
- Flexibility: Decoupling the scanning and processing cycles provides greater flexibility in terms of how the system is designed and configured. For example, it may be possible to adjust the scanning cycle frequency or processing cycle duration to optimize performance for different types of data or workloads.
- Reduced resource consumption: By decoupling the scanning and processing cycles, it may be possible to reduce resource consumption (e.g. CPU, memory, power) by optimizing each cycle independently. This can help reduce operational costs and improve the overall sustainability of the system.