### PR TITLE
sort tasks by UID when task index parsing fails

### DIFF
--- a/pkg/controllers/job/helpers/helpers.go
+++ b/pkg/controllers/job/helpers/helpers.go
@@ -54,6 +54,9 @@ func CompareTask(lv, rv *api.TaskInfo) bool {
 	lIndex, lErr := strconv.Atoi(lStr)
 	rIndex, rErr := strconv.Atoi(rStr)
 	if lErr != nil || rErr != nil || lIndex == rIndex {
+		if lv.Pod.CreationTimestamp.Equal(&rv.Pod.CreationTimestamp) {
+			return lv.UID < rv.UID
+		}
 		return lv.Pod.CreationTimestamp.Before(&rv.Pod.CreationTimestamp)
 	}
 	if lIndex > rIndex {

--- a/pkg/controllers/job/helpers/helpers_test.go
+++ b/pkg/controllers/job/helpers/helpers_test.go
@@ -35,23 +35,33 @@ func TestCompareTask(t *testing.T) {
 		expect bool
 	}{
 		{
-			generateTaskInfo("prod-worker-21", createTime),
-			generateTaskInfo("prod-worker-1", createTime),
+			generateTaskInfo("prod-worker-21", createTime, "pod-1"),
+			generateTaskInfo("prod-worker-1", createTime, "pod-2"),
 			false,
 		},
 		{
-			generateTaskInfo("prod-worker-0", createTime),
-			generateTaskInfo("prod-worker-3", createTime),
+			generateTaskInfo("prod-worker-0", createTime, "pod-1"),
+			generateTaskInfo("prod-worker-3", createTime, "pod-2"),
 			true,
 		},
 		{
-			generateTaskInfo("prod-worker", createTime),
-			generateTaskInfo("prod-worker-3", createTime.Add(time.Hour)),
+			generateTaskInfo("prod-worker", createTime, "pod-1"),
+			generateTaskInfo("prod-worker-3", createTime.Add(time.Hour), "pod-2"),
 			true,
 		},
 		{
-			generateTaskInfo("prod-worker", createTime),
-			generateTaskInfo("prod-worker-3", createTime.Add(-time.Hour)),
+			generateTaskInfo("prod-worker", createTime, "pod-1"),
+			generateTaskInfo("prod-worker-3", createTime.Add(-time.Hour), "pod-2"),
+			false,
+		},
+		{
+			generateTaskInfo("prod-worker", createTime, "pod-1"),
+			generateTaskInfo("prod-worker-3", createTime, "pod-2"),
+			true,
+		},
+		{
+			generateTaskInfo("prod-worker", createTime, "pod-2"),
+			generateTaskInfo("prod-worker-3", createTime, "pod-1"),
 			false,
 		},
 	}
@@ -63,7 +73,7 @@ func TestCompareTask(t *testing.T) {
 	}
 }
 
-func generateTaskInfo(name string, createTime time.Time) *api.TaskInfo {
+func generateTaskInfo(name string, createTime time.Time, uid api.TaskID) *api.TaskInfo {
 	pod := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:              name,
@@ -72,6 +82,7 @@ func generateTaskInfo(name string, createTime time.Time) *api.TaskInfo {
 	}
 	return &api.TaskInfo{
 		Name: name,
+		UID:  uid,
 		Pod:  pod,
 	}
 }


### PR DESCRIPTION
Resolves [#3386](https://github.com/volcano-sh/volcano/issues/3386)

The tasks of vc-job is created in goroutine, and the CreationTimestamp of tasks is random. So, sorting by UID when task index parsed failed is a more clear and reasonable method.