### PR TITLE
[cherry-pick for release-1.10]Add config field to the ControllerOption

### DIFF
--- a/cmd/controller-manager/app/server.go
+++ b/cmd/controller-manager/app/server.go
@@ -127,6 +127,7 @@ func startControllers(config *rest.Config, opt *options.ServerOption) func(ctx c
 	controllerOpt.InheritOwnerAnnotations = opt.InheritOwnerAnnotations
 	controllerOpt.WorkerThreadsForPG = opt.WorkerThreadsForPG
 	controllerOpt.WorkerThreadsForGC = opt.WorkerThreadsForGC
+	controllerOpt.Config = config
 
 	return func(ctx context.Context) {
 		framework.ForeachController(func(c framework.Controller) {

--- a/pkg/controllers/framework/interface.go
+++ b/pkg/controllers/framework/interface.go
@@ -19,6 +19,7 @@ package framework
 import (
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 
 	vcclientset "volcano.sh/apis/pkg/client/clientset/versioned"
 	vcinformer "volcano.sh/apis/pkg/client/informers/externalversions"
@@ -37,6 +38,10 @@ type ControllerOption struct {
 	InheritOwnerAnnotations bool
 	WorkerThreadsForPG      uint32
 	WorkerThreadsForGC      uint32
+
+	// Config holds the common attributes that can be passed to a Kubernetes client
+	// and controllers registered by the users can use it.
+	Config *rest.Config
 }
 
 // Controller is the interface of all controllers.


### PR DESCRIPTION
Add config field to the ControllerOption, pass the config parameter to the controllers, and the controllers can use config to create a custom clientset

cherry-pick from https://github.com/volcano-sh/volcano/pull/3615