### PR TITLE
fix: if the capability cpu or memory is not specified in the hierarchical queue, it will be set to the corresponding value of the parent queue

### DIFF
--- a/pkg/scheduler/api/test_utils.go
+++ b/pkg/scheduler/api/test_utils.go
@@ -94,10 +94,16 @@ type ScalarResource struct {
 
 // BuildResourceList builds resource list object
 func BuildResourceList(cpu string, memory string, scalarResources ...ScalarResource) v1.ResourceList {
-	resourceList := v1.ResourceList{
-		v1.ResourceCPU:    resource.MustParse(cpu),
-		v1.ResourceMemory: resource.MustParse(memory),
+	resourceList := v1.ResourceList{}
+
+	if len(cpu) > 0 {
+		resourceList[v1.ResourceCPU] = resource.MustParse(cpu)
 	}
+
+	if len(memory) > 0 {
+		resourceList[v1.ResourceMemory] = resource.MustParse(memory)
+	}
+
 	for _, scalar := range scalarResources {
 		resourceList[v1.ResourceName(scalar.Name)] = resource.MustParse(scalar.Value)
 	}
@@ -107,13 +113,9 @@ func BuildResourceList(cpu string, memory string, scalarResources ...ScalarResou
 
 // BuildResourceListWithGPU builds resource list with GPU
 func BuildResourceListWithGPU(cpu string, memory string, GPU string, scalarResources ...ScalarResource) v1.ResourceList {
-	resourceList := v1.ResourceList{
-		v1.ResourceCPU:    resource.MustParse(cpu),
-		v1.ResourceMemory: resource.MustParse(memory),
-		GPUResourceName:   resource.MustParse(GPU),
-	}
-	for _, scalar := range scalarResources {
-		resourceList[v1.ResourceName(scalar.Name)] = resource.MustParse(scalar.Value)
+	resourceList := BuildResourceList(cpu, memory, scalarResources...)
+	if len(GPU) > 0 {
+		resourceList[GPUResourceName] = resource.MustParse(GPU)
 	}
 
 	return resourceList

--- a/pkg/scheduler/plugins/capacity/capacity_test.go
+++ b/pkg/scheduler/plugins/capacity/capacity_test.go
@@ -353,7 +353,7 @@ func Test_capacityPlugin_OnSessionOpenWithHierarchy(t *testing.T) {
 	// podgroup
 	pg1 := util.BuildPodGroup("pg1", "ns1", "q11", 1, nil, schedulingv1beta1.PodGroupInqueue)
 	// queue
-	root := buildQueueWithParents("root", "", api.BuildResourceList("8", "8Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), api.BuildResourceList("8", "8Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...))
+	root := buildQueueWithParents("root", "", nil, nil)
 	queue1 := buildQueueWithParents("q1", "root", nil, api.BuildResourceList("4", "4Gi"))
 	queue2 := buildQueueWithParents("q2", "root", nil, api.BuildResourceList("4", "4Gi"))
 	queue11 := buildQueueWithParents("q11", "q1", nil, api.BuildResourceList("1", "1Gi"))
@@ -393,6 +393,15 @@ func Test_capacityPlugin_OnSessionOpenWithHierarchy(t *testing.T) {
 	pg6 := util.BuildPodGroup("pg6", "ns1", "q32", 1, nil, schedulingv1beta1.PodGroupInqueue)
 	pg7 := util.BuildPodGroup("pg7", "ns1", "q32", 1, nil, schedulingv1beta1.PodGroupRunning)
 	pg8 := util.BuildPodGroup("pg8", "ns1", "q33", 1, nil, schedulingv1beta1.PodGroupInqueue)
+
+	// resources for test case 5
+	// queue
+	queue5 := buildQueueWithParents("q5", "root", nil, api.BuildResourceList("", "4Gi", []api.ScalarResource{}...))
+	queue51 := buildQueueWithParents("q51", "q5", nil, api.BuildResourceList("", "2Gi", []api.ScalarResource{}...))
+	// podgroup
+	pg9 := util.BuildPodGroup("pg9", "ns1", "q51", 1, nil, schedulingv1beta1.PodGroupRunning)
+	// pod
+	p11 := util.BuildPod("ns1", "p11", "", corev1.PodPending, api.BuildResourceList("1", ""), "pg9", make(map[string]string), map[string]string{})
 
 	tests := []uthelper.TestCommonStruct{
 		{
@@ -452,6 +461,18 @@ func Test_capacityPlugin_OnSessionOpenWithHierarchy(t *testing.T) {
 			Queues:         []*schedulingv1beta1.Queue{root, queue3, queue31, queue32, queue33},
 			ExpectBindMap:  map[string]string{},
 			ExpectBindsNum: 0,
+		},
+		{
+			Name:      "case5: If the capability cpu or memory is not specified, the value should be inherited from parent queue",
+			Plugins:   plugins,
+			Pods:      []*corev1.Pod{p11},
+			Nodes:     []*corev1.Node{n1},
+			PodGroups: []*schedulingv1beta1.PodGroup{pg9},
+			Queues:    []*schedulingv1beta1.Queue{root, queue5, queue51},
+			ExpectBindMap: map[string]string{
+				"ns1/p11": "n1",
+			},
+			ExpectBindsNum: 1,
 		},
 	}
 


### PR DESCRIPTION
fix #3914 

### validation
1. Set the log level of volcano-scheduler to 4
2. Create a parent-queue, with capability CPU 100, memory 10Gi
3. Create a child-queue, with capability memory 5Gi
4. Check if there are any logs related with `Failed to check queue's hierarchical structure`

Results:
Hierarchical structure can be successfully checked in capacity plugin, without `Failed to check queue's hierarchical structure` log:
![image](https://github.com/user-attachments/assets/93dbe0cc-d337-4e89-b3d2-7343cd8ef5d4)
