### PR TITLE
fix:an unschedulable bestEffort Pod affects the scheduling of other pending bestEffort pods

### DIFF
--- a/pkg/scheduler/actions/backfill/backfill.go
+++ b/pkg/scheduler/actions/backfill/backfill.go
@@ -59,13 +59,13 @@ func (backfill *Action) Execute(ssn *framework.Session) {
 				fe.SetNodeError(ni.Name, err)
 			}
 			job.NodesFitErrors[task.UID] = fe
-			break
+			continue
 		}
 
 		predicateNodes, fitErrors := ph.PredicateNodes(task, ssn.NodeList, predicateFunc, true)
 		if len(predicateNodes) == 0 {
 			job.NodesFitErrors[task.UID] = fitErrors
-			break
+			continue
 		}
 
 		node := predicateNodes[0]


### PR DESCRIPTION
fix:an unschedulable bestEffort Pod affects the scheduling of other pending bestEffort pods

If there is a pending BestEffort Pod in the cluster that cannot be scheduled, for example, the node affinity cannot be satisfied. The processing loop will break and the subsequent Pending Pods in `pendingTasks` slice can never be processed.