### PR TITLE
feature: Add podgroups statistics

### DIFF
--- a/pkg/cli/podgroup/podgroup.go
+++ b/pkg/cli/podgroup/podgroup.go
@@ -1,0 +1,26 @@
+package podgroup
+
+import "volcano.sh/apis/pkg/apis/scheduling/v1beta1"
+
+type PodGroupStatistics struct {
+	Inqueue   int
+	Pending   int
+	Running   int
+	Unknown   int
+	Completed int
+}
+
+func (pgStats *PodGroupStatistics) StatPodGroupCountsForQueue(pg *v1beta1.PodGroup) {
+	switch pg.Status.Phase {
+	case v1beta1.PodGroupInqueue:
+		pgStats.Inqueue++
+	case v1beta1.PodGroupPending:
+		pgStats.Pending++
+	case v1beta1.PodGroupRunning:
+		pgStats.Running++
+	case v1beta1.PodGroupUnknown:
+		pgStats.Unknown++
+	case v1beta1.PodGroupCompleted:
+		pgStats.Completed++
+	}
+}

--- a/pkg/cli/queue/list.go
+++ b/pkg/cli/queue/list.go
@@ -28,6 +28,7 @@ import (
 
 	"volcano.sh/apis/pkg/apis/scheduling/v1beta1"
 	"volcano.sh/apis/pkg/client/clientset/versioned"
+	"volcano.sh/volcano/pkg/cli/podgroup"
 )
 
 type listFlags struct {
@@ -52,6 +53,9 @@ const (
 
 	// Inqueue status of queue
 	Inqueue string = "Inqueue"
+
+	// Completed status of the queue
+	Completed string = "Completed"
 
 	// State is state of queue
 	State string = "State"
@@ -81,22 +85,41 @@ func ListQueue(ctx context.Context) error {
 		fmt.Printf("No resources found\n")
 		return nil
 	}
-	PrintQueues(queues, os.Stdout)
+
+	// Although the featuregate called CustomResourceFieldSelectors is enabled by default after v1.31, there are still
+	// users using k8s versions lower than v1.31. Therefore we can only get all the podgroups from kube-apiserver
+	// and then filtering them.
+	pgList, err := jobClient.SchedulingV1beta1().PodGroups("").List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to list podgroups with err: %v", err)
+	}
+
+	queueStats := make(map[string]*podgroup.PodGroupStatistics, len(queues.Items))
+	for _, queue := range queues.Items {
+		queueStats[queue.Name] = &podgroup.PodGroupStatistics{}
+	}
+
+	for _, pg := range pgList.Items {
+		queueStats[pg.Spec.Queue].StatPodGroupCountsForQueue(&pg)
+	}
+
+	PrintQueues(queues, queueStats, os.Stdout)
 
 	return nil
 }
 
 // PrintQueues prints queue information.
