### PR TITLE
Update gen-admission-secret.sh

### DIFF
--- a/installer/dockerfile/webhook-manager/gen-admission-secret.sh
+++ b/installer/dockerfile/webhook-manager/gen-admission-secret.sh
@@ -104,7 +104,7 @@ function patchSecret() {
   TLS_CRT=$(base64 < ${CERTDIR}/server.crt | tr -d '\n')
   CA_CRT=$(base64 < ${CERTDIR}/ca.crt | tr -d '\n')
 
-  cat <<EOF > patch.json
+  cat <<EOF > ${CERTDIR}/patch.json
 [
   {"op": "replace", "path": "/data/tls.key", "value": "$TLS_KEY"},
   {"op": "replace", "path": "/data/tls.crt", "value": "$TLS_CRT"},
@@ -112,7 +112,7 @@ function patchSecret() {
 ]
 EOF
 
-  kubectl patch secret ${SECRET} -n ${NAMESPACE} --type=json -p="$(cat patch.json)"
+  kubectl patch secret ${SECRET} -n ${NAMESPACE} --type=json -p="$(cat ${CERTDIR}/patch.json)"
 }
 
 createCerts


### PR DESCRIPTION
Seeing this error when starting the volcano-admission-service:

```
creating certs in dir /tmp
Certificate request self-signature ok
subject=CN=volcano-admission-service.volcano-system.svc
The secret volcano-admission-secret2 -n volcano-system already exists. Will update it.
./gen-admission-secret.sh: line 107: can't create patch.json: Read-only file system
```

It might be good to use `/tmp` for the patch file too.
