### PR TITLE
Update unit-test && e2e to run on Mac

### DIFF
--- a/hack/generate-groups.sh
+++ b/hack/generate-groups.sh
@@ -50,7 +50,7 @@ shift 4
   # To support running this script from anywhere, first cd into this directory,
   # and then install with forced module mode on and fully qualified name.
   cd "$(dirname "${0}")"
-  GO111MODULE=on go install k8s.io/code-generator/cmd/{defaulter-gen,client-gen,lister-gen,informer-gen,deepcopy-gen}
+  GO111MODULE=on GOOS=${OS} go install k8s.io/code-generator/cmd/{defaulter-gen,client-gen,lister-gen,informer-gen,deepcopy-gen}
 )
 # Go installs the above commands to get installed in $GOBIN if defined, and $GOPATH/bin otherwise:
 GOBIN="$(go env GOBIN)"

--- a/hack/generate-internal-groups.sh
+++ b/hack/generate-internal-groups.sh
@@ -51,7 +51,7 @@ shift 5
   # To support running this script from anywhere, first cd into this directory,
   # and then install with forced module mode on and fully qualified name.
   cd "$(dirname "${0}")"
-  GO111MODULE=on go install k8s.io/code-generator/cmd/{defaulter-gen,conversion-gen,client-gen,lister-gen,informer-gen,deepcopy-gen,openapi-gen}
+  GO111MODULE=on GOOS=${OS} go install k8s.io/code-generator/cmd/{defaulter-gen,conversion-gen,client-gen,lister-gen,informer-gen,deepcopy-gen,openapi-gen}
 )
 
 function codegen::join() { local IFS="$1"; shift; echo "$*"; }

--- a/hack/lib/install.sh
+++ b/hack/lib/install.sh
@@ -69,7 +69,7 @@ function check-kind {
   which kind >/dev/null 2>&1
   if [[ $? -ne 0 ]]; then
     echo "Installing kind ..."
-    go install sigs.k8s.io/kind@v0.21.0
+    GOOS=${OS} go install sigs.k8s.io/kind@v0.21.0
   else
     echo -n "Found kind, version: " && kind version
   fi
@@ -94,7 +94,7 @@ function install-ginkgo-if-not-exist {
   which ginkgo >/dev/null 2>&1
   if [[ $? -ne 0 ]]; then
     echo "Installing ginkgo ..."
-    go install github.com/onsi/ginkgo/v2/ginkgo
+    GOOS=${OS} go install github.com/onsi/ginkgo/v2/ginkgo
   else
     echo -n "Found ginkgo, version: " && ginkgo version
   fi

--- a/hack/run-e2e-kind.sh
+++ b/hack/run-e2e-kind.sh
@@ -133,35 +133,35 @@ install-ginkgo-if-not-exist
 case ${E2E_TYPE} in
 "ALL")
     echo "Running e2e..."
-    KUBECONFIG=${KUBECONFIG} ginkgo -r --nodes=4 --compilers=4 --randomize-all --randomize-suites --fail-on-pending --cover --trace --race --slow-spec-threshold='30s' --progress ./test/e2e/jobp/
-    KUBECONFIG=${KUBECONFIG} ginkgo -r --slow-spec-threshold='30s' --progress ./test/e2e/jobseq/
-    KUBECONFIG=${KUBECONFIG} ginkgo -r --slow-spec-threshold='30s' --progress ./test/e2e/schedulingbase/
-    KUBECONFIG=${KUBECONFIG} ginkgo -r --slow-spec-threshold='30s' --progress ./test/e2e/schedulingaction/
-    KUBECONFIG=${KUBECONFIG} ginkgo -r --slow-spec-threshold='30s' --progress ./test/e2e/vcctl/
+    KUBECONFIG=${KUBECONFIG} GOOS=${OS} ginkgo -r --nodes=4 --compilers=4 --randomize-all --randomize-suites --fail-on-pending --cover --trace --race --slow-spec-threshold='30s' --progress ./test/e2e/jobp/
+    KUBECONFIG=${KUBECONFIG} GOOS=${OS} ginkgo -r --slow-spec-threshold='30s' --progress ./test/e2e/jobseq/
+    KUBECONFIG=${KUBECONFIG} GOOS=${OS} ginkgo -r --slow-spec-threshold='30s' --progress ./test/e2e/schedulingbase/
+    KUBECONFIG=${KUBECONFIG} GOOS=${OS} ginkgo -r --slow-spec-threshold='30s' --progress ./test/e2e/schedulingaction/
+    KUBECONFIG=${KUBECONFIG} GOOS=${OS} ginkgo -r --slow-spec-threshold='30s' --progress ./test/e2e/vcctl/
     ;;
 "JOBP")
     echo "Running parallel job e2e suite..."
