### PR TITLE
resource compare support only consider the requested resource item

### DIFF
--- a/pkg/scheduler/api/resource_info.go
+++ b/pkg/scheduler/api/resource_info.go
@@ -429,6 +429,42 @@ func (r *Resource) LessEqual(rr *Resource, defaultValue DimensionDefaultValue) b
 	return true
 }
 
+// LessEqualWithDimension only compare the resource items in req param
+// @param req define the resource item to be compared
+// if req is nil, equals r.LessEqual(rr, zero)
+func (r *Resource) LessEqualWithDimension(rr *Resource, req *Resource) bool {
+	if r == nil {
+		return true
+	}
+	if rr == nil {
+		return false
+	}
+	if req == nil {
+		return r.LessEqual(rr, Zero)
+	}
+
+	if req.MilliCPU > 0 && r.MilliCPU > rr.MilliCPU {
+		return false
+	}
+	if req.Memory > 0 && r.Memory > rr.Memory {
+		return false
+	}
+
+	// if r.scalar is nil, whatever rr.scalar is, r is less or equal to rr
+	if r.ScalarResources == nil {
+		return true
+	}
+
+	for name, quant := range req.ScalarResources {
+		rQuant := r.ScalarResources[name]
+		rrQuant := rr.ScalarResources[name]
+		if quant > 0 && rQuant > rrQuant {
+			return false
+		}
+	}
+	return true
+}
+
 // LessEqualWithResourcesName returns true, []string{} only on condition that all dimensions of resources in r are less than or equal with that of rr,
 // Otherwise returns false and err string ,which show what resources are insufficient.
 // @param defaultValue "default value for resource dimension not defined in ScalarResources. Its value can only be one of 'Zero' and 'Infinity'"

--- a/pkg/scheduler/api/resource_info_test.go
+++ b/pkg/scheduler/api/resource_info_test.go
@@ -818,6 +818,21 @@ func TestLessEqualWithDimension(t *testing.T) {
 			},
 			expected: true,
 		},
