### PR TITLE
replace dynamic-resource-allocation and adapt k8s v1.27.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -168,4 +168,5 @@ replace (
 	k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.27.2
 	k8s.io/sample-cli-plugin => k8s.io/sample-cli-plugin v0.27.2
 	k8s.io/sample-controller => k8s.io/sample-controller v0.27.2
+	k8s.io/dynamic-resource-allocation => k8s.io/dynamic-resource-allocation v0.27.2
 )

--- a/go.mod
+++ b/go.mod
@@ -154,6 +154,7 @@ replace (
 	k8s.io/controller-manager => k8s.io/controller-manager v0.27.2
 	k8s.io/cri-api => k8s.io/cri-api v0.27.2
 	k8s.io/csi-translation-lib => k8s.io/csi-translation-lib v0.27.2
+	k8s.io/dynamic-resource-allocation => k8s.io/dynamic-resource-allocation v0.27.2
 	k8s.io/kube-aggregator => k8s.io/kube-aggregator v0.27.2
 	k8s.io/kube-controller-manager => k8s.io/kube-controller-manager v0.27.2
 	k8s.io/kube-proxy => k8s.io/kube-proxy v0.27.2
@@ -168,5 +169,4 @@ replace (
 	k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.27.2
 	k8s.io/sample-cli-plugin => k8s.io/sample-cli-plugin v0.27.2
 	k8s.io/sample-controller => k8s.io/sample-controller v0.27.2
-	k8s.io/dynamic-resource-allocation => k8s.io/dynamic-resource-allocation v0.27.2
 )


### PR DESCRIPTION
Command `go list` failed due to getting k8s modules failed.