### PR TITLE
verify-golangci-lint fails to run in CI, code merging is not allowed

### DIFF
--- a/hack/verify-golangci-lint.sh
+++ b/hack/verify-golangci-lint.sh
@@ -43,7 +43,22 @@ function check_golangci-lint() {
 function golangci-lint_run() {
   echo "begin run golangci-lint"
   cd ${KUBE_ROOT}
-  golangci-lint run -v
+  ret=0
+  golangci-lint run -v || ret=$?
+  if [ $ret -eq 0 ]; then
+    echo "SUCCESS: golangci-lint verified."
+  else
+    echo "FAILED: golangci-lint stale."
+    echo
+    echo "Please review the above warnings. You can test via './hack/verify-golangci-lint.sh' or 'make lint'."
+    echo "If the above warnings do not make sense, you can exempt this warning with a comment"
+    echo " (if your reviewer is okay with it)."
+    echo "In general please prefer to fix the error, we have already disabled specific lints"
+    echo " that the project chooses to ignore."
+    echo "See: https://golangci-lint.run/usage/false-positives/"
+    echo
+    exit 1
+  fi
 }
 
 set +e


### PR DESCRIPTION
resolve #2806 
Need to merge after #2801 

Add judgment to the result of verify-golangci-lint in CI, if the operation fails, code integration is not allowed.