### PR TITLE
MVP implementation of Hierarchical Proportion

### DIFF
--- a/config/crd/volcano/bases/scheduling.volcano.sh_queues.yaml
+++ b/config/crd/volcano/bases/scheduling.volcano.sh_queues.yaml
@@ -119,6 +119,9 @@ spec:
                       Just set either `percentage` or `resource`
                     type: object
                 type: object
+              parent:
+                description: Parent define the parent of queue
+                type: string
               reclaimable:
                 description: Reclaimable indicate whether the queue can be reclaimed
                   by other queue

--- a/config/crd/volcano/v1beta1/scheduling.volcano.sh_queues.yaml
+++ b/config/crd/volcano/v1beta1/scheduling.volcano.sh_queues.yaml
@@ -118,6 +118,9 @@ spec:
                     Just set either `percentage` or `resource`
                   type: object
               type: object
+            parent:
+              description: Parent define the parent of queue
+              type: string
             reclaimable:
               description: Reclaimable indicate whether the queue can be reclaimed
                 by other queue

--- a/go.mod
+++ b/go.mod
@@ -40,8 +40,10 @@ require (
 	sigs.k8s.io/controller-runtime v0.13.0
 	sigs.k8s.io/yaml v1.3.0
 	stathat.com/c/consistent v1.0.0
-	volcano.sh/apis v1.8.0-alpha.0.0.20231028020234-1a5aa81107d7
+	volcano.sh/apis v0.0.0-20231122054104-6e892cf22bd8
 )
