### PR TITLE
Fix staticcheck warnings on pkg/controller and pkg/scheduler

### DIFF
--- a/pkg/controllers/garbagecollector/garbagecollector.go
+++ b/pkg/controllers/garbagecollector/garbagecollector.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"time"
 
-	"k8s.io/apimachinery/pkg/api/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -196,7 +195,7 @@ func (gc *gccontroller) processJob(key string) error {
 	klog.V(4).Infof("Checking if Job %s/%s is ready for cleanup", namespace, name)
 	// Ignore the Jobs that are already deleted or being deleted, or the ones that don't need clean up.
 	job, err := gc.jobLister.Jobs(namespace).Get(name)
-	if errors.IsNotFound(err) {
+	if apierrors.IsNotFound(err) {
 		return nil
 	}
 	if err != nil {
@@ -214,7 +213,7 @@ func (gc *gccontroller) processJob(key string) error {
 	// If TTL is modified before we do this check, we cannot be sure if the TTL truly expires.
 	// The latest Job may have a different UID, but it's fine because the checks will be run again.
 	fresh, err := gc.vcClient.BatchV1alpha1().Jobs(namespace).Get(context.TODO(), name, metav1.GetOptions{})
-	if errors.IsNotFound(err) {
+	if apierrors.IsNotFound(err) {
 		return nil
 	}
 	if err != nil {

--- a/pkg/controllers/job/job_controller_actions.go
+++ b/pkg/controllers/job/job_controller_actions.go
@@ -26,7 +26,6 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
-	"k8s.io/apimachinery/pkg/api/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog/v2"
@@ -137,7 +136,7 @@ func (cc *jobcontroller) killJob(jobInfo *apis.JobInfo, podRetainPhase state.Pha
 
 	// Update Job status
 	newJob, err := cc.vcClient.BatchV1alpha1().Jobs(job.Namespace).UpdateStatus(context.TODO(), job, metav1.UpdateOptions{})
-	if errors.IsNotFound(err) {
+	if apierrors.IsNotFound(err) {
 		klog.Errorf("Job %v/%v was not found", job.Namespace, job.Name)
 		return nil
 	}

--- a/pkg/controllers/job/job_controller_util_test.go
+++ b/pkg/controllers/job/job_controller_util_test.go
@@ -25,7 +25,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"volcano.sh/apis/pkg/apis/batch/v1alpha1"
-	batch "volcano.sh/apis/pkg/apis/batch/v1alpha1"
 	busv1alpha1 "volcano.sh/apis/pkg/apis/bus/v1alpha1"
 	"volcano.sh/volcano/pkg/controllers/apis"
 )
@@ -1027,10 +1026,10 @@ func TestTaskPriority_CalcPGMin(t *testing.T) {
 
 func TestCalcPGMinResources(t *testing.T) {
 	jc := newFakeController()
-	job := &batch.Job{
+	job := &v1alpha1.Job{
 		TypeMeta: metav1.TypeMeta{},
-		Spec: batch.JobSpec{
-			Tasks: []batch.TaskSpec{
+		Spec: v1alpha1.JobSpec{
+			Tasks: []v1alpha1.TaskSpec{
 				master, worker,
 			},
 		},

--- a/pkg/controllers/jobflow/jobflow_controller.go
+++ b/pkg/controllers/jobflow/jobflow_controller.go
@@ -39,7 +39,6 @@ import (
 	flowlister "volcano.sh/apis/pkg/client/listers/flow/v1alpha1"
 	"volcano.sh/volcano/pkg/controllers/apis"
 	"volcano.sh/volcano/pkg/controllers/framework"
-	"volcano.sh/volcano/pkg/controllers/jobflow/state"
 	jobflowstate "volcano.sh/volcano/pkg/controllers/jobflow/state"
 )
 
@@ -129,7 +128,7 @@ func (jf *jobflowcontroller) Initialize(opt *framework.ControllerOption) error {
 
 	jf.syncHandler = jf.handleJobFlow
 
-	state.SyncJobFlow = jf.syncJobFlow
+	jobflowstate.SyncJobFlow = jf.syncJobFlow
 	return nil
 }
 

--- a/pkg/scheduler/api/devices/nvidia/gpushare/share.go
+++ b/pkg/scheduler/api/devices/nvidia/gpushare/share.go
@@ -211,7 +211,7 @@ func (g *GPUDevice) getUsedGPUMemory() uint {
 
 // isIdleGPU check if the device is idled.
 func (g *GPUDevice) isIdleGPU() bool {
-	return g.PodMap == nil || len(g.PodMap) == 0
+	return len(g.PodMap) == 0
 }
 
 // getGPUMemoryPod returns the GPU memory required by the pod.

--- a/pkg/scheduler/api/unschedule_info_test.go
+++ b/pkg/scheduler/api/unschedule_info_test.go
@@ -16,7 +16,7 @@ limitations under the License.
 package api
 
 import (
-	"fmt"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -95,7 +95,7 @@ func TestFitErrors(t *testing.T) {
 		{
 			node:   "node1",
 			fitStr: "fit failed",
-			err:    fmt.Errorf(NodePodNumberExceeded),
+			err:    errors.New(NodePodNumberExceeded),
 			want:   "fit failed: 1 node(s) pod number exceeded.",
 			// no node has UnschedulableAndUnresolvable
 			filterNodes: map[string]sets.Empty{},
@@ -103,7 +103,7 @@ func TestFitErrors(t *testing.T) {
 		{
 			node:   "node1",
 			fitStr: "NodeResourceFitFailed",
-			err:    fmt.Errorf(NodePodNumberExceeded),
+			err:    errors.New(NodePodNumberExceeded),
 			fiterr: &FitError{
 				taskNamespace: "ns1", taskName: "task1", NodeName: "node2",
 				Status: []*Status{{Reason: nodeAffinity, Code: UnschedulableAndUnresolvable}},

--- a/pkg/scheduler/cache/cache.go
+++ b/pkg/scheduler/cache/cache.go
@@ -18,6 +18,7 @@ package cache
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"strconv"
@@ -173,7 +174,7 @@ type imageState struct {
 	// Size of the image
 	size int64
 	// A set of node names for nodes having this image present
-	nodes sets.String
+	nodes sets.Set[string]
 }
 
 // DefaultBinder with kube client and event recorder
@@ -370,11 +371,11 @@ func (dvb *defaultVolumeBinder) GetPodVolumes(task *schedulingapi.TaskInfo,
 	if err != nil {
 		return nil, err
 	} else if len(reasons) > 0 {
-		var errors []string
+		var errorslice []string
 		for _, reason := range reasons {
-			errors = append(errors, string(reason))
+			errorslice = append(errorslice, string(reason))
 		}
-		return nil, fmt.Errorf(strings.Join(errors, ","))
+		return nil, errors.New(strings.Join(errorslice, ","))
 	}
 
 	return podVolumes, err

--- a/pkg/scheduler/cache/event_handlers.go
+++ b/pkg/scheduler/cache/event_handlers.go
@@ -458,7 +458,7 @@ func (sc *SchedulerCache) addNodeImageStates(node *v1.Node, nodeInfo *scheduling
 			if !ok {
 				state = &imageState{
 					size:  image.SizeBytes,
-					nodes: sets.NewString(node.Name),
+					nodes: sets.New(node.Name),
 				}
 				sc.imageStates[name] = state
 			} else {

--- a/pkg/scheduler/metrics/source/metrics_client.go
+++ b/pkg/scheduler/metrics/source/metrics_client.go
@@ -52,8 +52,8 @@ func NewMetricsClient(restConfig *rest.Config, metricsConf map[string]string) (M
 	} else if metricsType == Metrics_Type_Prometheus_Adaptor {
 		return NewCustomMetricsClient(restConfig)
 	} else {
-		return nil, fmt.Errorf("Data cannot be collected from the %s monitoring system. "+
-			"The supported monitoring systems are %s, %s, and %s.",
+		return nil, fmt.Errorf("data cannot be collected from the %s monitoring system. "+
+			"The supported monitoring systems are %s, %s, and %s",
 			metricsType, Metrics_Type_Elasticsearch, Metrics_Tpye_Prometheus, Metrics_Type_Prometheus_Adaptor)
 	}
 }

--- a/pkg/scheduler/plugins/drf/hdrf_test.go
+++ b/pkg/scheduler/plugins/drf/hdrf_test.go
@@ -37,20 +37,6 @@ func mergePods(pods ...[]*v1.Pod) []*v1.Pod {
 	return ret
 }
 
-type queueSpec struct {
-	name      string
-	hierarchy string
-	weights   string
-}
-
-type pgSpec struct {
-	taskNum int
-	cpu     string
-	mem     string
-	pg      string
-	queue   string
-}
-
 func TestHDRF(t *testing.T) {
 	options.Default()
 

--- a/pkg/scheduler/plugins/predicates/predicates.go
+++ b/pkg/scheduler/plugins/predicates/predicates.go
@@ -346,7 +346,7 @@ func (pp *predicatesPlugin) OnSessionOpen(ssn *framework.Session) {
 			// require to run the Pod. So there will be no overbooking. However, to
 			// avoid the inconsistency in resource calculation between the scheduler
 			// and the older (before v1.28) kubelet, make the Pod unschedulable.
-			return fmt.Errorf("Pod has a restartable init container and the SidecarContainers feature is disabled")
+			return fmt.Errorf("pod has a restartable init container and the SidecarContainers feature is disabled")
 		}
 
 		// InterPodAffinity Predicate

--- a/pkg/scheduler/plugins/util/k8s/snapshot_test.go
+++ b/pkg/scheduler/plugins/util/k8s/snapshot_test.go
@@ -125,7 +125,7 @@ func TestSnapshot(t *testing.T) {
 				t.Fatalf("unexpected list PodsWithRequiredAntiAffinity nodeInfos value (+got: %s/-want: %s), err: %s", nodeInfoList, tc.expectedNodeInfos, err)
 			}
 
-			sel, err := labels.Parse("test==test")
+			sel, _ := labels.Parse("test==test")
 			pods, err := snapshot.Pods().List(sel)
 			if !reflect.DeepEqual(tc.expectedPods, pods) || err != nil {
 				t.Fatalf("unexpected list pods value (+got: %s/-want: %s), err: %s", pods, tc.expectedNodeInfos, err)

--- a/pkg/scheduler/uthelper/helper.go
+++ b/pkg/scheduler/uthelper/helper.go
@@ -176,7 +176,7 @@ func (test *TestCommonStruct) CheckBind(caseIndex int) error {
 		select {
 		case <-binder.Channel:
 		case <-time.After(300 * time.Millisecond):
-			return fmt.Errorf("Failed to get Bind request in case %d(%s).", caseIndex, test.Name)
+			return fmt.Errorf("failed to get Bind request in case %d(%s)", caseIndex, test.Name)
 		}
 	}
 
@@ -210,7 +210,7 @@ func (test *TestCommonStruct) CheckEvict(caseIndex int) error {
 		select {
 		case <-evictor.Channel:
 		case <-time.After(300 * time.Millisecond):
-			return fmt.Errorf("Failed to get Evict request in case %d(%s).", caseIndex, test.Name)
+			return fmt.Errorf("failed to get Evict request in case %d(%s)", caseIndex, test.Name)
 		}
 	}
 

--- a/pkg/webhooks/admission/jobs/validate/admit_job.go
+++ b/pkg/webhooks/admission/jobs/validate/admit_job.go
@@ -36,7 +36,6 @@ import (
 
 	"volcano.sh/apis/pkg/apis/batch/v1alpha1"
 	schedulingv1beta1 "volcano.sh/apis/pkg/apis/scheduling/v1beta1"
-	"volcano.sh/volcano/pkg/controllers/job/helpers"
 	jobhelpers "volcano.sh/volcano/pkg/controllers/job/helpers"
 	"volcano.sh/volcano/pkg/controllers/job/plugins"
 	controllerMpi "volcano.sh/volcano/pkg/controllers/job/plugins/distributed-framework/mpi"
@@ -144,8 +143,8 @@ func validateJobCreate(job *v1alpha1.Job, reviewResponse *admissionv1.AdmissionR
 
 	if _, ok := job.Spec.Plugins[controllerMpi.MPIPluginName]; ok {
 		mp := controllerMpi.NewInstance(job.Spec.Plugins[controllerMpi.MPIPluginName])
-		masterIndex := helpers.GetTaskIndexUnderJob(mp.GetMasterName(), job)
-		workerIndex := helpers.GetTaskIndexUnderJob(mp.GetWorkerName(), job)
+		masterIndex := jobhelpers.GetTaskIndexUnderJob(mp.GetMasterName(), job)
+		workerIndex := jobhelpers.GetTaskIndexUnderJob(mp.GetWorkerName(), job)
 		if masterIndex == -1 {
 			reviewResponse.Allowed = false
 			return "The specified mpi master task was not found"


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
fix staticcheck warnings on pkg/controllers and pkg/scheduler, warnings like this
```text
pkg/controllers/garbagecollector/garbagecollector.go:24:2: package "k8s.io/apimachinery/pkg/api/errors" is being imported more than once (ST1019)
	pkg/controllers/garbagecollector/garbagecollector.go:25:2: other import of "k8s.io/apimachinery/pkg/api/errors"
pkg/controllers/job/job_controller_actions.go:29:2: package "k8s.io/apimachinery/pkg/api/errors" is being imported more than once (ST1019)
	pkg/controllers/job/job_controller_actions.go:30:2: other import of "k8s.io/apimachinery/pkg/api/errors"
pkg/controllers/job/job_controller_util_test.go:27:2: package "volcano.sh/apis/pkg/apis/batch/v1alpha1" is being imported more than once (ST1019)
	pkg/controllers/job/job_controller_util_test.go:28:2: other import of "volcano.sh/apis/pkg/apis/batch/v1alpha1"
pkg/controllers/jobflow/jobflow_controller.go:42:2: package "volcano.sh/volcano/pkg/controllers/jobflow/state" is being imported more than once (ST1019)
	pkg/controllers/jobflow/jobflow_controller.go:43:2: other import of "volcano.sh/volcano/pkg/controllers/jobflow/state"

pkg/scheduler/api/devices/nvidia/gpushare/share.go:214:9: should omit nil check; len() for map[string]*k8s.io/api/core/v1.Pod is defined as zero (S1009)
pkg/scheduler/api/unschedule_info_test.go:98:12: printf-style function with dynamic format string and no further arguments should use print-style function instead (SA1006)
pkg/scheduler/api/unschedule_info_test.go:106:12: printf-style function with dynamic format string and no further arguments should use print-style function instead (SA1006)
pkg/scheduler/cache/cache.go:176:8: sets.String is deprecated: use generic Set instead. new ways: s1 := Set[string]{} s2 := New[string]()  (SA1019)
pkg/scheduler/cache/cache.go:377:15: printf-style function with dynamic format string and no further arguments should use print-style function instead (SA1006)
pkg/scheduler/metrics/source/metrics_client.go:55:15: error strings should not be capitalized (ST1005)
pkg/scheduler/metrics/source/metrics_client.go:55:15: error strings should not end with punctuation or newlines (ST1005)
pkg/scheduler/plugins/drf/hdrf_test.go:40:6: type queueSpec is unused (U1000)
pkg/scheduler/plugins/drf/hdrf_test.go:46:6: type pgSpec is unused (U1000)
pkg/scheduler/plugins/predicates/predicates.go:349:11: error strings should not be capitalized (ST1005)
pkg/scheduler/plugins/proportion/proportion_test.go:216:5: should use a simple channel send/receive instead of select with a single case (S1000)
pkg/scheduler/plugins/proportion/proportion_test.go:277:3: should use for range instead of for { select {} } (S1000)
pkg/scheduler/plugins/util/k8s/snapshot_test.go:128:4: this value of err is never used (SA4006)
pkg/scheduler/uthelper/helper.go:172:11: error strings should not be capitalized (ST1005)
pkg/scheduler/uthelper/helper.go:172:11: error strings should not end with punctuation or newlines (ST1005)
pkg/scheduler/uthelper/helper.go:206:11: error strings should not be capitalized (ST1005)
pkg/scheduler/uthelper/helper.go:206:11: error strings should not end with punctuation or newlines (ST1005)
pkg/webhooks/admission/jobs/validate/admit_job.go:39:2: package "volcano.sh/volcano/pkg/controllers/job/helpers" is being imported more than once (ST1019)
	pkg/webhooks/admission/jobs/validate/admit_job.go:40:2: other import of "volcano.sh/volcano/pkg/controllers/job/helpers"
```



#### Which issue(s) this PR fixes:
Parts of https://github.com/volcano-sh/volcano/issues/3713