### PR TITLE
remove deletedJobs queue in cache model

### DIFF
--- a/pkg/controllers/apis/request.go
+++ b/pkg/controllers/apis/request.go
@@ -30,10 +30,11 @@ type Request struct {
 	TaskName  string
 	QueueName string
 
-	Event      v1alpha1.Event
-	ExitCode   int32
-	Action     v1alpha1.Action
-	JobVersion int32
+	Event             v1alpha1.Event
+	ExitCode          int32
+	Action            v1alpha1.Action
+	JobVersion        int32
+	IsDeleteJobAction bool
 }
 
 // String function returns the request in string format.

--- a/pkg/controllers/cache/cache_test.go
+++ b/pkg/controllers/cache/cache_test.go
@@ -378,7 +378,7 @@ func TestJobCache_Delete(t *testing.T) {
 			}
 		}
 
-		err := jobCache.Delete(testcase.DeleteJob)
+		err := jobCache.Delete(JobKey(testcase.DeleteJob))
 		if err != nil && testcase.ExpectedErr != nil && err.Error() != testcase.ExpectedErr.Error() {
 			t.Errorf("Expected to get: %s, but got: %s in case %d", testcase.ExpectedErr, err, i)
 		}

--- a/pkg/controllers/cache/interface.go
+++ b/pkg/controllers/cache/interface.go
@@ -25,13 +25,11 @@ import (
 
 // Cache Interface.
 type Cache interface {
-	Run(stopCh <-chan struct{})
-
 	Get(key string) (*apis.JobInfo, error)
 	GetStatus(key string) (*v1alpha1.JobStatus, error)
 	Add(obj *v1alpha1.Job) error
 	Update(obj *v1alpha1.Job) error
-	Delete(obj *v1alpha1.Job) error
+	Delete(key string) error
 
 	AddPod(pod *v1.Pod) error
 	UpdatePod(pod *v1.Pod) error

--- a/pkg/controllers/job/job_controller.go
+++ b/pkg/controllers/job/job_controller.go
@@ -265,8 +265,6 @@ func (cc *jobcontroller) Run(stopCh <-chan struct{}) {
 		}(i)
 	}
 
-	go cc.cache.Run(stopCh)
-
 	// Re-sync error tasks.
 	go wait.Until(cc.processResyncTask, 0, stopCh)
 
@@ -326,6 +324,12 @@ func (cc *jobcontroller) processNextReq(count uint32) bool {
 	}
 
 	klog.V(3).Infof("Try to handle request <%v>", req)
+	if req.IsDeleteJobAction {
+		klog.V(3).Infof("process delete job action for %s", key)
+		cc.cache.Delete(key)
+		queue.Forget(req)
+		return true
+	}
 
 	jobInfo, err := cc.cache.Get(key)
 	if err != nil {

--- a/pkg/controllers/job/job_controller_handler.go
+++ b/pkg/controllers/job/job_controller_handler.go
@@ -127,11 +127,14 @@ func (cc *jobcontroller) deleteJob(obj interface{}) {
 			return
 		}
 	}
-
-	if err := cc.cache.Delete(job); err != nil {
-		klog.Errorf("Failed to delete job <%s/%s>: %v in cache",
-			job.Namespace, job.Name, err)
+	req := apis.Request{
+		Namespace:         job.Namespace,
+		JobName:           job.Name,
+		IsDeleteJobAction: true,
 	}
+	key := jobhelpers.GetJobKeyByReq(&req)
+	queue := cc.getWorkerQueue(key)
+	queue.Add(req)
 }
 
 func (cc *jobcontroller) addPod(obj interface{}) {


### PR DESCRIPTION
To troubleshoot this issue, my colleague and I worked until 3 AM. I sincerely hope that this fix will be merged into the community repository.

## Backgroud

In the controller component, the cache module has a separate deletedJobs queue specifically for handling job deletions. The job-controller also has a queue to process pod and job events. In edge cases, a situation may occur where a job is deleted from etcd but not from the cache. This leads to pods being created by the job-controller and immediately deleted by the gc-controller, causing a repetitive loop until the controller is restarted.