### PR TITLE
fix always update pod nominatedNodeName when pod is pipelined

### DIFF
--- a/pkg/scheduler/actions/allocate/allocate.go
+++ b/pkg/scheduler/actions/allocate/allocate.go
@@ -278,7 +278,7 @@ func (alloc *Action) allocateResourcesForTasks(tasks *util.PriorityQueue, job *a
 			if task.InitResreq.LessEqual(bestNode.FutureIdle(), api.Zero) {
 				klog.V(3).Infof("Pipelining Task <%v/%v> to node <%v> for <%v> on <%v>",
 					task.Namespace, task.Name, bestNode.Name, task.InitResreq, bestNode.Releasing)
-				if err := stmt.Pipeline(task, bestNode.Name); err != nil {
+				if err := stmt.Pipeline(task, bestNode.Name, false); err != nil {
 					klog.Errorf("Failed to pipeline Task %v on %v in Session %v for %v.",
 						task.UID, bestNode.Name, ssn.UID, err)
 				} else {

--- a/pkg/scheduler/actions/backfill/backfill_test.go
+++ b/pkg/scheduler/actions/backfill/backfill_test.go
@@ -145,7 +145,7 @@ func TestPickUpPendingTasks(t *testing.T) {
 			stmt := framework.NewStatement(ssn)
 			task, found := ssn.Jobs[jobID].Tasks[api.PodKey(pod)]
 			if found {
-				stmt.Pipeline(task, "node1")
+				stmt.Pipeline(task, "node1", false)
 			}
 		}
 

--- a/pkg/scheduler/actions/preempt/preempt.go
+++ b/pkg/scheduler/actions/preempt/preempt.go
@@ -278,13 +278,18 @@ func preempt(
 			preempted.Add(preemptee.Resreq)
 		}
 
+		evictionOccurred := false
+		if !preempted.IsEmpty() {
+			evictionOccurred = true
+		}
+
 		metrics.RegisterPreemptionAttempts()
 		klog.V(3).Infof("Preempted <%v> for Task <%s/%s> requested <%v>.",
 			preempted, preemptor.Namespace, preemptor.Name, preemptor.InitResreq)
 
 		// If preemptor's queue is overused, it means preemptor can not be allocated. So no need care about the node idle resource
 		if ssn.Allocatable(currentQueue, preemptor) && preemptor.InitResreq.LessEqual(node.FutureIdle(), api.Zero) {
-			if err := stmt.Pipeline(preemptor, node.Name); err != nil {
+			if err := stmt.Pipeline(preemptor, node.Name, evictionOccurred); err != nil {
 				klog.Errorf("Failed to pipeline Task <%s/%s> on Node <%s>",
 					preemptor.Namespace, preemptor.Name, node.Name)
 			}

--- a/pkg/scheduler/api/job_info.go
+++ b/pkg/scheduler/api/job_info.go
@@ -69,8 +69,9 @@ type TaskID types.UID
 
 // TransactionContext holds all the fields that needed by scheduling transaction
 type TransactionContext struct {
-	NodeName string
-	Status   TaskStatus
+	NodeName         string
+	EvictionOccurred bool
+	Status           TaskStatus
 }
 
 // Clone returns a clone of TransactionContext
@@ -683,7 +684,10 @@ func (ji *JobInfo) TaskSchedulingReason(tid TaskID) (reason, msg, nominatedNodeN
 		return PodReasonSchedulable, msg, ""
 	case Pipelined:
 		msg = fmt.Sprintf("Pod %s/%s can possibly be assigned to %s, once resource is released", taskInfo.Namespace, taskInfo.Name, ctx.NodeName)
-		return PodReasonUnschedulable, msg, ctx.NodeName
+		if ctx.EvictionOccurred {
+			nominatedNodeName = ctx.NodeName
+		}
+		return PodReasonUnschedulable, msg, nominatedNodeName
 	case Pending:
 		if fe := ji.NodesFitErrors[tid]; fe != nil {
 			// Pod is unschedulable

--- a/pkg/scheduler/framework/statement.go
+++ b/pkg/scheduler/framework/statement.go
@@ -142,7 +142,7 @@ func (s *Statement) unevict(reclaimee *api.TaskInfo) error {
 }
 
 // Pipeline the task for the node
-func (s *Statement) Pipeline(task *api.TaskInfo, hostname string) error {
+func (s *Statement) Pipeline(task *api.TaskInfo, hostname string, evictionOccurred bool) error {
 	job, found := s.ssn.Jobs[task.Job]
 	if found {
 		if err := job.UpdateTaskStatus(task, api.Pipelined); err != nil {
@@ -155,6 +155,7 @@ func (s *Statement) Pipeline(task *api.TaskInfo, hostname string) error {
 	}
 
 	task.NodeName = hostname
+	task.EvictionOccurred = evictionOccurred
 
 	if node, found := s.ssn.Nodes[hostname]; found {
 		if err := node.AddTask(task); err != nil {


### PR DESCRIPTION
in the #3498 , we support updating NominatedNodeName for pipelined task
When a pod is in the pipelined status, Volcano always updates the pod's nominatedNodeName. However, according to the native Kubernetes semantics, nominatedNodeName should only be updated in the event of preemption.

For example, if there is a pod in the terminating state in the cluster and a new pending pod is created with no extra resources available, the kube-scheduler will mark the pending pod as unschedulable and will not update its nominatedNodeName field. This would immediately trigger autoscaler to scale up. However, Volcano would update the pod's nominatedNodeName field, and the autoscaler wont scaling up.
More detail description in this issue #3681 

This PR fixes the issue, making Volcano's behavior consistent with that of kube-scheduler.