### PR TITLE
Automatically clean up and install Volcano's initialization job

### DIFF
--- a/installer/helm/chart/volcano/templates/admission.yaml
+++ b/installer/helm/chart/volcano/templates/admission.yaml
@@ -154,6 +154,7 @@ metadata:
     app: volcano-admission-init
 spec:
   backoffLimit: 3
+  ttlSecondsAfterFinished: 100
   template:
     spec:
       serviceAccountName: {{ .Release.Name }}-admission

--- a/installer/volcano-development.yaml
+++ b/installer/volcano-development.yaml
@@ -178,6 +178,7 @@ metadata:
     app: volcano-admission-init
 spec:
   backoffLimit: 3
+  ttlSecondsAfterFinished: 100
   template:
     spec:
       serviceAccountName: volcano-admission


### PR DESCRIPTION
**Introduction：**
Types such as job will fail during helm upgrade, such as: [volcano-admission-init error is reported when the volcano is uninstalled and reinstalled or the helm is used to upgrade the volcano #2833](https://github.com/volcano-sh/volcano/issues/2833)

Add `ttlSecondsAfterFinished` to automatically clean up and initialize job resources, avoiding errors when upgrading Volcano through helm

**constraint：**
The default job cleaning time is 100s. If you upgrade within 100s after installing Volcano, an upgrade error will occur.