### PR TITLE
fix: vgpu metrics not update when pod deleted

### DIFF
--- a/pkg/scheduler/api/devices/nvidia/vgpu/device_info.go
+++ b/pkg/scheduler/api/devices/nvidia/vgpu/device_info.go
@@ -176,6 +176,7 @@ func (gs *GPUDevices) SubResource(pod *v1.Pod) {
 			}
 		}
 	}
+	gs.GetStatus()
 }
 
 func (gs *GPUDevices) HasDeviceRequest(pod *v1.Pod) bool {


### PR DESCRIPTION
fix: https://github.com/volcano-sh/volcano/issues/3605

When a pod is deleted, we need to re-update the metrics

```go
// SubResource frees the gpu hold by the pod
func (gs *GPUDevices) SubResource(pod *v1.Pod) {
	ids, ok := pod.Annotations[AssignedIDsAnnotations]
	if !ok {
		return
	}
	podDev := decodePodDevices(ids)
	for _, val := range podDev {
		for _, deviceused := range val {
			if gs == nil {
				break
			}
			for index, gsdevice := range gs.Device {
				if gsdevice.UUID == deviceused.UUID {
					klog.V(4).Infoln("VGPU subsctracting pod", pod.Name, "device", deviceused)
					gs.Device[index].UsedMem -= uint(deviceused.Usedmem)
					gs.Device[index].UsedNum--
					gs.Device[index].UsedCore -= uint(deviceused.Usedcores)
				}
			}
		}
	}
	gs.GetStatus()
}

```