### PR TITLE
Fix session JobOrderFn to be predictable

### DIFF
--- a/pkg/scheduler/framework/session_plugins.go
+++ b/pkg/scheduler/framework/session_plugins.go
@@ -17,6 +17,7 @@ limitations under the License.
 package framework
 
 import (
+	"k8s.io/klog/v2"
 	k8sframework "k8s.io/kubernetes/pkg/scheduler/framework"
 
 	"volcano.sh/apis/pkg/apis/scheduling"
@@ -538,12 +539,15 @@ func (ssn *Session) JobOrderFn(l, r interface{}) bool {
 		}
 	}
 
-	// If no job order funcs, order job by CreationTimestamp first, then by UID.
+	// If no job order funcs, order job by CreationTimestamp first, then by Name.
 	lv := l.(*api.JobInfo)
 	rv := r.(*api.JobInfo)
 	if lv.CreationTimestamp.Equal(&rv.CreationTimestamp) {
-		return lv.UID < rv.UID
+		// Use the Name of the Job instead of UID to get deterministic order by Job name
+		klog.V(3).Infof("Creation timestamps are the same for job %v and %v: %v . using name to order", lv.Name, rv.Name, lv.CreationTimestamp)
+		return lv.Name < rv.Name
 	}
+	klog.V(3).Infof("Using creationTimestamp to order job priority %v: %v -- %v: %v ", lv.Name, lv.CreationTimestamp, rv.Name, rv.CreationTimestamp)
 	return lv.CreationTimestamp.Before(&rv.CreationTimestamp)
 }
 

--- a/pkg/scheduler/util/scheduler_helper.go
+++ b/pkg/scheduler/util/scheduler_helper.go
@@ -136,6 +136,14 @@ func SortNodes(nodeScores map[float64][]*api.NodeInfo) []*api.NodeInfo {
 	sort.Sort(sort.Reverse(sort.Float64Slice(keys)))
 	for _, key := range keys {
 		nodes := nodeScores[key]
+		// if the scores are the same, sort the nodes in predictable order using their names
+		// this is to avoid randomness in scheduling when scores are the same
+		if len(nodes) > 1 {
+			sort.Slice(nodes, func(i, j int) bool {
+				return nodes[i].Name < nodes[j].Name
+			})
+			klog.V(3).Infof("nodes with same score %v found. ordered nodes by name: %v", key, nodes)
+		}
 		nodesInorder = append(nodesInorder, nodes...)
 	}
 	return nodesInorder


### PR DESCRIPTION


#### What type of PR is this?
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind failing-test
/kind flake


Optionally add one of the following areas, help us further classify and filter PRs:
/area scheduling
/area controllers
/area cli
/area dependency
/area webhooks
/area deploy
/area documentation
/area performance
/area test
-->

/kind bug
/area scheduling

#### What this PR does / why we need it:

- This fixes an issue we've been seeing where the JobOrder doesn't return the same consistent list order when compared by job UUID. We are ordering by Job Name now
- Additionally it makes sure that when two jobs have the same score the list is always in the consistent order. We are also ordering by Job Name.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Notice that do not add `Fixes` if the issue is associated with multiple PRs.
-->
Fixes #

#### Special notes for your reviewer:

Do we need to open an issue?

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
- Fixes an issue we've been seeing where the JobOrder doesn't return the same consistent list order when compared by job UUID. We are ordering by Job Name now
- Makes sure that when two jobs have the same score the list is always in the consistent order. We are also ordering by Job Name.
```