### PR TITLE
fix panic in overcommit plugin

### DIFF
--- a/pkg/scheduler/api/resource_info.go
+++ b/pkg/scheduler/api/resource_info.go
@@ -260,6 +260,16 @@ func (r *Resource) Sub(rr *Resource) *Resource {
 	return r.sub(rr)
 }
 
+// SubWithoutAssert subtracts two Resource objects without assertion,
+// this function is added because some resource subtraction allows negative results, while others do not.
+func (r *Resource) SubWithoutAssert(rr *Resource) *Resource {
+	ok, resources := rr.LessEqualWithResourcesName(r, Zero)
+	if !ok {
+		klog.Errorf("resources <%v> are not sufficient to do operation: <%v> sub <%v>", resources, r, rr)
+	}
+	return r.sub(rr)
+}
+
 // sub subtracts two Resource objects.
 func (r *Resource) sub(rr *Resource) *Resource {
 	r.MilliCPU -= rr.MilliCPU

--- a/pkg/scheduler/plugins/overcommit/overcommit.go
+++ b/pkg/scheduler/plugins/overcommit/overcommit.go
@@ -88,7 +88,7 @@ func (op *overcommitPlugin) OnSessionOpen(ssn *framework.Session) {
 	for _, node := range ssn.Nodes {
 		used.Add(node.Used)
 	}
-	op.idleResource = op.totalResource.Clone().Multi(op.overCommitFactor).Sub(used)
+	op.idleResource = op.totalResource.Clone().Multi(op.overCommitFactor).SubWithoutAssert(used)
 
 	for _, job := range ssn.Jobs {
 		// calculate inqueue job resources


### PR DESCRIPTION
fix panic in overcommit plugin when the gpu plugin is uninstalled or the gpu card fails, triggering a continuous panic。
fix：https://github.com/volcano-sh/volcano/issues/3362