### PR TITLE
add mock cache for ut and performance test

### DIFF
--- a/cmd/scheduler/app/options/options.go
+++ b/cmd/scheduler/app/options/options.go
@@ -191,3 +191,11 @@ func (s *ServerOption) ParseCAFiles(decryptFunc DecryptFunc) error {
 
 	return nil
 }
+
+// Default new and registry a default one
+func Default() *ServerOption {
+	s := NewServerOption()
+	s.AddFlags(pflag.CommandLine)
+	s.RegisterOptions()
+	return s
+}

--- a/pkg/scheduler/cache/cache_mock.go
+++ b/pkg/scheduler/cache/cache_mock.go
@@ -1,0 +1,126 @@
+package cache
+
+import (
+	"math"
+	"os"
+	"strconv"
+
+	schedulingv1 "k8s.io/api/scheduling/v1"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/util/workqueue"
+
+	fakevcClient "volcano.sh/apis/pkg/client/clientset/versioned/fake"
+	"volcano.sh/volcano/cmd/scheduler/app/options"
+	schedulingapi "volcano.sh/volcano/pkg/scheduler/api"
+)
+
+// NewCustomMockSchedulerCache returns a mock scheduler cache with custom interface
+func NewCustomMockSchedulerCache(schedulerName string,
+	binder Binder,
+	evictor Evictor,
+	statusUpdater StatusUpdater,
+	PodGroupBinder BatchBinder,
+	volumeBinder VolumeBinder,
+	recorder record.EventRecorder,
+) *SchedulerCache {
+	msc := newMockSchedulerCache(schedulerName)
+	// add all events handlers
+	msc.addEventHandler()
+	msc.Recorder = recorder
+	msc.Binder = binder
+	msc.Evictor = evictor
+	msc.StatusUpdater = statusUpdater
+	msc.PodGroupBinder = PodGroupBinder
+	// use custom volume binder
+	msc.VolumeBinder = volumeBinder
+	checkAndSetDefaultInterface(msc)
+	return msc
+}
+
+// NewDefaultMockSchedulerCache returns a mock scheduler cache with interface mocked with default fake clients
+// Notes that default events recorder's buffer only has a length 100;
+// when use it do performance test, should use a &FakeRecorder{} without length limit to avoid block
+func NewDefaultMockSchedulerCache(schedulerName string) *SchedulerCache {
+	msc := newMockSchedulerCache(schedulerName)
+	// add all events handlers
+	msc.addEventHandler()
+	checkAndSetDefaultInterface(msc)
+	return msc
+}
+
+func checkAndSetDefaultInterface(sc *SchedulerCache) {
+	if sc.Recorder == nil {
+		sc.Recorder = record.NewFakeRecorder(100) // to avoid blocking, we can pass in &FakeRecorder{} to NewCustomMockSchedulerCache
+	}
+	if sc.Binder == nil {
+		sc.Binder = &DefaultBinder{
+			kubeclient: sc.kubeClient,
+			recorder:   sc.Recorder,
+		}
+	}
+	if sc.Evictor == nil {
+		sc.Evictor = &defaultEvictor{
+			kubeclient: sc.kubeClient,
+			recorder:   sc.Recorder,
+		}
+	}
+	if sc.StatusUpdater == nil {
+		sc.StatusUpdater = &defaultStatusUpdater{
+			kubeclient: sc.kubeClient,
+			vcclient:   sc.vcClient,
+		}
+	}
+	if sc.PodGroupBinder == nil {
+		sc.PodGroupBinder = &podgroupBinder{
+			kubeclient: sc.kubeClient,
+			vcclient:   sc.vcClient,
+		}
+	}
+	// finally, init default fake volume binder which has dependencies on other informers
+	if sc.VolumeBinder == nil {
+		sc.setDefaultVolumeBinder()
+	}
+}
+
+func getNodeWorkers() uint32 {
+	if options.ServerOpts.NodeWorkerThreads > 0 {
+		return options.ServerOpts.NodeWorkerThreads
+	}
+	threads, err := strconv.Atoi(os.Getenv("NODE_WORKER_THREADS"))
+	if err == nil && threads > 0 && threads <= math.MaxUint32 {
+		return uint32(threads)
+	}
+	return 2 //default 2
+}
+
+// newMockSchedulerCache init the mock scheduler cache structure
+func newMockSchedulerCache(schedulerName string) *SchedulerCache {
+	msc := &SchedulerCache{
+		Jobs:                make(map[schedulingapi.JobID]*schedulingapi.JobInfo),
+		Nodes:               make(map[string]*schedulingapi.NodeInfo),
+		Queues:              make(map[schedulingapi.QueueID]*schedulingapi.QueueInfo),
+		PriorityClasses:     make(map[string]*schedulingv1.PriorityClass),
+		errTasks:            workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter()),
+		nodeQueue:           workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter()),
+		DeletedJobs:         workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter()),
+		kubeClient:          fake.NewSimpleClientset(),
+		vcClient:            fakevcClient.NewSimpleClientset(),
+		restConfig:          nil,
+		defaultQueue:        "default",
+		schedulerNames:      []string{schedulerName},
+		nodeSelectorLabels:  make(map[string]string),
+		NamespaceCollection: make(map[string]*schedulingapi.NamespaceCollection),
+		CSINodesStatus:      make(map[string]*schedulingapi.CSINodeStatusInfo),
+		imageStates:         make(map[string]*imageState),
+
+		NodeList: []string{},
+	}
+	if len(options.ServerOpts.NodeSelector) > 0 {
+		msc.updateNodeSelectors(options.ServerOpts.NodeSelector)
+	}
+	msc.setBatchBindParallel()
+	msc.nodeWorkers = getNodeWorkers()
+
+	return msc
+}

