### PR TITLE
feat: support scalar resources metric

### DIFF
--- a/docs/design/metrics.md
+++ b/docs/design/metrics.md
@@ -27,32 +27,41 @@ This metrics track execution of plugins and actions of volcano loop.
 ### volcano operations
 This metrics describe internal state of volcano.
 
-| **Metric Name**                 | **Metric Type** | **Labels**                                                  | **Description**                               |
-|---------------------------------|-----------------|-------------------------------------------------------------|-----------------------------------------------|
-| `schedule_attempts_total`       | Counter         | `result`=&lt;result&gt;                                     | The number of attempts to schedule pods       |
-| `pod_preemption_victims`        | Gauge           | None                                                        | The number of selected preemption victims     |
-| `total_preemption_attempts`     | Counter         | None                                                        | Total preemption attempts in the cluster      |
-| `unschedule_task_count`         | Gauge           | `job_id`=&lt;job_id&gt;                                     | The number of tasks failed to schedule        |
-| `unschedule_job_counts`         | Gauge           | None                                                        | The number of jobs could not be scheduled     |
-| `queue_allocated_milli_cpu`     | Gauge           | `queue_name`=&lt;queue_name&gt;                             | Allocated CPU count for one queue             |
-| `queue_allocated_memory_bytes`  | Gauge           | `queue_name`=&lt;queue_name&gt;                             | Allocated memory for one queue                |
-| `queue_request_milli_cpu`       | Gauge           | `queue_name`=&lt;queue_name&gt;                             | Requested CPU count for one queue             |
-| `queue_request_memory_bytes`    | Gauge           | `queue_name`=&lt;queue_name&gt;                             | Requested memory for one queue                |
-| `queue_deserved_milli_cpu`      | Gauge           | `queue_name`=&lt;queue_name&gt;                             | Deserved CPU count for one queue              |
-| `queue_deserved_memory_bytes`   | Gauge           | `queue_name`=&lt;queue_name&gt;                             | Deserved memory for one queue                 |
-| `queue_share`                   | Gauge           | `queue_name`=&lt;queue_name&gt;                             | Share for one queue                           |
-| `queue_weight`                  | Gauge           | `queue_name`=&lt;queue_name&gt;                             | Weight for one queue                          |
-| `queue_overused`                | Gauge           | `queue_name`=&lt;queue_name&gt;                             | Whether one queue is overused                 |
-| `queue_pod_group_inqueue_count` | Gauge           | `queue_name`=&lt;queue_name&gt;                             | The number of Inqueue PodGroups in this queue |
-| `queue_pod_group_pending_count` | Gauge           | `queue_name`=&lt;queue_name&gt;                             | The number of Pending PodGroups in this queue |
-| `queue_pod_group_running_count` | Gauge           | `queue_name`=&lt;queue_name&gt;                             | The number of Running PodGroups in this queue |
-| `queue_pod_group_unknown_count` | Gauge           | `queue_name`=&lt;queue_name&gt;                             | The number of Unknown PodGroups in this queue |
-| `namespace_share`               | Gauge           | `namespace_name`=&lt;namespace_name&gt;                     | Deserved CPU count for one namespace          |
-| `namespace_weight`              | Gauge           | `namespace_name`=&lt;namespace_name&gt;                     | Weight for one namespace                      |
-| `job_share`                     | Gauge           | `job_id`=&lt;job_id&gt;, `job_ns`=&lt;job_ns&gt;            | Share for one job                             |
-| `job_retry_counts`              | Counter         | `job_id`=&lt;job_id&gt;                                     | The number of retry counts for one job        |
-| `job_completed_phase_count`     | Counter         | `job_name`=&lt;job_name&gt; `queue_name`=&lt;queue_name&gt; | The number of job completed phase             |
-| `job_failed_phase_count`        | Counter         | `job_name`=&lt;job_name&gt; `queue_name`=&lt;queue_name&gt; | The number of job failed phase                |
+| **Metric Name**                        | **Metric Type** | **Labels**                                                        | **Description**                               |
+|----------------------------------------|-----------------|-------------------------------------------------------------------|-----------------------------------------------|
+| `schedule_attempts_total`              | Counter         | `result`=&lt;result&gt;                                           | The number of attempts to schedule pods       |
+| `pod_preemption_victims`               | Gauge           | None                                                              | The number of selected preemption victims     |
+| `total_preemption_attempts`            | Counter         | None                                                              | Total preemption attempts in the cluster      |
+| `unschedule_task_count`                | Gauge           | `job_id`=&lt;job_id&gt;                                           | The number of tasks failed to schedule        |
+| `unschedule_job_counts`                | Gauge           | None                                                              | The number of jobs could not be scheduled     |
+| `queue_allocated_milli_cpu`            | Gauge           | `queue_name`=&lt;queue_name&gt;                                   | Allocated CPU count for one queue             |
+| `queue_allocated_memory_bytes`         | Gauge           | `queue_name`=&lt;queue_name&gt;                                   | Allocated memory for one queue                |
+| `queue_allocated_scalar_resources`     | Gauge           | `queue_name`=&lt;queue_name&gt;, `resource`=&lt;resource_name&gt; | Allocated scalar resource for one queue       |
+| `queue_request_milli_cpu`              | Gauge           | `queue_name`=&lt;queue_name&gt;                                   | Requested CPU count for one queue             |
+| `queue_request_memory_bytes`           | Gauge           | `queue_name`=&lt;queue_name&gt;                                   | Requested memory for one queue                |
+| `queue_request_scalar_resources`       | Gauge           | `queue_name`=&lt;queue_name&gt;, `resource`=&lt;resource_name&gt; | Requested scalar resource for one queue       |
+| `queue_deserved_milli_cpu`             | Gauge           | `queue_name`=&lt;queue_name&gt;                                   | Deserved CPU count for one queue              |
+| `queue_deserved_memory_bytes`          | Gauge           | `queue_name`=&lt;queue_name&gt;                                   | Deserved memory for one queue                 |
+| `queue_deserved_scalar_resources`      | Gauge           | `queue_name`=&lt;queue_name&gt;,                                  | Deserved scalar resource for one queue        |
+| `queue_capacity_mill_cpu`              | Gauge           | `queue_name`=&lt;queue_name&gt;,                                  | CPU count capacity for one queue              |
+| `queue_capacity_memory_bytes`          | Gauge           | `queue_name`=&lt;queue_name&gt;,                                  | memory capacity for one queue                 |
+| `queue_capacity_scalar_resources`      | Gauge           | `queue_name`=&lt;queue_name&gt;, `resource`=&lt;resource_name&gt; | Scalar resource capacity for one queue        |
+| `queue_real_capacity_mill_cpu`         | Gauge           | `queue_name`=&lt;queue_name&gt;,                                  | CPU count real capacity for one queue         |
+| `queue_real_capacity_memory_bytes`     | Gauge           | `queue_name`=&lt;queue_name&gt;,                                  | Memory real capacity for one queue            |
+| `queue_real_capacity_scalar_resources` | Gauge           | `queue_name`=&lt;queue_name&gt;, `resource`=&lt;resource_name&gt; | Scalar resource real capacity for one queue   |
+| `queue_share`                          | Gauge           | `queue_name`=&lt;queue_name&gt;                                   | Share for one queue                           |
+| `queue_weight`                         | Gauge           | `queue_name`=&lt;queue_name&gt;                                   | Weight for one queue                          |
+| `queue_overused`                       | Gauge           | `queue_name`=&lt;queue_name&gt;                                   | Whether one queue is overused                 |
+| `queue_pod_group_inqueue_count`        | Gauge           | `queue_name`=&lt;queue_name&gt;                                   | The number of Inqueue PodGroups in this queue |
+| `queue_pod_group_pending_count`        | Gauge           | `queue_name`=&lt;queue_name&gt;                                   | The number of Pending PodGroups in this queue |
+| `queue_pod_group_running_count`        | Gauge           | `queue_name`=&lt;queue_name&gt;                                   | The number of Running PodGroups in this queue |
+| `queue_pod_group_unknown_count`        | Gauge           | `queue_name`=&lt;queue_name&gt;                                   | The number of Unknown PodGroups in this queue |
+| `namespace_share`                      | Gauge           | `namespace_name`=&lt;namespace_name&gt;                           | Deserved CPU count for one namespace          |
+| `namespace_weight`                     | Gauge           | `namespace_name`=&lt;namespace_name&gt;                           | Weight for one namespace                      |
+| `job_share`                            | Gauge           | `job_id`=&lt;job_id&gt;, `job_ns`=&lt;job_ns&gt;                  | Share for one job                             |
+| `job_retry_counts`                     | Counter         | `job_id`=&lt;job_id&gt;                                           | The number of retry counts for one job        |
+| `job_completed_phase_count`            | Counter         | `job_name`=&lt;job_name&gt; `queue_name`=&lt;queue_name&gt;       | The number of job completed phase             |
+| `job_failed_phase_count`               | Counter         | `job_name`=&lt;job_name&gt; `queue_name`=&lt;queue_name&gt;       | The number of job failed phase                |
 
 ### volcano Liveness
 Healthcheck last time of volcano activity and timeout

