### PR TITLE
Fix #3604: Include Aborted Jobs in Garbage Collector Cleanup

### DIFF
--- a/pkg/controllers/garbagecollector/garbagecollector.go
+++ b/pkg/controllers/garbagecollector/garbagecollector.go
@@ -273,6 +273,7 @@ func isJobFinished(job *v1alpha1.Job) bool {
 	return job.Status.State.Phase == v1alpha1.Completed ||
 		job.Status.State.Phase == v1alpha1.Failed ||
 		job.Status.State.Phase == v1alpha1.Terminated
+		job.Status.State.Phase == v1alpha1.Aborted
 }
 
 func getFinishAndExpireTime(j *v1alpha1.Job) (*time.Time, *time.Time, error) {


### PR DESCRIPTION
Changes:

 Modified the isJobFinished function in pkg/controllers/garbagecollector/garbagecollector.go to include the Aborted state.