### PR TITLE
fix calculations of podgroup min resource

### DIFF
--- a/pkg/controllers/job/job_controller_util.go
+++ b/pkg/controllers/job/job_controller_util.go
@@ -18,11 +18,13 @@ package job
 
 import (
 	"fmt"
+	"sort"
 	"strconv"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	quotav1 "k8s.io/apiserver/pkg/quota/v1"
 	"k8s.io/klog/v2"
 
 	batch "volcano.sh/apis/pkg/apis/batch/v1alpha1"
@@ -31,6 +33,7 @@ import (
 	schedulingv2 "volcano.sh/apis/pkg/apis/scheduling/v1beta1"
 	"volcano.sh/volcano/pkg/controllers/apis"
 	jobhelpers "volcano.sh/volcano/pkg/controllers/job/helpers"
+	"volcano.sh/volcano/pkg/controllers/util"
 )
 
 // MakePodName append podname,jobname,taskName and index and returns the string.
@@ -258,4 +261,66 @@ func isControlledBy(obj metav1.Object, gvk schema.GroupVersionKind) bool {
 		return true
 	}
 	return false
+}
+
+// CalcPGMinResources sums up all task's min available; if not enough, then fill up to jobMinAvailable via task's replicas
+func (p TasksPriority) CalcPGMinResources(jobMinAvailable int32) v1.ResourceList {
+	sort.Sort(p)
+	minReq := v1.ResourceList{}
+	podCnt := int32(0)
+
+	// 1. first sum up those tasks whose MinAvailable is set
+	for _, task := range p {
+		if task.MinAvailable == nil { // actually, all task's min available is set by webhook
+			continue
+		}
+
+		validReplics := *task.MinAvailable
+		if left := jobMinAvailable - podCnt; left < validReplics {
+			validReplics = left
+		}
+		minReq = quotav1.Add(minReq, calTaskRequests(&v1.Pod{Spec: task.Template.Spec}, validReplics))
+		podCnt += validReplics
+		if podCnt >= jobMinAvailable {
+			break
+		}
+	}
+
+	if podCnt >= jobMinAvailable {
+		return minReq
+	}
+
+	// 2. fill up the count of pod to jobMinAvailable with tasks whose replicas is not used up, higher priority first
+	leftCnt := jobMinAvailable - podCnt
+	for _, task := range p {
+		left := task.Replicas
+		if task.MinAvailable != nil {
+			if *task.MinAvailable == task.Replicas {
+				continue
+			} else {
+				left = task.Replicas - *task.MinAvailable
+			}
+		}
+
+		if leftCnt >= left {
+			minReq = quotav1.Add(minReq, calTaskRequests(&v1.Pod{Spec: task.Template.Spec}, left))
+			leftCnt -= left
+		} else {
+			minReq = quotav1.Add(minReq, calTaskRequests(&v1.Pod{Spec: task.Template.Spec}, leftCnt))
+			leftCnt = 0
+		}
+		if leftCnt <= 0 {
+			break
+		}
+	}
+	return minReq
+}
+
+// calTaskRequests returns requests resource with validReplica replicas
+func calTaskRequests(pod *v1.Pod, validReplica int32) v1.ResourceList {
+	minReq := v1.ResourceList{}
+	for i := int32(0); i < validReplica; i++ {
+		minReq = quotav1.Add(minReq, *util.GetPodQuotaUsage(pod))
+	}
+	return minReq
 }

--- a/pkg/scheduler/api/job_info.go
+++ b/pkg/scheduler/api/job_info.go
@@ -390,12 +390,7 @@ func (ji *JobInfo) SetPodGroup(pg *PodGroup) {
 	ji.RevocableZone = ji.extractRevocableZone(pg)
 	ji.Budget = ji.extractBudget(pg)
 
-	taskMinAvailableTotal := int32(0)
-	for task, member := range pg.Spec.MinTaskMember {
-		ji.TaskMinAvailable[TaskID(task)] = member
-		taskMinAvailableTotal += member
-	}
-	ji.TaskMinAvailableTotal = taskMinAvailableTotal
+	ji.ParseMinMemberInfo(pg)
 
 	ji.PgUID = pg.UID
 	ji.PodGroup = pg
@@ -481,6 +476,18 @@ func (ji *JobInfo) extractBudget(pg *PodGroup) *DisruptionBudget {
 	}
 
 	return NewDisruptionBudget("", "")
+}
+
+// ParseMinMemberInfo set the information about job's min member
+// 1. set number of each role to TaskMinAvailable
+// 2. calculate sum of all roles' min members and set to TaskMinAvailableTotal
+func (ji *JobInfo) ParseMinMemberInfo(pg *PodGroup) {
+	taskMinAvailableTotal := int32(0)
+	for task, member := range pg.Spec.MinTaskMember {
+		ji.TaskMinAvailable[TaskID(task)] = member
+		taskMinAvailableTotal += member
+	}
+	ji.TaskMinAvailableTotal = taskMinAvailableTotal
 }
 
 // GetMinResources return the min resources of podgroup.


### PR DESCRIPTION
commit 1: refact jobinfo's calculation to a function.
commit 2: fix cal podgroup min resource and add testcase. relative design docs: [docs about job's min resource #2945](https://github.com/volcano-sh/volcano/pull/2945)
commit 3: when jobMinAvailable < totalTask's, keep the origin logic of calculate podgorup minResource: sum up first jobMinAvailable

Fix https://github.com/volcano-sh/volcano/issues/2921 also.