### PR TITLE
[cherry-pick for release-1.10]don't enable error cache if task role spec is empty

### DIFF
--- a/pkg/scheduler/actions/allocate/allocate_test.go
+++ b/pkg/scheduler/actions/allocate/allocate_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 
 	"github.com/agiledragon/gomonkey/v2"
+	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -51,6 +52,16 @@ import (
 func TestMain(m *testing.M) {
 	options.Default()
 	os.Exit(m.Run())
+}
+
+func TestParseArgs(t *testing.T) {
+	test := uthelper.TestCommonStruct{Name: "set cache false"}
+
+	action := New()
+	test.RegisterSession(nil, []conf.Configuration{{Name: action.Name(),
+		Arguments: map[string]interface{}{conf.EnablePredicateErrCacheKey: false}}})
+	test.Run([]framework.Action{action})
+	assert.False(t, action.enablePredicateErrorCache)
 }
 
 func TestAllocate(t *testing.T) {

--- a/pkg/scheduler/conf/constants.go
+++ b/pkg/scheduler/conf/constants.go
@@ -1,0 +1,6 @@
+package conf
+
+const (
+	// EnablePredicateErrCacheKey is the key whether predicate error cache is enabled
+	EnablePredicateErrCacheKey = "predicateErrorCacheEnable"
+)

--- a/pkg/scheduler/util/predicate_helper.go
+++ b/pkg/scheduler/util/predicate_helper.go
@@ -25,6 +25,13 @@ func (ph *predicateHelper) PredicateNodes(task *api.TaskInfo, nodes []*api.NodeI
 	var errorLock sync.RWMutex
 	fe := api.NewFitErrors()
 
+	// don't enable error cache if task's TaskRole is empty, because different pods with empty TaskRole will all
+	// have the same taskGroupID, and one pod predicate failed, all other pods will also be failed
+	// see issue: https://github.com/volcano-sh/volcano/issues/3527
+	if len(task.TaskRole) == 0 {
+		enableErrorCache = false
+	}
+
 	allNodes := len(nodes)
 	if allNodes == 0 {
 		return make([]*api.NodeInfo, 0), fe


### PR DESCRIPTION

cherry-pick for PR #3649 (don't enable error cache if task role spec is empty)