### PR TITLE
Use the latest example-mpi mirror

### DIFF
--- a/docs/user-guide/how_to_use_mpi_plugin.md
+++ b/docs/user-guide/how_to_use_mpi_plugin.md
@@ -55,7 +55,7 @@ spec:
                 - |
                   mkdir -p /var/run/sshd; /usr/sbin/sshd;
                   mpiexec --allow-run-as-root --host ${MPI_HOST} -np 2 mpi_hello_world;
-              image: volcanosh/example-mpi:0.0.1
+              image: volcanosh/example-mpi:0.0.3
               name: mpimaster
               workingDir: /home
           restartPolicy: OnFailure
@@ -69,7 +69,7 @@ spec:
                 - -c
                 - |
                   mkdir -p /var/run/sshd; /usr/sbin/sshd -D;
-              image: volcanosh/example-mpi:0.0.1
+              image: volcanosh/example-mpi:0.0.3
               name: mpiworker
               workingDir: /home
           restartPolicy: OnFailure

--- a/example/integrations/mpi/mpi-example.yaml
+++ b/example/integrations/mpi/mpi-example.yaml
@@ -24,7 +24,7 @@ spec:
                   MPI_HOST=`cat /etc/volcano/mpiworker.host | tr "\n" ","`;
                   mkdir -p /var/run/sshd; /usr/sbin/sshd;
                   mpiexec --allow-run-as-root --host ${MPI_HOST} -np 2 mpi_hello_world;
-              image: volcanosh/example-mpi:0.0.1
+              image: volcanosh/example-mpi:0.0.3
               name: mpimaster
               ports:
                 - containerPort: 22
@@ -41,7 +41,7 @@ spec:
                 - -c
                 - |
                   mkdir -p /var/run/sshd; /usr/sbin/sshd -D;
-              image: volcanosh/example-mpi:0.0.1
+              image: volcanosh/example-mpi:0.0.3
               name: mpiworker
               ports:
                 - containerPort: 22

--- a/example/task-start-dependency/mpi.yaml
+++ b/example/task-start-dependency/mpi.yaml
@@ -24,7 +24,7 @@ spec:
                   MPI_HOST=`cat /etc/volcano/mpiworker.host | tr "\n" ","`;
                   mkdir -p /var/run/sshd; /usr/sbin/sshd;
                   mpiexec --allow-run-as-root --host ${MPI_HOST} -np 10 mpi_hello_world;
-              image: volcanosh/example-mpi:0.0.1
+              image: volcanosh/example-mpi:0.0.3
               name: mpimaster
               ports:
                 - containerPort: 22
@@ -44,7 +44,7 @@ spec:
                 - -c
                 - |
                   mkdir -p /var/run/sshd; /usr/sbin/sshd -D;
-              image: volcanosh/example-mpi:0.0.1
+              image: volcanosh/example-mpi:0.0.3
               name: mpiworker
               ports:
                 - containerPort: 22

--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -74,7 +74,7 @@ const (
 const (
 	DefaultBusyBoxImage = "busybox:1.24"
 	DefaultNginxImage   = "nginx:1.14"
-	DefaultMPIImage     = "volcanosh/example-mpi:0.0.1"
+	DefaultMPIImage     = "volcanosh/example-mpi:0.0.3"
 	DefaultTFImage      = "volcanosh/dist-mnist-tf-example:0.0.1"
 	// "volcanosh/pytorch-mnist-v1beta1-9ee8fda-example:0.0.1" is from "docker.io/kubeflowkatib/pytorch-mnist:v1beta1-9ee8fda"
 	DefaultPytorchImage = "volcanosh/pytorch-mnist-v1beta1-9ee8fda-example:0.0.1"


### PR DESCRIPTION
After [#2714](https://github.com/volcano-sh/volcano/pull/2714) is merged into the trunk, the example-mpi:0.0.3 image has been updated on dockerhub, and the current PR is to update the image version used in the example.