-func PrintQueues(queues *v1beta1.QueueList, writer io.Writer) {
-	_, err := fmt.Fprintf(writer, "%-25s%-8s%-8s%-8s%-8s%-8s%-8s\n",
-		Name, Weight, State, Inqueue, Pending, Running, Unknown)
+func PrintQueues(queues *v1beta1.QueueList, queueStats map[string]*podgroup.PodGroupStatistics, writer io.Writer) {
+	_, err := fmt.Fprintf(writer, "%-25s%-8s%-8s%-8s%-8s%-8s%-8s%-8s\n",
+		Name, Weight, State, Inqueue, Pending, Running, Unknown, Completed)
 	if err != nil {
 		fmt.Printf("Failed to print queue command result: %s.\n", err)
 	}
+
 	for _, queue := range queues.Items {
-		_, err = fmt.Fprintf(writer, "%-25s%-8d%-8s%-8d%-8d%-8d%-8d\n",
-			queue.Name, queue.Spec.Weight, queue.Status.State, queue.Status.Inqueue,
-			queue.Status.Pending, queue.Status.Running, queue.Status.Unknown)
+		_, err = fmt.Fprintf(writer, "%-25s%-8d%-8s%-8d%-8d%-8d%-8d%-8d\n",
+			queue.Name, queue.Spec.Weight, queue.Status.State, queueStats[queue.Name].Inqueue, queueStats[queue.Name].Pending,
+			queueStats[queue.Name].Running, queueStats[queue.Name].Unknown, queueStats[queue.Name].Completed)
 		if err != nil {
 			fmt.Printf("Failed to print queue command result: %s.\n", err)
 		}

--- a/pkg/controllers/metrics/queue.go
+++ b/pkg/controllers/metrics/queue.go
@@ -1,0 +1,93 @@
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+
+	"volcano.sh/apis/pkg/apis/scheduling/v1beta1"
+	"volcano.sh/volcano/pkg/scheduler/metrics"
+)
+
+var (
+	queuePodGroupInqueue = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Subsystem: metrics.VolcanoNamespace,
+			Name:      "queue_pod_group_inqueue_count",
+			Help:      "The number of Inqueue PodGroup in this queue",
+		}, []string{"queue_name"},
+	)
+
+	queuePodGroupPending = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Subsystem: metrics.VolcanoNamespace,
+			Name:      "queue_pod_group_pending_count",
+			Help:      "The number of Pending PodGroup in this queue",
+		}, []string{"queue_name"},
+	)
+
+	queuePodGroupRunning = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Subsystem: metrics.VolcanoNamespace,
+			Name:      "queue_pod_group_running_count",
+			Help:      "The number of Running PodGroup in this queue",
+		}, []string{"queue_name"},
+	)
+
+	queuePodGroupUnknown = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Subsystem: metrics.VolcanoNamespace,
+			Name:      "queue_pod_group_unknown_count",
+			Help:      "The number of Unknown PodGroup in this queue",
+		}, []string{"queue_name"},
+	)
+
+	queuePodGroupCompleted = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Subsystem: metrics.VolcanoNamespace,
+			Name:      "queue_pod_group_completed_count",
+			Help:      "The number of Completed PodGroup in this queue",
+		}, []string{"queue_name"},
+	)
+)
+
+// UpdateQueuePodGroupInqueueCount records the number of Inqueue PodGroup in this queue
+func UpdateQueuePodGroupInqueueCount(queueName string, count int32) {
+	queuePodGroupInqueue.WithLabelValues(queueName).Set(float64(count))
+}
+
+// UpdateQueuePodGroupPendingCount records the number of Pending PodGroup in this queue
+func UpdateQueuePodGroupPendingCount(queueName string, count int32) {
+	queuePodGroupPending.WithLabelValues(queueName).Set(float64(count))
+}
+
+// UpdateQueuePodGroupRunningCount records the number of Running PodGroup in this queue
+func UpdateQueuePodGroupRunningCount(queueName string, count int32) {
+	queuePodGroupRunning.WithLabelValues(queueName).Set(float64(count))
+}
+
+// UpdateQueuePodGroupUnknownCount records the number of Unknown PodGroup in this queue
+func UpdateQueuePodGroupUnknownCount(queueName string, count int32) {
+	queuePodGroupUnknown.WithLabelValues(queueName).Set(float64(count))
+}
+
+// UpdateQueuePodGroupCompletedCount records the number of Completed PodGroup in this queue
+func UpdateQueuePodGroupCompletedCount(queueName string, count int32) {
+	queuePodGroupCompleted.WithLabelValues(queueName).Set(float64(count))
+}
+
+// DeleteQueueMetrics delete all metrics related to the queue
+func DeleteQueueMetrics(queueName string) {
+	queuePodGroupInqueue.DeleteLabelValues(queueName)
+	queuePodGroupPending.DeleteLabelValues(queueName)
+	queuePodGroupRunning.DeleteLabelValues(queueName)
+	queuePodGroupUnknown.DeleteLabelValues(queueName)
+	queuePodGroupCompleted.DeleteLabelValues(queueName)
+}
+
+func UpdateQueueMetrics(queueName string, queueStatus *v1beta1.QueueStatus) {
+	UpdateQueuePodGroupPendingCount(queueName, queueStatus.Pending)
+	UpdateQueuePodGroupRunningCount(queueName, queueStatus.Running)
+	UpdateQueuePodGroupUnknownCount(queueName, queueStatus.Unknown)
+	UpdateQueuePodGroupInqueueCount(queueName, queueStatus.Inqueue)
+	UpdateQueuePodGroupCompletedCount(queueName, queueStatus.Completed)
+}

