### PR TITLE
Fix preempt: when skipping continue on preempting, the overused judgement didn't consider the current task's resource

### DIFF
--- a/pkg/scheduler/actions/allocate/allocate_test.go
+++ b/pkg/scheduler/actions/allocate/allocate_test.go
@@ -80,18 +80,7 @@ func TestAllocate(t *testing.T) {
 		{
 			name: "one Job with two Pods on one node",
 			podGroups: []*schedulingv1.PodGroup{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "pg1",
-						Namespace: "c1",
-					},
-					Spec: schedulingv1.PodGroupSpec{
-						Queue: "c1",
-					},
-					Status: schedulingv1.PodGroupStatus{
-						Phase: schedulingv1.PodGroupInqueue,
-					},
-				},
+				util.BuildPodGroup("pg1", "c1", "c1", 0, nil, schedulingv1.PodGroupInqueue),
 			},
 			pods: []*v1.Pod{
 				util.BuildPod("c1", "p1", "", v1.PodPending, api.BuildResourceList("1", "1G"), "pg1", make(map[string]string), make(map[string]string)),
@@ -101,14 +90,7 @@ func TestAllocate(t *testing.T) {
 				util.BuildNode("n1", api.BuildResourceList("2", "4Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), make(map[string]string)),
 			},
 			queues: []*schedulingv1.Queue{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "c1",
-					},
-					Spec: schedulingv1.QueueSpec{
-						Weight: 1,
-					},
-				},
+				util.BuildQueue("c1", 1, nil),
 			},
 			expected: map[string]string{
 				"c1/p1": "n1",
@@ -118,30 +100,8 @@ func TestAllocate(t *testing.T) {
 		{
 			name: "two Jobs on one node",
 			podGroups: []*schedulingv1.PodGroup{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "pg1",
-						Namespace: "c1",
-					},
-					Spec: schedulingv1.PodGroupSpec{
-						Queue: "c1",
-					},
-					Status: schedulingv1.PodGroupStatus{
-						Phase: schedulingv1.PodGroupInqueue,
-					},
-				},
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "pg2",
-						Namespace: "c2",
-					},
-					Spec: schedulingv1.PodGroupSpec{
-						Queue: "c2",
-					},
-					Status: schedulingv1.PodGroupStatus{
-						Phase: schedulingv1.PodGroupInqueue,
-					},
-				},
+				util.BuildPodGroup("pg1", "c1", "c1", 0, nil, schedulingv1.PodGroupInqueue),
+				util.BuildPodGroup("pg2", "c2", "c2", 0, nil, schedulingv1.PodGroupInqueue),
 			},
 
 			// pod name should be like "*-*-{index}",
