### PR TITLE
check kind-cluster exist or not when create it

### DIFF
--- a/hack/lib/install.sh
+++ b/hack/lib/install.sh
@@ -19,7 +19,11 @@ function kind-up-cluster {
   check-kind
 
   echo "Running kind: [kind create cluster ${CLUSTER_CONTEXT} ${KIND_OPT}]"
-  kind create cluster ${CLUSTER_CONTEXT} ${KIND_OPT}
+  echo "Kind cluster name: ${CLUSTER_NAME}"
+  kind get clusters |grep ${CLUSTER_NAME}
+  if [[ $? -ne 0 ]]; then
+    kind create cluster ${CLUSTER_CONTEXT} ${KIND_OPT}
+  fi
 
   echo
   check-images


### PR DESCRIPTION
Fix #2889 
about `ERROR: failed to create cluster: node(s) already exist for a cluster with the name "integration"`