### PR TITLE
fix: configmgr need wait for all processed avoid tests data race

### DIFF
--- a/pkg/agent/config/source/fake_source.go
+++ b/pkg/agent/config/source/fake_source.go
@@ -46,7 +46,7 @@ func (f *fakeSource) GetLatestConfig() (cfg *api.ColocationConfig, err error) {
 func (f *fakeSource) Stop() {
 	for {
 		if f.queue.Len() == 0 {
-			f.queue.ShutDown()
+			f.queue.ShutDownWithDrain()
 			return
 		}
 		time.Sleep(1 * time.Second)


### PR DESCRIPTION
configmgr `Start` test need ensure all queue source be processed then do `assert` action. avoid call `l.called` when it write at `SyncConfig`.

@lowang-bh  
/close #3884 