### PR TITLE
Refactor PredicateFn for allocate and preempt actions

### DIFF
--- a/docs/design/device-sharing.md
+++ b/docs/design/device-sharing.md
@@ -26,7 +26,26 @@ type Devices interface {
 	//HasDeviceRequest checks if the 'pod' request this device
 	HasDeviceRequest(pod *v1.Pod) bool
 	//FiltreNode checks if the 'pod' fit in current node
-	FilterNode(pod *v1.Pod) (bool, error)
+	// The first return value represents the filtering result, and the value range is "0, 1, 2, 3"
+	// 0: Success
+	// Success means that plugin ran correctly and found pod schedulable.
+
+	// 1: Error
+	// Error is used for internal plugin errors, unexpected input, etc.
+
+	// 2: Unschedulable
+	// Unschedulable is used when a plugin finds a pod unschedulable. The scheduler might attempt to
+	// preempt other pods to get this pod scheduled. Use UnschedulableAndUnresolvable to make the
+	// scheduler skip preemption.
+	// The accompanying status message should explain why the pod is unschedulable.
+
+	// 3: UnschedulableAndUnresolvable
+	// UnschedulableAndUnresolvable is used when a plugin finds a pod unschedulable and
+	// preemption would not change anything. Plugins should return Unschedulable if it is possible
+	// that the pod can get scheduled with preemption.
+	// The accompanying status message should explain why the pod is unschedulable.
+	FilterNode(pod *v1.Pod) (int, string, error)
+	
 	//Allocate action in predicate
 	Allocate(kubeClient kubernetes.Interface, pod *v1.Pod) error
 	//Release action in predicate

--- a/pkg/scheduler/actions/allocate/allocate.go
+++ b/pkg/scheduler/actions/allocate/allocate.go
@@ -17,7 +17,6 @@
 package allocate
 
 import (
-	"fmt"
 	"time"
 
 	"k8s.io/klog/v2"
@@ -177,7 +176,13 @@ func (alloc *Action) Execute(ssn *framework.Session) {
 
 			klog.V(3).Infof("There are <%d> nodes for Job <%v/%v>", len(ssn.Nodes), job.Namespace, job.Name)
 
-			if err := prePredicateforAllocate(ssn, task, allNodes, job); err != nil {
+			if err := ssn.PrePredicateFn(task); err != nil {
+				klog.V(3).Infof("PrePredicate for task %s/%s failed for: %v", task.Namespace, task.Name, err)
+				fitErrors := api.NewFitErrors()
+				for _, ni := range allNodes {
+					fitErrors.SetNodeError(ni.Name, err)
+				}
+				job.NodesFitErrors[task.UID] = fitErrors
 				break
 			}
 
@@ -252,34 +257,6 @@ func (alloc *Action) Execute(ssn *framework.Session) {
 			}
 		}
 	}
-}
-
-func prePredicateforAllocate(ssn *framework.Session, task *api.TaskInfo, allNodes []*api.NodeInfo, job *api.JobInfo) error {
-	prePredicateStatus, err := ssn.PrePredicateFn(task)
-	if err != nil {
-		klog.V(3).Infof("PrePredicate for task %s/%s failed for: %v", task.Namespace, task.Name, err)
-		fitErrors := api.NewFitErrors()
-		for _, ni := range allNodes {
-			fitErrors.SetNodeError(ni.Name, err)
-		}
-		job.NodesFitErrors[task.UID] = fitErrors
-		return fmt.Errorf("PrePredicate for task %s/%s failed for: %v", task.Namespace, task.Name, err)
-	}
-
-	for _, status := range prePredicateStatus {
-		if status != nil && status.Code != api.Success {
-			klog.V(3).Infof("PrePredicate for task %s/%s failed, Code is %d, reason is  %s",
-				task.Namespace, task.Name, status.Code, status.Reason)
-			fitErrors := api.NewFitErrors()
-			err := fmt.Errorf("PrePredicate for task %s/%s, %s", task.Namespace, task.Name, status.Reason)
-			for _, ni := range allNodes {
-				fitErrors.SetNodeError(ni.Name, err)
-			}
-			job.NodesFitErrors[task.UID] = fitErrors
-			return err
-		}
-	}
-	return nil
 }
 
 func (alloc *Action) UnInitialize() {}

--- a/pkg/scheduler/actions/allocate/allocate.go
+++ b/pkg/scheduler/actions/allocate/allocate.go
@@ -105,7 +105,7 @@ func (alloc *Action) Execute(ssn *framework.Session) {
 		var statusSets util.StatusSets
 		statusSets, err := ssn.PredicateFn(task, node)
 		if err != nil {
-			return nil, fmt.Errorf("allocate predicates failed for task <%s/%s> on node <%s>: %v",
+			return nil, fmt.Errorf("predicates failed in allocate for task <%s/%s> on node <%s>: %v",
 				task.Namespace, task.Name, node.Name, err)
 		}
 
@@ -229,7 +229,7 @@ func (alloc *Action) Execute(ssn *framework.Session) {
 					metrics.UpdateE2eSchedulingLastTimeByJob(job.Name, string(job.Queue), job.Namespace, time.Now())
 				}
 			} else {
-				klog.V(3).Infof("Predicates failed for task <%s/%s> on node <%s> with limited resources",
+				klog.V(3).Infof("Predicates failed in allocate for task <%s/%s> on node <%s> with limited resources",
 					task.Namespace, task.Name, node.Name)
 
 				// Allocate releasing resource to the task if any.

--- a/pkg/scheduler/actions/backfill/backfill.go
+++ b/pkg/scheduler/actions/backfill/backfill.go
@@ -17,6 +17,7 @@ limitations under the License.
 package backfill
 
 import (
+	"fmt"
 	"time"
 
 	"k8s.io/klog/v2"
@@ -74,20 +75,20 @@ func (backfill *Action) Execute(ssn *framework.Session) {
 					// TODO (k82cn): predicates did not consider pod number for now, there'll
 					// be ping-pong case here.
 					// Only nodes whose status is success after predicate filtering can be scheduled.
-					admitStatus := map[int]struct{}{
-						api.Success: {},
-					}
-					predicateStatus, err := ssn.PredicateFn(task, node)
+					var statusSets util.StatusSets
+					statusSets, err := ssn.PredicateFn(task, node)
 					if err != nil {
 						klog.V(3).Infof("backfill predicates failed for task <%s/%s> on node <%s>: %v",
 							task.Namespace, task.Name, node.Name, err)
 						fe.SetNodeError(node.Name, err)
 						continue
 					}
-					err = util.CheckPredicateStatus(predicateStatus, admitStatus)
-					if err != nil {
-						klog.V(3).Infof("backfill predicates failed for task <%s/%s> on node <%s>: %v",
-							task.Namespace, task.Name, node.Name, err)
+
+					if statusSets.ContainsUnschedulable() || statusSets.ContainsUnschedulableAndUnresolvable() ||
+						statusSets.ContainsErrorSkipOrWait() {
+						err := fmt.Errorf("predicates failed in backfill for task <%s/%s> on node <%s>, status is not success",
+							task.Namespace, task.Name, node.Name)
+						klog.V(3).Infof("err: %v", err)
 						fe.SetNodeError(node.Name, err)
 						continue
 					}

--- a/pkg/scheduler/actions/backfill/backfill.go
+++ b/pkg/scheduler/actions/backfill/backfill.go
@@ -78,7 +78,7 @@ func (backfill *Action) Execute(ssn *framework.Session) {
 					var statusSets util.StatusSets
 					statusSets, err := ssn.PredicateFn(task, node)
 					if err != nil {
-						klog.V(3).Infof("backfill predicates failed for task <%s/%s> on node <%s>: %v",
+						klog.V(3).Infof("predicates failed in backfill for task <%s/%s> on node <%s>: %v",
 							task.Namespace, task.Name, node.Name, err)
 						fe.SetNodeError(node.Name, err)
 						continue
@@ -88,7 +88,7 @@ func (backfill *Action) Execute(ssn *framework.Session) {
 						statusSets.ContainsErrorSkipOrWait() {
 						err := fmt.Errorf("predicates failed in backfill for task <%s/%s> on node <%s>, status is not success",
 							task.Namespace, task.Name, node.Name)
-						klog.V(3).Infof("err: %v", err)
+						klog.V(3).Infof("%v", err)
 						fe.SetNodeError(node.Name, err)
 						continue
 					}

--- a/pkg/scheduler/actions/backfill/backfill.go
+++ b/pkg/scheduler/actions/backfill/backfill.go
@@ -17,6 +17,7 @@ limitations under the License.
 package backfill
 
 import (
+	"fmt"
 	"time"
 
 	"k8s.io/klog/v2"
@@ -56,26 +57,20 @@ func (backfill *Action) Execute(ssn *framework.Session) {
 		for _, task := range job.TaskStatusIndex[api.Pending] {
 			if task.InitResreq.IsEmpty() {
 				allocated := false
-				fe := api.NewFitErrors()
-
-				if err := ssn.PrePredicateFn(task); err != nil {
-					klog.V(3).Infof("PrePredicate for task %s/%s failed for: %v", task.Namespace, task.Name, err)
-					for _, ni := range ssn.Nodes {
-						fe.SetNodeError(ni.Name, err)
-					}
-					job.NodesFitErrors[task.UID] = fe
-					break
+				if err := prePredicateforBackfill(ssn, task, job); err != nil {
+					klog.V(3).Infof("backfill %s", err.Error())
+					continue
 				}
 
+				fe := api.NewFitErrors()
 				// As task did not request resources, so it only need to meet predicates.
 				// TODO (k82cn): need to prioritize nodes to avoid pod hole.
 				for _, node := range ssn.Nodes {
 					// TODO (k82cn): predicates did not consider pod number for now, there'll
 					// be ping-pong case here.
-					if err := ssn.PredicateFn(task, node); err != nil {
-						klog.V(3).Infof("Predicates failed for task <%s/%s> on node <%s>: %v",
-							task.Namespace, task.Name, node.Name, err)
-						fe.SetNodeError(node.Name, err)
+					err := predicateforBackfill(ssn, task, node, fe)
+					if err != nil {
+						klog.V(3).Infof("backfill %s", err.Error())
 						continue
 					}
 
@@ -99,6 +94,47 @@ func (backfill *Action) Execute(ssn *framework.Session) {
 			// TODO (k82cn): backfill for other case.
 		}
 	}
+}
+
+func predicateforBackfill(ssn *framework.Session, task *api.TaskInfo, node *api.NodeInfo, fe *api.FitErrors) error {
+	predicateStatus, err := ssn.PredicateFn(task, node)
+	if err != nil {
+		fe.SetNodeError(node.Name, err)
+		return fmt.Errorf("Predicates failed for task <%s/%s> on node <%s>: %v",
+			task.Namespace, task.Name, node.Name, err)
+	}
+	for _, status := range predicateStatus {
+		if status != nil && status.Code != api.Success {
+			return fmt.Errorf("Predicates failed for task <%s/%s> on node <%s>: %s",
+				task.Namespace, task.Name, node.Name, status.Reason)
+		}
+	}
+	return nil
+}
+
+func prePredicateforBackfill(ssn *framework.Session, task *api.TaskInfo, job *api.JobInfo) error {
+	prePredicateStatus, err := ssn.PrePredicateFn(task)
+	if err != nil {
+		fitErrors := api.NewFitErrors()
+		for _, ni := range ssn.Nodes {
+			fitErrors.SetNodeError(ni.Name, err)
+		}
+		job.NodesFitErrors[task.UID] = fitErrors
+		return fmt.Errorf("PrePredicate for task %s/%s failed for: %v", task.Namespace, task.Name, err)
+	}
+
+	for _, status := range prePredicateStatus {
+		if status != nil && status.Code != api.Success {
+			fitErrors := api.NewFitErrors()
+			err := fmt.Errorf("PrePredicate for task %s/%s failed, %s", task.Namespace, task.Name, status.Reason)
+			for _, ni := range ssn.Nodes {
+				fitErrors.SetNodeError(ni.Name, err)
+			}
+			job.NodesFitErrors[task.UID] = fitErrors
+			return err
+		}
+	}
+	return nil
 }
 
 func (backfill *Action) UnInitialize() {}

--- a/pkg/scheduler/actions/preempt/preempt.go
+++ b/pkg/scheduler/actions/preempt/preempt.go
@@ -204,14 +204,9 @@ func preempt(
 ) (bool, error) {
 	assigned := false
 	allNodes := ssn.NodeList
-	prePredicateStatus, err := ssn.PrePredicateFn(preemptor)
+	err := ssn.PrePredicateFn(preemptor)
 	if err != nil {
 		return false, fmt.Errorf("PrePredicate for task %s/%s failed for: %v", preemptor.Namespace, preemptor.Name, err)
-	}
-	for _, status := range prePredicateStatus {
-		if status != nil && status.Code != api.Success && status.Code != api.Unschedulable {
-			return false, fmt.Errorf("PrePredicate for task %s/%s failed, %v", preemptor.Namespace, preemptor.Name, status.Reason)
-		}
 	}
 
 	predicateFn := func(task *api.TaskInfo, node *api.NodeInfo) ([]*api.Status, error) {

--- a/pkg/scheduler/actions/reclaim/reclaim.go
+++ b/pkg/scheduler/actions/reclaim/reclaim.go
@@ -128,9 +128,16 @@ func (ra *Action) Execute(ssn *framework.Session) {
 				api.Success:       {},
 				api.Unschedulable: {},
 			}
+			predicateStatus, err := ssn.PredicateFn(task, n)
+			if err != nil {
+				klog.V(3).Infof("reclaim predicates failed for task <%s/%s> on node <%s>: %v",
+					task.Namespace, task.Name, n.Name, err)
+				continue
+			}
 			// If predicates failed, next node.
-			if err := util.PredicateForAdmitStatus(ssn, task, n, admitStatus); err != nil {
-				klog.V(3).Infof("reclaim %s", err.Error())
+			if err := util.CheckPredicateStatus(predicateStatus, admitStatus); err != nil {
+				klog.V(3).Infof("reclaim predicates failed for task <%s/%s> on node <%s>: %v",
+					task.Namespace, task.Name, n.Name, err)
 				continue
 			}
 

--- a/pkg/scheduler/actions/reclaim/reclaim.go
+++ b/pkg/scheduler/actions/reclaim/reclaim.go
@@ -118,8 +118,8 @@ func (ra *Action) Execute(ssn *framework.Session) {
 			continue
 		}
 
-		if err := prePredicateforReclaim(ssn, task); err != nil {
-			klog.V(3).Infof("reclaim %s", err.Error())
+		if err := ssn.PrePredicateFn(task); err != nil {
+			klog.V(3).Infof("PrePredicate for task %s/%s failed for: %v", task.Namespace, task.Name, err)
 			continue
 		}
 
@@ -220,20 +220,6 @@ func predicateforReclaim(ssn *framework.Session, task *api.TaskInfo, n *api.Node
 		if status != nil && status.Code != api.Success && status.Code != api.Unschedulable {
 			return fmt.Errorf("Predicates failed for task <%s/%s> on node <%s>: %v",
 				task.Namespace, task.Name, n.Name, status.Reason)
-		}
-	}
-	return nil
-}
-
-func prePredicateforReclaim(ssn *framework.Session, task *api.TaskInfo) error {
-	prePredicateStatus, err := ssn.PrePredicateFn(task)
-	if err != nil {
-		return fmt.Errorf("PrePredicate for task %s/%s failed for: %v", task.Namespace, task.Name, err)
-	}
-
-	for _, status := range prePredicateStatus {
-		if status != nil && status.Code != api.Success && status.Code != api.Unschedulable {
-			return fmt.Errorf("PrePredicate for task %s/%s failed, %v", task.Namespace, task.Name, status.Reason)
 		}
 	}
 	return nil

--- a/pkg/scheduler/api/devices/util.go
+++ b/pkg/scheduler/api/devices/util.go
@@ -1,0 +1,38 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package devices
+
+// These are predefined codes used in a Status.
+const (
+	// Success means that plugin ran correctly and found pod schedulable.
+	// NOTE: A nil status is also considered as "Success".
+	Success int = iota
+	// Error is used for internal plugin errors, unexpected input, etc.
+	Error
+	// Unschedulable is used when a plugin finds a pod unschedulable. The scheduler might attempt to
+	// preempt other pods to get this pod scheduled. Use UnschedulableAndUnresolvable to make the
+	// scheduler skip preemption.
+	// The accompanying status message should explain why the pod is unschedulable.
+	Unschedulable
+	// UnschedulableAndUnresolvable is used when a plugin finds a pod unschedulable and
+	// preemption would not change anything. Plugins should return Unschedulable if it is possible
+	// that the pod can get scheduled with preemption.
+	// The accompanying status message should explain why the pod is unschedulable.
+	UnschedulableAndUnresolvable
+	// Wait is used when a Permit plugin finds a pod scheduling should wait.
+	Wait
+	// Skip is used when a Bind plugin chooses to skip binding.
+	Skip
+)

--- a/pkg/scheduler/api/shared_device_pool.go
+++ b/pkg/scheduler/api/shared_device_pool.go
@@ -39,7 +39,25 @@ type Devices interface {
 	//HasDeviceRequest checks if the 'pod' request this device
 	HasDeviceRequest(pod *v1.Pod) bool
 	//FiltreNode checks if the 'pod' fit in current node
-	FilterNode(pod *v1.Pod) (bool, error)
+	// The first return value represents the filtering result, and the value range is "0, 1, 2, 3"
+	// 0: Success
+	// Success means that plugin ran correctly and found pod schedulable.
+
+	// 1: Error
+	// Error is used for internal plugin errors, unexpected input, etc.
+
+	// 2: Unschedulable
+	// Unschedulable is used when a plugin finds a pod unschedulable. The scheduler might attempt to
+	// preempt other pods to get this pod scheduled. Use UnschedulableAndUnresolvable to make the
+	// scheduler skip preemption.
+	// The accompanying status message should explain why the pod is unschedulable.
+
+	// 3: UnschedulableAndUnresolvable
+	// UnschedulableAndUnresolvable is used when a plugin finds a pod unschedulable and
+	// preemption would not change anything. Plugins should return Unschedulable if it is possible
+	// that the pod can get scheduled with preemption.
+	// The accompanying status message should explain why the pod is unschedulable.
+	FilterNode(pod *v1.Pod) (int, string, error)
 	//Allocate action in predicate
 	Allocate(kubeClient kubernetes.Interface, pod *v1.Pod) error
 	//Release action in predicate

--- a/pkg/scheduler/api/types.go
+++ b/pkg/scheduler/api/types.go
@@ -165,7 +165,7 @@ type JobEnqueuedFn func(interface{})
 type PredicateFn func(*TaskInfo, *NodeInfo) ([]*Status, error)
 
 // PrePredicateFn is the func declaration used to pre-predicate node for task.
-type PrePredicateFn func(*TaskInfo) ([]*Status, error)
+type PrePredicateFn func(*TaskInfo) error
 
 // BestNodeFn is the func declaration used to return the nodeScores to plugins.
 type BestNodeFn func(*TaskInfo, map[float64][]*NodeInfo) *NodeInfo

--- a/pkg/scheduler/framework/session_plugins.go
+++ b/pkg/scheduler/framework/session_plugins.go
@@ -623,8 +623,7 @@ func (ssn *Session) PredicateFn(task *api.TaskInfo, node *api.NodeInfo) ([]*api.
 }
 
 // PrePredicateFn invoke predicate function of the plugins
-func (ssn *Session) PrePredicateFn(task *api.TaskInfo) ([]*api.Status, error) {
-	prePredicateStatus := make([]*api.Status, 0)
+func (ssn *Session) PrePredicateFn(task *api.TaskInfo) error {
 	for _, tier := range ssn.Tiers {
 		for _, plugin := range tier.Plugins {
 			// we use same option as predicates for they are
@@ -635,14 +634,13 @@ func (ssn *Session) PrePredicateFn(task *api.TaskInfo) ([]*api.Status, error) {
 			if !found {
 				continue
 			}
-			status, err := pfn(task)
-			prePredicateStatus = append(prePredicateStatus, status...)
+			err := pfn(task)
 			if err != nil {
-				return prePredicateStatus, err
+				return err
 			}
 		}
 	}
-	return prePredicateStatus, nil
+	return nil
 }
 
 // BestNodeFn invoke bestNode function of the plugins

--- a/pkg/scheduler/framework/util.go
+++ b/pkg/scheduler/framework/util.go
@@ -266,7 +266,7 @@ func (nl *NodeLister) List() ([]*v1.Node, error) {
 	return nodes, nil
 }
 
-// The state of the k8s prefile is converted to the internal state of the volcano
+// ConvertPredicateStatus return predicate status from k8sframework status
 func ConvertPredicateStatus(status *k8sframework.Status) (*api.Status, error) {
 	internalStatus := &api.Status{}
 	if status.Code() == k8sframework.Success {

--- a/pkg/scheduler/plugins/extender/argument.go
+++ b/pkg/scheduler/plugins/extender/argument.go
@@ -22,7 +22,7 @@ type PredicateRequest struct {
 }
 
 type PredicateResponse struct {
-	ErrorMessage string `json:"errorMessage"`
+	Status []*api.Status `json:"status"`
 }
 
 type PrioritizeRequest struct {

--- a/pkg/scheduler/plugins/extender/extender.go
+++ b/pkg/scheduler/plugins/extender/extender.go
@@ -161,22 +161,20 @@ func (ep *extenderPlugin) OnSessionOpen(ssn *framework.Session) {
 	}
 
 	if ep.config.predicateVerb != "" {
-		ssn.AddPredicateFn(ep.Name(), func(task *api.TaskInfo, node *api.NodeInfo) error {
+		ssn.AddPredicateFn(ep.Name(), func(task *api.TaskInfo, node *api.NodeInfo) ([]*api.Status, error) {
 			resp := &PredicateResponse{}
 			err := ep.send(ep.config.predicateVerb, &PredicateRequest{Task: task, Node: node}, resp)
 			if err != nil {
 				klog.Warningf("Predicate failed with error %v", err)
 
 				if ep.config.ignorable {
-					return nil
+					return nil, nil
 				}
-				return err
+				return nil, err
 			}
 
-			if resp.ErrorMessage == "" {
-				return nil
-			}
-			return errors.New(resp.ErrorMessage)
+			predicateStatus := resp.Status
+			return predicateStatus, nil
 		})
 	}
 

--- a/pkg/scheduler/plugins/predicates/predicates.go
+++ b/pkg/scheduler/plugins/predicates/predicates.go
@@ -351,7 +351,8 @@ func (pp *predicatesPlugin) OnSessionOpen(ssn *framework.Session) {
 
 	state := k8sframework.NewCycleState()
 
-	ssn.AddPrePredicateFn(pp.Name(), func(task *api.TaskInfo) error {
+	ssn.AddPrePredicateFn(pp.Name(), func(task *api.TaskInfo) ([]*api.Status, error) {
+		prePredicateStatus := make([]*api.Status, 0)
 		// Check NodePorts
 		if predicate.nodePortEnable {
 			nodePortFilter.PreFilter(context.TODO(), state, task.Pod)
@@ -369,8 +370,10 @@ func (pp *predicatesPlugin) OnSessionOpen(ssn *framework.Session) {
 		// the processing logic needs to be added to the return value result.
 		if predicate.podAffinityEnable {
 			_, status := podAffinityFilter.PreFilter(context.TODO(), state, task.Pod)
-			if !status.IsSuccess() {
-				return fmt.Errorf("plugin %s pre-predicates failed %s", interpodaffinity.Name, status.Message())
+			podAffinityStatus, err := framework.ConvertPredicateStatus(status)
+			prePredicateStatus = append(prePredicateStatus, podAffinityStatus)
+			if err != nil {
+				return prePredicateStatus, fmt.Errorf("plugin %s pre-predicates failed %s", interpodaffinity.Name, status.Message())
 			}
 		}
 
@@ -386,58 +389,74 @@ func (pp *predicatesPlugin) OnSessionOpen(ssn *framework.Session) {
 		// the processing logic needs to be added to the return value result.
 		if predicate.podTopologySpreadEnable {
 			_, status := podTopologySpreadFilter.PreFilter(context.TODO(), state, task.Pod)
-			if !status.IsSuccess() {
-				return fmt.Errorf("plugin %s pre-predicates failed %s", podTopologySpreadFilter.Name(), status.Message())
+			podTopologyStatus, err := framework.ConvertPredicateStatus(status)
+			prePredicateStatus = append(prePredicateStatus, podTopologyStatus)
+			if err != nil {
+				return prePredicateStatus, fmt.Errorf("plugin %s pre-predicates failed %s", podTopologySpreadFilter.Name(), status.Message())
 			}
 		}
-		return nil
+		return prePredicateStatus, nil
 	})
 
-	ssn.AddPredicateFn(pp.Name(), func(task *api.TaskInfo, node *api.NodeInfo) error {
+	ssn.AddPredicateFn(pp.Name(), func(task *api.TaskInfo, node *api.NodeInfo) ([]*api.Status, error) {
+		predicateStatus := make([]*api.Status, 0)
 		nodeInfo, found := nodeMap[node.Name]
 		if !found {
-			return fmt.Errorf("failed to predicates, node info for %s not found", node.Name)
+			return predicateStatus, fmt.Errorf("failed to predicates, node info for %s not found", node.Name)
 		}
 
 		if node.Allocatable.MaxTaskNum <= len(nodeInfo.Pods) {
 			klog.V(4).Infof("NodePodNumber predicates Task <%s/%s> on Node <%s> failed",
 				task.Namespace, task.Name, node.Name)
-			return api.NewFitError(task, node, api.NodePodNumberExceeded)
+			podsNumStatus := &api.Status{
+				Code: api.Unschedulable,
+				Reason: fmt.Sprintf("Task <%s/%s> on Node <%s> failed, reason: %s",
+					task.Namespace, task.Name, node.Name, api.NodePodNumberExceeded),
+			}
+			predicateStatus = append(predicateStatus, podsNumStatus)
 		}
 
-		predicateByStablefilter := func(pod *v1.Pod, nodeInfo *k8sframework.NodeInfo) (bool, error) {
+		predicateByStablefilter := func(pod *v1.Pod, nodeInfo *k8sframework.NodeInfo) ([]*api.Status, bool, error) {
 			// CheckNodeUnschedulable
+			predicateStatus := make([]*api.Status, 0)
 			status := nodeUnscheduleFilter.Filter(context.TODO(), state, task.Pod, nodeInfo)
-			if !status.IsSuccess() {
-				return false, fmt.Errorf("plugin %s predicates failed %s", nodeunschedulable.Name, status.Message())
+			nodeUnscheduleStatus, err := framework.ConvertPredicateStatus(status)
+			predicateStatus = append(predicateStatus, nodeUnscheduleStatus)
+			if err != nil {
+				return predicateStatus, false, fmt.Errorf("plugin %s predicates failed %s", nodeunschedulable.Name, status.Message())
 			}
 
 			// Check NodeAffinity
 			if predicate.nodeAffinityEnable {
 				status := nodeAffinityFilter.Filter(context.TODO(), state, task.Pod, nodeInfo)
-				if !status.IsSuccess() {
-					return false, fmt.Errorf("plugin %s predicates failed %s", nodeaffinity.Name, status.Message())
+				nodeAffinityStatus, err := framework.ConvertPredicateStatus(status)
+				predicateStatus = append(predicateStatus, nodeAffinityStatus)
+				if err != nil {
+					return predicateStatus, false, fmt.Errorf("plugin %s predicates failed %s", nodeaffinity.Name, status.Message())
 				}
 			}
 
 			// PodToleratesNodeTaints: TaintToleration
 			if predicate.taintTolerationEnable {
 				status := tolerationFilter.Filter(context.TODO(), state, task.Pod, nodeInfo)
-				if !status.IsSuccess() {
-					return false, fmt.Errorf("plugin %s predicates failed %s", tainttoleration.Name, status.Message())
+				tolerationStatus, err := framework.ConvertPredicateStatus(status)
+				predicateStatus = append(predicateStatus, tolerationStatus)
+				if err != nil {
+					return predicateStatus, false, fmt.Errorf("plugin %s predicates failed %s", tainttoleration.Name, status.Message())
 				}
 			}
 
-			return true, nil
+			return predicateStatus, true, nil
 		}
 
 		// Check PredicateWithCache
 		var err error
 		var fit bool
+		predicateCacheStatus := make([]*api.Status, 0)
 		if predicate.cacheEnable {
 			fit, err = pCache.PredicateWithCache(node.Name, task.Pod)
 			if err != nil {
-				fit, err = predicateByStablefilter(task.Pod, nodeInfo)
+				predicateCacheStatus, fit, err = predicateByStablefilter(task.Pod, nodeInfo)
 				pCache.UpdateCache(node.Name, task.Pod, fit)
 			} else {
 				if !fit {
@@ -445,58 +464,74 @@ func (pp *predicatesPlugin) OnSessionOpen(ssn *framework.Session) {
 				}
 			}
 		} else {
-			fit, err = predicateByStablefilter(task.Pod, nodeInfo)
+			predicateCacheStatus, fit, err = predicateByStablefilter(task.Pod, nodeInfo)
 		}
 
+		predicateStatus = append(predicateStatus, predicateCacheStatus...)
 		if !fit {
-			return err
+			return predicateStatus, err
 		}
 
 		// Check NodePort
 		if predicate.nodePortEnable {
 			status := nodePortFilter.Filter(context.TODO(), state, nil, nodeInfo)
-			if !status.IsSuccess() {
-				return fmt.Errorf("plugin %s predicates failed %s", nodeports.Name, status.Message())
+			nodePortStatus, err := framework.ConvertPredicateStatus(status)
+			predicateStatus = append(predicateStatus, nodePortStatus)
+			if err != nil {
+				return predicateStatus, fmt.Errorf("plugin %s predicates failed %s", nodeports.Name, status.Message())
 			}
 		}
 
 		// Check PodAffinity
 		if predicate.podAffinityEnable {
 			status := podAffinityFilter.Filter(context.TODO(), state, task.Pod, nodeInfo)
-			if !status.IsSuccess() {
-				return fmt.Errorf("plugin %s predicates failed %s", interpodaffinity.Name, status.Message())
+			podAffinityStatus, err := framework.ConvertPredicateStatus(status)
+			predicateStatus = append(predicateStatus, podAffinityStatus)
+			if err != nil {
+				return predicateStatus, fmt.Errorf("plugin %s predicates failed %s", interpodaffinity.Name, status.Message())
 			}
 		}
 
 		// Check NodeVolumeLimits
 		if predicate.nodeVolumeLimitsEnable {
 			status := nodeVolumeLimitsCSIFilter.Filter(context.TODO(), state, task.Pod, nodeInfo)
-			if !status.IsSuccess() {
-				return fmt.Errorf("plugin %s predicates failed %s", nodeVolumeLimitsCSIFilter.Name(), status.Message())
+			nodeVolumeStatus, err := framework.ConvertPredicateStatus(status)
+			predicateStatus = append(predicateStatus, nodeVolumeStatus)
+			if err != nil {
+				return predicateStatus, fmt.Errorf("plugin %s predicates failed %s", nodeVolumeLimitsCSIFilter.Name(), status.Message())
 			}
 		}
 
 		// Check VolumeZone
 		if predicate.volumeZoneEnable {
 			status := volumeZoneFilter.Filter(context.TODO(), state, task.Pod, nodeInfo)
-			if !status.IsSuccess() {
-				return fmt.Errorf("plugin %s predicates failed %s", volumeZoneFilter.Name(), status.Message())
+			volumeZoneStatus, err := framework.ConvertPredicateStatus(status)
+			predicateStatus = append(predicateStatus, volumeZoneStatus)
+			if err != nil {
+				return predicateStatus, fmt.Errorf("plugin %s predicates failed %s", volumeZoneFilter.Name(), status.Message())
 			}
 		}
 
 		// Check PodTopologySpread
 		if predicate.podTopologySpreadEnable {
 			status := podTopologySpreadFilter.Filter(context.TODO(), state, task.Pod, nodeInfo)
-			if !status.IsSuccess() {
-				return fmt.Errorf("plugin %s predicates failed %s", podTopologySpreadFilter.Name(), status.Message())
+			podTopologyStatus, err := framework.ConvertPredicateStatus(status)
+			predicateStatus = append(predicateStatus, podTopologyStatus)
+			if err != nil {
+				return predicateStatus, fmt.Errorf("plugin %s predicates failed %s", podTopologySpreadFilter.Name(), status.Message())
 			}
 		}
 
 		for _, val := range api.RegisteredDevices {
 			if devices, ok := node.Others[val].(api.Devices); ok {
-				fit, err = devices.FilterNode(task.Pod)
+				code, msg, err := devices.FilterNode(task.Pod)
+				filterNodeStatus := &api.Status{
+					Code:   code,
+					Reason: msg,
+				}
+				predicateStatus = append(predicateStatus, filterNodeStatus)
 				if err != nil {
-					return err
+					return predicateStatus, err
 				}
 			} else {
 				klog.Warningf("Devices %s assertion conversion failed, skip", val)
@@ -508,14 +543,15 @@ func (pp *predicatesPlugin) OnSessionOpen(ssn *framework.Session) {
 
 		if predicate.proportionalEnable {
 			// Check ProportionalPredicate
-			fit, err := checkNodeResourceIsProportional(task, node, predicate.proportional)
+			proportionalStatus, err := checkNodeResourceIsProportional(task, node, predicate.proportional)
+			predicateStatus = append(predicateStatus, proportionalStatus)
 			if err != nil {
-				return err
+				return predicateStatus, err
 			}
 			klog.V(4).Infof("checkNodeResourceIsProportional predicates Task <%s/%s> on Node <%s>: fit %v",
 				task.Namespace, task.Name, node.Name, fit)
 		}
-		return nil
+		return predicateStatus, nil
 	})
 }
 

--- a/pkg/scheduler/plugins/predicates/proportional_test.go
+++ b/pkg/scheduler/plugins/predicates/proportional_test.go
@@ -45,7 +45,7 @@ func Test_checkNodeResourceIsProportional(t *testing.T) {
 	tests := []struct {
 		name    string
 		args    args
-		want    bool
+		want    int
 		wantErr bool
 	}{
 		{
@@ -55,7 +55,7 @@ func Test_checkNodeResourceIsProportional(t *testing.T) {
 				node:         n1,
 				proportional: proportional,
 			},
-			true,
+			api.Success,
 			false,
 		},
 		{
@@ -65,7 +65,7 @@ func Test_checkNodeResourceIsProportional(t *testing.T) {
 				node:         n1,
 				proportional: proportional,
 			},
-			false,
+			api.Unschedulable,
 			true,
 		},
 		{
@@ -75,7 +75,7 @@ func Test_checkNodeResourceIsProportional(t *testing.T) {
 				node:         n1,
 				proportional: proportional,
 			},
-			true,
+			api.Success,
 			false,
 		},
 		{
@@ -85,7 +85,7 @@ func Test_checkNodeResourceIsProportional(t *testing.T) {
 				node:         n2,
 				proportional: proportional,
 			},
-			true,
+			api.Success,
 			false,
 		},
 	}
@@ -96,7 +96,7 @@ func Test_checkNodeResourceIsProportional(t *testing.T) {
 				t.Errorf("checkNodeResourceIsProportional() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if got != tt.want {
+			if got.Code != tt.want {
 				t.Errorf("checkNodeResourceIsProportional() got = %v, want %v", got, tt.want)
 			}
 		})

--- a/pkg/scheduler/plugins/tdm/tdm_test.go
+++ b/pkg/scheduler/plugins/tdm/tdm_test.go
@@ -288,7 +288,18 @@ func Test_TDM(t *testing.T) {
 
 					predicatedNode := make([]*api.NodeInfo, 0)
 					for _, node := range ssn.Nodes {
-						if err := ssn.PredicateFn(task, node); err != nil {
+						predicateStatus, err := ssn.PredicateFn(task, node)
+						if err != nil {
+							continue
+						}
+						predicateIsSuccess := true
+						for _, status := range predicateStatus {
+							if status != nil && status.Code != api.Success {
+								predicateIsSuccess = false
+								break
+							}
+						}
+						if predicateIsSuccess == false {
 							continue
 						}
 						predicatedNode = append(predicatedNode, node)

--- a/pkg/scheduler/util/predicate_helper.go
+++ b/pkg/scheduler/util/predicate_helper.go
@@ -108,12 +108,6 @@ func NewPredicateHelper() PredicateHelper {
 	return &predicateHelper{taskPredicateErrorCache: map[string]map[string]error{}}
 }
 
-type PredicateStatus interface {
-	IsContainsUnschedulable() bool
-	IsContainsUnschedulableAndUnresolvable() bool
-	IsContainsErrorSkipOrWait() bool
-}
-
 type StatusSets []*api.Status
 
 func (s StatusSets) ContainsUnschedulable() bool {

--- a/pkg/scheduler/util/predicate_helper.go
+++ b/pkg/scheduler/util/predicate_helper.go
@@ -10,6 +10,7 @@ import (
 	"k8s.io/klog/v2"
 
 	"volcano.sh/volcano/pkg/scheduler/api"
+	"volcano.sh/volcano/pkg/scheduler/framework"
 )
 
 type PredicateHelper interface {
@@ -98,6 +99,24 @@ func (ph *predicateHelper) PredicateNodes(task *api.TaskInfo, nodes []*api.NodeI
 	lastProcessedNodeIndex = (lastProcessedNodeIndex + int(processedNodes)) % allNodes
 	predicateNodes = predicateNodes[:numFoundNodes]
 	return predicateNodes, fe
+}
+
+func PredicateForAdmitStatus(ssn *framework.Session, task *api.TaskInfo, n *api.NodeInfo, admitStatus map[int]struct{}) error {
+	predicateStatus, err := ssn.PredicateFn(task, n)
+	if err != nil {
+		return fmt.Errorf("Predicates failed for task <%s/%s> on node <%s>: %v",
+			task.Namespace, task.Name, n.Name, err)
+	}
+	for _, status := range predicateStatus {
+		if status == nil {
+			continue
+		}
+		if _, ok := admitStatus[status.Code]; !ok {
+			return fmt.Errorf("Predicates failed for task <%s/%s> on node <%s>: %v",
+				task.Namespace, task.Name, n.Name, status.Reason)
+		}
+	}
+	return nil
 }
 
 func taskGroupID(task *api.TaskInfo) string {

--- a/pkg/scheduler/util/predicate_helper.go
+++ b/pkg/scheduler/util/predicate_helper.go
@@ -70,7 +70,7 @@ func (ph *predicateHelper) PredicateNodes(task *api.TaskInfo, nodes []*api.NodeI
 		}
 
 		// TODO (k82cn): Enable eCache for performance improvement.
-		if err := fn(task, node); err != nil {
+		if _, err := fn(task, node); err != nil {
 			klog.V(3).Infof("Predicates failed for task <%s/%s> on node <%s>: %v",
 				task.Namespace, task.Name, node.Name, err)
 			errorLock.Lock()


### PR DESCRIPTION
fix: [#2739](https://github.com/volcano-sh/volcano/issues/2739)

## Problem phenomenon:
Related issue: [Reclaim is not working with GPUSharingEnable if resource used is volcano.sh/gpu-memory #2739](https://github.com/volcano-sh/volcano/issues/2739)

Submit low-priority jobs to occupy all the GPU resources of the cluster, and submit high-priority jobs to request GPU resources.
- **Expectation:** High-priority jobs trigger preemption and run successfully, while some low-priority jobs are evicted and become pending;
- **Actual result:** The high-priority job does not trigger the preemption action and remains in the pending state;

## problem causes:
The scheduling process requires advanced node filtering and then optimization. The corresponding processes in Volcano are predicate and nodeorder, and preemption also needs to go through these two stages. In the predicate stage, each plug-in will be called to implement predicateFn to filter nodes. If a plug-in judges that the node does not meet the scheduling requirements and returns an error, the node will be filtered out.

When vgpu's predicateFn (FilterNode) performs node filtering judgment, it judges the remaining gpu resources of the node. If the remaining resources do not meet the pod scheduling, an error will be reported. This implementation is reasonable for allocate, but in preempt scenarios, judgment The logic of whether a pod can be scheduled to a node is whether the full resources of the node can satisfy pod scheduling, not the remaining resources, which causes this problem.

## Extended troubleshooting for similar issues:
In addition to the above-mentioned problems in the vgpu resource, check the implementation of other resources and plug-ins, and find that similar problems exist in many places, for example: the predicate-plugin has an upper limit on the number of pods supported by the filtering node node; it is compatible with kube-scheduler-related Filter functions Filtering logic, node port, pod affinity, node volume, pod topology spread, etc. all have similar problems, and it is necessary to provide a general solution to fix the above problems.

## Fix:
### Solution 1: 

Split the predicate function, and classify the resources that can be preempted and the resources that cannot be preempted. The details are as follows:

1. The predicateResourceFn function is added, and the logical judgment of dynamically changing (preemptible) resources is unified in the function processing, including: remaining resources of gpu, remaining schedulable pod quantity of node, ports supported by node, volume, pod topology spread, usage, etc.
1. The original predicateFn function handles node immutable (non-preemptive) resources, such as: taint toleration, node affinity, volume zone, numaaware, etc.
1. The allocate and backfile phases execute predicateFn and predicateResourceFn, which are unchanged from the original logic
1. Preempt and reclaim execute predicatFn, and when the node is filtered, it is judged that the node is immutable resource, so the above problem can be solved

**The pr corresponding to this program:**  [Split the predicate function to solve the resource filtering problem encountered during preemption #2818](https://github.com/volcano-sh/volcano/pull/2818)

### shortcoming:
Splitting the predicate function requires exposing too many filtering functions, the semantic distinction is not clear enough, and it is difficult for development and users to understand and maintain

### Solution 2: 

Extend the return value type of the predicate and add the Status type, indicating that after the node is filtered, scheduling, preemption is allowed, or preemption is not allowed. The details are as follows:

1. Add status, the status value is Success, Error, Unschedulable, UnschedulableAndUnresolvable, Wait, Skip, etc. (refer to and be compatible with the processing mode of Filter in kube-scheduler)
1. Micro-refactor the predicate function in each plug-in, allowing to return Unschedulable when preempted resources are insufficient, and returning UnschedulableAndUnresolvable when preempted resources are not allowed.
1. `allocate` and `backfill` accept nodes whose predicate status is Success, and `preempt` and `reclaim` accept nodes whose predicate status is Success and Unschedulable.

**This scheme corresponds to pr:** [Predicate adapts allocate and preempt #2916](https://github.com/volcano-sh/volcano/pull/2916)

### advantage:
1. No need to add a new predicate interface, all filtering logic is completed in one function, and the logic processing is more elegant
1. Compatible with kube-scheduler plug-in filter capabilities, more convenient to expand

## After comprehensive consideration, `Solution 2` is more suitable