--- a/pkg/controllers/queue/queue_controller_handler.go
+++ b/pkg/controllers/queue/queue_controller_handler.go
@@ -23,6 +23,7 @@ import (
 	busv1alpha1 "volcano.sh/apis/pkg/apis/bus/v1alpha1"
 	schedulingv1beta1 "volcano.sh/apis/pkg/apis/scheduling/v1beta1"
 	"volcano.sh/volcano/pkg/controllers/apis"
+	"volcano.sh/volcano/pkg/controllers/metrics"
 )
 
 func (c *queuecontroller) enqueue(req *apis.Request) {
@@ -57,6 +58,7 @@ func (c *queuecontroller) deleteQueue(obj interface{}) {
 		}
 	}
 
+	metrics.DeleteQueueMetrics(queue.Name)
 	c.pgMutex.Lock()
 	defer c.pgMutex.Unlock()
 	delete(c.podGroups, queue.Name)

--- a/pkg/controllers/queue/queue_controller_util.go
+++ b/pkg/controllers/queue/queue_controller_util.go
@@ -22,6 +22,10 @@ import (
 	schedulingv1beta1 "volcano.sh/apis/pkg/apis/scheduling/v1beta1"
 )
 
+const (
+	controllerName = "queue-controller"
+)
+
 type patchOperation struct {
 	Op    string      `json:"op"`
 	Path  string      `json:"path"`

--- a/pkg/scheduler/metrics/queue.go
+++ b/pkg/scheduler/metrics/queue.go
@@ -93,38 +93,6 @@ var (
 			Help:      "If one queue is overused",
 		}, []string{"queue_name"},
 	)
-
-	queuePodGroupInqueue = promauto.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Subsystem: VolcanoNamespace,
-			Name:      "queue_pod_group_inqueue_count",
-			Help:      "The number of Inqueue PodGroup in this queue",
-		}, []string{"queue_name"},
-	)
-
-	queuePodGroupPending = promauto.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Subsystem: VolcanoNamespace,
-			Name:      "queue_pod_group_pending_count",
-			Help:      "The number of Pending PodGroup in this queue",
-		}, []string{"queue_name"},
-	)
-
-	queuePodGroupRunning = promauto.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Subsystem: VolcanoNamespace,
-			Name:      "queue_pod_group_running_count",
-			Help:      "The number of Running PodGroup in this queue",
-		}, []string{"queue_name"},
-	)
-
-	queuePodGroupUnknown = promauto.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Subsystem: VolcanoNamespace,
-			Name:      "queue_pod_group_unknown_count",
-			Help:      "The number of Unknown PodGroup in this queue",
-		}, []string{"queue_name"},
-	)
 )
 
 // UpdateQueueAllocated records allocated resources for one queue
@@ -166,26 +134,6 @@ func UpdateQueueOverused(queueName string, overused bool) {
 	queueOverused.WithLabelValues(queueName).Set(value)
 }
 
