### PR TITLE
:zap:  jobflow-controller jobtemplate-controller enqueue should use struct not pointer

### DIFF
--- a/pkg/controllers/jobflow/jobflow_controller.go
+++ b/pkg/controllers/jobflow/jobflow_controller.go
@@ -74,7 +74,7 @@ type jobflowcontroller struct {
 	recorder record.EventRecorder
 
 	queue          workqueue.RateLimitingInterface
-	enqueueJobFlow func(req *apis.FlowRequest)
+	enqueueJobFlow func(req apis.FlowRequest)
 
 	syncHandler func(req *apis.FlowRequest) error
 
@@ -164,13 +164,13 @@ func (jf *jobflowcontroller) processNextWorkItem() bool {
 	// period.
 	defer jf.queue.Done(obj)
 
-	req, ok := obj.(*apis.FlowRequest)
+	req, ok := obj.(apis.FlowRequest)
 	if !ok {
 		klog.Errorf("%v is not a valid queue request struct.", obj)
 		return true
 	}
 
-	err := jf.syncHandler(req)
+	err := jf.syncHandler(&req)
 	jf.handleJobFlowErr(err, obj)
 
 	return true
@@ -218,7 +218,7 @@ func (jf *jobflowcontroller) handleJobFlowErr(err error, obj interface{}) {
 		return
 	}
 
-	req, _ := obj.(*apis.FlowRequest)
+	req, _ := obj.(apis.FlowRequest)
 	jf.recordEventsForJobFlow(req.Namespace, req.JobFlowName, v1.EventTypeWarning, string(req.Action),
 		fmt.Sprintf("%v JobFlow failed for %v", req.Action, err))
 	klog.V(4).Infof("Dropping JobFlow request %v out of the queue for %v.", obj, err)

--- a/pkg/controllers/jobflow/jobflow_controller_handler.go
+++ b/pkg/controllers/jobflow/jobflow_controller_handler.go
@@ -25,7 +25,7 @@ import (
 	"volcano.sh/volcano/pkg/controllers/apis"
 )
 
-func (jf *jobflowcontroller) enqueue(req *apis.FlowRequest) {
+func (jf *jobflowcontroller) enqueue(req apis.FlowRequest) {
 	jf.queue.Add(req)
 }
 
@@ -36,7 +36,7 @@ func (jf *jobflowcontroller) addJobFlow(obj interface{}) {
 		return
 	}
 
-	req := &apis.FlowRequest{
+	req := apis.FlowRequest{
 		Namespace:   jobFlow.Namespace,
 		JobFlowName: jobFlow.Name,
 
@@ -69,7 +69,7 @@ func (jf *jobflowcontroller) updateJobFlow(oldObj, newObj interface{}) {
 		return
 	}
 
-	req := &apis.FlowRequest{
+	req := apis.FlowRequest{
 		Namespace:   newJobFlow.Namespace,
 		JobFlowName: newJobFlow.Name,
 
@@ -107,12 +107,12 @@ func (jf *jobflowcontroller) updateJob(oldObj, newObj interface{}) {
 		return
 	}
 
-	req := &apis.FlowRequest{
+	req := apis.FlowRequest{
 		Namespace:   newJob.Namespace,
 		JobFlowName: jobFlowName,
 		Action:      jobflowv1alpha1.SyncJobFlowAction,
 		Event:       jobflowv1alpha1.OutOfSyncEvent,
 	}
 
-	jf.queue.Add(req)
+	jf.enqueueJobFlow(req)
 }

--- a/pkg/controllers/jobflow/jobflow_controller_handler.go
+++ b/pkg/controllers/jobflow/jobflow_controller_handler.go
@@ -36,6 +36,7 @@ func (jf *jobflowcontroller) addJobFlow(obj interface{}) {
 		return
 	}
 
+	// use struct instead of pointer
 	req := apis.FlowRequest{
 		Namespace:   jobFlow.Namespace,
 		JobFlowName: jobFlow.Name,

--- a/pkg/controllers/jobtemplate/jobtemplate_controller.go
+++ b/pkg/controllers/jobtemplate/jobtemplate_controller.go
@@ -66,7 +66,7 @@ type jobtemplatecontroller struct {
 	recorder record.EventRecorder
 
 	queue              workqueue.RateLimitingInterface
-	enqueueJobTemplate func(req *apis.FlowRequest)
+	enqueueJobTemplate func(req apis.FlowRequest)
 
 	syncHandler func(req *apis.FlowRequest) error
 
@@ -149,13 +149,13 @@ func (jt *jobtemplatecontroller) processNextWorkItem() bool {
 	// period.
 	defer jt.queue.Done(obj)
 
-	req, ok := obj.(*apis.FlowRequest)
+	req, ok := obj.(apis.FlowRequest)
 	if !ok {
 		klog.Errorf("%v is not a valid queue request struct.", obj)
 		return true
 	}
 
-	err := jt.syncHandler(req)
+	err := jt.syncHandler(&req)
 	jt.handleJobTemplateErr(err, obj)
 
 	return true

--- a/pkg/controllers/jobtemplate/jobtemplate_controller_handler.go
+++ b/pkg/controllers/jobtemplate/jobtemplate_controller_handler.go
@@ -26,7 +26,7 @@ import (
 	"volcano.sh/volcano/pkg/controllers/apis"
 )
 
-func (jt *jobtemplatecontroller) enqueue(req *apis.FlowRequest) {
+func (jt *jobtemplatecontroller) enqueue(req apis.FlowRequest) {
 	jt.queue.Add(req)
 }
 
@@ -37,7 +37,7 @@ func (jt *jobtemplatecontroller) addJobTemplate(obj interface{}) {
 		return
 	}
 
-	req := &apis.FlowRequest{
+	req := apis.FlowRequest{
 		Namespace:       jobTemplate.Namespace,
 		JobTemplateName: jobTemplate.Name,
 	}
@@ -63,9 +63,9 @@ func (jt *jobtemplatecontroller) addJob(obj interface{}) {
 	}
 	namespace, name := namespaceName[0], namespaceName[1]
 
-	req := &apis.FlowRequest{
+	req := apis.FlowRequest{
 		Namespace:       namespace,
 		JobTemplateName: name,
 	}
-	jt.queue.Add(req)
+	jt.enqueueJobTemplate(req)
 }


### PR DESCRIPTION
# Why should not use pointer
The  workqueue will deduplicate same item in queue.
According the internal struct of workqueue, when we add a item to workqueue firstly, workqueue will also put it in **q.dirty** which is `map[interface]struct{}``
```go
// Add marks item as needing processing.
func (q *Type) Add(item interface{}) {
	
    ...

	q.dirty.insert(item)
	if q.processing.has(item) {
		return
	}

	q.queue = append(q.queue, item)
	q.cond.Signal()
}
```

before this item processed, if same item re added to the workqueue , this add will skiped

```go

// Add marks item as needing processing.
func (q *Type) Add(item interface{}) {
	q.cond.L.Lock()
	defer q.cond.L.Unlock()
	if q.shuttingDown {
		return
	}
	if q.dirty.has(item) {
		return
	}
    ...
}
```

the current code use  `*apis.FlowRequest` as item to add to the workqueue,  even the different apis.FlowRequest have same values, different `*apis.FlowRequest` will be considerd as different item in workqueue, so the deduplication is not work.

We can try the example code blow, 
```go
type empty struct{}
type t interface{}
type set map[t]empty

func (s set) has(item t) bool {
	_, exists := s[item]
	return exists
}

func (s set) insert(item t) {
	s[item] = empty{}
}

func (s set) delete(item t) {
	delete(s, item)
}

func CompareMap() {
	a := &FlowRequest{Namespace: "a", JobFlowName: "n"}
	a1 := &FlowRequest{Namespace: "a", JobFlowName: "n"}
	b := &FlowRequest{Namespace: "b", JobFlowName: "n"}

	frMap := set{}
	frMap.insert(a)
	fmt.Println(frMap.has(a1))
	fmt.Println(frMap.has(b))
}
func CompareMapB() {
	a := FlowRequest{Namespace: "a", JobFlowName: "n"}
	a1 := FlowRequest{Namespace: "a", JobFlowName: "n"}
	b := FlowRequest{Namespace: "b", JobFlowName: "n"}

	frMap := set{}
	frMap.insert(a)
	fmt.Println(frMap.has(a1))
	fmt.Println(frMap.has(b))

}
```

the `CompareMap` will Print
```shell
false
false
```

the `CompareMapB` will Print
```shell
true
false
```