### PR TITLE
fix wrong pods field format output of queue status

### DIFF
--- a/pkg/scheduler/util/scheduler_helper.go
+++ b/pkg/scheduler/util/scheduler_helper.go
@@ -210,6 +210,10 @@ func ConvertRes2ResList(res *api.Resource) v1.ResourceList {
 	rl[v1.ResourceCPU] = *resource.NewMilliQuantity(int64(res.MilliCPU), resource.DecimalSI)
 	rl[v1.ResourceMemory] = *resource.NewQuantity(int64(res.Memory), resource.BinarySI)
 	for resourceName, f := range res.ScalarResources {
+		if resourceName == v1.ResourcePods {
+			rl[resourceName] = *resource.NewQuantity(int64(f), resource.DecimalSI)
+			continue
+		}
 		rl[resourceName] = *resource.NewMilliQuantity(int64(f), resource.DecimalSI)
 	}
 	return rl


### PR DESCRIPTION
fix wrong pods field format output of queue status
before:
![image](https://github.com/volcano-sh/volcano/assets/16742217/18d1d2cf-3f28-474b-a515-e4d3325beaea)
after:
![image](https://github.com/volcano-sh/volcano/assets/16742217/b0e538ca-4d2c-4651-9386-0cf068e9aa44)
