### PR TITLE
volcano-devices unified config

### DIFF
--- a/pkg/scheduler/api/devices/config/config.go
+++ b/pkg/scheduler/api/devices/config/config.go
@@ -1,0 +1,106 @@
+/*
+Copyright 2025 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"gopkg.in/yaml.v2"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/klog/v2"
+
+	"volcano.sh/volcano/pkg/scheduler/api/devices"
+)
+
+const (
+	DeviceConfigFileName = "device-config.yaml"
+	ConfigMapName        = "volcano-vgpu-device-config"
+)
+
+/* Config Examples:
+    nvidia:
+      resourceCountName: "volcano.sh/vgpu"
+      ...
+    cambricon:
+      resourceCountName: "volcano.sh/vmlu"
+      ...
+    hygon:
+      resourceCountName: "volcano.sh/vdcu"
+	  ...
+*/
+
+type Config struct {
+	//NvidiaConfig is used for vGPU feature for nvidia, gpushare is not using this config
+	NvidiaConfig NvidiaConfig `yaml:"nvidia"`
+}
+
+var (
+	configs *Config
+	once    sync.Once
+)
+
+// GetConfig returns an already-initialized config
+func GetConfig() *Config {
+	return configs
+}
+
+func loadConfigFromCM(kubeClient kubernetes.Interface, cmName string) (*Config, error) {
+	cm, err := kubeClient.CoreV1().ConfigMaps("kube-system").Get(context.Background(), cmName, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	data, ok := cm.Data[DeviceConfigFileName]
+	if !ok {
+		return nil, fmt.Errorf("%s not found", DeviceConfigFileName)
+	}
+	var yamlData Config
+	err = yaml.Unmarshal([]byte(data), &yamlData)
+	if err != nil {
+		return nil, err
+	}
+	return &yamlData, nil
+}
+
+// InitDevicesConfig is called from devices, to load configs from a CM or construct a default one
+func InitDevicesConfig(cmName string) {
+	once.Do(func() {
+		var err error
+		configs, err = loadConfigFromCM(devices.GetClient(), cmName)
+		if err != nil {
+			klog.V(3).InfoS("Volcano device config not found in namespace kube-system, using default config",
+				"name", cmName)
+			configs = &Config{
+				NvidiaConfig: NvidiaConfig{
+					ResourceCountName:   VolcanoVGPUNumber,
+					ResourceCoreName:    VolcanoVGPUCores,
+					ResourceMemoryName:  VolcanoVGPUMemory,
+					DefaultMemory:       0,
+					DefaultCores:        0,
+					DefaultGPUNum:       1,
+					DeviceSplitCount:    10,
+					DeviceMemoryScaling: 1,
+					DeviceCoreScaling:   1,
+					DisableCoreLimit:    false,
+				},
+			}
+		}
+		klog.V(3).InfoS("Initializing volcano device config", "device-configs", configs)
+	})
+}

--- a/pkg/scheduler/api/devices/config/config_test.go
+++ b/pkg/scheduler/api/devices/config/config_test.go
@@ -1,0 +1,279 @@
+/*
+Copyright 2025 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/yaml.v2"
+)
+
+func TestParseDeviceConfig(t *testing.T) {
+	testCases := []struct {
+		name            string
+		deviceConfigStr string
+	}{
+		{
+			name: "construct config from file string",
+			deviceConfigStr: `nvidia:
+      resourceCountName: volcano.sh/vgpu-number
+      resourceMemoryName: volcano.sh/vgpu-memory
+      resourceMemoryPercentageName: volcano.sh/vgpu-memory-percentage
+      resourceCoreName: volcano.sh/vgpu-cores
+      overwriteEnv: false
+      defaultMemory: 0
+      defaultCores: 0
+      defaultGPUNum: 1
+      deviceSplitCount: 10
+      deviceMemoryScaling: 1
+      deviceCoreScaling: 1
+      gpuMemoryFactor: 1
+      knownMigGeometries:
+      - models: [ "A30" ]
+        allowedGeometries:
+          - group: group1
+            geometries: 
+            - name: 1g.6gb
+              memory: 6144
+              count: 4
+          - group: group2
+            geometries: 
+            - name: 2g.12gb
+              memory: 12288
+              count: 2
+          - group: group3
+            geometries: 
+            - name: 4g.24gb
+              memory: 24576
+              count: 1
+      - models: [ "A100-SXM4-40GB", "A100-40GB-PCIe", "A100-PCIE-40GB", "A100-SXM4-40GB" ]
+        allowedGeometries:
+          - group: "group1" 
+            geometries: 
+            - name: 1g.5gb
+              memory: 5120
+              count: 7
+          - group: "group2"
+            geometries: 
+            - name: 2g.10gb
+              memory: 10240
+              count: 3
+            - name: 1g.5gb
+              memory: 5120
+              count: 1
+          - group: "group3"
+            geometries: 
+            - name: 3g.20gb
+              memory: 20480
+              count: 2
+          - group: "group4"
+            geometries: 
+            - name: 7g.40gb
+              memory: 40960
+              count: 1
+      - models: [ "A100-SXM4-80GB", "A100-80GB-PCIe", "A100-PCIE-80GB"]
+        allowedGeometries:
+          - group: "group1" 
+            geometries: 
+            - name: 1g.10gb
+              memory: 10240
+              count: 7
+          - group: "group2"
+            geometries: 
+            - name: 2g.20gb
+              memory: 20480
+              count: 3
+            - name: 1g.10gb
+              memory: 10240
+              count: 1
+          - group: "group3"
+            geometries: 
+            - name: 3g.40gb
+              memory: 40960
+              count: 2
+          - group: "group4"
+            geometries: 
+            - name: 7g.79gb
+              memory: 80896
+              count: 1`,
+		},
+	}
+
+	expected := Config{
+		NvidiaConfig: NvidiaConfig{
+			ResourceCountName:            "volcano.sh/vgpu-number",
+			ResourceMemoryName:           "volcano.sh/vgpu-memory",
+			ResourceMemoryPercentageName: "volcano.sh/vgpu-memory-percentage",
+			ResourceCoreName:             "volcano.sh/vgpu-cores",
+			OverwriteEnv:                 false,
+			DefaultMemory:                0,
+			DefaultCores:                 0,
+			DefaultGPUNum:                1,
+			DeviceSplitCount:             10,
+			DeviceMemoryScaling:          1,
+			DeviceCoreScaling:            1,
+			GPUMemoryFactor:              1,
+			MigGeometriesList: []AllowedMigGeometries{
+				{
+					Models: []string{"A30"},
+					Geometries: []Geometry{
+						{
+							Group: "group1",
+							Instances: []MigTemplate{
+								{
+									Name:   "1g.6gb",
+									Memory: 6144,
+									Count:  4,
+								},
+							},
+						},
+						{
+							Group: "group2",
+							Instances: []MigTemplate{
+								{
+									Name:   "2g.12gb",
+									Memory: 12288,
+									Count:  2,
+								},
+							},
+						},
+						{
+							Group: "group3",
+							Instances: []MigTemplate{
+								{
+									Name:   "4g.24gb",
+									Memory: 24576,
+									Count:  1,
+								},
+							},
+						},
+					},
+				},
+				{
+					Models: []string{"A100-SXM4-40GB", "A100-40GB-PCIe", "A100-PCIE-40GB", "A100-SXM4-40GB"},
+					Geometries: []Geometry{
+						{
+							Group: "group1",
+							Instances: []MigTemplate{
+								{
+									Name:   "1g.5gb",
+									Memory: 5120,
+									Count:  7,
+								},
+							},
+						},
+						{
+							Group: "group2",
+							Instances: []MigTemplate{
+								{
+									Name:   "2g.10gb",
+									Memory: 10240,
+									Count:  3,
+								},
+								{
+									Name:   "1g.5gb",
+									Memory: 5120,
+									Count:  1,
+								},
+							},
+						},
+						{
+							Group: "group3",
+							Instances: []MigTemplate{
+								{
+									Name:   "3g.20gb",
+									Memory: 20480,
+									Count:  2,
+								},
+							},
+						},
+						{
+							Group: "group4",
+							Instances: []MigTemplate{
+								{
+									Name:   "7g.40gb",
+									Memory: 40960,
+									Count:  1,
+								},
+							},
+						},
+					},
+				},
+				{
+					Models: []string{"A100-SXM4-80GB", "A100-80GB-PCIe", "A100-PCIE-80GB"},
+					Geometries: []Geometry{
+						{
+							Group: "group1",
+							Instances: []MigTemplate{
+								{
+									Name:   "1g.10gb",
+									Memory: 10240,
+									Count:  7,
+								},
+							},
+						},
+						{
+							Group: "group2",
+							Instances: []MigTemplate{
+								{
+									Name:   "2g.20gb",
+									Memory: 20480,
+									Count:  3,
+								},
+								{
+									Name:   "1g.10gb",
+									Memory: 10240,
+									Count:  1,
+								},
+							},
+						},
+						{
+							Group: "group3",
+							Instances: []MigTemplate{
+								{
+									Name:   "3g.40gb",
+									Memory: 40960,
+									Count:  2,
+								},
+							},
+						},
+						{
+							Group: "group4",
+							Instances: []MigTemplate{
+								{
+									Name:   "7g.79gb",
+									Memory: 80896,
+									Count:  1,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var yamlData Config
+			err := yaml.Unmarshal([]byte(tc.deviceConfigStr), &yamlData)
+			assert.Nil(t, err)
+			assert.True(t, reflect.DeepEqual(yamlData, expected))
+		})
+	}
+}

--- a/pkg/scheduler/api/devices/config/vgpu.go
+++ b/pkg/scheduler/api/devices/config/vgpu.go
@@ -1,0 +1,113 @@
+/*
+Copyright 2025 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+const (
+	// VolcanoVGPUMemory extended gpu memory
+	VolcanoVGPUMemory = "volcano.sh/vgpu-memory"
+	// VolcanoVGPUMemoryPercentage extends gpu memory
+	VolcanoVGPUMemoryPercentage = "volcano.sh/vgpu-memory-percentage"
+	// VolcanoVGPUCores indicates utilization percentage of vgpu
+	VolcanoVGPUCores = "volcano.sh/vgpu-cores"
+	// VolcanoVGPUNumber virtual GPU card number
+	VolcanoVGPUNumber = "volcano.sh/vgpu-number"
+	// VolcanoVGPURegister virtual gpu information registered from device-plugin to scheduler
+	VolcanoVGPURegister = "volcano.sh/node-vgpu-register"
+	// VolcanoVGPUHandshake for vgpu
+	VolcanoVGPUHandshake = "volcano.sh/node-vgpu-handshake"
+)
+
+// MigTemplate is the template for a certain mig instance
+type MigTemplate struct {
+	// Name is the name for mig-instance, like '1g.10gb'
+	Name string `yaml:"name"`
+	// Memory is the device memory this mig-instance provides
+	Memory int32 `yaml:"memory"`
+	// Count is the number of corresponding mig-instances in this template
+	Count int32 `yaml:"count"`
+}
+
+// MigTemplateUsage is the usage mask about certain mig instance is using or not
+type MigTemplateUsage struct {
+	// Name is the name for mig-instance, like '1g.10gb'
+	Name string `json:"name,omitempty"`
+	// Memory is the device memory this mig-instance provides
+	Memory int32 `json:"memory,omitempty"`
+	// InUse represents whether this mig-instance is being used
+	InUse bool `json:"inuse,omitempty"`
+}
+
+// Geometry a group of mig instance, it represents a kind of mig pattern
+type Geometry struct {
+	// Group is the group name of Geometry
+	Group string `yaml:"group"`
+	// Instances is corresponding mig-instances in this geometry
+	Instances []MigTemplate `yaml:"geometries"`
+}
+
+// MIGS is an array of MigUsage
+type MIGS []MigTemplateUsage
+
+// MigInUse is about maintaining the status about certain GPU and its related mig-instances
+type MigInUse struct {
+	// Index is the index in geometry group
+	Index int32
+	// UsageList is the corresponding usage list
+	UsageList MIGS
+}
+
+// AllowedMigGeometries is about all kind of GPU curresponding supported and its mig patterns
+type AllowedMigGeometries struct {
+	// Models are the types of GPU
+	Models []string `yaml:"models"`
+	// Geometries are the mig-geometries of corresponding GPU
+	Geometries []Geometry `yaml:"allowedGeometries"`
+}
+
+// NvidiaConfig is used for Nvidia-vgpu
+type NvidiaConfig struct {
+	// ResourceCountName is the name of GPU count
+	ResourceCountName string `yaml:"resourceCountName"`
+	// ResourceMemoryName is the name of GPU device memory
+	ResourceMemoryName string `yaml:"resourceMemoryName"`
+	// ResourceCoreName is the name of GPU core
+	ResourceCoreName string `yaml:"resourceCoreName"`
+	// ResourceMemoryPercentageName is the name of GPU device memory
+	ResourceMemoryPercentageName string `yaml:"resourceMemoryPercentageName"`
+	// ResourcePriority is the name of GPU priority
+	ResourcePriority string `yaml:"resourcePriorityName"`
+	// OverwriteEnv is whether we overwrite 'NVIDIA_VISIBLE_DEVICES' to 'none' for non-gpu tasks
+	OverwriteEnv bool `yaml:"overwriteEnv"`
+	// DefaultMemory is the number of device memory if not specified
+	DefaultMemory int32 `yaml:"defaultMemory"`
+	// DefaultCores is the number of device cores if not specified
+	DefaultCores int32 `yaml:"defaultCores"`
+	// DefaultGPUNum is the number of device number if not specified
+	DefaultGPUNum int32 `yaml:"defaultGPUNum"`
+	// DeviceSplitCount is the number of fake-devices reported by vgpu-device-plugin per GPU
+	DeviceSplitCount uint `yaml:"deviceSplitCount"`
+	// DeviceMemoryScaling is the device memory oversubscription factor
+	DeviceMemoryScaling float64 `yaml:"deviceMemoryScaling"`
+	// DeviceCoreScaling is the device core oversubscription factor
+	DeviceCoreScaling float64 `yaml:"deviceCoreScaling"`
+	// DisableCoreLimit is whether we disable hard resource limit inside container
+	DisableCoreLimit bool `yaml:"disableCoreLimit"`
+	// MigGeometriesList is the mig-template geometries
+	MigGeometriesList []AllowedMigGeometries `yaml:"knownMigGeometries"`
+	// GPUMemoryFactor is the multiplier to every unit of device memory
+	GPUMemoryFactor uint `yaml:"gpuMemoryFactor"`
+}

--- a/pkg/scheduler/api/devices/nvidia/vgpu/device_info_test.go
+++ b/pkg/scheduler/api/devices/nvidia/vgpu/device_info_test.go
@@ -21,6 +21,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	"volcano.sh/volcano/pkg/scheduler/api/devices/config"
 )
 
 func TestGetGPUMemoryOfPod(t *testing.T) {
@@ -37,16 +38,16 @@ func TestGetGPUMemoryOfPod(t *testing.T) {
 						{
 							Resources: v1.ResourceRequirements{
 								Limits: v1.ResourceList{
-									VolcanoVGPUNumber: resource.MustParse("1"),
-									VolcanoVGPUMemory: resource.MustParse("3000"),
+									config.VolcanoVGPUNumber: resource.MustParse("1"),
+									config.VolcanoVGPUMemory: resource.MustParse("3000"),
 								},
 							},
 						},
 						{
 							Resources: v1.ResourceRequirements{
 								Limits: v1.ResourceList{
-									VolcanoVGPUNumber: resource.MustParse("3"),
-									VolcanoVGPUMemory: resource.MustParse("5000"),
+									config.VolcanoVGPUNumber: resource.MustParse("3"),
+									config.VolcanoVGPUMemory: resource.MustParse("5000"),
 								},
 							},
 						},

--- a/pkg/scheduler/api/devices/nvidia/vgpu/type.go
+++ b/pkg/scheduler/api/devices/nvidia/vgpu/type.go
@@ -16,9 +16,6 @@ limitations under the License.
 
 package vgpu
 
-var VGPUEnable bool
-var NodeLockEnable bool
-
 const (
 	// DeviceName used to indicate this device
 	DeviceName = "hamivgpu"
@@ -33,19 +30,6 @@ const (
 	DeviceBindPhase                  = "volcano.sh/bind-phase"
 
 	NvidiaGPUDevice = "NVIDIA"
-
-	// VolcanoVGPUMemory extended gpu memory
-	VolcanoVGPUMemory = "volcano.sh/vgpu-memory"
-	// VolcanoVGPUMemoryPercentage extends gpu memory
-	VolcanoVGPUMemoryPercentage = "volcano.sh/vgpu-memory-percentage"
-	// VolcanoVGPUCores indicates utilization percentage of vgpu
-	VolcanoVGPUCores = "volcano.sh/vgpu-cores"
-	// VolcanoVGPUNumber virtual GPU card number
-	VolcanoVGPUNumber = "volcano.sh/vgpu-number"
-	// VolcanoVGPURegister virtual gpu information registered from device-plugin to scheduler
-	VolcanoVGPURegister = "volcano.sh/node-vgpu-register"
-	// VolcanoVGPUHandshake for vgpu
-	VolcanoVGPUHandshake = "volcano.sh/node-vgpu-handshake"
 
 	// PredicateTime is the key of predicate time
 	PredicateTime = "volcano.sh/predicate-time"
@@ -64,6 +48,14 @@ const (
 	DefaultMemPercentage = 101
 	binpackMultiplier    = 100
 	spreadMultiplier     = 100
+
+	vGPUControllerHAMICore = "hami-core"
+	vGPUControllerMIG      = "mig"
+)
+
+var (
+	VGPUEnable     bool
+	NodeLockEnable bool
 )
 
 type ContainerDeviceRequest struct {

--- a/pkg/scheduler/api/devices/util.go
+++ b/pkg/scheduler/api/devices/util.go
@@ -14,6 +14,12 @@ limitations under the License.
 
 package devices
 
+import (
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/klog/v2"
+)
+
 // These are predefined codes used in a Status.
 const (
 	// Success means that plugin ran correctly and found pod schedulable.
@@ -36,3 +42,26 @@ const (
 	// Skip is used when a Bind plugin chooses to skip binding.
 	Skip
 )
+
+var kubeClient *kubernetes.Clientset
+
+func GetClient() kubernetes.Interface {
+	var err error
+	if kubeClient == nil {
+		kubeClient, err = NewClient()
+		if err != nil {
+			klog.ErrorS(err, "deviceshare initClient failed")
+		}
+	}
+	return kubeClient
+}
+
+// NewClient connects to an API server
+func NewClient() (*kubernetes.Clientset, error) {
+	config, err := rest.InClusterConfig()
+	if err != nil {
+		return nil, err
+	}
+	client, err := kubernetes.NewForConfig(config)
+	return client, err
+}


### PR DESCRIPTION
/kind feature

/area scheduling

After last Friday's discussion, we decided to use sync.once to initialize device config from configmap once during initializing. This Feature is used combined with latest version of 'https://github.com/Project-HAMi/volcano-vgpu-device-plugin'

This PR exposes vGPU resourceName as https://github.com/volcano-sh/volcano/pull/3926 does, Using device--configMap is a better than using scheduler-configmap, since device-config can be accessed by volcano-vgpu-device-plugin.

To be noticed:
1. This feature is fully compatible with earlier versions, a default config will be generated if CM not found.
2. The information got by configs is not processed now, it will be used for future dynamic-mig implementation
3. This PR won't change the behavior of volcano-vgpu feature, dynamic-mig is not implemented in this PR
4. This PR fix issue:https://github.com/volcano-sh/volcano/issues/3473