### PR TITLE
when Volcano is uninstalled, two resources will remain

### DIFF
--- a/cmd/controller-manager/app/server.go
+++ b/cmd/controller-manager/app/server.go
@@ -84,7 +84,7 @@ func Run(opt *options.ServerOption) error {
 	// add a uniquifier so that two processes on the same host don't accidentally both become active
 	id := hostname + "_" + string(uuid.NewUUID())
 
-	rl, err := resourcelock.New(resourcelock.ConfigMapsLeasesResourceLock,
+	rl, err := resourcelock.New(resourcelock.LeasesResourceLock,
 		opt.LockObjectNamespace,
 		"vc-controller-manager",
 		leaderElectionClient.CoreV1(),

--- a/cmd/scheduler/app/server.go
+++ b/cmd/scheduler/app/server.go
@@ -125,7 +125,7 @@ func Run(opt *options.ServerOption) error {
 	// add a uniquifier so that two processes on the same host don't accidentally both become active
 	id := hostname + "_" + string(uuid.NewUUID())
 
-	rl, err := resourcelock.New(resourcelock.ConfigMapsLeasesResourceLock,
+	rl, err := resourcelock.New(resourcelock.LeasesResourceLock,
 		opt.LockObjectNamespace,
 		commonutil.GenerateComponentName(opt.SchedulerNames),
 		leaderElectionClient.CoreV1(),


### PR DESCRIPTION
this PR  is releated to  https://github.com/volcano-sh/volcano/issues/2979
change resourcelock.New(resourcelock.ConfigMapsLeasesResourceLock to resourcelock.New(resourcelock.LeasesResourceLock

Why is this needed:
it will use fewer resource

beofore this PR

kubectl get cm -A
kube-system vc-controller-manager 0 171d
kube-system volcano 0 171d
kubectl get leases -A
kube-system vc-controller-manager volcano-controller-6bdcc5ccdf-qt7sx_0aeaadca-4c71-4cc3-945b-19a06db5e6b1 171d
kube-system volcano volcano-scheduler-1_5d9b01e2-01c5-4d85-ab48-9f931ec77efc 171d

after this PR
only left leases
kubectl get leases -A
kube-system vc-controller-manager volcano-controller-6bdcc5ccdf-qt7sx_0aeaadca-4c71-4cc3-945b-19a06db5e6b1 171d
kube-system volcano volcano-scheduler-1_5d9b01e2-01c5-4d85-ab48-9f931ec77efc 171d