### PR TITLE
ignore no metrics server error log;

### DIFF
--- a/pkg/scheduler/actions/allocate/allocate.go
+++ b/pkg/scheduler/actions/allocate/allocate.go
@@ -42,8 +42,8 @@ func (alloc *Action) Name() string {
 func (alloc *Action) Initialize() {}
 
 func (alloc *Action) Execute(ssn *framework.Session) {
-	klog.V(3).Infof("Enter Allocate ...")
-	defer klog.V(3).Infof("Leaving Allocate ...")
+	klog.V(5).Infof("Enter Allocate ...")
+	defer klog.V(5).Infof("Leaving Allocate ...")
 
 	// the allocation for pod may have many stages
 	// 1. pick a queue named Q (using ssn.QueueOrderFn)

--- a/pkg/scheduler/actions/backfill/backfill.go
+++ b/pkg/scheduler/actions/backfill/backfill.go
@@ -39,8 +39,8 @@ func (backfill *Action) Name() string {
 func (backfill *Action) Initialize() {}
 
 func (backfill *Action) Execute(ssn *framework.Session) {
-	klog.V(3).Infof("Enter Backfill ...")
-	defer klog.V(3).Infof("Leaving Backfill ...")
+	klog.V(5).Infof("Enter Backfill ...")
+	defer klog.V(5).Infof("Leaving Backfill ...")
 
 	// TODO (k82cn): When backfill, it's also need to balance between Queues.
 	for _, job := range ssn.Jobs {

--- a/pkg/scheduler/actions/enqueue/enqueue.go
+++ b/pkg/scheduler/actions/enqueue/enqueue.go
@@ -42,8 +42,8 @@ func (enqueue *Action) Name() string {
 func (enqueue *Action) Initialize() {}
 
 func (enqueue *Action) Execute(ssn *framework.Session) {
-	klog.V(3).Infof("Enter Enqueue ...")
-	defer klog.V(3).Infof("Leaving Enqueue ...")
+	klog.V(5).Infof("Enter Enqueue ...")
+	defer klog.V(5).Infof("Leaving Enqueue ...")
 
 	queues := util.NewPriorityQueue(ssn.QueueOrderFn)
 	queueSet := sets.NewString()

--- a/pkg/scheduler/actions/preempt/preempt.go
+++ b/pkg/scheduler/actions/preempt/preempt.go
@@ -40,8 +40,8 @@ func (pmpt *Action) Name() string {
 func (pmpt *Action) Initialize() {}
 
 func (pmpt *Action) Execute(ssn *framework.Session) {
-	klog.V(3).Infof("Enter Preempt ...")
-	defer klog.V(3).Infof("Leaving Preempt ...")
+	klog.V(5).Infof("Enter Preempt ...")
+	defer klog.V(5).Infof("Leaving Preempt ...")
 
 	preemptorsMap := map[api.QueueID]*util.PriorityQueue{}
 	preemptorTasks := map[api.JobID]*util.PriorityQueue{}

--- a/pkg/scheduler/actions/reclaim/reclaim.go
+++ b/pkg/scheduler/actions/reclaim/reclaim.go
@@ -37,8 +37,8 @@ func (ra *Action) Name() string {
 func (ra *Action) Initialize() {}
 
 func (ra *Action) Execute(ssn *framework.Session) {
-	klog.V(3).Infof("Enter Reclaim ...")
-	defer klog.V(3).Infof("Leaving Reclaim ...")
+	klog.V(5).Infof("Enter Reclaim ...")
+	defer klog.V(5).Infof("Leaving Reclaim ...")
 
 	queues := util.NewPriorityQueue(ssn.QueueOrderFn)
 	queueMap := map[api.QueueID]*api.QueueInfo{}

--- a/pkg/scheduler/actions/shuffle/shuffle.go
+++ b/pkg/scheduler/actions/shuffle/shuffle.go
@@ -46,8 +46,8 @@ func (shuffle *Action) Initialize() {}
 
 // Execute select evictees according given strategies and evict them.
 func (shuffle *Action) Execute(ssn *framework.Session) {
-	klog.V(3).Infoln("Enter Shuffle ...")
-	defer klog.V(3).Infoln("Leaving Shuffle ...")
+	klog.V(5).Infoln("Enter Shuffle ...")
+	defer klog.V(5).Infoln("Leaving Shuffle ...")
 
 	// select pods that may be evicted
 	tasks := make([]*api.TaskInfo, 0)

--- a/pkg/scheduler/cache/cache.go
+++ b/pkg/scheduler/cache/cache.go
@@ -671,11 +671,14 @@ func (sc *SchedulerCache) Run(stopCh <-chan struct{}) {
 	go wait.Until(sc.processBindTask, time.Millisecond*20, stopCh)
 
 	// Get metrics data
-	interval, err := time.ParseDuration(sc.metricsConf["interval"])
-	if err != nil || interval <= 0 {
-		interval = time.Duration(defaultMetricsInternal)
+	address := sc.metricsConf["address"]
+	if len(address) > 0 {
+		interval, err := time.ParseDuration(sc.metricsConf["interval"])
+		if err != nil || interval <= 0 {
+			interval = time.Duration(defaultMetricsInternal)
+		}
+		go wait.Until(sc.GetMetricsData, interval, stopCh)
 	}
-	go wait.Until(sc.GetMetricsData, interval, stopCh)
 }
 
 // WaitForCacheSync sync the cache with the api server

--- a/pkg/scheduler/plugins/binpack/binpack.go
+++ b/pkg/scheduler/plugins/binpack/binpack.go
@@ -162,12 +162,11 @@ func (bp *binpackPlugin) Name() string {
 }
 
 func (bp *binpackPlugin) OnSessionOpen(ssn *framework.Session) {
-	klog.V(4).Infof("Enter binpack plugin ...")
+	klog.V(5).Infof("Enter binpack plugin ...")
+	defer func() {
+		klog.V(5).Infof("Leaving binpack plugin. %s ...", bp.weight.String())
+	}()
 	if klog.V(4).Enabled() {
-		defer func() {
-			klog.V(4).Infof("Leaving binpack plugin. %s ...", bp.weight.String())
-		}()
-
 		notFoundResource := []string{}
 		for resource := range bp.weight.BinPackingResources {
 			found := false

--- a/pkg/scheduler/plugins/overcommit/overcommit.go
+++ b/pkg/scheduler/plugins/overcommit/overcommit.go
@@ -70,8 +70,8 @@ tiers:
     overcommit-factor: 1.0
 */
 func (op *overcommitPlugin) OnSessionOpen(ssn *framework.Session) {
-	klog.V(4).Infof("Enter overcommit plugin ...")
-	defer klog.V(4).Infof("Leaving overcommit plugin.")
+	klog.V(5).Infof("Enter overcommit plugin ...")
+	defer klog.V(5).Infof("Leaving overcommit plugin.")
 
 	op.pluginArguments.GetFloat64(&op.overCommitFactor, overCommitFactor)
 	if op.overCommitFactor < 1.0 {

--- a/pkg/scheduler/plugins/rescheduling/rescheduling.go
+++ b/pkg/scheduler/plugins/rescheduling/rescheduling.go
@@ -79,8 +79,8 @@ func (rp *reschedulingPlugin) Name() string {
 }
 
 func (rp *reschedulingPlugin) OnSessionOpen(ssn *framework.Session) {
-	klog.V(3).Infof("Enter rescheduling plugin ...")
-	defer klog.V(3).Infof("Leaving rescheduling plugin.")
+	klog.V(5).Infof("Enter rescheduling plugin ...")
+	defer klog.V(5).Infof("Leaving rescheduling plugin.")
 
 	// Parse all the rescheduling strategies and execution interval
 	Session = ssn

--- a/pkg/scheduler/plugins/tdm/tdm.go
+++ b/pkg/scheduler/plugins/tdm/tdm.go
@@ -137,12 +137,10 @@ func (tp *tdmPlugin) availableRevocableZone(rz string) error {
 }
 
 func (tp *tdmPlugin) OnSessionOpen(ssn *framework.Session) {
-	klog.V(4).Infof("Enter tdm plugin ...")
-	if klog.V(4).Enabled() {
-		defer func() {
-			klog.V(4).Infof("Leaving tdm plugin.")
-		}()
-	}
+	klog.V(5).Infof("Enter tdm plugin ...")
+	defer func() {
+		klog.V(5).Infof("Leaving tdm plugin.")
+	}()
 
 	// tdm plugin just handle revocable node
 	predicateFn := func(task *api.TaskInfo, node *api.NodeInfo) error {

--- a/pkg/scheduler/plugins/usage/usage.go
+++ b/pkg/scheduler/plugins/usage/usage.go
@@ -79,12 +79,10 @@ func (up *usagePlugin) Name() string {
 }
 
 func (up *usagePlugin) OnSessionOpen(ssn *framework.Session) {
-	klog.V(4).Infof("Enter usage plugin ...")
-	if klog.V(4).Enabled() {
-		defer func() {
-			klog.V(4).Infof("Leaving usage plugin ...")
-		}()
-	}
+	klog.V(5).Infof("Enter usage plugin ...")
+	defer func() {
+		klog.V(5).Infof("Leaving usage plugin ...")
+	}()
 
 	if klog.V(4).Enabled() {
 		for node := range ssn.Nodes {

--- a/pkg/webhooks/router/server.go
+++ b/pkg/webhooks/router/server.go
@@ -59,7 +59,7 @@ func Serve(w io.Writer, r *http.Request, admit AdmitFunc) {
 	} else {
 		reviewResponse = admit(ar)
 	}
-	klog.V(3).Infof("sending response: %v", reviewResponse)
+	klog.V(5).Infof("sending response: %v", reviewResponse)
 
 	response := createResponse(reviewResponse, &ar)
 	resp, err := json.Marshal(response)


### PR DESCRIPTION
if metrics server's configuration not set, volcano-scheduler.log will have the log blow; metrics server isn't a default start server, so if metricsConf["address"] is not set, do not start scheduled task GetMetricsData.

---
  E0324 15:25:08.686552       7 cache.go:1264] Error creating client: metrics address is empty
  E0324 15:25:13.687176       7 cache.go:1264] Error creating client: metrics address is empty
  E0324 15:25:18.688364       7 cache.go:1264] Error creating client: metrics address is empty
  ...
---

And for more efficient log print, lower actions, plugins enter and leave log prints.