@@ -160,22 +120,8 @@ func TestAllocate(t *testing.T) {
 				util.BuildNode("n1", api.BuildResourceList("2", "4G", []api.ScalarResource{{Name: "pods", Value: "10"}}...), make(map[string]string)),
 			},
 			queues: []*schedulingv1.Queue{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "c1",
-					},
-					Spec: schedulingv1.QueueSpec{
-						Weight: 1,
-					},
-				},
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "c2",
-					},
-					Spec: schedulingv1.QueueSpec{
-						Weight: 1,
-					},
-				},
+				util.BuildQueue("c1", 1, nil),
+				util.BuildQueue("c2", 1, nil),
 			},
 			expected: map[string]string{
 				"c2/pg2-p-1": "n1",
@@ -185,30 +131,8 @@ func TestAllocate(t *testing.T) {
 		{
 			name: "high priority queue should not block others",
 			podGroups: []*schedulingv1.PodGroup{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "pg1",
-						Namespace: "c1",
-					},
-					Spec: schedulingv1.PodGroupSpec{
-						Queue: "c1",
-					},
-					Status: schedulingv1.PodGroupStatus{
-						Phase: schedulingv1.PodGroupInqueue,
-					},
-				},
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "pg2",
-						Namespace: "c1",
-					},
-					Spec: schedulingv1.PodGroupSpec{
-						Queue: "c2",
-					},
-					Status: schedulingv1.PodGroupStatus{
-						Phase: schedulingv1.PodGroupInqueue,
-					},
-				},
+				util.BuildPodGroup("pg1", "c1", "c1", 0, nil, schedulingv1.PodGroupInqueue),
+				util.BuildPodGroup("pg2", "c1", "c2", 0, nil, schedulingv1.PodGroupInqueue),
 			},
 
 			pods: []*v1.Pod{
@@ -221,22 +145,8 @@ func TestAllocate(t *testing.T) {
 				util.BuildNode("n1", api.BuildResourceList("2", "4G", []api.ScalarResource{{Name: "pods", Value: "10"}}...), make(map[string]string)),
 			},
 			queues: []*schedulingv1.Queue{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "c1",
-					},
-					Spec: schedulingv1.QueueSpec{
-						Weight: 1,
-					},
-				},
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "c2",
-					},
-					Spec: schedulingv1.QueueSpec{
-						Weight: 1,
-					},
-				},
+				util.BuildQueue("c1", 1, nil),
+				util.BuildQueue("c2", 1, nil),
 			},
 			expected: map[string]string{
 				"c1/p2": "n1",
@@ -335,30 +245,8 @@ func TestAllocateWithDynamicPVC(t *testing.T) {
 
 	defer framework.CleanupPluginBuilders()
 
-	queue := &schedulingv1.Queue{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "c1",
-		},
-		Spec: schedulingv1.QueueSpec{
-			Weight: 1,
-		},
-	}
-	pg := &schedulingv1.PodGroup{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "pg1",
-			Namespace: "c1",
-		},
-		Spec: schedulingv1.PodGroupSpec{
-			Queue:     "c1",
-			MinMember: 2,
-			MinTaskMember: map[string]int32{
-				"": 2,
-			},
-		},
-		Status: schedulingv1.PodGroupStatus{
-			Phase: schedulingv1.PodGroupInqueue,
-		},
-	}
+	queue := util.BuildQueue("c1", 1, nil)
+	pg := util.BuildPodGroup("pg1", "c1", "c1", 2, map[string]int32{"": 2}, schedulingv1.PodGroupInqueue)
 
 	pvc, _, sc := util.BuildDynamicPVC("c1", "pvc", v1.ResourceList{
 		v1.ResourceStorage: resource.MustParse("1Gi"),

--- a/pkg/scheduler/actions/preempt/preempt.go
+++ b/pkg/scheduler/actions/preempt/preempt.go
@@ -271,8 +271,16 @@ func preempt(
 
 		for !victimsQueue.Empty() {
 			// If reclaimed enough resources, break loop to avoid Sub panic.
-			// If preemptor's queue is overused, it means preemptor can not be allocated. So no need care about the node idle resource
-			if !ssn.Overused(currentQueue) && preemptor.InitResreq.LessEqual(node.FutureIdle(), api.Zero) {
+			// Preempt action is about preempt in same queue, which job is not allocatable in allocate action, due to:
+			// 1. cluster has free resource, but queue not allocatable
+			// 2. cluster has no free resource, but queue not allocatable
+			// 3. cluster has no free resource, but queue allocatable
+			// for case 1 and 2, high priority job/task can preempt low priority job/task in same queue;
+			// for case 3, it need to do reclaim resource from other queue, in reclaim action;
+			// so if current queue is not allocatable(the queue will be overused when consider current preemptor's requests)
+			// or current idle resource is not enougth for preemptor, it need to continue preempting
+			// otherwise, break out
+			if ssn.Allocatable(currentQueue, preemptor) && preemptor.InitResreq.LessEqual(node.FutureIdle(), api.Zero) {
 				break
 			}
 			preemptee := victimsQueue.Pop().(*api.TaskInfo)
@@ -291,7 +299,7 @@ func preempt(
 			preempted, preemptor.Namespace, preemptor.Name, preemptor.InitResreq)
 
 		// If preemptor's queue is overused, it means preemptor can not be allocated. So no need care about the node idle resource
-		if !ssn.Overused(currentQueue) && preemptor.InitResreq.LessEqual(node.FutureIdle(), api.Zero) {
+		if ssn.Allocatable(currentQueue, preemptor) && preemptor.InitResreq.LessEqual(node.FutureIdle(), api.Zero) {
 			if err := stmt.Pipeline(preemptor, node.Name); err != nil {
 				klog.Errorf("Failed to pipeline Task <%s/%s> on Node <%s>",
 					preemptor.Namespace, preemptor.Name, node.Name)

--- a/pkg/scheduler/actions/preempt/preempt_test.go
+++ b/pkg/scheduler/actions/preempt/preempt_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/agiledragon/gomonkey/v2"
 	v1 "k8s.io/api/core/v1"
 	schedulingv1 "k8s.io/api/scheduling/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/record"
 
 	schedulingv1beta1 "volcano.sh/apis/pkg/apis/scheduling/v1beta1"
@@ -65,22 +64,7 @@ func TestPreempt(t *testing.T) {
 		{
 			name: "do not preempt if there are enough idle resources",
 			podGroups: []*schedulingv1beta1.PodGroup{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "pg1",
-						Namespace: "c1",
-					},
-					Spec: schedulingv1beta1.PodGroupSpec{
-						MinMember: 3,
-						MinTaskMember: map[string]int32{
-							"": 3,
-						},
-						Queue: "q1",
-					},
-					Status: schedulingv1beta1.PodGroupStatus{
-						Phase: schedulingv1beta1.PodGroupInqueue,
-					},
-				},
+				util.BuildPodGroup("pg1", "c1", "q1", 3, map[string]int32{"": 3}, schedulingv1beta1.PodGroupInqueue),
 			},
 			pods: []*v1.Pod{
 				util.BuildPod("c1", "preemptee1", "n1", v1.PodRunning, api.BuildResourceList("1", "1G"), "pg1", make(map[string]string), make(map[string]string)),
@@ -92,52 +76,15 @@ func TestPreempt(t *testing.T) {
 				util.BuildNode("n1", api.BuildResourceList("10", "10G", []api.ScalarResource{{Name: "pods", Value: "10"}}...), make(map[string]string)),
 			},
 			queues: []*schedulingv1beta1.Queue{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "q1",
-					},
-					Spec: schedulingv1beta1.QueueSpec{
-						Weight: 1,
-					},
-				},
+				util.BuildQueue("q1", 1, nil),
 			},
 			expected: 0,
 		},
 		{
 			name: "do not preempt if job is pipelined",
 			podGroups: []*schedulingv1beta1.PodGroup{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "pg1",
-						Namespace: "c1",
-					},
-					Spec: schedulingv1beta1.PodGroupSpec{
-						MinMember: 1,
-						MinTaskMember: map[string]int32{
-							"": 2,
-						},
-						Queue: "q1",
-					},
-					Status: schedulingv1beta1.PodGroupStatus{
-						Phase: schedulingv1beta1.PodGroupInqueue,
-					},
-				},
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "pg2",
-						Namespace: "c1",
-					},
-					Spec: schedulingv1beta1.PodGroupSpec{
-						MinMember: 1,
-						MinTaskMember: map[string]int32{
-							"": 2,
-						},
-						Queue: "q1",
-					},
-					Status: schedulingv1beta1.PodGroupStatus{
-						Phase: schedulingv1beta1.PodGroupInqueue,
-					},
-				},
+				util.BuildPodGroup("pg1", "c1", "q1", 1, map[string]int32{"": 2}, schedulingv1beta1.PodGroupInqueue),
+				util.BuildPodGroup("pg2", "c1", "q1", 1, map[string]int32{"": 2}, schedulingv1beta1.PodGroupInqueue),
 			},
 			// Both pg1 and pg2 jobs are pipelined, because enough pods are already running.
 			pods: []*v1.Pod{
@@ -151,54 +98,15 @@ func TestPreempt(t *testing.T) {
 				util.BuildNode("n1", api.BuildResourceList("3", "3G", []api.ScalarResource{{Name: "pods", Value: "10"}}...), make(map[string]string)),
 			},
 			queues: []*schedulingv1beta1.Queue{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "q1",
-					},
-					Spec: schedulingv1beta1.QueueSpec{
-						Weight: 1,
-					},
-				},
+				util.BuildQueue("q1", 1, nil),
 			},
 			expected: 0,
 		},
 		{
 			name: "preempt one task of different job to fit both jobs on one node",
 			podGroups: []*schedulingv1beta1.PodGroup{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "pg1",
-						Namespace: "c1",
-					},
-					Spec: schedulingv1beta1.PodGroupSpec{
-						MinMember: 1,
-						MinTaskMember: map[string]int32{
-							"": 2,
-						},
-						Queue:             "q1",
-						PriorityClassName: "low-priority",
-					},
-					Status: schedulingv1beta1.PodGroupStatus{
-						Phase: schedulingv1beta1.PodGroupInqueue,
-					},
-				},
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "pg2",
-						Namespace: "c1",
-					},
-					Spec: schedulingv1beta1.PodGroupSpec{
-						MinMember: 1,
-						MinTaskMember: map[string]int32{
-							"": 2,
-						},
-						Queue:             "q1",
-						PriorityClassName: "high-priority",
-					},
-					Status: schedulingv1beta1.PodGroupStatus{
-						Phase: schedulingv1beta1.PodGroupInqueue,
-					},
-				},
+				util.BuildPodGroupWithPrio("pg1", "c1", "q1", 1, map[string]int32{"": 2}, schedulingv1beta1.PodGroupInqueue, "low-priority"),
+				util.BuildPodGroupWithPrio("pg2", "c1", "q1", 1, map[string]int32{"": 2}, schedulingv1beta1.PodGroupInqueue, "high-priority"),
 			},
 			pods: []*v1.Pod{
 				util.BuildPod("c1", "preemptee1", "n1", v1.PodRunning, api.BuildResourceList("1", "1G"), "pg1", map[string]string{schedulingv1beta1.PodPreemptable: "true"}, make(map[string]string)),
@@ -210,54 +118,15 @@ func TestPreempt(t *testing.T) {
 				util.BuildNode("n1", api.BuildResourceList("2", "2G", []api.ScalarResource{{Name: "pods", Value: "10"}}...), make(map[string]string)),
 			},
 			queues: []*schedulingv1beta1.Queue{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "q1",
-					},
-					Spec: schedulingv1beta1.QueueSpec{
-						Weight: 1,
-					},
-				},
+				util.BuildQueue("q1", 1, nil),
 			},
 			expected: 1,
 		},
 		{
 			name: "preempt enough tasks to fit large task of different job",
 			podGroups: []*schedulingv1beta1.PodGroup{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "pg1",
-						Namespace: "c1",
-					},
-					Spec: schedulingv1beta1.PodGroupSpec{
-						MinMember: 1,
-						MinTaskMember: map[string]int32{
-							"": 3,
-						},
-						Queue:             "q1",
-						PriorityClassName: "low-priority",
-					},
-					Status: schedulingv1beta1.PodGroupStatus{
-						Phase: schedulingv1beta1.PodGroupInqueue,
-					},
-				},
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "pg2",
-						Namespace: "c1",
-					},
-					Spec: schedulingv1beta1.PodGroupSpec{
-						MinMember: 1,
-						MinTaskMember: map[string]int32{
-							"": 1,
-						},
-						Queue:             "q1",
-						PriorityClassName: "high-priority",
-					},
-					Status: schedulingv1beta1.PodGroupStatus{
-						Phase: schedulingv1beta1.PodGroupInqueue,
-					},
-				},
+				util.BuildPodGroupWithPrio("pg1", "c1", "q1", 1, map[string]int32{"": 3}, schedulingv1beta1.PodGroupInqueue, "low-priority"),
+				util.BuildPodGroupWithPrio("pg2", "c1", "q1", 1, map[string]int32{"": 1}, schedulingv1beta1.PodGroupInqueue, "high-priority"),
 			},
 			// There are 3 cpus and 3G of memory idle and 3 tasks running each consuming 1 cpu and 1G of memory.
 			// Big task requiring 5 cpus and 5G of memory should preempt 2 of 3 running tasks to fit into the node.
