### PR TITLE
Fix the restartPod action will cancel the restartJob delay action

### DIFF
--- a/pkg/controllers/apis/request.go
+++ b/pkg/controllers/apis/request.go
@@ -33,6 +33,7 @@ type Request struct {
 	TaskName  string
 	QueueName string
 	PodName   string
+	PodUID    types.UID
 
 	Event      v1alpha1.Event
 	ExitCode   int32

--- a/pkg/controllers/job/job_controller_handler.go
+++ b/pkg/controllers/job/job_controller_handler.go
@@ -185,6 +185,7 @@ func (cc *jobcontroller) addPod(obj interface{}) {
 		JobName:   jobName,
 		JobUid:    jobUid,
 		PodName:   pod.Name,
+		PodUID:    pod.UID,
 
 		Event:      bus.PodPendingEvent,
 		JobVersion: int32(dVersion),
@@ -302,6 +303,7 @@ func (cc *jobcontroller) updatePod(oldObj, newObj interface{}) {
 		JobUid:    jobUid,
 		TaskName:  taskName,
 		PodName:   newPod.Name,
+		PodUID:    newPod.UID,
 
 		Event:      event,
 		ExitCode:   exitCode,
@@ -371,6 +373,7 @@ func (cc *jobcontroller) deletePod(obj interface{}) {
 		JobUid:    jobUid,
 		TaskName:  taskName,
 		PodName:   pod.Name,
+		PodUID:    pod.UID,
 
 		Event:      bus.PodEvictedEvent,
 		JobVersion: int32(dVersion),

--- a/pkg/controllers/job/job_controller_util.go
+++ b/pkg/controllers/job/job_controller_util.go
@@ -173,6 +173,7 @@ func applyPolicies(job *batch.Job, req *apis.Request) (delayAct *delayAction) {
 		event:    req.Event,
 		taskName: req.TaskName,
 		podName:  req.PodName,
+		podUID:   req.PodUID,
 		// default action is sync job
 		action: v1alpha1.SyncJobAction,
 	}
@@ -435,4 +436,28 @@ func GetStateAction(delayAct *delayAction) state.Action {
 	}
 
 	return action
+}
+
+type ActionType int
+
+const (
+	JobAction ActionType = iota
+	TaskAction
+	PodAction
+)
+
+func GetActionType(action v1alpha1.Action) ActionType {
+	switch action {
+	case v1alpha1.AbortJobAction,
+		v1alpha1.RestartJobAction,
+		v1alpha1.TerminateJobAction,
+		v1alpha1.CompleteJobAction,
+		v1alpha1.ResumeJobAction:
+		return JobAction
+	case v1alpha1.RestartTaskAction:
+		return TaskAction
+	case v1alpha1.RestartPodAction:
+		return PodAction
+	}
+	return JobAction
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The restartPod action should not cancel the restartJob delay action

#### Which issue(s) this PR fixes:

Fixes #3812 

#### Special notes for your reviewer:

Add the action type check when try to cancel the delayed job actions

#### Does this PR introduce a user-facing change?

```release-note
NONE
```