### PR TITLE
Volcano automatically releases the corresponding helm charts package

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,6 +3,11 @@ on:
   schedule:
   # Runs at 0:00 and 12:00 UTC every day
   - cron:  '0 */12 * * *'
+  # Automatically push the image when releasing the version
+  push:
+    tags:
+      - "v*.*.*"
+
 
 jobs:
   docker:
@@ -28,6 +33,17 @@ jobs:
           fetch-depth: 0
           path: ./src/github.com/${{ github.repository }}
 
+      - name: Get tag or branch name
+        run: |
+          echo "TAG=${{ github.ref_name }}" >> $GITHUB_ENV
+          echo "RELEASE_VER=${{ github.ref_name }}" >> $GITHUB_ENV
+
+      - name: Update tag and release_ver
+        if: ${{ github.ref_name == 'master' }}
+        run: |
+          echo "TAG=latest" >> $GITHUB_ENV
+          echo "RELEASE_VER=latest" >> $GITHUB_ENV
+
       - uses: actions/cache@v2
         with:
           path: ~/go/pkg/mod
@@ -36,7 +52,7 @@ jobs:
       - name: Run verify test
         run: |
           make verify
-          make TAG=latest generate-yaml
+          make TAG=${{ env.TAG }} generate-yaml
           make verify-generated-yaml
           make unit-test
         working-directory: ./src/github.com/${{ github.repository }}
@@ -48,7 +64,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Daily Release
-        run: docker buildx create --use && make TAG=latest RELEASE_VER=latest DOCKER_USERNAME=${{ secrets.DOCKERHUB_USERNAME }} DOCKER_PASSWORD=${{ secrets.DOCKERHUB_TOKEN }} CC=/usr/local/musl/bin/musl-gcc DOCKER_PLATFORMS="linux/amd64,linux/arm64" BUILDX_OUTPUT_TYPE=registry release
+        run: docker buildx create --use && make TAG=${{ env.TAG }} RELEASE_VER=${{ env.RELEASE_VER }} DOCKER_USERNAME=${{ secrets.DOCKERHUB_USERNAME }} DOCKER_PASSWORD=${{ secrets.DOCKERHUB_TOKEN }} CC=/usr/local/musl/bin/musl-gcc DOCKER_PLATFORMS="linux/amd64,linux/arm64" BUILDX_OUTPUT_TYPE=registry release
         working-directory: ./src/github.com/${{ github.repository }}
 
       - name: Loginout DockerHub

--- a/.github/workflows/release_chart.yaml
+++ b/.github/workflows/release_chart.yaml
@@ -1,0 +1,84 @@
+name: Release Charts
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+jobs:
+  release-charts:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          repository: "${{ github.repository_owner }}/volcano"
+          path: "volcano"
+          fetch-depth: 0
+
+      - name: Checkout helm-charts
+        uses: actions/checkout@v3
+        with:
+          repository: "${{ github.repository_owner }}/helm-charts"
+          # use token for helm-charts repo
+          token: "${{ secrets.HELM_CHARTER_TOKEN }}"
+          path: "helm-charts"
+          fetch-depth: 0
+
+      - name: Get chart version
+        run: |
+          echo "chart_version=$(echo ${GITHUB_REF##*/v})" >> $GITHUB_ENV
+      
+      - name: Make charts
+        shell: bash
+        working-directory: volcano
+        run: |
+          TAG=${{ env.chart_version }} make generate-charts
+      
+      - name: Install chart-releaser
+        uses: helm/chart-releaser-action@v1.5.0
+        with:
+          install_only: true
+
+      # upload charts to helm-charts repos's release
+      - name: Upload charts
+        shell: bash
+        working-directory: volcano
+        run: |
+          cr upload -o ${{ github.repository_owner }}
+        env:
+          # GitHub repository
+          CR_GIT_REPO: "helm-charts"
+          # Path to directory with chart packages (default ".cr-release-packages")
+          CR_PACKAGE_PATH: "_output/release/chart/"
+          # use token for helm-charts repo
+          CR_TOKEN: "${{ secrets.HELM_CHARTER_TOKEN }}"
+
+      # copy artifacts to helm-charts repo, we need those for update index
+      - name: Copy artifacts
+        run: |
+          cp -r volcano/_output/ helm-charts/
+
+      - name: Configure Git
+        working-directory: helm-charts
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      # this step will directly push to the main branch, so make sure you have the right permissions
+      - name: Update index
+        working-directory: helm-charts
+        run: |
+          rm -rf index.yaml
+          rm -rf .cr-index
+          mkdir -p .cr-index
+          cr index -o ${{ github.repository_owner }} --push
+        env:
+          # GitHub repository
+          CR_GIT_REPO: "helm-charts"
+          # The GitHub pages branch (default "gh-pages")
+          CR_PAGES_BRANCH: "main"
+          # Path to directory with chart packages (default ".cr-release-packages")
+          CR_PACKAGE_PATH: "_output/release/chart/"
+          # use token for helm-charts repo
+          CR_TOKEN: "${{ secrets.HELM_CHARTER_TOKEN }}"