--- a/pkg/scheduler/cache/cache_test.go
+++ b/pkg/scheduler/cache/cache_test.go
@@ -26,16 +26,8 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/client-go/informers"
-	"k8s.io/client-go/kubernetes/fake"
-	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
-	"k8s.io/client-go/util/workqueue"
-	"k8s.io/klog/v2"
-
 	"volcano.sh/volcano/pkg/scheduler/api"
-	volumescheduling "volcano.sh/volcano/pkg/scheduler/capabilities/volumebinding"
 	"volcano.sh/volcano/pkg/scheduler/util"
 )
 
@@ -318,73 +310,35 @@ func TestNodeOperation(t *testing.T) {
 }
 
 func TestBindTasks(t *testing.T) {
-	logger := klog.FromContext(context.TODO())
 	owner := buildOwnerReference("j1")
 	scheduler := "fake-scheduler"
 
-	fakeKube := fake.NewSimpleClientset()
-	informerFactory := informers.NewSharedInformerFactory(fakeKube, 0)
-	sc := &SchedulerCache{
-		Jobs:            make(map[api.JobID]*api.JobInfo),
-		Nodes:           make(map[string]*api.NodeInfo),
-		kubeClient:      fakeKube,
-		schedulerNames:  []string{scheduler},
-		Recorder:        record.NewFakeRecorder(10),
-		BindFlowChannel: make(chan *api.TaskInfo, 5000),
-		podInformer:     informerFactory.Core().V1().Pods(),
-		nodeInformer:    informerFactory.Core().V1().Nodes(),
-		csiNodeInformer: informerFactory.Storage().V1().CSINodes(),
-		pvcInformer:     informerFactory.Core().V1().PersistentVolumeClaims(),
-		pvInformer:      informerFactory.Core().V1().PersistentVolumes(),
-		scInformer:      informerFactory.Storage().V1().StorageClasses(),
-		errTasks:        workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter()),
-		nodeQueue:       workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter()),
-	}
-
-	sc.Binder = &DefaultBinder{sc.kubeClient, sc.Recorder}
-	sc.VolumeBinder = &defaultVolumeBinder{
-		volumeBinder: volumescheduling.NewVolumeBinder(
-			logger,
-			sc.kubeClient,
-			sc.podInformer,
-			sc.nodeInformer,
-			sc.csiNodeInformer,
-			sc.pvcInformer,
-			sc.pvInformer,
-			sc.scInformer,
-			nil,
-			100*time.Millisecond,
-		)}
-
-	sc.podInformer.Informer().AddEventHandler(
-		cache.ResourceEventHandlerFuncs{
-			AddFunc:    sc.AddPod,
-			UpdateFunc: sc.UpdatePod,
-			DeleteFunc: sc.DeletePod,
-		},
-	)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	go wait.Until(sc.processBindTask, time.Millisecond*5, ctx.Done())
+
+	sc := NewDefaultMockSchedulerCache(scheduler)
+	sc.Run(ctx.Done())
+	kubeCli := sc.kubeClient
+
 	pod := buildPod("c1", "p1", "", v1.PodPending, api.BuildResourceList("1000m", "1G"), []metav1.OwnerReference{owner}, make(map[string]string))
 	node := buildNode("n1", api.BuildResourceList("2000m", "10G", []api.ScalarResource{{Name: "pods", Value: "10"}}...))
 	pod.Annotations = map[string]string{"scheduling.k8s.io/group-name": "j1"}
 	pod.Spec.SchedulerName = scheduler
 
 	// make sure pod exist when calling fake client binding
-	fakeKube.CoreV1().Pods(pod.Namespace).Create(ctx, pod, metav1.CreateOptions{})
-	informerFactory.Start(ctx.Done())
-	informerFactory.WaitForCacheSync(ctx.Done())
+	kubeCli.CoreV1().Pods(pod.Namespace).Create(ctx, pod, metav1.CreateOptions{})
 	// set node in cache directly
-	sc.AddOrUpdateNode(node)
+	kubeCli.CoreV1().Nodes().Create(ctx, node, metav1.CreateOptions{})
 
+	// wait for pod synced
+	time.Sleep(100 * time.Millisecond)
 	task := api.NewTaskInfo(pod)
 	task.NodeName = "n1"
 	err := sc.AddBindTask(task)
 	if err != nil {
 		t.Errorf("failed to bind pod to node: %v", err)
 	}
-	time.Sleep(200 * time.Millisecond)
+	time.Sleep(100 * time.Millisecond)
 	r := sc.Recorder.(*record.FakeRecorder)
 	if len(r.Events) != 1 {
 		t.Fatalf("succesfully binding task should have 1 event")

--- a/pkg/scheduler/cache/main_test.go
+++ b/pkg/scheduler/cache/main_test.go
@@ -1,0 +1,13 @@
+package cache
+
+import (
+	"os"
+	"testing"
+
+	"volcano.sh/volcano/cmd/scheduler/app/options"
+)
+
+func TestMain(m *testing.M) {
+	options.Default()
+	os.Exit(m.Run())
+}


### PR DESCRIPTION
This Pr supply mock SchedulerCache with two methods:
1. `NewCustomMockSchedulerCache` use customer's interface to replace those schedulerCache's interface
2. `NewDefaultMockSchedulerCache` use k8s fake client as the default one to replace schedulerCache's interface.

we can use mockSchedulerCache in this PR to do those things:

-  performance UT test in issue [Performance benchmark is need #3244](https://github.com/volcano-sh/volcano/issues/3244)

- Improve all UTs such as:
  1.  [UT didn't really run because of kubeclient init failed #2957](https://github.com/volcano-sh/volcano/issues/2957)
  2. [to simplify ut code](https://github.com/volcano-sh/volcano/issues/3270)