### PR TITLE
[cherry-pick for release-1.10] enquable and allocatable compare resource with the required dimensions and add testcaes

### DIFF
--- a/pkg/scheduler/api/resource_info.go
+++ b/pkg/scheduler/api/resource_info.go
@@ -456,6 +456,9 @@ func (r *Resource) LessEqualWithDimension(rr *Resource, req *Resource) bool {
 	}
 
 	for name, quant := range req.ScalarResources {
+		if IsIgnoredScalarResource(name) {
+			continue
+		}
 		rQuant := r.ScalarResources[name]
 		rrQuant := rr.ScalarResources[name]
 		if quant > 0 && rQuant > rrQuant {

--- a/pkg/scheduler/plugins/capacity/capacity.go
+++ b/pkg/scheduler/plugins/capacity/capacity.go
@@ -257,7 +257,8 @@ func (cp *capacityPlugin) OnSessionOpen(ssn *framework.Session) {
 		task := candidate.(*api.TaskInfo)
 		attr := cp.queueOpts[queue.UID]
 
-		overused := attr.deserved.LessEqualWithDimension(attr.allocated, task.InitResreq)
+		futureUsed := attr.allocated.Clone().Add(task.Resreq)
+		overused := !futureUsed.LessEqualWithDimension(attr.deserved, task.Resreq)
 		metrics.UpdateQueueOverused(attr.name, overused)
 		if overused {
 			klog.V(3).Infof("Queue <%v> can not reclaim, deserved <%v>, allocated <%v>, share <%v>",
@@ -272,8 +273,8 @@ func (cp *capacityPlugin) OnSessionOpen(ssn *framework.Session) {
 	ssn.AddAllocatableFn(cp.Name(), func(queue *api.QueueInfo, candidate *api.TaskInfo) bool {
 		attr := cp.queueOpts[queue.UID]
 
-		free, _ := attr.realCapability.Diff(attr.allocated, api.Zero)
-		allocatable := candidate.Resreq.LessEqual(free, api.Zero)
+		futureUsed := attr.allocated.Clone().Add(candidate.Resreq)
+		allocatable := futureUsed.LessEqualWithDimension(attr.realCapability, candidate.Resreq)
 		if !allocatable {
 			klog.V(3).Infof("Queue <%v>: realCapability <%v>, allocated <%v>; Candidate <%v>: resource request <%v>",
 				queue.Name, attr.realCapability, attr.allocated, candidate.Name, candidate.Resreq)
@@ -303,19 +304,12 @@ func (cp *capacityPlugin) OnSessionOpen(ssn *framework.Session) {
 		klog.V(5).Infof("job %s min resource <%s>, queue %s capability <%s> allocated <%s> inqueue <%s> elastic <%s>",
 			job.Name, minReq.String(), queue.Name, attr.realCapability.String(), attr.allocated.String(), attr.inqueue.String(), attr.elastic.String())
 		// The queue resource quota limit has not reached
-		r := minReq.Add(attr.allocated).Add(attr.inqueue).Sub(attr.elastic)
-		rr := attr.realCapability.Clone()
+		r := minReq.Clone().Add(attr.allocated).Add(attr.inqueue).Sub(attr.elastic)
 
-		for name := range rr.ScalarResources {
-			if _, ok := r.ScalarResources[name]; !ok {
-				delete(rr.ScalarResources, name)
-			}
-		}
-
-		inqueue := r.LessEqual(rr, api.Infinity)
+		inqueue := r.LessEqualWithDimension(attr.realCapability, minReq)
 		klog.V(5).Infof("job %s inqueue %v", job.Name, inqueue)
 		if inqueue {
-			attr.inqueue.Add(job.DeductSchGatedResources(job.GetMinResources()))
+			attr.inqueue.Add(job.DeductSchGatedResources(minReq))
 			return util.Permit
 		}
 		ssn.RecordPodGroupEvent(job.PodGroup, v1.EventTypeNormal, string(scheduling.PodGroupUnschedulableType), "queue resource quota insufficient")

--- a/pkg/scheduler/uthelper/helper.go
+++ b/pkg/scheduler/uthelper/helper.go
@@ -131,6 +131,13 @@ func (test *TestCommonStruct) Run(actions []framework.Action) {
 	if len(actions) == 0 {
 		panic("no actions provided, please specify a list of actions to execute")
 	}
+
+	// registry actions in conf variables
+	conf.EnabledActionMap = make(map[string]bool, len(actions))
+	for _, action := range actions {
+		conf.EnabledActionMap[action.Name()] = true
+	}
+
 	for _, action := range actions {
 		action.Initialize()
 		action.Execute(test.ssn)


### PR DESCRIPTION
cherry-pick for https://github.com/volcano-sh/volcano/pull/3696

There is a func `LessEqualWithDimension` to only compare the wanted dimension resource in request after PR #3522

This PR is to replcase those resource compare.

also fixes #3729
and fixes #3537