### PR TITLE
feat: add jobflow name for vcjob label and annotation when creating

### DIFF
--- a/pkg/controllers/jobflow/constant.go
+++ b/pkg/controllers/jobflow/constant.go
@@ -23,4 +23,6 @@ const (
 	JobFlow = "JobFlow"
 	// CreatedByJobTemplate the vcjob annotation and label of created by jobTemplate
 	CreatedByJobTemplate = "volcano.sh/createdByJobTemplate"
+	// CreatedByJobFlow the vcjob annotation and label of created by jobFlow
+	CreatedByJobFlow = "volcano.sh/createdByJobFlow"
 )

--- a/pkg/controllers/jobflow/jobflow_controller_action.go
+++ b/pkg/controllers/jobflow/jobflow_controller_action.go
@@ -260,10 +260,16 @@ func (jf *jobflowcontroller) loadJobTemplateAndSetJob(jobFlow *v1alpha1flow.JobF
 
 	*job = v1alpha1.Job{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        jobName,
-			Namespace:   jobFlow.Namespace,
-			Labels:      map[string]string{CreatedByJobTemplate: GetTemplateString(jobFlow.Namespace, flowName)},
-			Annotations: map[string]string{CreatedByJobTemplate: GetTemplateString(jobFlow.Namespace, flowName)},
+			Name:      jobName,
+			Namespace: jobFlow.Namespace,
+			Labels: map[string]string{
+				CreatedByJobTemplate: GenerateObjectString(jobFlow.Namespace, flowName),
+				CreatedByJobFlow:     GenerateObjectString(jobFlow.Namespace, jobFlow.Name),
+			},
+			Annotations: map[string]string{
+				CreatedByJobTemplate: GenerateObjectString(jobFlow.Namespace, flowName),
+				CreatedByJobFlow:     GenerateObjectString(jobFlow.Namespace, jobFlow.Name),
+			},
 		},
 		Spec:   jobTemplate.Spec,
 		Status: v1alpha1.JobStatus{},
@@ -292,7 +298,7 @@ func (jf *jobflowcontroller) deleteAllJobsCreatedByJobFlow(jobFlow *v1alpha1flow
 func (jf *jobflowcontroller) getAllJobsCreatedByJobFlow(jobFlow *v1alpha1flow.JobFlow) ([]*v1alpha1.Job, error) {
 	var flowNames []string
 	for _, flow := range jobFlow.Spec.Flows {
-		flowNames = append(flowNames, GetTemplateString(jobFlow.Namespace, flow.Name))
+		flowNames = append(flowNames, GenerateObjectString(jobFlow.Namespace, flow.Name))
 	}
 	selector := labels.NewSelector()
 	r, err := labels.NewRequirement(CreatedByJobTemplate, selection.In, flowNames)

--- a/pkg/controllers/jobflow/jobflow_controller_action_test.go
+++ b/pkg/controllers/jobflow/jobflow_controller_action_test.go
@@ -147,7 +147,7 @@ func TestSyncJobFlowFunc(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      getJobName(tt.args.jobFlow.Name, tt.args.jobTemplateList[i].Name),
 						Namespace: tt.args.jobFlow.Namespace,
-						Labels:    map[string]string{CreatedByJobTemplate: GetTemplateString(tt.args.jobFlow.Namespace, tt.args.jobTemplateList[i].Name)},
+						Labels:    map[string]string{CreatedByJobTemplate: GenerateObjectString(tt.args.jobFlow.Namespace, tt.args.jobTemplateList[i].Name)},
 					},
 					Spec: tt.args.jobTemplateList[i].Spec,
 					Status: v1alpha1.JobStatus{
@@ -466,10 +466,12 @@ func TestLoadJobTemplateAndSetJobFunc(t *testing.T) {
 					},
 				},
 				Annotations: map[string]string{
-					CreatedByJobTemplate: GetTemplateString("default", "jobtemplate"),
+					CreatedByJobTemplate: GenerateObjectString("default", "jobtemplate"),
+					CreatedByJobFlow:     GenerateObjectString("default", "jobflow"),
 				},
 				Labels: map[string]string{
-					CreatedByJobTemplate: GetTemplateString("default", "jobtemplate"),
+					CreatedByJobTemplate: GenerateObjectString("default", "jobtemplate"),
+					CreatedByJobFlow:     GenerateObjectString("default", "jobflow"),
 				},
 				Err: nil,
 			},

--- a/pkg/controllers/jobflow/jobflow_controller_util.go
+++ b/pkg/controllers/jobflow/jobflow_controller_util.go
@@ -29,8 +29,8 @@ func getJobName(jobFlowName string, jobTemplateName string) string {
 	return jobFlowName + "-" + jobTemplateName
 }
 
-// GetTemplateString get the JobTemplate information string
-func GetTemplateString(namespace, name string) string {
+// GenerateObjectString generates the object information string using namespace and name
+func GenerateObjectString(namespace, name string) string {
 	return namespace + "." + name
 }
 

--- a/pkg/controllers/jobflow/jobflow_controller_util_test.go
+++ b/pkg/controllers/jobflow/jobflow_controller_util_test.go
@@ -73,8 +73,8 @@ func TestGetConnectionOfJobAndJobTemplate(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := GetTemplateString(tt.args.namespace, tt.args.name); got != tt.want {
-				t.Errorf("GetTemplateString() = %v, want %v", got, tt.want)
+			if got := GenerateObjectString(tt.args.namespace, tt.args.name); got != tt.want {
+				t.Errorf("GenerateObjectString() = %v, want %v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
#### What type of PR is this?
/kind feature
<!--
-->

#### What this PR does / why we need it:
- add jobflow name for vcjob label and annotation when creating 
When jobflow creates the sub-resource vcjob, we should add the jobflow name to the label and annotation. Although there is already an `OwnerReference` field, the label and annotation will allow users to more intuitively know who created the upstream object of this vcjob.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
None
```
