### PR TITLE
Add container log size limit config for kind node

### DIFF
--- a/hack/e2e-kind-config.yaml
+++ b/hack/e2e-kind-config.yaml
@@ -5,6 +5,11 @@ apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
   # the control plane node config
   - role: control-plane
+    kubeadmConfigPatches:
+    - |
+      apiVersion: kubelet.config.k8s.io/v1beta1
+      kind: KubeletConfiguration
+      containerLogMaxSize: "50Mi"
   # the four workers
   - role: worker
   - role: worker


### PR DESCRIPTION
This pr https://github.com/volcano-sh/volcano/pull/3438 exported logs when e2e has error, but when check logs, the volcano scheduler logs have been compressed cause the default log limit size is only 10Mi，and we can't see the complete logs, so this pr adjust the log limit.