### PR TITLE
fix staticcheck deprecated workqueue.RateLimitingInterface warnings on pkg/controllers

### DIFF
--- a/pkg/controllers/job/job_controller.go
+++ b/pkg/controllers/job/job_controller.go
@@ -324,7 +324,7 @@ func (cc *jobcontroller) belongsToThisRoutine(key string, count uint32) bool {
 	return val%cc.workers == count
 }
 
-func (cc *jobcontroller) getWorkerQueue(key string) workqueue.RateLimitingInterface {
+func (cc *jobcontroller) getWorkerQueue(key string) workqueue.TypedRateLimitingInterface[any] {
 	var hashVal hash.Hash32
 	var val uint32
 

--- a/pkg/controllers/job/job_controller_resync.go
+++ b/pkg/controllers/job/job_controller_resync.go
@@ -29,11 +29,11 @@ import (
 	"k8s.io/klog/v2"
 )
 
-func newRateLimitingQueue() workqueue.RateLimitingInterface {
-	return workqueue.NewRateLimitingQueue(workqueue.NewMaxOfRateLimiter(
-		workqueue.NewItemExponentialFailureRateLimiter(5*time.Millisecond, 180*time.Second),
+func newRateLimitingQueue() workqueue.TypedRateLimitingInterface[any] {
+	return workqueue.NewTypedRateLimitingQueue(workqueue.NewTypedMaxOfRateLimiter[any](
+		workqueue.NewTypedItemExponentialFailureRateLimiter[any](5*time.Millisecond, 180*time.Second),
 		// 10 qps, 100 bucket size.  This is only for retry speed and its only the overall factor (not per item)
-		&workqueue.BucketRateLimiter{Limiter: rate.NewLimiter(rate.Limit(10), 100)},
+		&workqueue.TypedBucketRateLimiter[any]{Limiter: rate.NewLimiter(rate.Limit(10), 100)},
 	))
 }
 

--- a/pkg/controllers/queue/queue_controller_test.go
+++ b/pkg/controllers/queue/queue_controller_test.go
@@ -29,6 +29,7 @@ import (
 	schedulingv1beta1 "volcano.sh/apis/pkg/apis/scheduling/v1beta1"
 	vcclient "volcano.sh/apis/pkg/client/clientset/versioned/fake"
 	informerfactory "volcano.sh/apis/pkg/client/informers/externalversions"
+	"volcano.sh/volcano/pkg/controllers/apis"
 	"volcano.sh/volcano/pkg/controllers/framework"
 	"volcano.sh/volcano/pkg/controllers/queue/state"
 )
@@ -314,7 +315,7 @@ func TestProcessNextWorkItem(t *testing.T) {
 
 	for i, testcase := range testCases {
 		c := newFakeController()
-		c.queue.Add("test")
+		c.queue.Add(&apis.Request{JobName: "test"})
 		bVal := c.processNextWorkItem()
 		fmt.Println("The value of boolean is ", bVal)
 		if c.queue.Len() != 0 {


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
fix staticcheck deprecated workqueue.RateLimitingInterface warnings on `pkg/controllers`, warnings like this
```text
pkg/controllers/cache/cache.go:40:14: workqueue.RateLimitingInterface is deprecated: Use TypedRateLimitingInterface instead.  (SA1019)
pkg/controllers/cache/cache.go:78:11: workqueue.NewMaxOfRateLimiter is deprecated: NewMaxOfRateLimiter is deprecated, use NewTypedMaxOfRateLimiter instead.  (SA1019)
pkg/controllers/cache/cache.go:79:3: workqueue.NewItemExponentialFailureRateLimiter is deprecated: NewItemExponentialFailureRateLimiter is deprecated, use NewTypedItemExponentialFailureRateLimiter instead.  (SA1019)
pkg/controllers/cache/cache.go:81:4: workqueue.BucketRateLimiter is deprecated: BucketRateLimiter is deprecated, use TypedBucketRateLimiter instead.  (SA1019)
pkg/controllers/cache/cache.go:86:16: workqueue.NewRateLimitingQueue is deprecated: Use NewTypedRateLimitingQueue instead.  (SA1019)
pkg/controllers/garbagecollector/garbagecollector.go:64:8: workqueue.RateLimitingInterface is deprecated: Use TypedRateLimitingInterface instead.  (SA1019)
pkg/controllers/garbagecollector/garbagecollector.go:84:13: workqueue.NewRateLimitingQueue is deprecated: Use NewTypedRateLimitingQueue instead.  (SA1019)
pkg/controllers/garbagecollector/garbagecollector.go:84:44: workqueue.DefaultControllerRateLimiter is deprecated: Use DefaultTypedControllerRateLimiter instead.  (SA1019)
pkg/controllers/job/job_controller.go:109:17: workqueue.RateLimitingInterface is deprecated: Use TypedRateLimitingInterface instead.  (SA1019)
pkg/controllers/job/job_controller.go:110:15: workqueue.RateLimitingInterface is deprecated: Use TypedRateLimitingInterface instead.  (SA1019)
pkg/controllers/job/job_controller.go:115:16: workqueue.RateLimitingInterface is deprecated: Use TypedRateLimitingInterface instead.  (SA1019)
pkg/controllers/job/job_controller.go:138:24: workqueue.RateLimitingInterface is deprecated: Use TypedRateLimitingInterface instead.  (SA1019)
pkg/controllers/job/job_controller.go:139:20: workqueue.NewRateLimitingQueue is deprecated: Use NewTypedRateLimitingQueue instead.  (SA1019)
pkg/controllers/job/job_controller.go:139:51: workqueue.DefaultControllerRateLimiter is deprecated: Use DefaultTypedControllerRateLimiter instead.  (SA1019)
pkg/controllers/job/job_controller.go:151:21: workqueue.NewRateLimitingQueue is deprecated: Use NewTypedRateLimitingQueue instead.  (SA1019)
pkg/controllers/job/job_controller.go:151:52: workqueue.DefaultControllerRateLimiter is deprecated: Use DefaultTypedControllerRateLimiter instead.  (SA1019)
pkg/controllers/job/job_controller.go:295:53: workqueue.RateLimitingInterface is deprecated: Use TypedRateLimitingInterface instead.  (SA1019)
pkg/controllers/job/job_controller_resync.go:32:29: workqueue.RateLimitingInterface is deprecated: Use TypedRateLimitingInterface instead.  (SA1019)
pkg/controllers/job/job_controller_resync.go:33:9: workqueue.NewRateLimitingQueue is deprecated: Use NewTypedRateLimitingQueue instead.  (SA1019)
pkg/controllers/job/job_controller_resync.go:33:40: workqueue.NewMaxOfRateLimiter is deprecated: NewMaxOfRateLimiter is deprecated, use NewTypedMaxOfRateLimiter instead.  (SA1019)
pkg/controllers/job/job_controller_resync.go:34:3: workqueue.NewItemExponentialFailureRateLimiter is deprecated: NewItemExponentialFailureRateLimiter is deprecated, use NewTypedItemExponentialFailureRateLimiter instead.  (SA1019)
pkg/controllers/job/job_controller_resync.go:36:4: workqueue.BucketRateLimiter is deprecated: BucketRateLimiter is deprecated, use TypedBucketRateLimiter instead.  (SA1019)
pkg/controllers/jobflow/jobflow_controller.go:77:17: workqueue.RateLimitingInterface is deprecated: Use TypedRateLimitingInterface instead.  (SA1019)
pkg/controllers/jobflow/jobflow_controller.go:125:13: workqueue.NewRateLimitingQueue is deprecated: Use NewTypedRateLimitingQueue instead.  (SA1019)
pkg/controllers/jobflow/jobflow_controller.go:125:44: workqueue.DefaultControllerRateLimiter is deprecated: Use DefaultTypedControllerRateLimiter instead.  (SA1019)
pkg/controllers/jobtemplate/jobtemplate_controller.go:71:21: workqueue.RateLimitingInterface is deprecated: Use TypedRateLimitingInterface instead.  (SA1019)
pkg/controllers/jobtemplate/jobtemplate_controller.go:114:13: workqueue.NewRateLimitingQueue is deprecated: Use NewTypedRateLimitingQueue instead.  (SA1019)
pkg/controllers/jobtemplate/jobtemplate_controller.go:114:44: workqueue.DefaultControllerRateLimiter is deprecated: Use DefaultTypedControllerRateLimiter instead.  (SA1019)
pkg/controllers/podgroup/pg_controller.go:69:8: workqueue.RateLimitingInterface is deprecated: Use TypedRateLimitingInterface instead.  (SA1019)
pkg/controllers/podgroup/pg_controller.go:88:13: workqueue.NewRateLimitingQueue is deprecated: Use NewTypedRateLimitingQueue instead.  (SA1019)
pkg/controllers/podgroup/pg_controller.go:88:44: workqueue.DefaultControllerRateLimiter is deprecated: Use DefaultTypedControllerRateLimiter instead.  (SA1019)
pkg/controllers/queue/queue_controller.go:80:15: workqueue.RateLimitingInterface is deprecated: Use TypedRateLimitingInterface instead.  (SA1019)
pkg/controllers/queue/queue_controller.go:81:15: workqueue.RateLimitingInterface is deprecated: Use TypedRateLimitingInterface instead.  (SA1019)
pkg/controllers/queue/queue_controller.go:121:12: workqueue.NewRateLimitingQueue is deprecated: Use NewTypedRateLimitingQueue instead.  (SA1019)
pkg/controllers/queue/queue_controller.go:121:43: workqueue.DefaultControllerRateLimiter is deprecated: Use DefaultTypedControllerRateLimiter instead.  (SA1019)
pkg/controllers/queue/queue_controller.go:122:19: workqueue.NewRateLimitingQueue is deprecated: Use NewTypedRateLimitingQueue instead.  (SA1019)
pkg/controllers/queue/queue_controller.go:122:50: workqueue.DefaultControllerRateLimiter is deprecated: Use DefaultTypedControllerRateLimiter instead.  (SA1019)
```

#### Which issue(s) this PR fixes:
Parts of https://github.com/volcano-sh/volcano/issues/3713