--- a/pkg/scheduler/metrics/queue.go
+++ b/pkg/scheduler/metrics/queue.go
@@ -19,6 +19,7 @@ package metrics
 import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto" // auto-registry collectors in default registry
+	v1 "k8s.io/api/core/v1"
 )
 
 var (
@@ -38,6 +39,14 @@ var (
 		}, []string{"queue_name"},
 	)
 
+	queueAllocatedScalarResource = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Subsystem: VolcanoNamespace,
+			Name:      "queue_allocated_scalar_resources",
+			Help:      "Allocated scalar resources for one queue",
+		}, []string{"queue_name", "resource"},
+	)
+
 	queueRequestMilliCPU = promauto.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Subsystem: VolcanoNamespace,
@@ -54,6 +63,14 @@ var (
 		}, []string{"queue_name"},
 	)
 
+	queueRequestScalarResource = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Subsystem: VolcanoNamespace,
+			Name:      "queue_request_scalar_resources",
+			Help:      "Request scalar resources for one queue",
+		}, []string{"queue_name", "resource"},
+	)
+
 	queueDeservedMilliCPU = promauto.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Subsystem: VolcanoNamespace,
@@ -68,6 +85,14 @@ var (
 			Name:      "queue_deserved_memory_bytes",
 			Help:      "Deserved memory for one queue",
 		}, []string{"queue_name"},
