### PR TITLE
Make sure volcano schduler cache synced before first scheduling by waiting for handlers sync.

### DIFF
--- a/pkg/scheduler/cache/interface.go
+++ b/pkg/scheduler/cache/interface.go
@@ -39,6 +39,9 @@ type Cache interface {
 	// WaitForCacheSync waits for all cache synced
 	WaitForCacheSync(stopCh <-chan struct{})
 
+	// WaitForHandlersSync waits for EventHandlers to sync.
+	WaitForHandlersSync(stopCh <-chan struct{})
+
 	// AddBindTask binds Task to the target host.
 	// TODO(jinzhej): clean up expire Tasks.
 	AddBindTask(task *api.TaskInfo) error

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -85,10 +85,13 @@ func (pc *Scheduler) Run(stopCh <-chan struct{}) {
 	pc.loadSchedulerConf()
 	go pc.watchSchedulerConf(stopCh)
 	// Start cache for policy.
+	klog.V(2).Infof("scheduler starts to run cache")
 	pc.cache.SetMetricsConf(pc.metricsConf)
 	pc.cache.Run(stopCh)
 	pc.cache.WaitForCacheSync(stopCh)
-	klog.V(2).Infof("Scheduler completes Initialization and start to run")
+	klog.V(2).Infof("scheduler starts to wait for cache handlers sync")
+	pc.cache.WaitForHandlersSync(stopCh)
+	klog.V(2).Infof("scheduler completes Initialization and start to run")
 	go wait.Until(pc.runOnce, pc.schedulePeriod, stopCh)
 	if options.ServerOpts.EnableCacheDumper {
 		pc.dumper.ListenForSignal(stopCh)


### PR DESCRIPTION
### Ⅰ. Describe what this PR does
The issue https://github.com/kubernetes/kubernetes/issues/116717 mentions the bug that event handlers hadn't handled all events when informer cache synced. This can lead to a terrible result, which is that the scheduler starts scheduling in the wrong state. The K8s community itself has fixed this issue https://github.com/kubernetes/kubernetes/pull/116729.

The PR makes sure handlers have finished syncing before the scheduling cycles start,  just like the default scheduler does.
