### PR TITLE
vs-scheduler: use max function to simplify code of capacity plugin

### DIFF
--- a/pkg/scheduler/plugins/capacity/capacity.go
+++ b/pkg/scheduler/plugins/capacity/capacity.go
@@ -697,10 +697,7 @@ func (cp *capacityPlugin) updateShare(attr *queueAttr) {
 	res := float64(0)
 
 	for _, rn := range attr.deserved.ResourceNames() {
-		share := helpers.Share(attr.allocated.Get(rn), attr.deserved.Get(rn))
-		if share > res {
-			res = share
-		}
+		res = max(res, helpers.Share(attr.allocated.Get(rn), attr.deserved.Get(rn)))
 	}
 
 	attr.share = res


### PR DESCRIPTION
Now we can use max function provided by Go.