### PR TITLE
[cherry-pick for release-1.8] Fix: the task pipeline status is incompatible with cluster autoscaler

### DIFF
--- a/pkg/scheduler/api/job_info.go
+++ b/pkg/scheduler/api/job_info.go
@@ -653,13 +653,13 @@ func (ji *JobInfo) TaskSchedulingReason(tid TaskID) (reason string, msg string) 
 
 	msg = ji.JobFitErrors
 	switch status := ctx.Status; status {
-	case Allocated, Pipelined:
+	case Allocated:
 		// Pod is schedulable
 		msg = fmt.Sprintf("Pod %s/%s can possibly be assigned to %s", taskInfo.Namespace, taskInfo.Name, ctx.NodeName)
-		if status == Pipelined {
-			msg += " once resource is released"
-		}
 		return PodReasonSchedulable, msg
+	case Pipelined:
+		msg = fmt.Sprintf("Pod %s/%s can possibly be assigned to %s, once resource is released", taskInfo.Namespace, taskInfo.Name, ctx.NodeName)
+		return PodReasonUnschedulable, msg
 	case Pending:
 		if fe := ji.NodesFitErrors[tid]; fe != nil {
 			// Pod is not schedulable


### PR DESCRIPTION
cherry pick pr for release-1.8：[Fix: the pod pipeline status is incompatible with autoscaler capacity expansion #3001](https://github.com/volcano-sh/volcano/pull/3001)