### PR TITLE
fix Data Race leading to panic in Scheduler (and use more efficient strings comparison)

### DIFF
--- a/pkg/scheduler/api/devices/nvidia/vgpu/device_info.go
+++ b/pkg/scheduler/api/devices/nvidia/vgpu/device_info.go
@@ -131,7 +131,7 @@ func (gs *GPUDevices) AddResource(pod *v1.Pod) {
 				break
 			}
 			for index, gsdevice := range gs.Device {
-				if strings.Compare(gsdevice.UUID, deviceused.UUID) == 0 {
+				if gsdevice.UUID == deviceused.UUID {
 					klog.V(4).Infoln("VGPU recording pod", pod.Name, "device", deviceused)
 					gs.Device[index].UsedMem += uint(deviceused.Usedmem)
 					gs.Device[index].UsedNum++
@@ -156,7 +156,7 @@ func (gs *GPUDevices) SubResource(pod *v1.Pod) {
 				break
 			}
 			for index, gsdevice := range gs.Device {
-				if strings.Compare(gsdevice.UUID, deviceused.UUID) == 0 {
+				if gsdevice.UUID == deviceused.UUID {
 					klog.V(4).Infoln("VGPU subsctracting pod", pod.Name, "device", deviceused)
 					gs.Device[index].UsedMem -= uint(deviceused.Usedmem)
 					gs.Device[index].UsedNum--

--- a/pkg/scheduler/api/devices/nvidia/vgpu/utils.go
+++ b/pkg/scheduler/api/devices/nvidia/vgpu/utils.go
@@ -296,7 +296,7 @@ func checkType(annos map[string]string, d GPUDevice, n ContainerDeviceRequest) b
 	if !strings.Contains(d.Type, n.Type) {
 		return false
 	}
-	if strings.Compare(n.Type, NvidiaGPUDevice) == 0 {
+	if n.Type == NvidiaGPUDevice {
 		return checkGPUtype(annos, d.Type)
 	}
 	klog.Errorf("Unrecognized device %v", n.Type)

--- a/pkg/scheduler/api/node_info.go
+++ b/pkg/scheduler/api/node_info.go
@@ -345,11 +345,12 @@ func (ni *NodeInfo) SetNode(node *v1.Node) {
 
 // setNodeOthersResource initialize sharable devices
 func (ni *NodeInfo) setNodeOthersResource(node *v1.Node) {
-	IgnoredDevicesList = []string{}
 	ni.Others[GPUSharingDevice] = gpushare.NewGPUDevices(ni.Name, node)
 	ni.Others[vgpu.DeviceName] = vgpu.NewGPUDevices(ni.Name, node)
-	IgnoredDevicesList = append(IgnoredDevicesList, ni.Others[GPUSharingDevice].(Devices).GetIgnoredDevices()...)
-	IgnoredDevicesList = append(IgnoredDevicesList, ni.Others[vgpu.DeviceName].(Devices).GetIgnoredDevices()...)
+	IgnoredDevicesList.Set(
+		ni.Others[GPUSharingDevice].(Devices).GetIgnoredDevices(),
+		ni.Others[vgpu.DeviceName].(Devices).GetIgnoredDevices(),
+	)
 }
 
 // setNode sets kubernetes node object to nodeInfo object without assertion

--- a/pkg/scheduler/api/resource_info.go
+++ b/pkg/scheduler/api/resource_info.go
@@ -88,12 +88,13 @@ func NewResource(rl v1.ResourceList) *Resource {
 			//NOTE: When converting this back to k8s resource, we need record the format as well as / 1000
 			if v1helper.IsScalarResourceName(rName) {
 				ignore := false
-				for _, val := range IgnoredDevicesList {
-					if strings.Compare(rName.String(), val) == 0 {
+				IgnoredDevicesList.Range(func(_ int, val string) bool {
+					if rName.String() == val {
 						ignore = true
-						break
+						return false
 					}
-				}
+					return true
+				})
 				if !ignore {
 					r.AddScalar(rName, float64(rQuant.MilliValue()))
 				} else {

--- a/pkg/scheduler/api/shared_device_pool_test.go
+++ b/pkg/scheduler/api/shared_device_pool_test.go
@@ -1,0 +1,126 @@
+package api
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_ignoredDevicesList_Set_BasicUsage(t *testing.T) {
+	tests := []struct {
+		name                   string
+		deviceLists            [][]string
+		expectedIgnoredDevices []string
+	}{
+		{
+			name:                   "set several values to ignoredDevicesList",
+			deviceLists:            [][]string{{"volcano.sh/vgpu-memory", "volcano.sh/vgpu-memory-percentage", "volcano.sh/vgpu-cores"}},
+			expectedIgnoredDevices: []string{"volcano.sh/vgpu-memory", "volcano.sh/vgpu-memory-percentage", "volcano.sh/vgpu-cores"},
+		},
+		{
+			name:                   "set several lists of values to ignoredDevicesList atomically",
+			deviceLists:            [][]string{{"volcano.sh/vgpu-memory"}, {"volcano.sh/vgpu-memory-percentage", "volcano.sh/vgpu-cores"}},
+			expectedIgnoredDevices: []string{"volcano.sh/vgpu-memory", "volcano.sh/vgpu-memory-percentage", "volcano.sh/vgpu-cores"},
+		},
+		{
+			name:                   "possible way to clear ignoredDevicesList",
+			deviceLists:            nil,
+			expectedIgnoredDevices: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lst := ignoredDevicesList{}
+			lst.Set(tt.deviceLists...)
+			assert.Equal(t, tt.expectedIgnoredDevices, lst.ignoredDevices)
+		})
+	}
+}
+
+func Test_ignoredDevicesList_Range_BasicUsage(t *testing.T) {
+	lst := ignoredDevicesList{}
+	lst.Set([]string{"volcano.sh/vgpu-memory", "volcano.sh/vgpu-memory-percentage", "volcano.sh/vgpu-cores"})
+
+	t.Run("read and copy values from the ignoredDevicesList", func(t *testing.T) {
+		ignoredDevices := make([]string, 0, len(lst.ignoredDevices))
+		lst.Range(func(_ int, device string) bool {
+			ignoredDevices = append(ignoredDevices, device)
+			return true
+		})
+		assert.Equal(t, lst.ignoredDevices, ignoredDevices)
+	})
+
+	t.Run("break iteration through the ignoredDevicesList", func(t *testing.T) {
+		i := 0
+		flag := false
+		lst.Range(func(_ int, device string) bool {
+			i++
+			if lst.ignoredDevices[1] == device {
+				flag = true
+				return false
+			}
+			return true
+		})
+
+		assert.Equal(t, true, flag)
+		assert.Equal(t, 2, i)
+	})
+}
+
+func Test_ignoredDevicesList_Set_Concurrent(t *testing.T) {
+	lst := ignoredDevicesList{}
+	expected := []string{"volcano.sh/vgpu-memory", "volcano.sh/vgpu-memory-percentage", "volcano.sh/vgpu-cores"}
+
+	var wg sync.WaitGroup
+	wg.Add(8)
+	for i := 0; i < 8; i++ {
+		go func() {
+			defer wg.Done()
+			lst.Set(expected)
+		}()
+	}
+	wg.Wait()
+
+	assert.Equal(t, expected, lst.ignoredDevices)
+}
+
+func Test_ignoredDevicesList_Range_Concurrent(t *testing.T) {
+	lst := ignoredDevicesList{}
+	lst.Set([]string{"volcano.sh/vgpu-memory", "volcano.sh/vgpu-memory-percentage", "volcano.sh/vgpu-cores"})
+
+	var wg sync.WaitGroup
+	wg.Add(8)
+	for i := 0; i < 8; i++ {
+		go func() {
+			defer wg.Done()
+			ignoredDevices := make([]string, 0, len(lst.ignoredDevices))
+			lst.Range(func(_ int, device string) bool {
+				ignoredDevices = append(ignoredDevices, device)
+				return true
+			})
+			assert.Equal(t, ignoredDevices, lst.ignoredDevices)
+		}()
+	}
+	wg.Wait()
+}
+
+func Test_ignoredDevicesList_NoRace(t *testing.T) {
+	lst := ignoredDevicesList{}
+
+	var wg sync.WaitGroup
+	wg.Add(16)
+	for i := 0; i < 8; i++ {
+		go func() {
+			defer wg.Done()
+			lst.Set([]string{"volcano.sh/vgpu-memory", "volcano.sh/vgpu-memory-percentage", "volcano.sh/vgpu-cores"})
+		}()
+		go func() {
+			defer wg.Done()
+			lst.Range(func(_ int, _ string) bool {
+				return true
+			})
+		}()
+	}
+	wg.Wait()
+}

--- a/pkg/scheduler/plugins/util/util.go
+++ b/pkg/scheduler/plugins/util/util.go
@@ -106,12 +106,13 @@ func GetInqueueResource(job *api.JobInfo, allocated *api.Resource) *api.Resource
 				continue
 			}
 			ignore := false
-			for _, ignoredDevice := range api.IgnoredDevicesList {
+			api.IgnoredDevicesList.Range(func(_ int, ignoredDevice string) bool {
 				if len(ignoredDevice) > 0 && strings.Contains(rName.String(), ignoredDevice) {
 					ignore = true
-					break
+					return false
 				}
-			}
+				return true
+			})
 			if ignore {
 				continue
 			}


### PR DESCRIPTION
3e03d161efb603e92191ff46c092cf231c0c8803 - fix #3324 (scheduler panic in unexpected places due to Data Race):
reading operations during the modification of the `var IgnoredDevicesList []string` could lead to a panic:
```go
WARNING: DATA RACE
Read at 0x00000565d810 by goroutine 276:
  volcano.sh/volcano/pkg/scheduler/api.NewResource()
      /go/src/volcano.sh/volcano/pkg/scheduler/api/resource_info.go:89 +0x40a
  volcano.sh/volcano/pkg/scheduler/api.(*JobInfo).GetMinResources()
      /go/src/volcano.sh/volcano/pkg/scheduler/api/job_info.go:490 +0x1705
  volcano.sh/volcano/pkg/scheduler/plugins/proportion.(*proportionPlugin).OnSessionOpen.func5()
      /go/src/volcano.sh/volcano/pkg/scheduler/plugins/proportion/proportion.go:352 +0x16a1
  volcano.sh/volcano/pkg/scheduler/framework.(*Session).JobEnqueueable()
      /go/src/volcano.sh/volcano/pkg/scheduler/framework/session_plugins.go:401 +0x24a
  volcano.sh/volcano/pkg/scheduler/actions/enqueue.(*Action).Execute()
      /go/src/volcano.sh/volcano/pkg/scheduler/actions/enqueue/enqueue.go:95 +0xddd
  volcano.sh/volcano/pkg/scheduler.(*Scheduler).runOnce()
      /go/src/volcano.sh/volcano/pkg/scheduler/scheduler.go:126 +0x478
  volcano.sh/volcano/pkg/scheduler.(*Scheduler).runOnce-fm()
      <autogenerated>:1 +0x39
  k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1()
      /go/pkg/mod/k8s.io/apimachinery@v0.27.2/pkg/util/wait/backoff.go:226 +0x48
  k8s.io/apimachinery/pkg/util/wait.BackoffUntil()
      /go/pkg/mod/k8s.io/apimachinery@v0.27.2/pkg/util/wait/backoff.go:227 +0xce
  k8s.io/apimachinery/pkg/util/wait.JitterUntil()
      /go/pkg/mod/k8s.io/apimachinery@v0.27.2/pkg/util/wait/backoff.go:204 +0x10d
  k8s.io/apimachinery/pkg/util/wait.Until()
      /go/pkg/mod/k8s.io/apimachinery@v0.27.2/pkg/util/wait/backoff.go:161 +0x48
  volcano.sh/volcano/pkg/scheduler.(*Scheduler).Run.func2()
      /go/src/volcano.sh/volcano/pkg/scheduler/scheduler.go:95 +0x58
```

457d37bdb6b07ed525446658d53863605f49646a - a little more efficient string comparison:
taking into account the source code of [`strings.Compare`](https://cs.opensource.google/go/go/+/refs/tags/go1.22.0:src/strings/compare.go;l=13):
```go
// Compare returns an integer comparing two strings lexicographically.
// The result will be 0 if a == b, -1 if a < b, and +1 if a > b.
//
// Compare is included only for symmetry with package bytes.
// It is usually clearer and always faster to use the built-in
// string comparison operators ==, <, >, and so on.
func Compare(a, b string) int {
	// NOTE(rsc): This function does NOT call the runtime cmpstring function,
	// because we do not want to provide any performance justification for
	// using strings.Compare. Basically no one should use strings.Compare.
	// As the comment above says, it is here only for symmetry with package bytes.
	// If performance is important, the compiler should be changed to recognize
	// the pattern so that all code doing three-way comparisons, not just code
	// using strings.Compare, can benefit.
	if a == b {
		return 0
	}
	if a < b {
		return -1
	}
	return +1
}
```