### PR TITLE
bugfix and code refactor around klog

### DIFF
--- a/cmd/cli/vcancel/main.go
+++ b/cmd/cli/vcancel/main.go
@@ -16,30 +16,16 @@ limitations under the License.
 package main
 
 import (
-	"fmt"
 	"os"
-	"time"
 
 	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
-
-	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/klog/v2"
+	"k8s.io/component-base/cli"
 
 	"volcano.sh/volcano/cmd/cli/util"
 	"volcano.sh/volcano/pkg/cli/vcancel"
 )
 
-var logFlushFreq = pflag.Duration("log-flush-frequency", 5*time.Second, "Maximum number of seconds between log flushes")
-
 func main() {
-	// flag.InitFlags()
-	klog.InitFlags(nil)
-
-	// The default klog flush interval is 30 seconds, which is frighteningly long.
-	go wait.Until(klog.Flush, *logFlushFreq, wait.NeverStop)
-	defer klog.Flush()
-
 	rootCmd := cobra.Command{
 		Use:   "vcancel",
 		Short: "cancel a job",
@@ -51,8 +37,7 @@ func main() {
 
 	jobCancelCmd := &rootCmd
 	vcancel.InitCancelFlags(jobCancelCmd)
-	if err := rootCmd.Execute(); err != nil {
-		fmt.Printf("Failed to execute vcancel: %v\n", err)
-		os.Exit(-2)
-	}
+
+	code := cli.Run(&rootCmd)
+	os.Exit(code)
 }

--- a/cmd/cli/vcctl.go
+++ b/cmd/cli/vcctl.go
@@ -18,28 +18,15 @@ package main
 import (
 	"fmt"
 	"os"
-	"time"
 
 	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
-	"k8s.io/apimachinery/pkg/util/wait"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc"
-	"k8s.io/klog/v2"
+	"k8s.io/component-base/cli"
 
 	"volcano.sh/volcano/pkg/version"
 )
 
-var logFlushFreq = pflag.Duration("log-flush-frequency", 5*time.Second, "Maximum number of seconds between log flushes")
-
 func main() {
-	// flag.InitFlags()
-
-	klog.InitFlags(nil)
-
-	// The default klog flush interval is 30 seconds, which is frighteningly long.
-	go wait.Until(klog.Flush, *logFlushFreq, wait.NeverStop)
-	defer klog.Flush()
-
 	rootCmd := cobra.Command{
 		Use: "vcctl",
 	}
@@ -51,10 +38,8 @@ func main() {
 	rootCmd.AddCommand(buildQueueCmd())
 	rootCmd.AddCommand(versionCommand())
 
-	if err := rootCmd.Execute(); err != nil {
-		fmt.Printf("Failed to execute command: %v\n", err)
-		os.Exit(2)
-	}
+	code := cli.Run(&rootCmd)
+	os.Exit(code)
 }
 
 func checkError(cmd *cobra.Command, err error) {

--- a/cmd/cli/vjobs/main.go
+++ b/cmd/cli/vjobs/main.go
@@ -16,30 +16,16 @@ limitations under the License.
 package main
 
 import (
-	"fmt"
 	"os"
-	"time"
 
 	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
-
-	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/klog/v2"
+	"k8s.io/component-base/cli"
 
 	"volcano.sh/volcano/cmd/cli/util"
 	"volcano.sh/volcano/pkg/cli/vjobs"
 )
 
-var logFlushFreq = pflag.Duration("log-flush-frequency", 5*time.Second, "Maximum number of seconds between log flushes")
-
 func main() {
-	// flag.InitFlags()
-	klog.InitFlags(nil)
-
-	// The default klog flush interval is 30 seconds, which is frighteningly long.
-	go wait.Until(klog.Flush, *logFlushFreq, wait.NeverStop)
-	defer klog.Flush()
-
 	rootCmd := cobra.Command{
 		Use:   "vjobs",
 		Short: "view job information",
@@ -51,8 +37,7 @@ func main() {
 
 	jobViewCmd := &rootCmd
 	vjobs.InitViewFlags(jobViewCmd)
-	if err := rootCmd.Execute(); err != nil {
-		fmt.Printf("Failed to execute vjobs: %v\n", err)
-		os.Exit(-2)
-	}
+
+	code := cli.Run(&rootCmd)
+	os.Exit(code)
 }

--- a/cmd/cli/vqueues/main.go
+++ b/cmd/cli/vqueues/main.go
@@ -16,30 +16,16 @@ limitations under the License.
 package main
 
 import (
-	"fmt"
 	"os"
-	"time"
 
 	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
-
-	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/klog/v2"
+	"k8s.io/component-base/cli"
 
 	"volcano.sh/volcano/cmd/cli/util"
 	"volcano.sh/volcano/pkg/cli/vqueues"
 )
 
-var logFlushFreq = pflag.Duration("log-flush-frequency", 5*time.Second, "Maximum number of seconds between log flushes")
-
 func main() {
-	// flag.InitFlags()
-	klog.InitFlags(nil)
-
-	// The default klog flush interval is 30 seconds, which is frighteningly long.
-	go wait.Until(klog.Flush, *logFlushFreq, wait.NeverStop)
-	defer klog.Flush()
-
 	rootCmd := cobra.Command{
 		Use:   "vqueues",
 		Short: "view queue information",
@@ -51,8 +37,7 @@ func main() {
 
 	jobGetCmd := &rootCmd
 	vqueues.InitGetFlags(jobGetCmd)
-	if err := rootCmd.Execute(); err != nil {
-		fmt.Printf("Failed to execute vqueues: %v\n", err)
-		os.Exit(-2)
-	}
+
+	code := cli.Run(&rootCmd)
+	os.Exit(code)
 }

--- a/cmd/cli/vresume/main.go
+++ b/cmd/cli/vresume/main.go
@@ -16,30 +16,16 @@ limitations under the License.
 package main
 
 import (
-	"fmt"
 	"os"
-	"time"
 
 	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
-
-	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/klog/v2"
+	"k8s.io/component-base/cli"
 
 	"volcano.sh/volcano/cmd/cli/util"
 	"volcano.sh/volcano/pkg/cli/vresume"
 )
 
-var logFlushFreq = pflag.Duration("log-flush-frequency", 5*time.Second, "Maximum number of seconds between log flushes")
-
 func main() {
-	// flag.InitFlags()
-	klog.InitFlags(nil)
-
-	// The default klog flush interval is 30 seconds, which is frighteningly long.
-	go wait.Until(klog.Flush, *logFlushFreq, wait.NeverStop)
-	defer klog.Flush()
-
 	rootCmd := cobra.Command{
 		Use:   "vresume",
 		Short: "resume a job",
@@ -51,8 +37,7 @@ func main() {
 
 	jobResumeCmd := &rootCmd
 	vresume.InitResumeFlags(jobResumeCmd)
-	if err := rootCmd.Execute(); err != nil {
-		fmt.Printf("Failed to execute vresume: %v\n", err)
-		os.Exit(-2)
-	}
+
+	code := cli.Run(&rootCmd)
+	os.Exit(code)
 }

--- a/cmd/cli/vsub/main.go
+++ b/cmd/cli/vsub/main.go
@@ -16,30 +16,16 @@ limitations under the License.
 package main
 
 import (
-	"fmt"
 	"os"
-	"time"
 
 	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
-
-	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/klog/v2"
+	"k8s.io/component-base/cli"
 
 	"volcano.sh/volcano/cmd/cli/util"
 	"volcano.sh/volcano/pkg/cli/vsub"
 )
 
-var logFlushFreq = pflag.Duration("log-flush-frequency", 5*time.Second, "Maximum number of seconds between log flushes")
-
 func main() {
-	// flag.InitFlags()
-	klog.InitFlags(nil)
-
-	// The default klog flush interval is 30 seconds, which is frighteningly long.
-	go wait.Until(klog.Flush, *logFlushFreq, wait.NeverStop)
-	defer klog.Flush()
-
 	rootCmd := cobra.Command{
 		Use:   "vsub",
 		Short: "submit a job",
@@ -51,8 +37,7 @@ func main() {
 
 	jobSubCmd := &rootCmd
 	vsub.InitRunFlags(jobSubCmd)
-	if err := rootCmd.Execute(); err != nil {
-		fmt.Printf("Failed to execute vsub: %v\n", err)
-		os.Exit(-2)
-	}
+
+	code := cli.Run(&rootCmd)
+	os.Exit(code)
 }

--- a/cmd/cli/vsuspend/main.go
+++ b/cmd/cli/vsuspend/main.go
@@ -16,30 +16,16 @@ limitations under the License.
 package main
 
 import (
-	"fmt"
 	"os"
-	"time"
 
 	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
-
-	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/klog/v2"
+	"k8s.io/component-base/cli"
 
 	"volcano.sh/volcano/cmd/cli/util"
 	"volcano.sh/volcano/pkg/cli/vsuspend"
 )
 
-var logFlushFreq = pflag.Duration("log-flush-frequency", 5*time.Second, "Maximum number of seconds between log flushes")
-
 func main() {
-	// flag.InitFlags()
-	klog.InitFlags(nil)
-
-	// The default klog flush interval is 30 seconds, which is frighteningly long.
-	go wait.Until(klog.Flush, *logFlushFreq, wait.NeverStop)
-	defer klog.Flush()
-
 	rootCmd := cobra.Command{
 		Use:   "vsuspend",
 		Short: "suspend a job",
@@ -51,8 +37,7 @@ func main() {
 
 	jobSuspendCmd := &rootCmd
 	vsuspend.InitSuspendFlags(jobSuspendCmd)
-	if err := rootCmd.Execute(); err != nil {
-		fmt.Printf("Failed to execute vsuspend: %v\n", err)
-		os.Exit(-2)
-	}
+
+	code := cli.Run(&rootCmd)
+	os.Exit(code)
 }

--- a/cmd/controller-manager/main.go
+++ b/cmd/controller-manager/main.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/spf13/pflag"
 	_ "go.uber.org/automaxprocs"
-	"k8s.io/apimachinery/pkg/util/wait"
 	cliflag "k8s.io/component-base/cli/flag"
 	componentbaseoptions "k8s.io/component-base/config/options"
 	"k8s.io/klog/v2"
@@ -70,8 +69,7 @@ func main() {
 		}
 	}
 
-	// The default klog flush interval is 30 seconds, which is frighteningly long.
-	go wait.Until(klog.Flush, *logFlushFreq, wait.NeverStop)
+	klog.StartFlushDaemon(*logFlushFreq)
 	defer klog.Flush()
 
 	if err := app.Run(s); err != nil {

--- a/cmd/scheduler/main.go
+++ b/cmd/scheduler/main.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/spf13/pflag"
 	_ "go.uber.org/automaxprocs"
-	"k8s.io/apimachinery/pkg/util/wait"
 	cliflag "k8s.io/component-base/cli/flag"
 	componentbaseoptions "k8s.io/component-base/config/options"
 	"k8s.io/klog/v2"
@@ -70,7 +69,7 @@ func main() {
 		}
 	}
 
-	go wait.Until(klog.Flush, *logFlushFreq, wait.NeverStop)
+	klog.StartFlushDaemon(*logFlushFreq)
 	defer klog.Flush()
 
 	if err := app.Run(s); err != nil {

--- a/cmd/webhook-manager/main.go
+++ b/cmd/webhook-manager/main.go
@@ -24,7 +24,6 @@ import (
 	"github.com/spf13/pflag"
 	_ "go.uber.org/automaxprocs"
 
-	"k8s.io/apimachinery/pkg/util/wait"
 	cliflag "k8s.io/component-base/cli/flag"
 	"k8s.io/klog/v2"
 
@@ -51,7 +50,7 @@ func main() {
 
 	cliflag.InitFlags()
 
-	go wait.Until(klog.Flush, *logFlushFreq, wait.NeverStop)
+	klog.StartFlushDaemon(*logFlushFreq)
 	defer klog.Flush()
 
 	if err := config.CheckPortOrDie(); err != nil {

--- a/test/e2e/vcctl/vcctl.go
+++ b/test/e2e/vcctl/vcctl.go
@@ -40,6 +40,8 @@ Available Commands:
 Flags:
   -h, --help                           help for vcctl
       --log-flush-frequency duration   Maximum number of seconds between log flushes (default 5s)
+  -v, --v Level                        number for the log level verbosity
+      --vmodule moduleSpec             comma-separated list of pattern=N settings for file-filtered logging (only works for the default text log format)
 
 Use "vcctl [command] --help" for more information about a command.
 
@@ -70,6 +72,8 @@ Flags:
 
 Global Flags:
       --log-flush-frequency duration   Maximum number of seconds between log flushes (default 5s)
+  -v, --v Level                        number for the log level verbosity
+      --vmodule moduleSpec             comma-separated list of pattern=N settings for file-filtered logging (only works for the default text log format)
 
 Use "vcctl job [command] --help" for more information about a command.
 
@@ -99,6 +103,8 @@ Flags:
 
 Global Flags:
       --log-flush-frequency duration   Maximum number of seconds between log flushes (default 5s)
+  -v, --v Level                        number for the log level verbosity
+      --vmodule moduleSpec             comma-separated list of pattern=N settings for file-filtered logging (only works for the default text log format)
 
 `
 		command := []string{"job", "list", "--help"}
@@ -124,6 +130,8 @@ Flags:
 
 Global Flags:
       --log-flush-frequency duration   Maximum number of seconds between log flushes (default 5s)
+  -v, --v Level                        number for the log level verbosity
+      --vmodule moduleSpec             comma-separated list of pattern=N settings for file-filtered logging (only works for the default text log format)
 
 `
 		command := []string{"job", "suspend", "-n", "job1", "--help"}
@@ -149,6 +157,8 @@ Flags:
 
 Global Flags:
       --log-flush-frequency duration   Maximum number of seconds between log flushes (default 5s)
+  -v, --v Level                        number for the log level verbosity
+      --vmodule moduleSpec             comma-separated list of pattern=N settings for file-filtered logging (only works for the default text log format)
 
 `
 		command := []string{"job", "resume", "-n", "job1", "--help"}
@@ -181,6 +191,8 @@ Flags:
 
 Global Flags:
       --log-flush-frequency duration   Maximum number of seconds between log flushes (default 5s)
+  -v, --v Level                        number for the log level verbosity
+      --vmodule moduleSpec             comma-separated list of pattern=N settings for file-filtered logging (only works for the default text log format)
 
 `
 		command := []string{"job", "run", "--help"}


### PR DESCRIPTION
1. use `cli.Run` for cli commands, `cli.Run` has already integrated support for `--log-flush-frequency`. As a result, the code is simplified without having to deal with more details about klog.  Also, fix the following bugs:
- fix the bug that `--log-flush-frequency` does not take effect for cli commands (`Parse()` is not called, so it is always the default value 5s) .  And，klog has already reduced the default value from 30s to 5s https://github.com/kubernetes/klog/pull/40
- fix the bug that `-v` flag is not available for cli commands

Before:
```bash
$ ./_output/bin/vcctl -h
Usage:
  vcctl [command]

Available Commands:
  help        Help about any command
  job         vcctl command line operation job
  queue       Queue Operations
  version     Print the version information

Flags:
  -h, --help                           help for vcctl
      --log-flush-frequency duration   Maximum number of seconds between log flushes (default 5s)

Use "vcctl [command] --help" for more information about a command.
```
After:
```bash
After:
$  ./_output/bin/vcctl -h
Usage:
  vcctl [command]

Available Commands:
  help        Help about any command
  job         vcctl command line operation job
  queue       Queue Operations
  version     Print the version information

Flags:
  -h, --help                           help for vcctl
      --log-flush-frequency duration   Maximum number of seconds between log flushes (default 5s)
  -v, --v Level                        number for the log level verbosity
      --vmodule moduleSpec             comma-separated list of pattern=N settings for file-filtered logging (only works for the default text log format)

Use "vcctl [command] --help" for more information about a command.
```

2. use `klog.StartFlushDaemon` to config `--log-flush-frequency` instead of starting a new goroutine for controller commands