+	)
+
+	queueDeservedScalarResource = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Subsystem: VolcanoNamespace,
+			Name:      "queue_deserved_scalar_resources",
+			Help:      "Deserved scalar resources for one queue",
+		}, []string{"queue_name", "resource"},
 	)
 
 	queueShare = promauto.NewGaugeVec(
@@ -93,24 +118,81 @@ var (
 			Help:      "If one queue is overused",
 		}, []string{"queue_name"},
 	)
+
+	queueCapacityMilliCPU = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Subsystem: VolcanoNamespace,
+			Name:      "queue_capacity_milli_cpu",
+			Help:      "Capacity CPU count for one queue",
+		}, []string{"queue_name"},
+	)
+
+	queueCapacityMemory = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Subsystem: VolcanoNamespace,
+			Name:      "queue_capacity_memory_bytes",
+			Help:      "Capacity memory for one queue",
+		}, []string{"queue_name"},
+	)
+
+	queueCapacityScalarResource = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Subsystem: VolcanoNamespace,
+			Name:      "queue_capacity_scalar_resources",
+			Help:      "Capacity scalar resources for one queue",
+		}, []string{"queue_name", "resource"},
+	)
+
+	queueRealCapacityMilliCPU = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Subsystem: VolcanoNamespace,
+			Name:      "queue_real_capacity_milli_cpu",
+			Help:      "Capacity CPU count for one queue",
+		}, []string{"queue_name"},
+	)
+
+	queueRealCapacityMemory = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Subsystem: VolcanoNamespace,
+			Name:      "queue_real_capacity_memory_bytes",
+			Help:      "Capacity memory for one queue",
+		}, []string{"queue_name"},
+	)
+
+	queueRealCapacityScalarResource = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Subsystem: VolcanoNamespace,
+			Name:      "queue_real_capacity_scalar_resources",
+			Help:      "Capacity scalar resources for one queue",
+		}, []string{"queue_name", "resource"},
+	)
 )
 
 // UpdateQueueAllocated records allocated resources for one queue
