### PR TITLE
Fix resuming jobs will make job failing into failure

### DIFF
--- a/pkg/controllers/job/job_state_test.go
+++ b/pkg/controllers/job/job_state_test.go
@@ -228,8 +228,8 @@ func TestAbortingState_Execute(t *testing.T) {
 					t.Error("Error while retrieving value from Cache")
 				}
 
-				if jobInfo.Job.Status.RetryCount == 0 {
-					t.Error("Retry Count should not be zero")
+				if jobInfo.Job.Status.RetryCount != 0 {
+					t.Error("Retry Count should be zero")
 				}
 			}
 

--- a/pkg/controllers/job/state/aborted.go
+++ b/pkg/controllers/job/state/aborted.go
@@ -31,7 +31,6 @@ func (as *abortedState) Execute(action v1alpha1.Action) error {
 	case v1alpha1.ResumeJobAction:
 		return KillJob(as.job, PodRetainPhaseSoft, func(status *vcbatch.JobStatus) bool {
 			status.State.Phase = vcbatch.Restarting
-			status.RetryCount++
 			return true
 		})
 	default:

--- a/pkg/controllers/job/state/aborting.go
+++ b/pkg/controllers/job/state/aborting.go
@@ -31,7 +31,6 @@ func (ps *abortingState) Execute(action v1alpha1.Action) error {
 	case v1alpha1.ResumeJobAction:
 		return KillJob(ps.job, PodRetainPhaseSoft, func(status *vcbatch.JobStatus) bool {
 			status.State.Phase = vcbatch.Restarting
-			status.RetryCount++
 			return true
 		})
 	default:

--- a/test/e2e/vcctl/command.go
+++ b/test/e2e/vcctl/command.go
@@ -92,11 +92,13 @@ var _ = Describe("Job E2E Test: Test Job Command", func() {
 		Expect(err).NotTo(HaveOccurred())
 		err = e2eutil.WaitJobStateReady(ctx, job)
 		Expect(err).NotTo(HaveOccurred())
+		Expect(job.Status.RetryCount).To(Equal(int32(0)))
 
 		// Suspend job and wait status change
 		SuspendJob(jobName, ctx.Namespace)
 		err = e2eutil.WaitJobStateAborted(ctx, job)
 		Expect(err).NotTo(HaveOccurred())
+		Expect(job.Status.RetryCount).To(Equal(int32(0)))
 
 		// Pod is gone
 		podName := jobctl.MakePodName(jobName, taskName, 0)
@@ -111,6 +113,7 @@ var _ = Describe("Job E2E Test: Test Job Command", func() {
 		Expect(err).NotTo(HaveOccurred())
 		err = e2eutil.WaitJobStateReady(ctx, job)
 		Expect(err).NotTo(HaveOccurred())
+		Expect(job.Status.RetryCount).To(Equal(int32(0)))
 
 	})
 
@@ -141,11 +144,13 @@ var _ = Describe("Job E2E Test: Test Job Command", func() {
 		Expect(err).NotTo(HaveOccurred())
 		err = e2eutil.WaitJobStatePending(ctx, job)
 		Expect(err).NotTo(HaveOccurred())
+		Expect(job.Status.RetryCount).To(Equal(int32(0)))
 
 		// Suspend job and wait status change
 		SuspendJob(jobName, ctx.Namespace)
 		err = e2eutil.WaitJobStateAborted(ctx, job)
 		Expect(err).NotTo(HaveOccurred())
+		Expect(job.Status.RetryCount).To(Equal(int32(0)))
 
 		// Pod is gone
 		podName := jobctl.MakePodName(jobName, taskName, 0)


### PR DESCRIPTION
part of https://github.com/volcano-sh/volcano/issues/3875
fix https://github.com/volcano-sh/volcano/issues/3067

Here we take `resume != failure`, this is aligned with batch job, more general, `resume` OP should be idempotent which means we can suspend/resume for arbitrary times.

Further discussion is *Should we reset the `retryCount` instead*?