### PR TITLE
feat: dynamically change klog level through socket

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/stretchr/testify v1.8.3
 	go.uber.org/automaxprocs v1.4.0
 	golang.org/x/crypto v0.1.0
+	golang.org/x/sys v0.7.0
 	golang.org/x/time v0.3.0
 	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/api v0.27.2
@@ -111,7 +112,6 @@ require (
 	golang.org/x/net v0.9.0 // indirect
 	golang.org/x/oauth2 v0.7.0 // indirect
 	golang.org/x/sync v0.1.0 // indirect
-	golang.org/x/sys v0.7.0 // indirect
 	golang.org/x/term v0.7.0 // indirect
 	golang.org/x/text v0.9.0 // indirect
 	golang.org/x/tools v0.7.0 // indirect

--- a/installer/helm/chart/volcano/templates/scheduler.yaml
+++ b/installer/helm/chart/volcano/templates/scheduler.yaml
@@ -161,14 +161,22 @@ spec:
             {{- end }}
             - -v=3
             - 2>&1
+          env:
+            - name: DEBUG_SOCKET_DIR
+              value: /tmp/klog-socks
           imagePullPolicy: {{ .Values.basic.image_pull_policy }}
           volumeMounts:
             - name: scheduler-config
               mountPath: /volcano.scheduler
+            - name: klog-sock
+              mountPath: /tmp/klog-socks
       volumes:
         - name: scheduler-config
           configMap:
             name: {{ .Release.Name }}-scheduler-configmap
+        - name: klog-sock
+          hostPath:
+            path: /tmp/klog-socks
 ---
 apiVersion: v1
 kind: Service

--- a/installer/volcano-development.yaml
+++ b/installer/volcano-development.yaml
@@ -9177,14 +9177,22 @@ spec:
             - --leader-elect=false
             - -v=3
             - 2>&1
+          env:
+            - name: DEBUG_SOCKET_DIR
+              value: /tmp/klog-socks
           imagePullPolicy: Always
           volumeMounts:
             - name: scheduler-config
               mountPath: /volcano.scheduler
+            - name: klog-sock
+              mountPath: /tmp/klog-socks
       volumes:
         - name: scheduler-config
           configMap:
             name: volcano-scheduler-configmap
+        - name: klog-sock
+          hostPath:
+            path: /tmp/klog-socks
 ---
 # Source: volcano/templates/scheduling_v1beta1_podgroup.yaml
 apiVersion: apiextensions.k8s.io/v1

--- a/pkg/util/socket.go
+++ b/pkg/util/socket.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package util
 
 import (

--- a/pkg/util/socket.go
+++ b/pkg/util/socket.go
@@ -1,0 +1,210 @@
+package util
+
+import (
+	"context"
+	"fmt"
+	"html"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strconv"
+	"sync"
+	"time"
+
+	"golang.org/x/sys/unix"
+	"k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/klog/v2"
+)
+
+const (
+	DefaultSocketDir = "/tmp/klog-socks" // Default directory storing socket files
+	SocketSuffix     = "-klog.sock"
+	SocketDirEnvName = "DEBUG_SOCKET_DIR"
+	// The HTTP request patterns
+	setLogLevelPath  = "/setlevel"
+	getLogLevelPath  = "/getlevel"
+	exampleSocketCli = "\"Failed to change klog log level, because got wrong value from level argument\\n\"+\n\t\t\t\t\"example: curl --unix-socket /tmp/klog-socks/componentName-klog.sock \\\"http://localhost/setlevel?level=8&duration=60s\\\"\\n\"+\n\t\t\t\t\"level=8 means changing klog log level to 8\\n\"+\n\t\t\t\t\"duration=60s means maintaining level=8 for 60 seconds[60m -> 60 minutes; 60h -> 60 hours]\""
+)
+
+var (
+	// When users frequently make request to change klog log level, the previously registered timer may not expire.
+	// To improve performance, cancel the previous timer. prevCtx, prevCtxCancelFunc is used to achieve this target.
+	prevCtx           context.Context
+	prevCtxCancelFunc context.CancelFunc
+
+	// currentLogLevel stores current log level
+	currentLogLevel string
+	// startupLogLevel stores start-up log level
+	startupLogLevel string
+	// mutex is used to avoid data race about prevCtx, prevCtxCancelFunc and currentLogLevel
+	mutex sync.RWMutex
+)
+
+// responseOk returns a statusOK response to client
+func responseOk(w *http.ResponseWriter, okMsg string) {
+	(*w).Header().Set("Content-Type", "text/plain; charset=utf-8")
+	(*w).Header().Set("X-Content-Type-Options", "nosniff")
+	_, err := fmt.Fprint(*w, okMsg)
+	if err != nil {
+		klog.Error(err)
+		return
+	}
+}
+
+// responseError returns an error response containing specific httpCode and errMsg to client
+func responseError(w *http.ResponseWriter, errMsg string, httpCode int) {
+	http.Error(*w, errMsg, httpCode)
+}
+
+// modifyLoglevel will try to change current klog's log level to newLogLevel and assign it to currentLogLevel.
+// After prevCtxCancelFunc function corresponding to last timer executed, prevCtx and prevCtxCancelFunc will be reassigned
+// in order to represent brand-new timer.
+func modifyLoglevel(newLogLevel string) error {
+	mutex.Lock()
+	defer mutex.Unlock()
+
+	// Change klog log level to new value
+	var loglevel klog.Level
+	if err := loglevel.Set(newLogLevel); err != nil {
+		return err
+	}
+	currentLogLevel = newLogLevel
+
+	// Cancel the previous timer.
+	if prevCtxCancelFunc != nil {
+		prevCtxCancelFunc()
+	}
+	prevCtx, prevCtxCancelFunc = context.WithCancel(context.Background())
+	return nil
+}
+
+// reset creates a timer to make klog recover to start-up log level.
+func reset(ctx context.Context, duration time.Duration) {
+	defer runtime.HandleCrash()
+	select {
+	// Create a timer
+	case <-time.After(duration):
+		var loglevel klog.Level
+		mutex.Lock()
+		defer mutex.Unlock()
+		if err := loglevel.Set(startupLogLevel); err != nil {
+			klog.Error(err)
+			return
+		}
+		currentLogLevel = startupLogLevel
+		klog.InfoS("Klog recover to start-up log level successfully", "startupLogLevel", startupLogLevel)
+	// Cancel previous timer
+	case <-ctx.Done():
+		klog.InfoS("Cancel previous timer successfully")
+	}
+}
+
+// installKlogLogLevelHandler registers the HTTP request patterns that can set/get current klog log level
+func installKlogLogLevelHandler(mux *http.ServeMux, startup string) {
+	currentLogLevel, startupLogLevel = startup, startup
+	// Register the HTTP request patterns that can change klog log level
+	mux.Handle(setLogLevelPath, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		values := r.URL.Query()
+		rawLevel := values.Get("level")
+		rawDuration := values.Get("duration")
+		// Escape the data that needs to be output to the log, Prevent Reflected cross-site scripting
+		rawLevel = html.EscapeString(rawLevel)
+		rawDuration = html.EscapeString(rawDuration)
+		var duration time.Duration
+		var err error
+		// Validate argument in request
+		if level, err := strconv.ParseInt(rawLevel, 10, 64); err != nil || level <= 0 {
+			responseError(&w, exampleSocketCli, http.StatusBadRequest)
+			return
+		}
+		if duration, err = time.ParseDuration(rawDuration); err != nil || duration.Milliseconds() <= 0 {
+			responseError(&w, exampleSocketCli, http.StatusBadRequest)
+			return
+		}
+
+		if err := modifyLoglevel(rawLevel); err != nil {
+			responseError(&w, fmt.Sprintf("Failed to change klog log level. Error: %v\n", err.Error()), http.StatusInternalServerError)
+			return
+		}
+
+		mutex.RLock()
+		// Create a timer to make klog recover to start-up log level.
+		// There will be more than one timer using same prevCtx variable under extreme conditions.
+		// Therefore, put reset function in mutex range.
+		go reset(prevCtx, duration)
+		responseOk(&w, fmt.Sprintf("Change klog log level to %s successfully and  for %v\n", currentLogLevel, duration))
+		mutex.RUnlock()
+	}))
+
+	// Register the HTTP request patterns that can get current klog log level
+	mux.Handle(getLogLevelPath, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mutex.RLock()
+		responseOk(&w, fmt.Sprintf("Current klog log level: %s\n", currentLogLevel))
+		mutex.RUnlock()
+	}))
+}
+
+// listenUnix does net.Listen for a unix socket
+func listenUnix(componentName string, socketDir string) (net.Listener, error) {
+	// Use default directory to store socket files
+	if len(socketDir) == 0 {
+		socketDir = DefaultSocketDir
+	}
+
+	// Check whether KlogLogLevelSocketDir exists
+	if _, err := os.Stat(socketDir); os.IsNotExist(err) {
+		if err = os.MkdirAll(socketDir, 0750); err != nil {
+			return nil, fmt.Errorf("error creating klog log level socket dir: %v", err)
+		}
+	}
+
+	// Specify socket file full path
+	socketFileFullName := componentName + SocketSuffix
+	socketFileFullPath := filepath.Join(socketDir, socketFileFullName)
+
+	// Remove any socket, stale or not, but fall through for other files
+	fi, err := os.Stat(socketFileFullPath)
+	if err == nil && (fi.Mode()&os.ModeSocket) != 0 {
+		err := os.Remove(socketFileFullPath)
+		if err != nil {
+			klog.ErrorS(err, "failed to remote socket file", "file", socketFileFullPath)
+			return nil, err
+		}
+	}
+
+	// Default to only user accessible socket, caller can open up later if desired
+	// Result perm: 777 - 077 = 700
+	oldmask := unix.Umask(0077)
+	l, err := net.Listen("unix", socketFileFullPath)
+	unix.Umask(oldmask)
+
+	return l, err
+}
+
+// serveOnListener starts the server using given listener, loops forever.
+func serveOnListener(l net.Listener, m *http.ServeMux) error {
+	server := http.Server{
+		Handler: m,
+	}
+	return server.Serve(l)
+}
+
+// ListenAndServeKlogLogLevel registers a server on specific component to handle the HTTP request which set/get klog log level
+func ListenAndServeKlogLogLevel(componentName string, startupLogLevel string, socketDir string) {
+	var err error
+	defer runtime.HandleCrash()
+
+	mux := http.NewServeMux()
+	installKlogLogLevelHandler(mux, startupLogLevel)
+
+	var listener net.Listener
+	listener, err = listenUnix(componentName, socketDir)
+	if err != nil {
+		return
+	}
+
+	if err = serveOnListener(listener, mux); err != nil {
+		return
+	}
+}


