### PR TITLE
chore: use Infof for slice taskinfo instead of InfoS log less details

### DIFF
--- a/pkg/scheduler/plugins/capacity/capacity.go
+++ b/pkg/scheduler/plugins/capacity/capacity.go
@@ -138,7 +138,7 @@ func (cp *capacityPlugin) OnSessionOpen(ssn *framework.Session) {
 			allocated.Sub(reclaimee.Resreq)
 			victims = append(victims, reclaimee)
 		}
-		klog.V(4).InfoS("Victims from capacity plugin", "victims", victims, "reclaimer", reclaimer)
+		klog.V(4).Infof("Victims from capacity plugin, victims=%+v reclaimer=%s", victims, reclaimer)
 		return victims, util.Permit
 	})
 

--- a/pkg/scheduler/plugins/gang/gang.go
+++ b/pkg/scheduler/plugins/gang/gang.go
@@ -99,7 +99,7 @@ func (gp *gangPlugin) OnSessionOpen(ssn *framework.Session) {
 			}
 		}
 
-		klog.V(4).InfoS("Victims from Gang plugins", "victims", victims, "preemptor", preemptor)
+		klog.V(4).Infof("Victims from Gang plugins, victims=%+v preemptor=%s", victims, preemptor)
 
 		return victims, util.Permit
 	}


### PR DESCRIPTION
`klog.InfoS` log slice object will use json serializer, use `klog.Infof` instead



/close #3687 