### PR TITLE
fix: nil pointer when set node other resources

### DIFF
--- a/pkg/scheduler/api/node_info.go
+++ b/pkg/scheduler/api/node_info.go
@@ -345,6 +345,11 @@ func (ni *NodeInfo) SetNode(node *v1.Node) {
 
 // setNodeOthersResource initialize sharable devices
 func (ni *NodeInfo) setNodeOthersResource(node *v1.Node) {
+	if node == nil {
+		klog.Warningf("received argument of nil node, no need to set other resources for %s", ni.Name)
+		return
+	}
+
 	ni.Others[GPUSharingDevice] = gpushare.NewGPUDevices(ni.Name, node)
 	ni.Others[vgpu.DeviceName] = vgpu.NewGPUDevices(ni.Name, node)
 	IgnoredDevicesList.Set(


### PR DESCRIPTION
It is possible that `NewNodeInfo(node *v1.Node)` in node_info.go received a nil node argument. In this situation, volcano-scheduler will crash because of nil pointer dereference.
![b2cfdd32-1e80-4faa-bc2d-7cccf4c16d72](https://github.com/user-attachments/assets/d868424d-fca6-48d7-bc43-7af4fe57c2f3)

![crash](https://github.com/user-attachments/assets/aecf7abb-9ef7-423d-9beb-e0ec61c6e7e2)

