### PR TITLE
Use cases for blocking CI probabilistic failures

### DIFF
--- a/test/e2e/jobseq/pytorch_plugin.go
+++ b/test/e2e/jobseq/pytorch_plugin.go
@@ -10,6 +10,8 @@ import (
 
 var _ = Describe("Pytorch Plugin E2E Test", func() {
 	It("will run and complete finally", func() {
+		// Community CI can skip this use case, and enable this use case verification when releasing the version.
+		Skip("Pytorch's test image download fails probabilistically, causing the current use case to fail. ")
 		context := e2eutil.InitTestContext(e2eutil.Options{})
 		defer e2eutil.CleanupTestContext(context)
 


### PR DESCRIPTION
fix: [#2777](https://github.com/volcano-sh/volcano/issues/2777)

Pytorch's test image download fails probabilistically, causing the current use case to fail.

Community CI can skip this use case, and enable this use case verification when releasing the version.