### PR TITLE
[cherry-pick for release-1.8] fix: allocated field in queue status is calcutated error

### DIFF
--- a/pkg/scheduler/framework/session.go
+++ b/pkg/scheduler/framework/session.go
@@ -197,8 +197,10 @@ func updateQueueStatus(ssn *Session) {
 		allocatedResources[queueID] = &api.Resource{}
 	}
 	for _, job := range ssn.Jobs {
-		for _, runningTask := range job.TaskStatusIndex[api.Running] {
-			allocatedResources[job.Queue].Add(runningTask.Resreq)
+		for _, task := range job.Tasks {
+			if api.AllocatedStatus(task.Status) {
+				allocatedResources[job.Queue].Add(task.Resreq)
+			}
 		}
 	}
 


### PR DESCRIPTION
cherry-pick from main to release-1.8: https://github.com/volcano-sh/volcano/pull/3199