### PR TITLE
opt vgpu kubeclient use

### DIFF
--- a/pkg/scheduler/api/devices/nvidia/vgpu/device_info.go
+++ b/pkg/scheduler/api/devices/nvidia/vgpu/device_info.go
@@ -216,7 +216,7 @@ func (gs *GPUDevices) Allocate(kubeClient kubernetes.Interface, pod *v1.Pod) err
 
 		annotations[DeviceBindPhase] = "allocating"
 		annotations[BindTimeAnnotations] = strconv.FormatInt(time.Now().Unix(), 10)
-		err = patchPodAnnotations(pod, annotations)
+		err = patchPodAnnotations(kubeClient, pod, annotations)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
use same a `kubeclient` obj in the `Allocate` method, add `UseClient` method replease `kubeClient` init obj.

The current kubeClient object cannot be modified after initialization, and it cannot be faked well when writing unit tests.