### PR TITLE
Feature: add pdb plugin

### DIFF
--- a/pkg/scheduler/cache/cache.go
+++ b/pkg/scheduler/cache/cache.go
@@ -501,8 +501,10 @@ func newSchedulerCache(config *rest.Config, schedulerNames []string, defaultQueu
 	mySchedulerPodName, c := getMultiSchedulerInfo()
 
 	// explicitly register informers to the factory, otherwise resources listers cannot get anything
-	// even with no error returned. `Namespace` informer is used by `InterPodAffinity` plugin,
+	// even with no error returned. `PodDisruptionBudgets` informer is used by `Pdb` plugin
+	// `Namespace` informer is used by `InterPodAffinity` plugin,
 	// `SelectorSpread` and `PodTopologySpread` plugins uses the following four so far.
+	informerFactory.Policy().V1().PodDisruptionBudgets().Informer()
 	informerFactory.Core().V1().Namespaces().Informer()
 	informerFactory.Core().V1().Services().Informer()
 	if utilfeature.DefaultFeatureGate.Enabled(features.WorkLoadSupport) {
@@ -857,6 +859,11 @@ func (sc *SchedulerCache) ClientConfig() *rest.Config {
 // SharedInformerFactory returns the scheduler SharedInformerFactory
 func (sc *SchedulerCache) SharedInformerFactory() informers.SharedInformerFactory {
 	return sc.informerFactory
+}
+
+// SetSharedInformerFactory sets the scheduler SharedInformerFactory for unit test
+func (sc *SchedulerCache) SetSharedInformerFactory(factory informers.SharedInformerFactory) {
+	sc.informerFactory = factory
 }
 
 // UpdateSchedulerNumaInfo used to update scheduler node cache NumaSchedulerInfo

--- a/pkg/scheduler/plugins/factory.go
+++ b/pkg/scheduler/plugins/factory.go
@@ -27,6 +27,7 @@ import (
 	"volcano.sh/volcano/pkg/scheduler/plugins/nodeorder"
 	"volcano.sh/volcano/pkg/scheduler/plugins/numaaware"
 	"volcano.sh/volcano/pkg/scheduler/plugins/overcommit"
+	"volcano.sh/volcano/pkg/scheduler/plugins/pdb"
 	"volcano.sh/volcano/pkg/scheduler/plugins/predicates"
 	"volcano.sh/volcano/pkg/scheduler/plugins/priority"
 	"volcano.sh/volcano/pkg/scheduler/plugins/proportion"
@@ -55,6 +56,7 @@ func init() {
 	framework.RegisterPluginBuilder(cdp.PluginName, cdp.New)
 	framework.RegisterPluginBuilder(rescheduling.PluginName, rescheduling.New)
 	framework.RegisterPluginBuilder(usage.PluginName, usage.New)
+	framework.RegisterPluginBuilder(pdb.PluginName, pdb.New)
 
 	// Plugins for Queues
 	framework.RegisterPluginBuilder(proportion.PluginName, proportion.New)

--- a/pkg/scheduler/plugins/pdb/pdb.go
+++ b/pkg/scheduler/plugins/pdb/pdb.go
@@ -1,0 +1,147 @@
+/*
+Copyright 2023 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pdb
+
+import (
+	pdbPolicy "k8s.io/api/policy/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/informers"
+	policylisters "k8s.io/client-go/listers/policy/v1"
+	"k8s.io/klog/v2"
+
+	"volcano.sh/volcano/pkg/scheduler/api"
+	"volcano.sh/volcano/pkg/scheduler/framework"
+	"volcano.sh/volcano/pkg/scheduler/plugins/util"
+)
+
+// PluginName indicates name of volcano scheduler plugin
+const PluginName = "pdb"
+
+type pdbPlugin struct {
+	// Arguments given for pdb plugin
+	pluginArguments framework.Arguments
+	// Lister for PodDisruptionBudget
+	lister policylisters.PodDisruptionBudgetLister
+}
+
+// New function returns pdb plugin object
+func New(arguments framework.Arguments) framework.Plugin {
+	return &pdbPlugin{
+		pluginArguments: arguments,
+		lister:          nil,
+	}
+}
+
+// Name function returns pdb plugin name
+func (pp *pdbPlugin) Name() string {
+	return PluginName
+}
+
+func (pp *pdbPlugin) OnSessionOpen(ssn *framework.Session) {
+	klog.V(4).Infof("Enter pdb plugin ...")
+	defer klog.V(4).Infof("Leaving pdb plugin.")
+
+	// 0. Init the PDB lister
+	if pp.lister == nil {
+		pp.lister = getPDBLister(ssn.InformerFactory())
+	}
+
+	// 1. define the func to filter out tasks that violate PDB constraints
+	filterFn := func(tasks []*api.TaskInfo) []*api.TaskInfo {
+		var victims []*api.TaskInfo
+
+		// (a. get all PDBs
+		pdbs, err := getPodDisruptionBudgets(pp.lister)
+		if err != nil {
+			klog.Errorf("Failed to list pdbs condition: %v", err)
+			return victims
+		}
+
+		// (b. init the pdbsAllowed array
+		pdbsAllowed := make([]int32, len(pdbs))
+		for i, pdb := range pdbs {
+			pdbsAllowed[i] = pdb.Status.DisruptionsAllowed
+		}
+
+		// (c. range every task to check if it violates the PDB constraints.
+		// If task does not violate the PDB constraints, then add it to victims.
+		for _, task := range tasks {
+			pod := task.Pod
+			pdbForPodIsViolated := false
+			// A pod with no labels will not match any PDB. So, no need to check.
+			if len(pod.Labels) != 0 {
+				for i, pdb := range pdbs {
+					if pdb.Namespace != pod.Namespace {
+						continue
+					}
+					selector, err := metav1.LabelSelectorAsSelector(pdb.Spec.Selector)
+					if err != nil {
+						continue
+					}
+					// A PDB with a nil or empty selector matches nothing.
+					if selector.Empty() || !selector.Matches(labels.Set(pod.Labels)) {
+						continue
+					}
+
+					// Existing in DisruptedPods means it has been processed in API server,
+					// we don't treat it as a violating case.
+					if _, exist := pdb.Status.DisruptedPods[pod.Name]; exist {
+						continue
+					}
+					// Only decrement the matched pdb when it's not in its <DisruptedPods>;
+					// otherwise we may over-decrement the budget number.
+					pdbsAllowed[i]--
+
+					if pdbsAllowed[i] < 0 {
+						pdbForPodIsViolated = true
+					}
+				}
+			}
+			if !pdbForPodIsViolated {
+				victims = append(victims, task)
+			}
+		}
+		return victims
+	}
+
+	// 2. wrap filterFn to meet reclaimable and preemptable interface requirements
+	wrappedFilterFn := func(preemptor *api.TaskInfo, preemptees []*api.TaskInfo) ([]*api.TaskInfo, int) {
+		return filterFn(preemptees), util.Permit
+	}
+
+	// 3. register VictimTasksFns, ReclaimableFn and PreemptableFn
+	victimsFns := []api.VictimTasksFn{filterFn}
+	ssn.AddVictimTasksFns(pp.Name(), victimsFns)
+	ssn.AddReclaimableFn(pp.Name(), wrappedFilterFn)
+	ssn.AddPreemptableFn(pp.Name(), wrappedFilterFn)
+}
+
+func (pp *pdbPlugin) OnSessionClose(ssn *framework.Session) {}
+
+// getPDBLister returns the lister of PodDisruptionBudget
+func getPDBLister(informerFactory informers.SharedInformerFactory) policylisters.PodDisruptionBudgetLister {
+	return informerFactory.Policy().V1().PodDisruptionBudgets().Lister()
+}
+
+// getPodDisruptionBudgets returns all pdbs
+func getPodDisruptionBudgets(pdbLister policylisters.PodDisruptionBudgetLister) ([]*pdbPolicy.PodDisruptionBudget, error) {
+	if pdbLister != nil {
+		return pdbLister.List(labels.Everything())
+	}
+	return nil, nil
+}

--- a/pkg/scheduler/plugins/pdb/pdb_test.go
+++ b/pkg/scheduler/plugins/pdb/pdb_test.go
@@ -1,0 +1,169 @@
+/*
+Copyright 2023 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pdb
+
+import (
+	"reflect"
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	pdbPolicy "k8s.io/api/policy/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes/fake"
+	"volcano.sh/volcano/pkg/scheduler/api"
+	"volcano.sh/volcano/pkg/scheduler/cache"
+	"volcano.sh/volcano/pkg/scheduler/conf"
+	"volcano.sh/volcano/pkg/scheduler/framework"
+)
+
+const LabelName = "volcano.sh/job-name"
+
+func TestPreemptableAndReclaimableFn(t *testing.T) {
+	// 1. init task1 and task2
+	task1 := api.NewTaskInfo(makePod("test-pod1", map[string]string{LabelName: "job-1"}))
+	task2 := api.NewTaskInfo(makePod("test-pod2", map[string]string{LabelName: "job-1"}))
+	// 2. init tests
+	// (a. test without pdb
+	// (b. test with pdb, but no tasks can be evicted
+	// (c. test with pdb, but only test1 can be evicted
+	tests := []struct {
+		name             string
+		pdbs             []*pdbPolicy.PodDisruptionBudget
+		preemptees       []*api.TaskInfo
+		expectVictims    []*api.TaskInfo
+		expectVictimsMap map[*api.TaskInfo]bool
+	}{{
+		name:             "test without pdbs",
+		pdbs:             nil,
+		preemptees:       []*api.TaskInfo{task1, task2},
+		expectVictims:    []*api.TaskInfo{task1, task2},
+		expectVictimsMap: map[*api.TaskInfo]bool{task1: true, task2: true},
+	}, {
+		name: "test with pdbs(can evict 0 pod)",
+		pdbs: []*pdbPolicy.PodDisruptionBudget{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pdb",
+					Namespace: "default",
+				},
+				Spec:   pdbPolicy.PodDisruptionBudgetSpec{Selector: &metav1.LabelSelector{MatchLabels: map[string]string{LabelName: "job-1"}}},
+				Status: pdbPolicy.PodDisruptionBudgetStatus{DisruptionsAllowed: 0},
+			},
+		},
+		preemptees:       []*api.TaskInfo{task1, task2},
+		expectVictims:    nil,
+		expectVictimsMap: make(map[*api.TaskInfo]bool),
+	}, {
+		name: "test with pdbs(can evict 1 pod)",
+		pdbs: []*pdbPolicy.PodDisruptionBudget{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pdb",
+					Namespace: "default",
+				},
+				Spec:   pdbPolicy.PodDisruptionBudgetSpec{Selector: &metav1.LabelSelector{MatchLabels: map[string]string{LabelName: "job-1"}}},
+				Status: pdbPolicy.PodDisruptionBudgetStatus{DisruptionsAllowed: 1},
+			},
+		},
+		preemptees:       []*api.TaskInfo{task1, task2},
+		expectVictims:    []*api.TaskInfo{task1},
+		expectVictimsMap: map[*api.TaskInfo]bool{task1: true},
+	},
+	}
+
+	// 3. set the test plugin name and fns
+	enabled := true
+	pluginOption := conf.PluginOption{
+		Name:               PluginName,
+		EnabledPreemptable: &enabled,
+		EnabledReclaimable: &enabled,
+		EnabledVictim:      &enabled,
+	}
+
+	// 4. range every test
+	for _, test := range tests {
+
+		// (a. set the fake informerFactory and add pdbs to pdb informer
+		client := fake.NewSimpleClientset()
+		informerFactory := informers.NewSharedInformerFactory(client, 0)
+		informer := informerFactory.Policy().V1().PodDisruptionBudgets().Informer()
+		for _, pdb := range test.pdbs {
+			informer.GetStore().Add(pdb)
+		}
+
+		// (b. set the SchedulerCache
+		schedulerCache := &cache.SchedulerCache{}
+		schedulerCache.SetSharedInformerFactory(informerFactory)
+
+		// (c. set the Session with preempt, reclaim and shuffle action
+		ssn := framework.OpenSession(schedulerCache, []conf.Tier{
+			{
+				Plugins: []conf.PluginOption{pluginOption},
+			},
+		},
+			[]conf.Configuration{
+				{
+					Name: "preempt",
+				},
+				{
+					Name: "reclaim",
+				},
+				{
+					Name: "shuffle",
+				},
+			},
+		)
+
+		// (d. register actions
+		plugin := &pdbPlugin{}
+		plugin.OnSessionOpen(ssn) // register preempt fn
+
+		// (e. test the Preemptable in pdb plugin
+		victims := ssn.Preemptable(&api.TaskInfo{}, test.preemptees)
+		if !reflect.DeepEqual(test.expectVictims, victims) {
+			t.Errorf("Test of preemptable: test name: %s, expected: %v, got %v ", test.name, test.expectVictims, victims)
+		}
+
+		// (f. test the Reclaimable in pdb plugin
+		victims = ssn.Reclaimable(&api.TaskInfo{}, test.preemptees)
+		if !reflect.DeepEqual(test.expectVictims, victims) {
+			t.Errorf("Test of reclaimable: test name: %s, expected: %v, got %v ", test.name, test.expectVictims, victims)
+		}
+
+		// (g. test the VictimTasks in pdb plugin
+		victimsMap := ssn.VictimTasks(test.preemptees)
+		if !reflect.DeepEqual(test.expectVictimsMap, victimsMap) {
+			t.Errorf("Test of victimTasks: test name %s, expected: %v, got %v ", test.name, test.expectVictims, victims)
+		}
+	}
+}
+
+func makePod(name string, labels map[string]string) *v1.Pod {
+	return &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "default",
+			Labels:    labels,
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				{},
+			},
+		},
+	}
+}


### PR DESCRIPTION
Add PDB plugin for volcano to try to avoid deleting pods that violate PDB constraints as much as possible.

## Unit Test
If you want to verify this feature, you can run the unit test in pkg/scheduler/plugins/pdb/pdb_test.go

## Local Test
Start a local k8s cluster and install the latest valcano
```shell
$ cd <your-local-dir-to-volcano>
$ ./hack/local-up-volcano.sh
```
1. Scale the number of volcano-shceduler replicas to 0
```shell
$ kubectl scale --replicas=0 deployment -n volcano-system volcano-scheduler 
```
2. Create profile for volcano-shceduler to enable pdb support (like volcano-scheduler-configmap)
```shell
$ cd <your-local-dir-to-volcano>
$ cat<<EOF >volcano-scheduler.conf
actions: "enqueue, allocate, reclaim, preempt, backfill, shuffle"
tiers:
- plugins:
  - name: priority
  - name: pdb
EOF

```
> **Note**: This is a demo of volcano-scheduler.conf, you can create your own profile based on your needs.

3. Configure the startup file for debugging
```shell
$ cd <your-local-dir-to-volcano>
$ cat<<EOF >.vscode/launch.json
{
    "version": "0.2.0",
    "configurations": [
        {
            "name": "Scheduler Debug",
            "type": "go",
            "request": "launch",
            "mode": "debug",
            "program": "cmd/scheduler/main.go",
            "args": ["--logtostderr", "--scheduler-conf=<your-local-dir-to-volcano>/volcano-scheduler.conf", "--enable-healthz=true", 
            "--enable-metrics=true", "--leader-elect=false", "-v=4", "2>&1", "--kubeconfig=<your-local-path-to-kubeconfig>"]
        }
    ]
}
EOF

```
> **Note**: You need to change the `<your-local-dir-to-volcano>/volcano-scheduler.conf` to the local path to `volcano-scheduler.conf`, the `<your-local-path-to-kubeconfig>` to the local path to `kubeconfig` and adjust the other parameters based on your needs.

4. Make some examples to test locally