### PR TITLE
Fix: the pod pipeline status is incompatible with autoscaler capacity expansion

### DIFF
--- a/pkg/scheduler/api/job_info.go
+++ b/pkg/scheduler/api/job_info.go
@@ -653,13 +653,13 @@ func (ji *JobInfo) TaskSchedulingReason(tid TaskID) (reason string, msg string) 
 
 	msg = ji.JobFitErrors
 	switch status := ctx.Status; status {
-	case Allocated, Pipelined:
+	case Allocated:
 		// Pod is schedulable
 		msg = fmt.Sprintf("Pod %s/%s can possibly be assigned to %s", taskInfo.Namespace, taskInfo.Name, ctx.NodeName)
-		if status == Pipelined {
-			msg += " once resource is released"
-		}
 		return PodReasonSchedulable, msg
+	case Pipelined:
+		msg = fmt.Sprintf("Pod %s/%s can possibly be assigned to %s, once resource is released", taskInfo.Namespace, taskInfo.Name, ctx.NodeName)
+		return PodReasonUnschedulable, msg
 	case Pending:
 		if fe := ji.NodesFitErrors[tid]; fe != nil {
 			// Pod is not schedulable


### PR DESCRIPTION
fix: [Scale-out cannot be triggered by autoscaler for pods in the pipeline state #3000](https://github.com/volcano-sh/volcano/issues/3000)

If a terminating pod exists in a cluster, the pod queues up and waits for the terminating pod to release resources. Then the scheduling is successful. In the current scheduling period, pods in the pipeline state fail to be scheduled. Therefore, it is more appropriate to set the reason of pod status to Unschedulable.