### PR TITLE
fix k8s.io/dynamic-resource-allocation go mod not found err

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -155,6 +155,7 @@ replace (
 	k8s.io/controller-manager => k8s.io/controller-manager v0.27.2
 	k8s.io/cri-api => k8s.io/cri-api v0.27.2
 	k8s.io/csi-translation-lib => k8s.io/csi-translation-lib v0.27.2
+	k8s.io/dynamic-resource-allocation => k8s.io/dynamic-resource-allocation v0.27.2
 	k8s.io/kube-aggregator => k8s.io/kube-aggregator v0.27.2
 	k8s.io/kube-controller-manager => k8s.io/kube-controller-manager v0.27.2
 	k8s.io/kube-proxy => k8s.io/kube-proxy v0.27.2


### PR DESCRIPTION
k8s.io/dynamic-resource-allocation is imported in k8s v1.27, and should also be replaced with v0.27 like other sub libraries, or error will occur when execute go list -json command: 
`"D:\Program Files\Go\bin\go.exe" list -modfile=D:/go/src/volcano\go.mod -m -json -mod=mod all #gosetup
go: k8s.io/dynamic-resource-allocation@v0.0.0: reading https://cmc.centralrepo.rnd.huawei.com/artifactory/go-central-repo/k8s.io/dynamic-resource-allocation/@v/v0.0.0.info: 404 `