-func UpdateQueueAllocated(queueName string, milliCPU, memory float64) {
+func UpdateQueueAllocated(queueName string, milliCPU, memory float64, scalarResources map[v1.ResourceName]float64) {
 	queueAllocatedMilliCPU.WithLabelValues(queueName).Set(milliCPU)
 	queueAllocatedMemory.WithLabelValues(queueName).Set(memory)
+	for resource, value := range scalarResources {
+		queueAllocatedScalarResource.WithLabelValues(queueName, string(resource)).Set(value)
+	}
 }
 
 // UpdateQueueRequest records request resources for one queue
-func UpdateQueueRequest(queueName string, milliCPU, memory float64) {
+func UpdateQueueRequest(queueName string, milliCPU, memory float64, scalarResources map[v1.ResourceName]float64) {
 	queueRequestMilliCPU.WithLabelValues(queueName).Set(milliCPU)
 	queueRequestMemory.WithLabelValues(queueName).Set(memory)
+	for resource, value := range scalarResources {
+		queueRequestScalarResource.WithLabelValues(queueName, string(resource)).Set(value)
+	}
 }
 
 // UpdateQueueDeserved records deserved resources for one queue
-func UpdateQueueDeserved(queueName string, milliCPU, memory float64) {
+func UpdateQueueDeserved(queueName string, milliCPU, memory float64, scalarResources map[v1.ResourceName]float64) {
 	queueDeservedMilliCPU.WithLabelValues(queueName).Set(milliCPU)
 	queueDeservedMemory.WithLabelValues(queueName).Set(memory)
+	for resource, value := range scalarResources {
+		queueDeservedScalarResource.WithLabelValues(queueName, string(resource)).Set(value)
+	}
 }
 
 // UpdateQueueShare records share for one queue
@@ -134,6 +216,22 @@ func UpdateQueueOverused(queueName string, overused bool) {
 	queueOverused.WithLabelValues(queueName).Set(value)
 }
 
+func UpdateQueueCapacity(queueName string, milliCPU, memory float64, scalarResources map[v1.ResourceName]float64) {
+	queueCapacityMilliCPU.WithLabelValues(queueName).Set(milliCPU)
+	queueCapacityMemory.WithLabelValues(queueName).Set(memory)
+	for resource, value := range scalarResources {
+		queueCapacityScalarResource.WithLabelValues(queueName, string(resource)).Set(value)
+	}
+}
+
+func UpdateQueueRealCapacity(queueName string, milliCPU, memory float64, scalarResources map[v1.ResourceName]float64) {
+	queueRealCapacityMilliCPU.WithLabelValues(queueName).Set(milliCPU)
+	queueRealCapacityMemory.WithLabelValues(queueName).Set(memory)
+	for resource, value := range scalarResources {
+		queueRealCapacityScalarResource.WithLabelValues(queueName, string(resource)).Set(value)
+	}
+}
+
 // DeleteQueueMetrics delete all metrics related to the queue
 func DeleteQueueMetrics(queueName string) {
 	queueAllocatedMilliCPU.DeleteLabelValues(queueName)
@@ -145,4 +243,14 @@ func DeleteQueueMetrics(queueName string) {
 	queueShare.DeleteLabelValues(queueName)
 	queueWeight.DeleteLabelValues(queueName)
 	queueOverused.DeleteLabelValues(queueName)
+	queueCapacityMilliCPU.DeleteLabelValues(queueName)
+	queueCapacityMemory.DeleteLabelValues(queueName)
+	queueRealCapacityMilliCPU.DeleteLabelValues(queueName)
+	queueRealCapacityMemory.DeleteLabelValues(queueName)
+	partialLabelMap := map[string]string{"queue_name": queueName}
+	queueAllocatedScalarResource.DeletePartialMatch(partialLabelMap)
+	queueRequestScalarResource.DeletePartialMatch(partialLabelMap)
+	queueDeservedScalarResource.DeletePartialMatch(partialLabelMap)
+	queueCapacityScalarResource.DeletePartialMatch(partialLabelMap)
+	queueRealCapacityScalarResource.DeletePartialMatch(partialLabelMap)
 }

--- a/pkg/scheduler/metrics/queue_test.go
+++ b/pkg/scheduler/metrics/queue_test.go
@@ -1,0 +1,150 @@
+package metrics
+
+import (
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/util/retry"
+)
+
+func forMetricMap(fn func(map[string]float64)) error {
+	url := "http://127.0.0.1:8081/metrics"
+	method := "GET"
+
+	client := &http.Client{}
+	req, err := http.NewRequest(method, url, nil)
+
+	if err != nil {
+		return err
+	}
+	req.Header.Add("Authorization", "8cbdb37a-b880-4f2e-844c-e420858ea7eb")
+
+	res, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer res.Body.Close()
+
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		return err
+	}
+
+	split := strings.Split(string(body), "\n")
+	metricSet := map[string]float64{}
+	for _, v := range split {
+		if !strings.Contains(v, "#") && v != "" {
+			pair := strings.Split(v, " ")
+			if len(pair) < 2 {
+				metricSet[pair[0]] = 0
+			}
+			data, _ := strconv.ParseFloat(pair[1], 64)
+			metricSet[pair[0]] = data
+		}
+	}
+	fn(metricSet)
+	return nil
+}
+
+func retryOnConnectionRefused(fn func() error) error {
+	isConnectionRefused := func(err error) bool {
+		return err != nil && strings.Contains(err.Error(), "connection refused")
+	}
+	return retry.OnError(retry.DefaultBackoff, isConnectionRefused, fn)
+}
+
+func TestQueueResourceMetric(t *testing.T) {
+	UpdateQueueAllocated("queue1", 100, 1024, map[v1.ResourceName]float64{"nvidia.com/gpu": 0})
+	UpdateQueueRequest("queue2", 200, 2048, map[v1.ResourceName]float64{"nvidia.com/gpu": 1})
+	UpdateQueueDeserved("queue3", 300, 3096, map[v1.ResourceName]float64{"nvidia.com/gpu": 2})
+	UpdateQueueCapacity("queue1", 200., 2048., map[v1.ResourceName]float64{v1.ResourceName("nvidia.com/gpu"): 10.})
+	UpdateQueueRealCapacity("queue2", 200., 2048., map[v1.ResourceName]float64{v1.ResourceName("nvidia.com/gpu"): 10.})
+	go func() {
+		http.Handle("/metrics", promhttp.Handler())
+		err := http.ListenAndServe(":8081", nil)
+		if err != nil {
+			t.Errorf("ListenAndServe() err = %v", err.Error())
+		}
+	}()
+	err := retryOnConnectionRefused(func() error {
+		return forMetricMap(func(m map[string]float64) {
+			assert.Equal(t, 100., m["volcano_queue_allocated_milli_cpu{queue_name=\"queue1\"}"])
+			assert.Equal(t, 1024., m["volcano_queue_allocated_memory_bytes{queue_name=\"queue1\"}"])
+			assert.Contains(t, m, "volcano_queue_allocated_scalar_resources{queue_name=\"queue1\",resource=\"nvidia.com/gpu\"}",
+				"volcano_queue_allocated_scalar_resources for queue1 and resource nvidia.com/gpu should be present")
+			assert.Equal(t, 0., m["volcano_queue_allocated_scalar_resources{queue_name=\"queue1\",resource=\"nvidia.com/gpu\"}"])
+			assert.Equal(t, 200., m["volcano_queue_request_milli_cpu{queue_name=\"queue2\"}"])
+			assert.Equal(t, 2048., m["volcano_queue_request_memory_bytes{queue_name=\"queue2\"}"])
+			assert.Contains(t, m, "volcano_queue_request_scalar_resources{queue_name=\"queue2\",resource=\"nvidia.com/gpu\"}",
+				"volcano_queue_request_scalar_resources for queue2 and resource nvidia.com/gpu should be present")
+			assert.Equal(t, 1., m["volcano_queue_request_scalar_resources{queue_name=\"queue2\",resource=\"nvidia.com/gpu\"}"])
+			assert.Equal(t, 300., m["volcano_queue_deserved_milli_cpu{queue_name=\"queue3\"}"])
+			assert.Equal(t, 3096., m["volcano_queue_deserved_memory_bytes{queue_name=\"queue3\"}"])
+			assert.Contains(t, m, "volcano_queue_deserved_scalar_resources{queue_name=\"queue3\",resource=\"nvidia.com/gpu\"}",
+				"volcano_queue_deserved_scalar_resources for queue3 and resource nvidia.com/gpu should be present")
+			assert.Equal(t, 2., m["volcano_queue_deserved_scalar_resources{queue_name=\"queue3\",resource=\"nvidia.com/gpu\"}"])
+			assert.Equal(t, 200., m["volcano_queue_capacity_milli_cpu{queue_name=\"queue1\"}"])
+			assert.Equal(t, 2048., m["volcano_queue_capacity_memory_bytes{queue_name=\"queue1\"}"])
+			assert.Contains(t, m, "volcano_queue_capacity_scalar_resources{queue_name=\"queue1\",resource=\"nvidia.com/gpu\"}",
+				"volcano_queue_capacity_scalar_resources for queue1 and resource nvidia.com/gpu should be present")
+			assert.Equal(t, 10., m["volcano_queue_capacity_scalar_resources{queue_name=\"queue1\",resource=\"nvidia.com/gpu\"}"])
+			assert.Equal(t, 200., m["volcano_queue_real_capacity_milli_cpu{queue_name=\"queue2\"}"])
+			assert.Equal(t, 2048., m["volcano_queue_real_capacity_memory_bytes{queue_name=\"queue2\"}"])
+			assert.Contains(t, m, "volcano_queue_real_capacity_scalar_resources{queue_name=\"queue2\",resource=\"nvidia.com/gpu\"}",
+				"volcano_queue_real_capacity_scalar_resources for queue1 and resource nvidia.com/gpu should be present")
+			assert.Equal(t, 10., m["volcano_queue_real_capacity_scalar_resources{queue_name=\"queue2\",resource=\"nvidia.com/gpu\"}"])
+		})
+	})
+	if err != nil {
+		t.Fatalf("getLocalMetric() err = %v", err.Error())
+	}
+	DeleteQueueMetrics("queue1")
+	DeleteQueueMetrics("queue2")
+	err = retryOnConnectionRefused(func() error {
+		return forMetricMap(func(m map[string]float64) {
+			assert.NotContains(t, m, "volcano_queue_allocated_milli_cpu{queue_name=\"queue1\"}",
+				"volcano_queue_allocated_milli_cpu for queue1 should be removed")
+			assert.NotContains(t, m, "volcano_queue_allocated_memory_bytes{queue_name=\"queue1\"}",
+				"volcano_queue_allocated_memory_bytes for queue1 should be removed")
+			assert.NotContains(t, m, "volcano_queue_allocated_scalar_resources{queue_name=\"queue1\",resource=\"nvidia.com/gpu\"}",
+				"volcano_queue_allocated_scalar_resources for queue1 should be removed")
+			assert.NotContains(t, m, "volcano_queue_capacity_milli_cpu{queue_name=\"queue1\"}",
+				"volcano_queue_capacity_milli_cpu for queue1 should be removed")
+			assert.NotContains(t, m, "volcano_queue_capacity_memory_bytes{queue_name=\"queue1\"}",
+				"volcano_queue_capacity_memory_bytes for queue1 should be removed")
+			assert.NotContains(t, m, "volcano_queue_capacity_scalar_resources{queue_name=\"queue1\",resource=\"nvidia.com/gpu\"}",
+				"volcano_queue_capacity_scalar_resources for queue1 should be removed")
+			assert.NotContains(t, m, "volcano_queue_real_capacity_milli_cpu{queue_name=\"queue2\"}",
+				"volcano_queue_real_capacity_milli_cpu for queue1 should be removed")
+			assert.NotContains(t, m, "volcano_queue_real_capacity_memory_bytes{queue_name=\"queue2\"}",
+				"volcano_queue_real_capacity_memory_bytes for queue1 should be removed")
+			assert.NotContains(t, m, "volcano_queue_real_capacity_scalar_resources{queue_name=\"queue2\",resource=\"nvidia.com/gpu\"}",
+				"volcano_queue_real_capacity_scalar_resources for queue1 should be removed")
+			assert.NotContains(t, m, "volcano_queue_request_milli_cpu{queue_name=\"queue2\"}",
+				"volcano_queue_request_milli_cpu for queue2 should be removed")
+			assert.NotContains(t, m, "volcano_queue_request_memory_bytes{queue_name=\"queue2\"}",
+				"volcano_queue_request_memory_bytes for queue2 should be removed")
+			assert.NotContains(t, m, "volcano_queue_request_scalar_resources{queue_name=\"queue2\",resource=\"nvidia.com/gpu\"}",
+				"volcano_queue_request_scalar_resources for queue2 should be removed")
+			assert.Contains(t, m, "volcano_queue_deserved_milli_cpu{queue_name=\"queue3\"}",
+				"volcano_queue_deserved_milli_cpu for queue3 should not be removed")
+			assert.Equal(t, 300., m["volcano_queue_deserved_milli_cpu{queue_name=\"queue3\"}"])
+			assert.Contains(t, m, "volcano_queue_deserved_memory_bytes{queue_name=\"queue3\"}",
+				"volcano_queue_deserved_memory_bytes for queue3 should not be removed")
+			assert.Equal(t, 3096., m["volcano_queue_deserved_memory_bytes{queue_name=\"queue3\"}"])
+			assert.Contains(t, m, "volcano_queue_deserved_scalar_resources{queue_name=\"queue3\",resource=\"nvidia.com/gpu\"}",
+				"volcano_queue_deserved_scalar_resources for queue3 & nvidia.com/gpu should not be removed")
+			assert.Equal(t, 2., m["volcano_queue_deserved_scalar_resources{queue_name=\"queue3\",resource=\"nvidia.com/gpu\"}"])
+
+		})
+	})
+	if err != nil {
+		t.Fatalf("getLocalMetric() err = %v", err.Error())
+	}
+}

--- a/pkg/scheduler/plugins/capacity/capacity.go
+++ b/pkg/scheduler/plugins/capacity/capacity.go
@@ -247,7 +247,7 @@ func (cp *capacityPlugin) OnSessionOpen(ssn *framework.Session) {
 			job := ssn.Jobs[event.Task.Job]
 			attr := cp.queueOpts[job.Queue]
 			attr.allocated.Add(event.Task.Resreq)
-			metrics.UpdateQueueAllocated(attr.name, attr.allocated.MilliCPU, attr.allocated.Memory)
+			metrics.UpdateQueueAllocated(attr.name, attr.allocated.MilliCPU, attr.allocated.Memory, attr.allocated.ScalarResources)
 
 			cp.updateShare(attr)
 			if hierarchyEnabled {
@@ -264,7 +264,7 @@ func (cp *capacityPlugin) OnSessionOpen(ssn *framework.Session) {
 			job := ssn.Jobs[event.Task.Job]
 			attr := cp.queueOpts[job.Queue]
 			attr.allocated.Sub(event.Task.Resreq)
-			metrics.UpdateQueueAllocated(attr.name, attr.allocated.MilliCPU, attr.allocated.Memory)
+			metrics.UpdateQueueAllocated(attr.name, attr.allocated.MilliCPU, attr.allocated.Memory, attr.allocated.ScalarResources)
 
 			cp.updateShare(attr)
 			if hierarchyEnabled {
@@ -385,19 +385,36 @@ func (cp *capacityPlugin) buildQueueAttrs(ssn *framework.Session) {
 	for queueID, queueInfo := range ssn.Queues {
 		queue := ssn.Queues[queueID]
 		if attr, ok := cp.queueOpts[queueID]; ok {
-			metrics.UpdateQueueDeserved(attr.name, attr.deserved.MilliCPU, attr.deserved.Memory)
-			metrics.UpdateQueueAllocated(attr.name, attr.allocated.MilliCPU, attr.allocated.Memory)
-			metrics.UpdateQueueRequest(attr.name, attr.request.MilliCPU, attr.request.Memory)
+			metrics.UpdateQueueDeserved(attr.name, attr.deserved.MilliCPU, attr.deserved.Memory, attr.deserved.ScalarResources)
+			metrics.UpdateQueueAllocated(attr.name, attr.allocated.MilliCPU, attr.allocated.Memory, attr.allocated.ScalarResources)
+			metrics.UpdateQueueRequest(attr.name, attr.request.MilliCPU, attr.request.Memory, attr.request.ScalarResources)
+			if attr.capability != nil {
+				metrics.UpdateQueueCapacity(attr.name, attr.capability.MilliCPU, attr.capability.Memory, attr.capability.ScalarResources)
+			}
+			metrics.UpdateQueueRealCapacity(attr.name, attr.realCapability.MilliCPU, attr.realCapability.Memory, attr.realCapability.ScalarResources)
 			continue
 		}
-		deservedCPU, deservedMem := 0.0, 0.0
+		deservedCPU, deservedMem, scalarResources := 0.0, 0.0, map[v1.ResourceName]float64{}
 		if queue.Queue.Spec.Deserved != nil {
-			deservedCPU = float64(queue.Queue.Spec.Deserved.Cpu().MilliValue())
-			deservedMem = float64(queue.Queue.Spec.Deserved.Memory().Value())
+			attr := api.NewResource(queue.Queue.Spec.Deserved)
+			deservedCPU = attr.MilliCPU
+			deservedMem = attr.Memory
+			scalarResources = attr.ScalarResources
 		}
-		metrics.UpdateQueueDeserved(queueInfo.Name, deservedCPU, deservedMem)
-		metrics.UpdateQueueAllocated(queueInfo.Name, 0, 0)
-		metrics.UpdateQueueRequest(queueInfo.Name, 0, 0)
+		metrics.UpdateQueueDeserved(queueInfo.Name, deservedCPU, deservedMem, scalarResources)
+		metrics.UpdateQueueAllocated(queueInfo.Name, 0, 0, map[v1.ResourceName]float64{})
+		metrics.UpdateQueueRequest(queueInfo.Name, 0, 0, map[v1.ResourceName]float64{})
+		guarantee := api.EmptyResource()
+		if len(queue.Queue.Spec.Guarantee.Resource) != 0 {
+			guarantee = api.NewResource(queue.Queue.Spec.Guarantee.Resource)
+		}
+		realCapacity := api.ExceededPart(cp.totalResource, cp.totalGuarantee).Add(guarantee)
+		if len(queue.Queue.Spec.Capability) > 0 {
+			capacity := api.NewResource(queue.Queue.Spec.Capability)
+			realCapacity.MinDimensionResource(capacity, api.Infinity)
+			metrics.UpdateQueueCapacity(queueInfo.Name, capacity.MilliCPU, capacity.Memory, capacity.ScalarResources)
+		}
+		metrics.UpdateQueueRealCapacity(queueInfo.Name, realCapacity.MilliCPU, realCapacity.Memory, realCapacity.ScalarResources)
 	}
 
 	ssn.AddQueueOrderFn(cp.Name(), func(l, r interface{}) int {
@@ -520,9 +537,9 @@ func (cp *capacityPlugin) buildHierarchicalQueueAttrs(ssn *framework.Session) bo
 	// Record metrics
 	for queueID := range ssn.Queues {
 		attr := cp.queueOpts[queueID]
-		metrics.UpdateQueueDeserved(attr.name, attr.deserved.MilliCPU, attr.deserved.Memory)
-		metrics.UpdateQueueAllocated(attr.name, attr.allocated.MilliCPU, attr.allocated.Memory)
-		metrics.UpdateQueueRequest(attr.name, attr.request.MilliCPU, attr.request.Memory)
+		metrics.UpdateQueueDeserved(attr.name, attr.deserved.MilliCPU, attr.deserved.Memory, attr.deserved.ScalarResources)
+		metrics.UpdateQueueAllocated(attr.name, attr.allocated.MilliCPU, attr.allocated.Memory, attr.allocated.ScalarResources)
+		metrics.UpdateQueueRequest(attr.name, attr.request.MilliCPU, attr.request.Memory, attr.request.ScalarResources)
 	}
 
 	ssn.AddQueueOrderFn(cp.Name(), func(l, r interface{}) int {

--- a/pkg/scheduler/plugins/proportion/proportion.go
+++ b/pkg/scheduler/plugins/proportion/proportion.go
@@ -164,13 +164,13 @@ func (pp *proportionPlugin) OnSessionOpen(ssn *framework.Session) {
 	// Record metrics
 	for queueID, queueInfo := range ssn.Queues {
 		if attr, ok := pp.queueOpts[queueID]; ok {
-			metrics.UpdateQueueAllocated(attr.name, attr.allocated.MilliCPU, attr.allocated.Memory)
-			metrics.UpdateQueueRequest(attr.name, attr.request.MilliCPU, attr.request.Memory)
+			metrics.UpdateQueueAllocated(attr.name, attr.allocated.MilliCPU, attr.allocated.Memory, attr.allocated.ScalarResources)
+			metrics.UpdateQueueRequest(attr.name, attr.request.MilliCPU, attr.request.Memory, attr.request.ScalarResources)
 			metrics.UpdateQueueWeight(attr.name, attr.weight)
 			continue
 		}
-		metrics.UpdateQueueAllocated(queueInfo.Name, 0, 0)
-		metrics.UpdateQueueRequest(queueInfo.Name, 0, 0)
+		metrics.UpdateQueueAllocated(queueInfo.Name, 0, 0, map[v1.ResourceName]float64{})
+		metrics.UpdateQueueRequest(queueInfo.Name, 0, 0, map[v1.ResourceName]float64{})
 	}
 
 	remaining := pp.totalResource.Clone()
@@ -231,7 +231,7 @@ func (pp *proportionPlugin) OnSessionOpen(ssn *framework.Session) {
 			decreasedDeserved.Add(decreased)
 
 			// Record metrics
-			metrics.UpdateQueueDeserved(attr.name, attr.deserved.MilliCPU, attr.deserved.Memory)
+			metrics.UpdateQueueDeserved(attr.name, attr.deserved.MilliCPU, attr.deserved.Memory, attr.deserved.ScalarResources)
 		}
 
 		remaining.Sub(increasedDeserved).Add(decreasedDeserved)
@@ -366,7 +366,7 @@ func (pp *proportionPlugin) OnSessionOpen(ssn *framework.Session) {
 			job := ssn.Jobs[event.Task.Job]
 			attr := pp.queueOpts[job.Queue]
 			attr.allocated.Add(event.Task.Resreq)
-			metrics.UpdateQueueAllocated(attr.name, attr.allocated.MilliCPU, attr.allocated.Memory)
+			metrics.UpdateQueueAllocated(attr.name, attr.allocated.MilliCPU, attr.allocated.Memory, attr.allocated.ScalarResources)
 
 			pp.updateShare(attr)
 
@@ -377,7 +377,7 @@ func (pp *proportionPlugin) OnSessionOpen(ssn *framework.Session) {
 			job := ssn.Jobs[event.Task.Job]
 			attr := pp.queueOpts[job.Queue]
 			attr.allocated.Sub(event.Task.Resreq)
-			metrics.UpdateQueueAllocated(attr.name, attr.allocated.MilliCPU, attr.allocated.Memory)
+			metrics.UpdateQueueAllocated(attr.name, attr.allocated.MilliCPU, attr.allocated.Memory, attr.allocated.ScalarResources)
 
 			pp.updateShare(attr)
 


### PR DESCRIPTION
Add metric
```text
queue_allocated_scalar_resources{queue_name="<queue>", resource="<resource>"}
queue_request_scalar_resources{queue_name="<queue>", resource="<resource>"}
queue_deserved_scalar_resources{queue_name="<queue>", resource="<resource>"}
```

/close #3931

Need discuss: 
Shall we merge `cpu`, `memory` bulitin resources into scalar resource ?