### PR TITLE
feat: add vcctl jobtemplate

### DIFF
--- a/cmd/cli/jobtemplate.go
+++ b/cmd/cli/jobtemplate.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"github.com/spf13/cobra"
+
+	"volcano.sh/volcano/cmd/cli/util"
+	"volcano.sh/volcano/pkg/cli/jobtemplate"
+)
+
+func buildJobTemplateCmd() *cobra.Command {
+	jobTemplateCmd := &cobra.Command{
+		Use:   "jobtemplate",
+		Short: "vcctl command line operation jobtemplate",
+	}
+
+	jobTemplateCommandMap := map[string]struct {
+		Short       string
+		RunFunction func(cmd *cobra.Command, args []string)
+		InitFlags   func(cmd *cobra.Command)
+	}{
+		"create": {
+			Short: "create a jobtemplate",
+			RunFunction: func(cmd *cobra.Command, args []string) {
+				util.CheckError(cmd, jobtemplate.CreateJobTemplate(cmd.Context()))
+			},
+			InitFlags: jobtemplate.InitCreateFlags,
+		},
+		"list": {
+			Short: "list jobtemplates",
+			RunFunction: func(cmd *cobra.Command, args []string) {
+				util.CheckError(cmd, jobtemplate.ListJobTemplate(cmd.Context()))
+			},
+			InitFlags: jobtemplate.InitListFlags,
+		},
+		"get": {
+			Short: "get a jobtemplate",
+			RunFunction: func(cmd *cobra.Command, args []string) {
+				util.CheckError(cmd, jobtemplate.GetJobTemplate(cmd.Context()))
+			},
+			InitFlags: jobtemplate.InitGetFlags,
+		},
+		"delete": {
+			Short: "delete a jobtemplate",
+			RunFunction: func(cmd *cobra.Command, args []string) {
+				util.CheckError(cmd, jobtemplate.DeleteJobTemplate(cmd.Context()))
+			},
+			InitFlags: jobtemplate.InitDeleteFlags,
+		},
+		"describe": {
+			Short: "describe a jobtemplate",
+			RunFunction: func(cmd *cobra.Command, args []string) {
+				util.CheckError(cmd, jobtemplate.DescribeJobTemplate(cmd.Context()))
+			},
+			InitFlags: jobtemplate.InitDescribeFlags,
+		},
+	}
+
+	for command, config := range jobTemplateCommandMap {
+		cmd := &cobra.Command{
+			Use:   command,
+			Short: config.Short,
+			Run:   config.RunFunction,
+		}
+		config.InitFlags(cmd)
+		jobTemplateCmd.AddCommand(cmd)
+	}
+
+	return jobTemplateCmd
+}

--- a/cmd/cli/vcctl.go
+++ b/cmd/cli/vcctl.go
@@ -35,6 +35,7 @@ func main() {
 
 	rootCmd.AddCommand(buildJobCmd())
 	rootCmd.AddCommand(buildQueueCmd())
+	rootCmd.AddCommand(buildJobTemplateCmd())
 	rootCmd.AddCommand(versionCommand())
 
 	code := cli.Run(&rootCmd)

--- a/pkg/cli/jobtemplate/create.go
+++ b/pkg/cli/jobtemplate/create.go
@@ -1,0 +1,77 @@
+package jobtemplate
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/yaml"
+
+	flowv1alpha1 "volcano.sh/apis/pkg/apis/flow/v1alpha1"
+	"volcano.sh/apis/pkg/client/clientset/versioned"
+	"volcano.sh/volcano/pkg/cli/util"
+)
+
+type createFlags struct {
+	util.CommonFlags
+	// FilePath is the file path of job template.
+	FilePath string
+}
+
+var createJobTemplateFlags = &createFlags{}
+
+// InitCreateFlags is used to init all flags during queue creating.
+func InitCreateFlags(cmd *cobra.Command) {
+	util.InitFlags(cmd, &createJobTemplateFlags.CommonFlags)
+	cmd.Flags().StringVarP(&createJobTemplateFlags.FilePath, "file", "f", "", "the path to the YAML file containing the job template")
+}
+
+// CreateJobTemplate create a job template.
+func CreateJobTemplate(ctx context.Context) error {
+	config, err := util.BuildConfig(createJobTemplateFlags.Master, createJobTemplateFlags.Kubeconfig)
+	if err != nil {
+		return err
+	}
+
+	// Read YAML data from a file.
+	yamlData, err := os.ReadFile(createJobTemplateFlags.FilePath)
+	if err != nil {
+		return err
+	}
+	// Split YAML data into individual documents.
+	yamlDocs := strings.Split(string(yamlData), "---")
+
+	jobTemplateClient := versioned.NewForConfigOrDie(config)
+	createdCount := 0
+	for _, doc := range yamlDocs {
+		// Skip empty documents or documents with only whitespace.
+		doc = strings.TrimSpace(doc)
+		if doc == "" {
+			continue
+		}
+
+		// Parse each YAML document into a JobTemplate object.
+		obj := &flowv1alpha1.JobTemplate{}
+		if err = yaml.Unmarshal([]byte(doc), obj); err != nil {
+			return err
+		}
+		// Set the namespace if it's not specified.
+		if obj.Namespace == "" {
+			obj.Namespace = "default"
+		}
+
+		_, err = jobTemplateClient.FlowV1alpha1().JobTemplates(obj.Namespace).Create(ctx, obj, metav1.CreateOptions{})
+		if err == nil {
+			fmt.Printf("Created JobTemplate: %s/%s\n", obj.Namespace, obj.Name)
+			createdCount++
+		} else {
+			fmt.Printf("Failed to create JobTemplate: %v\n", err)
+		}
+	}
+
+	return nil
+}