+		{
+			resource1: &Resource{
+				MilliCPU: 110, Memory: 4000,
+				ScalarResources: map[v1.ResourceName]float64{"nvidia.com/gpu": 1, "nvidia.com/A100": 1, "scalar": 1},
+			},
+			resource2: &Resource{
+				MilliCPU: 100, Memory: 8000,
+				ScalarResources: map[v1.ResourceName]float64{"nvidia.com/A100": 1, "scalar": 1},
+			},
+			req: &Resource{
+				Memory:          4000,
+				ScalarResources: map[v1.ResourceName]float64{"nvidia.com/gpu": 0, "nvidia.com/A100": 1, "scalar": 1},
+			},
+			expected: true,
+		},
 	}
 
 	for i, test := range tests {

--- a/pkg/scheduler/plugins/capacity/capacity_test.go
+++ b/pkg/scheduler/plugins/capacity/capacity_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package capacity
 
 import (
+	"os"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
@@ -24,6 +25,7 @@ import (
 
 	"volcano.sh/volcano/cmd/scheduler/app/options"
 	"volcano.sh/volcano/pkg/scheduler/actions/allocate"
+	"volcano.sh/volcano/pkg/scheduler/actions/enqueue"
 	"volcano.sh/volcano/pkg/scheduler/actions/reclaim"
 	"volcano.sh/volcano/pkg/scheduler/api"
 	"volcano.sh/volcano/pkg/scheduler/conf"
@@ -33,11 +35,15 @@ import (
 	"volcano.sh/volcano/pkg/scheduler/util"
 )
 
+func TestMain(m *testing.M) {
+	options.Default()
+	os.Exit(m.Run())
+}
+
 func Test_capacityPlugin_OnSessionOpen(t *testing.T) {
 	plugins := map[string]framework.PluginBuilder{PluginName: New, predicates.PluginName: predicates.New}
 	trueValue := true
 	actions := []framework.Action{allocate.New(), reclaim.New()}
-	options.Default()
 
 	// nodes
 	n1 := util.BuildNode("n1", api.BuildResourceList("2", "4Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), map[string]string{"selector": "worker"})
@@ -133,6 +139,101 @@ func Test_capacityPlugin_OnSessionOpen(t *testing.T) {
 			test.RegisterSession(tiers, nil)
 			defer test.Close()
 			test.Run(actions)
+			if err := test.CheckAll(i); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
+func TestEnqueueAndAllocable(t *testing.T) {
+	// nodes
+	n1 := util.BuildNode("n1", api.BuildResourceList("3", "3G", []api.ScalarResource{{Name: "pods", Value: "10"}}...), nil)
+	n2 := util.BuildNode("n2", api.BuildResourceList("3", "3G", []api.ScalarResource{{Name: "pods", Value: "10"}}...), nil)
+
+	// resources
+	res1c3g := api.BuildResourceList("1", "3G")
+	res3c1g := api.BuildResourceList("3", "1G")
+	res1c0g := api.BuildResourceList("1", "0G")
+	res0c1g := api.BuildResourceList("0", "1G")
+	res1c1g := api.BuildResourceList("1", "1G")
+	// pod
+	p1 := util.BuildPod("ns1", "pod1", "n1", corev1.PodRunning, res1c3g, "pg1", nil, nil)
+	p2 := util.BuildPod("ns1", "pod2", "n2", corev1.PodRunning, res3c1g, "pg2", nil, nil)
+	p3 := util.BuildPod("ns1", "pod3", "", corev1.PodPending, res1c0g, "pg3", nil, nil)
+	p4 := util.BuildPod("ns1", "pod4", "", corev1.PodPending, res0c1g, "pg4", nil, nil)
+	p5 := util.BuildPod("ns1", "pod5", "", corev1.PodPending, res1c1g, "pg5", nil, nil)
+
+	// podgroup
+	pg1 := util.BuildPodGroup("pg1", "ns1", "q1", 1, nil, schedulingv1beta1.PodGroupRunning)
+	pg2 := util.BuildPodGroup("pg2", "ns1", "q2", 1, nil, schedulingv1beta1.PodGroupRunning)
+	pg3 := util.BuildPodGroup("pg3", "ns1", "q1", 1, nil, schedulingv1beta1.PodGroupPending)
+	pg4 := util.BuildPodGroup("pg4", "ns1", "q2", 1, nil, schedulingv1beta1.PodGroupPending)
+	pg5 := util.BuildPodGroup("pg5", "ns1", "q1", 1, nil, schedulingv1beta1.PodGroupPending)
+	pg1.Spec.MinResources = &res1c3g
+	pg2.Spec.MinResources = &res3c1g
+	pg3.Spec.MinResources = &res1c0g
+	pg4.Spec.MinResources = &res0c1g
+	pg5.Spec.MinResources = &res1c1g
+
+	queue1 := util.BuildQueueWithResourcesQuantity("q1", api.BuildResourceList("2", "2G"), api.BuildResourceList("2", "2G"))
+	queue2 := util.BuildQueueWithResourcesQuantity("q2", api.BuildResourceList("2", "2G"), api.BuildResourceList("3", "3G"))
+
+	plugins := map[string]framework.PluginBuilder{PluginName: New}
+	trueValue := true
+	tiers := []conf.Tier{
+		{
+			Plugins: []conf.PluginOption{
+				{
+					Name:               PluginName,
+					EnabledAllocatable: &trueValue,
+					EnablePreemptive:   &trueValue,
+					EnabledOverused:    &trueValue,
+					EnabledJobEnqueued: &trueValue,
+				},
+			},
+		},
+	}
+	tests := []uthelper.TestCommonStruct{
+		{
+			Name:           "case0: memory exceed derserved, job only request cpu can be enqueued and allocated",
+			Plugins:        plugins,
+			Pods:           []*corev1.Pod{p1, p2, p3},
+			Nodes:          []*corev1.Node{n1, n2},
+			PodGroups:      []*schedulingv1beta1.PodGroup{pg1, pg2, pg3},
+			Queues:         []*schedulingv1beta1.Queue{queue1, queue2},
+			ExpectBindsNum: 1,
+			ExpectBindMap:  map[string]string{"ns1/pod3": "n1"},
+		},
+		{
+			Name:           "case1: cpu exceed derserved, job only request memory can be enqueued and allocated",
+			Plugins:        plugins,
+			Pods:           []*corev1.Pod{p1, p2, p4},
+			Nodes:          []*corev1.Node{n1, n2},
+			PodGroups:      []*schedulingv1beta1.PodGroup{pg1, pg2, pg4},
+			Queues:         []*schedulingv1beta1.Queue{queue1, queue2},
+			ExpectBindsNum: 1,
+			ExpectBindMap:  map[string]string{"ns1/pod4": "n2"},
+		},
+		{
+			Name:           "case2: exceed capacity, can not enqueue",
+			Plugins:        plugins,
+			Pods:           []*corev1.Pod{p1, p2, p5},
+			Nodes:          []*corev1.Node{n1, n2},
+			PodGroups:      []*schedulingv1beta1.PodGroup{pg1, pg2, pg5},
+			Queues:         []*schedulingv1beta1.Queue{queue1, queue2},
+			ExpectBindsNum: 0,
+			ExpectBindMap:  map[string]string{},
+		},
+	}
+	actions := []framework.Action{enqueue.New(), allocate.New()}
+
+	for i, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			test.RegisterSession(tiers, nil)
+			defer test.Close()
+			test.Run(actions)
+
 			if err := test.CheckAll(i); err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/scheduler/plugins/overcommit/overcommit.go
+++ b/pkg/scheduler/plugins/overcommit/overcommit.go
@@ -119,7 +119,7 @@ func (op *overcommitPlugin) OnSessionOpen(ssn *framework.Session) {
 
 		//TODO: if allow 1 more job to be inqueue beyond overcommit-factor, large job may be inqueue and create pods
 		jobMinReq := api.NewResource(*job.PodGroup.Spec.MinResources)
-		if inqueue.Add(jobMinReq).LessEqual(idle, api.Zero) {
+		if inqueue.Add(jobMinReq).LessEqualWithDimension(idle, jobMinReq) { // only compare the requested resource
 			klog.V(4).Infof("Sufficient resources, permit job <%s/%s> to be inqueue", job.Namespace, job.Name)
 			return util.Permit
 		}


### PR DESCRIPTION
fixes #3520

some times, we need to only compare the required dimensions in the resource.
eg: when check  `Enqueueable`, `Allocatable` or `Preemptive`, even overused.
Will use this function to replcae comparision in `AddJobEnqueueableFn`, `AddPreemptiveFn` and `AddAllocatableFn`

- [x] AddJobEnqueueableFn
- [ ] AddAllocatableFn
- [ ] AddPreemptiveFn
- [ ] AddOverusedFn