### PR TITLE
fix: Ban schedule to share gpu when usedMemory more then allMemory

### DIFF
--- a/pkg/scheduler/api/devices/nvidia/gpushare/share.go
+++ b/pkg/scheduler/api/devices/nvidia/gpushare/share.go
@@ -34,7 +34,13 @@ func getDevicesIdleGPUMemory(gs *GPUDevices) map[int]uint {
 	res := map[int]uint{}
 	for id, allMemory := range devicesAllGPUMemory {
 		if usedMemory, found := devicesUsedGPUMemory[id]; found {
-			res[id] = allMemory - usedMemory
+			// When high concurrent schedule the pods to same gpu id, if earlier k8s pod add event
+			// it will lead to usedMemory more then allMemory sometime.
+			if allMemory > usedMemory {
+				res[id] = allMemory - usedMemory
+			} else {
+				res[id] = 0
+			}
 		} else {
 			res[id] = allMemory
 		}


### PR DESCRIPTION
fix https://github.com/volcano-sh/volcano/issues/2859

When high concurrent schedule the pods to same gpu id, if earlier k8s pod add event, it will lead to usedMemory more then allMemory sometime. So res[id] = allMemory - usedMemory may be a large number. Leak all pod schedule to this gpu of node