### PR TITLE
use replicas when initializing pg minResources

### DIFF
--- a/pkg/controllers/job/job_controller_util.go
+++ b/pkg/controllers/job/job_controller_util.go
@@ -327,10 +327,10 @@ func (p TasksPriority) CalcFirstCountResources(count int32) v1.ResourceList {
 
 	for _, task := range p {
 		if count <= task.Replicas {
-			minReq = quotav1.Add(minReq, calTaskRequests(&v1.Pod{Spec: task.Template.Spec}, count))
+			minReq = quotav1.Add(minReq, util.CalTaskRequests(&v1.Pod{Spec: task.Template.Spec}, count))
 			break
 		} else {
-			minReq = quotav1.Add(minReq, calTaskRequests(&v1.Pod{Spec: task.Template.Spec}, task.Replicas))
+			minReq = quotav1.Add(minReq, util.CalTaskRequests(&v1.Pod{Spec: task.Template.Spec}, task.Replicas))
 			count -= task.Replicas
 		}
 	}
@@ -353,7 +353,7 @@ func (p TasksPriority) CalcPGMinResources(jobMinAvailable int32) v1.ResourceList
 		if left := jobMinAvailable - podCnt; left < validReplics {
 			validReplics = left
 		}
-		minReq = quotav1.Add(minReq, calTaskRequests(&v1.Pod{Spec: task.Template.Spec}, validReplics))
+		minReq = quotav1.Add(minReq, util.CalTaskRequests(&v1.Pod{Spec: task.Template.Spec}, validReplics))
 		podCnt += validReplics
 		if podCnt >= jobMinAvailable {
 			break
@@ -377,25 +377,15 @@ func (p TasksPriority) CalcPGMinResources(jobMinAvailable int32) v1.ResourceList
 		}
 
 		if leftCnt >= left {
-			minReq = quotav1.Add(minReq, calTaskRequests(&v1.Pod{Spec: task.Template.Spec}, left))
+			minReq = quotav1.Add(minReq, util.CalTaskRequests(&v1.Pod{Spec: task.Template.Spec}, left))
 			leftCnt -= left
 		} else {
-			minReq = quotav1.Add(minReq, calTaskRequests(&v1.Pod{Spec: task.Template.Spec}, leftCnt))
+			minReq = quotav1.Add(minReq, util.CalTaskRequests(&v1.Pod{Spec: task.Template.Spec}, leftCnt))
 			leftCnt = 0
 		}
 		if leftCnt <= 0 {
 			break
 		}
-	}
-	return minReq
-}
-
-// calTaskRequests returns requests resource with validReplica replicas
-func calTaskRequests(pod *v1.Pod, validReplica int32) v1.ResourceList {
-	minReq := v1.ResourceList{}
-	usage := *util.GetPodQuotaUsage(pod)
-	for i := int32(0); i < validReplica; i++ {
-		minReq = quotav1.Add(minReq, usage)
 	}
 	return minReq
 }

--- a/pkg/controllers/podgroup/pg_controller.go
+++ b/pkg/controllers/podgroup/pg_controller.go
@@ -58,15 +58,9 @@ type pgcontroller struct {
 
 	// A store of pods
 	podLister corelisters.PodLister
-	podSynced func() bool
 
 	// A store of podgroups
 	pgLister schedulinglister.PodGroupLister
-	pgSynced func() bool
-
-	// A store of replicaset
-	rsSynced  func() bool
-	stsSynced func() bool
 
 	queue workqueue.TypedRateLimitingInterface[podRequest]
 
@@ -96,7 +90,6 @@ func (pg *pgcontroller) Initialize(opt *framework.ControllerOption) error {
 	pg.informerFactory = opt.SharedInformerFactory
 	pg.podInformer = opt.SharedInformerFactory.Core().V1().Pods()
 	pg.podLister = pg.podInformer.Lister()
-	pg.podSynced = pg.podInformer.Informer().HasSynced
 	pg.podInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: pg.addPod,
 	})
@@ -105,18 +98,15 @@ func (pg *pgcontroller) Initialize(opt *framework.ControllerOption) error {
 	pg.vcInformerFactory = factory
 	pg.pgInformer = factory.Scheduling().V1beta1().PodGroups()
 	pg.pgLister = pg.pgInformer.Lister()
-	pg.pgSynced = pg.pgInformer.Informer().HasSynced
 
 	if utilfeature.DefaultFeatureGate.Enabled(features.WorkLoadSupport) {
 		pg.rsInformer = pg.informerFactory.Apps().V1().ReplicaSets()
-		pg.rsSynced = pg.rsInformer.Informer().HasSynced
 		pg.rsInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 			AddFunc:    pg.addReplicaSet,
 			UpdateFunc: pg.updateReplicaSet,
 		})
 
 		pg.stsInformer = pg.informerFactory.Apps().V1().StatefulSets()
