### PR TITLE
upgrade kube-state-metrics image versio to v2.0.0-beta from v1.9.7

### DIFF
--- a/installer/helm/chart/volcano/templates/kubestatemetrics.yaml
+++ b/installer/helm/chart/volcano/templates/kubestatemetrics.yaml
@@ -171,7 +171,7 @@ spec:
         {{- end }}
     spec:
       containers:
-        - image: quay.io/coreos/kube-state-metrics:v1.9.7
+        - image: docker.io/volcanosh/kube-state-metrics:v2.0.0-beta
           imagePullPolicy: {{ .Values.basic.image_pull_policy }}
           name: kube-state-metrics
           ports:

--- a/installer/volcano-monitoring-latest.yaml
+++ b/installer/volcano-monitoring-latest.yaml
@@ -432,7 +432,7 @@ spec:
         k8s-app: kube-state-metrics
     spec:
       containers:
-        - image: quay.io/coreos/kube-state-metrics:v1.9.7
+        - image: volcanosh/kube-state-metrics:v2.0.0-beta
           imagePullPolicy: Always
           name: kube-state-metrics
           ports:


### PR DESCRIPTION
Fixes: https://github.com/volcano-sh/volcano/issues/3564

To avoid too big a version change, only a minor version was upgraded.

`v1.9.8` version having multi arch image. https://explore.ggcr.dev/?image=registry.k8s.io%2Fkube-state-metrics%2Fkube-state-metrics:v1.9.8
