### PR TITLE
Support Basic/Bearer Authorization for prometheus metrics query

### DIFF
--- a/docs/design/usage-based-scheduling.md
+++ b/docs/design/usage-based-scheduling.md
@@ -60,6 +60,10 @@ metrics:                               # metrics server related configuration
   type: prometheus                     # Optional, The metrics source type, prometheus by default, support prometheus and elasticsearch
   address: http://192.168.0.10:9090    # Mandatory, The metrics source address
   interval: 30s                        # Optional, The scheduler pull metrics from Prometheus with this interval, 5s by default
+  username: ""                         # Optional, The basic auth username for prometheus client
+  password: ""                         # Optional, The basic auth password for prometheus client
+  bearertoken: ""                      # Optional, The bearer auth token for prometheus client
+  bearertokenfile: ""                  # Optional, The bearer auth token file for prometheus client
   tls:                                 # Optional, The tls configuration
     insecureSkipVerify: "false"        # Optional, Skip the certificate verification, false by default
   elasticsearch:                       # Optional, The elasticsearch configuration

--- a/pkg/scheduler/metrics/source/metrics_client_prometheus.go
+++ b/pkg/scheduler/metrics/source/metrics_client_prometheus.go
@@ -64,6 +64,9 @@ func (p *PrometheusMetricsClient) NodeMetricsAvg(ctx context.Context, nodeName s
 		BearerToken:     p.conf["bearertoken"],
 		BearerTokenFile: p.conf["bearertokenfile"],
 	}
+	if tConf.HasBasicAuth() {
+		tConf.BearerToken, tConf.BearerTokenFile = "", ""
+	}
 	if tr, err = transport.HTTPWrappersForConfig(tConf, tr); err != nil {
 		klog.Errorf("Error while wrap http round tripper with error: %v\n", err)
 		return nil, err

--- a/pkg/scheduler/metrics/source/metrics_client_prometheus_test.go
+++ b/pkg/scheduler/metrics/source/metrics_client_prometheus_test.go
@@ -1,0 +1,48 @@
+package source
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+const (
+	basicAuthUser   = "username"
+	basicAuthPwd    = "password"
+	bearerAuthToken = "bearertoken"
+)
+
+func TestPrometheusMetricsClient_NodeMetricsAvg(t *testing.T) {
+	testServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		if strings.HasPrefix(req.URL.Path, "/basic-auth") {
+			userName, password, ok := req.BasicAuth()
+			if !ok || userName != basicAuthUser || password != basicAuthPwd {
+				t.Errorf("basic auth missmatch, ok: %v, userName: %v, password: %v", ok, userName, password)
+				res.WriteHeader(http.StatusUnauthorized)
+			}
+
+		} else if strings.HasPrefix(req.URL.Path, "/token-auth") {
+			if auth := req.Header.Get("Authorization"); auth != "Bearer "+bearerAuthToken {
+				t.Errorf("bearer token missmatch, token: %s", auth)
+				res.WriteHeader(http.StatusUnauthorized)
+			}
+		}
+		res.Write([]byte(`{"status":"success","data":{"resultType":"vector","result":[]}}`))
+		res.WriteHeader(http.StatusOK)
+	}))
+	defer testServer.Close()
+	// test basic auth
+	conf := map[string]string{"username": basicAuthUser, "password": basicAuthPwd}
+	metricsClient, _ := NewPrometheusMetricsClient(testServer.URL+"/basic-auth", conf)
+	if _, err := metricsClient.NodeMetricsAvg(context.TODO(), "node-name", "5m"); err != nil {
+		t.Errorf("Get Node Metric Avg with basic auth err %v", err)
+	}
+	// test token auth
+	conf = map[string]string{"bearertoken": bearerAuthToken}
+	metricsClient, _ = NewPrometheusMetricsClient(testServer.URL+"/token-auth", conf)
+	if _, err := metricsClient.NodeMetricsAvg(context.TODO(), "node-name", "5m"); err != nil {
+		t.Errorf("Get Node Metric Avg with token auth err %v", err)
+	}
+}


### PR DESCRIPTION
For security reasons, Prometheus generally adds some permission verification, such as Basic Authorization, Bearer Authorization. Someone may have encountered similar problems, so I support this feature.