### PR TITLE
Hotfix: keep updating task's min available number same as creating podgroup

### DIFF
--- a/pkg/controllers/job/job_controller_actions.go
+++ b/pkg/controllers/job/job_controller_actions.go
@@ -718,20 +718,21 @@ func (cc *jobcontroller) createOrUpdatePodGroup(job *batch.Job) error {
 	}
 
 	for _, task := range job.Spec.Tasks {
-		if task.MinAvailable == nil {
-			continue
+		cnt := task.Replicas
+		if task.MinAvailable != nil {
+			cnt = *task.MinAvailable
 		}
 
 		if taskMember, ok := pg.Spec.MinTaskMember[task.Name]; !ok {
 			pgShouldUpdate = true
-			pg.Spec.MinTaskMember[task.Name] = *task.MinAvailable
+			pg.Spec.MinTaskMember[task.Name] = cnt
 		} else {
-			if taskMember == *task.MinAvailable {
+			if taskMember == cnt {
 				continue
 			}
 
 			pgShouldUpdate = true
-			pg.Spec.MinTaskMember[task.Name] = *task.MinAvailable
+			pg.Spec.MinTaskMember[task.Name] = cnt
 		}
 	}
 

--- a/pkg/controllers/job/job_controller_actions_test.go
+++ b/pkg/controllers/job/job_controller_actions_test.go
@@ -282,6 +282,7 @@ func TestSyncJobFunc(t *testing.T) {
 			testcase.JobInfo.Job.Spec.Plugins = jobPlugins
 
 			fakeController.pgInformer.Informer().GetIndexer().Add(testcase.PodGroup)
+			fakeController.vcClient.SchedulingV1beta1().PodGroups(testcase.PodGroup.Namespace).Create(context.TODO(), testcase.PodGroup, metav1.CreateOptions{})
 
 			for _, pod := range testcase.Pods {
 				_, err := fakeController.kubeClient.CoreV1().Pods(namespace).Create(context.TODO(), pod, metav1.CreateOptions{})


### PR DESCRIPTION
task's min avaiable member is set to task.Replicas if `task.MinAvailable` is nil when creating podgroup;
but it  doesn't keep this logic when updating a podgroup.

fix #2792