-// UpdateQueuePodGroupInqueueCount records the number of Inqueue PodGroup in this queue
-func UpdateQueuePodGroupInqueueCount(queueName string, count int32) {
-	queuePodGroupInqueue.WithLabelValues(queueName).Set(float64(count))
-}
-
-// UpdateQueuePodGroupPendingCount records the number of Pending PodGroup in this queue
-func UpdateQueuePodGroupPendingCount(queueName string, count int32) {
-	queuePodGroupPending.WithLabelValues(queueName).Set(float64(count))
-}
-
-// UpdateQueuePodGroupRunningCount records the number of Running PodGroup in this queue
-func UpdateQueuePodGroupRunningCount(queueName string, count int32) {
-	queuePodGroupRunning.WithLabelValues(queueName).Set(float64(count))
-}
-
-// UpdateQueuePodGroupUnknownCount records the number of Unknown PodGroup in this queue
-func UpdateQueuePodGroupUnknownCount(queueName string, count int32) {
-	queuePodGroupUnknown.WithLabelValues(queueName).Set(float64(count))
-}
-
 // DeleteQueueMetrics delete all metrics related to the queue
 func DeleteQueueMetrics(queueName string) {
 	queueAllocatedMilliCPU.DeleteLabelValues(queueName)
@@ -197,8 +145,4 @@ func DeleteQueueMetrics(queueName string) {
 	queueShare.DeleteLabelValues(queueName)
 	queueWeight.DeleteLabelValues(queueName)
 	queueOverused.DeleteLabelValues(queueName)
-	queuePodGroupInqueue.DeleteLabelValues(queueName)
-	queuePodGroupPending.DeleteLabelValues(queueName)
-	queuePodGroupRunning.DeleteLabelValues(queueName)
-	queuePodGroupUnknown.DeleteLabelValues(queueName)
 }

--- a/pkg/scheduler/plugins/capacity/capacity.go
+++ b/pkg/scheduler/plugins/capacity/capacity.go
@@ -375,10 +375,6 @@ func (cp *capacityPlugin) buildQueueAttrs(ssn *framework.Session) {
 			metrics.UpdateQueueDeserved(attr.name, attr.deserved.MilliCPU, attr.deserved.Memory)
 			metrics.UpdateQueueAllocated(attr.name, attr.allocated.MilliCPU, attr.allocated.Memory)
 			metrics.UpdateQueueRequest(attr.name, attr.request.MilliCPU, attr.request.Memory)
-			metrics.UpdateQueuePodGroupInqueueCount(attr.name, queue.Queue.Status.Inqueue)
-			metrics.UpdateQueuePodGroupPendingCount(attr.name, queue.Queue.Status.Pending)
-			metrics.UpdateQueuePodGroupRunningCount(attr.name, queue.Queue.Status.Running)
-			metrics.UpdateQueuePodGroupUnknownCount(attr.name, queue.Queue.Status.Unknown)
 			continue
 		}
 		deservedCPU, deservedMem := 0.0, 0.0
@@ -389,10 +385,6 @@ func (cp *capacityPlugin) buildQueueAttrs(ssn *framework.Session) {
 		metrics.UpdateQueueDeserved(queueInfo.Name, deservedCPU, deservedMem)
 		metrics.UpdateQueueAllocated(queueInfo.Name, 0, 0)
 		metrics.UpdateQueueRequest(queueInfo.Name, 0, 0)
-		metrics.UpdateQueuePodGroupInqueueCount(queueInfo.Name, 0)
-		metrics.UpdateQueuePodGroupPendingCount(queueInfo.Name, 0)
-		metrics.UpdateQueuePodGroupRunningCount(queueInfo.Name, 0)
-		metrics.UpdateQueuePodGroupUnknownCount(queueInfo.Name, 0)
 	}
 
 	ssn.AddQueueOrderFn(cp.Name(), func(l, r interface{}) int {
@@ -509,15 +501,10 @@ func (cp *capacityPlugin) buildHierarchicalQueueAttrs(ssn *framework.Session) bo
 
 	// Record metrics
 	for queueID := range ssn.Queues {
-		queue := ssn.Queues[queueID]
 		attr := cp.queueOpts[queueID]
 		metrics.UpdateQueueDeserved(attr.name, attr.deserved.MilliCPU, attr.deserved.Memory)
 		metrics.UpdateQueueAllocated(attr.name, attr.allocated.MilliCPU, attr.allocated.Memory)
 		metrics.UpdateQueueRequest(attr.name, attr.request.MilliCPU, attr.request.Memory)
-		metrics.UpdateQueuePodGroupInqueueCount(attr.name, queue.Queue.Status.Inqueue)
-		metrics.UpdateQueuePodGroupPendingCount(attr.name, queue.Queue.Status.Pending)
-		metrics.UpdateQueuePodGroupRunningCount(attr.name, queue.Queue.Status.Running)
-		metrics.UpdateQueuePodGroupUnknownCount(attr.name, queue.Queue.Status.Unknown)
 	}
 
 	ssn.AddQueueOrderFn(cp.Name(), func(l, r interface{}) int {

--- a/pkg/scheduler/plugins/proportion/proportion.go
+++ b/pkg/scheduler/plugins/proportion/proportion.go
@@ -167,19 +167,10 @@ func (pp *proportionPlugin) OnSessionOpen(ssn *framework.Session) {
 			metrics.UpdateQueueAllocated(attr.name, attr.allocated.MilliCPU, attr.allocated.Memory)
 			metrics.UpdateQueueRequest(attr.name, attr.request.MilliCPU, attr.request.Memory)
 			metrics.UpdateQueueWeight(attr.name, attr.weight)
-			queue := ssn.Queues[attr.queueID]
-			metrics.UpdateQueuePodGroupInqueueCount(attr.name, queue.Queue.Status.Inqueue)
-			metrics.UpdateQueuePodGroupPendingCount(attr.name, queue.Queue.Status.Pending)
-			metrics.UpdateQueuePodGroupRunningCount(attr.name, queue.Queue.Status.Running)
-			metrics.UpdateQueuePodGroupUnknownCount(attr.name, queue.Queue.Status.Unknown)
 			continue
 		}
 		metrics.UpdateQueueAllocated(queueInfo.Name, 0, 0)
 		metrics.UpdateQueueRequest(queueInfo.Name, 0, 0)
-		metrics.UpdateQueuePodGroupInqueueCount(queueInfo.Name, 0)
-		metrics.UpdateQueuePodGroupPendingCount(queueInfo.Name, 0)
-		metrics.UpdateQueuePodGroupRunningCount(queueInfo.Name, 0)
-		metrics.UpdateQueuePodGroupUnknownCount(queueInfo.Name, 0)
 	}
 
 	remaining := pp.totalResource.Clone()

--- a/test/e2e/util/podgroup.go
+++ b/test/e2e/util/podgroup.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 
 	schedulingv1beta1 "volcano.sh/apis/pkg/apis/scheduling/v1beta1"
+	"volcano.sh/volcano/pkg/cli/podgroup"
 )
 
 // CreatePodGroup creates a PodGroup with the specified name in the namespace
@@ -89,4 +90,16 @@ func PodGroupIsReady(ctx *TestContext, namespace string) (bool, error) {
 	}
 
 	return false, fmt.Errorf("pod group phase is Pending")
+}
+
+func GetPodGroupStatistics(ctx *TestContext, namespace, queue string) *podgroup.PodGroupStatistics {
+	pgList, err := ctx.Vcclient.SchedulingV1beta1().PodGroups(namespace).List(context.TODO(), metav1.ListOptions{})
+	Expect(err).NotTo(HaveOccurred(), "List podgroups failed")
+	pgStats := &podgroup.PodGroupStatistics{}
+	for _, pg := range pgList.Items {
+		if pg.Spec.Queue == queue {
+			pgStats.StatPodGroupCountsForQueue(&pg)
+		}
+	}
+	return pgStats
 }


### PR DESCRIPTION
fix #3597, related proposal pr: https://github.com/volcano-sh/volcano/pull/3750

# Implementation
- In `syncQueue` of queue controller, concurrently using `UpdateStatus` will cause conflict, use `ApplyStatus` instead, and need to add patch permission of vc-controller for `patch/status`. And we record the statistics of podgroups in each state in queue as metrics to be exported outside, we don't update the statistics of podgroups in queue's status now. 
- `vcctl get -n [name]` and `vcctl list` display the statistics of podgroups in each state from queue's status directly, instead we do one more step, query the podgroups owend in the queue, stat the counts of podgroups in each state at the vcctl side, and then display them.

# Verification
- vcctl list
  -  When there are no podgroups in queue, list is normal:
  ![image](https://github.com/user-attachments/assets/d59b8cb0-7ac3-4fc9-bd1f-be13d2efda54)
  -  When there are podgroups in queue, list can also get the statistics of podgroups:
  ![image](https://github.com/user-attachments/assets/69c8d526-00ff-4c10-904a-06cccaca3fad)
- vcctl get
  -  get is normal:
    ![image](https://github.com/user-attachments/assets/cdfead09-a6ce-493a-a257-f147cd0ab099)
- metrics
![image](https://github.com/user-attachments/assets/e6496c4a-6990-4267-8595-aaad53e8f3ef)