@@ -271,14 +140,7 @@ func TestPreempt(t *testing.T) {
 				util.BuildNode("n1", api.BuildResourceList("6", "6G", []api.ScalarResource{{Name: "pods", Value: "10"}}...), make(map[string]string)),
 			},
 			queues: []*schedulingv1beta1.Queue{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "q1",
-					},
-					Spec: schedulingv1beta1.QueueSpec{
-						Weight: 1,
-					},
-				},
+				util.BuildQueue("q1", 1, nil),
 			},
 			expected: 2,
 		},

--- a/pkg/scheduler/actions/reclaim/reclaim_test.go
+++ b/pkg/scheduler/actions/reclaim/reclaim_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/agiledragon/gomonkey/v2"
 	v1 "k8s.io/api/core/v1"
 	schedulingv1 "k8s.io/api/scheduling/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/record"
 
 	schedulingv1beta1 "volcano.sh/apis/pkg/apis/scheduling/v1beta1"
@@ -61,32 +60,8 @@ func TestReclaim(t *testing.T) {
 		{
 			name: "Two Queue with one Queue overusing resource, should reclaim",
 			podGroups: []*schedulingv1beta1.PodGroup{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "pg1",
-						Namespace: "c1",
-					},
-					Spec: schedulingv1beta1.PodGroupSpec{
-						Queue:             "q1",
-						PriorityClassName: "low-priority",
-					},
-					Status: schedulingv1beta1.PodGroupStatus{
-						Phase: schedulingv1beta1.PodGroupInqueue,
-					},
-				},
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "pg2",
-						Namespace: "c1",
-					},
-					Spec: schedulingv1beta1.PodGroupSpec{
-						Queue:             "q2",
-						PriorityClassName: "high-priority",
-					},
-					Status: schedulingv1beta1.PodGroupStatus{
-						Phase: schedulingv1beta1.PodGroupInqueue,
-					},
-				},
+				util.BuildPodGroupWithPrio("pg1", "c1", "q1", 0, nil, schedulingv1beta1.PodGroupInqueue, "low-priority"),
+				util.BuildPodGroupWithPrio("pg2", "c1", "q2", 0, nil, schedulingv1beta1.PodGroupInqueue, "high-priority"),
 			},
 			pods: []*v1.Pod{
 				util.BuildPod("c1", "preemptee1", "n1", v1.PodRunning, api.BuildResourceList("1", "1G"), "pg1", map[string]string{schedulingv1beta1.PodPreemptable: "true"}, make(map[string]string)),
@@ -98,22 +73,8 @@ func TestReclaim(t *testing.T) {
 				util.BuildNode("n1", api.BuildResourceList("3", "3Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), make(map[string]string)),
 			},
 			queues: []*schedulingv1beta1.Queue{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "q1",
-					},
-					Spec: schedulingv1beta1.QueueSpec{
-						Weight: 1,
-					},
-				},
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "q2",
-					},
-					Spec: schedulingv1beta1.QueueSpec{
-						Weight: 1,
-					},
-				},
+				util.BuildQueue("q1", 1, nil),
+				util.BuildQueue("q2", 1, nil),
 			},
 			expected: 1,
 		},

