### PR TITLE
export logs via workflow

### DIFF
--- a/.github/workflows/e2e_parallel_jobs.yaml
+++ b/.github/workflows/e2e_parallel_jobs.yaml
@@ -39,3 +39,19 @@ jobs:
       - name: Run E2E Tests
         run: |
           make e2e-test-jobp CC=/usr/local/musl/bin/musl-gcc
+
+      - name: export logs for e2e parallel jobs
+        if: failure()
+        run: |
+          export ARTIFACTS_PATH=${{ github.workspace }}/e2e-parallel-jobs-logs
+          mkdir -p $ARTIFACTS_PATH
+          
+          kdir -p $ARTIFACTS_PATH/integration
+          kind export logs --name=integration $ARTIFACTS_PATH/integration
+
+      - name: upload e2e parallel jobs logs
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: volcano_e2e_parallel_jobs_logs
+          path: ${{ github.workspace }}/e2e-parallel-jobs-logs

--- a/.github/workflows/e2e_scheduling_actions.yaml
+++ b/.github/workflows/e2e_scheduling_actions.yaml
@@ -39,3 +39,19 @@ jobs:
       - name: Run E2E Tests
         run: |
           make e2e-test-schedulingaction CC=/usr/local/musl/bin/musl-gcc
+
+      - name: export logs for e2e scheduling actions
+        if: failure()
+        run: |
+          export ARTIFACTS_PATH=${{ github.workspace }}/e2e-scheduling-actions-logs
+          mkdir -p $ARTIFACTS_PATH
+          
+          kdir -p $ARTIFACTS_PATH/integration
+          kind export logs --name=integration $ARTIFACTS_PATH/integration
+
+      - name: upload e2e scheduling actions logs
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: volcano_e2e_scheduling_actions_logs
+          path: ${{ github.workspace }}/e2e-scheduling-actions-logs

--- a/.github/workflows/e2e_scheduling_basic.yaml
+++ b/.github/workflows/e2e_scheduling_basic.yaml
@@ -39,3 +39,19 @@ jobs:
       - name: Run E2E Tests
         run: |
           make e2e-test-schedulingbase CC=/usr/local/musl/bin/musl-gcc
+
+      - name: export logs for e2e scheduling basic
+        if: failure()
+        run: |
+          export ARTIFACTS_PATH=${{ github.workspace }}/e2e-scheduling-basic-logs
+          mkdir -p $ARTIFACTS_PATH
+          
+          kdir -p $ARTIFACTS_PATH/integration
+          kind export logs --name=integration $ARTIFACTS_PATH/integration
+
+      - name: upload e2e scheduling basic logs
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: volcano_e2e_scheduling_basic_logs
+          path: ${{ github.workspace }}/e2e-scheduling-basic-logs

--- a/.github/workflows/e2e_sequence.yaml
+++ b/.github/workflows/e2e_sequence.yaml
@@ -39,3 +39,19 @@ jobs:
       - name: Run E2E Tests
         run: |
           make e2e-test-jobseq CC=/usr/local/musl/bin/musl-gcc
+
+      - name: export logs for e2e sequence
+        if: failure()
+        run: |
+          export ARTIFACTS_PATH=${{ github.workspace }}/e2e-sequence-logs
+          mkdir -p $ARTIFACTS_PATH
+          
+          kdir -p $ARTIFACTS_PATH/integration
+          kind export logs --name=integration $ARTIFACTS_PATH/integration
+
+      - name: upload e2e sequence logs
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: volcano_e2e_sequence_logs
+          path: ${{ github.workspace }}/e2e-sequence-logs

--- a/.github/workflows/e2e_spark.yaml
+++ b/.github/workflows/e2e_spark.yaml
@@ -113,3 +113,19 @@ jobs:
       if: always()
       run: |
         minikube delete
+
+    - name: export logs for e2e spark
+      if: failure()
+      run: |
+        export ARTIFACTS_PATH=${{ github.workspace }}/e2e-spark-logs
+        mkdir -p $ARTIFACTS_PATH
+            
+        kdir -p $ARTIFACTS_PATH/integration
+        kind export logs --name=integration $ARTIFACTS_PATH/integration
+
+    - name: upload e2e spark logs
+      if: failure()
+      uses: actions/upload-artifact@v4
+      with:
+        name: volcano_e2e_spark_logs
+        path: ${{ github.workspace }}/e2e-spark-logs

--- a/.github/workflows/e2e_vcctl.yaml
+++ b/.github/workflows/e2e_vcctl.yaml
@@ -39,3 +39,19 @@ jobs:
       - name: Run E2E Tests
         run: |
           make e2e-test-vcctl CC=/usr/local/musl/bin/musl-gcc
+
+      - name: export logs for e2e vcctl
+        if: failure()
+        run: |
+          export ARTIFACTS_PATH=${{ github.workspace }}/e2e-vcctl-logs
+          mkdir -p $ARTIFACTS_PATH
+          
+          kdir -p $ARTIFACTS_PATH/integration
+          kind export logs --name=integration $ARTIFACTS_PATH/integration
+
+      - name: upload e2e vcctl logs
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: volcano_e2e_vcctl_logs
+          path: ${{ github.workspace }}/e2e-vcctl-logs

--- a/hack/run-e2e-kind.sh
+++ b/hack/run-e2e-kind.sh
@@ -68,19 +68,6 @@ function generate-log {
     kubectl logs deployment/${CLUSTER_NAME}-scheduler -n ${NAMESPACE} > volcano-scheduler.log
 }
 
-function show-log() {
-  log_files=("volcano-admission.log" "volcano-controller.log" "volcano-scheduler.log")
-  for log_file in "${log_files[@]}"; do
-    if [ -f "$log_file" ]; then
-      echo "Showing ${log_file}..."
-      cat "$log_file"
-    else
-      echo "${log_file} not found"
-    fi
-  done
-}
-
-
 # clean up
 function cleanup {
   uninstall-volcano
@@ -89,7 +76,8 @@ function cleanup {
   kind delete cluster ${CLUSTER_CONTEXT}
 
   if [[ ${SHOW_VOLCANO_LOGS} -eq 1 ]]; then
-    show-log
+    #TODO: Add volcano logs support in future.
+    echo "Volcano logs are currently not supported."
   fi
 }
 


### PR DESCRIPTION
This pr containes two parts:

1. capture logs via github workfow.
2. revert https://github.com/volcano-sh/volcano/pull/3438/ as it will print lots of logs in console, which is too large.