### PR TITLE
fix nil pointer panic when evict

### DIFF
--- a/pkg/scheduler/cache/cache.go
+++ b/pkg/scheduler/cache/cache.go
@@ -878,7 +878,13 @@ func (sc *SchedulerCache) Evict(taskInfo *schedulingapi.TaskInfo, reason string)
 	}()
 
 	podgroup := &vcv1beta1.PodGroup{}
-	if err := schedulingscheme.Scheme.Convert(&job.PodGroup.PodGroup, podgroup, nil); err != nil {
+	if job.PodGroup != nil {
+		err = schedulingscheme.Scheme.Convert(&job.PodGroup.PodGroup, podgroup, nil)
+	} else {
+		err = fmt.Errorf("the PodGroup of Job <%s/%s> is nil", job.Namespace, job.Name)
+	}
+
+	if err != nil {
 		klog.Errorf("Error while converting PodGroup to v1alpha1.PodGroup with error: %v", err)
 		return err
 	}


### PR DESCRIPTION
i met panic when i use volcano, it shows there are nil pointer deference when excuting the cache's function Evict:

> volcano.sh/volcano@v1.9.0-alpha.0.0.20240425023141-ffd0588b539a/pkg/scheduler/cache/cache.go:865 +0x51c

Maybe we should check if the job.PodGroup is nil before calling Convert function

The more information: #3445 