### PR TITLE
Signed-off-by: limengxuan <391013634@qq.com>

### DIFF
--- a/pkg/scheduler/api/devices/nvidia/gpushare/device_info.go
+++ b/pkg/scheduler/api/devices/nvidia/gpushare/device_info.go
@@ -88,6 +88,11 @@ func NewGPUDevices(name string, node *v1.Node) *GPUDevices {
 	return &gpudevices
 }
 
+// GetIgnoredDevices return device names which wish vc-scheduler to ignore
+func (gs *GPUDevices) GetIgnoredDevices() []string {
+	return []string{""}
+}
+
 // AddGPUResource adds the pod to GPU pool if it is assigned
 func (gs *GPUDevices) AddResource(pod *v1.Pod) {
 	gpuRes := getGPUMemoryOfPod(pod)

--- a/pkg/scheduler/api/node_info.go
+++ b/pkg/scheduler/api/node_info.go
@@ -343,7 +343,9 @@ func (ni *NodeInfo) SetNode(node *v1.Node) {
 
 // setNodeOthersResource initialize sharable devices
 func (ni *NodeInfo) setNodeOthersResource(node *v1.Node) {
+	IgnoredDevicesList = []string{}
 	ni.Others[GPUSharingDevice] = gpushare.NewGPUDevices(ni.Name, node)
+	IgnoredDevicesList = append(IgnoredDevicesList, ni.Others[GPUSharingDevice].(Devices).GetIgnoredDevices()...)
 }
 
 // setNode sets kubernetes node object to nodeInfo object without assertion

--- a/pkg/scheduler/api/resource_info.go
+++ b/pkg/scheduler/api/resource_info.go
@@ -23,6 +23,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/klog/v2"
 	v1helper "k8s.io/kubernetes/pkg/scheduler/util"
 
 	"volcano.sh/volcano/pkg/scheduler/util/assert"
@@ -84,7 +85,18 @@ func NewResource(rl v1.ResourceList) *Resource {
 			}
 			//NOTE: When converting this back to k8s resource, we need record the format as well as / 1000
 			if v1helper.IsScalarResourceName(rName) {
-				r.AddScalar(rName, float64(rQuant.MilliValue()))
+				ignore := false
+				for _, val := range IgnoredDevicesList {
+					if strings.Compare(val, rName.String()) == 0 {
+						ignore = true
+						break
+					}
+				}
+				if !ignore {
+					r.AddScalar(rName, float64(rQuant.MilliValue()))
+				} else {
+					klog.V(4).Infof("Ignoring resource", rName.String())
+				}
 			}
 		}
 	}

--- a/pkg/scheduler/api/shared_device_pool.go
+++ b/pkg/scheduler/api/shared_device_pool.go
@@ -44,9 +44,14 @@ type Devices interface {
 	//Release action in predicate
 	Release(kubeClient kubernetes.Interface, pod *v1.Pod) error
 
+	//IgnredDevices notify vc-scheduler to ignore devices in return list
+	GetIgnoredDevices() []string
+
 	//used for debug and monitor
 	GetStatus() string
 }
 
 // make sure GPUDevices implements Devices interface
 var _ Devices = new(gpushare.GPUDevices)
+
+var IgnoredDevicesList []string


### PR DESCRIPTION
third-party devices can choose to let vc-scheduler ignore some resources(do not pass it down to device-plugin), here we add a new interface to implement that. It's behaves the same like "kubeSchedulerConfiguration.managedResources.ignoredByScheduler=true" 