### PR TITLE
Let the make manifest work properly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -157,7 +157,6 @@ clean:
 verify:
 	hack/verify-gofmt.sh
 	hack/verify-gencode.sh
-	hack/verify-vendor.sh
 	hack/verify-vendor-licenses.sh
 
 lint: ## Lint the files

--- a/Makefile
+++ b/Makefile
@@ -102,6 +102,7 @@ generate-code:
 
 # Generate manifests e.g. CRD, RBAC etc.
 manifests: controller-gen
+	go mod vendor
 	$(CONTROLLER_GEN) $(CRD_OPTIONS) paths="./vendor/volcano.sh/apis/pkg/apis/scheduling/v1beta1;./vendor/volcano.sh/apis/pkg/apis/batch/v1alpha1;./vendor/volcano.sh/apis/pkg/apis/bus/v1alpha1;./vendor/volcano.sh/apis/pkg/apis/nodeinfo/v1alpha1/;./vendor/volcano.sh/apis/pkg/apis/flow/v1alpha1" output:crd:artifacts:config=config/crd/bases
 	$(CONTROLLER_GEN) "crd:crdVersions=v1beta1" paths="./vendor/volcano.sh/apis/pkg/apis/scheduling/v1beta1;./vendor/volcano.sh/apis/pkg/apis/batch/v1alpha1;./vendor/volcano.sh/apis/pkg/apis/bus/v1alpha1;./vendor/volcano.sh/apis/pkg/apis/flow/v1alpha1;./vendor/volcano.sh/apis/pkg/apis/nodeinfo/v1alpha1" output:crd:artifacts:config=config/crd/v1beta1
 

--- a/hack/generate-groups.sh
+++ b/hack/generate-groups.sh
@@ -46,8 +46,12 @@ APIS_PKG="$3"
 GROUPS_WITH_VERSIONS="$4"
 shift 4
 
-GO111MODULE=off go get k8s.io/code-generator/cmd/{defaulter-gen,client-gen,lister-gen,informer-gen,deepcopy-gen,conversion-gen}
-
+(
+  # To support running this script from anywhere, first cd into this directory,
+  # and then install with forced module mode on and fully qualified name.
+  cd "$(dirname "${0}")"
+  GO111MODULE=on go install k8s.io/code-generator/cmd/{defaulter-gen,client-gen,lister-gen,informer-gen,deepcopy-gen}
+)
 # Go installs the above commands to get installed in $GOBIN if defined, and $GOPATH/bin otherwise:
 GOBIN="$(go env GOBIN)"
 gobin="${GOBIN:-$(go env GOPATH)/bin}"
@@ -67,7 +71,7 @@ done
 
 if [ "${GENS}" = "all" ] || grep -qw "deepcopy" <<<"${GENS}"; then
   echo "Generating deepcopy funcs"
-  "${gobin}/deepcopy-gen" --input-dirs "$(codegen::join , "${FQ_APIS[@]}")" -O zz_generated.deepcopy --bounding-dirs "${APIS_PKG}" "$@"
+  "${gobin}/deepcopy-gen" --input-dirs "$(codegen::join , "${FQ_APIS[@]}")" -O zz_generated.deepcopy "$@"
 fi
 
 if [ "${GENS}" = "all" ] || grep -qw "client" <<<"${GENS}"; then

--- a/hack/update-gencode.sh
+++ b/hack/update-gencode.sh
@@ -26,12 +26,12 @@ SCRIPT_ROOT=$(unset CDPATH && cd $(dirname "${BASH_SOURCE[0]}")/.. && pwd)
 # --output-base    because this script should also be able to run inside the vendor dir of
 #                  k8s.io/kubernetes. The output-base is needed for the generators to output into the vendor dir
 #                  instead of the $GOPATH directly. For normal projects this can be dropped.
-bash vendor/k8s.io/code-generator/generate-groups.sh "deepcopy,client,informer,lister" \
+bash hack/generate-groups.sh "deepcopy,client,informer,lister" \
   volcano.sh/apis/pkg/client volcano.sh/apis/pkg/apis \
   "batch:v1alpha1 bus:v1alpha1 scheduling:v1beta1" \
   --go-header-file ${SCRIPT_ROOT}/hack/boilerplate/boilerplate.go.txt
 
-bash vendor/k8s.io/code-generator/generate-internal-groups.sh "deepcopy,conversion" \
+bash hack/generate-internal-groups.sh "deepcopy,conversion" \
   volcano.sh/apis/pkg/apis/ volcano.sh/apis/pkg/apis volcano.sh/apis/pkg/apis\
   "scheduling:v1beta1"   \
   --output-base "$(dirname "${BASH_SOURCE[0]}")/../../.." \


### PR DESCRIPTION
[Remove vendor #2863](https://github.com/volcano-sh/volcano/pull/2863) cleans up the vendor directory in the code warehouse, but some scripts in the CI project depend on part of the content in the local vendor. After the pr is merged, the CI operation fails.

The current pr fixes the problem of CI running failure:
1. When the make manifest is executed, the advanced go mod vendor builds locally. The current method may not be the optimal solution, but it can ensure the normal operation of CI first, and then consider the optimization of the make manifest
2. The generate-code check uses the script in the hack directory
3. verify-vendor.sh