### PR TITLE
Fix device share plugins npe

### DIFF
--- a/pkg/scheduler/api/devices/nvidia/vgpu/device_info.go
+++ b/pkg/scheduler/api/devices/nvidia/vgpu/device_info.go
@@ -100,7 +100,7 @@ func NewGPUDevices(name string, node *v1.Node) *GPUDevices {
 			klog.Infof("node %v device %s leave", node.Name, handshake)
 
 			tmppat := make(map[string]string)
-			tmppat[handshake] = "Deleted_" + time.Now().Format("2006.01.02 15:04:05")
+			tmppat[VolcanoVGPUHandshake] = "Deleted_" + time.Now().Format("2006.01.02 15:04:05")
 			patchNodeAnnotations(node, tmppat)
 			return nil
 		}


### PR DESCRIPTION
There is an NPE issue with the device share plugin， #3241 Not really solving the problem

unit testing 
```golang
func TestDevices(t *testing.T) {
	others := make(map[string]interface{})
	nodeDevices := vgpu.DecodeNodeDevices("k8s01", "GPU-c496852d-f5df-316c-e2d5-86f0b322ec4c,20,30720,100,NVIDIA-NVIDIA GeForce RTX 3080 Ti,0,false:")
	others["gpu1"] = nodeDevices
	var dev2 *vgpu.GPUDevices = nil
	others["gpu2"] = dev2
	var dev3 Devices = nil
	others["gpu3"] = dev3
	var dev4 Devices = dev2
	others["gpu4"] = dev4
	for key, val := range others {
		if dev, ok := val.(Devices); ok {
			if dev == nil {
				fmt.Println(key, "is nil")
				continue
			}
			fmt.Println(key, "is not nil")
		} else {
			fmt.Println(key, "is not devices")
		}
	}
}
```
Output results
```
=== RUN   TestDevices
gpu1 is not nil
gpu2 is not nil
gpu3 is not devices
gpu4 is not nil
--- PASS: TestDevices (0.00s)
```
This does not meet expectations