### PR TITLE
Split the predicate function to solve the resource filtering problem encountered during preemption

### DIFF
--- a/docs/design/predicate-plugin.md
+++ b/docs/design/predicate-plugin.md
@@ -1,0 +1,45 @@
+## Introduction
+
+Before scheduling and scoring, filter out the nodes that do not meet the requirements. The filter items mainly include: whether the node is available, port, stain, node affinity, container affinity, volume, container topology, idle resources, etc.
+
+## Design
+- PrePredicate  
+    It mainly corresponds to the Prefilter stage of kube-scheduler. The current filter content is:
+    - nodePort
+    - podAffinity
+    - podTopologySpread
+
+- Predicate  
+    It mainly corresponds to the Filter stage of kube-scheduler. The current filtering content is:
+    - nodeUnscheduler
+    - nodeAffinity
+    - taintToleration
+    - nodePort
+    - podAffinity
+    - nodeVolumeLimitsCSI
+    - volumeZone
+    - podTopologySpread
+
+- PredicateResource  
+    The current function is an independent function disassembled from the predicate, which is responsible for filtering the content related to the idle resources of the node, such as: the number of pods, CPU, Memory, user-defined resources, etc.
+
+    Because both allocation and preemption (preempt and reclaim) require predicate operations, if resource filtering is also processed in the predicate function, the allocation and preemption actions are incompatible, see [#2739](https://github.com /volcano-sh/volcano/issues/2739). After the disassembly process, the allocation action (allocate) judges the Predicate and PredicateResource, and the preemption action (preempt, reclaim) judges the Predicate.
+
+    Filter content mainly includes:
+    - podNumber
+    - CPU
+    - Memory
+    - ScalerResources
+
+## Recommend practice
+Configure the predicate plugin by:
+```
+  actions: "enqueue, allocate, preempt, backfill"
+  tiers:
+  - plugins:
+    - name: priority
+    - name: gang
+    - name: predicate
+      enablePredicate: false
+```
+`enablePredicate` is the switch of the predicate plug-in, the default is true, you can turn off the filtering function of the predicate plug-in according to the above method. `PrePredicate`, `Predicate` and `PredicateResource` are simultaneously controlled by the `enablePredicate` switch.

--- a/pkg/scheduler/actions/allocate/allocate.go
+++ b/pkg/scheduler/actions/allocate/allocate.go
@@ -98,11 +98,16 @@ func (alloc *Action) Execute(ssn *framework.Session) {
 	allNodes := ssn.NodeList
 	predicateFn := func(task *api.TaskInfo, node *api.NodeInfo) error {
 		// Check for Resource Predicate
-		if ok, reason := task.InitResreq.LessEqualWithReason(node.FutureIdle(), api.Zero); !ok {
-			return api.NewFitError(task, node, reason)
+		if err := ssn.PredicateResourceFn(task, node); err != nil {
+			return err
 		}
 
-		return ssn.PredicateFn(task, node)
+		// Check for predicate
+		if err := ssn.PredicateFn(task, node); err != nil {
+			return err
+		}
+
+		return nil
 	}
 
 	// To pick <namespace, queue> tuple for job, we choose to pick namespace firstly.

--- a/pkg/scheduler/api/types.go
+++ b/pkg/scheduler/api/types.go
@@ -136,6 +136,9 @@ type JobEnqueuedFn func(interface{})
 // PredicateFn is the func declaration used to predicate node for task.
 type PredicateFn func(*TaskInfo, *NodeInfo) error
 
+// PredicateResourceFn is the func declaration used to predicate node resource information for task.
+type PredicateResourceFn func(*TaskInfo, *NodeInfo) error
+
 // PrePredicateFn is the func declaration used to pre-predicate node for task.
 type PrePredicateFn func(*TaskInfo) error
 

--- a/pkg/scheduler/conf/scheduler_conf.go
+++ b/pkg/scheduler/conf/scheduler_conf.go
@@ -67,8 +67,6 @@ type PluginOption struct {
 	EnabledClusterOrder *bool `yaml:"EnabledClusterOrder"`
 	// EnabledPredicate defines whether predicateFn is enabled
 	EnabledPredicate *bool `yaml:"enablePredicate"`
-	// EnabledPredicateResource defines whether predicateResourceFn is enabled
-	EnabledPredicateResource *bool `yaml:"enablePredicateResource"`
 	// EnabledBestNode defines whether bestNodeFn is enabled
 	EnabledBestNode *bool `yaml:"enableBestNode"`
 	// EnabledNodeOrder defines whether NodeOrderFn is enabled

--- a/pkg/scheduler/conf/scheduler_conf.go
+++ b/pkg/scheduler/conf/scheduler_conf.go
@@ -63,10 +63,12 @@ type PluginOption struct {
 	EnabledReclaimable *bool `yaml:"enableReclaimable"`
 	// EnabledQueueOrder defines whether queueOrderFn is enabled
 	EnabledQueueOrder *bool `yaml:"enableQueueOrder"`
-	// EnabledPredicate defines whether predicateFn is enabled
-	EnabledClusterOrder *bool `yaml:"EnabledClusterOrder"`
 	// EnableClusterOrder defines whether clusterOrderFn is enabled
+	EnabledClusterOrder *bool `yaml:"EnabledClusterOrder"`
+	// EnabledPredicate defines whether predicateFn is enabled
 	EnabledPredicate *bool `yaml:"enablePredicate"`
+	// EnabledPredicateResource defines whether predicateResourceFn is enabled
+	EnabledPredicateResource *bool `yaml:"enablePredicateResource"`
 	// EnabledBestNode defines whether bestNodeFn is enabled
 	EnabledBestNode *bool `yaml:"enableBestNode"`
 	// EnabledNodeOrder defines whether NodeOrderFn is enabled

--- a/pkg/scheduler/framework/session.go
+++ b/pkg/scheduler/framework/session.go
@@ -72,32 +72,33 @@ type Session struct {
 	Configurations []conf.Configuration
 	NodeList       []*api.NodeInfo
 
-	plugins           map[string]Plugin
-	eventHandlers     []*EventHandler
-	jobOrderFns       map[string]api.CompareFn
-	queueOrderFns     map[string]api.CompareFn
-	taskOrderFns      map[string]api.CompareFn
-	clusterOrderFns   map[string]api.CompareFn
-	predicateFns      map[string]api.PredicateFn
-	prePredicateFns   map[string]api.PrePredicateFn
-	bestNodeFns       map[string]api.BestNodeFn
-	nodeOrderFns      map[string]api.NodeOrderFn
-	batchNodeOrderFns map[string]api.BatchNodeOrderFn
-	nodeMapFns        map[string]api.NodeMapFn
-	nodeReduceFns     map[string]api.NodeReduceFn
-	preemptableFns    map[string]api.EvictableFn
-	reclaimableFns    map[string]api.EvictableFn
-	overusedFns       map[string]api.ValidateFn
-	allocatableFns    map[string]api.AllocatableFn
-	jobReadyFns       map[string]api.ValidateFn
-	jobPipelinedFns   map[string]api.VoteFn
-	jobValidFns       map[string]api.ValidateExFn
-	jobEnqueueableFns map[string]api.VoteFn
-	jobEnqueuedFns    map[string]api.JobEnqueuedFn
-	targetJobFns      map[string]api.TargetJobFn
-	reservedNodesFns  map[string]api.ReservedNodesFn
-	victimTasksFns    map[string][]api.VictimTasksFn
-	jobStarvingFns    map[string]api.ValidateFn
+	plugins              map[string]Plugin
+	eventHandlers        []*EventHandler
+	jobOrderFns          map[string]api.CompareFn
+	queueOrderFns        map[string]api.CompareFn
+	taskOrderFns         map[string]api.CompareFn
+	clusterOrderFns      map[string]api.CompareFn
+	predicateFns         map[string]api.PredicateFn
+	predicateResourceFns map[string]api.PredicateResourceFn
+	prePredicateFns      map[string]api.PrePredicateFn
+	bestNodeFns          map[string]api.BestNodeFn
+	nodeOrderFns         map[string]api.NodeOrderFn
+	batchNodeOrderFns    map[string]api.BatchNodeOrderFn
+	nodeMapFns           map[string]api.NodeMapFn
+	nodeReduceFns        map[string]api.NodeReduceFn
+	preemptableFns       map[string]api.EvictableFn
+	reclaimableFns       map[string]api.EvictableFn
+	overusedFns          map[string]api.ValidateFn
+	allocatableFns       map[string]api.AllocatableFn
+	jobReadyFns          map[string]api.ValidateFn
+	jobPipelinedFns      map[string]api.VoteFn
+	jobValidFns          map[string]api.ValidateExFn
+	jobEnqueueableFns    map[string]api.VoteFn
+	jobEnqueuedFns       map[string]api.JobEnqueuedFn
+	targetJobFns         map[string]api.TargetJobFn
+	reservedNodesFns     map[string]api.ReservedNodesFn
+	victimTasksFns       map[string][]api.VictimTasksFn
+	jobStarvingFns       map[string]api.ValidateFn
 }
 
 func openSession(cache cache.Cache) *Session {
@@ -118,31 +119,32 @@ func openSession(cache cache.Cache) *Session {
 		RevocableNodes: map[string]*api.NodeInfo{},
 		Queues:         map[api.QueueID]*api.QueueInfo{},
 
-		plugins:           map[string]Plugin{},
-		jobOrderFns:       map[string]api.CompareFn{},
-		queueOrderFns:     map[string]api.CompareFn{},
-		taskOrderFns:      map[string]api.CompareFn{},
-		clusterOrderFns:   map[string]api.CompareFn{},
-		predicateFns:      map[string]api.PredicateFn{},
-		prePredicateFns:   map[string]api.PrePredicateFn{},
-		bestNodeFns:       map[string]api.BestNodeFn{},
-		nodeOrderFns:      map[string]api.NodeOrderFn{},
-		batchNodeOrderFns: map[string]api.BatchNodeOrderFn{},
-		nodeMapFns:        map[string]api.NodeMapFn{},
-		nodeReduceFns:     map[string]api.NodeReduceFn{},
-		preemptableFns:    map[string]api.EvictableFn{},
-		reclaimableFns:    map[string]api.EvictableFn{},
-		overusedFns:       map[string]api.ValidateFn{},
-		allocatableFns:    map[string]api.AllocatableFn{},
-		jobReadyFns:       map[string]api.ValidateFn{},
-		jobPipelinedFns:   map[string]api.VoteFn{},
-		jobValidFns:       map[string]api.ValidateExFn{},
-		jobEnqueueableFns: map[string]api.VoteFn{},
-		jobEnqueuedFns:    map[string]api.JobEnqueuedFn{},
-		targetJobFns:      map[string]api.TargetJobFn{},
-		reservedNodesFns:  map[string]api.ReservedNodesFn{},
-		victimTasksFns:    map[string][]api.VictimTasksFn{},
-		jobStarvingFns:    map[string]api.ValidateFn{},
+		plugins:              map[string]Plugin{},
+		jobOrderFns:          map[string]api.CompareFn{},
+		queueOrderFns:        map[string]api.CompareFn{},
+		taskOrderFns:         map[string]api.CompareFn{},
+		clusterOrderFns:      map[string]api.CompareFn{},
+		predicateFns:         map[string]api.PredicateFn{},
+		predicateResourceFns: map[string]api.PredicateResourceFn{},
+		prePredicateFns:      map[string]api.PrePredicateFn{},
+		bestNodeFns:          map[string]api.BestNodeFn{},
+		nodeOrderFns:         map[string]api.NodeOrderFn{},
+		batchNodeOrderFns:    map[string]api.BatchNodeOrderFn{},
+		nodeMapFns:           map[string]api.NodeMapFn{},
+		nodeReduceFns:        map[string]api.NodeReduceFn{},
+		preemptableFns:       map[string]api.EvictableFn{},
+		reclaimableFns:       map[string]api.EvictableFn{},
+		overusedFns:          map[string]api.ValidateFn{},
+		allocatableFns:       map[string]api.AllocatableFn{},
+		jobReadyFns:          map[string]api.ValidateFn{},
+		jobPipelinedFns:      map[string]api.VoteFn{},
+		jobValidFns:          map[string]api.ValidateExFn{},
+		jobEnqueueableFns:    map[string]api.VoteFn{},
+		jobEnqueuedFns:       map[string]api.JobEnqueuedFn{},
+		targetJobFns:         map[string]api.TargetJobFn{},
+		reservedNodesFns:     map[string]api.ReservedNodesFn{},
+		victimTasksFns:       map[string][]api.VictimTasksFn{},
+		jobStarvingFns:       map[string]api.ValidateFn{},
 	}
 
 	snapshot := cache.Snapshot()

--- a/pkg/scheduler/framework/session_plugins.go
+++ b/pkg/scheduler/framework/session_plugins.go
@@ -631,7 +631,7 @@ func (ssn *Session) PredicateFn(task *api.TaskInfo, node *api.NodeInfo) error {
 func (ssn *Session) PredicateResourceFn(task *api.TaskInfo, node *api.NodeInfo) error {
 	for _, tier := range ssn.Tiers {
 		for _, plugin := range tier.Plugins {
-			if !isEnabled(plugin.EnabledPredicateResource) {
+			if !isEnabled(plugin.EnabledPredicate) {
 				continue
 			}
 			pfn, found := ssn.predicateResourceFns[plugin.Name]

--- a/pkg/scheduler/plugins/extender/argument.go
+++ b/pkg/scheduler/plugins/extender/argument.go
@@ -25,6 +25,10 @@ type PredicateResponse struct {
 	ErrorMessage string `json:"errorMessage"`
 }
 
+type PredicateResourceResponse struct {
+	ErrorMessage string `json:"errorMessage"`
+}
+
 type PrioritizeRequest struct {
 	Task  *api.TaskInfo   `json:"task"`
 	Nodes []*api.NodeInfo `json:"nodes"`

--- a/pkg/scheduler/plugins/usage/usage.go
+++ b/pkg/scheduler/plugins/usage/usage.go
@@ -124,20 +124,20 @@ func (up *usagePlugin) OnSessionOpen(ssn *framework.Session) {
 		klog.V(4).Infof("Threshold arguments :%v", argsValue)
 	}
 
-	predicateFn := func(task *api.TaskInfo, node *api.NodeInfo) error {
+	predicateResourceFn := func(task *api.TaskInfo, node *api.NodeInfo) error {
 		for period, value := range up.threshold.cpuUsageAvg {
-			klog.V(4).Infof("predicateFn cpuUsageAvg:%v", up.threshold.cpuUsageAvg)
+			klog.V(4).Infof("predicateResourceFn cpuUsageAvg:%v", up.threshold.cpuUsageAvg)
 			if node.ResourceUsage.CPUUsageAvg[period] > value {
 				msg := fmt.Sprintf("Node %s cpu usage %f exceeds the threshold %f", node.Name, node.ResourceUsage.CPUUsageAvg[period], value)
-				return fmt.Errorf("plugin %s predicates failed %s", up.Name(), msg)
+				return fmt.Errorf("plugin %s predicates resource failed %s", up.Name(), msg)
 			}
 		}
 
 		for period, value := range up.threshold.memUsageAvg {
-			klog.V(4).Infof("predicateFn memUsageAvg:%v", up.threshold.memUsageAvg)
+			klog.V(4).Infof("predicateResourceFn memUsageAvg:%v", up.threshold.memUsageAvg)
 			if node.ResourceUsage.MEMUsageAvg[period] > value {
 				msg := fmt.Sprintf("Node %s mem usage %f exceeds the threshold %f", node.Name, node.ResourceUsage.MEMUsageAvg[period], value)
-				return fmt.Errorf("plugin %s memory usage predicates failed %s", up.Name(), msg)
+				return fmt.Errorf("plugin %s memory usage predicates resource failed %s", up.Name(), msg)
 			}
 		}
 		klog.V(4).Infof("Usage plugin filter for task %s/%s on node %s pass.", task.Namespace, task.Name, node.Name)
@@ -157,7 +157,7 @@ func (up *usagePlugin) OnSessionOpen(ssn *framework.Session) {
 		return score, nil
 	}
 
-	ssn.AddPredicateFn(up.Name(), predicateFn)
+	ssn.AddPredicateResourceFn(up.Name(), predicateResourceFn)
 	ssn.AddNodeOrderFn(up.Name(), nodeOrderFn)
 }
 


### PR DESCRIPTION
**Background:**
allocate, preempt, and reclaim all call the predicate to filter nodes. If the predicate has a filter condition for setting whether idle resources are satisfied, then preempt and reclaim will not be able to perform the preemption action.

**Solution:**
Split the resource-related filter conditions in the predicate into predicateResource for independent judgment. The allocate phase calls predicate and predicateResource to filter nodes, and preempt and reclaim call predicate to filter nodes.

**Notice:**
Subsequent custom plug-ins also need to comply with the above principles, and the resource filter conditions are uniformly placed in the predicateResource node for processing, otherwise the preemption function may be affected

associate: [#2739](https://github.com/volcano-sh/volcano/issues/2739)