### PR TITLE
[WIP]feature: Create hyperNode cr by node label

### DIFF
--- a/cmd/controller-manager/main.go
+++ b/cmd/controller-manager/main.go
@@ -34,6 +34,7 @@ import (
 	"volcano.sh/volcano/cmd/controller-manager/app/options"
 	"volcano.sh/volcano/pkg/controllers/framework"
 	_ "volcano.sh/volcano/pkg/controllers/garbagecollector"
+	_ "volcano.sh/volcano/pkg/controllers/hypernode"
 	_ "volcano.sh/volcano/pkg/controllers/job"
 	_ "volcano.sh/volcano/pkg/controllers/jobflow"
 	_ "volcano.sh/volcano/pkg/controllers/jobtemplate"

--- a/go.mod
+++ b/go.mod
@@ -190,4 +190,5 @@ replace (
 	k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.31.1
 	k8s.io/sample-cli-plugin => k8s.io/sample-cli-plugin v0.31.1
 	k8s.io/sample-controller => k8s.io/sample-controller v0.31.1
+	volcano.sh/apis => github.com/Monokaix/apis v0.0.0-20241127085549-793b1b3cedb3
 )

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,8 @@
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/Microsoft/go-winio v0.6.0 h1:slsWYD/zyx7lCXoZVlvQrj0hPTM1HI4+v1sIda2yDvg=
 github.com/Microsoft/go-winio v0.6.0/go.mod h1:cTAf44im0RAYeL23bpB+fzCyDH2MJiz2BO69KH/soAE=
+github.com/Monokaix/apis v0.0.0-20241127085549-793b1b3cedb3 h1:DXkPHi5DFo8To9EHw+xtyBe7fz0DewqzoprQbJM7WWI=
+github.com/Monokaix/apis v0.0.0-20241127085549-793b1b3cedb3/go.mod h1:XHIjTlHDMZTLRg2Y2JAkj85iP0iiet2tv+HfPQZrsHs=
 github.com/NYTimes/gziphandler v1.1.1 h1:ZUDjpQae29j0ryrS0u/B8HZfJBtBQHjqw2rQ2cqUQ3I=
 github.com/NYTimes/gziphandler v1.1.1/go.mod h1:n/CVRwUEOgIxrgPvAQhUUr9oeUtvrhMomdKFjzJNB0c=
 github.com/agiledragon/gomonkey/v2 v2.11.0 h1:5oxSgA+tC1xuGsrIorR+sYiziYltmJyEZ9qA25b6l5U=
@@ -510,5 +512,3 @@ sigs.k8s.io/yaml v1.4.0 h1:Mk1wCc2gy/F0THH0TAp1QYyJNzRm2KCLy3o5ASXVI5E=
 sigs.k8s.io/yaml v1.4.0/go.mod h1:Ejl7/uTz7PSA4eKMyQCUTnhZYNmLIl+5c2lQPGR2BPY=
 stathat.com/c/consistent v1.0.0 h1:ezyc51EGcRPJUxfHGSgJjWzJdj3NiMU9pNfLNGiXV0c=
 stathat.com/c/consistent v1.0.0/go.mod h1:QkzMWzcbB+yQBL2AttO6sgsQS/JSTapcDISJalmCDS0=
-volcano.sh/apis v1.10.0-alpha.0.0.20241016111016-bb93758bd51f h1:wqvGQgzYCPJSS07xE1LZbJ/Mxb1f/xFWThnII6BzMhg=
-volcano.sh/apis v1.10.0-alpha.0.0.20241016111016-bb93758bd51f/go.mod h1:XHIjTlHDMZTLRg2Y2JAkj85iP0iiet2tv+HfPQZrsHs=

--- a/installer/helm/chart/volcano/templates/controllers.yaml
+++ b/installer/helm/chart/volcano/templates/controllers.yaml
@@ -84,6 +84,12 @@ rules:
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]
     verbs: ["get", "create", "update", "watch"]
