### PR TITLE
Change the error message.

### DIFF
--- a/pkg/scheduler/actions/allocate/allocate.go
+++ b/pkg/scheduler/actions/allocate/allocate.go
@@ -98,8 +98,8 @@ func (alloc *Action) Execute(ssn *framework.Session) {
 	allNodes := ssn.NodeList
 	predicateFn := func(task *api.TaskInfo, node *api.NodeInfo) error {
 		// Check for Resource Predicate
-		if !task.InitResreq.LessEqual(node.FutureIdle(), api.Zero) {
-			return api.NewFitError(task, node, api.NodeResourceFitFailed)
+		if ok, reason := task.InitResreq.LessEqualWithReason(node.FutureIdle(), api.Zero); !ok {
+			return api.NewFitError(task, node, reason)
 		}
 
 		return ssn.PredicateFn(task, node)

--- a/pkg/scheduler/api/job_info_test.go
+++ b/pkg/scheduler/api/job_info_test.go
@@ -231,7 +231,7 @@ func TestTaskSchedulingReason(t *testing.T) {
 				t3.UID: "Pod ns1/task-3 can possibly be assigned to node1",
 				t4.UID: "Pod ns1/task-4 can possibly be assigned to node2",
 				t5.UID: "Pod ns1/task-5 can possibly be assigned to node3",
-				t6.UID: "all nodes are unavailable: 1 node(s) pod number exceeded, 2 node(s) resource fit failed.",
+				t6.UID: "0/3 nodes are unavailable: 1 node(s) pod number exceeded, 2 node(s) resource fit failed.",
 			},
 		},
 	}

--- a/pkg/scheduler/api/resource_info.go
+++ b/pkg/scheduler/api/resource_info.go
@@ -389,6 +389,38 @@ func (r *Resource) LessEqual(rr *Resource, defaultValue DimensionDefaultValue) b
 	return true
 }
 
+// LessEqualWithReason returns true, "" only on condition that all dimensions of resources in r are less than or equal with that of rr,
+// Otherwise returns false and err string ,which show which resource is insufficient.
+// @param defaultValue "default value for resource dimension not defined in ScalarResources. Its value can only be one of 'Zero' and 'Infinity'"
+// this function is the same as LessEqual , and it will be merged to LessEqual in the future
+func (r *Resource) LessEqualWithReason(rr *Resource, defaultValue DimensionDefaultValue) (bool, string) {
+	lessEqualFunc := func(l, r, diff float64) bool {
+		if l < r || math.Abs(l-r) < diff {
+			return true
+		}
+		return false
+	}
+
+	if !lessEqualFunc(r.MilliCPU, rr.MilliCPU, minResource) {
+		return false, "Insufficient cpu"
+	}
+	if !lessEqualFunc(r.Memory, rr.Memory, minResource) {
+		return false, "Insufficient memory"
+	}
+
+	for resourceName, leftValue := range r.ScalarResources {
+		rightValue, ok := rr.ScalarResources[resourceName]
+		if !ok && defaultValue == Infinity {
+			continue
+		}
+
+		if !lessEqualFunc(leftValue, rightValue, minResource) {
+			return false, "Insufficient " + string(resourceName)
+		}
+	}
+	return true, ""
+}
+
 // LessPartly returns true if there exists any dimension whose resource amount in r is less than that in rr.
 // Otherwise returns false.
 // @param defaultValue "default value for resource dimension not defined in ScalarResources. Its value can only be one of 'Zero' and 'Infinity'"

--- a/pkg/scheduler/api/unschedule_info.go
+++ b/pkg/scheduler/api/unschedule_info.go
@@ -66,7 +66,7 @@ func (f *FitErrors) SetNodeError(nodeName string, err error) {
 // Error returns the final error message
 func (f *FitErrors) Error() string {
 	if f.err == "" {
-		f.err = AllNodeUnavailableMsg
+		f.err = fmt.Sprintf("0/%v", len(f.nodes)) + " nodes are unavailable"
 	}
 	if len(f.nodes) == 0 {
 		return f.err


### PR DESCRIPTION
this MR is the relization of this issue :  https://github.com/volcano-sh/volcano/issues/2774
when pod is unscheduled, make the error message similar  to kube-scheduler。

test message
the default scheduler error message is "0/2 nodes are available: 2 Insufficient cpu."

before this MR
volcano   error message is  "all nodes are unavailable: 2/2 nodes node(s) resource fit failed."

after this MR
volcano   error message is  "all nodes are unavailable: 2/2 nodes Insufficient cpu."

And in the future。 I will continue to make volcano  error event or something which is showed to  user    is more similar  to  k8s default scheduler