### PR TITLE
feature: add approve workflows action

### DIFF
--- a/.github/workflows/workflows-approve.yaml
+++ b/.github/workflows/workflows-approve.yaml
@@ -1,0 +1,44 @@
+name: Approve Workflows
+
+on:
+  pull_request_target:
+    types:
+      - labeled
+      - synchronize
+    branches:
+      - master
+      - release-**
+
+permissions:
+  contents: read
+
+jobs:
+  approve:
+    name: Approve workflows if contains ok-to-test label
+    if: contains(github.event.pull_request.labels.*.name, 'ok-to-test')
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - name: Execute workflows
+        uses: actions/github-script@v7
+        continue-on-error: true
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const result = await github.rest.actions.listWorkflowRunsForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              event: "pull_request",
+              status: "action_required",
+              head_sha: context.payload.pull_request.head.sha,
+              per_page: 100
+            });
+
+            for (var run of result.data.workflow_runs) {
+              await github.rest.actions.approveWorkflowRun({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                run_id: run.id
+              });
+            }


### PR DESCRIPTION
# BackGround
When contributors from outside contribute their first PR to volcano repo, the repo admin has to click the `approve and run` button to run the CI, even the approvers don't have the permissions to run the CIs when they are not repo admin. And the volcano-bot cannot automatically run CIs, because the bot uses `prow` as the testing framework. Currently `prow` uses k8s' own testing framework, and its integration with github workflow is not so good. So, inspired by this issue: https://github.com/kubernetes-sigs/prow/issues/194, and this config: https://github.com/kubernetes-sigs/cluster-api/blob/main/.github/workflows/pr-gh-workflow-approve.yaml, we can add a action, when there is `ok-to-test` label in this first PR(which is already reviewed by reviewers), this github workflow can be ran to call other workflows. Therefore, approvers can have the right to run CIs, not only the repo admin.

# Testing
## Test-1
Add `ok-to-test` label, `Approve Workflow` action can run:
![image](https://github.com/user-attachments/assets/e5970822-040c-41ad-8561-f44deb47c749)
And other workflows can run subsequently:
![image](https://github.com/user-attachments/assets/e5970822-040c-41ad-8561-f44deb47c749)
## Test-2
Tag other labels, other workflows can't run, and `Approve Workflows` action is skipped
![image](https://github.com/user-attachments/assets/95331ee4-c0a6-457b-b285-248fb2cf5dd9)
## Test-3
PR to non `release-**` and `master` branch, `ok-to-test` label is useless, only PR to `release-**` and `master` branch is useful.
![image](https://github.com/user-attachments/assets/1787efa5-3a1a-4954-b3f4-ffea45fc87d8)

