### PR TITLE
pod admission  mutate patch affinity

### DIFF
--- a/pkg/webhooks/admission/pods/mutate/mutate_pod_test.go
+++ b/pkg/webhooks/admission/pods/mutate/mutate_pod_test.go
@@ -28,6 +28,9 @@ import (
 )
 
 func TestMutatePods(t *testing.T) {
+	affinityJsonStr := `{"nodeAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":{"nodeSelectorTerms":[{"matchExpressions":[{"key":"kubernetes.io/os","operator":"In","values":["linux"]}]}]}}}`
+	var affinity v1.Affinity
+	json.Unmarshal([]byte(affinityJsonStr), &affinity)
 
 	admissionConfigData := &webconfig.AdmissionConfiguration{
 		ResGroupsConfig: []webconfig.ResGroupConfig{
@@ -48,6 +51,7 @@ func TestMutatePods(t *testing.T) {
 						Effect:   v1.TaintEffectNoSchedule,
 					},
 				},
+				Affinity: affinityJsonStr,
 				Labels: map[string]string{
 					"volcano.sh/nodetype": "management",
 				},
@@ -104,6 +108,11 @@ func TestMutatePods(t *testing.T) {
 					Value: map[string]string{
 						"volcano.sh/nodetype": "management",
 					},
+				},
+				{
+					Op:    "add",
+					Path:  "/spec/affinity",
+					Value: affinity,
 				},
 				{
 					Op:   "add",

--- a/pkg/webhooks/config/config.go
+++ b/pkg/webhooks/config/config.go
@@ -42,6 +42,7 @@ type ResGroupConfig struct {
 	SchedulerName string            `yaml:"schedulerName"`
 	Tolerations   []v1.Toleration   `yaml:"tolerations"`
 	Labels        map[string]string `yaml:"labels"`
+	Affinity      string            `yaml:"affinity"`
 }
 
 // AdmissionConfiguration defines the configuration of admission.


### PR DESCRIPTION
Admission pods, resourceGroups support mutate patch pod affinity. The format is a json string.

volcano-admission.conf example
```yaml
apiVersion: v1
data:
  volcano-admission.conf: |
    resourceGroups:
    - resourceGroup: fixed                        # if the object is unsetted, default is:  the key is annotation,
      schedulerName: volcano                      # the annotation key is fixed and is "volcano.sh/resource-group", The corresponding value is the resourceGroup field
      object:
        key: annotation
        value:
        - "volcano.sh/resource-group-job-role: master"
      # set the affinity for patching, the format is a json string.
      affinity: "{\"nodeAffinity\":{\"requiredDuringSchedulingIgnoredDuringExecution\":{\"nodeSelectorTerms\":[{\"matchExpressions\":[{\"key\":\"volcano.sh/nodetype",\"operator\":\"In\",\"values\":[\"fixed\"]}]}]}}}"
kind: ConfigMap
metadata:
  annotations:
    meta.helm.sh/release-name: volcano
    meta.helm.sh/release-namespace: volcano-system
  labels:
    app.kubernetes.io/managed-by: Helm
  name: volcano-admission-configmap
  namespace: volcano-system
```