### PR TITLE
fix: json marsh error for unsupport type: func()

### DIFF
--- a/pkg/scheduler/api/job_info.go
+++ b/pkg/scheduler/api/job_info.go
@@ -133,7 +133,7 @@ type TaskInfo struct {
 	Pod        *v1.Pod
 
 	// CustomBindErrHandler is a custom callback func called when task bind err.
-	CustomBindErrHandler func() error
+	CustomBindErrHandler func() error `json:"-"`
 	// CustomBindErrHandlerSucceeded indicates whether CustomBindErrHandler is executed successfully.
 	CustomBindErrHandlerSucceeded bool
 }


### PR DESCRIPTION
split from https://github.com/volcano-sh/volcano/pull/3162

Fixes https://github.com/volcano-sh/volcano/issues/3240

The original issue and background:
#3256