### PR TITLE
fix: remove cache sync repeatedly

### DIFF
--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -87,7 +87,6 @@ func (pc *Scheduler) Run(stopCh <-chan struct{}) {
 	// Start cache for policy.
 	pc.cache.SetMetricsConf(pc.metricsConf)
 	pc.cache.Run(stopCh)
-	pc.cache.WaitForCacheSync(stopCh)
 	klog.V(2).Infof("Scheduler completes Initialization and start to run")
 	go wait.Until(pc.runOnce, pc.schedulePeriod, stopCh)
 	if options.ServerOpts.EnableCacheDumper {


### PR DESCRIPTION



SchedulerCache has sync cache in Run() https://github.com/volcano-sh/volcano/blob/master/pkg/scheduler/cache/cache.go#L790 , so it has no need to sync cache again in Scheduler.


```

func (sc *SchedulerCache) Run(stopCh <-chan struct{}) {
	sc.informerFactory.Start(stopCh)
	sc.vcInformerFactory.Start(stopCh)
	sc.WaitForCacheSync(stopCh)
	for i := 0; i < int(sc.nodeWorkers); i++ {
		go wait.Until(sc.runNodeWorker, 0, stopCh)
	}

```

