### PR TITLE
disable the enableJobEnqueued default in scheduler-configmap

### DIFF
--- a/installer/helm/chart/volcano/config/volcano-scheduler.conf
+++ b/installer/helm/chart/volcano/config/volcano-scheduler.conf
@@ -11,5 +11,6 @@ tiers:
     enablePreemptable: false
   - name: predicates
   - name: proportion
+    enableJobEnqueued: false
   - name: nodeorder
   - name: binpack

--- a/installer/volcano-development.yaml
+++ b/installer/volcano-development.yaml
@@ -8646,6 +8646,7 @@ data:
         enablePreemptable: false
       - name: predicates
       - name: proportion
+        enableJobEnqueued: false
       - name: nodeorder
       - name: binpack
 ---
@@ -8669,7 +8670,7 @@ rules:
     verbs: ["create", "list", "watch", "update", "patch"]
   - apiGroups: [""]
     resources: ["pods", "pods/status"]
-    verbs: ["create", "get", "list", "watch", "update", "patch", "bind", "updateStatus", "delete"]
+    verbs: ["create", "get", "list", "watch", "update", "patch", "bind", "delete"]
   - apiGroups: [""]
     resources: ["pods/binding"]
     verbs: ["create"]


### PR DESCRIPTION
fix #2814 
issue conclusion:
The introduction of guarantee is an allocation scenario related to elastic queues. For most user scenarios, it is not a rigidly needed function. We can add the following configuration to the default configuration of the trunk. The guarantee capability is disabled by default. If users need it, they can manually enable it.

found a useless verb `updateStatus`,delete it .