### PR TITLE
fix: log when outputting preempt error

### DIFF
--- a/pkg/scheduler/actions/allocate/allocate.go
+++ b/pkg/scheduler/actions/allocate/allocate.go
@@ -69,16 +69,16 @@ func (alloc *Action) pickUpQueuesAndJobs(queues *util.PriorityQueue, jobsMap map
 	ssn := alloc.session
 	for _, job := range ssn.Jobs {
 		// If not config enqueue action, change Pending pg into Inqueue statue to avoid blocking job scheduling.
-		if conf.EnabledActionMap["enqueue"] {
-			if job.IsPending() {
+		if job.IsPending() {
+			if conf.EnabledActionMap["enqueue"] {
 				klog.V(4).Infof("Job <%s/%s> Queue <%s> skip allocate, reason: job status is pending.",
 					job.Namespace, job.Name, job.Queue)
 				continue
+			} else {
+				klog.V(4).Infof("Job <%s/%s> Queue <%s> status update from pending to inqueue, reason: no enqueue action is configured.",
+					job.Namespace, job.Name, job.Queue)
+				job.PodGroup.Status.Phase = scheduling.PodGroupInqueue
 			}
-		} else if job.IsPending() {
-			klog.V(4).Infof("Job <%s/%s> Queue <%s> status update from pending to inqueue, reason: no enqueue action is configured.",
-				job.Namespace, job.Name, job.Queue)
-			job.PodGroup.Status.Phase = scheduling.PodGroupInqueue
 		}
 
 		if vr := ssn.JobValid(job); vr != nil && !vr.Pass {

--- a/pkg/scheduler/actions/reclaim/reclaim.go
+++ b/pkg/scheduler/actions/reclaim/reclaim.go
@@ -60,8 +60,7 @@ func (ra *Action) Execute(ssn *framework.Session) {
 		}
 
 		if queue, found := ssn.Queues[job.Queue]; !found {
-			klog.Errorf("Failed to find Queue <%s> for Job <%s/%s>",
-				job.Queue, job.Namespace, job.Name)
+			klog.Errorf("Failed to find Queue <%s> for Job <%s/%s>", job.Queue, job.Namespace, job.Name)
 			continue
 		} else if _, existed := queueMap[queue.UID]; !existed {
 			klog.V(4).Infof("Added Queue <%s> for Job <%s/%s>", queue.Name, job.Namespace, job.Name)
@@ -137,8 +136,7 @@ func (ra *Action) Execute(ssn *framework.Session) {
 					task.Namespace, task.Name, n.Name, statusSets.Message())
 				continue
 			}
-			klog.V(3).Infof("Considering Task <%s/%s> on Node <%s>.",
-				task.Namespace, task.Name, n.Name)
+			klog.V(3).Infof("Considering Task <%s/%s> on Node <%s>.", task.Namespace, task.Name, n.Name)
 
 			var reclaimees []*api.TaskInfo
 			for _, task := range n.Tasks {


### PR DESCRIPTION
#### What type of PR is this?
log when outputting preempt error
<!--
-->

#### What this PR does / why we need it:
- log when outputting preempt error：preempt should be an important method. If an error occurs, a log should be printed.
- refector the judgment statement of allocate action to make it more readable
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
None
```
