### PR TITLE
Fix CSI node selector not take effect

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -51,7 +51,6 @@ linters:
     - gosimple
     - ineffassign
     - staticcheck
-    - structcheck
     - typecheck
     - unused
     - varcheck

--- a/pkg/controllers/garbagecollector/garbagecollector.go
+++ b/pkg/controllers/garbagecollector/garbagecollector.go
@@ -22,13 +22,13 @@ import (
 	"time"
 
 	"k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2"
 
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"volcano.sh/apis/pkg/apis/batch/v1alpha1"
 	vcclientset "volcano.sh/apis/pkg/client/clientset/versioned"
 	vcinformer "volcano.sh/apis/pkg/client/informers/externalversions"

--- a/pkg/scheduler/cache/cache.go
+++ b/pkg/scheduler/cache/cache.go
@@ -50,6 +50,7 @@ import (
 	"k8s.io/klog/v2"
 	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
+	"stathat.com/c/consistent"
 
 	batch "volcano.sh/apis/pkg/apis/batch/v1alpha1"
 	"volcano.sh/apis/pkg/apis/scheduling"
@@ -101,7 +102,7 @@ type SchedulerCache struct {
 	defaultQueue string
 	// schedulerName is the name for volcano scheduler
 	schedulerNames     []string
-	nodeSelectorLabels map[string]string
+	nodeSelectorLabels map[string]sets.Empty
 	metricsConf        map[string]string
 
 	podInformer                infov1.PodInformer
@@ -157,6 +158,15 @@ type SchedulerCache struct {
 	// not be counted in pod pvc resource request and node.Allocatable, because the spec.drivers of csinode resource
 	// is always null, these provisioners usually are host path csi controllers like rancher.io/local-path and hostpath.csi.k8s.io.
 	IgnoredCSIProvisioners sets.Set[string]
+
+	// multiSchedulerInfo holds multi schedulers info without using node selector, please see the following link for more details.
+	// https://github.com/volcano-sh/volcano/blob/master/docs/design/deploy-multi-volcano-schedulers-without-using-selector.md
+	multiSchedulerInfo
+}
+
+type multiSchedulerInfo struct {
+	schedulerPodName string
+	c                *consistent.Consistent
 }
 
 type imageState struct {
@@ -441,7 +451,7 @@ func (sc *SchedulerCache) updateNodeSelectors(nodeSelectors []string) {
 		nodeSelectorLabelName := strings.TrimSpace(nodeSelectorLabel[:index])
 		nodeSelectorLabelValue := strings.TrimSpace(nodeSelectorLabel[index+1:])
 		key := nodeSelectorLabelName + ":" + nodeSelectorLabelValue
-		sc.nodeSelectorLabels[key] = ""
+		sc.nodeSelectorLabels[key] = sets.Empty{}
 	}
 }
 
@@ -547,7 +557,7 @@ func newSchedulerCache(config *rest.Config, schedulerNames []string, defaultQueu
 		restConfig:          config,
 		defaultQueue:        defaultQueue,
 		schedulerNames:      schedulerNames,
-		nodeSelectorLabels:  make(map[string]string),
+		nodeSelectorLabels:  make(map[string]sets.Empty),
 		NamespaceCollection: make(map[string]*schedulingapi.NamespaceCollection),
 		CSINodesStatus:      make(map[string]*schedulingapi.CSINodeStatusInfo),
 		imageStates:         make(map[string]*imageState),
@@ -556,6 +566,7 @@ func newSchedulerCache(config *rest.Config, schedulerNames []string, defaultQueu
 		nodeWorkers: nodeWorkers,
 	}
 
+	sc.schedulerPodName, sc.c = getMultiSchedulerInfo()
 	ignoredProvisionersSet := sets.New[string]()
 	for _, provisioner := range append(ignoredProvisioners, defaultIgnoredProvisioners...) {
 		ignoredProvisionersSet.Insert(provisioner)
@@ -603,7 +614,6 @@ func newSchedulerCache(config *rest.Config, schedulerNames []string, defaultQueu
 func (sc *SchedulerCache) addEventHandler() {
 	informerFactory := informers.NewSharedInformerFactory(sc.kubeClient, 0)
 	sc.informerFactory = informerFactory
-	mySchedulerPodName, c := getMultiSchedulerInfo()
 
 	// explicitly register informers to the factory, otherwise resources listers cannot get anything
 	// even with no error returned.
@@ -627,35 +637,20 @@ func (sc *SchedulerCache) addEventHandler() {
 	sc.nodeInformer.Informer().AddEventHandlerWithResyncPeriod(
 		cache.FilteringResourceEventHandler{
 			FilterFunc: func(obj interface{}) bool {
-				var node *v1.Node
 				switch t := obj.(type) {
 				case *v1.Node:
-					node = t
+					return true
 				case cache.DeletedFinalStateUnknown:
 					var ok bool
-					node, ok = t.Obj.(*v1.Node)
+					_, ok = t.Obj.(*v1.Node)
 					if !ok {
 						klog.Errorf("Cannot convert to *v1.Node: %v", t.Obj)
 						return false
 					}
+					return true
 				default:
 					return false
 				}
-
-				if !responsibleForNode(node.Name, mySchedulerPodName, c) {
-					return false
-				}
-				if len(sc.nodeSelectorLabels) == 0 {
-					return true
-				}
-				for labelName, labelValue := range node.Labels {
-					key := labelName + ":" + labelValue
-					if _, ok := sc.nodeSelectorLabels[key]; ok {
-						return true
-					}
-				}
-				klog.Infof("node %s ignore add/update/delete into schedulerCache", node.Name)
-				return false
 			},
 			Handler: cache.ResourceEventHandlerFuncs{
 				AddFunc:    sc.AddNode,
@@ -690,11 +685,11 @@ func (sc *SchedulerCache) addEventHandler() {
 			FilterFunc: func(obj interface{}) bool {
 				switch v := obj.(type) {
 				case *v1.Pod:
-					if !responsibleForPod(v, sc.schedulerNames, mySchedulerPodName, c) {
+					if !responsibleForPod(v, sc.schedulerNames, sc.schedulerPodName, sc.c) {
 						if len(v.Spec.NodeName) == 0 {
 							return false
 						}
-						if !responsibleForNode(v.Spec.NodeName, mySchedulerPodName, c) {
+						if !responsibleForNode(v.Spec.NodeName, sc.schedulerPodName, sc.c) {
 							return false
 						}
 					}
@@ -756,7 +751,7 @@ func (sc *SchedulerCache) addEventHandler() {
 					return false
 				}
 
-				return responsibleForPodGroup(pg, mySchedulerPodName, c)
+				return responsibleForPodGroup(pg, sc.schedulerPodName, sc.c)
 			},
 			Handler: cache.ResourceEventHandlerFuncs{
 				AddFunc:    sc.AddPodGroupV1beta1,

--- a/pkg/scheduler/cache/cache_mock.go
+++ b/pkg/scheduler/cache/cache_mock.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 
 	schedulingv1 "k8s.io/api/scheduling/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
@@ -109,7 +110,7 @@ func newMockSchedulerCache(schedulerName string) *SchedulerCache {
 		restConfig:          nil,
 		defaultQueue:        "default",
 		schedulerNames:      []string{schedulerName},
-		nodeSelectorLabels:  make(map[string]string),
+		nodeSelectorLabels:  make(map[string]sets.Empty),
 		NamespaceCollection: make(map[string]*schedulingapi.NamespaceCollection),
 		CSINodesStatus:      make(map[string]*schedulingapi.CSINodeStatusInfo),
 		imageStates:         make(map[string]*imageState),


### PR DESCRIPTION
Fix https://github.com/volcano-sh/volcano/issues/3587.
Also remve the deprecated check `structcheck` cause it has been replaced by `unused` check.
```
WARN [runner] The linter 'structcheck' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter. Replaced by unused.
```