### PR TITLE
improve: rename variable of task spec name for more readable

### DIFF
--- a/pkg/controllers/apis/job_info.go
+++ b/pkg/controllers/apis/job_info.go
@@ -30,7 +30,7 @@ type JobInfo struct {
 	Name      string
 
 	Job  *batch.Job
-	Pods map[string]map[string]*v1.Pod
+	Pods map[string]map[string]*v1.Pod // roleSpec-> podName->podObject
 }
 
 // Clone function clones the k8s pod values to the JobInfo struct.
@@ -63,50 +63,45 @@ func (ji *JobInfo) SetJob(job *batch.Job) {
 // AddPod adds the k8s pod object values to the Pods field
 // of JobStruct if it doesn't exist. Otherwise it throws error.
 func (ji *JobInfo) AddPod(pod *v1.Pod) error {
-	taskName, found := pod.Annotations[batch.TaskSpecKey]
+	taskSpec, found := pod.Annotations[batch.TaskSpecKey]
 	if !found {
-		return fmt.Errorf("failed to find taskName of Pod <%s/%s>",
-			pod.Namespace, pod.Name)
+		return fmt.Errorf("failed to find task-spec in annotation of Pod <%s/%s>", pod.Namespace, pod.Name)
 	}
 
 	_, found = pod.Annotations[batch.JobVersion]
 	if !found {
-		return fmt.Errorf("failed to find jobVersion of Pod <%s/%s>",
-			pod.Namespace, pod.Name)
+		return fmt.Errorf("failed to find jobVersion of Pod <%s/%s>", pod.Namespace, pod.Name)
 	}
 
-	if _, found := ji.Pods[taskName]; !found {
-		ji.Pods[taskName] = make(map[string]*v1.Pod)
+	if _, found := ji.Pods[taskSpec]; !found {
+		ji.Pods[taskSpec] = make(map[string]*v1.Pod)
 	}
-	if _, found := ji.Pods[taskName][pod.Name]; found {
+	if _, found := ji.Pods[taskSpec][pod.Name]; found {
 		return fmt.Errorf("duplicated pod")
 	}
-	ji.Pods[taskName][pod.Name] = pod
+	ji.Pods[taskSpec][pod.Name] = pod
 
 	return nil
 }
 
 // UpdatePod updates the k8s pod object values to the existing pod.
 func (ji *JobInfo) UpdatePod(pod *v1.Pod) error {
-	taskName, found := pod.Annotations[batch.TaskSpecKey]
+	taskSpec, found := pod.Annotations[batch.TaskSpecKey]
 	if !found {
-		return fmt.Errorf("failed to find taskName of Pod <%s/%s>",
-			pod.Namespace, pod.Name)
+		return fmt.Errorf("failed to find task-spec in annotation of Pod <%s/%s>", pod.Namespace, pod.Name)
 	}
 	_, found = pod.Annotations[batch.JobVersion]
 	if !found {
-		return fmt.Errorf("failed to find jobVersion of Pod <%s/%s>",
-			pod.Namespace, pod.Name)
+		return fmt.Errorf("failed to find jobVersion of Pod <%s/%s>", pod.Namespace, pod.Name)
 	}
 
-	if _, found := ji.Pods[taskName]; !found {
-		return fmt.Errorf("can not find task %s in cache", taskName)
+	if _, found := ji.Pods[taskSpec]; !found {
+		return fmt.Errorf("can not find task-spec %s in cache", taskSpec)
 	}
-	if _, found := ji.Pods[taskName][pod.Name]; !found {
-		return fmt.Errorf("can not find pod <%s/%s> in cache",
-			pod.Namespace, pod.Name)
+	if _, found := ji.Pods[taskSpec][pod.Name]; !found {
+		return fmt.Errorf("can not find pod <%s/%s> in cache", pod.Namespace, pod.Name)
 	}
-	ji.Pods[taskName][pod.Name] = pod
+	ji.Pods[taskSpec][pod.Name] = pod
 
 	return nil
 }

--- a/pkg/controllers/job/helpers/helpers.go
+++ b/pkg/controllers/job/helpers/helpers.go
@@ -121,9 +121,9 @@ func GetJobKeyByReq(req *apis.Request) string {
 }
 
 // GetTasklndexUnderJob return index of the task in the job.
-func GetTasklndexUnderJob(taskName string, job *batch.Job) int {
+func GetTasklndexUnderJob(specName string, job *batch.Job) int {
 	for index, task := range job.Spec.Tasks {
-		if task.Name == taskName {
+		if task.Name == specName {
 			return index
 		}
 	}
@@ -131,12 +131,12 @@ func GetTasklndexUnderJob(taskName string, job *batch.Job) int {
 }
 
 // GetPodsNameUnderTask return names of all pods in the task.
-func GetPodsNameUnderTask(taskName string, job *batch.Job) []string {
+func GetPodsNameUnderTask(specName string, job *batch.Job) []string {
 	var res []string
 	for _, task := range job.Spec.Tasks {
-		if task.Name == taskName {
+		if task.Name == specName {
 			for index := 0; index < int(task.Replicas); index++ {
-				res = append(res, MakePodName(job.Name, taskName, index))
+				res = append(res, MakePodName(job.Name, specName, index))
 			}
 			break
 		}


### PR DESCRIPTION
`taskName` for task role has some ambiguity to understand, `specName` is more meaningful for task role, in my opinion 