### PR TITLE
add image registry for helm

### DIFF
--- a/installer/helm/chart/volcano/templates/admission.yaml
+++ b/installer/helm/chart/volcano/templates/admission.yaml
@@ -120,7 +120,7 @@ spec:
             - --port={{.Values.basic.admission_port}}
             - -v=4
             - 2>&1
-          image: {{.Values.basic.admission_image_name}}:{{.Values.basic.image_tag_version}}
+          image: {{ .Values.basic.image_registry }}/{{.Values.basic.admission_image_name}}:{{.Values.basic.image_tag_version}}
           imagePullPolicy: {{ .Values.basic.image_pull_policy }}
           name: admission
           {{- if .Values.custom.admission_resources }}
@@ -201,7 +201,7 @@ spec:
           resources:
           {{- toYaml .Values.custom.admission_resources | nindent 12 }}
           {{- end }}
-          image: {{.Values.basic.admission_image_name}}:{{.Values.basic.image_tag_version}}
+          image: {{ .Values.basic.image_registry }}/{{.Values.basic.admission_image_name}}:{{.Values.basic.image_tag_version}}
           imagePullPolicy: {{ .Values.basic.image_pull_policy }}
           command: ["./gen-admission-secret.sh", "--service", "{{ .Release.Name }}-admission-service", "--namespace",
                     "{{ .Release.Namespace }}", "--secret", "{{.Values.basic.admission_secret_name}}"]

--- a/installer/helm/chart/volcano/templates/controllers.yaml
+++ b/installer/helm/chart/volcano/templates/controllers.yaml
@@ -139,7 +139,7 @@ spec:
             resources:
             {{- toYaml .Values.custom.controller_resources | nindent 14 }}
             {{- end }}
-            image: {{.Values.basic.controller_image_name}}:{{.Values.basic.image_tag_version}}
+            image: {{ .Values.basic.image_registry }}/{{.Values.basic.controller_image_name}}:{{.Values.basic.image_tag_version}}
             args:
               - --logtostderr
               - --enable-healthz=true

--- a/installer/helm/chart/volcano/templates/scheduler.yaml
+++ b/installer/helm/chart/volcano/templates/scheduler.yaml
@@ -145,7 +145,7 @@ spec:
       {{- end }}
       containers:
         - name: {{ .Release.Name }}-scheduler
-          image: {{.Values.basic.scheduler_image_name}}:{{.Values.basic.image_tag_version}}
+          image: {{ .Values.basic.image_registry }}/{{.Values.basic.scheduler_image_name}}:{{.Values.basic.image_tag_version}}
           {{- if .Values.custom.scheduler_resources }}
           resources:
           {{- toYaml .Values.custom.scheduler_resources | nindent 12 }}

--- a/installer/helm/chart/volcano/values.yaml
+++ b/installer/helm/chart/volcano/values.yaml
@@ -9,6 +9,7 @@ basic:
   image_pull_policy: "Always"
   image_tag_version: "latest"
   admission_port: 8443
+  image_registry: "docker.io"
 custom:
   metrics_enable: false
   admission_enable: true
@@ -113,3 +114,4 @@ custom:
 #
 # Note that {{ .Release.Namespace }} and kube-system namespaces are always ignored.
   webhooks_namespace_selector_expressions: ~
+

--- a/installer/volcano-development.yaml
+++ b/installer/volcano-development.yaml
@@ -150,7 +150,7 @@ spec:
             - --port=8443
             - -v=4
             - 2>&1
-          image: volcanosh/vc-webhook-manager:latest
+          image: docker.io/volcanosh/vc-webhook-manager:latest
           imagePullPolicy: Always
           name: admission
           volumeMounts:
@@ -185,7 +185,7 @@ spec:
       restartPolicy: Never
       containers:
         - name: main
-          image: volcanosh/vc-webhook-manager:latest
+          image: docker.io/volcanosh/vc-webhook-manager:latest
           imagePullPolicy: Always
           command: ["./gen-admission-secret.sh", "--service", "volcano-admission-service", "--namespace",
                     "volcano-system", "--secret", "volcano-admission-secret"]
@@ -4033,7 +4033,7 @@ spec:
       priorityClassName: system-cluster-critical
       containers:
           - name: volcano-controllers
-            image: volcanosh/vc-controller-manager:latest
+            image: docker.io/volcanosh/vc-controller-manager:latest
             args:
               - --logtostderr
               - --enable-healthz=true
@@ -4201,7 +4201,7 @@ spec:
       priorityClassName: system-cluster-critical
       containers:
         - name: volcano-scheduler
-          image: volcanosh/vc-scheduler:latest
+          image: docker.io/volcanosh/vc-scheduler:latest
           args:
             - --logtostderr
             - --scheduler-conf=/volcano.scheduler/volcano-scheduler.conf


### PR DESCRIPTION
There are two scenarios where we need to set up the registry for the image:

1. image proxy: It is slow to pull a image from docker.io, so we need to switch a proxy.
2. Offline environment:  load volcano images we need to a private repository and set up a new registry.

