### PR TITLE
update parameter BestEffort of taskInfo after changing parameter InitResreq

### DIFF
--- a/pkg/scheduler/cache/event_handlers.go
+++ b/pkg/scheduler/cache/event_handlers.go
@@ -228,6 +228,8 @@ func (sc *SchedulerCache) NewTaskInfo(pod *v1.Pod) (*schedulingapi.TaskInfo, err
 	if err := sc.addPodCSIVolumesToTask(taskInfo); err != nil {
 		return taskInfo, err
 	}
+	// Update BestEffort because the InitResreq maybe changes
+	taskInfo.BestEffort = taskInfo.InitResreq.IsEmpty()
 	return taskInfo, nil
 }
 


### PR DESCRIPTION
update parameter BestEffort of taskInfo after changing parameter InitResreq

InitResreq may be changed by func addPodCSIVolumesToTask