--- a/pkg/cli/jobtemplate/delete.go
+++ b/pkg/cli/jobtemplate/delete.go
@@ -1,0 +1,104 @@
+package jobtemplate
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/yaml"
+
+	flowv1alpha1 "volcano.sh/apis/pkg/apis/flow/v1alpha1"
+	"volcano.sh/apis/pkg/client/clientset/versioned"
+	"volcano.sh/volcano/pkg/cli/util"
+)
+
+type deleteFlags struct {
+	util.CommonFlags
+
+	// Name is name of job template
+	Name string
+	// Namespace is namespace of job template
+	Namespace string
+	// FilePath is the file path of job template.
+	FilePath string
+}
+
+var deleteJobTemplateFlags = &deleteFlags{}
+
+// InitDeleteFlags is used to init all flags during job template deleting.
+func InitDeleteFlags(cmd *cobra.Command) {
+	util.InitFlags(cmd, &deleteJobTemplateFlags.CommonFlags)
+	cmd.Flags().StringVarP(&deleteJobTemplateFlags.Name, "name", "N", "", "the name of job template")
+	cmd.Flags().StringVarP(&deleteJobTemplateFlags.Namespace, "namespace", "n", "default", "the namespace of job template")
+	cmd.Flags().StringVarP(&deleteJobTemplateFlags.FilePath, "file", "f", "", "the path to the YAML file containing the job template")
+}
+
+// DeleteJobTemplate is used to delete a job template.
+func DeleteJobTemplate(ctx context.Context) error {
+	config, err := util.BuildConfig(deleteJobTemplateFlags.Master, deleteJobTemplateFlags.Kubeconfig)
+	if err != nil {
+		return err
+	}
+
+	jobTemplateClient := versioned.NewForConfigOrDie(config)
+	if err != nil {
+		return err
+	}
+
+	if deleteJobTemplateFlags.FilePath != "" {
+		yamlData, err := os.ReadFile(deleteJobTemplateFlags.FilePath)
+		if err != nil {
+			return err
+		}
+
+		yamlDocs := strings.Split(string(yamlData), "---")
+
+		deletedCount := 0
+		for _, doc := range yamlDocs {
+			doc = strings.TrimSpace(doc)
+			if doc == "" {
+				continue
+			}
+
+			jobTemplate := &flowv1alpha1.JobTemplate{}
+			if err := yaml.Unmarshal([]byte(doc), jobTemplate); err != nil {
+				return err
+			}
+
+			if jobTemplate.Namespace == "" {
+				jobTemplate.Namespace = "default"
+			}
+
+			err := jobTemplateClient.FlowV1alpha1().JobTemplates(jobTemplate.Namespace).Delete(ctx, jobTemplate.Name, metav1.DeleteOptions{})
+			if err == nil {
+				fmt.Printf("Deleted JobTemplate: %s/%s\n", jobTemplate.Namespace, jobTemplate.Name)
+				deletedCount++
+			} else {
+				fmt.Printf("Failed to delete JobTemplate: %v\n", err)
+			}
+		}
+		return nil
+	}
+
+	if deleteJobTemplateFlags.Name == "" {
+		return fmt.Errorf("job template name must be specified")
+	}
+
+	jobTemplate, err := jobTemplateClient.FlowV1alpha1().JobTemplates(deleteJobTemplateFlags.Namespace).Get(ctx, deleteJobTemplateFlags.Name, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+
+	err = jobTemplateClient.FlowV1alpha1().JobTemplates(jobTemplate.Namespace).Delete(ctx, jobTemplate.Name, metav1.DeleteOptions{})
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("Deleted JobTemplate: %s/%s\n", jobTemplate.Namespace, jobTemplate.Name)
+
+	return nil
+}

--- a/pkg/cli/jobtemplate/describe.go
+++ b/pkg/cli/jobtemplate/describe.go
@@ -1,0 +1,96 @@
+package jobtemplate
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/yaml"
+
+	"volcano.sh/apis/pkg/apis/flow/v1alpha1"
+	"volcano.sh/apis/pkg/client/clientset/versioned"
+	"volcano.sh/volcano/pkg/cli/util"
+)
+
+type describeFlags struct {
+	util.CommonFlags
+
+	// Name is name of job template
+	Name string
+	// Namespace is namespace of job template
+	Namespace string
+	// Format print format: yaml or json format
+	Format string
+}
+
+var describeJobTemplateFlags = &describeFlags{}
+
+// InitDescribeFlags is used to init all flags.
+func InitDescribeFlags(cmd *cobra.Command) {
+	util.InitFlags(cmd, &describeJobTemplateFlags.CommonFlags)
+	cmd.Flags().StringVarP(&describeJobTemplateFlags.Name, "name", "N", "", "the name of job template")
+	cmd.Flags().StringVarP(&describeJobTemplateFlags.Namespace, "namespace", "n", "default", "the namespace of job template")
+	cmd.Flags().StringVarP(&describeJobTemplateFlags.Format, "format", "o", "yaml", "the format of output")
+}
+
+// DescribeJobTemplate is used to get the particular job template details.
+func DescribeJobTemplate(ctx context.Context) error {
+	config, err := util.BuildConfig(describeJobTemplateFlags.Master, describeJobTemplateFlags.Kubeconfig)
+	if err != nil {
+		return err
+	}
+	jobTemplateClient := versioned.NewForConfigOrDie(config)
+
+	// Get job template list detail
+	if describeJobTemplateFlags.Name == "" {
+		jobTemplates, err := jobTemplateClient.FlowV1alpha1().JobTemplates(describeJobTemplateFlags.Namespace).List(ctx, metav1.ListOptions{})
+		if err != nil {
+			return err
+		}
+		for _, jobTemplate := range jobTemplates.Items {
+			PrintJobTemplateDetail(&jobTemplate, describeJobTemplateFlags.Format)
+		}
+		// Get job template detail
+	} else {
+		jobTemplate, err := jobTemplateClient.FlowV1alpha1().JobTemplates(describeJobTemplateFlags.Namespace).Get(ctx, describeJobTemplateFlags.Name, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		PrintJobTemplateDetail(jobTemplate, describeJobTemplateFlags.Format)
+	}
+
+	return nil
+}
+
+// PrintJobTemplateDetail print job template details
+func PrintJobTemplateDetail(jobTemplate *v1alpha1.JobTemplate, format string) {
+	switch format {
+	case "json":
+		printJSON(jobTemplate)
+	case "yaml":
+		printYAML(jobTemplate)
+	default:
+		fmt.Printf("Unsupported format: %s", format)
+	}
+}
+
+func printJSON(jobTemplate *v1alpha1.JobTemplate) {
+	b, err := json.MarshalIndent(jobTemplate, "", "  ")
+	if err != nil {
+		fmt.Printf("Error marshaling JSON: %v\n", err)
+	}
+	fmt.Println(string(b))
+	fmt.Println("---------------------------------")
+}
+
+func printYAML(jobTemplate *v1alpha1.JobTemplate) {
+	b, err := yaml.Marshal(jobTemplate)
+	if err != nil {
+		fmt.Printf("Error marshaling YAML: %v\n", err)
+	}
+	fmt.Println(string(b))
+	fmt.Println("---------------------------------")
+}

--- a/pkg/cli/jobtemplate/get.go
+++ b/pkg/cli/jobtemplate/get.go
@@ -1,0 +1,85 @@
+package jobtemplate
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"volcano.sh/apis/pkg/apis/flow/v1alpha1"
+	"volcano.sh/apis/pkg/client/clientset/versioned"
+	"volcano.sh/volcano/pkg/cli/util"
+)
+
+type getFlags struct {
+	util.CommonFlags
+	// Name of the job template.
+	Name string
+	// Namespace of the job template.
+	Namespace string
+}
+
+var getJobTemplateFlags = &getFlags{}
+
+// InitGetFlags is used to init all flags.
+func InitGetFlags(cmd *cobra.Command) {
+	util.InitFlags(cmd, &getJobTemplateFlags.CommonFlags)
+	cmd.Flags().StringVarP(&getJobTemplateFlags.Name, "name", "N", "", "the name of job template")
+	cmd.Flags().StringVarP(&getJobTemplateFlags.Namespace, "namespace", "n", "default", "the namespace of job template")
+}
+
+// GetJobTemplate gets a job template.
+func GetJobTemplate(ctx context.Context) error {
+	config, err := util.BuildConfig(getJobTemplateFlags.Master, getJobTemplateFlags.Kubeconfig)
+	if err != nil {
+		return err
+	}
+
+	if getJobTemplateFlags.Name == "" {
+		err := fmt.Errorf("name is mandatory to get the particular job template details")
+		return err
+	}
+
+	jobTemplateClient := versioned.NewForConfigOrDie(config)
+	jobTemplate, err := jobTemplateClient.FlowV1alpha1().JobTemplates(getJobTemplateFlags.Namespace).Get(ctx, getJobTemplateFlags.Name, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+
+	PrintJobTemplate(jobTemplate, os.Stdout)
+
+	return nil
+}
+
+// PrintJobTemplate prints the job template details.
+func PrintJobTemplate(jobTemplate *v1alpha1.JobTemplate, writer io.Writer) {
+	maxNameLen := len(Name)
+	maxNamespaceLen := len(Namespace)
+	if len(jobTemplate.Name) > maxNameLen {
+		maxNameLen = len(jobTemplate.Name)
+	}
+	if len(jobTemplate.Namespace) > maxNamespaceLen {
+		maxNamespaceLen = len(jobTemplate.Namespace)
+	}
+
+	columnSpacing := 4
+	maxNameLen += columnSpacing
+	maxNamespaceLen += columnSpacing
+	// Find the max length of the name, namespace.
+	formatStr := fmt.Sprintf("%%-%ds%%-%ds\n", maxNameLen, maxNamespaceLen)
+
+	// Print the header.
+	_, err := fmt.Fprintf(writer, formatStr, Name, Namespace)
+	if err != nil {
+		fmt.Printf("Failed to print JobTemplate command result: %s.\n", err)
+	}
+	// Print the separator.
+	_, err = fmt.Fprintf(writer, formatStr, jobTemplate.Name, jobTemplate.Namespace)
+	if err != nil {
+		fmt.Printf("Failed to print JobTemplate command result: %s.\n", err)
+	}
+}

--- a/pkg/cli/jobtemplate/jobtemplate_test.go
+++ b/pkg/cli/jobtemplate/jobtemplate_test.go
@@ -1,0 +1,508 @@
+package jobtemplate
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	flowv1alpha1 "volcano.sh/apis/pkg/apis/flow/v1alpha1"
+)
+
+func TestListJobTemplate(t *testing.T) {
+	testCases := []struct {
+		name           string
+		Response       interface{}
+		Namespace      string
+		ExpectedErr    error
+		ExpectedOutput string
+	}{
+		{
+			name: "Normal Case",
+			Response: &flowv1alpha1.JobTemplateList{
+				Items: []flowv1alpha1.JobTemplate{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "test-jobtemplate",
+							Namespace: "default",
+						},
+					},
+				},
+			},
+			Namespace:   "default",
+			ExpectedErr: nil,
+			ExpectedOutput: `Name                Namespace    
+test-jobtemplate    default`,
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			server := createTestServer(testCase.Response)
+			defer server.Close()
+			// Set the server URL as the master flag
+			listJobTemplateFlags.Master = server.URL
+			listJobTemplateFlags.Namespace = testCase.Namespace
+
+			r, oldStdout := redirectStdout()
+			defer r.Close()
+			err := ListJobTemplate(context.TODO())
+			gotOutput := captureOutput(r, oldStdout)
+
+			if !reflect.DeepEqual(err, testCase.ExpectedErr) {
+				t.Fatalf("test case: %s failed: got: %v, want: %v", testCase.name, err, testCase.ExpectedErr)
+			}
+			if gotOutput != testCase.ExpectedOutput {
+				t.Errorf("test case: %s failed: got: %s, want: %s", testCase.name, gotOutput, testCase.ExpectedOutput)
+			}
+		})
+	}
+}
+
+func TestGetJobTemplate(t *testing.T) {
+	testCases := []struct {
+		name           string
+		Response       *flowv1alpha1.JobTemplate
+		Namespace      string
+		Name           string
+		ExpectedErr    error
+		ExpectedOutput string
+	}{
+		{
+			name: "Normal Case",
+			Response: &flowv1alpha1.JobTemplate{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-jobtemplate",
+					Namespace: "default",
+				},
+			},
+			Namespace:   "default",
+			Name:        "test-jobtemplate",
+			ExpectedErr: nil,
+			ExpectedOutput: `Name                Namespace    
+test-jobtemplate    default`,
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			server := createTestServer(testCase.Response)
+			defer server.Close()
+			// Set the server URL as the master flag
+			getJobTemplateFlags.Master = server.URL
+			// Set the namespace and name as the flags
+			getJobTemplateFlags.Namespace = testCase.Namespace
+			getJobTemplateFlags.Name = testCase.Name
+
+			r, oldStdout := redirectStdout()
+			defer r.Close()
+			err := GetJobTemplate(context.TODO())
+			gotOutput := captureOutput(r, oldStdout)
+			if !reflect.DeepEqual(err, testCase.ExpectedErr) {
+				t.Fatalf("test case: %s failed: got: %v, want: %v", testCase.name, err, testCase.ExpectedErr)
+			}
+			if gotOutput != testCase.ExpectedOutput {
+				fmt.Println(gotOutput)
+				t.Fatalf("test case: %s failed: got: %s, want: %s", testCase.name, gotOutput, testCase.ExpectedOutput)
+			}
+		})
+	}
+}
+
+func TestDeleteJobTemplate(t *testing.T) {
+	testCases := []struct {
+		name           string
+		Response       *flowv1alpha1.JobTemplate
+		Namespace      string
+		Name           string
+		FilePath       string
+		ExpectedErr    error
+		ExpectedOutput string
+	}{
+		{
+			name: "Normal Case",
+			Response: &flowv1alpha1.JobTemplate{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-jobtemplate",
+					Namespace: "default",
+				},
+			},
+			Namespace:      "default",
+			Name:           "test-jobtemplate",
+			ExpectedErr:    nil,
+			ExpectedOutput: `Deleted JobTemplate: default/test-jobtemplate`,
+		},
+		{
+			name: "Normal Case",
+			Response: &flowv1alpha1.JobTemplate{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-jobtemplate",
+					Namespace: "default",
+				},
+			},
+			FilePath:    "test.yaml",
+			ExpectedErr: nil,
+			ExpectedOutput: `Deleted JobTemplate: default/a
+Deleted JobTemplate: default/b`,
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			server := createTestServer(testCase.Response)
+			defer server.Close()
+			// Set the server URL as the master flag
+			deleteJobTemplateFlags.Master = server.URL
+			deleteJobTemplateFlags.Namespace = testCase.Namespace
+			deleteJobTemplateFlags.Name = testCase.name
+			deleteJobTemplateFlags.FilePath = testCase.FilePath
+
+			if testCase.FilePath != "" {
+				err := createAndWriteFile(testCase.FilePath, content)
+				if err != nil {
+					t.Fatalf("Failed to create and write file: %v", err)
+				}
+				// Delete the file after the test
+				defer func() {
+					err := os.Remove(testCase.FilePath)
+					if err != nil {
+						t.Fatalf("Failed to remove file: %v", err)
+					}
+				}()
+			}
+
+			r, oldStdout := redirectStdout()
+			defer r.Close()
+			err := DeleteJobTemplate(context.TODO())
+			gotOutput := captureOutput(r, oldStdout)
+			if !reflect.DeepEqual(err, testCase.ExpectedErr) {
+				t.Fatalf("test case: %s failed: got: %v, want: %v", testCase.name, err, testCase.ExpectedErr)
+			}
+			if gotOutput != testCase.ExpectedOutput {
+				t.Fatalf("test case: %s failed: got: %s, want: %s", testCase.name, gotOutput, testCase.ExpectedOutput)
+			}
+		})
+	}
+}
+
+func TestCreateJobTemplate(t *testing.T) {
+	testCases := []struct {
+		name           string
+		Response       *flowv1alpha1.JobTemplate
+		FilePath       string
+		ExpectedErr    error
+		ExpectedOutput string
+	}{
+		{
+			name: "Normal Case",
+			Response: &flowv1alpha1.JobTemplate{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-jobtemplate",
+					Namespace: "default",
+				},
+			},
+			FilePath:    "test.yaml",
+			ExpectedErr: nil,
+			ExpectedOutput: `Created JobTemplate: default/a
+Created JobTemplate: default/b`,
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			server := createTestServer(testCase.Response)
+			defer server.Close()
+			// Set the server URL as the master flag
+			createJobTemplateFlags.Master = server.URL
+			createJobTemplateFlags.FilePath = testCase.FilePath
+
+			if testCase.FilePath != "" {
+				err := createAndWriteFile(testCase.FilePath, content)
+				if err != nil {
+					t.Fatalf("Failed to create and write file: %v", err)
+				}
+				// Delete the file after the test
+				defer func() {
+					err := os.Remove(testCase.FilePath)
+					if err != nil {
+						t.Fatalf("Failed to remove file: %v", err)
+					}
+				}()
+			}
+			r, oldStdout := redirectStdout()
+			defer r.Close()
+			err := CreateJobTemplate(context.TODO())
+			gotOutput := captureOutput(r, oldStdout)
+			if !reflect.DeepEqual(err, testCase.ExpectedErr) {
+				t.Fatalf("test case: %s failed: got: %v, want: %v", testCase.name, err, testCase.ExpectedErr)
+			}
+			if gotOutput != testCase.ExpectedOutput {
+				t.Fatalf("test case: %s failed: got: %s, want: %s", testCase.name, gotOutput, testCase.ExpectedOutput)
+			}
+		})
+	}
+}
+
+func TestDescribeJobTemplate(t *testing.T) {
+	testCases := []struct {
+		name           string
+		Response       *flowv1alpha1.JobTemplate
+		Namespace      string
+		Name           string
+		Format         string
+		ExpectedErr    error
+		ExpectedOutput string
+	}{
+		{
+			name: "Normal Case, use yaml format",
+			Response: &flowv1alpha1.JobTemplate{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-jobtemplate",
+					Namespace: "default",
+				},
+			},
+			Namespace:   "default",
+			Name:        "test-jobtemplate",
+			Format:      "yaml",
+			ExpectedErr: nil,
+			ExpectedOutput: `metadata:
+  creationTimestamp: null
+  name: test-jobtemplate
+  namespace: default
+spec: {}
+status: {}
+
+---------------------------------`,
+		},
+		{
+			name: "Normal Case, use json format",
+			Response: &flowv1alpha1.JobTemplate{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-jobtemplate",
+					Namespace: "default",
+				},
+			},
+			Namespace:   "default",
+			Name:        "test-jobtemplate",
+			Format:      "json",
+			ExpectedErr: nil,
+			ExpectedOutput: `{
+  "metadata": {
+    "name": "test-jobtemplate",
+    "namespace": "default",
+    "creationTimestamp": null
+  },
+  "spec": {},
+  "status": {}
+}
+---------------------------------`,
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			server := createTestServer(testCase.Response)
+			defer server.Close()
+			// Set the server URL as the master flag
+			describeJobTemplateFlags.Master = server.URL
+			describeJobTemplateFlags.Namespace = testCase.Namespace
+			describeJobTemplateFlags.Name = testCase.name
+			describeJobTemplateFlags.Format = testCase.Format
+
+			r, oldStdout := redirectStdout()
+			defer r.Close()
+			err := DescribeJobTemplate(context.TODO())
+			gotOutput := captureOutput(r, oldStdout)
+			if !reflect.DeepEqual(err, testCase.ExpectedErr) {
+				t.Fatalf("test case: %s failed: got: %v, want: %v", testCase.name, err, testCase.ExpectedErr)
+			}
+			if gotOutput != testCase.ExpectedOutput {
+				t.Fatalf("test case: %s failed: got: %s, want: %s", testCase.name, gotOutput, testCase.ExpectedOutput)
+			}
+		})
+	}
+}
+
+func createTestServer(response interface{}) *httptest.Server {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		val, err := json.Marshal(response)
+		if err == nil {
+			w.Write(val)
+		}
+	})
+
+	server := httptest.NewServer(handler)
+	return server
+}
+
+// redirectStdout redirects os.Stdout to a pipe and returns the read and write ends of the pipe.
+func redirectStdout() (*os.File, *os.File) {
+	r, w, _ := os.Pipe()
+	oldStdout := os.Stdout
+	os.Stdout = w
+	return r, oldStdout
+}
+
+// captureOutput reads from r until EOF and returns the result as a string.
+func captureOutput(r *os.File, oldStdout *os.File) string {
+	w := os.Stdout
+	os.Stdout = oldStdout
+	w.Close()
+	gotOutput, _ := io.ReadAll(r)
+	return strings.TrimSpace(string(gotOutput))
+}
+
+func createAndWriteFile(filePath, content string) error {
+	if _, err := os.Stat(filePath); os.IsNotExist(err) {
+		file, err := os.Create(filePath)
+		if err != nil {
+			return err
+		}
+		defer file.Close()
+		_, err = io.WriteString(file, content)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func TestInitCreateFlags(t *testing.T) {
+	var cmd cobra.Command
+	InitCreateFlags(&cmd)
+
+	if cmd.Flag("file") == nil {
+		t.Errorf("Could not find the flag file")
+	}
+}
+
+func TestInitGetFlags(t *testing.T) {
+	var cmd cobra.Command
+	InitGetFlags(&cmd)
+
+	if cmd.Flag("name") == nil {
+		t.Errorf("Could not find the flag name")
+	}
+	if cmd.Flag("namespace") == nil {
+		t.Errorf("Could not find the flag name")
+	}
+}
+
+func TestInitListFlags(t *testing.T) {
+	var cmd cobra.Command
+	InitListFlags(&cmd)
+
+	if cmd.Flag("namespace") == nil {
+		t.Errorf("Could not find the flag namespace")
+	}
+}
+
+func TestInitDescribeFlags(t *testing.T) {
+	var cmd cobra.Command
+	InitDescribeFlags(&cmd)
+	if cmd.Flag("name") == nil {
+		t.Errorf("Could not find the flag name")
+	}
+	if cmd.Flag("namespace") == nil {
+		t.Errorf("Could not find the flag namespace")
+	}
+	if cmd.Flag("format") == nil {
+		t.Errorf("Could not find the flag format")
+	}
+}
+
+func TestInitDeleteFlags(t *testing.T) {
+	var cmd cobra.Command
+	InitDeleteFlags(&cmd)
+	if cmd.Flag("name") == nil {
+		t.Errorf("Could not find the flag name")
+	}
+	if cmd.Flag("namespace") == nil {
+		t.Errorf("Could not find the flag namespace")
+	}
+	if cmd.Flag("file") == nil {
+		t.Errorf("Could not find the flag file")
+	}
+}
+
+var content = `apiVersion: flow.volcano.sh/v1alpha1
+kind: JobTemplate
+metadata:
+  name: a
+  namespace: default
+spec:
+  minAvailable: 1
+  schedulerName: volcano
+  priorityClassName: high-priority
+  policies:
+    - event: PodEvicted
+      action: RestartJob
+  plugins:
+    ssh: []
+    env: []
+    svc: []
+  maxRetry: 5
+  queue: default
+  tasks:
+    - replicas: 1
+      name: "default-nginx"
+      template:
+        metadata:
+          name: web
+        spec:
+          containers:
+            - image: nginx:1.14.2
+              command:
+                - sh
+                - -c
+                - sleep 10s
+              imagePullPolicy: IfNotPresent
+              name: nginx
+              resources:
+                requests:
+                  cpu: "1"
+          restartPolicy: OnFailure
+---
+apiVersion: flow.volcano.sh/v1alpha1
+kind: JobTemplate
+metadata:
+  name: b
+spec:
+  minAvailable: 1
+  schedulerName: volcano
+  priorityClassName: high-priority
+  policies:
+    - event: PodEvicted
+      action: RestartJob
+  plugins:
+    ssh: []
+    env: []
+    svc: []
+  maxRetry: 5
+  queue: default
+  tasks:
+    - replicas: 1
+      name: "default-nginx"
+      template:
+        metadata:
+          name: web
+        spec:
+          containers:
+            - image: nginx:1.14.2
+              command:
+                - sh
+                - -c
+                - sleep 10s
+              imagePullPolicy: IfNotPresent
+              name: nginx
+              resources:
+                requests:
+                  cpu: "1"
+          restartPolicy: OnFailure
+---`

--- a/pkg/cli/jobtemplate/list.go
+++ b/pkg/cli/jobtemplate/list.go
@@ -1,0 +1,96 @@
+package jobtemplate
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"volcano.sh/apis/pkg/apis/flow/v1alpha1"
+	"volcano.sh/apis/pkg/client/clientset/versioned"
+	"volcano.sh/volcano/pkg/cli/util"
+)
+
+const (
+	// Name job template name
+	Name string = "Name"
+	// Namespace job template namespace
+	Namespace string = "Namespace"
+)
+
+type listFlags struct {
+	util.CommonFlags
+	// Namespace job template namespace
+	Namespace string
+}
+
+var listJobTemplateFlags = &listFlags{}
+
+// InitListFlags inits all flags.
+func InitListFlags(cmd *cobra.Command) {
+	util.InitFlags(cmd, &listJobTemplateFlags.CommonFlags)
+	cmd.Flags().StringVarP(&listJobTemplateFlags.Namespace, "namespace", "n", "default", "the namespace of job template")
+}
+
+// ListJobTemplate lists all job templates.
+func ListJobTemplate(ctx context.Context) error {
+	config, err := util.BuildConfig(listJobTemplateFlags.Master, listJobTemplateFlags.Kubeconfig)
+	if err != nil {
+		return err
+	}
+
+	jobClient := versioned.NewForConfigOrDie(config)
+	jobTemplates, err := jobClient.FlowV1alpha1().JobTemplates(listJobTemplateFlags.Namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+	if len(jobTemplates.Items) == 0 {
+		fmt.Printf("No resources found\n")
+		return nil
+	}
+	PrintJobTemplates(jobTemplates, os.Stdout)
+
+	return nil
+}
+
+// PrintJobTemplates prints all the job templates.
+func PrintJobTemplates(jobTemplates *v1alpha1.JobTemplateList, writer io.Writer) {
+	// Calculate the max length of the name, namespace on list.
+	maxNameLen, maxNamespaceLen := calculateMaxInfoLength(jobTemplates)
+	columnSpacing := 4
+	maxNameLen += columnSpacing
+	maxNamespaceLen += columnSpacing
+	formatStr := fmt.Sprintf("%%-%ds%%-%ds\n", maxNameLen, maxNamespaceLen)
+	// Print the header.
+	_, err := fmt.Fprintf(writer, formatStr, Name, Namespace)
+	if err != nil {
+		fmt.Printf("Failed to print JobTemplate command result: %s.\n", err)
+	}
+	// Print the job templates.
+	for _, jobTemplate := range jobTemplates.Items {
+		_, err := fmt.Fprintf(writer, formatStr, jobTemplate.Name, jobTemplate.Namespace)
+		if err != nil {
+			fmt.Printf("Failed to print JobTemplate command result: %s.\n", err)
+		}
+	}
+}
+
+// calculateMaxInfoLength calculates the maximum length of the Name, Namespace fields.
+func calculateMaxInfoLength(jobTemplates *v1alpha1.JobTemplateList) (int, int) {
+	maxNameLen := len(Name)
+	maxNamespaceLen := len(Namespace)
+
+	for _, jobTemplate := range jobTemplates.Items {
+		if len(jobTemplate.Name) > maxNameLen {
+			maxNameLen = len(jobTemplate.Name)
+		}
+		if len(jobTemplate.Namespace) > maxNamespaceLen {
+			maxNamespaceLen = len(jobTemplate.Namespace)
+		}
+	}
+	return maxNameLen, maxNamespaceLen
+}

--- a/test/e2e/vcctl/vcctl.go
+++ b/test/e2e/vcctl/vcctl.go
@@ -34,6 +34,7 @@ Usage:
 Available Commands:
   help        Help about any command
   job         vcctl command line operation job
+  jobtemplate vcctl command line operation jobtemplate
   queue       Queue Operations
   version     Print the version information
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature


#### What this PR does / why we need it:
- Added vcctl jobtemplate command feature
  - create : Support `-f` (file) to pass in yaml file to create jobtemplate resource
  - delete: Support `-f` (file) to pass in yaml file to delete jobtemplate resource or `-N`(name) `-n`(namespace) to delete jobtemplate resource
  - describe: Support `-o, --format` to output in yaml or json format, `-N`(name) `-n`(namespace) to inquire 
  - list: Support  `-n`(namespace) to inquire 
  - get: Support  `-N`(name) ` `-n`(namespace) to inquire 
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/volcano-sh/volcano/issues/3495

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?
Added vcctl jobtemplate command feature
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
root@VM-0-9-ubuntu:~# vcctl jobtemplate delete -f jobtemplate.yaml
Deleted JobTemplate: default/a
Deleted JobTemplate: default/b
Deleted JobTemplate: default/c
Deleted JobTemplate: default/d
Deleted JobTemplate: default/e
Deleted 5 JobTemplates successfully

root@VM-0-9-ubuntu:~# vcctl jobtemplate create -f jobtemplate.yaml
Created JobTemplate: default/a
Created JobTemplate: default/b
Created JobTemplate: default/c
Created JobTemplate: default/d
Created JobTemplate: default/e

root@VM-0-9-ubuntu:~# vcctl jobtemplate get -N=a
Name    Namespace
a       default

root@VM-0-9-ubuntu:~# vcctl jobtemplate list
Name    Namespace
a       default
b       default
c       default
d       default
e       default

root@VM-0-9-ubuntu:~# vcctl jobtemplate describe -N=a
metadata:
  creationTimestamp: "2024-06-03T12:20:28Z"
  generation: 1
  managedFields:
  - apiVersion: flow.volcano.sh/v1alpha1
    fieldsType: FieldsV1
    fieldsV1:
...
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
None
<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
