### PR TITLE
Remove runningEstimate from CRD

### DIFF
--- a/config/crd/jobflow/bases/flow.volcano.sh_jobtemplates.yaml
+++ b/config/crd/jobflow/bases/flow.volcano.sh_jobtemplates.yaml
@@ -91,8 +91,6 @@ spec:
                 type: string
               queue:
                 type: string
-              runningEstimate:
-                type: string
               schedulerName:
                 type: string
               tasks:

--- a/config/crd/volcano/bases/batch.volcano.sh_jobs.yaml
+++ b/config/crd/volcano/bases/batch.volcano.sh_jobs.yaml
@@ -109,8 +109,6 @@ spec:
                 type: string
               queue:
                 type: string
-              runningEstimate:
-                type: string
               schedulerName:
                 type: string
               tasks:

--- a/config/crd/volcano/v1beta1/batch.volcano.sh_jobs.yaml
+++ b/config/crd/volcano/v1beta1/batch.volcano.sh_jobs.yaml
@@ -86,8 +86,6 @@ spec:
               type: string
             queue:
               type: string
-            runningEstimate:
-              type: string
             schedulerName:
               type: string
             tasks:

--- a/installer/helm/chart/volcano/charts/jobflow/crd/bases/flow.volcano.sh_jobtemplates.yaml
+++ b/installer/helm/chart/volcano/charts/jobflow/crd/bases/flow.volcano.sh_jobtemplates.yaml
@@ -90,8 +90,6 @@ spec:
                 type: string
               queue:
                 type: string
-              runningEstimate:
-                type: string
               schedulerName:
                 type: string
               tasks:

--- a/installer/helm/chart/volcano/crd/bases/batch.volcano.sh_jobs.yaml
+++ b/installer/helm/chart/volcano/crd/bases/batch.volcano.sh_jobs.yaml
@@ -108,8 +108,6 @@ spec:
                 type: string
               queue:
                 type: string
-              runningEstimate:
-                type: string
               schedulerName:
                 type: string
               tasks:

--- a/installer/helm/chart/volcano/crd/v1beta1/batch.volcano.sh_jobs.yaml
+++ b/installer/helm/chart/volcano/crd/v1beta1/batch.volcano.sh_jobs.yaml
@@ -84,8 +84,6 @@ spec:
               type: string
             queue:
               type: string
-            runningEstimate:
-              type: string
             schedulerName:
               type: string
             tasks:

--- a/installer/volcano-development.yaml
+++ b/installer/volcano-development.yaml
@@ -347,8 +347,6 @@ spec:
                 type: string
               queue:
                 type: string
-              runningEstimate:
-                type: string
               schedulerName:
                 type: string
               tasks:
@@ -5501,8 +5499,6 @@ spec:
               priorityClassName:
                 type: string
               queue:
-                type: string
-              runningEstimate:
                 type: string
               schedulerName:
                 type: string


### PR DESCRIPTION
This doesn't appear to be referenced anywhere in any of the code
anymore. I don't think there is a reason to keep this field in the
manifest spec anymore.
