### PR TITLE
make adpative percentage nodes to find be consistent with kube-scheduler

### DIFF
--- a/cmd/scheduler/app/options/options.go
+++ b/cmd/scheduler/app/options/options.go
@@ -40,7 +40,7 @@ const (
 	// Default parameters to control the number of feasible nodes to find and score
 	defaultMinPercentageOfNodesToFind = 5
 	defaultMinNodesToFind             = 100
-	defaultPercentageOfNodesToFind    = 100
+	defaultPercentageOfNodesToFind    = 0
 	defaultLockObjectNamespace        = "volcano-system"
 )
 


### PR DESCRIPTION
kube-scheduler perform tuning design: https://kubernetes.io/docs/concepts/scheduling-eviction/scheduler-perf-tuning/

This pr

1. keep main logic of percentage of nodes to find with kube-scheduler, and set `minimum-percentage-nodes-to-find` param default to `0` to make volcano set adaptivePercentage node num to find.
2. Add ut.