### PR TITLE
feat:add printing of MemStats in dumpall

### DIFF
--- a/pkg/scheduler/cache/dumper.go
+++ b/pkg/scheduler/cache/dumper.go
@@ -19,6 +19,7 @@ package cache
 import (
 	"os"
 	"os/signal"
+	"runtime"
 	"strings"
 	"syscall"
 
@@ -45,6 +46,14 @@ func (d *Dumper) dumpAll() {
 	for _, jobInfo := range snapshot.Jobs {
 		klog.Info(d.printJobInfo(jobInfo))
 	}
+
+	d.displaySchedulerMemStats()
+}
+
+func (d *Dumper) displaySchedulerMemStats() {
+	var m runtime.MemStats
+	runtime.ReadMemStats(&m)
+	klog.Infof("volcano scheduler memory stat: %+v\n", m)
 }
 
 func (d *Dumper) printNodeInfo(node *api.NodeInfo) string {


### PR DESCRIPTION
Add SchedulerMemStats in dumpall.Having schedule MemStats info makes it easier to locate problems.
