### PR TITLE
Can not sync job status correctly when upgrading from v1.5 #3640

### DIFF
--- a/pkg/controllers/job/job_controller_actions_test.go
+++ b/pkg/controllers/job/job_controller_actions_test.go
@@ -103,6 +103,57 @@ func TestKillJobFunc(t *testing.T) {
 			Plugins:   []string{"svc", "ssh", "env"},
 			ExpectVal: nil,
 		},
+		{
+			Name: "KillJob compatibility with version lt 1.5 success case",
+			Job: &v1alpha1.Job{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            "job2",
+					Namespace:       namespace,
+					UID:             "e7f18111-1cec-11ea-b688-fa163ec79500",
+					ResourceVersion: "100",
+				},
+			},
+			PodGroup: &schedulingapi.PodGroup{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "job2",
+					Namespace: namespace,
+				},
+			},
+			PodRetainPhase: state.PodRetainPhaseNone,
+			UpdateStatus:   nil,
+			JobInfo: &apis.JobInfo{
+				Namespace: namespace,
+				Name:      "jobinfo2",
+				Pods: map[string]map[string]*v1.Pod{
+					"task1": {
+						"pod1": buildPod(namespace, "pod1", v1.PodRunning, nil),
+						"pod2": buildPod(namespace, "pod2", v1.PodRunning, nil),
+					},
+				},
+			},
+			Services: []v1.Service{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "job2",
+						Namespace: namespace,
+					},
+				},
+			},
+			Secrets: []v1.Secret{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "job2-e7f18111-1cec-11ea-b688-fa163ec79500-ssh",
+						Namespace: namespace,
+					},
+				},
+			},
+			Pods: map[string]*v1.Pod{
+				"pod1": buildPod(namespace, "pod1", v1.PodRunning, nil),
+				"pod2": buildPod(namespace, "pod2", v1.PodRunning, nil),
+			},
+			Plugins:   []string{"svc", "ssh", "env"},
+			ExpectVal: nil,
+		},
 	}
 
 	for i, testcase := range testcases {
@@ -588,6 +639,30 @@ func TestUpdatePodGroupIfJobUpdateFunc(t *testing.T) {
 			},
 			ExpectVal: nil,
 		},
+		{
+			Name: "UpdatePodGroup compatibility with version lt 1.5 success Case",
+			Job: &v1alpha1.Job{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace:       namespace,
+					Name:            "job2",
+					ResourceVersion: "100",
+					UID:             "e7f18111-1cec-11ea-b688-fa163ec79500",
+				},
+				Spec: v1alpha1.JobSpec{
+					PriorityClassName: "new",
+				},
+			},
+			PodGroup: &schedulingapi.PodGroup{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: namespace,
+					Name:      "job2",
+				},
+				Spec: schedulingapi.PodGroupSpec{
+					MinResources: &v1.ResourceList{},
+				},
+			},
+			ExpectVal: nil,
+		},
 	}
 
 	for _, testcase := range testcases {
@@ -601,8 +676,9 @@ func TestUpdatePodGroupIfJobUpdateFunc(t *testing.T) {
 				t.Errorf("Expected return value to be equal to expected: %s, but got: %s", testcase.ExpectVal, err)
 			}
 
-			pgName := testcase.Job.Name + "-" + string(testcase.Job.UID)
-			pg, err := fakeController.vcClient.SchedulingV1beta1().PodGroups(namespace).Get(context.TODO(), pgName, metav1.GetOptions{})
+			pgName := testcase.PodGroup.Name
+			pg, err := fakeController.vcClient.SchedulingV1beta1().PodGroups(namespace).
+				Get(context.TODO(), pgName, metav1.GetOptions{})
 			if err != nil {
 				t.Error("Expected PodGroup to be created, but not created")
 			}


### PR DESCRIPTION
v1.5 changed the naming logics of pod group by adding UID into the name: #2140, syncJob function should change some logic.