### PR TITLE
fix task scheduling latency metrics is not accurate #2879

### DIFF
--- a/pkg/scheduler/cache/cache.go
+++ b/pkg/scheduler/cache/cache.go
@@ -804,7 +804,7 @@ func (sc *SchedulerCache) Bind(tasks []*schedulingapi.TaskInfo) error {
 			sc.resyncTask(task)
 		}
 	}
-	return nil
+	return err
 }
 
 // BindPodGroup binds job to silo cluster


### PR DESCRIPTION
fix [#2879](https://github.com/volcano-sh/volcano/issues/2879)

bind func return always is nil

modify return value nil is err

```golang
func (sc *SchedulerCache) Bind(tasks []*schedulingapi.TaskInfo) error {
	tmp := time.Now()
	errTasks, err := sc.Binder.Bind(sc.kubeClient, tasks)
	if err == nil {
		klog.V(3).Infof("bind ok, latency %v", time.Since(tmp))
		for _, task := range tasks {
			sc.Recorder.Eventf(task.Pod, v1.EventTypeNormal, "Scheduled", "Successfully assigned %v/%v to %v",
				task.Namespace, task.Name, task.NodeName)
		}
	} else {
		for _, task := range errTasks {
			klog.V(2).Infof("resyncTask task %s", task.Name)
			sc.VolumeBinder.RevertVolumes(task, task.PodVolumes)
			sc.resyncTask(task)
		}
	}
	return nil
}

```


```golang
// Bind binds task to the target host.
func (sc *SchedulerCache) Bind(tasks []*schedulingapi.TaskInfo) error {
	tmp := time.Now()
	errTasks, err := sc.Binder.Bind(sc.kubeClient, tasks)
	if err == nil {
		klog.V(3).Infof("bind ok, latency %v", time.Since(tmp))
		for _, task := range tasks {
			sc.Recorder.Eventf(task.Pod, v1.EventTypeNormal, "Scheduled", "Successfully assigned %v/%v to %v",
				task.Namespace, task.Name, task.NodeName)
		}
	} else {
		for _, task := range errTasks {
			klog.V(2).Infof("resyncTask task %s", task.Name)
			sc.VolumeBinder.RevertVolumes(task, task.PodVolumes)
			sc.resyncTask(task)
		}
	}
	return err
}

```