### PR TITLE
fix ut permission err for release ci

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -54,7 +54,7 @@ jobs:
           make verify
           make TAG=${{ env.TAG }} generate-yaml
           make verify-generated-yaml
-          make unit-test
+          sudo make unit-test
         working-directory: ./src/github.com/${{ github.repository }}
 
       - name: Login to DockerHub


### PR DESCRIPTION
#### What type of PR is this?
/kind failing-test
<!--
Add one of the following kinds:

/kind cleanup
/kind documentation
/kind feature

/kind flake

Optionally add one of the following areas, help us further classify and filter PRs:
/area scheduling
/area controllers
/area cli
/area dependency
/area webhooks
/area deploy
/area documentation
/area performance
/area test
-->

#### What this PR does / why we need it:
daily release ci failed due to permission err, see https://github.com/volcano-sh/volcano/actions/runs/12624100771/job/35173889357
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Notice that do not add `Fixes` if the issue is associated with multiple PRs.
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```