### PR TITLE
update slack channel link and add Join slack link

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,6 @@ Resources:
 
 If you have any question, feel free to reach out to us in the following ways:
 
-[Volcano Slack Channel](https://volcano-sh.slack.com)
+[Volcano Slack Channel](https://cloud-native.slack.com/archives/C011GJDQS0N) | [Join](https://slack.cncf.io/)
 
 [Mailing List](https://groups.google.com/forum/#!forum/volcano-sh)


### PR DESCRIPTION
The volcano slack channel link volcano-sh.slack.com is out of date. This PR is to update and add joinning link

Fixes: https://github.com/volcano-sh/volcano/issues/3058