### PR TITLE
 Add podGroup status to session cache, fix the bug of repeatedly sending pordGroup update request when there is no condations field.

### DIFF
--- a/pkg/scheduler/framework/session.go
+++ b/pkg/scheduler/framework/session.go
@@ -149,8 +149,7 @@ func openSession(cache cache.Cache) *Session {
 
 	ssn.Jobs = snapshot.Jobs
 	for _, job := range ssn.Jobs {
-		// only conditions will be updated periodically
-		if job.PodGroup != nil && job.PodGroup.Status.Conditions != nil {
+		if job.PodGroup != nil {
 			ssn.podGroupStatus[job.UID] = *job.PodGroup.Status.DeepCopy()
 		}
 


### PR DESCRIPTION
fix [bug](https://github.com/volcano-sh/volcano/issues/3123)