### PR TITLE
[cherry-pick for release-1.8]fix: json marsh error for unsupport type: func()

### DIFF
--- a/pkg/scheduler/api/job_info.go
+++ b/pkg/scheduler/api/job_info.go
@@ -133,7 +133,7 @@ type TaskInfo struct {
 	Pod        *v1.Pod
 
 	// CustomBindErrHandler is a custom callback func called when task bind err.
-	CustomBindErrHandler func() error
+	CustomBindErrHandler func() error `json:"-"`
 	// CustomBindErrHandlerSucceeded indicates whether CustomBindErrHandler is executed successfully.
 	CustomBindErrHandlerSucceeded bool
 }


### PR DESCRIPTION
cherry-pick for [fix: json marsh error for unsupport type: func() #3273](https://github.com/volcano-sh/volcano/pull/3273)