### PR TITLE
helm chart: add container security context

### DIFF
--- a/installer/README.md
+++ b/installer/README.md
@@ -110,6 +110,10 @@ The following are the list configurable parameters of Volcano Chart and their de
 |`custom.admission_sc`|securityContext for Admission pods|`~`|
 |`custom.controller_sc`|securityContext for Controller pods|`~`|
 |`custom.scheduler_sc`|securityContext for Scheduler pods|`~`|
+|`custom.default_container_sc`|Default container securityContext for Admission/Controller/Scheduler pods|`~`|
+|`custom.admission_container_sc`|Container securityContext for Admission pods|`~`|
+|`custom.controller_container_sc`|Container securityContext for Controller pods|`~`|
+|`custom.scheduler_container_sc`|Container securityContext for Scheduler pods|`~`|
 |`custom.default_ns`|Default nodeSelector for Admission/Controller/Scheduler pods|`~`|
 |`custom.admission_ns`|nodeSelector for Admission pods|`~`|
 |`custom.controller_ns`|nodeSelector for Controller pods|`~`|

--- a/installer/helm/chart/volcano/templates/admission.yaml
+++ b/installer/helm/chart/volcano/templates/admission.yaml
@@ -2,6 +2,7 @@
 {{ $admission_affinity := or .Values.custom.admission_affinity .Values.custom.default_affinity }}
 {{ $admission_tolerations := or .Values.custom.admission_tolerations .Values.custom.default_tolerations }}
 {{ $admission_sc := or .Values.custom.admission_sc .Values.custom.default_sc }}
+{{ $admission_container_sc := or .Values.custom.admission_container_sc .Values.custom.default_container_sc }}
 {{ $admission_ns := or .Values.custom.admission_ns .Values.custom.default_ns }}
 apiVersion: v1
 kind: ConfigMap
@@ -127,6 +128,10 @@ spec:
           resources:
           {{- toYaml .Values.custom.admission_resources | nindent 12 }}
           {{- end }}
