### PR TITLE
Added version compatibility instructions for Volcano and K8s

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,20 @@ make TAG=latest generate-yaml
 kubectl create -f _output/release/volcano-monitoring-latest.yaml
 ```
 
+## Kubernetes compatibility
+
+|                        | Kubernetes 1.17 | Kubernetes 1.18 | Kubernetes 1.19 | Kubernetes 1.20 | Kubernetes 1.21 | Kubernetes 1.22 | Kubernetes 1.23 | Kubernetes 1.24 | Kubernetes 1.25 |
+|------------------------|-----------------|-----------------|-----------------|-----------------|-----------------|-----------------|-----------------|-----------------|-----------------|
+| Volcano v1.6          | ✓               | ✓               | ✓               | ✓               | ✓               | ✓               | ✓               | -               | -               |
+| Volcano v1.7          | -               | -               | ✓               | ✓               | ✓               | ✓               | ✓               |✓               |✓               |
+| Volcano HEAD (master) | -               | -               | ✓               | ✓               | ✓               | ✓               | ✓               |✓               |✓               |
+
+Key:
+* `✓` Volcano and the Kubernetes version are exactly compatible.
+* `+` Volcano has features or API objects that may not be present in the Kubernetes version.
+* `-` The Kubernetes version has features or API objects that Volcano can't use.
+
+
 ## Meeting
 
 Community weekly meeting for Asia: 15:00 - 16:00 (UTC+8) Friday. ([Convert to your timezone.](https://www.thetimezoneconverter.com/?t=10%3A00&tz=GMT%2B8&))


### PR DESCRIPTION
Add the Volcano and K8s version compatibility and adaptation information to Volcano's readme, so that users can find the matching Volcano on the corresponding k8s version for installation verification