### PR TITLE
pod-update-performance

### DIFF
--- a/pkg/scheduler/api/pod_info.go
+++ b/pkg/scheduler/api/pod_info.go
@@ -172,3 +172,9 @@ func GetPodResourceWithoutInitContainers(pod *v1.Pod) *Resource {
 
 	return result
 }
+
+type PodStatusRateLimit struct {
+	Enable         bool
+	MinPodNum      int
+	MinIntervalSec int
+}

--- a/pkg/scheduler/cache/event_handlers.go
+++ b/pkg/scheduler/cache/event_handlers.go
@@ -22,6 +22,7 @@ import (
 	"math"
 	"slices"
 	"strconv"
+	"sync/atomic"
 
 	v1 "k8s.io/api/core/v1"
 	schedulingv1 "k8s.io/api/scheduling/v1"
@@ -382,6 +383,7 @@ func (sc *SchedulerCache) AddPod(obj interface{}) {
 	sc.Mutex.Lock()
 	defer sc.Mutex.Unlock()
 
+	atomic.AddInt32(&sc.PodNum, 1)
 	err := sc.addPod(pod)
 	if err != nil {
 		klog.Errorf("Failed to add pod <%s/%s> into cache: %v",
@@ -437,6 +439,7 @@ func (sc *SchedulerCache) DeletePod(obj interface{}) {
 	sc.Mutex.Lock()
 	defer sc.Mutex.Unlock()
 
+	atomic.AddInt32(&sc.PodNum, -1)
 	err := sc.deletePod(pod)
 	if err != nil {
 		klog.Errorf("Failed to delete pod %v from cache: %v", pod.Name, err)

--- a/pkg/scheduler/cache/interface.go
+++ b/pkg/scheduler/cache/interface.go
@@ -52,10 +52,10 @@ type Cache interface {
 
 	// RecordJobStatusEvent records related events according to job status.
 	// Deprecated: remove it after removed PDB support.
-	RecordJobStatusEvent(job *api.JobInfo, updatePG bool)
+	RecordJobStatusEvent(job *api.JobInfo, updatePG bool, podStatusRateLimit *api.PodStatusRateLimit)
 
 	// UpdateJobStatus puts job in backlog for a while.
-	UpdateJobStatus(job *api.JobInfo, updatePG bool) (*api.JobInfo, error)
+	UpdateJobStatus(job *api.JobInfo, updatePG bool, podStatusRateLimit *api.PodStatusRateLimit) (*api.JobInfo, error)
 
 	// UpdateQueueStatus update queue status.
 	UpdateQueueStatus(queue *api.QueueInfo) error

--- a/pkg/scheduler/framework/framework.go
+++ b/pkg/scheduler/framework/framework.go
@@ -33,7 +33,7 @@ func OpenSession(cache cache.Cache, tiers []conf.Tier, configurations []conf.Con
 	ssn.Configurations = configurations
 	ssn.NodeMap = GenerateNodeMapAndSlice(ssn.Nodes)
 	ssn.PodLister = NewPodLister(ssn)
-
+	ssn.parsePodStatusRateLimitArguments()
 	for _, tier := range tiers {
 		for _, plugin := range tier.Plugins {
 			if pb, found := GetPluginBuilder(plugin.Name); !found {

--- a/pkg/scheduler/framework/job_updater.go
+++ b/pkg/scheduler/framework/job_updater.go
@@ -95,7 +95,7 @@ func (ju *jobUpdater) updateJob(index int) {
 	job.PodGroup.Status = jobStatus(ssn, job)
 	oldStatus, found := ssn.podGroupStatus[job.UID]
 	updatePG := !found || isPodGroupStatusUpdated(job.PodGroup.Status, oldStatus)
-	if _, err := ssn.cache.UpdateJobStatus(job, updatePG); err != nil {
+	if _, err := ssn.cache.UpdateJobStatus(job, updatePG, ssn.podStatusRateLimit); err != nil {
 		klog.Errorf("Failed to update job <%s/%s>: %v",
 			job.Namespace, job.Name, err)
 	}

--- a/pkg/scheduler/util/session_helper.go
+++ b/pkg/scheduler/util/session_helper.go
@@ -1,0 +1,42 @@
+package util
+
+import (
+	"sync"
+
+	"volcano.sh/volcano/pkg/scheduler/api"
+)
+
+type StatusLastSetCache struct {
+	Cache map[api.JobID]map[api.TaskID]int64
+	sync.RWMutex
+}
+
+var (
+	podStatusLastSetCache = StatusLastSetCache{Cache: map[api.JobID]map[api.TaskID]int64{}}
+)
+
+func SetPodStatusLastSetCache(jobID api.JobID, taskID api.TaskID, ts int64) {
+	podStatusLastSetCache.Lock()
+	defer podStatusLastSetCache.Unlock()
+	if _, ok := podStatusLastSetCache.Cache[jobID]; !ok {
+		podStatusLastSetCache.Cache[jobID] = map[api.TaskID]int64{}
+	}
+	podStatusLastSetCache.Cache[jobID][taskID] = ts
+}
+
+func GetPodStatusLastSetCache(jobID api.JobID, taskID api.TaskID) (ts int64, exist bool) {
+	podStatusLastSetCache.RLock()
+	defer podStatusLastSetCache.RUnlock()
+	ts, exist = podStatusLastSetCache.Cache[jobID][taskID]
+	return
+}
+
+func CleanUnusedPodStatusLastSetCache(jobs map[api.JobID]*api.JobInfo) {
+	podStatusLastSetCache.Lock()
+	defer podStatusLastSetCache.Unlock()
+	for jobID := range podStatusLastSetCache.Cache {
+		if _, ok := jobs[jobID]; !ok {
+			delete(podStatusLastSetCache.Cache, jobID)
+		}
+	}
+}


### PR DESCRIPTION
If there are thousands of pending pods in cluster, pod status update may become performance bottleneck of the whole system. I add PodStatusRateLimit config including minIntervalSec, minPodNum, enable. When the pod num of cluster is greater than minPodNum(default 10000), the times of pod status update will be limited by minIntervalSec(default 60s). If the pod unscheduleable status is updated minIntervalSec ago, we will ignore status update this time until after minIntervalSec.