### PR TITLE
add label to service, name to port, to make it selectable via Service Monitors

### DIFF
--- a/installer/helm/chart/volcano/templates/scheduler.yaml
+++ b/installer/helm/chart/volcano/templates/scheduler.yaml
@@ -145,11 +145,14 @@ metadata:
     prometheus.io/scrape: "true"
   name: {{ .Release.Name }}-scheduler-service
   namespace: {{ .Release.Namespace }}
+  labels:
+    app: volcano-scheduler
 spec:
   ports:
   - port: 8080
     protocol: TCP
     targetPort: 8080
+    name: "metrics"
   selector:
     app: volcano-scheduler
   type: ClusterIP

--- a/installer/volcano-development.yaml
+++ b/installer/volcano-development.yaml
@@ -8740,11 +8740,14 @@ metadata:
     prometheus.io/scrape: "true"
   name: volcano-scheduler-service
   namespace: volcano-system
+  labels:
+    app: volcano-scheduler
 spec:
   ports:
   - port: 8080
     protocol: TCP
     targetPort: 8080
+    name: "metrics"
   selector:
     app: volcano-scheduler
   type: ClusterIP


### PR DESCRIPTION
Hi! I am trying to monitor my installation of volcano with ServiceMonitors. It looks like since the service is not labeled, we are not able to select it via the ServiceMonitor. 

I also added a named port, since I believe that is required. 

Here are the docs around the ServiceMonitor. 

https://docs.openshift.com/container-platform/4.10/rest_api/monitoring_apis/servicemonitor-monitoring-coreos-com-v1.html

Thanks!