### PR TITLE
vcctl(jobtemplate): fix describe miss APIVersion and Kind bug, and remove ManagedFields

### DIFF
--- a/pkg/cli/jobflow/describe.go
+++ b/pkg/cli/jobflow/describe.go
@@ -71,9 +71,9 @@ func DescribeJobFlow(ctx context.Context) error {
 			// Remove managedFields
 			jobFlow.ManagedFields = nil
 			PrintJobFlowDetail(&jobFlow, describeJobFlowFlags.Format)
-			// Print a separator if it's not the last element
+			// Print space if it's not the last element
 			if len(jobFlows.Items) != 1 && i < len(jobFlows.Items)-1 {
-				fmt.Println("---------------------------------")
+				fmt.Printf("\n\n")
 			}
 		}
 		// Get jobflow detail

--- a/pkg/cli/jobtemplate/jobtemplate_test.go
+++ b/pkg/cli/jobtemplate/jobtemplate_test.go
@@ -284,14 +284,14 @@ func TestDescribeJobTemplate(t *testing.T) {
 			Name:        "test-jobtemplate",
 			Format:      "yaml",
 			ExpectedErr: nil,
-			ExpectedOutput: `metadata:
+			ExpectedOutput: `apiVersion: flow.volcano.sh/v1alpha1
+kind: JobTemplate
+metadata:
   creationTimestamp: null
   name: test-jobtemplate
   namespace: default
 spec: {}
-status: {}
-
----------------------------------`,
+status: {}`,
 		},
 		{
 			name: "Normal Case, use json format",
@@ -306,6 +306,8 @@ status: {}
 			Format:      "json",
 			ExpectedErr: nil,
 			ExpectedOutput: `{
+  "kind": "JobTemplate",
+  "apiVersion": "flow.volcano.sh/v1alpha1",
   "metadata": {
     "name": "test-jobtemplate",
     "namespace": "default",
@@ -313,8 +315,7 @@ status: {}
   },
   "spec": {},
   "status": {}
-}
----------------------------------`,
+}`,
 		},
 	}
 	for _, testCase := range testCases {


### PR DESCRIPTION
/kind bug
- fix `vcctl jobtemplate describe` miss APIVersion and Kind
- remove ManagedFields when using `vcctl jobtemplate describe`


part of issue: https://github.com/volcano-sh/volcano/issues/3495