### PR TITLE
fix: frequently create and delete vcjobs with the same name, and the …

### DIFF
--- a/pkg/controllers/apis/request.go
+++ b/pkg/controllers/apis/request.go
@@ -19,6 +19,8 @@ package apis
 import (
 	"fmt"
 
+	"k8s.io/apimachinery/pkg/types"
+
 	"volcano.sh/apis/pkg/apis/bus/v1alpha1"
 	flowv1alpha1 "volcano.sh/apis/pkg/apis/flow/v1alpha1"
 )
@@ -27,6 +29,7 @@ import (
 type Request struct {
 	Namespace string
 	JobName   string
+	JobUid    types.UID
 	TaskName  string
 	QueueName string
 

--- a/pkg/controllers/job/job_controller_util_test.go
+++ b/pkg/controllers/job/job_controller_util_test.go
@@ -332,6 +332,50 @@ func TestApplyPolicies(t *testing.T) {
 			ReturnVal: busv1alpha1.SyncJobAction,
 		},
 		{
+			Name: "Test Apply policies where job uid is inconsistent, ignore the existing policy action in the job and execute syncjob",
+			Job: &v1alpha1.Job{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "job1",
+					Namespace: namespace,
+					UID:       "job1-uid-10001",
+				},
+				Spec: v1alpha1.JobSpec{
+					SchedulerName: "volcano",
+					Tasks: []v1alpha1.TaskSpec{
+						{
+							Name:     "task1",
+							Replicas: 6,
+							Template: v1.PodTemplateSpec{
+								ObjectMeta: metav1.ObjectMeta{
+									Name:      "pods",
+									Namespace: namespace,
+								},
+								Spec: v1.PodSpec{
+									Containers: []v1.Container{
+										{
+											Name: "Containers",
+										},
+									},
+								},
+							},
+							Policies: []v1alpha1.LifecyclePolicy{
+								{
+									Action:   busv1alpha1.TerminateJobAction,
+									Event:    busv1alpha1.PodEvictedEvent,
+									ExitCode: &errorCode0,
+								},
+							},
+						},
+					},
+				},
+			},
+			Request: &apis.Request{
+				JobUid: "job1-uid-10000",
+				Event:  busv1alpha1.PodEvictedEvent,
+			},
+			ReturnVal: busv1alpha1.SyncJobAction,
+		},
+		{
 			Name: "Test Apply policies where version is outdated",
 			Job: &v1alpha1.Job{
 				ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
fix: [#3770 ](https://github.com/volcano-sh/volcano/issues/3770)

Repair solution:

Add the uid information of the vcjob to which the pod belongs to in the pod-related events. When processing the pod event, determine whether the uid of the vcjob with the same name in the current cache is consistent with the uid of the vcjob to which the pod belongs. If they are inconsistent, discard the original policy information and execute the syncjob action.