### PR TITLE
[cherry-pick for release-1.9] fix: not remove podgroup uid will cause topology annotation to be useless 

### DIFF
--- a/.github/workflows/e2e_spark.yaml
+++ b/.github/workflows/e2e_spark.yaml
@@ -87,7 +87,7 @@ jobs:
         kubectl describe node
     - name: Upload Spark on K8S integration tests log files
       if: failure()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: spark-on-kubernetes-it-log
         path: |

--- a/pkg/scheduler/plugins/task-topology/topology.go
+++ b/pkg/scheduler/plugins/task-topology/topology.go
@@ -247,15 +247,9 @@ func affinityCheck(job *api.JobInfo, affinity [][]string) error {
 
 	var taskNumber = len(job.Tasks)
 	var taskRef = make(map[string]bool, taskNumber)
-	var jobNamePrefix = job.Name + "-"
 	for _, task := range job.Tasks {
-		// the full task name looks like "${job name}-${task name}-${index}",
-		// so we can trim the jobNamePrefix and the indexSuffix to get the short task name.
-		tmpTaskName := task.Name[:strings.LastIndex(task.Name, "-")]
-		tmpTaskName = strings.TrimPrefix(tmpTaskName, jobNamePrefix)
-
-		if _, exist := taskRef[tmpTaskName]; !exist {
-			taskRef[tmpTaskName] = true
+		if _, exist := taskRef[task.TaskRole]; !exist {
+			taskRef[task.TaskRole] = true
 		}
 	}
 

--- a/pkg/scheduler/plugins/task-topology/topology_test.go
+++ b/pkg/scheduler/plugins/task-topology/topology_test.go
@@ -41,22 +41,28 @@ func Test_readTopologyFromPgAnnotations(t *testing.T) {
 				Namespace: "default",
 				Tasks: map[api.TaskID]*api.TaskInfo{
 					"0": {
-						Name: "job1-ps-0",
+						Name:     "job1-ps-0",
+						TaskRole: "ps",
 					},
 					"1": {
-						Name: "job1-ps-1",
+						Name:     "job1-ps-1",
+						TaskRole: "ps",
 					},
 					"2": {
-						Name: "job1-worker-0",
+						Name:     "job1-worker-0",
+						TaskRole: "worker",
 					},
 					"3": {
-						Name: "job1-worker-1",
+						Name:     "job1-worker-1",
+						TaskRole: "worker",
 					},
 					"4": {
-						Name: "job1-chief-0",
+						Name:     "job1-chief-0",
+						TaskRole: "chief",
 					},
 					"5": {
-						Name: "job1-evaluator-0",
+						Name:     "job1-evaluator-0",
+						TaskRole: "evaluator",
 					},
 				},
 				PodGroup: &api.PodGroup{
@@ -107,22 +113,28 @@ func Test_readTopologyFromPgAnnotations(t *testing.T) {
 				Namespace: "default",
 				Tasks: map[api.TaskID]*api.TaskInfo{
 					"0": {
-						Name: "job1-ps-some-0",
+						Name:     "job1-ps-some-0",
+						TaskRole: "ps-some",
 					},
 					"1": {
-						Name: "job1-ps-some-1",
+						Name:     "job1-ps-some-1",
+						TaskRole: "ps-some",
 					},
 					"2": {
-						Name: "job1-worker-another-some-0",
+						Name:     "job1-worker-another-some-0",
+						TaskRole: "worker-another-some",
 					},
 					"3": {
-						Name: "job1-worker-another-some-1",
+						Name:     "job1-worker-another-some-1",
+						TaskRole: "worker-another-some",
 					},
 					"4": {
-						Name: "job1-chief-kk-0",
+						Name:     "job1-chief-kk-0",
+						TaskRole: "chief-kk",
 					},
 					"5": {
-						Name: "job1-evaluator-tt-0",
+						Name:     "job1-evaluator-tt-0",
+						TaskRole: "evaluator-tt",
 					},
 				},
 				PodGroup: &api.PodGroup{
@@ -187,22 +199,28 @@ func Test_readTopologyFromPgAnnotations(t *testing.T) {
 				Namespace: "default",
 				Tasks: map[api.TaskID]*api.TaskInfo{
 					"0": {
-						Name: "job1-ps-0",
+						Name:     "job1-ps-0",
+						TaskRole: "ps",
 					},
 					"1": {
-						Name: "job1-ps-1",
+						Name:     "job1-ps-1",
+						TaskRole: "ps",
 					},
 					"2": {
-						Name: "job1-worker-0",
+						Name:     "job1-worker-0",
+						TaskRole: "worker",
 					},
 					"3": {
-						Name: "job1-worker-1",
+						Name:     "job1-worker-1",
+						TaskRole: "worker",
 					},
 					"4": {
-						Name: "job1-chief-0",
+						Name:     "job1-chief-0",
+						TaskRole: "chief",
 					},
 					"5": {
-						Name: "job1-evaluator-0",
+						Name:     "job1-evaluator-0",
+						TaskRole: "evaluator",
 					},
 				},
 				PodGroup: &api.PodGroup{
@@ -227,16 +245,20 @@ func Test_readTopologyFromPgAnnotations(t *testing.T) {
 				Namespace: "default",
 				Tasks: map[api.TaskID]*api.TaskInfo{
 					"0": {
-						Name: "job1-ps-0",
+						Name:     "job1-ps-0",
+						TaskRole: "ps",
 					},
 					"1": {
-						Name: "job1-ps-1",
+						Name:     "job1-ps-1",
+						TaskRole: "ps",
 					},
 					"2": {
-						Name: "job1-worker-0",
+						Name:     "job1-worker-0",
+						TaskRole: "worker",
 					},
 					"3": {
-						Name: "job1-worker-1",
+						Name:     "job1-worker-1",
+						TaskRole: "worker",
 					},
 				},
 				PodGroup: &api.PodGroup{
@@ -261,16 +283,20 @@ func Test_readTopologyFromPgAnnotations(t *testing.T) {
 				Namespace: "default",
 				Tasks: map[api.TaskID]*api.TaskInfo{
 					"0": {
-						Name: "job1-ps-0",
+						Name:     "job1-ps-0",
+						TaskRole: "ps",
 					},
 					"1": {
-						Name: "job1-ps-1",
+						Name:     "job1-ps-1",
+						TaskRole: "ps",
 					},
 					"2": {
-						Name: "job1-worker-0",
+						Name:     "job1-worker-0",
+						TaskRole: "worker",
 					},
 					"3": {
-						Name: "job1-worker-1",
+						Name:     "job1-worker-1",
+						TaskRole: "worker",
 					},
 				},
 				PodGroup: &api.PodGroup{
@@ -295,22 +321,28 @@ func Test_readTopologyFromPgAnnotations(t *testing.T) {
 				Namespace: "default",
 				Tasks: map[api.TaskID]*api.TaskInfo{
 					"0": {
-						Name: "job1-ps-0",
+						Name:     "job1-ps-0",
+						TaskRole: "ps",
 					},
 					"1": {
-						Name: "job1-ps-1",
+						Name:     "job1-ps-1",
+						TaskRole: "ps",
 					},
 					"2": {
-						Name: "job1-worker-0",
+						Name:     "job1-worker-0",
+						TaskRole: "worker",
 					},
 					"3": {
-						Name: "job1-worker-1",
+						Name:     "job1-worker-1",
+						TaskRole: "worker",
 					},
 					"4": {
-						Name: "job1-chief-0",
+						Name:     "job1-chief-0",
+						TaskRole: "chief",
 					},
 					"5": {
-						Name: "job1-evaluator-0",
+						Name:     "job1-evaluator-0",
+						TaskRole: "evaluator",
 					},
 				},
 				PodGroup: &api.PodGroup{

--- a/test/e2e/schedulingaction/allocate.go
+++ b/test/e2e/schedulingaction/allocate.go
@@ -120,6 +120,7 @@ var _ = ginkgo.Describe("Job E2E Test", func() {
 	})
 
 	ginkgo.It("allocate don't work when podgroup is pending", func() {
+		ginkgo.Skip("TODO: need to fix this test. It's useless to directly associate podgroup with job. The job will still create its own podgroup, so the resources are sufficient and j2 can be running.")
 		ctx := e2eutil.InitTestContext(e2eutil.Options{
 			NodesNumLimit: 2,
 			NodesResourceLimit: corev1.ResourceList{


### PR DESCRIPTION
cherry-pick #3711