+
+replace volcano.sh/apis v0.0.0-20231122054104-6e892cf22bd8 => github.com/hzq5477/apis v0.0.0-20231122054104-6e892cf22bd8
 
 require (
 	github.com/NYTimes/gziphandler v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -886,6 +886,8 @@ github.com/hashicorp/go-multierror v1.0.0 h1:iVjPR7a6H0tWELX5NxNe7bYopibicUzc7uP
 github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
+github.com/hzq5477/apis v0.0.0-20231122054104-6e892cf22bd8 h1:r/m8RQ3vYc1pGcPIfqzY5L+EkZQhSJFh0IM8cZixAwM=
+github.com/hzq5477/apis v0.0.0-20231122054104-6e892cf22bd8/go.mod h1:h+xbUpkjfRaHjktAi8h+7JNnNahjwhRSgpN9FUUwNXQ=
 github.com/iancoleman/strcase v0.2.0/go.mod h1:iwCmte+B7n89clKwxIoIXy/HfoL7AsD47ZCWhYzw7ho=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
@@ -1871,5 +1873,3 @@ sigs.k8s.io/yaml v1.3.0 h1:a2VclLzOGrwOHDiV8EfBGhvjHvP46CtW5j6POvhYGGo=
 sigs.k8s.io/yaml v1.3.0/go.mod h1:GeOyir5tyXNByN85N/dRIT9es5UQNerPYEKK56eTBm8=
 stathat.com/c/consistent v1.0.0 h1:ezyc51EGcRPJUxfHGSgJjWzJdj3NiMU9pNfLNGiXV0c=
 stathat.com/c/consistent v1.0.0/go.mod h1:QkzMWzcbB+yQBL2AttO6sgsQS/JSTapcDISJalmCDS0=
-volcano.sh/apis v1.8.0-alpha.0.0.20231028020234-1a5aa81107d7 h1:Meq/5hsE1nK9XFZrU5tLM29RjC2SfXpsfLWaKcRyGbE=
-volcano.sh/apis v1.8.0-alpha.0.0.20231028020234-1a5aa81107d7/go.mod h1:h+xbUpkjfRaHjktAi8h+7JNnNahjwhRSgpN9FUUwNXQ=

--- a/installer/helm/chart/volcano/crd/bases/scheduling.volcano.sh_queues.yaml
+++ b/installer/helm/chart/volcano/crd/bases/scheduling.volcano.sh_queues.yaml
@@ -117,6 +117,9 @@ spec:
                       Just set either `percentage` or `resource`
                     type: object
                 type: object
+              parent:
+                description: Parent define the parent of queue
+                type: string
               reclaimable:
                 description: Reclaimable indicate whether the queue can be reclaimed
                   by other queue

--- a/installer/helm/chart/volcano/crd/v1beta1/scheduling.volcano.sh_queues.yaml
+++ b/installer/helm/chart/volcano/crd/v1beta1/scheduling.volcano.sh_queues.yaml
@@ -116,6 +116,9 @@ spec:
                     Just set either `percentage` or `resource`
                   type: object
               type: object
+            parent:
+              description: Parent define the parent of queue
+              type: string
             reclaimable:
               description: Reclaimable indicate whether the queue can be reclaimed
                 by other queue

--- a/pkg/scheduler/plugins/proportion/proportion.go
+++ b/pkg/scheduler/plugins/proportion/proportion.go
@@ -246,6 +246,7 @@ func (pp *proportionPlugin) OnSessionOpen(ssn *framework.Session) {
 
 			attr.deserved = helpers.Max(attr.deserved, attr.guarantee)
 			pp.updateShare(attr)
+			pp.updateParentQueue(attr)
 			klog.V(4).Infof("Format queue <%s> deserved resource to <%v>", attr.name, attr.deserved)
 
 			if attr.request.LessEqual(attr.deserved, api.Zero) {
@@ -278,20 +279,91 @@ func (pp *proportionPlugin) OnSessionOpen(ssn *framework.Session) {
 	ssn.AddQueueOrderFn(pp.Name(), func(l, r interface{}) int {
 		lv := l.(*api.QueueInfo)
 		rv := r.(*api.QueueInfo)
+
+		// Compare leaf queues
+		if pp.isLeafNode(lv.UID) && pp.isLeafNode(rv.UID) {
+			// Find the parent of the leaf nodes
+			lvParent := pp.getParentQueue(lv.UID)
+			rvParent := pp.getParentQueue(rv.UID)
+			// If both leaf nodes have the same parent
+			if lvParent == rvParent {
+				// Compare the weight of the leaf nodes
+				if pp.queueOpts[lv.UID].weight != pp.queueOpts[rv.UID].weight {
+					return int(pp.queueOpts[rv.UID].weight - pp.queueOpts[lv.UID].weight)
+				}
+				// Compare the share of the leaf nodes
+				if pp.queueOpts[lv.UID].share != pp.queueOpts[rv.UID].share {
+					if pp.queueOpts[lv.UID].share < pp.queueOpts[rv.UID].share {
+						return -1
+					}
+					return 1
+				}
+				return 0
+			}
+
+			// Find the level of the leaf nodes
+			lvLevel := pp.getQueueLevel(lv.UID)
+			rvLevel := pp.getQueueLevel(rv.UID)
+
+			// If both leaf nodes are at the same level
+			if lvLevel == rvLevel {
+				// Compare the parent queues of the leaf nodes
+				lvParentQueue := pp.getParentQueue(lvParent)
+				rvParentQueue := pp.getParentQueue(rvParent)
+
+				// Compare the weight of the parent queues
+				if pp.queueOpts[lvParentQueue].weight != pp.queueOpts[rvParentQueue].weight {
+					return int(pp.queueOpts[rvParentQueue].weight - pp.queueOpts[lvParentQueue].weight)
+				}
+				// Compare the share of the parent queues
+				if pp.queueOpts[lvParentQueue].share != pp.queueOpts[rvParentQueue].share {
+					if pp.queueOpts[lvParentQueue].share < pp.queueOpts[rvParentQueue].share {
+						return -1
+					}
+					return 1
+				}
+				return 0
+			}
+
+			// Find the lowest common ancestor (LCA) of the leaf nodes
+			lca := pp.lowestCommonAncestor(lv.UID, rv.UID)
+
+			// Compare each leaf node with its parent queue at the level of the LCA
+			lvParentQueue := pp.getParentQueueBelowLCA(lv.UID, lca)
+			rvParentQueue := pp.getParentQueueBelowLCA(rv.UID, lca)
+
+			// Compare the weight of the parent queues
+			if pp.queueOpts[lvParentQueue].weight != pp.queueOpts[rvParentQueue].weight {
+				return int(pp.queueOpts[rvParentQueue].weight - pp.queueOpts[lvParentQueue].weight)
+			}
+			// Compare the share of the parent queues
+			if pp.queueOpts[lvParentQueue].share != pp.queueOpts[rvParentQueue].share {
+				if pp.queueOpts[lvParentQueue].share < pp.queueOpts[rvParentQueue].share {
+					return -1
+				}
+				return 1
+			}
+			return 0
+		}
+
+		// Compare leaf and non-leaf queues, non-leaf queues are always at the end of the queue
 		if pp.isLeafNode(lv.UID) && !pp.isLeafNode(rv.UID) {
 			return -1
 		}
 		if !pp.isLeafNode(lv.UID) && pp.isLeafNode(rv.UID) {
 			return 1
 		}
+
+		// Compare non-leaf queues
+		if pp.queueOpts[lv.UID].weight != pp.queueOpts[rv.UID].weight {
+			return int(pp.queueOpts[rv.UID].weight - pp.queueOpts[lv.UID].weight)
+		}
 		if pp.queueOpts[lv.UID].share == pp.queueOpts[rv.UID].share {
 			return 0
 		}
-
 		if pp.queueOpts[lv.UID].share < pp.queueOpts[rv.UID].share {
 			return -1
 		}
-
 		return 1
 	})
 
@@ -412,7 +484,7 @@ func (pp *proportionPlugin) OnSessionOpen(ssn *framework.Session) {
 			metrics.UpdateQueueAllocated(attr.name, attr.allocated.MilliCPU, attr.allocated.Memory)
 
 			pp.updateShare(attr)
-
+			pp.updateParentQueue(attr)
 			klog.V(4).Infof("Proportion AllocateFunc: task <%v/%v>, resreq <%v>,  share <%v>",
 				event.Task.Namespace, event.Task.Name, event.Task.Resreq, attr.share)
 		},
@@ -423,7 +495,7 @@ func (pp *proportionPlugin) OnSessionOpen(ssn *framework.Session) {
 			metrics.UpdateQueueAllocated(attr.name, attr.allocated.MilliCPU, attr.allocated.Memory)
 
 			pp.updateShare(attr)
-
+			pp.updateParentQueue(attr)
 			klog.V(4).Infof("Proportion EvictFunc: task <%v/%v>, resreq <%v>,  share <%v>",
 				event.Task.Namespace, event.Task.Name, event.Task.Resreq, attr.share)
 		},
@@ -460,17 +532,79 @@ func (pp *proportionPlugin) isLeafNode(queueID api.QueueID) bool {
 	return false
 }
 
+// get the parent queue ID
+func (pp *proportionPlugin) getParentQueue(queueID api.QueueID) api.QueueID {
+	attr := pp.queueOpts[queueID]
+	return attr.parent
+}
+
+// get the level of the queue
+func (pp *proportionPlugin) getQueueLevel(queueID api.QueueID) int {
+	attr := pp.queueOpts[queueID]
+	level := 0
+	for attr.parent != "" {
+		level++
+		attr = pp.queueOpts[attr.parent]
+	}
+	return level
+}
+
+// get the parent queue ID one level below the lowest common ancestor (LCA)
+func (pp *proportionPlugin) getParentQueueBelowLCA(queueID api.QueueID, lca api.QueueID) api.QueueID {
+	attr := pp.queueOpts[queueID]
+
+	// If the queue is one level below, return itself
+	if attr.parent == lca {
+		return queueID
+	}
+	// Otherwise, find the parent queue ID one level below the LCA
+	var lastParent api.QueueID = queueID
+	for attr.parent != lca {
+		lastParent = attr.parent
+		attr = pp.queueOpts[attr.parent]
+	}
+	return lastParent
+}
+
+// get the lowest common ancestor (LCA) of the two queues
+func (pp *proportionPlugin) lowestCommonAncestor(queueID1 api.QueueID, queueID2 api.QueueID) api.QueueID {
+	attr1 := pp.queueOpts[queueID1]
+	attr2 := pp.queueOpts[queueID2]
+
+	// find the level of the two queues
+	level1 := pp.getQueueLevel(queueID1)
+	level2 := pp.getQueueLevel(queueID2)
+
+	// equalize the level of the two queues
+	for level1 > level2 {
+		attr1 = pp.queueOpts[attr1.parent]
+		level1--
+	}
+	for level2 > level1 {
+		attr2 = pp.queueOpts[attr2.parent]
+		level2--
+	}
+
+	for attr1.parent != attr2.parent {
+		attr1 = pp.queueOpts[attr1.parent]
+		attr2 = pp.queueOpts[attr2.parent]
+	}
+	return attr1.parent
+}
+
 // Updates the resource state of parent queues based on the child queues' states.
-func (pp *proportionPlugin) updateParentQueue(queueID api.QueueID) {
+func (pp *proportionPlugin) updateParentQueue(attr *queueAttr) {
 	// find the child queue, return if not exists
-	childAttr, exists := pp.queueOpts[queueID]
+	childAttr, exists := pp.queueOpts[attr.queueID]
 	if !exists {
 		return
 	}
 
 	// get the parent queue ID
 	parentQueueID := childAttr.parent
-
+	if parentQueueID == "" {
+		return
+	}
 	// update the parent queue
 	if parentAttr, exists := pp.queueOpts[parentQueueID]; exists {
 		// initialize the parent queue's resource state
@@ -491,6 +625,6 @@ func (pp *proportionPlugin) updateParentQueue(queueID api.QueueID) {
 		parentAttr.guarantee = totalGuarantee
 		pp.updateShare(parentAttr)
 		// call itself recursively to get the most top parent queue
-		pp.updateParentQueue(parentQueueID)
+		pp.updateParentQueue(parentAttr)
 	}
 }

--- a/pkg/scheduler/plugins/proportion/proportion_test.go
+++ b/pkg/scheduler/plugins/proportion/proportion_test.go
@@ -167,6 +167,24 @@ func TestProportion(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "q1",
 		},
+		Spec: schedulingv1beta1.QueueSpec{
+			Parent: "root",
+			Weight: 2,
+		},
+	}
+	queue2 := &schedulingv1beta1.Queue{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "q2",
+		},
+		Spec: schedulingv1beta1.QueueSpec{
+			Parent: "root",
+			Weight: 1,
+		},
+	}
+	queueroot := &schedulingv1beta1.Queue{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "root",
+		},
 	}
 
 	// tests
@@ -232,6 +250,8 @@ func TestProportion(t *testing.T) {
 			schedulerCache.AddPodGroupV1beta1(pg)
 		}
 		schedulerCache.AddQueueV1beta1(queue1)
+		schedulerCache.AddQueueV1beta1(queue2)
+		schedulerCache.AddQueueV1beta1(queueroot)
 		// session
 		trueValue := true
 


### PR DESCRIPTION
[issue 3018](https://github.com/volcano-sh/volcano/issues/3018)

Due to API changes, this [pr](https://github.com/volcano-sh/apis/pull/118) needs to be merged first

This PR is for MVP implementation of the hierarchical proportion plugin, where I 

- implemented the data structure of hierarchical queues
- built the tree when a session opens
- add` isLeaf` Function to determine whether the queue is a leaf node
- add `updateParentQueue` to update the resource state of parent queues based on the child queues' states.

modified:

- AddQueueOrderFn(): sorts queues for resource allocation, prioritizing leaf queues before non-leaf queues.
- AddJobEnqueueableFn(): rejects jobs if not in a leaf queue.
- AddAllocatableFn(): return false jobs if not in a leaf queue.
- AddOverusedFn(): when a leaf queue is overusing, it is possible that its parent is also overusing resources, add check if parent queue is overusing in this function

