### PR TITLE
Switch hostPath to emptyDir

### DIFF
--- a/installer/helm/chart/volcano/templates/scheduler.yaml
+++ b/installer/helm/chart/volcano/templates/scheduler.yaml
@@ -175,8 +175,7 @@ spec:
           configMap:
             name: {{ .Release.Name }}-scheduler-configmap
         - name: klog-sock
-          hostPath:
-            path: /tmp/klog-socks
+          emptyDir: {}
 ---
 apiVersion: v1
 kind: Service

--- a/installer/volcano-development.yaml
+++ b/installer/volcano-development.yaml
@@ -4114,8 +4114,7 @@ spec:
           configMap:
             name: volcano-scheduler-configmap
         - name: klog-sock
-          hostPath:
-            path: /tmp/klog-socks
+          emptyDir: {}
 ---
 # Source: volcano/templates/scheduling_v1beta1_podgroup.yaml
 apiVersion: apiextensions.k8s.io/v1


### PR DESCRIPTION
Resolves #3298

hostPath should be avoided unless absolutely necessary as per the upstream k8s docs:

https://kubernetes.io/docs/concepts/storage/volumes/#hostpath

This change swaps the hostPath for an emptyDir allowing the tmp logs to be written to an ephemeral location.

`emptyDir` is preferable to not using a volume at all in case a users environment enforces Read Only Root Filesystems.

Since this log is already being written to `/tmp` it doesn't seem like there is a requirement to persist these logs using a PVC.