### PR DESCRIPTION
fix #2322 
docs #3111 
### Why not change klog level throuth change configmap
Volcano is a commercial project. Volcano is deployed in a customer cluster. The configmap cannot be modified easily, but curl can be executed. I thought of using curl to pass in the klog value that you want to modify through the scoket method.

###  Implementation Introduction
The vc-scheduler pod has an internal socket service to monitor changes in the klog.scok file. Because the socket service in the pod cannot be directly accessed in the k8s Node, the klog.sock file needs to be mounted from the pod to the cluster. Use The curl command modifies the klog.sock file.
![](https://p.ipic.vip/1x4537.png)

This machine is a mac, use minikube to simulate the k8s cluster, enter mimikube, execute curl to modify the /tmp/socks/klog.sock file through the socket
```
 sudo curl --unix-socket /tmp/klog-socks/klog-klog.sock "http://localhost/setlevel?level=5&duration=60s"
```
![image](https://github.com/volcano-sh/volcano/assets/87080562/11bb1a3d-ad1c-4733-a193-bae222c7ff1c)

Klog has been set to 5. This log can only be printed at level 5.
klog.V(5).Info("only klog v 5 can print this log ")
not using sudo will `curl: (7) Couldn't connect to server`
<img width="1036" alt="image" src="https://github.com/volcano-sh/volcano/assets/87080562/98227f1d-4210-4da3-9b4f-19013df07ea4">

example image:xiaojie99999/vc-scheduler:1.1.7
@wangyang0616 @william-wang @Monokaix @lowang-bh 

