### PR TITLE
Remove init variable in Reclaimable and Preemptable parts of session_plugins

### DIFF
--- a/pkg/scheduler/framework/session_plugins.go
+++ b/pkg/scheduler/framework/session_plugins.go
@@ -153,7 +153,6 @@ func (ssn *Session) AddJobStarvingFns(name string, fn api.ValidateFn) {
 // Reclaimable invoke reclaimable function of the plugins
 func (ssn *Session) Reclaimable(reclaimer *api.TaskInfo, reclaimees []*api.TaskInfo) []*api.TaskInfo {
 	var victims []*api.TaskInfo
-	var init bool
 
 	for _, tier := range ssn.Tiers {
 		for _, plugin := range tier.Plugins {
@@ -173,9 +172,9 @@ func (ssn *Session) Reclaimable(reclaimer *api.TaskInfo, reclaimees []*api.TaskI
 				victims = nil
 				break
 			}
-			if !init {
+			// first iteration - initialize victims list
+			if victims == nil {
 				victims = candidates
-				init = true
 			} else {
 				var intersection []*api.TaskInfo
 				// Get intersection of victims and candidates.
@@ -203,7 +202,6 @@ func (ssn *Session) Reclaimable(reclaimer *api.TaskInfo, reclaimees []*api.TaskI
 // Preemptable invoke preemptable function of the plugins
 func (ssn *Session) Preemptable(preemptor *api.TaskInfo, preemptees []*api.TaskInfo) []*api.TaskInfo {
 	var victims []*api.TaskInfo
-	var init bool
 
 	for _, tier := range ssn.Tiers {
 		for _, plugin := range tier.Plugins {
@@ -224,10 +222,9 @@ func (ssn *Session) Preemptable(preemptor *api.TaskInfo, preemptees []*api.TaskI
 				victims = nil
 				break
 			}
-
-			if !init {
+			// first iteration - initialize victims list
+			if victims == nil {
 				victims = candidates
-				init = true
 			} else {
 				var intersection []*api.TaskInfo
 				// Get intersection of victims and candidates.


### PR DESCRIPTION
Hello, 

it's a really small - so called - refactor. I've just changed values of init variable which shows if this is the first iteration of Reclaimable/Preemptable. In my opinion this if:
```
if init {
    victims = candidates
    init = false
}
```

is more readable than:
```
if !init {
    victims = candidates
    init = true
}
```
It's like a double negation. 