### PR TITLE
vc-scheduler: optimize bachNodeOrderFn in numaaware plugin

### DIFF
--- a/pkg/scheduler/plugins/numaaware/numaaware.go
+++ b/pkg/scheduler/plugins/numaaware/numaaware.go
@@ -169,15 +169,11 @@ func (pp *numaPlugin) OnSessionOpen(ssn *framework.Session) {
 	ssn.AddPredicateFn(pp.Name(), predicateFn)
 
 	batchNodeOrderFn := func(task *api.TaskInfo, nodeInfo []*api.NodeInfo) (map[string]float64, error) {
+		if _, found := pp.assignRes[task.UID]; !found || task.NumaInfo == nil || task.NumaInfo.Policy == "" || task.NumaInfo.Policy == "none" {
+			return nil, nil
+		}
+
 		nodeScores := make(map[string]float64, len(nodeInfo))
-		if task.NumaInfo == nil || task.NumaInfo.Policy == "" || task.NumaInfo.Policy == "none" {
-			return nodeScores, nil
-		}
-
-		if _, found := pp.assignRes[task.UID]; !found {
-			return nodeScores, nil
-		}
-
 		scoreList := getNodeNumaNumForTask(nodeInfo, pp.assignRes[task.UID])
 		util.NormalizeScore(api.DefaultMaxNodeScore, true, scoreList)
 


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:
/kind cleanup


Optionally add one of the following areas, help us further classify and filter PRs:
/area scheduling

-->

#### What this PR does / why we need it:

The  default value of float64 is 0, so we can directly return without creating a new map when the bachNodeOrderFn is inapplicable.