### PR TITLE
don't need gen-code anymore in this repo's code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,6 +128,7 @@ kubernetes.tar.gz
 
 # test coverage file
 coverage.txt
+/apis/
 
 # go vendor directory
 vendor

--- a/Makefile
+++ b/Makefile
@@ -98,9 +98,6 @@ images:
 		docker buildx build -t "${IMAGE_PREFIX}/vc-$$name:$(TAG)" . -f ./installer/dockerfile/$$name/Dockerfile --output=type=${BUILDX_OUTPUT_TYPE} --platform ${DOCKER_PLATFORMS} --build-arg APK_MIRROR=${APK_MIRROR}; \
 	done
 
-generate-code:
-	./hack/update-gencode.sh
-
 # Generate manifests e.g. CRD, RBAC etc.
 manifests: controller-gen
 	go mod vendor
@@ -167,7 +164,6 @@ clean:
 
 verify:
 	hack/verify-gofmt.sh
-	hack/verify-gencode.sh
     # this verify is deprecated and use make lint-licenses instead.
 	#hack/verify-vendor-licenses.sh
 


### PR DESCRIPTION
Fix #2878, as it describes, it will generate codes in apis dir when run make verify at local env. Remove it from code becualse code-generate is move to [apis](https://github.com/volcano-sh/apis/tree/master/pkg) repo.

/kind clean-up