### PR TITLE
reclaim: When choosing a preemptor, choose a starving one rather than one with pending tasks.

### DIFF
--- a/pkg/scheduler/actions/reclaim/reclaim.go
+++ b/pkg/scheduler/actions/reclaim/reclaim.go
@@ -69,7 +69,7 @@ func (ra *Action) Execute(ssn *framework.Session) {
 			queues.Push(queue)
 		}
 
-		if job.HasPendingTasks() {
+		if ssn.JobStarving(job) {
 			if _, found := preemptorsMap[job.Queue]; !found {
 				preemptorsMap[job.Queue] = util.NewPriorityQueue(ssn.JobOrderFn)
 			}
@@ -108,7 +108,7 @@ func (ra *Action) Execute(ssn *framework.Session) {
 		}
 
 		// Found "high" priority task to reclaim others
-		if tasks, found := preemptorTasks[job.UID]; !found || tasks.Empty() {
+		if tasks, found := preemptorTasks[job.UID]; !found || tasks.Empty() || !ssn.JobStarving(job) {
 			continue
 		} else {
 			task = tasks.Pop().(*api.TaskInfo)

--- a/pkg/scheduler/actions/reclaim/reclaim_test.go
+++ b/pkg/scheduler/actions/reclaim/reclaim_test.go
@@ -44,8 +44,8 @@ func TestReclaim(t *testing.T) {
 				proportion.PluginName:  proportion.New,
 			},
 			PodGroups: []*schedulingv1beta1.PodGroup{
-				util.BuildPodGroupWithPrio("pg1", "c1", "q1", 0, nil, schedulingv1beta1.PodGroupInqueue, "low-priority"),
-				util.BuildPodGroupWithPrio("pg2", "c1", "q2", 0, nil, schedulingv1beta1.PodGroupInqueue, "high-priority"),
+				util.BuildPodGroupWithPrio("pg1", "c1", "q1", 1, nil, schedulingv1beta1.PodGroupInqueue, "low-priority"),
+				util.BuildPodGroupWithPrio("pg2", "c1", "q2", 1, nil, schedulingv1beta1.PodGroupInqueue, "high-priority"),
 			},
 			Pods: []*v1.Pod{
 				util.BuildPod("c1", "preemptee1", "n1", v1.PodRunning, api.BuildResourceList("1", "1G"), "pg1", map[string]string{schedulingv1beta1.PodPreemptable: "false"}, make(map[string]string)),
@@ -77,9 +77,9 @@ func TestReclaim(t *testing.T) {
 				util.BuildPriorityClass("high-priority", 1000),
 			},
 			PodGroups: []*schedulingv1beta1.PodGroup{
-				util.BuildPodGroupWithPrio("pg1", "c1", "q1", 0, nil, schedulingv1beta1.PodGroupInqueue, "mid-priority"),
-				util.BuildPodGroupWithPrio("pg2", "c1", "q2", 0, nil, schedulingv1beta1.PodGroupInqueue, "low-priority"), // reclaimed first
-				util.BuildPodGroupWithPrio("pg3", "c1", "q3", 0, nil, schedulingv1beta1.PodGroupInqueue, "high-priority"),
+				util.BuildPodGroupWithPrio("pg1", "c1", "q1", 1, nil, schedulingv1beta1.PodGroupInqueue, "mid-priority"),
+				util.BuildPodGroupWithPrio("pg2", "c1", "q2", 1, nil, schedulingv1beta1.PodGroupInqueue, "low-priority"), // reclaimed first
+				util.BuildPodGroupWithPrio("pg3", "c1", "q3", 1, nil, schedulingv1beta1.PodGroupInqueue, "high-priority"),
 			},
 			Pods: []*v1.Pod{
 				util.BuildPod("c1", "preemptee1-1", "n1", v1.PodRunning, api.BuildResourceList("1", "1G"), "pg1", map[string]string{schedulingv1beta1.PodPreemptable: "true"}, make(map[string]string)),
@@ -107,9 +107,9 @@ func TestReclaim(t *testing.T) {
 				proportion.PluginName:  proportion.New,
 			},
 			PodGroups: []*schedulingv1beta1.PodGroup{
-				util.BuildPodGroupWithPrio("pg1", "c1", "q1", 0, nil, schedulingv1beta1.PodGroupInqueue, "mid-priority"),
-				util.BuildPodGroupWithPrio("pg2", "c1", "q2", 0, nil, schedulingv1beta1.PodGroupInqueue, "mid-priority"),
-				util.BuildPodGroupWithPrio("pg3", "c1", "q3", 0, nil, schedulingv1beta1.PodGroupInqueue, "mid-priority"),
+				util.BuildPodGroupWithPrio("pg1", "c1", "q1", 1, nil, schedulingv1beta1.PodGroupInqueue, "mid-priority"),
+				util.BuildPodGroupWithPrio("pg2", "c1", "q2", 1, nil, schedulingv1beta1.PodGroupInqueue, "mid-priority"),
+				util.BuildPodGroupWithPrio("pg3", "c1", "q3", 1, nil, schedulingv1beta1.PodGroupInqueue, "mid-priority"),
 			},
 			Pods: []*v1.Pod{
 				util.BuildPod("c1", "preemptee1-1", "n1", v1.PodRunning, api.BuildResourceList("1", "1G"), "pg1", map[string]string{schedulingv1beta1.PodPreemptable: "true"}, make(map[string]string)),
@@ -173,6 +173,7 @@ func TestReclaim(t *testing.T) {
 				{
 					Name:               gang.PluginName,
 					EnabledReclaimable: &trueValue,
+					EnabledJobStarving: &trueValue,
 				},
 				{ // proportion plugin will cause deserved resource large than preemptable pods's usage, and return less victims
 					Name:               proportion.PluginName,

--- a/pkg/scheduler/plugins/capacity/capacity_test.go
+++ b/pkg/scheduler/plugins/capacity/capacity_test.go
@@ -30,6 +30,7 @@ import (
 	"volcano.sh/volcano/pkg/scheduler/api"
 	"volcano.sh/volcano/pkg/scheduler/conf"
 	"volcano.sh/volcano/pkg/scheduler/framework"
+	"volcano.sh/volcano/pkg/scheduler/plugins/gang"
 	"volcano.sh/volcano/pkg/scheduler/plugins/predicates"
 	"volcano.sh/volcano/pkg/scheduler/uthelper"
 	"volcano.sh/volcano/pkg/scheduler/util"
@@ -41,7 +42,7 @@ func TestMain(m *testing.M) {
 }
 
 func Test_capacityPlugin_OnSessionOpenWithoutHierarchy(t *testing.T) {
-	plugins := map[string]framework.PluginBuilder{PluginName: New, predicates.PluginName: predicates.New}
+	plugins := map[string]framework.PluginBuilder{PluginName: New, predicates.PluginName: predicates.New, gang.PluginName: gang.New}
 	trueValue := true
 	actions := []framework.Action{allocate.New(), reclaim.New()}
 
@@ -224,6 +225,10 @@ func Test_capacityPlugin_OnSessionOpenWithoutHierarchy(t *testing.T) {
 					Name:             predicates.PluginName,
 					EnabledPredicate: &trueValue,
 				},
+				{
+					Name:               gang.PluginName,
+					EnabledJobStarving: &trueValue,
+				},
 			},
 		},
 	}
@@ -335,7 +340,7 @@ func TestEnqueueAndAllocatable(t *testing.T) {
 }
 
 func Test_capacityPlugin_OnSessionOpenWithHierarchy(t *testing.T) {
-	plugins := map[string]framework.PluginBuilder{PluginName: New, predicates.PluginName: predicates.New}
+	plugins := map[string]framework.PluginBuilder{PluginName: New, predicates.PluginName: predicates.New, gang.PluginName: gang.New}
 	trueValue := true
 	actions := []framework.Action{enqueue.New(), reclaim.New(), allocate.New()}
 
@@ -448,6 +453,10 @@ func Test_capacityPlugin_OnSessionOpenWithHierarchy(t *testing.T) {
 				{
 					Name:             predicates.PluginName,
 					EnabledPredicate: &trueValue,
+				},
+				{
+					Name:               gang.PluginName,
+					EnabledJobStarving: &trueValue,
 				},
 			},
 		},


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/area scheduling

#### What this PR does / why we need it:
When two jobs have pending pods at the same time and resources can be reclaimed, using PendingPod to determine whether the job can enter reclaim will cause the two jobs to compete with each other, leading to a deadlock. We need to use `JobStarving` instead.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Notice that do not add `Fixes` if the issue is associated with multiple PRs.
-->
Fixes #3869 

#### Special notes for your reviewer:
NONE

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```