### PR TITLE
Enrich job ready and job pipelined logs

### DIFF
--- a/case/fuck_volcano.sh
+++ b/case/fuck_volcano.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+podUID=""
+pgName=""
+queueName=""
+
+## get object
+get_object() {
+    podName=$1
+    ns=$2
+    podUID=$(kubectl get pod $podName -n $2 -o jsonpath='{.metadata.uid}')
+    echo "taskid:"$podUID
+
+    pgName=$(kubectl get pod $podName -n $2 -o jsonpath='{.metadata.annotations.scheduling\.k8s\.io/group-name}')
+    echo "pg:"$pgName
+
+    queueName=$(kubectl get podgroup $pgName -n $2 -o jsonpath='{.spec.queue}')
+    echo "queue:"$queueName
+    echo "###################"
+}
+
+get_object $1 $2
+
+get_one_session() {
+  tac v.log | awk '/Close Session/, /Open Session/'| awk '{print} /Open Session/ {exit}' > output.txt
+  tac output.txt >  output2.txt
+}
+
+check_enqueue() {
+    q=$1
+    filename=$2
+    grep 'Reject job enqueue, the queue resource quota limit has reached after add job' $filename
+    awk -v qq="$q" '/queue <'"$q"'> is meet/ { print; getline; if ($0 ~ "The attributes of queue <'"${q//\"}"'>") print }' $filename
+    echo "###################"
+}
+
+check_allocate() {
+    v1=$1
+    v2=$2
+    filename=$3
+    grep -P "Try to allocate resource to \d+ tasks of Job <$v1/$v2>" $filename
+    grep -F "Failed to bind Task $podUID" $filename
+    echo "###################"
+}
+
+
+get_one_session
+check_enqueue $queueName output2.txt
+check_allocate $2 $pgName  output2.txt

--- a/pkg/scheduler/api/job_info.go
+++ b/pkg/scheduler/api/job_info.go
@@ -849,9 +849,23 @@ func (ji *JobInfo) ValidTaskNum() int32 {
 func (ji *JobInfo) Ready() bool {
 	occupied := ji.ReadyTaskNum()
 
-	return occupied >= ji.MinAvailable
+	if occupied < ji.MinAvailable {
+		klog.V(4).Infof("Job %s/%s not Ready, because ready num(%d) less than MinAvailable(%d)", ji.Namespace, ji.Name, occupied, ji.MinAvailable)
+		return false
+	}
+	return true
 }
 
+// Pipelined returns whether job is Pipelined for run
+func (ji *JobInfo) Pipelined() bool {
+	occupied := ji.WaitingTaskNum() + ji.ReadyTaskNum()
+
+	if occupied < ji.MinAvailable {
+		klog.V(4).Infof("Job %s/%s not Pipelined, because Pipeline num(%d) less than MinAvailable(%d)", ji.Namespace, ji.Name, occupied, ji.MinAvailable)
+		return false
+	}
+	return true
+}
 // IsPending returns whether job is in pending status
 func (ji *JobInfo) IsPending() bool {
 	return ji.PodGroup == nil ||

--- a/pkg/scheduler/plugins/gang/gang.go
+++ b/pkg/scheduler/plugins/gang/gang.go
@@ -144,8 +144,7 @@ func (gp *gangPlugin) OnSessionOpen(ssn *framework.Session) {
 
 	pipelinedFn := func(obj interface{}) int {
 		ji := obj.(*api.JobInfo)
-		occupied := ji.WaitingTaskNum() + ji.ReadyTaskNum()
-		if ji.CheckTaskPipelined() && occupied >= ji.MinAvailable {
+		if ji.CheckTaskPipelined() && ji.Pipelined(){
 			return util.Permit
 		}
 		return util.Reject

--- a/pkg/scheduler/plugins/tdm/tdm.go
+++ b/pkg/scheduler/plugins/tdm/tdm.go
@@ -279,8 +279,7 @@ func (tp *tdmPlugin) OnSessionOpen(ssn *framework.Session) {
 
 	jobPipelinedFn := func(obj interface{}) int {
 		jobInfo := obj.(*api.JobInfo)
-		occupied := jobInfo.WaitingTaskNum() + jobInfo.ReadyTaskNum()
-		if occupied >= jobInfo.MinAvailable {
+		if jobInfo.Pipelined() {
 			return tutil.Permit
 		}
 		return tutil.Reject


### PR DESCRIPTION
When troubleshooting an issue, I encountered a job scheduling failure, and eventually, I found that it was due to job pipelined failed. However, the investigation process took too much time because the logging was not comprehensive. I believe that enriching relevant logs, especially during job ready and job pipelined failures, can be helpful. Therefore, I propose adding more detailed logs for these failure scenarios.