### PR TITLE
perf: imporve end to end queue processing latency

### DIFF
--- a/cmd/controller-manager/app/options/options.go
+++ b/cmd/controller-manager/app/options/options.go
@@ -39,6 +39,7 @@ const (
 	defaultHealthzAddress      = ":11251"
 	defaultLockObjectNamespace = "volcano-system"
 	defaultPodGroupWorkers     = 5
+	defaultQueueWorkers        = 5
 	defaultGCWorkers           = 1
 	defaultControllers         = "*"
 )
@@ -75,6 +76,9 @@ type ServerOption struct {
 	// WorkerThreadsForPG is the number of threads syncing podgroup operations
 	// The larger the number, the faster the podgroup processing, but requires more CPU load.
 	WorkerThreadsForPG uint32
+	// WorkerThreadsForQueue is the number of threads syncing queue operations
+	// The larger the number, the faster the queue processing, but requires more CPU load.
+	WorkerThreadsForQueue uint32
 	// WorkerThreadsForGC is the number of threads for recycling jobs
 	// The larger the number, the faster the job recycling, but requires more CPU load.
 	WorkerThreadsForGC uint32
@@ -117,6 +121,7 @@ func (s *ServerOption) AddFlags(fs *pflag.FlagSet, knownControllers []string) {
 	fs.BoolVar(&s.InheritOwnerAnnotations, "inherit-owner-annotations", true, "Enable inherit owner annotations for pods when create podgroup; it is enabled by default")
 	fs.Uint32Var(&s.WorkerThreadsForPG, "worker-threads-for-podgroup", defaultPodGroupWorkers, "The number of threads syncing podgroup operations. The larger the number, the faster the podgroup processing, but requires more CPU load.")
 	fs.Uint32Var(&s.WorkerThreadsForGC, "worker-threads-for-gc", defaultGCWorkers, "The number of threads for recycling jobs. The larger the number, the faster the job recycling, but requires more CPU load.")
+	fs.Uint32Var(&s.WorkerThreadsForQueue, "worker-threads-for-queue", defaultQueueWorkers, "The number of threads syncing queue operations. The larger the number, the faster the queue processing, but requires more CPU load.")
 	fs.StringSliceVar(&s.Controllers, "controllers", []string{defaultControllers}, fmt.Sprintf("Specify controller gates. Use '*' for all controllers, all knownController: %s ,and we can use "+
 		"'-' to disable controllers, e.g. \"-job-controller,-queue-controller\" to disable job and queue controllers.", knownControllers))
 }

--- a/cmd/controller-manager/app/options/options_test.go
+++ b/cmd/controller-manager/app/options/options_test.go
@@ -99,10 +99,11 @@ func TestAddFlags(t *testing.T) {
 			ResourceNamespace: defaultLockObjectNamespace,
 			ResourceName:      "vc-controller-manager",
 		},
-		LockObjectNamespace: defaultLockObjectNamespace,
-		WorkerThreadsForPG:  5,
-		WorkerThreadsForGC:  1,
-		Controllers:         []string{"*"},
+		LockObjectNamespace:   defaultLockObjectNamespace,
+		WorkerThreadsForPG:    5,
+		WorkerThreadsForQueue: 5,
+		WorkerThreadsForGC:    1,
+		Controllers:           []string{"*"},
 	}
 	expectedFeatureGates := map[featuregate.Feature]bool{features.ResourceTopology: false}
 

--- a/cmd/controller-manager/app/server.go
+++ b/cmd/controller-manager/app/server.go
@@ -128,6 +128,7 @@ func startControllers(config *rest.Config, opt *options.ServerOption) func(ctx c
 	controllerOpt.VCSharedInformerFactory = informerfactory.NewSharedInformerFactory(controllerOpt.VolcanoClient, 0)
 	controllerOpt.InheritOwnerAnnotations = opt.InheritOwnerAnnotations
 	controllerOpt.WorkerThreadsForPG = opt.WorkerThreadsForPG
+	controllerOpt.WorkerThreadsForQueue = opt.WorkerThreadsForQueue
 	controllerOpt.WorkerThreadsForGC = opt.WorkerThreadsForGC
 	controllerOpt.Config = config
 

--- a/pkg/controllers/framework/interface.go
+++ b/pkg/controllers/framework/interface.go
@@ -37,6 +37,7 @@ type ControllerOption struct {
 
 	InheritOwnerAnnotations bool
 	WorkerThreadsForPG      uint32
+	WorkerThreadsForQueue   uint32
 	WorkerThreadsForGC      uint32
 
 	// Config holds the common attributes that can be passed to a Kubernetes client


### PR DESCRIPTION
The current implementation of queue controller handles queue state operations and queuecommand operations for sequentially which may come into a performance bottleneck in performance-critical clusters. For example the end user may increase queuecommand & queue creation speed, so this pr add an option to make queue & queuecommand creation parallelly to handle such case.

Here, queue-controller workqueue pending process object metrics. 
![image](https://github.com/user-attachments/assets/924154bc-08e3-45be-989a-c878aa03681f)

After perf: imporve end to end queue processing latency, the queue-controller workqueue pending process object finally reduced.

![image](https://github.com/user-attachments/assets/de471732-3d45-4dfa-b786-ef757173edde)

