### PR TITLE
In webhook add match condition by scheduler name filter pod resources

### DIFF
--- a/installer/helm/chart/volcano/templates/webhooks.yaml
+++ b/installer/helm/chart/volcano/templates/webhooks.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.custom.admission_enable }}
-
+{{ $scheduler_name := .Values.custom.scheduler_name | default "volcano" }}
 {{- if .Values.custom.enabled_admissions | regexMatch "/pods/mutate" }}
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
@@ -18,7 +18,7 @@ webhooks:
         namespace: {{ .Release.Namespace }}
         path: /pods/mutate
         port: 443
-    failurePolicy: Fail
+    failurePolicy: Ignore
     matchPolicy: Equivalent
     name: mutatepod.volcano.sh
     namespaceSelector:
@@ -33,6 +33,9 @@ webhooks:
 {{- end }}
     objectSelector: {}
     reinvocationPolicy: Never
+    matchConditions:
+    - expression: object.spec.schedulerName == '{{- $scheduler_name }}'
+      name: scheduler-name-match
     rules:
       - apiGroups:
           - ""
@@ -262,7 +265,7 @@ webhooks:
         namespace: {{ .Release.Namespace }}
         path: /pods/validate
         port: 443
-    failurePolicy: Fail
+    failurePolicy: Ignore
     matchPolicy: Equivalent
     name: validatepod.volcano.sh
     namespaceSelector:
@@ -276,6 +279,9 @@ webhooks:
         {{- toYaml .Values.custom.webhooks_namespace_selector_expressions | nindent 8 }}
 {{- end }}
     objectSelector: {}
+    matchConditions:
+    - expression: object.spec.schedulerName == '{{- $scheduler_name }}'
+      name: scheduler-name-match
     rules:
       - apiGroups:
           - ""

--- a/installer/volcano-development.yaml
+++ b/installer/volcano-development.yaml
@@ -5032,7 +5032,7 @@ webhooks:
         namespace: volcano-system
         path: /pods/mutate
         port: 443
-    failurePolicy: Fail
+    failurePolicy: Ignore
     matchPolicy: Equivalent
     name: mutatepod.volcano.sh
     namespaceSelector:
@@ -5044,6 +5044,9 @@ webhooks:
             - kube-system
     objectSelector: {}
     reinvocationPolicy: Never
+    matchConditions:
+    - expression: object.spec.schedulerName == 'volcano'
+      name: scheduler-name-match
     rules:
       - apiGroups:
           - ""
@@ -5227,7 +5230,7 @@ webhooks:
         namespace: volcano-system
         path: /pods/validate
         port: 443
-    failurePolicy: Fail
+    failurePolicy: Ignore
     matchPolicy: Equivalent
     name: validatepod.volcano.sh
     namespaceSelector:
@@ -5238,6 +5241,9 @@ webhooks:
             - volcano-system
             - kube-system
     objectSelector: {}
+    matchConditions:
+    - expression: object.spec.schedulerName == 'volcano'
+      name: scheduler-name-match
     rules:
       - apiGroups:
           - ""


### PR DESCRIPTION
Add `matchConditions` in webhook when rules is pod resources create operation, to validate `object.spec.schedulerName` whether is default volcano scheduler name `volcano`, current we don't consider scheduler name change.

/kind feature

fixes: https://github.com/volcano-sh/volcano/issues/3734