### PR TITLE
metrics_accurate

### DIFF
--- a/pkg/scheduler/metrics/metrics.go
+++ b/pkg/scheduler/metrics/metrics.go
@@ -40,7 +40,7 @@ var (
 			Subsystem: VolcanoNamespace,
 			Name:      "e2e_scheduling_latency_milliseconds",
 			Help:      "E2e scheduling latency in milliseconds (scheduling algorithm + binding)",
-			Buckets:   prometheus.ExponentialBuckets(5, 2, 10),
+			Buckets:   prometheus.ExponentialBuckets(5, 2, 20),
 		},
 	)
 
@@ -94,7 +94,7 @@ var (
 			Subsystem: VolcanoNamespace,
 			Name:      "action_scheduling_latency_microseconds",
 			Help:      "Action scheduling latency in microseconds",
-			Buckets:   prometheus.ExponentialBuckets(5, 2, 10),
+			Buckets:   prometheus.ExponentialBuckets(5, 2, 30),
 		}, []string{"action"},
 	)
 


### PR DESCRIPTION
The metric volcano_action_scheduling_latency_microseconds origin bucket is defined as prometheus.ExponentialBuckets(5, 2, 10), which means the max microsecond is 2560us, in a large cluster, the action like allocate and preempt will cost about several seconds. so it is important to modify the max value of the bucket.