### PR TITLE
Optimize the admission log of vcjob update

### DIFF
--- a/pkg/webhooks/admission/jobs/validate/admit_job.go
+++ b/pkg/webhooks/admission/jobs/validate/admit_job.go
@@ -298,7 +298,7 @@ func validateJobUpdate(old, new *v1alpha1.Job) error {
 	}
 
 	if !apiequality.Semantic.DeepEqual(new.Spec, old.Spec) {
-		return fmt.Errorf("job updates may not change fields other than `minAvailable`, `tasks[*].replicas under spec`")
+		return fmt.Errorf("job updates may not change fields other than `minAvailable`, `tasks[*].replicas under spec` and `PriorityClassName`")
 	}
 
 	return nil


### PR DESCRIPTION
volcano allow modify `PriorityClassName`, logs are inaccurate.

https://github.com/volcano-sh/volcano/blob/41f6bfb25ba3061909bf30646194caa4e59590eb/pkg/webhooks/admission/jobs/validate/admit_job.go#L278

