### PR TITLE
in capacity plugin attr.deserved no need MinDimensionResource with attr.request

### DIFF
--- a/pkg/scheduler/plugins/capacity/capacity.go
+++ b/pkg/scheduler/plugins/capacity/capacity.go
@@ -349,8 +349,6 @@ func (cp *capacityPlugin) buildQueueAttrs(ssn *framework.Session) {
 		if attr.realCapability != nil {
 			attr.deserved.MinDimensionResource(attr.realCapability, api.Infinity)
 		}
-		// When scalar resource not specified in deserved such as "pods", we should skip it and consider deserved resource as infinity.
-		attr.deserved.MinDimensionResource(attr.request, api.Infinity)
 
 		attr.deserved = helpers.Max(attr.deserved, attr.guarantee)
 		cp.updateShare(attr)
@@ -679,7 +677,6 @@ func (cp *capacityPlugin) checkHierarchicalQueue(attr *queueAttr) error {
 		}
 		oldDeserved := childAttr.deserved.Clone()
 		childAttr.deserved.MinDimensionResource(childAttr.realCapability, api.Infinity)
-		childAttr.deserved.MinDimensionResource(childAttr.request, api.Zero)
 
 		childAttr.deserved = helpers.Max(childAttr.deserved, childAttr.guarantee)
 		totalDeserved.Sub(oldDeserved).Add(childAttr.deserved)

--- a/pkg/scheduler/plugins/capacity/capacity_test.go
+++ b/pkg/scheduler/plugins/capacity/capacity_test.go
@@ -347,7 +347,7 @@ func Test_capacityPlugin_OnSessionOpenWithHierarchy(t *testing.T) {
 	actions := []framework.Action{enqueue.New(), reclaim.New(), allocate.New()}
 
 	// nodes
-	n1 := util.BuildNode("n1", api.BuildResourceList("8", "8Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), map[string]string{})
+	n1 := util.BuildNode("n1", api.BuildResourceList("8", "8Gi", []api.ScalarResource{{Name: "pods", Value: "11"}}...), map[string]string{})
 
 	// resources for test case 0
 	// pod


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

/area scheduling

#### What this PR does / why we need it:

In capacity plugin attr.deserved no need MinDimensionResource with attr.request.
In proportion plugin, attr.deserved is computed dynamically using min-max faire share algorithm, so attr.deserved needs `MinDimensionResource` with attr.request to share the ununsed quota with other queues.
But in capacity plugin, attr.deserved is configured by the user, so the `MinDimensionResource` is not need any more.

#### Which issue(s) this PR fixes:

Fixes #3944

#### Special notes for your reviewer:

NONE

#### Does this PR introduce a user-facing change?

NONE

