### PR TITLE
docs: make user more easily to build custom plugin

### DIFF
--- a/example/custom-plugin/Dockerfile
+++ b/example/custom-plugin/Dockerfile
@@ -1,0 +1,2 @@
+FROM volcanosh/vc-scheduler:latest
+COPY plugins plugins


### PR DESCRIPTION
pr change
1、image name `volcano.sh/vc-scheduler:latest` is error ,correct is volcanosh/vc-scheduler:latest
2、build magic.so output to plugins/magic.so,because Dockerfile is `COPY plugins plugins`
3、add sample Dockerfile
@zen-xu 