+          {{- if $admission_container_sc }}
+          securityContext:
+            {{- toYaml $admission_container_sc | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - mountPath: /admission.local.config/certificates
               name: admission-certs
@@ -205,4 +210,8 @@ spec:
           imagePullPolicy: {{ .Values.basic.image_pull_policy }}
           command: ["./gen-admission-secret.sh", "--service", "{{ .Release.Name }}-admission-service", "--namespace",
                     "{{ .Release.Namespace }}", "--secret", "{{.Values.basic.admission_secret_name}}"]
+          {{- if $admission_container_sc }}
+          securityContext:
+            {{- toYaml $admission_container_sc | nindent 12 }}
+          {{- end }}
 {{- end }}

--- a/installer/helm/chart/volcano/templates/controllers.yaml
+++ b/installer/helm/chart/volcano/templates/controllers.yaml
@@ -2,6 +2,7 @@
 {{ $controller_affinity := or .Values.custom.controller_affinity .Values.custom.default_affinity }}
 {{ $controller_tolerations := or .Values.custom.controller_tolerations .Values.custom.default_tolerations }}
 {{ $controller_sc := or .Values.custom.controller_sc .Values.custom.default_sc }}
+{{ $controller_container_sc := or .Values.custom.controller_container_sc .Values.custom.default_container_sc }}
 {{ $controller_ns := or .Values.custom.controller_ns .Values.custom.default_ns }}
 apiVersion: v1
 kind: ServiceAccount
@@ -134,20 +135,24 @@ spec:
           - name: {{ .Values.basic.image_pull_secret }}
       {{- end }}
       containers:
-          - name: {{ .Release.Name }}-controllers
-            {{- if .Values.custom.controller_resources }}
-            resources:
-            {{- toYaml .Values.custom.controller_resources | nindent 14 }}
+        - name: {{ .Release.Name }}-controllers
+          {{- if .Values.custom.controller_resources }}
+          resources:
+          {{- toYaml .Values.custom.controller_resources | nindent 12 }}
+          {{- end }}
+          image: {{.Values.basic.controller_image_name}}:{{.Values.basic.image_tag_version}}
+          args:
+            - --logtostderr
+            - --enable-healthz=true
+            - --leader-elect={{ .Values.custom.leader_elect_enable }}
+            {{- if .Values.custom.leader_elect_enable }}
+            - --lock-object-namespace={{ .Release.Namespace }}
             {{- end }}
-            image: {{.Values.basic.controller_image_name}}:{{.Values.basic.image_tag_version}}
-            args:
-              - --logtostderr
-              - --enable-healthz=true
-              - --leader-elect={{ .Values.custom.leader_elect_enable }}
-              {{- if .Values.custom.leader_elect_enable }}
-              - --lock-object-namespace={{ .Release.Namespace }}
-              {{- end }}
-              - -v=4
-              - 2>&1
-            imagePullPolicy: {{ .Values.basic.image_pull_policy }}
+            - -v=4
+            - 2>&1
+          imagePullPolicy: {{ .Values.basic.image_pull_policy }}
+          {{- if $controller_container_sc }}
+          securityContext:
+            {{- toYaml $controller_container_sc | nindent 12 }}
+          {{- end }}
 {{- end }}

--- a/installer/helm/chart/volcano/templates/scheduler.yaml
+++ b/installer/helm/chart/volcano/templates/scheduler.yaml
@@ -2,6 +2,7 @@
 {{ $scheduler_affinity := or .Values.custom.scheduler_affinity .Values.custom.default_affinity }}
 {{ $scheduler_tolerations := or .Values.custom.scheduler_tolerations .Values.custom.default_tolerations }}
 {{ $scheduler_sc := or .Values.custom.scheduler_sc .Values.custom.default_sc }}
+{{ $scheduler_container_sc := or .Values.custom.scheduler_container_sc .Values.custom.default_container_sc }}
 {{ $scheduler_ns := or .Values.custom.scheduler_ns .Values.custom.default_ns }}
 apiVersion: v1
 kind: ConfigMap
@@ -165,6 +166,10 @@ spec:
             - name: DEBUG_SOCKET_DIR
               value: /tmp/klog-socks
           imagePullPolicy: {{ .Values.basic.image_pull_policy }}
+          {{- if $scheduler_container_sc }}
+          securityContext:
+            {{- toYaml $scheduler_container_sc | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - name: scheduler-config
               mountPath: /volcano.scheduler

--- a/installer/helm/chart/volcano/values.yaml
+++ b/installer/helm/chart/volcano/values.yaml
@@ -60,6 +60,19 @@ custom:
   admission_sc: ~
   controller_sc: ~
 
+# Specify container securityContext for all main Volcano components or per component
+# For example:
+#
+#  default_container_sc:
+#    runAsUser: 1000
+#    capabilities:
+#      drop:
+#      - ALL
+  default_container_sc: ~
+  scheduler_container_sc: ~
+  admission_container_sc: ~
+  controller_container_sc: ~
+
 # Specify nodeSelector for all main Volcano components or per component
 # For example:
 #

--- a/installer/volcano-development.yaml
+++ b/installer/volcano-development.yaml
@@ -4032,15 +4032,15 @@ spec:
       serviceAccount: volcano-controllers
       priorityClassName: system-cluster-critical
       containers:
-          - name: volcano-controllers
-            image: volcanosh/vc-controller-manager:latest
-            args:
-              - --logtostderr
-              - --enable-healthz=true
-              - --leader-elect=false
-              - -v=4
-              - 2>&1
-            imagePullPolicy: Always
+        - name: volcano-controllers
+          image: volcanosh/vc-controller-manager:latest
+          args:
+            - --logtostderr
+            - --enable-healthz=true
+            - --leader-elect=false
+            - -v=4
+            - 2>&1
+          imagePullPolicy: Always
 ---
 # Source: volcano/templates/scheduler.yaml
 apiVersion: v1


### PR DESCRIPTION
This change adds container security context to admission, controller, scheduler Deployments, and scheduler Job. Container security context is necessary in some restricted environments, e.g. in an environment that employs Restricted[ Pod Security Standard](https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted) as default.

This PR is just a cleaner version of #3322 