### PR TITLE
Fix podgroup not created

### DIFF
--- a/pkg/controllers/podgroup/pg_controller.go
+++ b/pkg/controllers/podgroup/pg_controller.go
@@ -171,6 +171,7 @@ func (pg *pgcontroller) processNextReq() bool {
 	}
 
 	// normal pod use volcano
+	klog.V(4).Infof("Try to create podgroup for pod %s/%s", pod.Namespace, pod.Name)
 	if err := pg.createNormalPodPGIfNotExist(pod); err != nil {
 		klog.Errorf("Failed to handle Pod <%s/%s>: %v", pod.Namespace, pod.Name, err)
 		pg.queue.AddRateLimited(req)


### PR DESCRIPTION
During the rolling upgrade of replicaset, pg_controller occasionally receives the addPod event and creates a podgroup. Then, pg_controller receives the addReplicaSet (replicas = 0) event and deletes the corresponding podgroup (to solve the pg fc problem). The updateReplicaSet (replicas = 1) event is received but not processed. As a result, the pod group corresponding to the pod is not correctly created.

issue: #3563