### PR TITLE
Move GetAncestors as HyperNodeInfoMap method and provide GetLCAHyperNode

### DIFF
--- a/pkg/scheduler/api/cluster_info.go
+++ b/pkg/scheduler/api/cluster_info.go
@@ -26,6 +26,7 @@ import (
 type ClusterInfo struct {
 	Jobs                      map[JobID]*JobInfo
 	Nodes                     map[string]*NodeInfo
+	HyperNodes                HyperNodeInfoMap
 	HyperNodesSetByTier       map[int]sets.Set[string]
 	RealNodesSet              map[string]sets.Set[string]
 	HyperNodesReadyToSchedule bool

--- a/pkg/scheduler/cache/cache.go
+++ b/pkg/scheduler/cache/cache.go
@@ -1368,6 +1368,7 @@ func (sc *SchedulerCache) Snapshot() *schedulingapi.ClusterInfo {
 
 	snapshot := &schedulingapi.ClusterInfo{
 		Nodes:               make(map[string]*schedulingapi.NodeInfo),
+		HyperNodes:          make(map[string]*schedulingapi.HyperNodeInfo),
 		HyperNodesSetByTier: make(map[int]sets.Set[string]),
 		RealNodesSet:        make(map[string]sets.Set[string]),
 		Jobs:                make(map[schedulingapi.JobID]*schedulingapi.JobInfo),
@@ -1401,6 +1402,7 @@ func (sc *SchedulerCache) Snapshot() *schedulingapi.ClusterInfo {
 
 	// Snapshot hyperNodes.
 	sc.HyperNodesInfo.Lock()
+	snapshot.HyperNodes = sc.HyperNodesInfo.HyperNodes()
 	snapshot.HyperNodesSetByTier = sc.HyperNodesInfo.HyperNodesSetByTier()
 	snapshot.RealNodesSet = sc.HyperNodesInfo.RealNodesSet()
 	snapshot.HyperNodesReadyToSchedule = sc.HyperNodesInfo.Ready()

--- a/pkg/scheduler/cache/dumper.go
+++ b/pkg/scheduler/cache/dumper.go
@@ -54,7 +54,7 @@ func (d *Dumper) dumpToJSONFile() {
 	defer file.Close()
 	klog.Infoln("Starting to dump info in scheduler cache to file", fName)
 
-	if err := encodeCache(file, snapshot.Nodes, snapshot.HyperNodesSetByTier, snapshot.RealNodesSet, snapshot.Jobs); err != nil {
+	if err := encodeCache(file, snapshot.Nodes, snapshot.HyperNodesSetByTier, snapshot.RealNodesSet, snapshot.HyperNodes, snapshot.Jobs); err != nil {
 		klog.Errorf("Failed to dump info in scheduler cache, json encode error: %v", err)
 		return
 	}
@@ -86,7 +86,7 @@ func (d *Dumper) dumpAll() {
 	}
 
 	klog.Info("Dump of hyperNodes info in scheduler cache")
-	d.printHyperNodeInfo(snapshot.HyperNodesSetByTier, snapshot.RealNodesSet)
+	d.printHyperNodeInfo(snapshot.HyperNodesSetByTier, snapshot.RealNodesSet, snapshot.HyperNodes)
 
 	d.displaySchedulerMemStats()
 }
@@ -113,12 +113,12 @@ func (d *Dumper) printJobInfo(jobInfo *api.JobInfo) string {
 	return data.String()
 }
 
-func (d *Dumper) printHyperNodeInfo(HyperNodesSetByTier map[int]sets.Set[string], HyperNodes map[string]sets.Set[string]) {
+func (d *Dumper) printHyperNodeInfo(HyperNodesSetByTier map[int]sets.Set[string], realNodesSet map[string]sets.Set[string], hyperNodeInfoMap api.HyperNodeInfoMap) {
 	var data strings.Builder
 	data.WriteString("\n")
 	for tier, hyperNodes := range HyperNodesSetByTier {
 		for hyperNode := range hyperNodes {
-			data.WriteString(fmt.Sprintf("Tier: %d, HyperNodeName: %s, Nodes: %s\n", tier, hyperNode, HyperNodes[hyperNode]))
+			data.WriteString(fmt.Sprintf("Tier: %d, HyperNodeName: %s, Nodes: %s, HyperNodeInfo: %#v\n", tier, hyperNode, realNodesSet[hyperNode], hyperNodeInfoMap[hyperNode]))
 		}
 	}
 	data.WriteString("\n")

--- a/pkg/scheduler/framework/session.go
+++ b/pkg/scheduler/framework/session.go
@@ -76,6 +76,8 @@ type Session struct {
 	Tiers          []conf.Tier
 	Configurations []conf.Configuration
 	NodeList       []*api.NodeInfo
+	// HyperNodes stores the HyperNodeInfo of each HyperNode
+	HyperNodes api.HyperNodeInfoMap
 	// HyperNodesSetByTier contains a set of hyperNodes by tier from down to top, nodes under the same hyperNode
 	// have the same topology domain, e.g., nodes under the same switch or tor, jobs allocated in the same
 	// hyperNode can gain a better performance, the lower the tier of hyperNode, the better performance.
@@ -195,6 +197,7 @@ func openSession(cache cache.Cache) *Session {
 		}
 	}
 	ssn.NodeList = util.GetNodeList(snapshot.Nodes, snapshot.NodeList)
+	ssn.HyperNodes = snapshot.HyperNodes
 	ssn.HyperNodesSetByTier = snapshot.HyperNodesSetByTier
 	ssn.RealNodesList = util.GetRealNodesListByHyperNode(snapshot.RealNodesSet, snapshot.Nodes)
 	ssn.HyperNodesReadyToSchedule = snapshot.HyperNodesReadyToSchedule


### PR DESCRIPTION
#### What type of PR is this?
/kind feature
/area scheduling

#### What this PR does / why we need it:
Provide a `GetLCAHyperNode` method for allocate action or network topology plugin 

#### Which issue(s) this PR fixes:
NONE

#### Special notes for your reviewer:
1. I have changed the type of `hypernodes` in HyperNodesInfo to a new type called `HyperNodeInfoMap`, and moved the `GetAncestors`, `getparent` as its methods, therefore in allocate action or network topology plugin, it can call `ssn.HyperNodes.GetLCAHyperNode` to get the LCAHyperNode
2. Add a new field `HyperNodes` in snapshot, cache and session
3. `GetAncestors` changed to return []string slice instead, this ensures that the order of the returned ancestors list is from child hypernode to ancestor hypernode, making it easier for `GetLCAHyperNode` to find the LCAHyperNode

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```