### PR TITLE
test: add some ut test in plugins numaaware policy

### DIFF
--- a/pkg/scheduler/actions/preempt/preempt_test.go
+++ b/pkg/scheduler/actions/preempt/preempt_test.go
@@ -271,7 +271,7 @@ func TestPreempt(t *testing.T) {
 		test.Plugins = plugins
 		test.PriClass = []*schedulingv1.PriorityClass{highPrio, lowPrio}
 		t.Run(test.Name, func(t *testing.T) {
-			test.RegistSession(tiers, nil)
+			test.RegisterSession(tiers, nil)
 			defer test.Close()
 			test.Run(actions)
 			if err := test.CheckAll(i); err != nil {

--- a/pkg/scheduler/plugins/drf/hdrf_test.go
+++ b/pkg/scheduler/plugins/drf/hdrf_test.go
@@ -200,7 +200,7 @@ func TestHDRF(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(t.Name(), func(t *testing.T) {
-			ssn := test.RegistSession(tiers, nil)
+			ssn := test.RegisterSession(tiers, nil)
 			defer test.Close()
 			test.Run([]framework.Action{allocate.New()})
 			for _, job := range ssn.Jobs {

--- a/pkg/scheduler/plugins/numaaware/policy/policy_best_effort_test.go
+++ b/pkg/scheduler/plugins/numaaware/policy/policy_best_effort_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 func Test_best_effort_predicate(t *testing.T) {
-	teseCases := []struct {
+	testCases := []struct {
 		name           string
 		providersHints []map[string][]TopologyHint
 		expect         TopologyHint
@@ -312,7 +312,7 @@ func Test_best_effort_predicate(t *testing.T) {
 		},
 	}
 
-	for _, testcase := range teseCases {
+	for _, testcase := range testCases {
 		policy := NewPolicyBestEffort([]int{0, 1})
 		bestHit, _ := policy.Predicate(testcase.providersHints)
 		if !reflect.DeepEqual(bestHit, testcase.expect) {

--- a/pkg/scheduler/plugins/numaaware/policy/policy_none_test.go
+++ b/pkg/scheduler/plugins/numaaware/policy/policy_none_test.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2021 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package policy
+
+import (
+	"reflect"
+	"testing"
+)
+
+func Test_none_predicate(t *testing.T) {
+	testCases := []struct {
+		name           string
+		providersHints []map[string][]TopologyHint
+		expect         TopologyHint
+	}{
+		{
+			name:           "test-1",
+			providersHints: []map[string][]TopologyHint{},
+			expect:         TopologyHint{},
+		},
+	}
+
+	for _, testcase := range testCases {
+		policy := NewPolicyNone([]int{0, 1})
+		bestHit, _ := policy.Predicate(testcase.providersHints)
+		if !reflect.DeepEqual(bestHit, testcase.expect) {
+			t.Errorf("%s failed, expect %v, bestHit= %v\n", testcase.name, testcase.expect, bestHit)
+		}
+	}
+}

--- a/pkg/scheduler/plugins/numaaware/policy/policy_restricted_test.go
+++ b/pkg/scheduler/plugins/numaaware/policy/policy_restricted_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 func Test_restricted_predicate(t *testing.T) {
-	teseCases := []struct {
+	testCases := []struct {
 		name           string
 		providersHints []map[string][]TopologyHint
 		expect         TopologyHint
@@ -312,7 +312,7 @@ func Test_restricted_predicate(t *testing.T) {
 		},
 	}
 
-	for _, testcase := range teseCases {
+	for _, testcase := range testCases {
 		policy := NewPolicyRestricted([]int{0, 1})
 		bestHit, _ := policy.Predicate(testcase.providersHints)
 		if !reflect.DeepEqual(bestHit, testcase.expect) {

--- a/pkg/scheduler/plugins/numaaware/policy/policy_single_numa_node_test.go
+++ b/pkg/scheduler/plugins/numaaware/policy/policy_single_numa_node_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 func Test_single_numa_node_predicate(t *testing.T) {
-	teseCases := []struct {
+	testCases := []struct {
 		name           string
 		providersHints []map[string][]TopologyHint
 		expect         TopologyHint
@@ -278,7 +278,7 @@ func Test_single_numa_node_predicate(t *testing.T) {
 		},
 	}
 
-	for _, testcase := range teseCases {
+	for _, testcase := range testCases {
 		policy := NewPolicySingleNumaNode([]int{0, 1})
 		bestHit, _ := policy.Predicate(testcase.providersHints)
 		if !reflect.DeepEqual(bestHit, testcase.expect) {

--- a/pkg/scheduler/plugins/predicates/predicates_test.go
+++ b/pkg/scheduler/plugins/predicates/predicates_test.go
@@ -111,7 +111,7 @@ func TestEventHandler(t *testing.T) {
 			},
 		}
 		t.Run(test.Name, func(t *testing.T) {
-			test.RegistSession(tiers, nil)
+			test.RegisterSession(tiers, nil)
 			defer test.Close()
 			test.Run(actions)
 			if err := test.CheckAll(i); err != nil {

--- a/pkg/scheduler/uthelper/helper.go
+++ b/pkg/scheduler/uthelper/helper.go
@@ -33,8 +33,8 @@ import (
 	"volcano.sh/volcano/pkg/scheduler/util"
 )
 
-// RegistPlugins plugins
-func RegistPlugins(plugins map[string]framework.PluginBuilder) {
+// RegisterPlugins plugins
+func RegisterPlugins(plugins map[string]framework.PluginBuilder) {
 	for name, plugin := range plugins {
 		framework.RegisterPluginBuilder(name, plugin)
 	}
@@ -68,8 +68,8 @@ type TestCommonStruct struct {
 
 var _ Interface = &TestCommonStruct{}
 
-// RegistSession open session with tiers and configuration, and mock schedulerCache with self-defined FakeBinder and FakeEvictor
-func (test *TestCommonStruct) RegistSession(tiers []conf.Tier, config []conf.Configuration) *framework.Session {
+// RegisterSession open session with tiers and configuration, and mock schedulerCache with self-defined FakeBinder and FakeEvictor
+func (test *TestCommonStruct) RegisterSession(tiers []conf.Tier, config []conf.Configuration) *framework.Session {
 	binder := &util.FakeBinder{
 		Binds:   map[string]string{},
 		Channel: make(chan string),
@@ -102,7 +102,7 @@ func (test *TestCommonStruct) RegistSession(tiers []conf.Tier, config []conf.Con
 		schedulerCache.AddPriorityClass(pc)
 	}
 
-	RegistPlugins(test.Plugins)
+	RegisterPlugins(test.Plugins)
 	ssn := framework.OpenSession(schedulerCache, tiers, config)
 	test.ssn = ssn
 	schedulerCache.Run(test.stop)

--- a/pkg/scheduler/uthelper/interface.go
+++ b/pkg/scheduler/uthelper/interface.go
@@ -25,8 +25,8 @@ import (
 type Interface interface {
 	// Run executes the actions
 	Run(actions []framework.Action)
-	// RegistSession init the session
-	RegistSession(tiers []conf.Tier, config []conf.Configuration) *framework.Session
+	// RegisterSession init the session
+	RegisterSession(tiers []conf.Tier, config []conf.Configuration) *framework.Session
 	// Close release session and do cleanup
 	Close()
 	// CheckAll do all checks


### PR DESCRIPTION
#### What type of PR is this?
/kind test
<!--
-->

#### What this PR does / why we need it:
- add some unit test for plugins/numaaware/policy
- fix some typo and error print
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
See more detail https://github.com/volcano-sh/volcano/issues/3053#issuecomment-2042837878

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
None
```
