### PR TITLE
Fix staticcheck warnings on cmd and example

### DIFF
--- a/cmd/controller-manager/app/server.go
+++ b/cmd/controller-manager/app/server.go
@@ -81,7 +81,9 @@ func Run(opt *options.ServerOption) error {
 	// add a uniquifier so that two processes on the same host don't accidentally both become active
 	id := hostname + "_" + string(uuid.NewUUID())
 	// set ResourceNamespace value to LockObjectNamespace when it's not empty,compatible with old flag
+	//lint:ignore SA1019 LockObjectNamespace is deprecated and will be removed in a future release
 	if len(opt.LockObjectNamespace) > 0 {
+		//lint:ignore SA1019 LockObjectNamespace is deprecated and will be removed in a future release
 		opt.LeaderElection.ResourceNamespace = opt.LockObjectNamespace
 	}
 	rl, err := resourcelock.New(opt.LeaderElection.ResourceLock,

--- a/cmd/scheduler/app/server.go
+++ b/cmd/scheduler/app/server.go
@@ -114,7 +114,9 @@ func Run(opt *options.ServerOption) error {
 	// add a uniquifier so that two processes on the same host don't accidentally both become active
 	id := hostname + "_" + string(uuid.NewUUID())
 	// set ResourceNamespace value to LockObjectNamespace when it's not empty,compatible with old flag
+	//lint:ignore SA1019 LockObjectNamespace is deprecated and will be removed in a future release
 	if len(opt.LockObjectNamespace) > 0 {
+		//lint:ignore SA1019 LockObjectNamespace is deprecated and will be removed in a future release
 		opt.LeaderElection.ResourceNamespace = opt.LockObjectNamespace
 	}
 	rl, err := resourcelock.New(resourcelock.LeasesResourceLock,

--- a/cmd/webhook-manager/app/util.go
+++ b/cmd/webhook-manager/app/util.go
@@ -46,7 +46,7 @@ func addCaCertForWebhook(kubeClient *kubernetes.Clientset, service *router.Admis
 		var mutatingWebhookName = volcanoAdmissionPrefix + strings.ReplaceAll(service.Path, "/", "-")
 		var mutatingWebhook *v1.MutatingWebhookConfiguration
 		webhookChanged := false
-		if err := wait.Poll(time.Second, 5*time.Minute, func() (done bool, err error) {
+		if err := wait.PollUntilContextTimeout(context.Background(), time.Second, 5*time.Minute, true, func(_ context.Context) (done bool, err error) {
 			mutatingWebhook, err = kubeClient.AdmissionregistrationV1().MutatingWebhookConfigurations().Get(context.TODO(), mutatingWebhookName, metav1.GetOptions{})
 			if err != nil {
 				if apierrors.IsNotFound(err) {
@@ -79,7 +79,7 @@ func addCaCertForWebhook(kubeClient *kubernetes.Clientset, service *router.Admis
 		var validatingWebhookName = volcanoAdmissionPrefix + strings.ReplaceAll(service.Path, "/", "-")
 		var validatingWebhook *v1.ValidatingWebhookConfiguration
 		webhookChanged := false
-		if err := wait.Poll(time.Second, 5*time.Minute, func() (done bool, err error) {
+		if err := wait.PollUntilContextTimeout(context.Background(), time.Second, 5*time.Minute, true, func(_ context.Context) (done bool, err error) {
 			validatingWebhook, err = kubeClient.AdmissionregistrationV1().ValidatingWebhookConfigurations().Get(context.TODO(), validatingWebhookName, metav1.GetOptions{})
 			if err != nil {
 				if apierrors.IsNotFound(err) {

--- a/example/extender/extender.go
+++ b/example/extender/extender.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"net/http"
 
+	"k8s.io/klog/v2"
 	"volcano.sh/volcano/pkg/scheduler/api"
 	"volcano.sh/volcano/pkg/scheduler/plugins/extender"
 )
@@ -49,6 +50,7 @@ func onSessionOpen(w http.ResponseWriter, r *http.Request) {
 		NamespaceInfo:  req.NamespaceInfo,
 		RevocableNodes: req.RevocableNodes,
 	}
+	klog.V(4).Infof("the snapshot of cluster %+v", *snapshot)
 }
 
 func onSessionClose(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
fix staticcheck warnings on cmd and example, warnings like this
```text
cmd/controller-manager/app/server.go:84:9: opt.LockObjectNamespace is deprecated: use ResourceNamespace instead.  (SA1019)
cmd/controller-manager/app/server.go:85:42: opt.LockObjectNamespace is deprecated: use ResourceNamespace instead.  (SA1019)
cmd/scheduler/app/server.go:117:9: opt.LockObjectNamespace is deprecated: use ResourceNamespace instead.  (SA1019)
cmd/scheduler/app/server.go:118:42: opt.LockObjectNamespace is deprecated: use ResourceNamespace instead.  (SA1019)
cmd/webhook-manager/app/util.go:49:13: wait.Poll is deprecated: This method does not return errors from context, use PollUntilContextTimeout. Note that the new method will no longer return ErrWaitTimeout and instead return errors defined by the context package. Will be removed in a future release.  (SA1019)
cmd/webhook-manager/app/util.go:82:13: wait.Poll is deprecated: This method does not return errors from context, use PollUntilContextTimeout. Note that the new method will no longer return ErrWaitTimeout and instead return errors defined by the context package. Will be removed in a future release.  (SA1019)
example/extender/extender.go:28:5: var snapshot is unused (U1000)
```

#### Which issue(s) this PR fixes:
Parts of https://github.com/volcano-sh/volcano/issues/3713