### PR TITLE
add helm values scheduler_plugins_dir

### DIFF
--- a/installer/README.md
+++ b/installer/README.md
@@ -130,6 +130,7 @@ The following are the list configurable parameters of Volcano Chart and their de
 |`custom.controller_log_level`|Settings log print level for Controller|`4`|
 |`custom.scheduler_resources`|Resources for Scheduler pods|`~`|
 |`custom.scheduler_log_level`|Settings log print level for Scheduler|`3`|
+|`custom.scheduler_plugins_dir`| Settings dir for the Scheduler to load custom plugins|``|
 |`custom.webhooks_namespace_selector_expressions`|Additional namespace selector expressions for Volcano admission webhooks|`~`|
 |`service.ipFamilyPolicy`|Settings service the family policy|``|
 |`service.ipFamilies`|Settings service the address families|`[]`|

--- a/installer/helm/chart/volcano/templates/scheduler.yaml
+++ b/installer/helm/chart/volcano/templates/scheduler.yaml
@@ -201,6 +201,9 @@ spec:
             {{- if .Values.custom.scheduler_node_worker_threads }}
             - --node-worker-threads={{.Values.custom.scheduler_node_worker_threads}}
             {{- end }}
+            {{- if .Values.custom.scheduler_plugins_dir }}
+            - --plugins-dir={{ .Values.custom.scheduler_plugins_dir }}
+            {{- end }}
             - -v={{.Values.custom.scheduler_log_level}}
             - 2>&1
           env:

--- a/installer/helm/chart/volcano/values.yaml
+++ b/installer/helm/chart/volcano/values.yaml
@@ -21,6 +21,7 @@ custom:
   scheduler_enable: true
   scheduler_replicas: 1
   scheduler_metrics_enable: true
+  scheduler_plugins_dir: ""
   scheduler_name: ~
   leader_elect_enable: false
   controller_kube_api_qps: 50


### PR DESCRIPTION

<!--
/kind feature
Optionally add one of the following areas, help us further classify and filter PRs:
/area dependency
-->

#### What this PR does / why we need it:
现在helm charts values 不支持配置scheduler 的plugins-dir。实际上npu 插件部署经常需要指定这个参数

