### PR TITLE
feat: add oidc's auth provider

### DIFF
--- a/cmd/controller-manager/main.go
+++ b/cmd/controller-manager/main.go
@@ -25,6 +25,7 @@ import (
 	"github.com/spf13/pflag"
 	_ "go.uber.org/automaxprocs"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	cliflag "k8s.io/component-base/cli/flag"
 	componentbaseoptions "k8s.io/component-base/config/options"
 	"k8s.io/klog/v2"

--- a/cmd/scheduler/main.go
+++ b/cmd/scheduler/main.go
@@ -24,6 +24,7 @@ import (
 	"github.com/spf13/pflag"
 	_ "go.uber.org/automaxprocs"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	cliflag "k8s.io/component-base/cli/flag"
 	componentbaseoptions "k8s.io/component-base/config/options"
 	"k8s.io/klog/v2"

--- a/cmd/webhook-manager/main.go
+++ b/cmd/webhook-manager/main.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/spf13/pflag"
 	_ "go.uber.org/automaxprocs"
+	_ "k8s.io/client-go/plugin/pkg/client/auth"
 
 	cliflag "k8s.io/component-base/cli/flag"
 	"k8s.io/klog/v2"


### PR DESCRIPTION
#3662 

What is the problem you're trying to solve
I will like to add support to scheduler such that also clusters that use oidc authentication will work.
webhook-manager belike:
![image](https://github.com/user-attachments/assets/a45fd6e8-1aea-426b-915f-6216ebb4aa70)
controller-manager belike:
![image](https://github.com/user-attachments/assets/7b61279e-0914-4f86-a531-5d2095b21fe2)
scheduler belike:
![image](https://github.com/user-attachments/assets/2ff2da76-60ea-4154-bbb3-782c90c1ffd4)

Describe the solution you'd like
add oidc's auth provider in the /cmd/scheduler/main.go  /cmd/webhook-manager/main.go  /cmd/controller-manager/main.go 

_ "k8s.io/client-go/plugin/pkg/client/auth"

Arfter adding, all the comment running expectedly.

controller-manager belike:
![image](https://github.com/user-attachments/assets/a51d55fa-ecfa-4bf4-9265-8f3b7185f316)

scheduler belike:
![image](https://github.com/user-attachments/assets/688ff76e-7158-48af-9dbc-e50753c449c8)
