### PR TITLE
Fix MPI example not working in IPv6

### DIFF
--- a/example/integrations/mpi/Dockerfile
+++ b/example/integrations/mpi/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:22.04
 MAINTAINER volcano <maintainer@volcano.sh>
 RUN  apt-get update --fix-missing \
      && apt-get install -y libopenmpi-dev openmpi-bin \


### PR DESCRIPTION
This is to fix errors for the MPI example in #2713.

This PR does 2 things:

- By updating the Docker base image, the OpenMPI version is effectively upgraded.
- Add `--mca` option to mpiexec. This seems to have fixed the IPv6 issue. 

## Before:

```
$ k -n gengwg exec -it lm-mpi-job-mpiworker-0 -- mpirun --version
mpirun (Open MPI) 1.10.2
```

Besides, getting the mount error in #2713. Example:

```
Unexpected end of /proc/mounts line `overlay / overlay rw,relatime,lowerdir=/var/lib/docker/overlay2/l/4GCDNOZIAYJDMKBWJVVSMRDLWE:/var/lib/docker/overlay2/l/RJ4EXRGNG4CKKFCJPAANAG6KWQ:/var/lib/docker/overlay2/l/3GCIAIOLS32GIVNV3KMWN6TPNN:/var/lib/docker/overlay2/l/RDG5AJQ3G64UCFYZPHBDGC7PR6:/var/lib/docker/overlay2/l/LZSWVN7NELVR3CTN6D254MGKD6:/var/lib/docker/overlay2/l/OMLRKFEAEDPGWVCU5JGAZVSL3X:/var/lib/docker/overlay2/l/FTXOND2LJMKTD5FQJSXBG6JEWN,upperdir=/var/lib/docker/overlay2/fbfe3afd54f7512357817dde4c887fd8083bbcb9508d3c4265dfb4344f4c'
```

## After:

```
$ k -n gengwg exec -it lm-mpi-job-mpimaster-0 -- mpirun --version
mpirun (Open MPI) 2.1.1 
```

No mount error any more. Also MPI runs successful:

```
$ k logs lm-mpi-job-mpimaster-0 -n gengwg
Hello world from processor lm-mpi-job-mpimaster-0, rank 1 out of 2 processors
Hello world from processor lm-mpi-job-mpimaster-0, rank 0 out of 2 processors
```

Would it be possible for someone to perform a test of this on a cluster that uses only IPv4? (should still be many in current world). This would ensure that backward compatibility is maintained. It's worth noting that our environment consists of hosts and pods that are IPv6 only, so it's a bit hard for me to test IPv4.
