### PR TITLE
improve unschedule message

### DIFF
--- a/pkg/scheduler/api/job_info.go
+++ b/pkg/scheduler/api/job_info.go
@@ -654,6 +654,20 @@ func (ji *JobInfo) FitError() string {
 	if len(reasons) > 0 {
 		reasonMsg += "; " + fmt.Sprintf("%s: %s", Pending.String(), strings.Join(sortReasonsHistogram(reasons), ", "))
 	}
+
+	// record the original reason: such as can not enqueue or failed reasons of first pod failed to predicated
+	if ji.JobFitErrors != "" {
+		reasonMsg += ". Origin reason is: " + ji.JobFitErrors
+	} else {
+		for _, taskInfo := range ji.Tasks {
+			fitError := ji.NodesFitErrors[taskInfo.UID]
+			if fitError != nil {
+				reasonMsg += fmt.Sprintf(". Origin reason is %v: %v", taskInfo.Name, fitError.Error())
+				break
+			}
+		}
+	}
+
 	return reasonMsg
 }
 

--- a/pkg/scheduler/cache/cache.go
+++ b/pkg/scheduler/cache/cache.go
@@ -1430,18 +1430,19 @@ func (sc *SchedulerCache) RecordJobStatusEvent(job *schedulingapi.JobInfo, updat
 			job.PodGroup.Status.Phase == scheduling.PodGroupPending ||
 			job.PodGroup.Status.Phase == scheduling.PodGroupInqueue)
 
+	fitErrStr := job.FitError()
 	// If pending or unschedulable, record unschedulable event.
 	if pgUnschedulable {
 		msg := fmt.Sprintf("%v/%v tasks in gang unschedulable: %v",
 			len(job.TaskStatusIndex[schedulingapi.Pending]),
 			len(job.Tasks),
-			job.FitError())
+			fitErrStr)
 		sc.recordPodGroupEvent(job.PodGroup, v1.EventTypeWarning, string(scheduling.PodGroupUnschedulableType), msg)
 	} else if updatePG {
 		sc.recordPodGroupEvent(job.PodGroup, v1.EventTypeNormal, string(scheduling.PodGroupScheduled), string(scheduling.PodGroupReady))
 	}
 
-	baseErrorMessage := job.JobFitErrors
+	baseErrorMessage := fitErrStr
 	if baseErrorMessage == "" {
 		baseErrorMessage = schedulingapi.AllNodeUnavailableMsg
 	}

--- a/pkg/scheduler/plugins/gang/gang.go
+++ b/pkg/scheduler/plugins/gang/gang.go
@@ -179,7 +179,6 @@ func (gp *gangPlugin) OnSessionClose(ssn *framework.Session) {
 			unreadyTaskCount = job.MinAvailable - schedulableTaskNum()
 			msg := fmt.Sprintf("%v/%v tasks in gang unschedulable: %v",
 				unreadyTaskCount, len(job.Tasks), job.FitError())
-			job.JobFitErrors = msg
 
 			unScheduleJobCount++
 			metrics.RegisterJobRetries(job.Name)
@@ -196,18 +195,6 @@ func (gp *gangPlugin) OnSessionClose(ssn *framework.Session) {
 			if err := ssn.UpdatePodGroupCondition(job, jc); err != nil {
 				klog.Errorf("Failed to update job <%s/%s> condition: %v",
 					job.Namespace, job.Name, err)
-			}
-
-			// allocated task should follow the job fit error
-			for _, taskInfo := range job.TaskStatusIndex[api.Allocated] {
-				fitError := job.NodesFitErrors[taskInfo.UID]
-				if fitError != nil {
-					continue
-				}
-
-				fitError = api.NewFitErrors()
-				job.NodesFitErrors[taskInfo.UID] = fitError
-				fitError.SetError(msg)
 			}
 		} else {
 			jc := &scheduling.PodGroupCondition{


### PR DESCRIPTION
This PR is aim to add useful message in podgroup status so that user is easy to find the reason why job is unschedulable.

it also fixes #2993

<details>

<summary>example YAML </summary>

### server-0 allocate success, but server-1 allocate failed

```yaml
apiVersion: batch.volcano.sh/v1alpha1
kind: Job
metadata:
  name: my-apps
spec:
  schedulerName: volcano
  minAvailable: 2
  tasks:
    - replicas: 2
      name: "web"
      minAvailable: 1
      template:
        spec:
          containers:
            - image: nginx:1.14.2
              name: web
              resources:
                requests:
                  cpu: "1000m"
                  memory: "100Mi"
          restartPolicy: OnFailure
    - replicas: 2
      minAvailable: 1
      name: "server"
      template:
        spec:
          containers:
            - image: nginx:1.14.2
              name: server
              resources:
                requests:
                  cpu: "2000m"
                  memory: "100Mi"
          restartPolicy: OnFailure
          priorityClassName: high-priority
```
</details>

#### podgroup message
<img width="846" alt="image" src="https://github.com/volcano-sh/volcano/assets/21003791/e2d150f0-7267-48fd-9d31-d48dcfe0dfce">

<details>

<summary>pod message</summary>

<img width="849" alt="image" src="https://github.com/volcano-sh/volcano/assets/21003791/9bc402c5-5a7d-479e-8dff-cd9d8f77e87a">

</details>