### PR TITLE
feature: use multi factor for overcommit plugin

### DIFF
--- a/pkg/scheduler/plugins/overcommit/overcommit_test.go
+++ b/pkg/scheduler/plugins/overcommit/overcommit_test.go
@@ -1,8 +1,10 @@
 package overcommit
 
 import (
+	"sort"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 
@@ -16,7 +18,7 @@ import (
 )
 
 func TestOvercommitPlugin(t *testing.T) {
-	n1 := util.BuildNode("n1", api.BuildResourceList("2", "4Gi"), make(map[string]string))
+	n1 := util.BuildNode("n1", api.BuildResourceList("2", "4Gi", api.ScalarResource{Name: "ephemeral-storage", Value: "32Gi"}, api.ScalarResource{Name: "nvidia.com/gpu", Value: "8"}), make(map[string]string))
 	n2 := util.BuildNode("n2", api.BuildResourceList("4", "16Gi"), make(map[string]string))
 	hugeResource := api.BuildResourceList("20000m", "20G")
 	normalResource := api.BuildResourceList("2000m", "2G")
@@ -41,7 +43,7 @@ func TestOvercommitPlugin(t *testing.T) {
 	}{
 		{
 			TestCommonStruct: uthelper.TestCommonStruct{
-				Name:      "overCommitFactor is more than 0",
+				Name:      "overCommitFactor is more than 1",
 				Plugins:   map[string]framework.PluginBuilder{PluginName: New},
 				PodGroups: []*schedulingv1.PodGroup{pg1},
 				Queues:    []*schedulingv1.Queue{queue1},
@@ -54,7 +56,7 @@ func TestOvercommitPlugin(t *testing.T) {
 		},
 		{
 			TestCommonStruct: uthelper.TestCommonStruct{
-				Name:      "overCommitFactor is less than 0",
+				Name:      "overCommitFactor is less than 1",
 				Plugins:   map[string]framework.PluginBuilder{PluginName: New},
 				PodGroups: []*schedulingv1.PodGroup{pg1},
 				Queues:    []*schedulingv1.Queue{queue1},
@@ -91,6 +93,33 @@ func TestOvercommitPlugin(t *testing.T) {
 			},
 			expectedEnqueueAble: true,
 		},
+		{
+			TestCommonStruct: uthelper.TestCommonStruct{
+				Name:      "overCommitFactor is more than 1 with different overcommit factors",
+				Plugins:   map[string]framework.PluginBuilder{PluginName: New},
+				PodGroups: []*schedulingv1.PodGroup{pg1},
+				Queues:    []*schedulingv1.Queue{queue1},
+				Nodes:     []*v1.Node{n1, n2},
+			},
+			arguments: framework.Arguments{
+				"overcommit-factor.cpu":               1.3,
+				"overcommit-factor.memory":            1.4,
+				"overcommit-factor.ephemeral-storage": 1.4,
+				"overcommit-factor.nvidia.com/gpu":    1.3,
+			},
+			expectedEnqueueAble: true,
+		},
+		{
+			TestCommonStruct: uthelper.TestCommonStruct{
+				Name:      "overCommitFactor is not set",
+				Plugins:   map[string]framework.PluginBuilder{PluginName: New},
+				PodGroups: []*schedulingv1.PodGroup{pg3},
+				Queues:    []*schedulingv1.Queue{queue2},
+				Nodes:     []*v1.Node{n1, n2},
+			},
+			arguments:           framework.Arguments{},
+			expectedEnqueueAble: true,
+		},
 	}
 
 	for _, test := range tests {
@@ -118,5 +147,79 @@ func TestOvercommitPlugin(t *testing.T) {
 			}
 		})
 	}
+}
 
+func TestParseFactor(t *testing.T) {
+	tests := []struct {
+		name         string
+		arguments    framework.Arguments
+		expectedMaps map[string]float64
+	}{
+		{
+			name: "overCommitFactor with float64 type",
+			arguments: framework.Arguments{
+				"overcommit-factor.cpu":               1.3,
+				"overcommit-factor.memory":            1.4,
+				"overcommit-factor.ephemeral-storage": 1.4,
+				"overcommit-factor.nvidia.com/gpu":    1.3,
+			},
+			expectedMaps: map[string]float64{
+				// default value
+				"overcommit-factor": 1.2,
+				"cpu":               1.3,
+				"memory":            1.4,
+				"ephemeral-storage": 1.4,
+				"nvidia.com/gpu":    1.3,
+			},
+		},
+		{
+			name: "overCommitFactor with int type",
+			arguments: framework.Arguments{
+				"overcommit-factor.cpu":               2,
+				"overcommit-factor.memory":            2,
+				"overcommit-factor.ephemeral-storage": 2,
+				"overcommit-factor.nvidia.com/gpu":    2,
+			},
+			expectedMaps: map[string]float64{
+				// default value
+				"overcommit-factor": 1.2,
+				"cpu":               2.0,
+				"memory":            2.0,
+				"ephemeral-storage": 2.0,
+				"nvidia.com/gpu":    2.0,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			op := New(test.arguments).(*overcommitPlugin)
+			op.parseFactor(test.arguments, op.overCommitFactors.factorMaps)
+			// Sort expected and resulting maps by keys for comparison
+			expectedKeys := sortMapByKey(test.expectedMaps)
+			resultKeys := sortMapByKey(op.overCommitFactors.factorMaps)
+
+			// Check if the sorted keys match
+			if diff := cmp.Diff(expectedKeys, resultKeys); diff != "" {
+				t.Errorf("sorted keys mismatch: %s", diff)
+			}
+
+			// Check if the values match after sorting by keys
+			for _, key := range expectedKeys {
+				if test.expectedMaps[key] != op.overCommitFactors.factorMaps[key] {
+					t.Errorf("value mismatch for key %s: expected %f, got %f",
+						key, test.expectedMaps[key], op.overCommitFactors.factorMaps[key])
+				}
+			}
+		})
+	}
+}
+
+func sortMapByKey(m map[string]float64) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
- different resources should have different factors, so using the same overcommit-factor is not appropriate.

#### Which issue(s) this PR fixes: 
https://github.com/volcano-sh/volcano/issues/3635


#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?
User could give different overcommit factors (cpu-overcommit-factor, mem-overcommit-factor, other-overcommit-factor, overcommit-factor) through overcommit plugin arguments
