### PR TITLE
fix: task-topology plugin cannot handle the tasks whose name contains `-`

### DIFF
--- a/pkg/scheduler/plugins/task-topology/topology.go
+++ b/pkg/scheduler/plugins/task-topology/topology.go
@@ -247,10 +247,15 @@ func affinityCheck(job *api.JobInfo, affinity [][]string) error {
 
 	var taskNumber = len(job.Tasks)
 	var taskRef = make(map[string]bool, taskNumber)
+	var jobNamePrefix = job.Name + "-"
 	for _, task := range job.Tasks {
-		tmpStrings := strings.Split(task.Name, "-")
-		if _, exist := taskRef[tmpStrings[len(tmpStrings)-2]]; !exist {
-			taskRef[tmpStrings[len(tmpStrings)-2]] = true
+		// the full task name looks like "${job name}-${task name}-${index}",
+		// so we can trim the jobNamePrefix and the indexSuffix to get the short task name.
+		tmpTaskName := task.Name[:strings.LastIndex(task.Name, "-")]
+		tmpTaskName = strings.TrimPrefix(tmpTaskName, jobNamePrefix)
+
+		if _, exist := taskRef[tmpTaskName]; !exist {
+			taskRef[tmpTaskName] = true
 		}
 	}
 

--- a/pkg/scheduler/plugins/task-topology/topology_test.go
+++ b/pkg/scheduler/plugins/task-topology/topology_test.go
@@ -101,6 +101,72 @@ func Test_readTopologyFromPgAnnotations(t *testing.T) {
 			err: nil,
 		},
 		{
+			description: "correct annotation with tasks whose names contain `-`",
+			job: &api.JobInfo{
+				Name:      "job1",
+				Namespace: "default",
+				Tasks: map[api.TaskID]*api.TaskInfo{
+					"0": {
+						Name: "job1-ps-some-0",
+					},
+					"1": {
+						Name: "job1-ps-some-1",
+					},
+					"2": {
+						Name: "job1-worker-another-some-0",
+					},
+					"3": {
+						Name: "job1-worker-another-some-1",
+					},
+					"4": {
+						Name: "job1-chief-kk-0",
+					},
+					"5": {
+						Name: "job1-evaluator-tt-0",
+					},
+				},
+				PodGroup: &api.PodGroup{
+					PodGroup: scheduling.PodGroup{
+						ObjectMeta: metav1.ObjectMeta{
+							Annotations: map[string]string{
+								JobAffinityAnnotations:     "ps-some,worker-another-some;ps-some,chief-kk",
+								JobAntiAffinityAnnotations: "ps-some;worker-another-some,chief-kk",
+								TaskOrderAnnotations:       "ps-some,worker-another-some,chief-kk,evaluator-tt",
+							},
+						},
+					},
+				},
+			},
+			topology: &TaskTopology{
+				Affinity: [][]string{
+					{
+						"ps-some",
+						"worker-another-some",
+					},
+					{
+						"ps-some",
+						"chief-kk",
+					},
+				},
+				AntiAffinity: [][]string{
+					{
+						"ps-some",
+					},
+					{
+						"worker-another-some",
+						"chief-kk",
+					},
+				},
+				TaskOrder: []string{
+					"ps-some",
+					"worker-another-some",
+					"chief-kk",
+					"evaluator-tt",
+				},
+			},
+			err: nil,
+		},
+		{
 			description: "nil annotation",
 			job: &api.JobInfo{
 				PodGroup: &api.PodGroup{


### PR DESCRIPTION
fix #2939 