-    KUBECONFIG=${KUBECONFIG} ginkgo -r --nodes=4 --compilers=4 --randomize-all --randomize-suites --fail-on-pending --cover --trace --race --slow-spec-threshold='30s' --progress ./test/e2e/jobp/
+    KUBECONFIG=${KUBECONFIG} GOOS=${OS} ginkgo -r --nodes=4 --compilers=4 --randomize-all --randomize-suites --fail-on-pending --cover --trace --race --slow-spec-threshold='30s' --progress ./test/e2e/jobp/
     ;;
 "JOBSEQ")
     echo "Running sequence job e2e suite..."
-    KUBECONFIG=${KUBECONFIG} ginkgo -r --slow-spec-threshold='30s' --progress ./test/e2e/jobseq/
+    KUBECONFIG=${KUBECONFIG} GOOS=${OS} ginkgo -r --slow-spec-threshold='30s' --progress ./test/e2e/jobseq/
     ;;
 "SCHEDULINGBASE")
     echo "Running scheduling base e2e suite..."
-    KUBECONFIG=${KUBECONFIG} ginkgo -r --slow-spec-threshold='30s' --progress ./test/e2e/schedulingbase/
+    KUBECONFIG=${KUBECONFIG} GOOS=${OS} ginkgo -r --slow-spec-threshold='30s' --progress ./test/e2e/schedulingbase/
     ;;
 "SCHEDULINGACTION")
     echo "Running scheduling action e2e suite..."
-    KUBECONFIG=${KUBECONFIG} ginkgo -r --slow-spec-threshold='30s' --progress ./test/e2e/schedulingaction/
+    KUBECONFIG=${KUBECONFIG} GOOS=${OS} ginkgo -r --slow-spec-threshold='30s' --progress ./test/e2e/schedulingaction/
     ;;
 "VCCTL")
     echo "Running vcctl e2e suite..."
-    KUBECONFIG=${KUBECONFIG} ginkgo -r --slow-spec-threshold='30s' --progress ./test/e2e/vcctl/
+    KUBECONFIG=${KUBECONFIG} GOOS=${OS} ginkgo -r --slow-spec-threshold='30s' --progress ./test/e2e/vcctl/
     ;;
 "STRESS")
     echo "Running stress e2e suite..."
-    KUBECONFIG=${KUBECONFIG} ginkgo -r --slow-spec-threshold='30s' --progress ./test/e2e/stress/
+    KUBECONFIG=${KUBECONFIG} GOOS=${OS} ginkgo -r --slow-spec-threshold='30s' --progress ./test/e2e/stress/
     ;;
 esac
 


### PR DESCRIPTION
I encountered several issues in `make controller-gen`, `make unit-test`, `make e2e` on Mac.

Please see the detailed error message here:

* `make controller-gen`
  ```bash
  ➜ volcano (master) make controller-gen                       
  go: creating new go.mod: module tmp
  go: cannot install cross-compiled binaries when GOBIN is set
  make: *** [controller-gen] Error 1
  ```
* `make unit-test`
  ```bash
  ➜ volcano (master) make unit-test
  go clean -testcache
  if [ Darwin = 'Darwin' ];then\
                  GOOS=darwin go list ./... | grep -v "/e2e" | xargs  go test;\
          else\
                  go test -p 8 -race $(find pkg cmd -type f -name '*_test.go' | sed -r 's|/[^/]+$||' | sort | uniq | sed "s|^|volcano.sh/volcano/|");\
          fi;
  ?       volcano.sh/volcano/cmd/cli      [no test files]
  ...
  ?       volcano.sh/volcano/example/kubecon-2019-china/scripts   [no test files]
  fork/exec /var/folders/p9/dbq3q88x7c39y7tmwqgj6yjr0000gn/T/go-build3785830628/b889/options.test: exec format error
  FAIL    volcano.sh/volcano/cmd/controller-manager/app/options   0.001s
  fork/exec /var/folders/p9/dbq3q88x7c39y7tmwqgj6yjr0000gn/T/go-build3785830628/b1041/options.test: exec format error
  FAIL    volcano.sh/volcano/cmd/scheduler/app/options    0.002s
  ```

This is because `GOOS ?= linux` is explicitly set in `Makefile` and consumed in making docker images, etc.

So I slightly update the `OS` env and access it whenever needed (e.g. `go test/install`, `ginkgo`) and everything works perfectly on Mac && Linux.

### Testing done (on both Mac && Linux):
1. `make vcctl` -> ok
2. `make unit-test` -> ok
3. `make controller-gen` -> ok
4. `make mirror-licenses` -> ok
5. `make generate-code` -> ok
6. `make e2e-test-jobp` -> ok