--- a/Makefile
+++ b/Makefile
@@ -127,6 +127,9 @@ e2e-test-stress: images
 generate-yaml: init manifests
 	./hack/generate-yaml.sh TAG=${RELEASE_VER} CRD_VERSION=${CRD_VERSION}
 
+generate-charts: init manifests
+	./hack/generate-charts.sh 
+	
 release-env:
 	./hack/build-env.sh release
 

--- a/hack/generate-charts.sh
+++ b/hack/generate-charts.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+
+#
+# Copyright 2021 The Volcano Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+VK_ROOT=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/..
+export HELM_BIN_DIR=${VK_ROOT}/${BIN_DIR}
+export RELEASE_FOLDER=${VK_ROOT}/${RELEASE_DIR}
+
+export HELM_VER=${HELM_VER:-v3.6.3}
+export VOLCANO_CHART_VERSION=${TAG:-"latest"}
+export VOLCANO_IMAGE_TAG=${VOLCANO_CHART_VERSION}
+
+LOCAL_OS=${OSTYPE}
+case $LOCAL_OS in
+  "linux"*)
+    LOCAL_OS='linux'
+    ;;
+  "darwin"*)
+    LOCAL_OS='darwin'
+    ;;
+  *)
+    echo "This system's OS ${LOCAL_OS} isn't recognized/supported"
+    exit 1
+    ;;
+esac
+
+ARCH=$(go env GOARCH)
+
+# Step1. install helm binary
+if [[ ! -f "${HELM_BIN_DIR}/version.helm.${HELM_VER}" ]] || [[ ! -f "${HELM_BIN_DIR}/helm" ]] ; then
+    TD=$(mktemp -d)
+    cd "${TD}" && \
+        curl -Lo "${TD}/helm.tgz" "https://get.helm.sh/helm-${HELM_VER}-${LOCAL_OS}-${ARCH}.tar.gz" && \
+        tar xfz helm.tgz && \
+        mv ${LOCAL_OS}-${ARCH}/helm "${HELM_BIN_DIR}/helm-${HELM_VER}" && \
+        cp "${HELM_BIN_DIR}/helm-${HELM_VER}" "${HELM_BIN_DIR}/helm" && \
+        chmod +x ${HELM_BIN_DIR}/helm
+        rm -rf "${TD}"
+
+        if [[ ! -f "${HELM_BIN_DIR}/version.helm.${HELM_VER}" ]] ; then
+          touch "${HELM_BIN_DIR}/version.helm.${HELM_VER}"
+        fi
+fi
+
+echo "generate chart"
+CHART_ORIGIN_PATH=${VK_ROOT}/installer/helm/chart
+CHART_OUT_PATH=${RELEASE_FOLDER}/chart
+cp -r "${CHART_ORIGIN_PATH}" "${CHART_OUT_PATH}"
+sed -i "s|image_tag_version: \"latest\"|image_tag_version: \"${VOLCANO_IMAGE_TAG}\"|g" $(find ${CHART_OUT_PATH} -type f | grep values.yaml)
+sed -i "s|version: 1.5|version: ${VOLCANO_CHART_VERSION}|g" $(find ${CHART_OUT_PATH} -type f | grep Chart.yaml)
+sed -i "s|appVersion: 0.1|appVersion: ${VOLCANO_CHART_VERSION}|g" $(find ${CHART_OUT_PATH} -type f | grep Chart.yaml)
+helm package "${CHART_OUT_PATH}/volcano" -d "${CHART_OUT_PATH}"
+echo "helm package end, charts is in ${CHART_OUT_PATH}"


### PR DESCRIPTION
**Description of Requirement:**

refer: [#2766](https://github.com/volcano-sh/volcano/issues/2766),

Volcano can be installed through helm at present, but you need to download the source code of the entire warehouse, the operation is relatively troublesome, and it does not conform to the standard usage of helm.

**Target:**
Build the helm repo corresponding to Volcano, and automatically publish helm charts.

Users can view the latest released packages through `helm repo update`, and install and use them through `helm install`

**accomplish:**
1. Build the charts warehouse of Volcano, see [helm-charts](https://github.com/volcano-sh/helm-charts)
2. When the Volcano main warehouse releases the tag, the release version is pushed to the helm-charts warehouse, with the charts information attached, and the repo information is updated at the same time. 
(It is automatically completed through github action without manual intervention.)
4. When the Volcano main warehouse publishes a tag, it pushes the image corresponding to the tag to dockerhub. 
(It is automatically completed through github action without manual intervention.)