### PR TITLE
support min-max elastic quota scheduling

### DIFF
--- a/pkg/scheduler/conf/constants.go
+++ b/pkg/scheduler/conf/constants.go
@@ -3,4 +3,6 @@ package conf
 const (
 	// EnablePredicateErrCacheKey is the key whether predicate error cache is enabled
 	EnablePredicateErrCacheKey = "predicateErrorCacheEnable"
+	// EnableGangCheckOverusedKey is the key whether check the job's min request when check queue overused
+	EnableGangCheckOverusedKey = "overusedCheckGangEnable"
 )

--- a/pkg/scheduler/framework/session.go
+++ b/pkg/scheduler/framework/session.go
@@ -92,7 +92,7 @@ type Session struct {
 	nodeReduceFns       map[string]api.NodeReduceFn
 	preemptableFns      map[string]api.EvictableFn
 	reclaimableFns      map[string]api.EvictableFn
-	overusedFns         map[string]api.ValidateFn
+	overusedFns         map[string]api.ValidateWithCandidateFn
 	// preemptiveFns means whether current queue can reclaim from other queue,
 	// while reclaimableFns means whether current queue's resources can be reclaimed.
 	preemptiveFns     map[string]api.ValidateWithCandidateFn
@@ -143,7 +143,7 @@ func openSession(cache cache.Cache) *Session {
 		nodeReduceFns:       map[string]api.NodeReduceFn{},
 		preemptableFns:      map[string]api.EvictableFn{},
 		reclaimableFns:      map[string]api.EvictableFn{},
-		overusedFns:         map[string]api.ValidateFn{},
+		overusedFns:         map[string]api.ValidateWithCandidateFn{},
 		preemptiveFns:       map[string]api.ValidateWithCandidateFn{},
 		allocatableFns:      map[string]api.AllocatableFn{},
 		jobReadyFns:         map[string]api.ValidateFn{},

--- a/pkg/scheduler/framework/session_plugins.go
+++ b/pkg/scheduler/framework/session_plugins.go
@@ -106,7 +106,7 @@ func (ssn *Session) AddNodeReduceFn(name string, pf api.NodeReduceFn) {
 }
 
 // AddOverusedFn add overused function
-func (ssn *Session) AddOverusedFn(name string, fn api.ValidateFn) {
+func (ssn *Session) AddOverusedFn(name string, fn api.ValidateWithCandidateFn) {
 	ssn.overusedFns[name] = fn
 }
 
@@ -255,7 +255,7 @@ func (ssn *Session) Preemptable(preemptor *api.TaskInfo, preemptees []*api.TaskI
 }
 
 // Overused invoke overused function of the plugins
-func (ssn *Session) Overused(queue *api.QueueInfo) bool {
+func (ssn *Session) Overused(queue *api.QueueInfo, req interface{}) bool {
 	for _, tier := range ssn.Tiers {
 		for _, plugin := range tier.Plugins {
 			if !isEnabled(plugin.EnabledOverused) {
@@ -265,7 +265,7 @@ func (ssn *Session) Overused(queue *api.QueueInfo) bool {
 			if !found {
 				continue
 			}
-			if of(queue) {
+			if of(queue, req) {
 				return true
 			}
 		}
@@ -275,7 +275,7 @@ func (ssn *Session) Overused(queue *api.QueueInfo) bool {
 }
 
 // Preemptive invoke can preemptive function of the plugins
-func (ssn *Session) Preemptive(queue *api.QueueInfo, candidate *api.TaskInfo) bool {
+func (ssn *Session) Preemptive(queue *api.QueueInfo, candidate interface{}) bool {
 	for _, tier := range ssn.Tiers {
 		for _, plugin := range tier.Plugins {
 			of, found := ssn.preemptiveFns[plugin.Name]

--- a/pkg/scheduler/plugins/extender/argument.go
+++ b/pkg/scheduler/plugins/extender/argument.go
@@ -58,7 +58,8 @@ type JobEnqueueableResponse struct {
 }
 
 type QueueOverusedRequest struct {
-	Queue *api.QueueInfo `json:"queue"`
+	Queue   *api.QueueInfo `json:"queue"`
+	Requsts *api.Resource  `json:"requsts"`
 }
 type QueueOverusedResponse struct {
 	Overused bool `json:"overused"`

--- a/pkg/scheduler/plugins/proportion/proportion.go
+++ b/pkg/scheduler/plugins/proportion/proportion.go
@@ -298,7 +298,7 @@ func (pp *proportionPlugin) OnSessionOpen(ssn *framework.Session) {
 		return victims, util.Permit
 	})
 
-	ssn.AddOverusedFn(pp.Name(), func(obj interface{}) bool {
+	ssn.AddOverusedFn(pp.Name(), func(obj interface{}, req interface{}) bool {
 		queue := obj.(*api.QueueInfo)
 		attr := pp.queueOpts[queue.UID]
 


### PR DESCRIPTION
Image this scene：queue has some guranteed quota called `Min`. Pods can be scheduled when queue's used quota  + requests <= Min.  And there is also a limit quota called `Max`, which means the upper quota a queue's tasks can used. While the quota between Min and Max can only be used by preemtable tasks in a queue, because those quota are borrowed from other queues' Min, and should be returned back when need. So preemtable pods can be scheduled when queue's used quota + requests <= Max.

This feature also called Elastic Quota or Capacity Scheduling.
referance:
[capacity-scheduling](https://github.com/kubernetes-sigs/scheduler-plugins/tree/master/kep/9-capacity-scheduling)
[Elastic Quota Management](https://koordinator.sh/docs/user-manuals/capacity-scheduling/)

This Pr will do those things base on capacity plugin: `Min` equals to `deserved` and `Max` equals to `capability`

1. Add a feature switch to enable or disable this feature, so that origin function will not be effected.
2. Add an overused function in capacity plugin, this function make sure queue's used will be under `Min` if job's tasks are not preemptable, or queue's used will be under `Max` if job's tasks are preemptable when schedule a job.
3. Change `Preemtive` function in capacity plugin to support check if queue's future used (a job's request + queue's allocated) is under `Min`. Only a job in a queue whose futrue used will not exceed its Min can preemt other victims.

relative issues: #3537
fixes #3703

The 1st commit is base on https://github.com/volcano-sh/volcano/pull/3649, please merge that PR first.