-		pg.stsSynced = pg.stsInformer.Informer().HasSynced
 		pg.stsInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 			AddFunc:    pg.addStatefulSet,
 			UpdateFunc: pg.updateStatefulSet,

--- a/pkg/controllers/podgroup/pg_controller_test.go
+++ b/pkg/controllers/podgroup/pg_controller_test.go
@@ -20,8 +20,10 @@ import (
 	"context"
 	"testing"
 
+	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/informers"
@@ -46,6 +48,7 @@ func newFakeController() *pgcontroller {
 		SharedInformerFactory:   sharedInformers,
 		VCSharedInformerFactory: vcSharedInformers,
 		SchedulerNames:          []string{"volcano"},
+		InheritOwnerAnnotations: true,
 	}
 
 	controller.Initialize(opt)
@@ -57,34 +60,39 @@ func TestAddPodGroup(t *testing.T) {
 	namespace := "test"
 	isController := true
 	blockOwnerDeletion := true
+	replicas := int32(2)
+	gpuKey := v1.ResourceName("nvidia.com/gpu")
 
 	testCases := []struct {
 		name             string
-		pod              *v1.Pod
+		rs               *appsv1.ReplicaSet
+		pods             []*v1.Pod
 		expectedPodGroup *scheduling.PodGroup
 	}{
 		{
 			name: "AddPodGroup: pod has ownerReferences and priorityClassName",
-			pod: &v1.Pod{
-				TypeMeta: metav1.TypeMeta{
-					APIVersion: "v1",
-					Kind:       "Pod",
-				},
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "pod1",
-					Namespace: namespace,
-					OwnerReferences: []metav1.OwnerReference{
-						{
-							APIVersion: "app/v1",
-							Kind:       "ReplicaSet",
-							Name:       "rs1",
-							UID:        "7a09885b-b753-4924-9fba-77c0836bac20",
-							Controller: &isController,
+			pods: []*v1.Pod{
+				{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+						Kind:       "Pod",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "pod1",
+						Namespace: namespace,
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								APIVersion: "app/v1",
+								Kind:       "ReplicaSet",
+								Name:       "rs1",
+								UID:        "7a09885b-b753-4924-9fba-77c0836bac20",
+								Controller: &isController,
+							},
 						},
 					},
-				},
-				Spec: v1.PodSpec{
-					PriorityClassName: "test-pc",
+					Spec: v1.PodSpec{
+						PriorityClassName: "test-pc",
+					},
 				},
 			},
 			expectedPodGroup: &scheduling.PodGroup{
@@ -113,15 +121,17 @@ func TestAddPodGroup(t *testing.T) {
 		},
 		{
 			name: "AddPodGroup: pod has no ownerReferences or priorityClassName",
-			pod: &v1.Pod{
-				TypeMeta: metav1.TypeMeta{
-					APIVersion: "v1",
-					Kind:       "Pod",
-				},
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "pod1",
-					Namespace: namespace,
-					UID:       types.UID("7a09885b-b753-4924-9fba-77c0836bac20"),
+			pods: []*v1.Pod{
+				{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+						Kind:       "Pod",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "pod1",
+						Namespace: namespace,
+						UID:       types.UID("7a09885b-b753-4924-9fba-77c0836bac20"),
+					},
 				},
 			},
 			expectedPodGroup: &scheduling.PodGroup{
@@ -148,45 +158,198 @@ func TestAddPodGroup(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "AddPodGroup: pod owners with group-min-member annotation",
+			rs: &appsv1.ReplicaSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "rs1",
+					Namespace: namespace,
+					UID:       "7a09885b-b753-4924-9fba-77c0836bac20",
+					Annotations: map[string]string{
+						scheduling.VolcanoGroupMinMemberAnnotationKey: "2",
+					},
+				},
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "v1",
+					Kind:       "ReplicaSet",
+				},
+				Spec: appsv1.ReplicaSetSpec{
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"app": "rs1",
+						},
+					},
+					Replicas: &replicas,
+					Template: v1.PodTemplateSpec{
+						Spec: v1.PodSpec{
+							Containers: []v1.Container{
+								{
+									Name: "container1",
+									Resources: v1.ResourceRequirements{
+										Requests: v1.ResourceList{
+											gpuKey: resource.MustParse("1"),
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			pods: []*v1.Pod{
+				{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+						Kind:       "Pod",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "pod1",
+						Namespace: namespace,
+						Labels: map[string]string{
+							"app": "rs1",
+						},
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								APIVersion: "app/v1",
+								Kind:       "ReplicaSet",
+								Name:       "rs1",
+								UID:        "7a09885b-b753-4924-9fba-77c0836bac20",
+								Controller: &isController,
+							},
+						},
+					},
+					Spec: v1.PodSpec{
+						Containers: []v1.Container{
+							{
+								Name: "container1",
+								Resources: v1.ResourceRequirements{
+									Requests: v1.ResourceList{
+										gpuKey: resource.MustParse("1"),
+									},
+								},
+							},
+						},
+					},
+				},
+				{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+						Kind:       "Pod",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "pod2",
+						Namespace: namespace,
+						Labels: map[string]string{
+							"app": "rs1",
+						},
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								APIVersion: "app/v1",
+								Kind:       "ReplicaSet",
+								Name:       "rs1",
+								UID:        "7a09885b-b753-4924-9fba-77c0836bac20",
+								Controller: &isController,
+							},
+						},
+					},
+					Spec: v1.PodSpec{
+						Containers: []v1.Container{
+							{
+								Name: "container1",
+								Resources: v1.ResourceRequirements{
+									Requests: v1.ResourceList{
+										gpuKey: resource.MustParse("1"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedPodGroup: &scheduling.PodGroup{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "scheduling.volcano.sh/v1beta1",
+					Kind:       "PodGroup",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "podgroup-7a09885b-b753-4924-9fba-77c0836bac20",
+					Namespace: namespace,
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion: "app/v1",
+							Kind:       "ReplicaSet",
+							Name:       "rs1",
+							UID:        "7a09885b-b753-4924-9fba-77c0836bac20",
+							Controller: &isController,
+						},
+					},
+				},
+				Spec: scheduling.PodGroupSpec{
+					MinMember: 2,
+					MinResources: &v1.ResourceList{
+						gpuKey: resource.MustParse("2"),
+					},
+				},
+			},
+		},
 	}
 
 	for _, testCase := range testCases {
 		c := newFakeController()
 
-		pod, err := c.kubeClient.CoreV1().Pods(testCase.pod.Namespace).Create(context.TODO(), testCase.pod, metav1.CreateOptions{})
-		if err != nil {
-			t.Errorf("Case %s failed when creating pod for %v", testCase.name, err)
+		if testCase.rs != nil {
+			rs, err := c.kubeClient.AppsV1().ReplicaSets(namespace).Create(context.TODO(), testCase.rs, metav1.CreateOptions{})
+			if err != nil {
+				t.Errorf("Case %s failed when creating replicaSet for %v", testCase.name, err)
+			}
+
+			c.addReplicaSet(rs)
 		}
 
-		c.addPod(pod)
-		c.createNormalPodPGIfNotExist(pod)
+		for i := range testCase.pods {
+			pod, err := c.kubeClient.CoreV1().Pods(testCase.pods[i].Namespace).Create(context.TODO(), testCase.pods[i], metav1.CreateOptions{})
+			if err != nil {
+				t.Errorf("Case %s failed when creating pod for %v", testCase.name, err)
+			}
 
-		pg, err := c.vcClient.SchedulingV1beta1().PodGroups(pod.Namespace).Get(context.TODO(),
-			testCase.expectedPodGroup.Name,
-			metav1.GetOptions{},
-		)
-		if err != nil {
-			t.Errorf("Case %s failed when getting podGroup for %v", testCase.name, err)
-		}
+			c.addPod(pod)
+			c.createNormalPodPGIfNotExist(pod)
 
-		if false == equality.Semantic.DeepEqual(pg.OwnerReferences, testCase.expectedPodGroup.OwnerReferences) {
-			t.Errorf("Case %s failed, expect %v, got %v", testCase.name, testCase.expectedPodGroup, pg)
-		}
+			pg, err := c.vcClient.SchedulingV1beta1().PodGroups(pod.Namespace).Get(context.TODO(),
+				testCase.expectedPodGroup.Name,
+				metav1.GetOptions{},
+			)
+			if err != nil {
+				t.Errorf("Case %s failed when getting podGroup for %v", testCase.name, err)
+			}
 
-		newpod, err := c.kubeClient.CoreV1().Pods(testCase.pod.Namespace).Get(context.TODO(), pod.Name, metav1.GetOptions{})
-		if err != nil {
-			t.Errorf("Case %s failed when creating pod for %v", testCase.name, err)
-		}
+			if false == equality.Semantic.DeepEqual(pg.OwnerReferences, testCase.expectedPodGroup.OwnerReferences) {
+				t.Errorf("Case %s failed, expect %v, got %v", testCase.name, testCase.expectedPodGroup, pg)
+			}
 
-		podAnnotation := newpod.Annotations[scheduling.KubeGroupNameAnnotationKey]
-		if testCase.expectedPodGroup.Name != podAnnotation {
-			t.Errorf("Case %s failed, expect %v, got %v", testCase.name,
-				testCase.expectedPodGroup.Name, podAnnotation)
-		}
+			newpod, err := c.kubeClient.CoreV1().Pods(testCase.pods[i].Namespace).Get(context.TODO(), pod.Name, metav1.GetOptions{})
+			if err != nil {
+				t.Errorf("Case %s failed when creating pod for %v", testCase.name, err)
+			}
 
-		if testCase.expectedPodGroup.Spec.PriorityClassName != pod.Spec.PriorityClassName {
-			t.Errorf("Case %s failed, expect %v, got %v", testCase.name,
-				testCase.expectedPodGroup.Spec.PriorityClassName, pod.Spec.PriorityClassName)
+			podAnnotation := newpod.Annotations[scheduling.KubeGroupNameAnnotationKey]
+			if testCase.expectedPodGroup.Name != podAnnotation {
+				t.Errorf("Case %s failed, expect %v, got %v", testCase.name,
+					testCase.expectedPodGroup.Name, podAnnotation)
+			}
+
+			if testCase.expectedPodGroup.Spec.PriorityClassName != pod.Spec.PriorityClassName {
+				t.Errorf("Case %s failed, expect %v, got %v", testCase.name,
+					testCase.expectedPodGroup.Spec.PriorityClassName, pod.Spec.PriorityClassName)
+			}
+
+			if pg.Spec.MinMember != testCase.expectedPodGroup.Spec.MinMember {
+				t.Errorf("Case %s failed, expect %v, got %v", testCase.name, testCase.expectedPodGroup.Spec.MinMember, pg.Spec.MinMember)
+			}
+
+			if testCase.expectedPodGroup.Spec.MinResources != nil && false == equality.Semantic.DeepEqual(pg.Spec.MinResources.Name(gpuKey, resource.DecimalSI), testCase.expectedPodGroup.Spec.MinResources.Name(gpuKey, resource.DecimalSI)) {
+				t.Errorf("Case %s failed, expect %v, got %v", testCase.name, testCase.expectedPodGroup.Spec.MinResources.Name(gpuKey, resource.DecimalSI), pg.Spec.MinResources.Name(gpuKey, resource.DecimalSI))
+			}
 		}
 	}
 }

--- a/pkg/controllers/util/util.go
+++ b/pkg/controllers/util/util.go
@@ -4,17 +4,28 @@ import (
 	"strings"
 
 	v1 "k8s.io/api/core/v1"
+	quotav1 "k8s.io/apiserver/pkg/quota/v1"
 	"k8s.io/kubernetes/pkg/apis/core/v1/helper"
 	quotacore "k8s.io/kubernetes/pkg/quota/v1/evaluator/core"
 	"k8s.io/utils/clock"
 )
 
-func GetPodQuotaUsage(pod *v1.Pod) *v1.ResourceList {
+func GetPodQuotaUsage(pod *v1.Pod) v1.ResourceList {
 	res, _ := quotacore.PodUsageFunc(pod, clock.RealClock{})
 	for name, quantity := range res {
 		if !helper.IsNativeResource(name) && strings.HasPrefix(string(name), v1.DefaultResourceRequestsPrefix) {
 			res[v1.ResourceName(strings.TrimPrefix(string(name), v1.DefaultResourceRequestsPrefix))] = quantity
 		}
 	}
-	return &res
+	return res
+}
+
+// calTaskRequests returns requests resource with validReplica replicas
+func CalTaskRequests(pod *v1.Pod, validReplica int32) v1.ResourceList {
+	minReq := v1.ResourceList{}
+	usage := GetPodQuotaUsage(pod)
+	for i := int32(0); i < validReplica; i++ {
+		minReq = quotav1.Add(minReq, usage)
+	}
+	return minReq
 }

--- a/pkg/controllers/util/util_test.go
+++ b/pkg/controllers/util/util_test.go
@@ -43,7 +43,7 @@ func TestGetPodQuotaUsage(t *testing.T) {
 		"requests.cpu":            2,
 	}
 
-	res := *GetPodQuotaUsage(pod)
+	res := GetPodQuotaUsage(pod)
 	for name, quantity := range expected {
 		value, ok := res[corev1.ResourceName(name)]
 		if !ok {


### PR DESCRIPTION
When creating pod using replicaSet, the minMember of podgroup created is always 1, this is not reasonable. Consider this case:
1. we created a deployment with 2 replicas, totally requesting 16 gpus 
2. the podgroup created has 1 minMember and 8 gpus
3. the capability of queue has 8 gpus and the scheduler configmap disables  AllocatableFn of proportion plugin
4. the podgroup will be enqueued and running since minResources(8 gpus) is not bigger than queue capability
5. finally the queue allocated 16 gpus, more than its deserved

As can be seen from this picture:   
![image](https://github.com/user-attachments/assets/a3e3041d-44d2-4f3d-b948-005ab0e227ca)

In the case that pod has replicas from its owners, the podgroup should consider relicas, just as training-operator does, which creates pod group based on resources from all replicas