### PR TITLE
Update owners: add archlitchi to approver in scheduler plugins

### DIFF
--- a/pkg/scheduler/plugins/OWNERS
+++ b/pkg/scheduler/plugins/OWNERS
@@ -5,6 +5,7 @@ approvers:
   - shinytang6
   - zen-xu
   - qiankunli
+  - archlitchi
 reviewers:
   - k82cn
   - animeshsingh


### PR DESCRIPTION
i'm responsible for deviceshare plugin for volcano. it provides the volcano-vgpu feature, i'll continue to provide more device-sharing features for more manufactures, and integrate MIG and MPS for NVIDIA