### PR TITLE
Fix spark ci error

### DIFF
--- a/.github/workflows/e2e_spark.yaml
+++ b/.github/workflows/e2e_spark.yaml
@@ -10,7 +10,7 @@ on:
 jobs:
   k8s-integration-tests:
     name: "E2E about Spark Integration test"
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-20.04
     steps:
 
     - name: Checkout current Volcano repository


### PR DESCRIPTION
When install pip3 and pip using Ubuntu24.04，debain package managed by pip3 and python packages managed by pip have conflict，and ubuntu20.04 has no such problem，it's also consistent with upstream spark https://github.com/Monokaix/spark/blob/2962796ca3a61b7d0a57e9280bcee1e77e75fcec/.github/workflows/build_and_test.yml#L891
Fix https://github.com/volcano-sh/volcano/issues/3623