### PR TITLE
fix update-development-yaml will remove more webhooks than disabled one

### DIFF
--- a/installer/helm/chart/volcano/templates/webhooks.yaml
+++ b/installer/helm/chart/volcano/templates/webhooks.yaml
@@ -40,9 +40,8 @@ webhooks:
     timeoutSeconds: 10
 {{- end }}
 
----
-
 {{- if .Values.custom.enabled_admissions | regexMatch "/queues/mutate" }}
+---
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
@@ -82,9 +81,9 @@ webhooks:
     timeoutSeconds: 10
 {{- end }}
 
----
 
 {{- if .Values.custom.enabled_admissions | regexMatch "/podgroups/mutate" }}
+---
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
@@ -124,9 +123,9 @@ webhooks:
     timeoutSeconds: 10
 {{- end }}
 
----
 
 {{- if .Values.custom.enabled_admissions | regexMatch "/jobs/mutate" }}
+---
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
@@ -166,9 +165,9 @@ webhooks:
     timeoutSeconds: 10
 {{- end }}
 
----
 
 {{- if .Values.custom.enabled_admissions | regexMatch "/jobs/validate" }}
+---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
@@ -208,9 +207,9 @@ webhooks:
     timeoutSeconds: 10
 {{- end }}
 
----
 
 {{- if .Values.custom.enabled_admissions | regexMatch "/pods/validate" }}
+---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
@@ -249,9 +248,9 @@ webhooks:
     timeoutSeconds: 10
 {{- end }}
 
----
 
 {{- if .Values.custom.enabled_admissions | regexMatch "/queues/validate" }}
+---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:


### PR DESCRIPTION
eg: when disable /pod/validate, then /queue/validate webook yaml also be removed. this pr fixed this issue

fixes #3129

*The following pictures shows that extra webhook is removed before this PR.*
<img width="1280" alt="image" src="https://github.com/volcano-sh/volcano/assets/21003791/2782edf6-ef23-4371-bc9a-2a79ba71cf65">
<img width="488" alt="image" src="https://github.com/volcano-sh/volcano/assets/21003791/3535d89a-3d1e-4ad7-a76c-b6b68106251d">
