### PR TITLE
Use watch to listen expected event instead of wait.poll

### DIFF
--- a/test/e2e/jobseq/queue_job_status.go
+++ b/test/e2e/jobseq/queue_job_status.go
@@ -20,20 +20,30 @@ import (
 	"context"
 	"fmt"
 	"strconv"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/tools/cache"
+	watchtools "k8s.io/client-go/tools/watch"
 
+	"volcano.sh/apis/pkg/apis/scheduling/v1beta1"
 	e2eutil "volcano.sh/volcano/test/e2e/util"
 )
 
 var _ = Describe("Queue Job Status Transition", func() {
 
+	var ctx *e2eutil.TestContext
+	AfterEach(func() {
+		e2eutil.CleanupTestContext(ctx)
+	})
+
 	It("Transform from inqueque to running should succeed", func() {
 		By("Prepare 2 job")
-		var ctx *e2eutil.TestContext
 		var q1 string
 		var rep int32
 		q1 = "queue-jobs-status-transition"
@@ -80,12 +90,10 @@ var _ = Describe("Queue Job Status Transition", func() {
 			return queue.Status.Running > 0, nil
 		})
 		Expect(err).NotTo(HaveOccurred(), "Error waiting for queue running")
-		e2eutil.CleanupTestContext(ctx)
 	})
 
 	It("Transform from running to pending should succeed", func() {
 		By("Prepare 2 job")
-		var ctx *e2eutil.TestContext
 		var q1 string
 		var podNamespace string
 		var rep int32
@@ -147,12 +155,10 @@ var _ = Describe("Queue Job Status Transition", func() {
 			return queue.Status.Pending > 0, nil
 		})
 		Expect(err).NotTo(HaveOccurred(), "Error waiting for queue Pending")
-		e2eutil.CleanupTestContext(ctx)
 	})
 
 	It("Transform from running to unknown should succeed", func() {
 		By("Prepare 2 job")
-		var ctx *e2eutil.TestContext
 		var q1 string
 		var podNamespace string
 		var rep int32
@@ -214,12 +220,26 @@ var _ = Describe("Queue Job Status Transition", func() {
 		}
 
 		By("Verify queue have pod groups unknown")
-		err = e2eutil.WaitQueueStatus(func() (bool, error) {
-			queue, err := ctx.Vcclient.SchedulingV1beta1().Queues().Get(context.TODO(), q1, metav1.GetOptions{})
-			Expect(err).NotTo(HaveOccurred(), "Get queue %s failed", q1)
-			return queue.Status.Unknown > 0, nil
+		fieldSelector := fields.OneTermEqualSelector("metadata.name", q1).String()
+		w := &cache.ListWatch{
+			WatchFunc: func(options metav1.ListOptions) (i watch.Interface, e error) {
+				options.FieldSelector = fieldSelector
+				return ctx.Vcclient.SchedulingV1beta1().Queues().Watch(context.TODO(), options)
+			},
+		}
+		wctx, cancel := watchtools.ContextWithOptionalTimeout(context.Background(), 5*time.Minute)
+		defer cancel()
+
+		_, err = watchtools.Until(wctx, clusterPods.ResourceVersion, w, func(event watch.Event) (bool, error) {
+			switch t := event.Object.(type) {
+			case *v1beta1.Queue:
+				if t.Status.Unknown > 0 {
+					return true, nil
+				}
+			}
+			return false, nil
 		})
+
 		Expect(err).NotTo(HaveOccurred(), "Error waiting for queue unknown")
-		e2eutil.CleanupTestContext(ctx)
 	})
 })


### PR DESCRIPTION
Fix unstable e2e case, https://github.com/volcano-sh/volcano/actions/runs/11228371786/job/31212142643#step:7:74563
use `watch` to listen event, wait.poll is not accurate becasue the status of pod/queue will change and use `watch` can catch all events and status.