### PR TITLE
Support to get  the metric data  from a prometheus metric api with basic auth enabled 

### DIFF
--- a/pkg/scheduler/metrics/source/basicauth.go
+++ b/pkg/scheduler/metrics/source/basicauth.go
@@ -1,0 +1,23 @@
+package source
+
+import (
+	"net/http"
+	"encoding/base64"
+	"fmt"
+)
+
+type BasicAuthTransport struct {
+	Username string
+	Password string
+}
+
+func (bat BasicAuthTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	req.Header.Set("Authorization", fmt.Sprintf("Basic %s",
+		base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s",
+			bat.Username, bat.Password)))))
+	return http.DefaultTransport.RoundTrip(req)
+}
+
+func (bat *BasicAuthTransport) Client() *http.Client {
+	return &http.Client{Transport: bat}
+}


### PR DESCRIPTION
support to get the metrics data from prometheus metric api with basic auth enabled 


the configmap of volcano-scheduler can be  like this:
```
actions: "enqueue, allocate, backfill"
tiers:
- plugins:
  - name: priority
  - name: conformance
  - name: usage
    enablePredicate: false
    arguments:
      usage.weight: 50
      cpu.weight: 1
      memory.weight: 1
      thresholds:
        cpu: 80
        mem: 70
- plugins:
  - name: overcommit
  - name: drf
    enablePreemptable: false
  - name: predicates
  - name: proportion
  - name: nodeorder
  - name: binpack
  - name: gang
metrics:
  type: prometheus
  address: http://xxx:9090/
  basicauth: true
  username: yy
  password: zz
  interval: 30s
```