### PR TITLE
Delete duplicate logs generated by the predicate_helper method

### DIFF
--- a/pkg/scheduler/util/predicate_helper.go
+++ b/pkg/scheduler/util/predicate_helper.go
@@ -72,8 +72,7 @@ func (ph *predicateHelper) PredicateNodes(task *api.TaskInfo, nodes []*api.NodeI
 
 		// TODO (k82cn): Enable eCache for performance improvement.
 		if _, err := fn(task, node); err != nil {
-			klog.V(3).Infof("Predicates failed for task <%s/%s> on node <%s>: %v",
-				task.Namespace, task.Name, node.Name, err)
+			klog.V(3).Infof("Predicates failed: %v", err)
 			errorLock.Lock()
 			nodeErrorCache[node.Name] = err
 			ph.taskPredicateErrorCache[taskGroupid] = nodeErrorCache


### PR DESCRIPTION
Delete duplicate logs generated by the predicate_helper method.
When the predicate plugin in failes, the logs about task information is repeatedly printed:
![image](https://github.com/volcano-sh/volcano/assets/151122323/7311d123-d05f-4982-afb4-d26cec5eac52)