### PR TITLE
Enhance usage plugin

### DIFF
--- a/pkg/scheduler/cache/cache.go
+++ b/pkg/scheduler/cache/cache.go
@@ -1303,7 +1303,7 @@ func (sc *SchedulerCache) GetMetricsData() {
 	}
 	sc.Mutex.Unlock()
 
-	supportedPeriods := []string{"5m"}
+	supportedPeriods := []string{source.Period}
 	for node := range nodeUsageMap {
 		for _, period := range supportedPeriods {
 			nodeMetrics, err := client.NodeMetricsAvg(ctx, node, period)

--- a/pkg/scheduler/metrics/source/metrics_client_prometheus.go
+++ b/pkg/scheduler/metrics/source/metrics_client_prometheus.go
@@ -47,6 +47,7 @@ func NewPrometheusMetricsClient(address string, conf map[string]string) (*Promet
 	return &PrometheusMetricsClient{address: address, conf: conf}, nil
 }
 
+var Period string
 func (p *PrometheusMetricsClient) NodeMetricsAvg(ctx context.Context, nodeName string, period string) (*NodeMetrics, error) {
 	klog.V(4).Infof("Get node metrics from Prometheus: %s", p.address)
 	var client api.Client
@@ -66,10 +67,11 @@ func (p *PrometheusMetricsClient) NodeMetricsAvg(ctx context.Context, nodeName s
 	}
 	v1api := prometheusv1.NewAPI(client)
 	nodeMetrics := &NodeMetrics{}
-	for _, metric := range []string{promCPUUsageAvg, promMemUsageAvg} {
-		queryStr := fmt.Sprintf("%s_%s{instance=\"%s\"}", metric, period, nodeName)
-		klog.V(4).Infof("Query prometheus by %s", queryStr)
-		res, warnings, err := v1api.Query(ctx, queryStr, time.Now())
+	cpuQueryStr := fmt.Sprintf("avg_over_time((100 - (avg by (instance) (irate(node_cpu_seconds_total{mode=\"idle\",instance=\"%s\"}[30s])) * 100))[%s:30s])", nodeName, period)
+	memQueryStr := fmt.Sprintf("100*avg_over_time(((1-node_memory_MemAvailable_bytes{instance=\"%s\"}/node_memory_MemTotal_bytes{instance=\"%s\"}))[%s:30s])", nodeName, nodeName, period)
+
+	for _, metric := range []string{cpuQueryStr, memQueryStr} {
+		res, warnings, err := v1api.Query(ctx, metric, time.Now())
 		if err != nil {
 			klog.Errorf("Error querying Prometheus: %v", err)
 		}
@@ -77,7 +79,7 @@ func (p *PrometheusMetricsClient) NodeMetricsAvg(ctx context.Context, nodeName s
 			klog.V(3).Infof("Warning querying Prometheus: %v", warnings)
 		}
 		if res == nil || res.String() == "" {
-			klog.Warningf("Warning querying Prometheus: no data found for %s", queryStr)
+			klog.Warningf("Warning querying Prometheus: no data found for %s", metric)
 			continue
 		}
 		// plugin.usage only need type pmodel.ValVector in Prometheus.rulues
@@ -89,10 +91,10 @@ func (p *PrometheusMetricsClient) NodeMetricsAvg(ctx context.Context, nodeName s
 		rowValues := strings.Split(strings.TrimSpace(firstRowValVector), "=>")
 		value := strings.Split(strings.TrimSpace(rowValues[1]), " ")
 		switch metric {
-		case promCPUUsageAvg:
+		case cpuQueryStr:
 			cpuUsage, _ := strconv.ParseFloat(value[0], 64)
 			nodeMetrics.CPU = cpuUsage
-		case promMemUsageAvg:
+		case memQueryStr:
 			memUsage, _ := strconv.ParseFloat(value[0], 64)
 			nodeMetrics.Memory = memUsage
 		}


### PR DESCRIPTION
solve https://github.com/volcano-sh/volcano/issues/3042

First optimize the usage plugin configuration of Volcano.
before that

 - name: usage
   arguments:
      thresholds:
        CPUUsageAvg.5m: 80
        MEMUsageAvg.5m: 90

after that

    name: usage
    arguments:
    usage.weight: 10
    type: average
    thresholds:
    cpu: 70
    mem: 70
    period: 10m

Second, make it easier for users to use the usage plugin
before
You must first define the rules of Pro, as follows

groups:

    name: cpu_mem_usage_active
    interval: 30s
    rules:
        record: mem_usage_active
        expr: 100*(1-node_memory_MemAvailable_bytes/node_memory_MemTotal_bytes)
    name: cpu-usage-1m
    interval: 1m
    rules:
        record: cpu_usage_avg_5m
        expr: 100 - (avg by (instance) (irate(node_cpu_seconds_total{mode="idle"}[5m])) * 100)
    name: mem-usage-1m
    interval: 1m
    rules:
        record: mem_usage_avg_5m
        expr: avg_over_time(mem_usage_active[5m])

after that
You don't need to define general rules, you can use the usage plugin directly