### PR TITLE
fix: JSON serialization issue

### DIFF
--- a/pkg/scheduler/api/job_info.go
+++ b/pkg/scheduler/api/job_info.go
@@ -133,7 +133,7 @@ type TaskInfo struct {
 	Pod        *v1.Pod
 
 	// CustomBindErrHandler is a custom callback func called when task bind err.
-	CustomBindErrHandler func() error
+	CustomBindErrHandler func() error `json:"-"`
 	// CustomBindErrHandlerSucceeded indicates whether CustomBindErrHandler is executed successfully.
 	CustomBindErrHandlerSucceeded bool
 }


### PR DESCRIPTION
This PR addresses the JSON serialization issue(#3256) related to the `CustomBindErrHandler` field in the `TaskInfo` struct. It excludes the `CustomBindErrHandler` field from JSON serialization to resolve the error.

Let me know the further changes required.