### PR TITLE
refact preempt ut

### DIFF
--- a/pkg/scheduler/actions/preempt/preempt_test.go
+++ b/pkg/scheduler/actions/preempt/preempt_test.go
@@ -17,330 +17,265 @@ limitations under the License.
 package preempt
 
 import (
-	"reflect"
 	"testing"
-	"time"
 
-	"github.com/agiledragon/gomonkey/v2"
 	v1 "k8s.io/api/core/v1"
 	schedulingv1 "k8s.io/api/scheduling/v1"
-	"k8s.io/client-go/tools/record"
 
 	schedulingv1beta1 "volcano.sh/apis/pkg/apis/scheduling/v1beta1"
 	"volcano.sh/volcano/cmd/scheduler/app/options"
 	"volcano.sh/volcano/pkg/scheduler/api"
-	"volcano.sh/volcano/pkg/scheduler/cache"
 	"volcano.sh/volcano/pkg/scheduler/conf"
 	"volcano.sh/volcano/pkg/scheduler/framework"
 	"volcano.sh/volcano/pkg/scheduler/plugins/conformance"
 	"volcano.sh/volcano/pkg/scheduler/plugins/gang"
 	"volcano.sh/volcano/pkg/scheduler/plugins/priority"
 	"volcano.sh/volcano/pkg/scheduler/plugins/proportion"
+	"volcano.sh/volcano/pkg/scheduler/uthelper"
 	"volcano.sh/volcano/pkg/scheduler/util"
 )
 
 func TestPreempt(t *testing.T) {
-	var tmp *cache.SchedulerCache
-	patchUpdateQueueStatus := gomonkey.ApplyMethod(reflect.TypeOf(tmp), "UpdateQueueStatus", func(scCache *cache.SchedulerCache, queue *api.QueueInfo) error {
-		return nil
-	})
-	defer patchUpdateQueueStatus.Reset()
-
-	framework.RegisterPluginBuilder(conformance.PluginName, conformance.New)
-	framework.RegisterPluginBuilder(gang.PluginName, gang.New)
-	framework.RegisterPluginBuilder(priority.PluginName, priority.New)
-	framework.RegisterPluginBuilder(proportion.PluginName, proportion.New)
-	options.ServerOpts = &options.ServerOption{
-		MinNodesToFind:             100,
-		MinPercentageOfNodesToFind: 5,
-		PercentageOfNodesToFind:    100,
+	plugins := map[string]framework.PluginBuilder{
+		conformance.PluginName: conformance.New,
+		gang.PluginName:        gang.New,
+		priority.PluginName:    priority.New,
+		proportion.PluginName:  proportion.New,
 	}
-	defer framework.CleanupPluginBuilders()
+	highPrio := util.BuildPriorityClass("high-priority", 100000)
+	lowPrio := util.BuildPriorityClass("low-priority", 10)
+	options.Default()
 
-	tests := []struct {
-		name      string
-		podGroups []*schedulingv1beta1.PodGroup
-		pods      []*v1.Pod
-		nodes     []*v1.Node
-		queues    []*schedulingv1beta1.Queue
-		expected  int
-	}{
+	tests := []uthelper.TestCommonStruct{
 		{
-			name: "do not preempt if there are enough idle resources",
-			podGroups: []*schedulingv1beta1.PodGroup{
+			Name: "do not preempt if there are enough idle resources",
+			PodGroups: []*schedulingv1beta1.PodGroup{
 				util.BuildPodGroup("pg1", "c1", "q1", 3, map[string]int32{"": 3}, schedulingv1beta1.PodGroupInqueue),
 			},
-			pods: []*v1.Pod{
+			Pods: []*v1.Pod{
 				util.BuildPod("c1", "preemptee1", "n1", v1.PodRunning, api.BuildResourceList("1", "1G"), "pg1", make(map[string]string), make(map[string]string)),
 				util.BuildPod("c1", "preemptee2", "n1", v1.PodRunning, api.BuildResourceList("1", "1G"), "pg1", make(map[string]string), make(map[string]string)),
 				util.BuildPod("c1", "preemptor1", "", v1.PodPending, api.BuildResourceList("1", "1G"), "pg1", make(map[string]string), make(map[string]string)),
 			},
 			// If there are enough idle resources on the node, then there is no need to preempt anything.
-			nodes: []*v1.Node{
+			Nodes: []*v1.Node{
 				util.BuildNode("n1", api.BuildResourceList("10", "10G", []api.ScalarResource{{Name: "pods", Value: "10"}}...), make(map[string]string)),
 			},
-			queues: []*schedulingv1beta1.Queue{
+			Queues: []*schedulingv1beta1.Queue{
 				util.BuildQueue("q1", 1, nil),
 			},
-			expected: 0,
+			EvictNum: 0,
 		},
 		{
-			name: "do not preempt if job is pipelined",
-			podGroups: []*schedulingv1beta1.PodGroup{
+			Name: "do not preempt if job is pipelined",
+			PodGroups: []*schedulingv1beta1.PodGroup{
 				util.BuildPodGroup("pg1", "c1", "q1", 1, map[string]int32{"": 2}, schedulingv1beta1.PodGroupInqueue),
 				util.BuildPodGroup("pg2", "c1", "q1", 1, map[string]int32{"": 2}, schedulingv1beta1.PodGroupInqueue),
 			},
 			// Both pg1 and pg2 jobs are pipelined, because enough pods are already running.
-			pods: []*v1.Pod{
+			Pods: []*v1.Pod{
 				util.BuildPod("c1", "preemptee1", "n1", v1.PodRunning, api.BuildResourceList("1", "1G"), "pg1", make(map[string]string), make(map[string]string)),
 				util.BuildPod("c1", "preemptee2", "n1", v1.PodRunning, api.BuildResourceList("1", "1G"), "pg1", make(map[string]string), make(map[string]string)),
 				util.BuildPod("c1", "preemptee3", "n1", v1.PodRunning, api.BuildResourceList("1", "1G"), "pg2", make(map[string]string), make(map[string]string)),
 				util.BuildPod("c1", "preemptor2", "", v1.PodPending, api.BuildResourceList("1", "1G"), "pg2", make(map[string]string), make(map[string]string)),
 			},
 			// All resources on the node will be in use.
-			nodes: []*v1.Node{
+			Nodes: []*v1.Node{
 				util.BuildNode("n1", api.BuildResourceList("3", "3G", []api.ScalarResource{{Name: "pods", Value: "10"}}...), make(map[string]string)),
 			},
-			queues: []*schedulingv1beta1.Queue{
+			Queues: []*schedulingv1beta1.Queue{
 				util.BuildQueue("q1", 1, nil),
 			},
-			expected: 0,
+			EvictNum: 0,
 		},
 		{
-			name: "preempt one task of different job to fit both jobs on one node",
-			podGroups: []*schedulingv1beta1.PodGroup{
+			Name: "preempt one task of different job to fit both jobs on one node",
+			PodGroups: []*schedulingv1beta1.PodGroup{
 				util.BuildPodGroupWithPrio("pg1", "c1", "q1", 1, map[string]int32{"": 2}, schedulingv1beta1.PodGroupInqueue, "low-priority"),
 				util.BuildPodGroupWithPrio("pg2", "c1", "q1", 1, map[string]int32{"": 2}, schedulingv1beta1.PodGroupInqueue, "high-priority"),
 			},
-			pods: []*v1.Pod{
+			Pods: []*v1.Pod{
 				util.BuildPod("c1", "preemptee1", "n1", v1.PodRunning, api.BuildResourceList("1", "1G"), "pg1", map[string]string{schedulingv1beta1.PodPreemptable: "true"}, make(map[string]string)),
-				util.BuildPod("c1", "preemptee2", "n1", v1.PodRunning, api.BuildResourceList("1", "1G"), "pg1", make(map[string]string), make(map[string]string)),
+				util.BuildPod("c1", "preemptee2", "n1", v1.PodRunning, api.BuildResourceList("1", "1G"), "pg1", map[string]string{schedulingv1beta1.PodPreemptable: "false"}, make(map[string]string)),
 				util.BuildPod("c1", "preemptor1", "", v1.PodPending, api.BuildResourceList("1", "1G"), "pg2", make(map[string]string), make(map[string]string)),
 				util.BuildPod("c1", "preemptor2", "", v1.PodPending, api.BuildResourceList("1", "1G"), "pg2", make(map[string]string), make(map[string]string)),
 			},
-			nodes: []*v1.Node{
+			Nodes: []*v1.Node{
 				util.BuildNode("n1", api.BuildResourceList("2", "2G", []api.ScalarResource{{Name: "pods", Value: "10"}}...), make(map[string]string)),
 			},
-			queues: []*schedulingv1beta1.Queue{
+			Queues: []*schedulingv1beta1.Queue{
 				util.BuildQueue("q1", 1, nil),
 			},
-			expected: 1,
+			Evicted:  []string{"c1/preemptee1"},
+			EvictNum: 1,
 		},
 		{
-			name: "preempt enough tasks to fit large task of different job",
-			podGroups: []*schedulingv1beta1.PodGroup{
+			Name: "preempt enough tasks to fit large task of different job",
+			PodGroups: []*schedulingv1beta1.PodGroup{
 				util.BuildPodGroupWithPrio("pg1", "c1", "q1", 1, map[string]int32{"": 3}, schedulingv1beta1.PodGroupInqueue, "low-priority"),
 				util.BuildPodGroupWithPrio("pg2", "c1", "q1", 1, map[string]int32{"": 1}, schedulingv1beta1.PodGroupInqueue, "high-priority"),
 			},
 			// There are 3 cpus and 3G of memory idle and 3 tasks running each consuming 1 cpu and 1G of memory.
 			// Big task requiring 5 cpus and 5G of memory should preempt 2 of 3 running tasks to fit into the node.
-			pods: []*v1.Pod{
+			Pods: []*v1.Pod{
 				util.BuildPod("c1", "preemptee1", "n1", v1.PodRunning, api.BuildResourceList("1", "1G"), "pg1", map[string]string{schedulingv1beta1.PodPreemptable: "true"}, make(map[string]string)),
 				util.BuildPod("c1", "preemptee2", "n1", v1.PodRunning, api.BuildResourceList("1", "1G"), "pg1", map[string]string{schedulingv1beta1.PodPreemptable: "true"}, make(map[string]string)),
-				util.BuildPod("c1", "preemptee3", "n1", v1.PodRunning, api.BuildResourceList("1", "1G"), "pg1", map[string]string{schedulingv1beta1.PodPreemptable: "true"}, make(map[string]string)),
+				util.BuildPod("c1", "preemptee3", "n1", v1.PodRunning, api.BuildResourceList("1", "1G"), "pg1", map[string]string{schedulingv1beta1.PodPreemptable: "false"}, make(map[string]string)),
 				util.BuildPod("c1", "preemptor1", "", v1.PodPending, api.BuildResourceList("5", "5G"), "pg2", make(map[string]string), make(map[string]string)),
 			},
-			nodes: []*v1.Node{
+			Nodes: []*v1.Node{
 				util.BuildNode("n1", api.BuildResourceList("6", "6G", []api.ScalarResource{{Name: "pods", Value: "10"}}...), make(map[string]string)),
 			},
-			queues: []*schedulingv1beta1.Queue{
+			Queues: []*schedulingv1beta1.Queue{
 				util.BuildQueue("q1", 1, nil),
 			},
-			expected: 2,
+			Evicted:  []string{"c1/preemptee2", "c1/preemptee1"},
+			EvictNum: 2,
 		},
 		{
 			// case about #3161
-			name: "preempt low priority job in same queue",
-			podGroups: []*schedulingv1beta1.PodGroup{
+			Name: "preempt low priority job in same queue",
+			PodGroups: []*schedulingv1beta1.PodGroup{
 				util.BuildPodGroupWithPrio("pg1", "c1", "q1", 0, map[string]int32{}, schedulingv1beta1.PodGroupInqueue, "low-priority"),
 				util.BuildPodGroupWithPrio("pg2", "c1", "q1", 1, map[string]int32{"": 1}, schedulingv1beta1.PodGroupInqueue, "high-priority"),
 			},
-			pods: []*v1.Pod{
+			Pods: []*v1.Pod{
 				util.BuildPod("c1", "preemptee1", "n1", v1.PodRunning, api.BuildResourceList("3", "3G"), "pg1", map[string]string{schedulingv1beta1.PodPreemptable: "true"}, make(map[string]string)),
 				util.BuildPod("c1", "preemptor1", "", v1.PodPending, api.BuildResourceList("3", "3G"), "pg2", make(map[string]string), make(map[string]string)),
 			},
-			nodes: []*v1.Node{
+			Nodes: []*v1.Node{
 				util.BuildNode("n1", api.BuildResourceList("12", "12G", []api.ScalarResource{{Name: "pods", Value: "10"}}...), make(map[string]string)),
 			},
-			queues: []*schedulingv1beta1.Queue{
+			Queues: []*schedulingv1beta1.Queue{
 				util.BuildQueue("q1", 1, api.BuildResourceList("4", "4G")),
 			},
-			expected: 1,
+			Evicted:  []string{"c1/preemptee1"},
+			EvictNum: 1,
 		},
 		{
 			// case about #3161
-			name: "preempt low priority job in same queue: allocatable and has enough resource, don't preempt",
-			podGroups: []*schedulingv1beta1.PodGroup{
+			Name: "preempt low priority job in same queue: allocatable and has enough resource, don't preempt",
+			PodGroups: []*schedulingv1beta1.PodGroup{
 				util.BuildPodGroupWithPrio("pg1", "c1", "q1", 1, map[string]int32{}, schedulingv1beta1.PodGroupInqueue, "low-priority"),
 				util.BuildPodGroupWithPrio("pg2", "c1", "q1", 1, map[string]int32{"": 1}, schedulingv1beta1.PodGroupInqueue, "high-priority"),
 			},
-			pods: []*v1.Pod{
+			Pods: []*v1.Pod{
 				util.BuildPod("c1", "preemptee1", "n1", v1.PodRunning, api.BuildResourceList("3", "3G"), "pg1", map[string]string{schedulingv1beta1.PodPreemptable: "true"}, make(map[string]string)),
 				util.BuildPod("c1", "preemptor1", "", v1.PodPending, api.BuildResourceList("3", "3G"), "pg2", make(map[string]string), make(map[string]string)),
 			},
-			nodes: []*v1.Node{
+			Nodes: []*v1.Node{
 				util.BuildNode("n1", api.BuildResourceList("12", "12G", []api.ScalarResource{{Name: "pods", Value: "10"}}...), make(map[string]string)),
 			},
-			queues: []*schedulingv1beta1.Queue{
+			Queues: []*schedulingv1beta1.Queue{
 				util.BuildQueue("q1", 1, api.BuildResourceList("6", "6G")),
 			},
-			expected: 0,
+			EvictNum: 0,
 		},
 		{
 			// case about issue #2232
-			name: "preempt low priority job in same queue",
-			podGroups: []*schedulingv1beta1.PodGroup{
+			Name: "preempt low priority job in same queue",
+			PodGroups: []*schedulingv1beta1.PodGroup{
 				util.BuildPodGroupWithPrio("pg1", "c1", "q1", 1, map[string]int32{}, schedulingv1beta1.PodGroupInqueue, "low-priority"),
 				util.BuildPodGroupWithPrio("pg2", "c1", "q1", 1, map[string]int32{"": 1}, schedulingv1beta1.PodGroupInqueue, "high-priority"),
 			},
-			pods: []*v1.Pod{
-				util.BuildPod("c1", "preemptee1", "n1", v1.PodRunning, api.BuildResourceList("1", "1G"), "pg1", map[string]string{schedulingv1beta1.PodPreemptable: "true"}, make(map[string]string)),
+			Pods: []*v1.Pod{
+				util.BuildPod("c1", "preemptee1", "n1", v1.PodRunning, api.BuildResourceList("1", "1G"), "pg1", map[string]string{schedulingv1beta1.PodPreemptable: "false"}, make(map[string]string)),
 				util.BuildPod("c1", "preemptee2", "n1", v1.PodRunning, api.BuildResourceList("1", "1G"), "pg1", map[string]string{schedulingv1beta1.PodPreemptable: "true"}, make(map[string]string)),
-				util.BuildPod("c1", "preemptee3", "n1", v1.PodRunning, api.BuildResourceList("1", "1G"), "pg1", map[string]string{schedulingv1beta1.PodPreemptable: "true"}, make(map[string]string)),
+				util.BuildPodWithPriority("c1", "preemptee3", "n1", v1.PodRunning, api.BuildResourceList("1", "1G"), "pg1", map[string]string{schedulingv1beta1.PodPreemptable: "true"}, make(map[string]string), &highPrio.Value),
 				util.BuildPod("c1", "preemptor1", "", v1.PodPending, api.BuildResourceList("1", "1G"), "pg2", make(map[string]string), make(map[string]string)),
 			},
-			nodes: []*v1.Node{
+			Nodes: []*v1.Node{
 				util.BuildNode("n1", api.BuildResourceList("12", "12G", []api.ScalarResource{{Name: "pods", Value: "10"}}...), make(map[string]string)),
 			},
-			queues: []*schedulingv1beta1.Queue{
+			Queues: []*schedulingv1beta1.Queue{
 				util.BuildQueue("q1", 1, api.BuildResourceList("3", "3G")),
 			},
-			expected: 1,
+			Evicted:  []string{"c1/preemptee2"},
+			EvictNum: 1,
 		},
 		{
 			// case about #3335
-			name: "unBestEffort high-priority pod preempt BestEffort low-priority pod in same queue",
-			podGroups: []*schedulingv1beta1.PodGroup{
+			Name: "unBestEffort high-priority pod preempt BestEffort low-priority pod in same queue",
+			PodGroups: []*schedulingv1beta1.PodGroup{
 				util.BuildPodGroupWithPrio("pg1", "c1", "q1", 0, map[string]int32{}, schedulingv1beta1.PodGroupInqueue, "low-priority"),
 				util.BuildPodGroupWithPrio("pg2", "c1", "q1", 1, map[string]int32{"": 1}, schedulingv1beta1.PodGroupInqueue, "high-priority"),
 			},
-			pods: []*v1.Pod{
+			Pods: []*v1.Pod{
 				util.BuildPod("c1", "preemptee1", "n1", v1.PodRunning, v1.ResourceList{}, "pg1", map[string]string{schedulingv1beta1.PodPreemptable: "true"}, make(map[string]string)),
 				util.BuildPod("c1", "preemptor1", "", v1.PodPending, api.BuildResourceList("3", "3G"), "pg2", make(map[string]string), make(map[string]string)),
 			},
-			nodes: []*v1.Node{
+			Nodes: []*v1.Node{
 				util.BuildNode("n1", api.BuildResourceList("12", "12G", []api.ScalarResource{{Name: "pods", Value: "1"}}...), make(map[string]string)),
 			},
-			queues: []*schedulingv1beta1.Queue{
+			Queues: []*schedulingv1beta1.Queue{
 				util.BuildQueue("q1", 1, api.BuildResourceList("6", "6G")),
 			},
-			expected: 1,
+			Evicted:  []string{"c1/preemptee1"},
+			EvictNum: 1,
 		},
 		{
 			// case about #3335
-			name: "BestEffort high-priority pod preempt BestEffort low-priority pod in same queue",
-			podGroups: []*schedulingv1beta1.PodGroup{
+			Name: "BestEffort high-priority pod preempt BestEffort low-priority pod in same queue",
+			PodGroups: []*schedulingv1beta1.PodGroup{
 				util.BuildPodGroupWithPrio("pg1", "c1", "q1", 0, map[string]int32{}, schedulingv1beta1.PodGroupInqueue, "low-priority"),
 				util.BuildPodGroupWithPrio("pg2", "c1", "q1", 1, map[string]int32{"": 1}, schedulingv1beta1.PodGroupInqueue, "high-priority"),
 			},
-			pods: []*v1.Pod{
+			Pods: []*v1.Pod{
 				util.BuildPod("c1", "preemptee1", "n1", v1.PodRunning, v1.ResourceList{}, "pg1", map[string]string{schedulingv1beta1.PodPreemptable: "true"}, make(map[string]string)),
 				util.BuildPod("c1", "preemptor1", "", v1.PodPending, v1.ResourceList{}, "pg2", make(map[string]string), make(map[string]string)),
 			},
-			nodes: []*v1.Node{
+			Nodes: []*v1.Node{
 				util.BuildNode("n1", api.BuildResourceList("12", "12G", []api.ScalarResource{{Name: "pods", Value: "1"}}...), make(map[string]string)),
 			},
-			queues: []*schedulingv1beta1.Queue{
+			Queues: []*schedulingv1beta1.Queue{
 				util.BuildQueue("q1", 1, api.BuildResourceList("6", "6G")),
 			},
-			expected: 1,
+			Evicted:  []string{"c1/preemptee1"},
+			EvictNum: 1,
 		},
 	}
 
-	preempt := New()
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			binder := &util.FakeBinder{
-				Binds:   map[string]string{},
-				Channel: make(chan string),
-			}
-			evictor := &util.FakeEvictor{
-				Channel: make(chan string),
-			}
-			schedulerCache := &cache.SchedulerCache{
-				Nodes:           make(map[string]*api.NodeInfo),
-				Jobs:            make(map[api.JobID]*api.JobInfo),
-				Queues:          make(map[api.QueueID]*api.QueueInfo),
-				Binder:          binder,
-				Evictor:         evictor,
-				StatusUpdater:   &util.FakeStatusUpdater{},
-				VolumeBinder:    &util.FakeVolumeBinder{},
-				PriorityClasses: make(map[string]*schedulingv1.PriorityClass),
-
-				Recorder: record.NewFakeRecorder(100),
-			}
-			schedulerCache.PriorityClasses["high-priority"] = &schedulingv1.PriorityClass{
-				Value: 100000,
-			}
-			schedulerCache.PriorityClasses["low-priority"] = &schedulingv1.PriorityClass{
-				Value: 10,
-			}
-			for _, node := range test.nodes {
-				schedulerCache.AddOrUpdateNode(node)
-			}
-			for _, pod := range test.pods {
-				schedulerCache.AddPod(pod)
-			}
-
-			for _, ss := range test.podGroups {
-				schedulerCache.AddPodGroupV1beta1(ss)
-			}
-
-			for _, q := range test.queues {
-				schedulerCache.AddQueueV1beta1(q)
-			}
-
-			trueValue := true
-			ssn := framework.OpenSession(schedulerCache, []conf.Tier{
+	trueValue := true
+	tiers := []conf.Tier{
+		{
+			Plugins: []conf.PluginOption{
 				{
-					Plugins: []conf.PluginOption{
-						{
-							Name:               conformance.PluginName,
-							EnabledPreemptable: &trueValue,
-						},
-						{
-							Name:                gang.PluginName,
-							EnabledPreemptable:  &trueValue,
-							EnabledJobPipelined: &trueValue,
-							EnabledJobStarving:  &trueValue,
-						},
-						{
-							Name:                priority.PluginName,
-							EnabledTaskOrder:    &trueValue,
-							EnabledJobOrder:     &trueValue,
-							EnabledPreemptable:  &trueValue,
-							EnabledJobPipelined: &trueValue,
-							EnabledJobStarving:  &trueValue,
-						},
-						{
-							Name:               proportion.PluginName,
-							EnabledOverused:    &trueValue,
-							EnabledAllocatable: &trueValue,
-							EnabledQueueOrder:  &trueValue,
-						},
-					},
+					Name:               conformance.PluginName,
+					EnabledPreemptable: &trueValue,
 				},
-			}, nil)
-			defer framework.CloseSession(ssn)
+				{
+					Name:                gang.PluginName,
+					EnabledPreemptable:  &trueValue,
+					EnabledJobPipelined: &trueValue,
+					EnabledJobStarving:  &trueValue,
+				},
+				{
+					Name:                priority.PluginName,
+					EnabledTaskOrder:    &trueValue,
+					EnabledJobOrder:     &trueValue,
+					EnabledPreemptable:  &trueValue,
+					EnabledJobPipelined: &trueValue,
+					EnabledJobStarving:  &trueValue,
+				},
+				{
+					Name:               proportion.PluginName,
+					EnabledOverused:    &trueValue,
+					EnabledAllocatable: &trueValue,
+					EnabledQueueOrder:  &trueValue,
+				},
+			},
+		}}
 
-			preempt.Execute(ssn)
-
-			for i := 0; i < test.expected; i++ {
-				select {
-				case <-evictor.Channel:
-				case <-time.After(time.Second):
-					t.Errorf("not enough evictions")
-				}
-			}
-			select {
-			case key, opened := <-evictor.Channel:
-				if opened {
-					t.Errorf("unexpected eviction: %s", key)
-				}
-			case <-time.After(50 * time.Millisecond):
-				// TODO: Active waiting here is not optimal, but there is no better way currently.
-				//	 Ideally we would like to wait for evict and bind request goroutines to finish first.
+	actions := []framework.Action{New()}
+	for i, test := range tests {
+		test.Plugins = plugins
+		test.PriClass = []*schedulingv1.PriorityClass{highPrio, lowPrio}
+		t.Run(test.Name, func(t *testing.T) {
+			test.RegistSession(tiers, nil)
+			defer test.Close()
+			test.Run(actions)
+			if err := test.CheckAll(i); err != nil {
+				t.Fatal(err)
 			}
 		})
 	}


### PR DESCRIPTION
This Pr refact the UTs in preempt actions. There are two points to do that:
1. use the ut framework build on mockSchedulerCache to unify all the uts；
2. remove `gomonkey` which has no permit to be run on MACOS