### PR TITLE
skip the jobs that have no tasks during the close session step in gang plugin

### DIFF
--- a/pkg/scheduler/plugins/gang/gang.go
+++ b/pkg/scheduler/plugins/gang/gang.go
@@ -163,6 +163,10 @@ func (gp *gangPlugin) OnSessionClose(ssn *framework.Session) {
 	var unreadyTaskCount int32
 	var unScheduleJobCount int
 	for _, job := range ssn.Jobs {
+		// skip the jobs that have no tasks.
+		if len(job.Tasks) == 0 {
+			continue
+		}
 		if !job.IsReady() {
 			schedulableTaskNum := func() (num int32) {
 				for _, task := range job.TaskStatusIndex[api.Pending] {


### PR DESCRIPTION
#### What type of PR is this?

/kind flake
/area scheduling



#### What this PR does / why we need it:
In the `OnSessionClose` function, the new PR skip the unavailable job. Unnecessary podgroup condition updates are avoided in the following scenarios:

1. In the vj deletion scenario, the Pod deletion event is watched earlier than the PG deletion event. At this time, `len(jobInfo.Tasks) == 0 && jobInfo.PodGroup != nil`, and a new PodGroupUnschedulableType condition is added
2. In the vj creation scenario, the podgroup has been created but the pod has not been created yet. In this case, a new PodGroupUnschedulableType condition is added similar to scenario 1

#### Which issue(s) this PR fixes:
Fixes #4011

#### Special notes for your reviewer:
NONE

#### Does this PR introduce a user-facing change?
NONE