--- a/pkg/scheduler/actions/shuffle/shuffle_test.go
+++ b/pkg/scheduler/actions/shuffle/shuffle_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/golang/mock/gomock"
 	v1 "k8s.io/api/core/v1"
 	schedulingv1 "k8s.io/api/scheduling/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/record"
 
 	schedulingv1beta1 "volcano.sh/apis/pkg/apis/scheduling/v1beta1"
@@ -74,52 +73,12 @@ func TestShuffle(t *testing.T) {
 				util.BuildNode("node2", api.BuildResourceList("4", "8Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), make(map[string]string)),
 			},
 			queues: []*schedulingv1beta1.Queue{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "default",
-					},
-					Spec: schedulingv1beta1.QueueSpec{
-						Weight: 1,
-					},
-				},
+				util.BuildQueue("default", 1, nil),
 			},
 			podGroups: []*schedulingv1beta1.PodGroup{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "pg1",
-						Namespace: "test",
-					},
-					Spec: schedulingv1beta1.PodGroupSpec{
-						Queue: "default",
-					},
-					Status: schedulingv1beta1.PodGroupStatus{
-						Phase: schedulingv1beta1.PodGroupRunning,
-					},
-				},
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "pg2",
-						Namespace: "test",
-					},
-					Spec: schedulingv1beta1.PodGroupSpec{
-						Queue: "default",
-					},
-					Status: schedulingv1beta1.PodGroupStatus{
-						Phase: schedulingv1beta1.PodGroupRunning,
-					},
-				},
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "pg3",
-						Namespace: "test",
-					},
-					Spec: schedulingv1beta1.PodGroupSpec{
-						Queue: "default",
-					},
-					Status: schedulingv1beta1.PodGroupStatus{
-						Phase: schedulingv1beta1.PodGroupRunning,
-					},
-				},
+				util.BuildPodGroup("pg1", "test", "default", 0, nil, schedulingv1beta1.PodGroupRunning),
+				util.BuildPodGroup("pg2", "test", "default", 0, nil, schedulingv1beta1.PodGroupRunning),
+				util.BuildPodGroup("pg3", "test", "default", 0, nil, schedulingv1beta1.PodGroupRunning),
 			},
 			pods: []*v1.Pod{
 				util.BuildPodWithPriority("test", "pod1-1", "node1", v1.PodRunning, api.BuildResourceList("1", "2G"), "pg1", make(map[string]string), make(map[string]string), &lowPriority),

--- a/pkg/scheduler/util/test_utils.go
+++ b/pkg/scheduler/util/test_utils.go
@@ -30,7 +30,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
 
-	schedulingv1 "volcano.sh/apis/pkg/apis/scheduling/v1beta1"
+	schedulingv1beta1 "volcano.sh/apis/pkg/apis/scheduling/v1beta1"
 	"volcano.sh/volcano/pkg/scheduler/api"
 	volumescheduling "volcano.sh/volcano/pkg/scheduler/capabilities/volumebinding"
 )
