### PR TITLE
fix: allocated field in queue status is calcutated error

### DIFF
--- a/pkg/scheduler/framework/session.go
+++ b/pkg/scheduler/framework/session.go
@@ -197,8 +197,10 @@ func updateQueueStatus(ssn *Session) {
 		allocatedResources[queueID] = &api.Resource{}
 	}
 	for _, job := range ssn.Jobs {
-		for _, runningTask := range job.TaskStatusIndex[api.Running] {
-			allocatedResources[job.Queue].Add(runningTask.Resreq)
+		for _, task := range job.Tasks {
+			if api.AllocatedStatus(task.Status) {
+				allocatedResources[job.Queue].Add(task.Resreq)
+			}
 		}
 	}
 


### PR DESCRIPTION
The allocated field in the queue status should be calculated based on tasks with the status "bound", "binding", "allocated", and "running".

If the container is slow to be running status (such as stuck on image pull stage), we can't obtain the correct value for the allocated field from the queue status even if volcano is finished to scheduler the task.