### PR TITLE
Fix some potential null pointer panic

### DIFF
--- a/pkg/scheduler/api/devices/nvidia/gpushare/device_info.go
+++ b/pkg/scheduler/api/devices/nvidia/gpushare/device_info.go
@@ -57,9 +57,6 @@ func NewGPUDevice(id int, mem uint) *GPUDevice {
 }
 
 func NewGPUDevices(name string, node *v1.Node) *GPUDevices {
-	if node == nil {
-		return nil
-	}
 	memory, ok := node.Status.Capacity[VolcanoGPUResource]
 	if !ok {
 		return nil

--- a/pkg/scheduler/api/devices/nvidia/vgpu/device_info.go
+++ b/pkg/scheduler/api/devices/nvidia/vgpu/device_info.go
@@ -77,9 +77,6 @@ func NewGPUDevice(id int, mem uint) *GPUDevice {
 }
 
 func NewGPUDevices(name string, node *v1.Node) *GPUDevices {
-	if node == nil {
-		return nil
-	}
 	annos, ok := node.Annotations[VolcanoVGPURegister]
 	if !ok {
 		return nil
@@ -138,9 +135,6 @@ func (gs *GPUDevices) AddResource(pod *v1.Pod) {
 	podDev := decodePodDevices(ids)
 	for _, val := range podDev {
 		for _, deviceused := range val {
-			if gs == nil {
-				break
-			}
 			for index, gsdevice := range gs.Device {
 				if gsdevice.UUID == deviceused.UUID {
 					klog.V(4).Infoln("VGPU recording pod", pod.Name, "device", deviceused)
@@ -163,9 +157,6 @@ func (gs *GPUDevices) SubResource(pod *v1.Pod) {
 	podDev := decodePodDevices(ids)
 	for _, val := range podDev {
 		for _, deviceused := range val {
-			if gs == nil {
-				break
-			}
 			for index, gsdevice := range gs.Device {
 				if gsdevice.UUID == deviceused.UUID {
 					klog.V(4).Infoln("VGPU subsctracting pod", pod.Name, "device", deviceused)

--- a/pkg/scheduler/plugins/deviceshare/deviceshare.go
+++ b/pkg/scheduler/plugins/deviceshare/deviceshare.go
@@ -98,9 +98,11 @@ func createStatus(code int, reason string) *api.Status {
 func getDeviceScore(ctx context.Context, pod *v1.Pod, node *api.NodeInfo, schedulePolicy string) (int64, *k8sframework.Status) {
 	s := float64(0)
 	for _, devices := range node.Others {
-		if devices.(api.Devices).HasDeviceRequest(pod) {
-			ns := devices.(api.Devices).ScoreNode(pod, schedulePolicy)
-			s += ns
+		if dev, ok := devices.(api.Devices); ok && !reflect.ValueOf(dev).IsNil() {
+			if dev.HasDeviceRequest(pod) {
+				ns := dev.ScoreNode(pod, schedulePolicy)
+				s += ns
+			}
 		}
 	}
 	klog.V(4).Infof("deviceScore for task %s/%s is: %v", pod.Namespace, pod.Name, s)

--- a/pkg/scheduler/plugins/predicates/predicates.go
+++ b/pkg/scheduler/plugins/predicates/predicates.go
@@ -19,6 +19,7 @@ package predicates
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"strings"
 
 	v1 "k8s.io/api/core/v1"
@@ -230,6 +231,9 @@ func (pp *predicatesPlugin) OnSessionOpen(ssn *framework.Session) {
 			//predicate gpu sharing
 			for _, val := range api.RegisteredDevices {
 				if devices, ok := nodeInfo.Others[val].(api.Devices); ok {
+					if reflect.ValueOf(devices).IsNil() {
+						continue
+					}
 					if !devices.HasDeviceRequest(pod) {
 						continue
 					}
@@ -264,6 +268,9 @@ func (pp *predicatesPlugin) OnSessionOpen(ssn *framework.Session) {
 
 			for _, val := range api.RegisteredDevices {
 				if devices, ok := nodeInfo.Others[val].(api.Devices); ok {
+					if reflect.ValueOf(devices).IsNil() {
+						continue
+					}
 					if !devices.HasDeviceRequest(pod) {
 						continue
 					}


### PR DESCRIPTION
There may be some potential null pointer panic during certain stages of the device sharing plugin lifecycle，We need to avoid as much as possible, reduce unnecessary null judgments, and improve stability

```txt
E0522 09:37:32.729272       1 node_info.go:396] "Idle resources turn into negative after allocated" nodeName="yjy-server" task="jupyter/d3018-fbd69-0" resources=["volcano.sh/vgpu-number"] idle="cpu 94900.00, memory 538562419712.00, pods 107.00, volcano.sh/vgpu-number -1000.00, attachable-volumes-csi-cephfs.csi.ceph.com 2147483647.00, ephemeral-storage 16605673168980000.00, hugepages-1Gi 0.00, hugepages-2Mi 0.00" req="cpu 1000.00, memory 2000000000.00, volcano.sh/vgpu-number 1000.00, pods 1.00"
E0522 09:37:32.729498       1 runtime.go:79] Observed a panic: "invalid memory address or nil pointer dereference" (runtime error: invalid memory address or nil pointer dereference)
goroutine 352 [running]:
k8s.io/apimachinery/pkg/util/runtime.logPanic({0x1f58d40?, 0x373f900})
        /go/pkg/mod/k8s.io/apimachinery@v0.29.0/pkg/util/runtime/runtime.go:75 +0x99
k8s.io/apimachinery/pkg/util/runtime.HandleCrash({0x0, 0x0, 0xc0004723a0?})
        /go/pkg/mod/k8s.io/apimachinery@v0.29.0/pkg/util/runtime/runtime.go:49 +0x75
panic({0x1f58d40, 0x373f900})
        /usr/local/go/src/runtime/panic.go:884 +0x213
volcano.sh/volcano/pkg/scheduler/api/devices/nvidia/vgpu.(*GPUDevices).GetStatus(0xc0007173c0?)
        /go/src/volcano.sh/volcano/pkg/scheduler/api/devices/nvidia/vgpu/metrics.go:71 +0x18
volcano.sh/volcano/pkg/scheduler/api/devices/nvidia/vgpu.(*GPUDevices).AddResource(0x0, 0xc000b10d80)
        /go/src/volcano.sh/volcano/pkg/scheduler/api/devices/nvidia/vgpu/device_info.go:148 +0xca
volcano.sh/volcano/pkg/scheduler/api.(*NodeInfo).addResource(0xc000f26600, 0xc000d155c0?)
        /go/src/volcano.sh/volcano/pkg/scheduler/api/node_info.go:496 +0xb9
volcano.sh/volcano/pkg/scheduler/api.(*NodeInfo).setNode(0xc000f26600, 0xc0004802c0)
        /go/src/volcano.sh/volcano/pkg/scheduler/api/node_info.go:383 +0x98b
volcano.sh/volcano/pkg/scheduler/api.(*NodeInfo).SetNode(0xc000b8e180, 0xc0002a1500?)
        /go/src/volcano.sh/volcano/pkg/scheduler/api/node_info.go:333 +0x54
volcano.sh/volcano/pkg/scheduler/cache.(*SchedulerCache).AddOrUpdateNode(0xc000236280, 0xc0004802c0)
        /go/src/volcano.sh/volcano/pkg/scheduler/cache/event_handlers.go:495 +0x125
volcano.sh/volcano/pkg/scheduler/cache.(*SchedulerCache).SyncNode(0xc000236280, {0xc00005d8d0, 0xa})
        /go/src/volcano.sh/volcano/pkg/scheduler/cache/event_handlers.go:612 +0x45b
volcano.sh/volcano/pkg/scheduler/cache.(*SchedulerCache).processSyncNode(0xc000236280)
        /go/src/volcano.sh/volcano/pkg/scheduler/cache/cache.go:1167 +0x1b6
volcano.sh/volcano/pkg/scheduler/cache.(*SchedulerCache).runNodeWorker(...)
        /go/src/volcano.sh/volcano/pkg/scheduler/cache/cache.go:1149
k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1(0x30?)
        /go/pkg/mod/k8s.io/apimachinery@v0.29.0/pkg/util/wait/backoff.go:226 +0x3e
k8s.io/apimachinery/pkg/util/wait.BackoffUntil(0x0?, {0x253f680, 0xc000ae0db0}, 0x1, 0xc0004e81e0)
        /go/pkg/mod/k8s.io/apimachinery@v0.29.0/pkg/util/wait/backoff.go:227 +0xb6
k8s.io/apimachinery/pkg/util/wait.JitterUntil(0x0?, 0x0, 0x0, 0x0?, 0x0?)
        /go/pkg/mod/k8s.io/apimachinery@v0.29.0/pkg/util/wait/backoff.go:204 +0x89
k8s.io/apimachinery/pkg/util/wait.Until(0x0?, 0x0?, 0x0?)
        /go/pkg/mod/k8s.io/apimachinery@v0.29.0/pkg/util/wait/backoff.go:161 +0x25
created by volcano.sh/volcano/pkg/scheduler/cache.(*SchedulerCache).Run
        /go/src/volcano.sh/volcano/pkg/scheduler/cache/cache.go:790 +0x92
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
        panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0x17c8038]
```