### PR TITLE
Avoid repeatedly creating links to obtain node metrics

### DIFF
--- a/pkg/scheduler/metrics/source/metrics_client.go
+++ b/pkg/scheduler/metrics/source/metrics_client.go
@@ -43,7 +43,7 @@ type MetricsClient interface {
 }
 
 func NewMetricsClient(restConfig *rest.Config, metricsConf map[string]string) (MetricsClient, error) {
-	klog.V(3).Infof("New metrics client begin, resconfig is %v, metricsConf is %v", restConfig, metricsConf)
+	klog.V(3).Infof("New metrics client begin, metricsConf is %v", metricsConf)
 	metricsType := metricsConf["type"]
 	if metricsType == Metrics_Type_Elasticsearch {
 		return NewElasticsearchMetricsClient(metricsConf)


### PR DESCRIPTION
After enabling the load-aware scheduling capability, Volcano will obtain node monitoring data through the Custom metrics API. 

Optimize the logic of the link with the apiserver to avoid repeated link creation, resulting in increased pressure on the apiserver.