### PR TITLE
Fix: the admission-init error is reported when Volcano is installed repeatedly.

### DIFF
--- a/installer/dockerfile/webhook-manager/gen-admission-secret.sh
+++ b/installer/dockerfile/webhook-manager/gen-admission-secret.sh
@@ -99,6 +99,13 @@ function createSecret() {
       -n ${NAMESPACE}
 }
 
+ret=0
+kubectl get secret ${SECRET} -n ${NAMESPACE} > /dev/null || ret=$?
+if [[ ${ret} -eq 0 ]]; then
+  echo -e "The secret ${SECRET} -n ${NAMESPACE} already exists. Do not create it again."
+  exit 0
+fi
+
 createCerts
 
 createSecret


### PR DESCRIPTION
fix: [volcano-admission-init error is reported when the volcano is uninstalled and reinstalled or the helm is used to upgrade the volcano #2833](https://github.com/volcano-sh/volcano/issues/2833)