@@ -59,7 +59,7 @@ func BuildPod(namespace, name, nodeName string, p v1.PodPhase, req v1.ResourceLi
 			Namespace: namespace,
 			Labels:    labels,
 			Annotations: map[string]string{
-				schedulingv1.KubeGroupNameAnnotationKey: groupName,
+				schedulingv1beta1.KubeGroupNameAnnotationKey: groupName,
 			},
 		},
 		Status: v1.PodStatus{
@@ -88,7 +88,7 @@ func BuildPodWithPVC(namespace, name, nodename string, p v1.PodPhase, req v1.Res
 			Namespace: namespace,
 			Labels:    labels,
 			Annotations: map[string]string{
-				schedulingv1.KubeGroupNameAnnotationKey: groupName,
+				schedulingv1beta1.KubeGroupNameAnnotationKey: groupName,
 			},
 		},
 		Status: v1.PodStatus{
@@ -184,7 +184,7 @@ func BuildBestEffortPod(namespace, name, nodeName string, p v1.PodPhase, groupNa
 			Namespace: namespace,
 			Labels:    labels,
 			Annotations: map[string]string{
-				schedulingv1.KubeGroupNameAnnotationKey: groupName,
+				schedulingv1beta1.KubeGroupNameAnnotationKey: groupName,
 			},
 		},
 		Status: v1.PodStatus{
@@ -213,7 +213,7 @@ func BuildPodWithPriority(namespace, name, nodeName string, p v1.PodPhase, req v
 			Namespace: namespace,
 			Labels:    labels,
 			Annotations: map[string]string{
-				schedulingv1.KubeGroupNameAnnotationKey: groupName,
+				schedulingv1beta1.KubeGroupNameAnnotationKey: groupName,
 			},
 		},
 		Status: v1.PodStatus{
@@ -235,25 +235,25 @@ func BuildPodWithPriority(namespace, name, nodeName string, p v1.PodPhase, req v
 }
 
 // BuildPodGroup return podgroup with base spec and phase status
-func BuildPodGroup(name, ns, queue string, minMember int32, taskMinMember map[string]int32, status schedulingv1.PodGroupPhase) *schedulingv1.PodGroup {
-	return &schedulingv1.PodGroup{
+func BuildPodGroup(name, ns, queue string, minMember int32, taskMinMember map[string]int32, status schedulingv1beta1.PodGroupPhase) *schedulingv1beta1.PodGroup {
+	return &schedulingv1beta1.PodGroup{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: ns,
 		},
-		Spec: schedulingv1.PodGroupSpec{
+		Spec: schedulingv1beta1.PodGroupSpec{
 			Queue:         queue,
 			MinMember:     minMember,
 			MinTaskMember: taskMinMember,
 		},
-		Status: schedulingv1.PodGroupStatus{
+		Status: schedulingv1beta1.PodGroupStatus{
 			Phase: status,
 		},
 	}
 }
 
 // BuildPodGroup return podgroup
-func BuildPodGroupWithPrio(name, ns, queue string, minMember int32, taskMinMember map[string]int32, status schedulingv1.PodGroupPhase, prioName string) *schedulingv1.PodGroup {
+func BuildPodGroupWithPrio(name, ns, queue string, minMember int32, taskMinMember map[string]int32, status schedulingv1beta1.PodGroupPhase, prioName string) *schedulingv1beta1.PodGroup {
 	pg := BuildPodGroup(name, ns, queue, minMember, taskMinMember, status)
 	pg.Spec.PriorityClassName = prioName
 	return pg
@@ -262,12 +262,12 @@ func BuildPodGroupWithPrio(name, ns, queue string, minMember int32, taskMinMembe
 ///////////// function to build queue  ///////////////////
 
 // BuildQueue return a scheduling Queue
-func BuildQueue(qname string, weight int32, cap v1.ResourceList) *schedulingv1.Queue {
-	return &schedulingv1.Queue{
+func BuildQueue(qname string, weight int32, cap v1.ResourceList) *schedulingv1beta1.Queue {
+	return &schedulingv1beta1.Queue{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: qname,
 		},
-		Spec: schedulingv1.QueueSpec{
+		Spec: schedulingv1beta1.QueueSpec{
 			Weight:     weight,
 			Capability: cap,
 		},

--- a/pkg/scheduler/util/test_utils.go
+++ b/pkg/scheduler/util/test_utils.go
@@ -30,7 +30,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
 
-	schedulingv2 "volcano.sh/apis/pkg/apis/scheduling/v1beta1"
+	schedulingv1 "volcano.sh/apis/pkg/apis/scheduling/v1beta1"
 	"volcano.sh/volcano/pkg/scheduler/api"
 	volumescheduling "volcano.sh/volcano/pkg/scheduler/capabilities/volumebinding"
 )
@@ -59,7 +59,7 @@ func BuildPod(namespace, name, nodeName string, p v1.PodPhase, req v1.ResourceLi
 			Namespace: namespace,
 			Labels:    labels,
 			Annotations: map[string]string{
-				schedulingv2.KubeGroupNameAnnotationKey: groupName,
+				schedulingv1.KubeGroupNameAnnotationKey: groupName,
 			},
 		},
 		Status: v1.PodStatus{
@@ -88,7 +88,7 @@ func BuildPodWithPVC(namespace, name, nodename string, p v1.PodPhase, req v1.Res
 			Namespace: namespace,
 			Labels:    labels,
 			Annotations: map[string]string{
-				schedulingv2.KubeGroupNameAnnotationKey: groupName,
+				schedulingv1.KubeGroupNameAnnotationKey: groupName,
 			},
 		},
 		Status: v1.PodStatus{
@@ -184,7 +184,7 @@ func BuildBestEffortPod(namespace, name, nodeName string, p v1.PodPhase, groupNa
 			Namespace: namespace,
 			Labels:    labels,
 			Annotations: map[string]string{
-				schedulingv2.KubeGroupNameAnnotationKey: groupName,
+				schedulingv1.KubeGroupNameAnnotationKey: groupName,
 			},
 		},
 		Status: v1.PodStatus{
@@ -213,7 +213,7 @@ func BuildPodWithPriority(namespace, name, nodeName string, p v1.PodPhase, req v
 			Namespace: namespace,
 			Labels:    labels,
 			Annotations: map[string]string{
-				schedulingv2.KubeGroupNameAnnotationKey: groupName,
+				schedulingv1.KubeGroupNameAnnotationKey: groupName,
 			},
 		},
 		Status: v1.PodStatus{
@@ -230,6 +230,46 @@ func BuildPodWithPriority(namespace, name, nodeName string, p v1.PodPhase, req v
 					},
 				},
 			},
+		},
+	}
+}
+
+// BuildPodGroup return podgroup with base spec and phase status
+func BuildPodGroup(name, ns, queue string, minMember int32, taskMinMember map[string]int32, status schedulingv1.PodGroupPhase) *schedulingv1.PodGroup {
+	return &schedulingv1.PodGroup{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: ns,
+		},
+		Spec: schedulingv1.PodGroupSpec{
+			Queue:         queue,
+			MinMember:     minMember,
+			MinTaskMember: taskMinMember,
+		},
+		Status: schedulingv1.PodGroupStatus{
+			Phase: status,
+		},
+	}
+}
+
+// BuildPodGroup return podgroup
+func BuildPodGroupWithPrio(name, ns, queue string, minMember int32, taskMinMember map[string]int32, status schedulingv1.PodGroupPhase, prioName string) *schedulingv1.PodGroup {
+	pg := BuildPodGroup(name, ns, queue, minMember, taskMinMember, status)
+	pg.Spec.PriorityClassName = prioName
+	return pg
+}
+
+///////////// function to build queue  ///////////////////
+
+// BuildQueue return a scheduling Queue
+func BuildQueue(qname string, weight int32, cap v1.ResourceList) *schedulingv1.Queue {
+	return &schedulingv1.Queue{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: qname,
+		},
+		Spec: schedulingv1.QueueSpec{
+			Weight:     weight,
+			Capability: cap,
 		},
 	}
 }


### PR DESCRIPTION
Fix #3161 (Preemption fails when queue resources are insufficient and node resources are sufficient )