+  - apiGroups: ["topology.volcano.sh"]
+    resources: ["hypernodes", "hypernodes/status"]
+    verbs: ["get", "list", "watch", "create", "delete", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list", "watch"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/pkg/controllers/hypernode/cache/hyper_nodes_cache.go
+++ b/pkg/controllers/hypernode/cache/hyper_nodes_cache.go
@@ -1,0 +1,126 @@
+/*
+Copyright 2024 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cache
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"sync"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/client-go/tools/cache"
+	topologyv1alpha1 "volcano.sh/apis/pkg/apis/topology/v1alpha1"
+)
+
+var (
+	NotFoundError = errors.New("not found")
+)
+
+type HyperNodesCache struct {
+	// The indexer called HyperNodes is used to store pointers of all hypernodes,
+	// including those hypernodes already listed/watched to the controller,
+	// and those that have sent hypernode create/update/delete requests to the api-server but have not yet listed/watched
+	// to the controller's cache
+	HyperNodes cache.Indexer
+	// MembersToHyperNode is used to find the hypernode it belongs to based on the member,
+	// so that we can quickly find the hypernode and to update its members.
+	// The key is member's name, value is the pointer of HyperNode.
+	MembersToHyperNode sync.Map
+}
+
+func NewHyperNodesCache(store cache.Indexer) *HyperNodesCache {
+	return &HyperNodesCache{
+		HyperNodes: store,
+	}
+}
+
+func (h *HyperNodesCache) GetHyperNode(name string) (*topologyv1alpha1.HyperNode, error) {
+	obj, ok, err := h.HyperNodes.GetByKey(name)
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		return nil, fmt.Errorf("%w: hypernode %s does not exists in local cache", NotFoundError, name)
+	}
+
+	hn := obj.(*topologyv1alpha1.HyperNode)
+	return hn, nil
+}
+
+func (h *HyperNodesCache) UpdateHyperNode(newHN *topologyv1alpha1.HyperNode) error {
+	name, err := cache.MetaNamespaceKeyFunc(newHN)
+	if err != nil {
+		return err
+	}
+
+	storedHN, err := h.GetHyperNode(name)
+	if err != nil {
+		if !errors.Is(err, NotFoundError) {
+			return fmt.Errorf("failed to update hypernode %s: %v", newHN.Name, err)
+		}
+		err = h.HyperNodes.Add(newHN)
+		if err != nil {
+			return fmt.Errorf("failed to add hypernode %s to local cache: %v", newHN.Name, err)
+		}
+		return nil
+	}
+
+	storedRV, err := h.getResourceVersion(storedHN)
+	if err != nil {
+		return err
+	}
+
+	newRV, err := h.getResourceVersion(newHN)
+	if err != nil {
+		return err
+	}
+
+	if newRV <= storedRV {
+		// if the new hypernode's resource version is less or equal to the already stored hypernode's resource version, we do nothing
+		return nil
+	}
+
+	err = h.HyperNodes.Update(newHN)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (h *HyperNodesCache) DeleteHyperNode(hn *topologyv1alpha1.HyperNode) error {
+	err := h.HyperNodes.Delete(hn)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (h *HyperNodesCache) getResourceVersion(hn *topologyv1alpha1.HyperNode) (int64, error) {
+	objAccessor, err := meta.Accessor(hn)
+	if err != nil {
+		return -1, err
+	}
+
+	objResourceVersion, err := strconv.ParseInt(objAccessor.GetResourceVersion(), 10, 64)
+	if err != nil {
+		return -1, fmt.Errorf("error parsing ResourceVersion %q for %s: %v", objAccessor.GetResourceVersion(), hn.Name, err)
+	}
+	return objResourceVersion, nil
+}

--- a/pkg/controllers/hypernode/cache/hyper_nodes_cache_test.go
+++ b/pkg/controllers/hypernode/cache/hyper_nodes_cache_test.go
@@ -1,0 +1,89 @@
+package cache
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/api/equality"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/cache"
+	topologyv1alpha1 "volcano.sh/apis/pkg/apis/topology/v1alpha1"
+)
+
+func newSimpleFakeHyperNode(name, resourceVersion string) *topologyv1alpha1.HyperNode {
+	return &topologyv1alpha1.HyperNode{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            name,
+			ResourceVersion: resourceVersion,
+		},
+	}
+}
+
+func TestUpdateHyperNode(t *testing.T) {
+	testCases := []struct {
+		name            string
+		updateHyperNode *topologyv1alpha1.HyperNode
+		initCacheFunc   func(cache *HyperNodesCache)
+		expectErr       bool
+		expectHyperNode *topologyv1alpha1.HyperNode
+	}{
+		{
+			name:            "hypernode does not exist in local cache, add it",
+			updateHyperNode: newSimpleFakeHyperNode("s1", "1"),
+			expectErr:       false,
+			expectHyperNode: newSimpleFakeHyperNode("s1", "1"),
+		},
+		{
+			name:            "failed to parse resource version",
+			updateHyperNode: newSimpleFakeHyperNode("s1", "invalid"),
+			initCacheFunc: func(cache *HyperNodesCache) {
+				initHyperNode := newSimpleFakeHyperNode("s1", "1")
+				cache.HyperNodes.Add(initHyperNode)
+			},
+			expectErr: true,
+		},
+		{
+			name:            "resource version of hypernode need to be updated is smaller than the hypernode in local cache",
+			updateHyperNode: newSimpleFakeHyperNode("s1", "1"),
+			initCacheFunc: func(cache *HyperNodesCache) {
+				initHyperNode := newSimpleFakeHyperNode("s1", "2")
+				cache.HyperNodes.Add(initHyperNode)
+			},
+			expectErr: false,
+		},
+		{
+			name:            "successfully updated hypernode",
+			updateHyperNode: newSimpleFakeHyperNode("s1", "2"),
+			initCacheFunc: func(cache *HyperNodesCache) {
+				initHyperNode := newSimpleFakeHyperNode("s1", "1")
+				cache.HyperNodes.Add(initHyperNode)
+			},
+			expectErr:       false,
+			expectHyperNode: newSimpleFakeHyperNode("s1", "2"),
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			hnc := NewHyperNodesCache(cache.NewIndexer(
+				cache.MetaNamespaceKeyFunc,
+				cache.Indexers{
+					cache.NamespaceIndex: cache.MetaNamespaceIndexFunc,
+				},
+			))
+			if tc.initCacheFunc != nil {
+				tc.initCacheFunc(hnc)
+			}
+
+			err := hnc.UpdateHyperNode(tc.updateHyperNode)
+			assert.Equal(t, tc.expectErr, err != nil)
+
+			if tc.expectHyperNode != nil {
+				gotHyperNode, err := hnc.GetHyperNode(tc.expectHyperNode.Name)
+				assert.NoError(t, err)
+				if !equality.Semantic.DeepEqual(gotHyperNode, tc.expectHyperNode) {
+					t.Errorf("hypernode is not equal, got %v, expect %v", gotHyperNode, tc.expectHyperNode)
+				}
+			}
+		})
+	}
+}

--- a/pkg/controllers/hypernode/event.go
+++ b/pkg/controllers/hypernode/event.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2024 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hypernode
+
+import "fmt"
+
+type eventType int
+
+func (e eventType) String() string {
+	switch e {
+	case addEvent:
+		return "add"
+	case updateEvent:
+		return "update"
+	case deleteEvent:
+		return "delete"
+	default:
+		return fmt.Sprintf("unknown(%d)", int(e))
+	}
+}
+
+const (
+	addEvent eventType = iota
+	updateEvent
+	deleteEvent
+)
+
+// event is used by eventhandlerFuncs to pass information to workers.
+type event struct {
+	eventType eventType
+	obj       interface{}
+	oldObj    interface{}
+}

--- a/pkg/controllers/hypernode/hypernode_controller.go
+++ b/pkg/controllers/hypernode/hypernode_controller.go
@@ -1,0 +1,124 @@
+/*
+Copyright 2024 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hypernode
+
+import (
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+	corelisters "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+	"k8s.io/klog/v2"
+	vcclientset "volcano.sh/apis/pkg/client/clientset/versioned"
+	vcinformer "volcano.sh/apis/pkg/client/informers/externalversions"
+	topologyv1alpha1lister "volcano.sh/apis/pkg/client/listers/topology/v1alpha1"
+
+	"volcano.sh/volcano/pkg/controllers/framework"
+	hncache "volcano.sh/volcano/pkg/controllers/hypernode/cache"
+)
+
+func init() {
+	framework.RegisterController(&hyperNodeController{})
+}
+
+type hyperNodeController struct {
+	kubeClient kubernetes.Interface
+	vcClient   vcclientset.Interface
+
+	nodeLister      corelisters.NodeLister
+	hyperNodeLister topologyv1alpha1lister.HyperNodeLister
+
+	informerFactory   informers.SharedInformerFactory
+	vcInformerFactory vcinformer.SharedInformerFactory
+
+	nodeQueue      workqueue.RateLimitingInterface
+	hyperNodeQueue workqueue.RateLimitingInterface
+
+	hyperNodesCache *hncache.HyperNodesCache
+}
+
+func (hnc *hyperNodeController) Name() string {
+	return "hypernode-controller"
+}
+
+func (hnc *hyperNodeController) Initialize(opt *framework.ControllerOption) error {
+	hnc.kubeClient = opt.KubeClient
+	hnc.vcClient = opt.VolcanoClient
+
+	hnc.informerFactory = opt.SharedInformerFactory
+	hnc.vcInformerFactory = opt.VCSharedInformerFactory
+
+	nodeInformer := hnc.informerFactory.InformerFor(&v1.Node{}, newNodeInformer)
+	hnc.nodeLister = corelisters.NewNodeLister(nodeInformer.GetIndexer())
+	hyperNodeInformer := hnc.vcInformerFactory.Topology().V1alpha1().HyperNodes()
+	hnc.hyperNodeLister = hyperNodeInformer.Lister()
+
+	hnc.nodeQueue = workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter())
+	hnc.hyperNodeQueue = workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter())
+
+	nodeInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    hnc.addNode,
+		UpdateFunc: hnc.updateNode,
+		DeleteFunc: hnc.deleteNode,
+	})
+
+	hnc.hyperNodesCache = hncache.NewHyperNodesCache(cache.NewIndexer(
+		cache.MetaNamespaceKeyFunc,
+		cache.Indexers{
+			cache.NamespaceIndex: cache.MetaNamespaceIndexFunc,
+		},
+	))
+
+	hyperNodeInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    hnc.addHyperNode,
+		UpdateFunc: hnc.updateHyperNode,
+		DeleteFunc: hnc.deleteHyperNode,
+	})
+
+	return nil
+}
+
+func (hnc *hyperNodeController) Run(stopCh <-chan struct{}) {
+	klog.Infof("Starting hypernode controller.")
+	defer klog.Infof("Shutting down hypernode controller.")
+
+	hnc.informerFactory.Start(stopCh)
+
+	for informerType, ok := range hnc.informerFactory.WaitForCacheSync(stopCh) {
+		if !ok {
+			klog.Errorf("caches failed to sync: %v", informerType)
+			return
+		}
+	}
+
+	go wait.Until(hnc.nodeWorker, 0, stopCh)
+	go wait.Until(hnc.hyperNodeWorker, 0, stopCh)
+
+	<-stopCh
+}
+
+func (hnc *hyperNodeController) nodeWorker() {
+	for hnc.processNextNodeEvent() {
+	}
+}
+
+func (hnc *hyperNodeController) hyperNodeWorker() {
+	for hnc.processNextHyperNodeEvent() {
+	}
+}

--- a/pkg/controllers/hypernode/hypernode_controller_handler.go
+++ b/pkg/controllers/hypernode/hypernode_controller_handler.go
@@ -1,0 +1,304 @@
+/*
+Copyright 2024 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hypernode
+
+import (
+	"strings"
+
+	v1 "k8s.io/api/core/v1"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/util/workqueue"
+	"k8s.io/klog/v2"
+	topologyv1alpha1 "volcano.sh/apis/pkg/apis/topology/v1alpha1"
+)
+
+const (
+	// maxRetries is the number of times an event will be retried
+	// before it is dropped out of the queue
+	maxRetries = 15
+	// labelSeparator is the separator to split hypernodes in the label
+	labelSeparator = ","
+)
+
+func (hnc *hyperNodeController) addNode(obj interface{}) {
+	node, ok := obj.(*v1.Node)
+	if !ok {
+		klog.Errorf("%T is not a type of Node", obj)
+		return
+	}
+
+	nodeEvent := &event{
+		eventType: addEvent,
+		obj:       node,
+	}
+	hnc.nodeQueue.Add(nodeEvent)
+}
+
+func (hnc *hyperNodeController) updateNode(oldObj, newObj interface{}) {
+	oldNode, ok := oldObj.(*v1.Node)
+	if !ok {
+		klog.Errorf("%T is not a type of Node", oldObj)
+		return
+	}
+
+	newNode, ok := newObj.(*v1.Node)
+	if !ok {
+		klog.Errorf("%T is not a type of Node", newObj)
+		return
+	}
+
+	if newNode.Labels[hyperNodesLabelKey] == oldNode.Labels[hyperNodesLabelKey] {
+		return
+	}
+
+	nodeEvent := &event{
+		eventType: updateEvent,
+		obj:       newNode,
+		oldObj:    oldNode,
+	}
+	hnc.nodeQueue.Add(nodeEvent)
+}
+
+func (hnc *hyperNodeController) deleteNode(obj interface{}) {
+	node, ok := obj.(*v1.Node)
+	if !ok {
+		klog.Errorf("%T is not a type of Node", obj)
+		return
+	}
+
+	nodeEvent := &event{
+		eventType: deleteEvent,
+		obj:       node,
+	}
+	hnc.nodeQueue.Add(nodeEvent)
+}
+
+func (hnc *hyperNodeController) processNextNodeEvent() bool {
+	eventObj, shutdown := hnc.nodeQueue.Get()
+	if shutdown {
+		klog.Errorf("Fail to get items from work queue, it is already been closed")
+		return false
+	}
+	defer hnc.nodeQueue.Done(eventObj)
+
+	nodeEvent := eventObj.(*event)
+	switch nodeEvent.eventType {
+	case addEvent:
+		node := nodeEvent.obj.(*v1.Node)
+
+		hyperNodesList := strings.Split(node.Labels[hyperNodesLabelKey], labelSeparator)
+		err := func() error {
+			hnas := make([]*hyperNodeAction, 0)
+
+			addHNAs, err := hnc.addHyperNodesList(node, hyperNodesList)
+			if err != nil {
+				return err
+			}
+			hnas = append(hnas, addHNAs...)
+			err = hnc.executeHyperNodeActions(hnas)
+			if err != nil {
+				return err
+			}
+
+			return nil
+		}()
+		hnc.handleErr(err, hnc.nodeQueue, eventObj)
+	case updateEvent:
+		newNode := nodeEvent.obj.(*v1.Node)
+		oldNode := nodeEvent.oldObj.(*v1.Node)
+
+		newHNsList := strings.Split(newNode.Labels[hyperNodesLabelKey], labelSeparator)
+		oldHNsList := strings.Split(oldNode.Labels[hyperNodesLabelKey], labelSeparator)
+		err := func() error {
+			hnas := make([]*hyperNodeAction, 0)
+
+			updateHNAs, err := hnc.updateHyperNodeList(newNode, newHNsList, oldHNsList)
+			if err != nil {
+				return err
+			}
+			hnas = append(hnas, updateHNAs...)
+			err = hnc.executeHyperNodeActions(hnas)
+			if err != nil {
+				return err
+			}
+
+			return nil
+		}()
+		hnc.handleErr(err, hnc.nodeQueue, eventObj)
+	case deleteEvent:
+		node := nodeEvent.obj.(*v1.Node)
+		err := func() error {
+			hnas := make([]*hyperNodeAction, 0)
+
+			if obj, exist := hnc.hyperNodesCache.MembersToHyperNode.Load(node.Name); exist {
+				parentHN := obj.(*topologyv1alpha1.HyperNode)
+				newHNAs, err := hnc.removeMemberFromHyperNode(parentHN.Name, node.Name)
+				if err != nil {
+					return err
+				}
+				hnas = append(hnas, newHNAs...)
+				err = hnc.executeHyperNodeActions(hnas)
+				if err != nil {
+					return err
+				}
+				hnc.hyperNodesCache.MembersToHyperNode.Delete(node.Name)
+			}
+
+			return nil
+		}()
+		hnc.handleErr(err, hnc.nodeQueue, eventObj)
+	}
+
+	return true
+}
+
+func (hnc *hyperNodeController) addHyperNode(obj interface{}) {
+	hn, ok := obj.(*topologyv1alpha1.HyperNode)
+	if !ok {
+		klog.Errorf("%T is not a type of HyperNode", obj)
+		return
+	}
+
+	hnEvent := &event{
+		eventType: addEvent,
+		obj:       hn,
+	}
+	hnc.hyperNodeQueue.Add(hnEvent)
+}
+
+func (hnc *hyperNodeController) updateHyperNode(oldObj, newObj interface{}) {
+	oldHN, ok := oldObj.(*topologyv1alpha1.HyperNode)
+	if !ok {
+		klog.Errorf("%T is not a type of HyperNode", oldObj)
+		return
+	}
+
+	newHN, ok := newObj.(*topologyv1alpha1.HyperNode)
+	if !ok {
+		klog.Errorf("%T is not a type of HyperNode", newObj)
+		return
+	}
+
+	hnEvent := &event{
+		eventType: updateEvent,
+		obj:       newHN,
+		oldObj:    oldHN,
+	}
+	hnc.hyperNodeQueue.Add(hnEvent)
+}
+
+func (hnc *hyperNodeController) deleteHyperNode(obj interface{}) {
+	hn, ok := obj.(*topologyv1alpha1.HyperNode)
+	if !ok {
+		klog.Errorf("%T is not a type of HyperNode", obj)
+		return
+	}
+
+	hnEvent := &event{
+		eventType: deleteEvent,
+		obj:       hn,
+	}
+	hnc.hyperNodeQueue.Add(hnEvent)
+}
+
+func (hnc *hyperNodeController) processNextHyperNodeEvent() bool {
+	eventObj, shutdown := hnc.hyperNodeQueue.Get()
+	if shutdown {
+		klog.Errorf("Fail to get items from work queue, it is already been closed")
+		return false
+	}
+	defer hnc.hyperNodeQueue.Done(eventObj)
+
+	hnEvent := eventObj.(*event)
+	switch hnEvent.eventType {
+	case addEvent:
+		hn := hnEvent.obj.(*topologyv1alpha1.HyperNode)
+		err := hnc.hyperNodesCache.UpdateHyperNode(hn)
+		hnc.handleErr(err, hnc.hyperNodeQueue, eventObj)
+		for _, member := range hn.Spec.Members {
+			hnc.hyperNodesCache.MembersToHyperNode.Store(member.Selector.ExactMatch.Name, hn)
+		}
+	case updateEvent:
+		newHN := hnEvent.obj.(*topologyv1alpha1.HyperNode)
+		err := hnc.hyperNodesCache.UpdateHyperNode(newHN)
+		hnc.handleErr(err, hnc.hyperNodeQueue, eventObj)
+		oldHN := hnEvent.oldObj.(*topologyv1alpha1.HyperNode)
+		addMembers, removeMembers := hnc.getMemberDifferences(oldHN.Spec.Members, newHN.Spec.Members)
+		for _, member := range addMembers {
+			hnc.hyperNodesCache.MembersToHyperNode.Store(member.Selector.ExactMatch.Name, newHN)
+		}
+		for _, member := range removeMembers {
+			hnc.hyperNodesCache.MembersToHyperNode.Delete(member.Selector.ExactMatch.Name)
+		}
+	case deleteEvent:
+		hn := eventObj.(*topologyv1alpha1.HyperNode)
+		err := hnc.hyperNodesCache.DeleteHyperNode(hn)
+		hnc.handleErr(err, hnc.hyperNodeQueue, eventObj)
+		// 1. Delete the members cache entry of itself as a member
+		hnc.hyperNodesCache.MembersToHyperNode.Delete(hn.Name)
+		// 2. Delete the members cache entries under itself
+		for _, member := range hn.Spec.Members {
+			hnc.hyperNodesCache.MembersToHyperNode.Delete(member.Selector.ExactMatch.Name)
+		}
+	}
+
+	return true
+}
+
+func (hnc *hyperNodeController) getMemberDifferences(oldMembers, newMembers []topologyv1alpha1.MemberSpec) (addMembers []topologyv1alpha1.MemberSpec, removeMembers []topologyv1alpha1.MemberSpec) {
+	oldSet := make(map[string]struct{})
+	newSet := make(map[string]struct{})
+
+	for _, member := range oldMembers {
+		oldSet[member.Selector.ExactMatch.Name] = struct{}{}
+	}
+
+	for _, member := range newMembers {
+		newSet[member.Selector.ExactMatch.Name] = struct{}{}
+	}
+
+	for _, member := range oldMembers {
+		if _, exists := newSet[member.Selector.ExactMatch.Name]; !exists {
+			removeMembers = append(removeMembers, member)
+		}
+	}
+
+	for _, member := range newMembers {
+		if _, exists := oldSet[member.Selector.ExactMatch.Name]; !exists {
+			addMembers = append(addMembers, member)
+		}
+	}
+
+	return removeMembers, addMembers
+}
+
+func (hnc *hyperNodeController) handleErr(err error, queue workqueue.RateLimitingInterface, item interface{}) {
+	if err == nil {
+		queue.Forget(item)
+		return
+	}
+
+	if queue.NumRequeues(item) < maxRetries {
+		klog.Errorf("Error to handle event type: %v, retrying", err)
+		queue.AddRateLimited(item)
+		return
+	}
+
+	klog.Errorf("Retry budget exceeded: %v, dropping event type out of the queue", err)
+	queue.Forget(item)
+	utilruntime.HandleError(err)
+}

--- a/pkg/controllers/hypernode/hypernode_controller_helper.go
+++ b/pkg/controllers/hypernode/hypernode_controller_helper.go
@@ -1,0 +1,325 @@
+/*
+Copyright 2024 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hypernode
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
+	coreinformers "k8s.io/client-go/informers/core/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2"
+	topologyv1alpha1 "volcano.sh/apis/pkg/apis/topology/v1alpha1"
+
+	hncache "volcano.sh/volcano/pkg/controllers/hypernode/cache"
+)
+
+const (
+	hyperNodesLabelKey = "volcano.sh/hypernodes"
+	TypeHyperNode      = "HyperNode"
+	TypeNode           = "Node"
+)
+
+type hyperNodeAction struct {
+	hyperNode *topologyv1alpha1.HyperNode
+	action    action
+	// used in executeHyperNodeActions as a callback func
+	callback func(*topologyv1alpha1.HyperNode)
+}
+
+// action represents the type of request sent to api-server
+type action string
+
+const (
+	updateAction action = "update"
+	createAction action = "create"
+	deleteAction action = "delete"
+)
+
+func (a hyperNodeAction) String() string {
+	return fmt.Sprintf("hypernode: %v, action: %s", a.hyperNode, a.action)
+}
+
+func (hnc *hyperNodeController) executeHyperNodeActions(hyperNodeActions []*hyperNodeAction) error {
+	for _, hna := range hyperNodeActions {
+		switch hna.action {
+		case createAction:
+			createdHN, err := hnc.vcClient.TopologyV1alpha1().HyperNodes().Create(context.TODO(), hna.hyperNode, metav1.CreateOptions{})
+			if err != nil {
+				return fmt.Errorf("failed to create hypernode %s: %v", hna.hyperNode.Name, err)
+			}
+			// Add the created HyperNode to the hyperNodesCache to avoid the situation where the controller has not listed/watched
+			// the hyperNode to the informer cache yet but continues to process the next node, it may lead to the controller misjudges that
+			// the hypernode does not exist but continues to create a new hyperNode.
+			err = hnc.hyperNodesCache.UpdateHyperNode(createdHN)
+			if err != nil {
+				return fmt.Errorf("failed to add hypernode %s to local cache: %v", createdHN.Name, err)
+			}
+			klog.V(3).Infof("Succeeded to create the hypernode %s", createdHN.Name)
+			hna.callback(createdHN)
+		case updateAction:
+			updatedHN, err := hnc.vcClient.TopologyV1alpha1().HyperNodes().Update(context.TODO(), hna.hyperNode, metav1.UpdateOptions{})
+			if err != nil {
+				return fmt.Errorf("failed to update hypernode %s: %v", hna.hyperNode.Name, err)
+			}
+			err = hnc.hyperNodesCache.UpdateHyperNode(updatedHN)
+			if err != nil {
+				return fmt.Errorf("failed to update hypernode %s in local cache: %v", updatedHN.Name, err)
+			}
+			klog.V(3).Infof("Succeeded to update the hypernode %s", updatedHN.Name)
+			hna.callback(updatedHN)
+		case deleteAction:
+			err := hnc.vcClient.TopologyV1alpha1().HyperNodes().Delete(context.TODO(), hna.hyperNode.Name, metav1.DeleteOptions{})
+			if err != nil {
+				return fmt.Errorf("failed to delete hypernode %s: %v", hna.hyperNode.Name, err)
+			}
+			err = hnc.hyperNodesCache.DeleteHyperNode(hna.hyperNode)
+			if err != nil {
+				return fmt.Errorf("failed to update hypernode %s in local cache: %v", hna.hyperNode.Name, err)
+			}
+			klog.V(3).Infof("Succeeded to delete the hypernode %s", hna.hyperNode.Name)
+			hna.callback(hna.hyperNode)
+		}
+	}
+
+	return nil
+}
+
+func newHyperNodeWithEmptyMembers(tier, hyperNodeName string) *topologyv1alpha1.HyperNode {
+	hn := &topologyv1alpha1.HyperNode{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: hyperNodeName,
+		},
+		Spec: topologyv1alpha1.HyperNodeSpec{
+			Tier:    tier,
+			Members: []topologyv1alpha1.MemberSpec{},
+		},
+	}
+	return hn
+}
+
+func newHyperNodeMember(nodeType, memberName string) topologyv1alpha1.MemberSpec {
+	member := topologyv1alpha1.MemberSpec{
+		Type: nodeType,
+		Selector: topologyv1alpha1.MemberSelector{
+			Type: topologyv1alpha1.ExactMatchMemberSelectorType,
+			ExactMatch: &topologyv1alpha1.ExactMatch{
+				Name: memberName,
+			},
+		},
+	}
+	return member
+}
+
+func newNodeInformer(client kubernetes.Interface, rsyncPeriod time.Duration) cache.SharedIndexInformer {
+	require, _ := labels.NewRequirement(hyperNodesLabelKey, selection.Exists, nil)
+	tweakListOptions := func(options *metav1.ListOptions) {
+		options.LabelSelector = require.String()
+	}
+	informer := coreinformers.NewFilteredNodeInformer(
+		client,
+		rsyncPeriod,
+		cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
+		tweakListOptions,
+	)
+	return informer
+}
+
+func (hnc *hyperNodeController) addHyperNodesList(node *v1.Node, hyperNodesList []string) ([]*hyperNodeAction, error) {
+	hnas := make([]*hyperNodeAction, 0)
+
+	for index := 0; index < len(hyperNodesList); index++ {
+		hna, err := hnc.createOrUpdateHyperNode(node, hyperNodesList, index)
+		if err != nil {
+			// if meet error when traverse hyperNodesList, we return empty hyperNodeActionList
+			return []*hyperNodeAction{}, fmt.Errorf("failed to get action for hypernode %s: %v", hyperNodesList[index], err)
+		}
+		if hna != nil {
+			hnas = append(hnas, hna)
+		}
+	}
+
+	return hnas, nil
+}
+
+func (hnc *hyperNodeController) updateHyperNodeList(node *v1.Node, oldHyperNodesList, newHyperNodesList []string) ([]*hyperNodeAction, error) {
+	hnas := make([]*hyperNodeAction, 0)
+
+	// case 1: new hypernodes list label is empty but old is not, we need to delete the member node in the tier-1 hypernode
+	if len(oldHyperNodesList) != 0 && len(newHyperNodesList) == 0 {
+		if obj, exist := hnc.hyperNodesCache.MembersToHyperNode.Load(node.Name); exist {
+			parentHN := obj.(*topologyv1alpha1.HyperNode)
+			newHNAs, err := hnc.removeMemberFromHyperNode(parentHN.Name, node.Name)
+			if err != nil {
+				return []*hyperNodeAction{}, err
+			}
+			hnas = append(hnas, newHNAs...)
+		}
+	}
+
+	// case 2:
+	// oldHyperNodesList: [s0,s4,s6], newHyperNodesList: [s1,s4,s6]
+	// The tier-1 hypernode to which the node belongs has changed. s0 needs to delete the node, and s1 needs to add the node as member.
+	// Currently, we don't support change the tier>1 hypernode, such as from [s0,s4,s6] to [s0,s5,s6], so judge index 0 is enough.
+	if len(oldHyperNodesList) != 0 && len(newHyperNodesList) != 0 && oldHyperNodesList[0] != newHyperNodesList[0] {
+		newHNAs, err := hnc.removeMemberFromHyperNode(oldHyperNodesList[0], node.Name)
+		if err != nil {
+			return []*hyperNodeAction{}, err
+		}
+		hnas = append(hnas, newHNAs...)
+
+		hna, err := hnc.createOrUpdateHyperNode(node, newHyperNodesList, 0)
+		if err != nil {
+			return []*hyperNodeAction{}, err
+		}
+		if hna != nil {
+			hnas = append(hnas, hna)
+		}
+	}
+
+	return hnas, nil
+}
+
+func (hnc *hyperNodeController) createOrUpdateHyperNode(node *v1.Node, hyperNodesList []string, index int) (*hyperNodeAction, error) {
+	var hna *hyperNodeAction
+
+	hn, err := hnc.hyperNodesCache.GetHyperNode(hyperNodesList[index])
+	if err != nil {
+		if !errors.Is(err, hncache.NotFoundError) {
+			klog.Errorf("met error when get hypernode %s from local cache", hyperNodesList[index])
+			return nil, err
+		}
+		// create a new hyper node with empty members
+		tier := strconv.Itoa(index + 1)
+		hn = newHyperNodeWithEmptyMembers(tier, hyperNodesList[index])
+		hna = &hyperNodeAction{
+			hyperNode: hn,
+			action:    createAction,
+		}
+	} else {
+		hna = &hyperNodeAction{
+			hyperNode: hn,
+			action:    updateAction,
+		}
+	}
+
+	member := hnc.createMember(node, hyperNodesList, index)
+	if member == nil {
+		// no new members need to be added
+		return nil, nil
+	}
+	hna.hyperNode.Spec.Members = append(hna.hyperNode.Spec.Members, *member)
+	hna.callback = func(hn *topologyv1alpha1.HyperNode) {
+		hnc.hyperNodesCache.MembersToHyperNode.Store(member.Selector.ExactMatch.Name, hn)
+	}
+
+	return hna, nil
+}
+
+func (hnc *hyperNodeController) createMember(node *v1.Node, hyperNodesList []string, index int) *topologyv1alpha1.MemberSpec {
+	var member topologyv1alpha1.MemberSpec
+	if index == 0 {
+		member = newHyperNodeMember(TypeNode, node.Name)
+	} else {
+		member = newHyperNodeMember(TypeHyperNode, hyperNodesList[index-1])
+	}
+
+	if cachedObj, exists := hnc.hyperNodesCache.MembersToHyperNode.Load(member.Selector.ExactMatch.Name); exists {
+		cachedHN := cachedObj.(*topologyv1alpha1.HyperNode)
+		// The current member already exists, check whether the parent hypernode is the same
+		if cachedHN.Name == hyperNodesList[index] {
+			klog.V(4).Infof("member %s already exists under the hypernode %s, skipping", member.Selector.ExactMatch.Name, cachedHN.Name)
+			return nil
+		}
+		// The parent hypernode is inconsistent and need to update
+		klog.V(4).Infof("member %s exists but belongs to a different hypernode %s, updating parent", member.Selector.ExactMatch.Name, cachedHN.Name)
+	}
+
+	return &member
+}
+
+func (hnc *hyperNodeController) removeMemberFromHyperNode(hyperNodeName, memberName string) ([]*hyperNodeAction, error) {
+	hn, err := hnc.hyperNodesCache.GetHyperNode(hyperNodeName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get hypernode %s from local cache: %v", hyperNodeName, err)
+	}
+
+	memberIndex := -1
+	for index, member := range hn.Spec.Members {
+		if member.Selector.ExactMatch.Name == memberName {
+			memberIndex = index
+			break
+		}
+	}
+
+	if memberIndex == -1 {
+		return nil, fmt.Errorf("did not find the member %s in hypernode %s", memberName, hyperNodeName)
+	}
+
+	// If the member to be deleted is the only member of this hypernode, then we just directly delete the hypernode.
+	// Correspondingly, if this hypernode is a child hypernode of the other hypernode, then we should also remove the member of its parent hypernode.
+	// e.g., there are two nodes node-0 and node-1 under hypernode s0. And then the hypernode which they belong to is changed to s1.
+	// Then s0 needs to be deleted, and s0 needs to be removed from the member list of s4 ( s0 is the child of s4).
+	if len(hn.Spec.Members) == 1 {
+		return hnc.recursivelyDeleteHyperNode(hn)
+	}
+
+	hn.Spec.Members = append(hn.Spec.Members[:memberIndex], hn.Spec.Members[memberIndex+1:]...)
+	klog.V(3).Infof("Removed member %s from hypernode %s", memberName, hyperNodeName)
+	hna := &hyperNodeAction{
+		hyperNode: hn,
+		action:    updateAction,
+		callback: func(hn *topologyv1alpha1.HyperNode) {
+			hnc.hyperNodesCache.MembersToHyperNode.Delete(memberName)
+		},
+	}
+	return []*hyperNodeAction{hna}, nil
+}
+
+func (hnc *hyperNodeController) recursivelyDeleteHyperNode(hn *topologyv1alpha1.HyperNode) ([]*hyperNodeAction, error) {
+	hnas := []*hyperNodeAction{
+		{
+			hyperNode: hn,
+			action:    deleteAction,
+			callback: func(hn *topologyv1alpha1.HyperNode) {
+				for _, member := range hn.Spec.Members {
+					hnc.hyperNodesCache.MembersToHyperNode.Delete(member.Selector.ExactMatch.Name)
+				}
+			},
+		},
+	}
+
+	// If the hypernode belongs to another hypernode, recursively delete the members of the parent hypernode
+	if obj, exist := hnc.hyperNodesCache.MembersToHyperNode.Load(hn.Name); exist {
+		parentHN := obj.(*topologyv1alpha1.HyperNode)
+		recurHNAs, err := hnc.removeMemberFromHyperNode(parentHN.Name, hn.Name)
+		if err != nil {
+			return hnas, err
+		}
+		hnas = append(hnas, recurHNAs...)
+	}
+
+	return hnas, nil
+}

--- a/pkg/controllers/hypernode/hypernode_controller_helper_test.go
+++ b/pkg/controllers/hypernode/hypernode_controller_helper_test.go
@@ -1,0 +1,422 @@
+package hypernode
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/informers"
+	kubeclient "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/cache"
+	topologyv1alpha1 "volcano.sh/apis/pkg/apis/topology/v1alpha1"
+	volcanoclient "volcano.sh/apis/pkg/client/clientset/versioned/fake"
+	vcinformer "volcano.sh/apis/pkg/client/informers/externalversions"
+	"volcano.sh/volcano/pkg/controllers/framework"
+
+	hncache "volcano.sh/volcano/pkg/controllers/hypernode/cache"
+)
+
+func newFakeHyperNodeController() *hyperNodeController {
+	vcClient := volcanoclient.NewSimpleClientset()
+	vcSharedInformers := vcinformer.NewSharedInformerFactory(vcClient, 0)
+	kubeClient := kubeclient.NewClientset()
+	kubeSharedInformers := informers.NewSharedInformerFactory(kubeClient, 0)
+
+	hnc := &hyperNodeController{}
+
+	opt := &framework.ControllerOption{
+		KubeClient:              kubeClient,
+		VolcanoClient:           vcClient,
+		SharedInformerFactory:   kubeSharedInformers,
+		VCSharedInformerFactory: vcSharedInformers,
+	}
+
+	hnc.Initialize(opt)
+
+	return hnc
+}
+
+type member struct {
+	name     string
+	nodeType string
+}
+
+func newFakeNode(name, hyperNodeList string) *v1.Node {
+	return &v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+			Labels: map[string]string{
+				hyperNodesLabelKey: hyperNodeList,
+			},
+		}}
+}
+
+func newFakeHyperNode(tier, hyperNodeName, resourceVersion string, memberList []member) *topologyv1alpha1.HyperNode {
+	hn := newHyperNodeWithEmptyMembers(tier, hyperNodeName)
+	for _, m := range memberList {
+		memberSpec := newHyperNodeMember(m.nodeType, m.name)
+		hn.Spec.Members = append(hn.Spec.Members, memberSpec)
+	}
+	hn.ResourceVersion = resourceVersion
+	return hn
+}
+
+func compareHyperNodeActions(actionsI []*hyperNodeAction, actionsJ []*hyperNodeAction) bool {
+	if len(actionsI) != len(actionsJ) {
+		return false
+	}
+
+	for index := range actionsI {
+		if !equality.Semantic.DeepEqual(actionsI[index].hyperNode, actionsJ[index].hyperNode) ||
+			actionsI[index].action != actionsJ[index].action {
+			return false
+		}
+	}
+
+	return true
+}
+
+func CloneHyperNodesCache(originalCache *hncache.HyperNodesCache) (*hncache.HyperNodesCache, error) {
+	newCache := hncache.NewHyperNodesCache(cache.NewIndexer(cache.MetaNamespaceKeyFunc,
+		cache.Indexers{
+			cache.NamespaceIndex: cache.MetaNamespaceIndexFunc,
+		}))
+
+	for _, obj := range originalCache.HyperNodes.List() {
+		hn, _ := obj.(*topologyv1alpha1.HyperNode)
+		copiedHN := hn.DeepCopy()
+		err := newCache.UpdateHyperNode(copiedHN)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	originalCache.MembersToHyperNode.Range(func(key, value interface{}) bool {
+		hn, _ := value.(*topologyv1alpha1.HyperNode)
+		copiedHN := hn.DeepCopy()
+		newCache.MembersToHyperNode.Store(key, copiedHN)
+		return true
+	})
+
+	return newCache, nil
+}
+
+// TestHyperNodesList tests according to the following tree structure
+//	          s6
+//	       /       \
+//	     s4          s5
+//	   /   \       /    \
+//	 s0     s1    s2     s3
+//	/  \   /  \  /  \   /  \
+// n0  n1 n2  n3 n4 n5 n6  n7
+
+func TestHyperNodesList(t *testing.T) {
+	hnc := newFakeHyperNodeController()
+
+	// create hypernodes tree according to the node's label
+	addTestCases := []struct {
+		name          string
+		node          *v1.Node
+		hyperNodeList []string
+		expectActions []*hyperNodeAction
+	}{
+		{
+			name:          "add n0",
+			node:          newFakeNode("n0", "s0,s4,s6"),
+			hyperNodeList: []string{"s0", "s4", "s6"},
+			expectActions: []*hyperNodeAction{
+				{
+					hyperNode: newFakeHyperNode("1", "s0", "", []member{{name: "n0", nodeType: TypeNode}}),
+					action:    createAction,
+				},
+				{
+					hyperNode: newFakeHyperNode("2", "s4", "", []member{{name: "s0", nodeType: TypeHyperNode}}),
+					action:    createAction,
+				},
+				{
+					hyperNode: newFakeHyperNode("3", "s6", "", []member{{name: "s4", nodeType: TypeHyperNode}}),
+					action:    createAction,
+				},
+			},
+		},
+		{
+			name:          "add n1",
+			node:          newFakeNode("n1", "s0,s4,s6"),
+			hyperNodeList: []string{"s0", "s4", "s6"},
+			expectActions: []*hyperNodeAction{
+				{
+					hyperNode: newFakeHyperNode("1", "s0", "1", []member{
+						{name: "n0", nodeType: TypeNode},
+						{name: "n1", nodeType: TypeNode},
+					}),
+					action: updateAction,
+				},
+			},
+		},
+		{
+			name:          "add n2",
+			node:          newFakeNode("n2", "s1,s4,s6"),
+			hyperNodeList: []string{"s1", "s4", "s6"},
+			expectActions: []*hyperNodeAction{
+				{
+					hyperNode: newFakeHyperNode("1", "s1", "", []member{{name: "n2", nodeType: TypeNode}}),
+					action:    createAction,
+				},
+				{
+					hyperNode: newFakeHyperNode("2", "s4", "1", []member{
+						{name: "s0", nodeType: TypeHyperNode},
+						{name: "s1", nodeType: TypeHyperNode},
+					}),
+					action: updateAction,
+				},
+			},
+		},
+		{
+			name:          "add n3",
+			node:          newFakeNode("n3", "s1,s4,s6"),
+			hyperNodeList: []string{"s1", "s4", "s6"},
+			expectActions: []*hyperNodeAction{
+				{
+					hyperNode: newFakeHyperNode("1", "s1", "1", []member{
+						{name: "n2", nodeType: TypeNode},
+						{name: "n3", nodeType: TypeNode},
+					}),
+					action: updateAction,
+				},
+			},
+		},
+		{
+			name:          "add n4",
+			node:          newFakeNode("n4", "s2,s5,s6"),
+			hyperNodeList: []string{"s2", "s5", "s6"},
+			expectActions: []*hyperNodeAction{
+				{
+					hyperNode: newFakeHyperNode("1", "s2", "", []member{{name: "n4", nodeType: TypeNode}}),
+					action:    createAction,
+				},
+				{
+					hyperNode: newFakeHyperNode("2", "s5", "", []member{{name: "s2", nodeType: TypeHyperNode}}),
+					action:    createAction,
+				},
+				{
+					hyperNode: newFakeHyperNode("3", "s6", "1", []member{
+						{name: "s4", nodeType: TypeHyperNode},
+						{name: "s5", nodeType: TypeHyperNode},
+					}),
+					action: updateAction,
+				},
+			},
+		},
+		{
+			name:          "add n5",
+			node:          newFakeNode("n5", "s2,s5,s6"),
+			hyperNodeList: []string{"s2", "s5", "s6"},
+			expectActions: []*hyperNodeAction{
+				{
+					hyperNode: newFakeHyperNode("1", "s2", "1", []member{
+						{name: "n4", nodeType: TypeNode},
+						{name: "n5", nodeType: TypeNode},
+					}),
+					action: updateAction,
+				},
+			},
+		},
+		{
+			name:          "add n6",
+			node:          newFakeNode("n6", "s3,s5,s6"),
+			hyperNodeList: []string{"s3", "s5", "s6"},
+			expectActions: []*hyperNodeAction{
+				{
+					hyperNode: newFakeHyperNode("1", "s3", "", []member{{name: "n6", nodeType: TypeNode}}),
+					action:    createAction,
+				},
+				{
+					hyperNode: newFakeHyperNode("2", "s5", "1", []member{
+						{name: "s2", nodeType: TypeHyperNode},
+						{name: "s3", nodeType: TypeHyperNode},
+					}),
+					action: updateAction,
+				},
+			},
+		},
+		{
+			name:          "add n7",
+			node:          newFakeNode("n7", "s3,s5,s6"),
+			hyperNodeList: []string{"s3", "s5", "s6"},
+			expectActions: []*hyperNodeAction{
+				{
+					hyperNode: newFakeHyperNode("1", "s3", "1", []member{
+						{name: "n6", nodeType: TypeNode},
+						{name: "n7", nodeType: TypeNode},
+					}),
+					action: updateAction,
+				},
+			},
+		},
+	}
+
+	for _, tc := range addTestCases {
+		actions, err := hnc.addHyperNodesList(tc.node, tc.hyperNodeList)
+		assert.NoError(t, err)
+		if !compareHyperNodeActions(actions, tc.expectActions) {
+			t.Errorf("test case %s: hypernode actions list are not equal, got %v, expect %v", tc.name, actions, tc.expectActions)
+		}
+
+		// update local hyperNodesCache
+		for index := range actions {
+			copiedHN := actions[index].hyperNode.DeepCopy()
+			if len(copiedHN.ResourceVersion) == 0 {
+				// init resource version if resource version is empty
+				copiedHN.ResourceVersion = "1"
+			} else {
+				currentRV, err := strconv.Atoi(copiedHN.ResourceVersion)
+				assert.NoError(t, err)
+				copiedHN.ResourceVersion = strconv.Itoa(currentRV + 1)
+			}
+			err = hnc.hyperNodesCache.UpdateHyperNode(copiedHN)
+			assert.NoError(t, err)
+			for _, m := range actions[index].hyperNode.Spec.Members {
+				hnc.hyperNodesCache.MembersToHyperNode.Store(m.Selector.ExactMatch.Name, actions[index].hyperNode)
+			}
+		}
+	}
+
+	type updateNode struct {
+		node             *v1.Node
+		oldHyperNodeList []string
+		newHyperNodeList []string
+	}
+
+	// update node's label
+	updateTestCases := []struct {
+		name           string
+		updateNodeList []*updateNode
+		expectActions  []*hyperNodeAction
+	}{
+		{
+			name: "node0: s0,s4,s6 -> s1,s4,s6",
+			updateNodeList: []*updateNode{
+				{
+					node:             newFakeNode("n0", "s1,s4,s6"),
+					oldHyperNodeList: []string{"s0", "s4", "s6"},
+					newHyperNodeList: []string{"s1", "s4", "s6"},
+				},
+			},
+			expectActions: []*hyperNodeAction{
+				{
+					hyperNode: newFakeHyperNode("1", "s0", "2", []member{
+						{name: "n1", nodeType: TypeNode},
+					}),
+					action: updateAction,
+				},
+				{
+					hyperNode: newFakeHyperNode("1", "s1", "2", []member{
+						{name: "n2", nodeType: TypeNode},
+						{name: "n3", nodeType: TypeNode},
+						{name: "n0", nodeType: TypeNode},
+					}),
+					action: updateAction,
+				},
+			},
+		},
+		{
+			name: "node0,node1: s0,s4,s6 -> s1,s4,s6, remove hypernode s0",
+			updateNodeList: []*updateNode{
+				{
+					node:             newFakeNode("n0", "s1,s4,s6"),
+					oldHyperNodeList: []string{"s0", "s4", "s6"},
+					newHyperNodeList: []string{"s1", "s4", "s6"},
+				},
+				{
+					node:             newFakeNode("n1", "s1,s4,s6"),
+					oldHyperNodeList: []string{"s0", "s4", "s6"},
+					newHyperNodeList: []string{"s1", "s4", "s6"},
+				},
+			},
+			expectActions: []*hyperNodeAction{
+				{
+					hyperNode: newFakeHyperNode("1", "s0", "2", []member{
+						{name: "n1", nodeType: TypeNode},
+					}),
+					action: updateAction,
+				},
+				{
+					hyperNode: newFakeHyperNode("1", "s1", "2", []member{
+						{name: "n2", nodeType: TypeNode},
+						{name: "n3", nodeType: TypeNode},
+						{name: "n0", nodeType: TypeNode},
+					}),
+					action: updateAction,
+				},
+				{
+					hyperNode: newFakeHyperNode("1", "s0", "3", []member{
+						{name: "n1", nodeType: TypeNode},
+					}),
+					action: deleteAction,
+				},
+				{
+					hyperNode: newFakeHyperNode("2", "s4", "2", []member{
+						{name: "s1", nodeType: TypeHyperNode},
+					}),
+					action: updateAction,
+				},
+				{
+					hyperNode: newFakeHyperNode("1", "s1", "3", []member{
+						{name: "n2", nodeType: TypeNode},
+						{name: "n3", nodeType: TypeNode},
+						{name: "n0", nodeType: TypeNode},
+						{name: "n1", nodeType: TypeNode},
+					}),
+					action: updateAction,
+				},
+			},
+		},
+	}
+
+	originalHNTree, err := CloneHyperNodesCache(hnc.hyperNodesCache)
+	assert.NoError(t, err)
+
+	for _, tc := range updateTestCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// we use the same hypernodes cache updated every time
+			clonedCache, err := CloneHyperNodesCache(originalHNTree)
+			assert.NoError(t, err)
+			hnc.hyperNodesCache = clonedCache
+
+			actions := make([]*hyperNodeAction, 0)
+			for _, update := range tc.updateNodeList {
+				newActions, err := hnc.updateHyperNodeList(update.node, update.oldHyperNodeList, update.newHyperNodeList)
+				assert.NoError(t, err)
+				actions = append(actions, newActions...)
+				// update local hyperNodesCache
+				for index := range actions {
+					copiedHN := actions[index].hyperNode.DeepCopy()
+					currentRV, err := strconv.Atoi(copiedHN.ResourceVersion)
+					assert.NoError(t, err)
+
+					copiedHN.ResourceVersion = strconv.Itoa(currentRV + 1)
+					err = hnc.hyperNodesCache.UpdateHyperNode(copiedHN)
+					assert.NoError(t, err)
+
+					for _, m := range actions[index].hyperNode.Spec.Members {
+						if cachedObj, exists := hnc.hyperNodesCache.MembersToHyperNode.Load(m.Selector.ExactMatch.Name); exists {
+							cachedHN := cachedObj.(*topologyv1alpha1.HyperNode)
+							// The current member already exists, check whether the parent hypernode is the same
+							if cachedHN.Name == actions[index].hyperNode.Name {
+								continue
+							}
+							hnc.hyperNodesCache.MembersToHyperNode.Store(m.Selector.ExactMatch.Name, actions[index].hyperNode)
+						}
+					}
+				}
+			}
+
+			if !compareHyperNodeActions(actions, tc.expectActions) {
+				t.Errorf("test case %s: hypernode actions list are not equal, got %v, expect %v", tc.name, actions, tc.expectActions)
+			}
+		})
+	}
+}


### PR DESCRIPTION
feature: #3888

The hypernode controller will list/watch node(only node with label `volcano.sh/hypernodes` will be list/watched) and hypernode, the format of label `volcano.sh/hypernode` is "hypernode-0,hypernode-1,...,hypernode-0`, use commas to separate the hypernodes of different layers that the node is connected to, from near to far, the front hypernode means the closer to the node.

Take this picture as an example:
![image](https://github.com/user-attachments/assets/888e0c7f-b6dc-4ecd-9467-d26c78195244)
### Create Hypernodes Tree
1. The node-0 has the label `volcano.sh/hypernodes:"s0,s4,s6"`, then hypernode controller judge there is no s0,s4,s6 hypernodes created, it will create them sequentially( use hyperNodeAction)
2. The node-1 then has the same label, the hypernode s0 will add the member node-1, there are no operations with s4 and s6.
3. same as the previous...

### Update Hypernode Tree
Currently, we only allow node label to change tier 1 hypernode, e.g., node-0's label can only from "s0,s4,s6" to "s1,s4,s6", that is, only allowed to change the node's parent hypernode, we don't allow to change the hypernode tier>1, like from "s0,s4,s6" to "s0,s5,s6". And we don't allow to add more hypernode or delete some hypernodes, like "s0,s4,s6" to "s0,s4" or from "s0,s4,s6" to "s0,s4,s6,s7", it may cause some strange hypernode tree structure, and then causing strange scheduling. 

--- 
Now, I only designed the hypernode controller to have one goroutine to handle the node's events. If there are multiple goroutines processing events at the same time, it may cause multiple create requests of the same hypernode to be issued at the same time. Even if there is only one goroutine processing events, when the hypernode create/update requests is already sent to the api-server, the controller may still not have list/watch add/update/delete hypernode events to the hypernode controller yet, so I added hyperNodesCache. After the hypernode create/update/delete request is sent, the local cache will be updated.After hypernode create/update/delete events arriving, the controller will overwride the hypernode in cache.
