### PR TITLE
update volcano.sh/apis version

### DIFF
--- a/cmd/controller-manager/app/options/options.go
+++ b/cmd/controller-manager/app/options/options.go
@@ -40,8 +40,10 @@ type ServerOption struct {
 	KubeClientOptions    kube.ClientOptions
 	CertFile             string
 	KeyFile              string
+	CaCertFile           string
 	CertData             []byte
 	KeyData              []byte
+	CaCertData           []byte
 	EnableLeaderElection bool
 	LockObjectNamespace  string
 	PrintVersion         bool
@@ -76,6 +78,7 @@ func NewServerOption() *ServerOption {
 func (s *ServerOption) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&s.KubeClientOptions.Master, "master", s.KubeClientOptions.Master, "The address of the Kubernetes API server (overrides any value in kubeconfig)")
 	fs.StringVar(&s.KubeClientOptions.KubeConfig, "kubeconfig", s.KubeClientOptions.KubeConfig, "Path to kubeconfig file with authorization and master location information.")
+	fs.StringVar(&s.CaCertFile, "ca-cert-file", s.CaCertFile, "File containing the x509 Certificate for HTTPS.")
 	fs.StringVar(&s.CertFile, "tls-cert-file", s.CertFile, ""+
 		"File containing the default x509 Certificate for HTTPS. (CA cert, if any, concatenated "+
 		"after server cert).")
@@ -107,6 +110,11 @@ func (s *ServerOption) CheckOptionOrDie() error {
 // readCAFiles read data from ca file path
 func (s *ServerOption) readCAFiles() error {
 	var err error
+
+	s.CaCertData, err = os.ReadFile(s.CaCertFile)
+	if err != nil {
+		return fmt.Errorf("failed to read cacert file (%s): %v", s.CaCertFile, err)
+	}
 
 	s.CertData, err = os.ReadFile(s.CertFile)
 	if err != nil {

--- a/cmd/controller-manager/app/server.go
+++ b/cmd/controller-manager/app/server.go
@@ -56,7 +56,7 @@ func Run(opt *options.ServerOption) error {
 	}
 
 	if opt.EnableHealthz {
-		if err := helpers.StartHealthz(opt.HealthzBindAddress, "volcano-controller", opt.CertData, opt.KeyData); err != nil {
+		if err := helpers.StartHealthz(opt.HealthzBindAddress, "volcano-controller", opt.CaCertData, opt.CertData, opt.KeyData); err != nil {
 			return err
 		}
 	}

--- a/cmd/controller-manager/main.go
+++ b/cmd/controller-manager/main.go
@@ -58,7 +58,7 @@ func main() {
 		fmt.Fprintf(os.Stderr, "%v\n", err)
 		os.Exit(1)
 	}
-	if s.CertFile != "" && s.KeyFile != "" {
+	if s.CaCertFile != "" && s.CertFile != "" && s.KeyFile != "" {
 		if err := s.ParseCAFiles(nil); err != nil {
 			fmt.Fprintf(os.Stderr, "Failed to parse CA file: %v\n", err)
 			os.Exit(1)

--- a/cmd/scheduler/app/options/options.go
+++ b/cmd/scheduler/app/options/options.go
@@ -49,8 +49,10 @@ type ServerOption struct {
 	KubeClientOptions    kube.ClientOptions
 	CertFile             string
 	KeyFile              string
+	CaCertFile           string
 	CertData             []byte
 	KeyData              []byte
+	CaCertData           []byte
 	SchedulerNames       []string
 	SchedulerConf        string
 	SchedulePeriod       time.Duration
@@ -91,6 +93,7 @@ func NewServerOption() *ServerOption {
 func (s *ServerOption) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&s.KubeClientOptions.Master, "master", s.KubeClientOptions.Master, "The address of the Kubernetes API server (overrides any value in kubeconfig)")
 	fs.StringVar(&s.KubeClientOptions.KubeConfig, "kubeconfig", s.KubeClientOptions.KubeConfig, "Path to kubeconfig file with authorization and master location information")
+	fs.StringVar(&s.CaCertFile, "ca-cert-file", s.CaCertFile, "File containing the x509 Certificate for HTTPS.")
 	fs.StringVar(&s.CertFile, "tls-cert-file", s.CertFile, ""+
 		"File containing the default x509 Certificate for HTTPS. (CA cert, if any, concatenated "+
 		"after server cert).")
@@ -147,6 +150,11 @@ func (s *ServerOption) RegisterOptions() {
 // readCAFiles read data from ca file path
 func (s *ServerOption) readCAFiles() error {
 	var err error
+
+	s.CaCertData, err = os.ReadFile(s.CaCertFile)
+	if err != nil {
+		return fmt.Errorf("failed to read cacert file (%s): %v", s.CaCertFile, err)
+	}
 
 	s.CertData, err = os.ReadFile(s.CertFile)
 	if err != nil {

--- a/cmd/scheduler/app/server.go
+++ b/cmd/scheduler/app/server.go
@@ -92,7 +92,7 @@ func Run(opt *options.ServerOption) error {
 	}
 
 	if opt.EnableHealthz {
-		if err := helpers.StartHealthz(opt.HealthzBindAddress, "volcano-scheduler", opt.CertData, opt.KeyData); err != nil {
+		if err := helpers.StartHealthz(opt.HealthzBindAddress, "volcano-scheduler", opt.CaCertData, opt.CertData, opt.KeyData); err != nil {
 			return err
 		}
 	}

--- a/cmd/scheduler/main.go
+++ b/cmd/scheduler/main.go
@@ -59,7 +59,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	if s.CertFile != "" && s.KeyFile != "" {
+	if s.CaCertFile != "" && s.CertFile != "" && s.KeyFile != "" {
 		if err := s.ParseCAFiles(nil); err != nil {
 			klog.Fatalf("Failed to parse CA file: %v", err)
 		}

--- a/cmd/webhook-manager/app/server.go
+++ b/cmd/webhook-manager/app/server.go
@@ -47,7 +47,7 @@ func Run(config *options.Config) error {
 	}
 
 	if config.EnableHealthz {
-		if err := helpers.StartHealthz(config.HealthzBindAddress, "volcano-admission", config.CertData, config.KeyData); err != nil {
+		if err := helpers.StartHealthz(config.HealthzBindAddress, "volcano-admission", config.CaCertData, config.CertData, config.KeyData); err != nil {
 			return err
 		}
 	}

--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,7 @@ require (
 	sigs.k8s.io/controller-runtime v0.13.0
 	sigs.k8s.io/yaml v1.3.0
 	stathat.com/c/consistent v1.0.0
-	volcano.sh/apis v1.8.0
+	volcano.sh/apis v1.8.0-alpha.0.0.20231028020234-1a5aa81107d7
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -1868,5 +1868,5 @@ sigs.k8s.io/yaml v1.3.0 h1:a2VclLzOGrwOHDiV8EfBGhvjHvP46CtW5j6POvhYGGo=
 sigs.k8s.io/yaml v1.3.0/go.mod h1:GeOyir5tyXNByN85N/dRIT9es5UQNerPYEKK56eTBm8=
 stathat.com/c/consistent v1.0.0 h1:ezyc51EGcRPJUxfHGSgJjWzJdj3NiMU9pNfLNGiXV0c=
 stathat.com/c/consistent v1.0.0/go.mod h1:QkzMWzcbB+yQBL2AttO6sgsQS/JSTapcDISJalmCDS0=
-volcano.sh/apis v1.8.0 h1:TO9mxoqLMToBAEB195OPuiC3pnupqsUqfXVJroT7KEI=
-volcano.sh/apis v1.8.0/go.mod h1:h+xbUpkjfRaHjktAi8h+7JNnNahjwhRSgpN9FUUwNXQ=
+volcano.sh/apis v1.8.0-alpha.0.0.20231028020234-1a5aa81107d7 h1:Meq/5hsE1nK9XFZrU5tLM29RjC2SfXpsfLWaKcRyGbE=
+volcano.sh/apis v1.8.0-alpha.0.0.20231028020234-1a5aa81107d7/go.mod h1:h+xbUpkjfRaHjktAi8h+7JNnNahjwhRSgpN9FUUwNXQ=


### PR DESCRIPTION
currently, healthz Authentication use the default authentication policy and it is insecure .
So it is necessary to set a list of cipher suites to enhance the security of TLS client authentication

related pr:  https://github.com/volcano-sh/apis/pull/117

