### PR TITLE
Fix Issue 2262: add priority capability for reclaim action

### DIFF
--- a/docs/design/preempt-action.md
+++ b/docs/design/preempt-action.md
@@ -18,7 +18,7 @@ In preempt action, multiple plugin function are getting used like
 2.  JobOrderFn(Plugin: Priority, DRF, Gang),
 3.  NodeOrderFn(Plugin: NodeOrder),
 4.  PredicateFn(Plugin: Predicates),
-5.  PreemptableFn(Plugin: Conformance, Gang, DRF).
+5.  PreemptableFn(Plugin: Conformance, Gang, DRF, Priority).
 
 ### 1. TaskOrderFn:
 #### Priority:

--- a/docs/design/priority.md
+++ b/docs/design/priority.md
@@ -1,0 +1,39 @@
+# Priority Plugin
+
+## Introduction
+
+When users apply jobs to volcano, they may need to support different priority to different kind of jobs. For example, important serving jobs can have a higher priority when allocating resources, or preempting other jobs in same queue. Even in the same job, the important roles may have a higher priority than others roles, so that it can finished running without interruption.
+
+## Solution
+
+1. `priority` plugin return 5 callback functions: `taskOrderFn`, `jobOrderFn`, `preemptableFn`, `reclaimableFn`, and `jobStarvingFn`:
+
+   1. `taskOrderFn` adjusts the order of task in a job. The higher priority a task has, the higher scored of this task in `taskOrderFn` of `priority` plugin, so that task would have larger probability to be front in priority queue.
+
+   2. `JobOrderFn` adjusts the order of this job. The higher priority (set in podgroup spec) a job has, the higher scored of this job in `JobOrderFn` of `priority` plugin, so that job would have larger probability to be front int priority queue.
+
+   3. `preemptableFn` compares the priority of preemptor and victims. If preemptor task and victim task belong to different job, then compares their job's priority and job with higher priority can preempt job with lower priority. Otherwise, compares preemptor task's priority and victim task's priority. Task with higher priority can preempt task with lower priority in same job.
+
+   4. `reclaimableFn` compares the priority of preemptor job and victim job. Job with higher priority can reclaim job with lower priority.
+
+**Note**: `reclaimableFn` usually is used in `reclaim` action to reclaim a queue's deserved resource when cluster has not enough resource to allocate new coming tasks in this queue. So it should be carefully used in `priority` plugin, in case that a queue's resource owned by high priority jobs can not be released.
+
+## Feature Interaction
+
+At first, `reclaimableFn` is not supported in priority plugin. Now it is added as [issue2262](https://github.com/volcano-sh/volcano/issues/2262) required.  `enableReclaimable` is disabled by default for compatibility. Please be carefully to set `enableReclaimable` to `true` in `priority` plugin, because it may cause a queue's overused resource can not be reclaimed if the overused resource is own by jobs with high priority.
+
+```yaml
+    actions: "enqueue, allocate, preempt, reclaim"
+    tiers:
+    - plugins:
+      - name: priority
+        enableReclaimable: false
+      - name: gang
+        enablePreemptable: false
+      - name: conformance
+    - plugins:
+      - name: drf
+      - name: predicates
+      - name: proportion
+      - name: nodeorder
+```

--- a/docs/design/reclaim-action.md
+++ b/docs/design/reclaim-action.md
@@ -22,41 +22,62 @@ creating tasks.
 
 In Reclaim Action, there are multiple plugin functions that are getting used like,
 
-1.  TaskOrderFn(Plugin: Priority),
-2.  JobOrderFn(Plugin: Priority, DRF, Gang),
-3.  NodeOrderFn(Plugin: NodeOrder),
-4.  PredicateFn(Plugin: Predicates),
-5.  ReclaimableFn(Plugin: Conformance, Gang, Proportion).
+1. TaskOrderFn(Plugin: Priority),
+2. JobOrderFn(Plugin: Priority, DRF, Gang),
+3. NodeOrderFn(Plugin: NodeOrder),
+4. PredicateFn(Plugin: Predicates),
+5. ReclaimableFn(Plugin: Conformance, Gang, Proportion, Priority).
 
-### 1. TaskOrderFn:
-#### Priority:
+### 1. TaskOrderFn
+
+#### Priority
+
 Compares taskPriority set in PodSpec and returns the decision of comparison between two priorities.
 
-### 2. JobOrderFn:
-#### Priority:
+### 2. JobOrderFn
+
+#### Priority
+
 Compares jobPriority set in Spec(using PriorityClass) and returns the decision of comparison between two priorities.
 
-#### DRF:
+#### DRF
+
 The job having the lowest share will have higher priority.
 
-#### Gang:
+#### Gang
+
 The job which is not yet ready(i.e. minAvailable number of task is not yet in Bound, Binding, Running, Allocated, Succeeded, Pipelined state) will have high priority.
 
-### 3. NodeOrderFn:
-#### NodeOrder:
+### 3. NodeOrderFn
+
+#### NodeOrder
+
 NodeOrderFn returns the score of a particular node for a specific task by running through sets of priorities.
 
-### 4. PredicateFn:
-#### Predicates:
+### 4. PredicateFn
+
+#### Predicates
+
 PredicateFn returns whether a task can be bounded to a node or not by running through set of predicates.
 
-### 5. ReclaimableFn:
+### 5. ReclaimableFn
+
 Checks whether a task can be evicted or not, which returns set of tasks that can be evicted so that new task can be created in new queue.
-#### Conformance:
+
+#### Conformance
+
 In conformance plugin, it checks whether a task is critical or running in kube-system namespace, so that it can be avoided while computing set of tasks that can be preempted.
-#### Gang:
+
+#### Gang
+
 It checks whether by evicting a task, it affects gang scheduling in kube-batch.  It checks whether by evicting particular task,
 total number of tasks running for a job is going to be less than the minAvailable requirement for gang scheduling requirement.
-#### Proportion:
+
+#### Proportion
+
 It checks whether by evicting a task, that task's queue has allocated resource less than the deserved share.  If so, that task
 is added as a victim task that can be evicted so that resource can be reclaimed.
+
+#### Priority
+
+In priority plugin, it checks whether a task's job has a higher priority set in job spec, so that it can be avoided while computing set of tasks that can be preempted.

--- a/docs/design/reclaim-design.md
+++ b/docs/design/reclaim-design.md
@@ -21,10 +21,8 @@ Reclaim runs in each session and the workflow of the session is explained below 
         2. Send preemptor task and set of **reclaimees** task to ReclaimableFn which has been loaded by following plugins such as conformance, gang and proportion
 5. ReclaimableFn returns all possible victim tasks that can be evicted
 6. If number or victim tasks is zero or resource requirement of preemptor task is greater than total resource of all victim tasks, then move on to next node
-7. If resouce requirement of preemptor task is satisfied, then evict tasks from victim tasks one by one until preemptor task can be pipelined
+7. If resource requirement of preemptor task is satisfied, then evict tasks from victim tasks one by one until preemptor task can be pipelined
 8. Run this until **queues** object is empty
 
 ![Execution flow graph for Reclaim](./images/ReclaimDesign.png)
-
-
 

--- a/installer/helm/chart/volcano/config/volcano-scheduler-ci.conf
+++ b/installer/helm/chart/volcano/config/volcano-scheduler-ci.conf
@@ -2,6 +2,7 @@ actions: "enqueue, allocate, backfill, reclaim, preempt"
 tiers:
 - plugins:
   - name: priority
+    enableReclaimable: false
   - name: gang
     enablePreemptable: false
   - name: conformance

--- a/installer/helm/chart/volcano/config/volcano-scheduler.conf
+++ b/installer/helm/chart/volcano/config/volcano-scheduler.conf
@@ -2,6 +2,7 @@ actions: "enqueue, allocate, backfill"
 tiers:
 - plugins:
   - name: priority
+    enableReclaimable: false
   - name: gang
     enablePreemptable: false
   - name: conformance

--- a/installer/volcano-development.yaml
+++ b/installer/volcano-development.yaml
@@ -4112,6 +4112,7 @@ data:
     tiers:
     - plugins:
       - name: priority
+        enableReclaimable: false
       - name: gang
         enablePreemptable: false
       - name: conformance

--- a/pkg/scheduler/plugins/priority/priority.go
+++ b/pkg/scheduler/plugins/priority/priority.go
@@ -112,10 +112,10 @@ func (pp *priorityPlugin) OnSessionOpen(ssn *framework.Session) {
 		return victims, util.Permit
 	}
 	ssn.AddPreemptableFn(pp.Name(), preemptableFn)
-	reclaimbleFn := func(reclaimor *api.TaskInfo, reclaimee []*api.TaskInfo) ([]*api.TaskInfo, int) {
+	reclaimableFn := func(reclaimor *api.TaskInfo, reclaimees []*api.TaskInfo) ([]*api.TaskInfo, int) {
 		reclaimorJob := ssn.Jobs[reclaimor.Job]
 		var victims []*api.TaskInfo
-		for _, reclaimee := range reclaimee {
+		for _, reclaimee := range reclaimees {
 			reclaimeeJob := ssn.Jobs[reclaimee.Job]
 			if reclaimeeJob == nil {
 				continue
@@ -130,7 +130,7 @@ func (pp *priorityPlugin) OnSessionOpen(ssn *framework.Session) {
 		klog.V(4).Infof("Victims from Priority plugins are %+v", victims)
 		return victims, util.Permit
 	}
-	ssn.AddReclaimableFn(pp.Name(), reclaimbleFn)
+	ssn.AddReclaimableFn(pp.Name(), reclaimableFn)
 
 	jobStarvingFn := func(obj interface{}) bool {
 		ji := obj.(*api.JobInfo)

--- a/pkg/scheduler/plugins/priority/priority_test.go
+++ b/pkg/scheduler/plugins/priority/priority_test.go
@@ -26,6 +26,7 @@ import (
 	"volcano.sh/volcano/cmd/scheduler/app/options"
 	"volcano.sh/volcano/pkg/scheduler/actions/allocate"
 	"volcano.sh/volcano/pkg/scheduler/actions/preempt"
+	"volcano.sh/volcano/pkg/scheduler/actions/reclaim"
 	"volcano.sh/volcano/pkg/scheduler/api"
 	"volcano.sh/volcano/pkg/scheduler/conf"
 	"volcano.sh/volcano/pkg/scheduler/framework"
@@ -58,6 +59,137 @@ var (
 		EnabledJobStarving: &trueValue,
 	}
 )
+
+func TestReclaim(t *testing.T) {
+	actions := []framework.Action{allocate.New(), reclaim.New()}
+	plugins := map[string]framework.PluginBuilder{PluginName: New}
+
+	tests := []struct {
+		uthelper.TestCommonStruct
+		actions []framework.Action
+		tiers   []conf.Tier
+	}{
+		{
+			actions: actions,
+			tiers: []conf.Tier{
+				{
+					Plugins: []conf.PluginOption{pluginEnableEvict},
+				},
+			},
+			TestCommonStruct: uthelper.TestCommonStruct{
+				Name:    "enable reclaim low priority: enableReclaimable:true",
+				Plugins: plugins,
+				PriClass: []*schedulingv1.PriorityClass{
+					util.BuildPriorityClass("low-priority", 100),
+					util.BuildPriorityClass("high-priority", 1000),
+				},
+				PodGroups: []*vcapisv1.PodGroup{
+					util.BuildPodGroupWithPrio("pg1", "ns1", "q1", 1, map[string]int32{}, vcapisv1.PodGroupInqueue, "low-priority"),
+					util.BuildPodGroupWithPrio("pg2", "ns2", "q2", 1, map[string]int32{}, vcapisv1.PodGroupInqueue, "high-priority"),
+				},
+				Pods: []*v1.Pod{
+					util.BuildPod("ns1", "reclaimee1", "node1", v1.PodRunning, api.BuildResourceList("3", "3G"), "pg1", map[string]string{vcapisv1.PodPreemptable: "true"}, make(map[string]string)),
+					util.BuildPod("ns1", "reclaimee2", "node2", v1.PodRunning, api.BuildResourceList("3", "3G"), "pg1", map[string]string{vcapisv1.PodPreemptable: "false"}, make(map[string]string)),
+					util.BuildPod("ns2", "preemptor1", "", v1.PodPending, api.BuildResourceList("3", "3G"), "pg2", make(map[string]string), make(map[string]string)),
+				},
+				Nodes: []*v1.Node{
+					util.BuildNode("node1", api.BuildResourceList("3", "3G", []api.ScalarResource{{Name: "pods", Value: "10"}}...), make(map[string]string)),
+					util.BuildNode("node2", api.BuildResourceList("3", "3G", []api.ScalarResource{{Name: "pods", Value: "10"}}...), make(map[string]string)),
+				},
+				Queues: []*vcapisv1.Queue{
+					util.BuildQueue("q1", 1, api.BuildResourceList("6", "6G")),
+					util.BuildQueue("q2", 1, api.BuildResourceList("6", "6G")),
+				},
+				ExpectEvicted:   []string{"ns1/reclaimee1"},
+				ExpectEvictNum:  1,
+				ExpectPipeLined: map[string][]string{"ns2/pg2": {"node1"}},
+			},
+		},
+		{
+			actions: actions,
+			tiers: []conf.Tier{
+				{
+					Plugins: []conf.PluginOption{pluginDisableEvict},
+				},
+			},
+			TestCommonStruct: uthelper.TestCommonStruct{
+				Name:    "disable reclaim low priority: enableReclaimable:false",
+				Plugins: plugins,
+				PriClass: []*schedulingv1.PriorityClass{
+					util.BuildPriorityClass("low-priority", 100),
+					util.BuildPriorityClass("high-priority", 1000),
+				},
+				PodGroups: []*vcapisv1.PodGroup{
+					util.BuildPodGroupWithPrio("pg1", "ns1", "q1", 1, map[string]int32{}, vcapisv1.PodGroupInqueue, "low-priority"),
+					util.BuildPodGroupWithPrio("pg2", "ns2", "q2", 1, map[string]int32{}, vcapisv1.PodGroupInqueue, "high-priority"),
+				},
+				Pods: []*v1.Pod{
+					util.BuildPod("ns1", "reclaimee1", "node1", v1.PodRunning, api.BuildResourceList("3", "3G"), "pg1", map[string]string{vcapisv1.PodPreemptable: "true"}, make(map[string]string)),
+					util.BuildPod("ns1", "reclaimee2", "node2", v1.PodRunning, api.BuildResourceList("3", "3G"), "pg1", map[string]string{vcapisv1.PodPreemptable: "false"}, make(map[string]string)),
+					util.BuildPod("ns2", "preemptor1", "", v1.PodPending, api.BuildResourceList("3", "3G"), "pg2", make(map[string]string), make(map[string]string)),
+				},
+				Nodes: []*v1.Node{
+					util.BuildNode("node1", api.BuildResourceList("3", "3G", []api.ScalarResource{{Name: "pods", Value: "10"}}...), make(map[string]string)),
+					util.BuildNode("node2", api.BuildResourceList("3", "3G", []api.ScalarResource{{Name: "pods", Value: "10"}}...), make(map[string]string)),
+				},
+				Queues: []*vcapisv1.Queue{
+					util.BuildQueue("q1", 1, api.BuildResourceList("6", "6G")),
+					util.BuildQueue("q2", 1, api.BuildResourceList("6", "6G")),
+				},
+				ExpectEvicted:   []string{},
+				ExpectEvictNum:  0,
+				ExpectPipeLined: map[string][]string{},
+			},
+		},
+		{ // test allocate task order and job order
+			actions: actions,
+			tiers: []conf.Tier{
+				{
+					Plugins: []conf.PluginOption{pluginEnableEvict},
+				},
+			},
+			TestCommonStruct: uthelper.TestCommonStruct{
+				Name:    "high priority job allocate first, and higher priority task allocate first in same job",
+				Plugins: plugins,
+				PriClass: []*schedulingv1.PriorityClass{
+					util.BuildPriorityClass("low-priority", 100),
+					util.BuildPriorityClass("high-priority", 1000),
+				},
+				PodGroups: []*vcapisv1.PodGroup{
+					util.BuildPodGroupWithPrio("pg1", "ns1", "q1", 1, map[string]int32{}, vcapisv1.PodGroupInqueue, "high-priority"),
+					util.BuildPodGroupWithPrio("pg2", "ns2", "q1", 1, map[string]int32{}, vcapisv1.PodGroupInqueue, "low-priority"),
+				},
+				Pods: []*v1.Pod{
+					util.BuildPod("ns1", "pod1", "", v1.PodPending, api.BuildResourceList("3", "3G"), "pg1", map[string]string{}, make(map[string]string)),
+					util.BuildPodWithPriority("ns1", "pod2", "", v1.PodPending, api.BuildResourceList("3", "3G"), "pg1", map[string]string{}, make(map[string]string), &priority),
+					util.BuildPodWithPriority("ns2", "pod3", "", v1.PodPending, api.BuildResourceList("3", "3G"), "pg2", make(map[string]string), make(map[string]string), &priority),
+				},
+				Nodes: []*v1.Node{
+					util.BuildNode("node1", api.BuildResourceList("3", "3G", []api.ScalarResource{{Name: "pods", Value: "10"}}...), make(map[string]string)),
+					util.BuildNode("node2", api.BuildResourceList("1", "1G", []api.ScalarResource{{Name: "pods", Value: "10"}}...), make(map[string]string)),
+				},
+				Queues: []*vcapisv1.Queue{
+					util.BuildQueue("q1", 1, api.BuildResourceList("6", "6G")),
+				},
+				ExpectBindsNum: 1, ExpectEvictNum: 0,
+				ExpectBindMap: map[string]string{"ns1/pod2": "node1"},
+				ExpectEvicted: []string{}, ExpectPipeLined: map[string][]string{},
+			},
+		},
+	}
+	for i, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			test.RegisterSession(test.tiers, nil)
+			defer test.Close()
+			test.Run(test.actions)
+			err := test.CheckAll(i)
+			if err != nil {
+				t.Fatal(err)
+			}
+		})
+
+	}
+}
 
 func TestPreempt(t *testing.T) {
 	actions := []framework.Action{allocate.New(), preempt.New()}


### PR DESCRIPTION
Fixes #2262

1. priority plugin support `reclaimable` switch and add UT about priority plugin
2. priority plugin docs

**Note**: `reclaimableFn` usually is used in `reclaim` action to reclaim a queue's deserved resource when cluster has not enough resource to allocate new coming tasks in this queue. So please be carefully to set `enableReclaimable` to `true` in `priority` plugin, in case that a queue's resource owned by high priority jobs can not be released. And `enableReclaimable` is disabled by default for compatibility