### PR TITLE
use create pod result for statistic of job status

### DIFF
--- a/pkg/controllers/job/job_controller_actions.go
+++ b/pkg/controllers/job/job_controller_actions.go
@@ -410,7 +410,7 @@ func (cc *jobcontroller) syncJob(jobInfo *apis.JobInfo, updateStatus state.Updat
 						appendError(&creationErrs, fmt.Errorf("failed to create pod %s, err: %#v", pod.Name, err))
 					} else {
 						classifyAndAddUpPodBaseOnPhase(newPod, &pending, &running, &succeeded, &failed, &unknown)
-						calcPodStatus(pod, taskStatusCount)
+						calcPodStatus(newPod, taskStatusCount)
 						klog.V(5).Infof("Created Task <%s> of Job <%s/%s>",
 							pod.Name, job.Namespace, job.Name)
 					}


### PR DESCRIPTION
In the current code, the `pod`'s phase is empty, it will be counted as `Unknown` rather than `Pending`. After the pod is created and execute `syncJob()` function again, it updates to `Pending`. Currently, it is not necessary to update the status twice.

We should use `newPod` for the `calcPodStatus()` function to maintain consistency with 'classifyAndAddUpPodBaseOnPhase()'. Additionally, this approach can reduce the frequency of job status updates, thereby indirectly reducing the load on the API server.