### PR TITLE
fix: FilterNode err miss predicateStatus

### DIFF
--- a/pkg/scheduler/api/shared_device_pool.go
+++ b/pkg/scheduler/api/shared_device_pool.go
@@ -32,13 +32,13 @@ type Devices interface {
 	//following two functions used in node_info
 	//AddResource is to add the corresponding device resource of this 'pod' into current scheduler cache
 	AddResource(pod *v1.Pod)
-	//SubResoure is to substract the corresponding device resource of this 'pod' from current scheduler cache
+	//SubResource is to subtract the corresponding device resource of this 'pod' from current scheduler cache
 	SubResource(pod *v1.Pod)
 
 	//following four functions used in predicate
 	//HasDeviceRequest checks if the 'pod' request this device
 	HasDeviceRequest(pod *v1.Pod) bool
-	//FiltreNode checks if the 'pod' fit in current node
+	// FilterNode checks if the 'pod' fit in current node
 	// The first return value represents the filtering result, and the value range is "0, 1, 2, 3"
 	// 0: Success
 	// Success means that plugin ran correctly and found pod schedulable.
@@ -58,15 +58,15 @@ type Devices interface {
 	// that the pod can get scheduled with preemption.
 	// The accompanying status message should explain why the pod is unschedulable.
 	FilterNode(pod *v1.Pod) (int, string, error)
-	//Allocate action in predicate
+	// Allocate action in predicate
 	Allocate(kubeClient kubernetes.Interface, pod *v1.Pod) error
-	//Release action in predicate
+	// Release action in predicate
 	Release(kubeClient kubernetes.Interface, pod *v1.Pod) error
 
-	//IgnredDevices notify vc-scheduler to ignore devices in return list
+	// GetIgnoredDevices notify vc-scheduler to ignore devices in return list
 	GetIgnoredDevices() []string
 
-	//used for debug and monitor
+	// GetStatus used for debug and monitor
 	GetStatus() string
 }
 


### PR DESCRIPTION
#### What type of PR is this?
- fix filterNode err miss predicateStatus
<!--
-->

#### What this PR does / why we need it:
- When `filterNode != err`, the predicateStatus returned should be added to the array.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
None
```
