### PR TITLE
Jobinfo enhancement

### DIFF
--- a/pkg/scheduler/api/job_info.go
+++ b/pkg/scheduler/api/job_info.go
@@ -485,10 +485,11 @@ func (ji *JobInfo) GetMinResources() *Resource {
 }
 
 func (ji *JobInfo) GetElasticResources() *Resource {
-	if ji.Allocated.LessEqualPartly(ji.GetMinResources(), Zero) {
+	minResource := ji.GetMinResources()
+	if ji.Allocated.LessEqualPartly(minResource, Zero) {
 		return EmptyResource()
 	}
-	return ji.Allocated.Clone().Sub(ji.GetMinResources())
+	return ji.Allocated.Clone().Sub(minResource)
 }
 
 func (ji *JobInfo) addTaskIndex(ti *TaskInfo) {

--- a/pkg/scheduler/plugins/overcommit/overcommit.go
+++ b/pkg/scheduler/plugins/overcommit/overcommit.go
@@ -101,8 +101,7 @@ func (op *overcommitPlugin) OnSessionOpen(ssn *framework.Session) {
 		if job.PodGroup.Status.Phase == scheduling.PodGroupRunning &&
 			job.PodGroup.Spec.MinResources != nil &&
 			int32(util.CalculateAllocatedTaskNum(job)) >= job.PodGroup.Spec.MinMember {
-			allocated := util.GetAllocatedResource(job)
-			inqueued := util.GetInqueueResource(job, allocated)
+			inqueued := util.GetInqueueResource(job, job.Allocated)
 			op.inqueueResource.Add(inqueued)
 		}
 	}

--- a/pkg/scheduler/plugins/proportion/proportion.go
+++ b/pkg/scheduler/plugins/proportion/proportion.go
@@ -151,8 +151,7 @@ func (pp *proportionPlugin) OnSessionOpen(ssn *framework.Session) {
 		if job.PodGroup.Status.Phase == scheduling.PodGroupRunning &&
 			job.PodGroup.Spec.MinResources != nil &&
 			int32(util.CalculateAllocatedTaskNum(job)) >= job.PodGroup.Spec.MinMember {
-			allocated := util.GetAllocatedResource(job)
-			inqueued := util.GetInqueueResource(job, allocated)
+			inqueued := util.GetInqueueResource(job, job.Allocated)
 			attr.inqueue.Add(inqueued)
 		}
 		attr.elastic.Add(job.GetElasticResources())


### PR DESCRIPTION
commit 1: get job min resource function: reduce function call to only once.
commit 2: fix #3061 (job's allocated does not need to re-calculate)