### PR TITLE
fix: vcctl unit test ci failed

### DIFF
--- a/pkg/cli/jobflow/jobflow_test.go
+++ b/pkg/cli/jobflow/jobflow_test.go
@@ -27,6 +27,7 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -49,7 +50,7 @@ func TestListJobFlow(t *testing.T) {
 						ObjectMeta: metav1.ObjectMeta{
 							Name:              "test-jobflow",
 							Namespace:         "default",
-							CreationTimestamp: metav1.Now(),
+							CreationTimestamp: metav1.Time{Time: time.Now().UTC().AddDate(0, 0, -3)},
 						},
 						Status: flowv1alpha1.JobFlowStatus{
 							State: flowv1alpha1.State{
@@ -62,7 +63,7 @@ func TestListJobFlow(t *testing.T) {
 			Namespace:   "default",
 			ExpectedErr: nil,
 			ExpectedOutput: `Name            Namespace    Phase      Age    
-test-jobflow    default      Succeed    0s`,
+test-jobflow    default      Succeed    3d`,
 		},
 	}
 	for _, testCase := range testCases {

--- a/pkg/cli/pod/pod_test.go
+++ b/pkg/cli/pod/pod_test.go
@@ -27,6 +27,7 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -58,7 +59,7 @@ func TestListPod(t *testing.T) {
 			JobName:     "",
 			ExpectedErr: nil,
 			ExpectedOutput: `Name          Ready      Status         Restart  Age       
-my-pod        0/1        Running        0        0s`,
+my-pod        0/1        Running        0        3d`,
 		},
 		{
 			name: "Normal Case with namespace filter",
@@ -72,7 +73,7 @@ my-pod        0/1        Running        0        0s`,
 			JobName:     "",
 			ExpectedErr: nil,
 			ExpectedOutput: `Name          Ready      Status         Restart  Age       
-my-pod        0/1        Running        0        0s`,
+my-pod        0/1        Running        0        3d`,
 		},
 		{
 			name: "Normal Case with jobName filter",
@@ -86,7 +87,7 @@ my-pod        0/1        Running        0        0s`,
 			JobName:     "my-job1",
 			ExpectedErr: nil,
 			ExpectedOutput: `Name          Ready      Status         Restart  Age       
-my-pod        0/1        Running        0        0s`,
+my-pod        0/1        Running        0        3d`,
 		},
 		{
 			name: "Normal Case with queueName filter",
@@ -104,9 +105,9 @@ my-pod        0/1        Running        0        0s`,
 			QueueName:   "my-queue1",
 			ExpectedErr: nil,
 			ExpectedOutput: `Name           Ready      Status         Restart  Age       
-my-pod1        0/1        Running        0        0s        
-my-pod2        0/1        Running        0        0s        
-my-pod3        0/1        Running        0        0s`,
+my-pod1        0/1        Running        0        3d        
+my-pod2        0/1        Running        0        3d        
+my-pod3        0/1        Running        0        3d`,
 		},
 		{
 			name: "Normal Case with queueName filter and jobName filter",
@@ -121,7 +122,7 @@ my-pod3        0/1        Running        0        0s`,
 			JobName:     "my-job1",
 			ExpectedErr: nil,
 			ExpectedOutput: `Name           Ready      Status         Restart  Age       
-my-pod1        0/1        Running        0        0s`,
+my-pod1        0/1        Running        0        3d`,
 		},
 		{
 			name: "Normal Case with queueName filter and jobName filter, and does not match",
@@ -202,7 +203,7 @@ func buildPod(namespace, name string, labels map[string]string, annotations map[
 			Namespace:         namespace,
 			Labels:            labels,
 			Annotations:       annotations,
-			CreationTimestamp: metav1.Now(),
+			CreationTimestamp: metav1.Time{Time: time.Now().UTC().AddDate(0, 0, -3)},
 		},
 		Spec: corev1.PodSpec{
 			Containers: []corev1.Container{


### PR DESCRIPTION
/kind bug
When using pipeline CI, there is a possibility that vcctl unit test failed will occur.
The reason is that `metav1.Now()` was originally used as the creation time. Now use `metav1.Time{Time: time.Now().Add(-3e11)}`

ci failed log: 
```bash
--- FAIL: TestListJobFlow (0.02s)
    --- FAIL: TestListJobFlow/Normal_Case (0.02s)
        jobflow_test.go:85: test case: Normal Case failed: got: Name            Namespace    Phase      Age    
            test-jobflow    default      Succeed    1s, want: Name            Namespace    Phase      Age    
            test-jobflow    default      Succeed    0s
FAIL
FAIL	volcano.sh/volcano/pkg/cli/jobflow	0.205s
ok  	volcano.sh/volcano/pkg/cli/jobtemplate	1.241s
--- FAIL: TestListPod (0.06s)
    --- FAIL: TestListPod/Normal_Case (0.04s)
        pod_test.go:161: test case: Normal Case failed: got: Name          Ready      Status         Restart  Age       
            my-pod        0/1        Running        0        1s, want: Name          Ready      Status         Restart  Age       
            my-pod        0/1        Running        0        0s
    --- FAIL: TestListPod/Normal_Case_with_namespace_filter (0.01s)
        pod_test.go:161: test case: Normal Case with namespace filter failed: got: Name          Ready      Status         Restart  Age       
            my-pod        0/1        Running        0        1s, want: Name          Ready      Status         Restart  Age       
            my-pod        0/1        Running        0        0s
    --- FAIL: TestListPod/Normal_Case_with_jobName_filter (0.01s)
        pod_test.go:161: test case: Normal Case with jobName filter failed: got: Name          Ready      Status         Restart  Age       
            my-pod        0/1        Running        0        1s, want: Name          Ready      Status         Restart  Age       
            my-pod        0/1        Running        0        0s
    --- FAIL: TestListPod/Normal_Case_with_queueName_filter (0.00s)
        pod_test.go:161: test case: Normal Case with queueName filter failed: got: Name           Ready      Status         Restart  Age       
            my-pod1        0/1        Running        0        1s        
            my-pod2        0/1        Running        0        1s        
            my-pod3        0/1        Running        0        1s, want: Name           Ready      Status         Restart  Age       
            my-pod1        0/1        Running        0        0s        
            my-pod2        0/1        Running        0        0s        
            my-pod3        0/1        Running        0        0s
    --- FAIL: TestListPod/Normal_Case_with_queueName_filter_and_jobName_filter (0.00s)
        pod_test.go:161: test case: Normal Case with queueName filter and jobName filter failed: got: Name           Ready      Status         Restart  Age       
            my-pod1        0/1        Running        0        1s, want: Name           Ready      Status         Restart  Age       
            my-pod1        0/1        Running        0        0s
FAIL
FAIL	volcano.sh/volcano/pkg/cli/pod	0.202s
```
https://github.com/volcano-sh/volcano/actions/runs/10693809659/job/29644570990?pr=3704
https://github.com/volcano-sh/volcano/actions/runs/10697377298/job/29654432187