### PR TITLE
refact reclaim ut with common test framework

### DIFF
--- a/pkg/scheduler/actions/reclaim/reclaim_test.go
+++ b/pkg/scheduler/actions/reclaim/reclaim_test.go
@@ -17,114 +17,58 @@ limitations under the License.
 package reclaim
 
 import (
-	"reflect"
 	"testing"
-	"time"
 
-	"github.com/agiledragon/gomonkey/v2"
 	v1 "k8s.io/api/core/v1"
-	schedulingv1 "k8s.io/api/scheduling/v1"
-	"k8s.io/client-go/tools/record"
 
 	schedulingv1beta1 "volcano.sh/apis/pkg/apis/scheduling/v1beta1"
 	"volcano.sh/volcano/pkg/scheduler/api"
-	"volcano.sh/volcano/pkg/scheduler/cache"
 	"volcano.sh/volcano/pkg/scheduler/conf"
 	"volcano.sh/volcano/pkg/scheduler/framework"
 	"volcano.sh/volcano/pkg/scheduler/plugins/conformance"
 	"volcano.sh/volcano/pkg/scheduler/plugins/gang"
 	"volcano.sh/volcano/pkg/scheduler/plugins/proportion"
+	"volcano.sh/volcano/pkg/scheduler/uthelper"
 	"volcano.sh/volcano/pkg/scheduler/util"
 )
 
 func TestReclaim(t *testing.T) {
-	var tmp *cache.SchedulerCache
-	patchUpdateQueueStatus := gomonkey.ApplyMethod(reflect.TypeOf(tmp), "UpdateQueueStatus", func(scCache *cache.SchedulerCache, queue *api.QueueInfo) error {
-		return nil
-	})
-	defer patchUpdateQueueStatus.Reset()
+	plugins := map[string]framework.PluginBuilder{
+		conformance.PluginName: conformance.New,
+		gang.PluginName:        gang.New,
+		proportion.PluginName:  proportion.New,
+	}
 
-	framework.RegisterPluginBuilder("conformance", conformance.New)
-	framework.RegisterPluginBuilder("gang", gang.New)
-	framework.RegisterPluginBuilder("proportion", proportion.New)
-	defer framework.CleanupPluginBuilders()
-
-	tests := []struct {
-		name      string
-		podGroups []*schedulingv1beta1.PodGroup
-		pods      []*v1.Pod
-		nodes     []*v1.Node
-		queues    []*schedulingv1beta1.Queue
-		expected  int
-	}{
+	tests := []uthelper.TestCommonStruct{
 		{
-			name: "Two Queue with one Queue overusing resource, should reclaim",
-			podGroups: []*schedulingv1beta1.PodGroup{
+			Name: "Two Queue with one Queue overusing resource, should reclaim",
+			PodGroups: []*schedulingv1beta1.PodGroup{
 				util.BuildPodGroupWithPrio("pg1", "c1", "q1", 0, nil, schedulingv1beta1.PodGroupInqueue, "low-priority"),
 				util.BuildPodGroupWithPrio("pg2", "c1", "q2", 0, nil, schedulingv1beta1.PodGroupInqueue, "high-priority"),
 			},
-			pods: []*v1.Pod{
+			Pods: []*v1.Pod{
 				util.BuildPod("c1", "preemptee1", "n1", v1.PodRunning, api.BuildResourceList("1", "1G"), "pg1", map[string]string{schedulingv1beta1.PodPreemptable: "true"}, make(map[string]string)),
 				util.BuildPod("c1", "preemptee2", "n1", v1.PodRunning, api.BuildResourceList("1", "1G"), "pg1", make(map[string]string), make(map[string]string)),
 				util.BuildPod("c1", "preemptee3", "n1", v1.PodRunning, api.BuildResourceList("1", "1G"), "pg1", make(map[string]string), make(map[string]string)),
 				util.BuildPod("c1", "preemptor1", "", v1.PodPending, api.BuildResourceList("1", "1G"), "pg2", make(map[string]string), make(map[string]string)),
 			},
-			nodes: []*v1.Node{
+			Nodes: []*v1.Node{
 				util.BuildNode("n1", api.BuildResourceList("3", "3Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), make(map[string]string)),
 			},
-			queues: []*schedulingv1beta1.Queue{
+			Queues: []*schedulingv1beta1.Queue{
 				util.BuildQueue("q1", 1, nil),
 				util.BuildQueue("q2", 1, nil),
 			},
-			expected: 1,
+			EvictNum: 1,
+			Evicted:  []string{"c1/preemptee1"},
 		},
 	}
 
 	reclaim := New()
 
 	for i, test := range tests {
-		binder := &util.FakeBinder{
-			Binds:   map[string]string{},
-			Channel: make(chan string),
-		}
-		evictor := &util.FakeEvictor{
-			Channel: make(chan string),
-		}
-		schedulerCache := &cache.SchedulerCache{
-			Nodes:           make(map[string]*api.NodeInfo),
-			Jobs:            make(map[api.JobID]*api.JobInfo),
-			Queues:          make(map[api.QueueID]*api.QueueInfo),
-			Binder:          binder,
-			Evictor:         evictor,
-			StatusUpdater:   &util.FakeStatusUpdater{},
-			VolumeBinder:    &util.FakeVolumeBinder{},
-			PriorityClasses: make(map[string]*schedulingv1.PriorityClass),
-
-			Recorder: record.NewFakeRecorder(100),
-		}
-		schedulerCache.PriorityClasses["high-priority"] = &schedulingv1.PriorityClass{
-			Value: 100000,
-		}
-		schedulerCache.PriorityClasses["low-priority"] = &schedulingv1.PriorityClass{
-			Value: 10,
-		}
-		for _, node := range test.nodes {
-			schedulerCache.AddOrUpdateNode(node)
-		}
-		for _, pod := range test.pods {
-			schedulerCache.AddPod(pod)
-		}
-
-		for _, ss := range test.podGroups {
-			schedulerCache.AddPodGroupV1beta1(ss)
-		}
-
-		for _, q := range test.queues {
-			schedulerCache.AddQueueV1beta1(q)
-		}
-
 		trueValue := true
-		ssn := framework.OpenSession(schedulerCache, []conf.Tier{
+		tiers := []conf.Tier{
 			{
 				Plugins: []conf.PluginOption{
 					{
@@ -141,21 +85,12 @@ func TestReclaim(t *testing.T) {
 					},
 				},
 			},
-		}, nil)
-		defer framework.CloseSession(ssn)
-
-		reclaim.Execute(ssn)
-
-		for i := 0; i < test.expected; i++ {
-			select {
-			case <-evictor.Channel:
-			case <-time.After(3 * time.Second):
-				t.Errorf("Failed to get Evictor request.")
-			}
 		}
-
-		if test.expected != len(evictor.Evicts()) {
-			t.Errorf("case %d (%s): expected: %v, got %v ", i, test.name, test.expected, len(evictor.Evicts()))
+		test.Plugins = plugins
+		test.RegistSession(tiers, nil)
+		test.Run([]framework.Action{reclaim})
+		if err := test.CheckAll(i); err != nil {
+			t.Fatal(err)
 		}
 	}
 }


### PR DESCRIPTION
Fixes part of #2810

Refact uts：
1. use the ut framework build on mockSchedulerCache to unify all the uts；
2. remove gomonkey which has no permit to be run on MACOS

<img width="886" alt="image" src="https://github.com/volcano-sh/volcano/assets/21003791/fcefd3d1-906d-4f0e-867f-19acc3924e3b">
