### PR TITLE
optimize nodeorder logprint to easy find from pod;

### DIFF
--- a/pkg/scheduler/plugins/nodeorder/nodeorder.go
+++ b/pkg/scheduler/plugins/nodeorder/nodeorder.go
@@ -267,7 +267,7 @@ func (pp *nodeOrderPlugin) OnSessionOpen(ssn *framework.Session) {
 
 			// If imageLocalityWeight is provided, host.Score is multiplied with weight, if not, host.Score is added to total score.
 			nodeScore += float64(score) * float64(weight.imageLocalityWeight)
-			klog.V(4).Infof("Node: %s, Image Locality score: %f", node.Name, nodeScore)
+			klog.V(5).Infof("Node: %s, task<%s/%s> Image Locality weight %d, score: %f", node.Name, task.Namespace, task.Name, weight.imageLocalityWeight, float64(score)*float64(weight.imageLocalityWeight))
 		}
 
 		// NodeResourcesLeastAllocated
@@ -280,7 +280,7 @@ func (pp *nodeOrderPlugin) OnSessionOpen(ssn *framework.Session) {
 
 			// If leastReqWeight is provided, host.Score is multiplied with weight, if not, host.Score is added to total score.
 			nodeScore += float64(score) * float64(weight.leastReqWeight)
-			klog.V(4).Infof("Node: %s, Least Request score: %f", node.Name, nodeScore)
+			klog.V(5).Infof("Node: %s, task<%s/%s> Least Request weight %d, score: %f", node.Name, task.Namespace, task.Name, weight.leastReqWeight, float64(score)*float64(weight.leastReqWeight))
 		}
 
 		// NodeResourcesMostAllocated
@@ -293,7 +293,7 @@ func (pp *nodeOrderPlugin) OnSessionOpen(ssn *framework.Session) {
 
 			// If mostRequestedWeight is provided, host.Score is multiplied with weight, it's 0 by default
 			nodeScore += float64(score) * float64(weight.mostReqWeight)
-			klog.V(4).Infof("Node: %s, Most Request score: %f", node.Name, nodeScore)
+			klog.V(5).Infof("Node: %s, task<%s/%s> Most Request weight %d, score: %f", node.Name, task.Namespace, task.Name, weight.mostReqWeight, float64(score)*float64(weight.mostReqWeight))
 		}
 
 		// NodeResourcesBalancedAllocation
@@ -306,7 +306,7 @@ func (pp *nodeOrderPlugin) OnSessionOpen(ssn *framework.Session) {
 
 			// If balancedResourceWeight is provided, host.Score is multiplied with weight, if not, host.Score is added to total score.
 			nodeScore += float64(score) * float64(weight.balancedResourceWeight)
-			klog.V(4).Infof("Node: %s, Balanced Request score: %f", node.Name, nodeScore)
+			klog.V(5).Infof("Node: %s, task<%s/%s> Balanced Request weight %d, score: %f", node.Name, task.Namespace, task.Name, weight.balancedResourceWeight, float64(score)*float64(weight.balancedResourceWeight))
 		}
 
 		// NodeAffinity
@@ -320,10 +320,10 @@ func (pp *nodeOrderPlugin) OnSessionOpen(ssn *framework.Session) {
 			// TODO: should we normalize the score
 			// If nodeAffinityWeight is provided, host.Score is multiplied with weight, if not, host.Score is added to total score.
 			nodeScore += float64(score) * float64(weight.nodeAffinityWeight)
-			klog.V(4).Infof("Node: %s, Node Affinity score: %f", node.Name, nodeScore)
+			klog.V(5).Infof("Node: %s, task<%s/%s> Node Affinity weight %d, score: %f", node.Name, task.Namespace, task.Name, weight.nodeAffinityWeight, float64(score)*float64(weight.nodeAffinityWeight))
 		}
 
-		klog.V(4).Infof("Total Score for task %s/%s on node %s is: %f", task.Namespace, task.Name, node.Name, nodeScore)
+		klog.V(4).Infof("Nodeorder Total Score for task<%s/%s> on node %s is: %f", task.Namespace, task.Name, node.Name, nodeScore)
 		return nodeScore, nil
 	}
 	ssn.AddNodeOrderFn(pp.Name(), nodeOrderFn)

--- a/pkg/scheduler/util/scheduler_helper.go
+++ b/pkg/scheduler/util/scheduler_helper.go
@@ -102,27 +102,27 @@ func PrioritizeNodes(task *api.TaskInfo, nodes []*api.NodeInfo, batchFn api.Batc
 		return nodeScores
 	}
 
+	nodeScoreMap := map[string]float64{}
 	for _, node := range nodes {
-		if score, found := reduceScores[node.Name]; found {
-			if orderScore, ok := nodeOrderScoreMap[node.Name]; ok {
-				score += orderScore
-			}
-			if batchScore, ok := batchNodeScore[node.Name]; ok {
-				score += batchScore
-			}
-			nodeScores[score] = append(nodeScores[score], node)
-		} else {
-			// If no plugin is applied to this node, the default is 0.0
-			score = 0.0
-			if orderScore, ok := nodeOrderScoreMap[node.Name]; ok {
-				score += orderScore
-			}
-			if batchScore, ok := batchNodeScore[node.Name]; ok {
-				score += batchScore
-			}
-			nodeScores[score] = append(nodeScores[score], node)
+		// If no plugin is applied to this node, the default is 0.0
+		score := 0.0
+		if reduceScore, ok := reduceScores[node.Name]; ok {
+			score += reduceScore
+		}
+		if orderScore, ok := nodeOrderScoreMap[node.Name]; ok {
+			score += orderScore
+		}
+		if batchScore, ok := batchNodeScore[node.Name]; ok {
+			score += batchScore
+		}
+		nodeScores[score] = append(nodeScores[score], node)
+
+		if klog.V(5).Enabled() {
+			nodeScoreMap[node.Name] = score
 		}
 	}
+
+	klog.V(5).Infof("Prioritize nodeScoreMap for task<%s/%s> is: %v", task.Namespace, task.Name, nodeScoreMap)
 	return nodeScores
 }
 


### PR DESCRIPTION
When locate the problem of assignment strategy, it's hardly figure out a task score detail in a batch assignment. Add pod name for each component score log printing in nodeorder plugin.