### PR TITLE
fix: remove the default nodeSelector value from the volcano monitoring installation yaml.

### DIFF
--- a/installer/volcano-monitoring-latest.yaml
+++ b/installer/volcano-monitoring-latest.yaml
@@ -446,9 +446,6 @@ spec:
             timeoutSeconds: 5
       dnsPolicy: ClusterFirst
       
-      nodeSelector:
-        node.kubernetes.io/instance-type: controlpanel
-      
       serviceAccountName: kube-state-metrics
 ---
 # Source: volcano/templates/grafana.yaml


### PR DESCRIPTION
Fix https://github.com/volcano-sh/volcano/issues/3779.

we can remove the nodeSelector default value from the volcano/installer/volcano-monitoring-latest.yaml file. If we want setting volcano-monitoring nodeSelector, we can run the helm chart with Values.custom.metrics_enable & Values.custom.kube_state_metrics_ns.