### PR TITLE
fix parse error: invalid go version '1.22.0': must match format 1.23

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module volcano.sh/volcano
 
-go 1.22.0
+go 1.22
 
 require (
 	github.com/agiledragon/gomonkey/v2 v2.11.0


### PR DESCRIPTION
go.mod should use version format 1.xx instead of 1.xx.yy

```sh
go: errors parsing go.mod:
/go/src/github.com/volcano-sh/volcano/go.mod:3: invalid go version '1.22.0': must match format 1.23
```