### PR TITLE
Add hyperNode controller framework and provider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -135,3 +135,5 @@ vendor
 
 # helm dependency files
 installer/helm/chart/volcano/requirements.lock
+
+*.so

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ IMAGE_PREFIX=volcanosh
 CRD_OPTIONS ?= "crd:crdVersions=v1,generateEmbeddedObjectMeta=true"
 CRD_OPTIONS_EXCLUDE_DESCRIPTION=${CRD_OPTIONS}",maxDescLen=0"
 CC ?= "gcc"
+MUSL_CC ?= "/usr/local/musl/bin/musl-gcc"
 SUPPORT_PLUGINS ?= "no"
 CRD_VERSION ?= v1
 BUILDX_OUTPUT_TYPE ?= "docker"
@@ -73,13 +74,17 @@ init:
 
 vc-scheduler: init
 	if [ ${SUPPORT_PLUGINS} = "yes" ];then\
-		CC=${CC} CGO_ENABLED=1 go build -ldflags ${LD_FLAGS} -o ${BIN_DIR}/vc-scheduler ./cmd/scheduler;\
+		CC=${MUSL_CC} CGO_ENABLED=1 go build -ldflags ${LD_FLAGS_CGO} -o ${BIN_DIR}/vc-scheduler ./cmd/scheduler;\
 	else\
 		CC=${CC} CGO_ENABLED=0 go build -ldflags ${LD_FLAGS} -o ${BIN_DIR}/vc-scheduler ./cmd/scheduler;\
 	fi;
 
 vc-controller-manager: init
-	CC=${CC} CGO_ENABLED=0 go build -ldflags ${LD_FLAGS} -o ${BIN_DIR}/vc-controller-manager ./cmd/controller-manager
+	if [ ${SUPPORT_PLUGINS} = "yes" ];then\
+		CC=${MUSL_CC} CGO_ENABLED=1 go build -ldflags ${LD_FLAGS_CGO} -o ${BIN_DIR}/vc-controller-manager ./cmd/controller-manager;\
+	else\
+		CC=${CC} CGO_ENABLED=0 go build -ldflags ${LD_FLAGS} -o ${BIN_DIR}/vc-controller-manager ./cmd/controller-manager;\
+	fi;
 
 vc-webhook-manager: init
 	CC=${CC} CGO_ENABLED=0 go build -ldflags ${LD_FLAGS} -o ${BIN_DIR}/vc-webhook-manager ./cmd/webhook-manager

--- a/Makefile.def
+++ b/Makefile.def
@@ -5,8 +5,12 @@ GitSHA=`git rev-parse HEAD`
 Date=`date "+%Y-%m-%d %H:%M:%S"`
 RELEASE_VER=v1.11.0-network-topology-preview.0
 OPEN_EULER_IMAGE_TAG ?= 22.03-lts-sp2
-LD_FLAGS=" \
+LD_FLAGS="\
     -X '${REPO_PATH}/pkg/version.GitSHA=${GitSHA}' \
     -X '${REPO_PATH}/pkg/version.Built=${Date}'   \
     -X '${REPO_PATH}/pkg/version.Version=${RELEASE_VER}'"
-
+LD_FLAGS_CGO="\
+    -linkmode=external \
+    -X '${REPO_PATH}/pkg/version.GitSHA=${GitSHA}' \
+    -X '${REPO_PATH}/pkg/version.Built=${Date}'   \
+    -X '${REPO_PATH}/pkg/version.Version=${RELEASE_VER}'"

--- a/cmd/controller-manager/app/options/options.go
+++ b/cmd/controller-manager/app/options/options.go
@@ -92,6 +92,9 @@ type ServerOption struct {
 	// Case3: "-gc-controller,-job-controller,-jobflow-controller,-jobtemplate-controller,-pg-controller,-queue-controller"
 	// to disable specific controllers,
 	Controllers []string
+	// HyperNodeProviderDir is the directory of hyperNode provider, vc controller
+	// read .so file in this directory to load hyperNode provider plugins.
+	HyperNodeProviderDir string
 }
 
 type DecryptFunc func(c *ServerOption) error
@@ -129,6 +132,7 @@ func (s *ServerOption) AddFlags(fs *pflag.FlagSet, knownControllers []string) {
 	fs.Uint32Var(&s.WorkerThreadsForQueue, "worker-threads-for-queue", defaultQueueWorkers, "The number of threads syncing queue operations. The larger the number, the faster the queue processing, but requires more CPU load.")
 	fs.StringSliceVar(&s.Controllers, "controllers", []string{defaultControllers}, fmt.Sprintf("Specify controller gates. Use '*' for all controllers, all knownController: %s ,and we can use "+
 		"'-' to disable controllers, e.g. \"-job-controller,-queue-controller\" to disable job and queue controllers.", knownControllers))
+	fs.StringVar(&s.HyperNodeProviderDir, "hypernode-provider-dir", "", "The directory of hyperNode provider, vc controller read .so file in this directory to load hyperNode provider plugin.")
 }
 
 // CheckOptionOrDie checks all options and returns all errors if they are invalid.

--- a/cmd/controller-manager/app/server.go
+++ b/cmd/controller-manager/app/server.go
@@ -139,6 +139,7 @@ func startControllers(config *rest.Config, opt *options.ServerOption) func(ctx c
 	controllerOpt.WorkerThreadsForQueue = opt.WorkerThreadsForQueue
 	controllerOpt.WorkerThreadsForGC = opt.WorkerThreadsForGC
 	controllerOpt.Config = config
+	controllerOpt.HyperNodeProviderDir = opt.HyperNodeProviderDir
 
 	return func(ctx context.Context) {
 		framework.ForeachController(func(c framework.Controller) {

--- a/cmd/controller-manager/main.go
+++ b/cmd/controller-manager/main.go
@@ -34,6 +34,7 @@ import (
 	"volcano.sh/volcano/cmd/controller-manager/app/options"
 	"volcano.sh/volcano/pkg/controllers/framework"
 	_ "volcano.sh/volcano/pkg/controllers/garbagecollector"
+	_ "volcano.sh/volcano/pkg/controllers/hypernode"
 	_ "volcano.sh/volcano/pkg/controllers/job"
 	_ "volcano.sh/volcano/pkg/controllers/jobflow"
 	_ "volcano.sh/volcano/pkg/controllers/jobtemplate"

--- a/example/hypernode-provider/Dockerfile
+++ b/example/hypernode-provider/Dockerfile
@@ -1,0 +1,32 @@
+FROM golang:1.22.2 AS builder
+
+WORKDIR /go/src/volcano.sh/
+
+# Install musl
+RUN apt-get update && \
+    apt-get install -y sudo
+
+RUN wget http://musl.libc.org/releases/musl-1.2.1.tar.gz && \
+    tar -xf musl-1.2.1.tar.gz && \
+    cd musl-1.2.1 && \
+    ./configure && make && sudo make install
+
+COPY go.mod go.sum ./
+
+RUN go mod download
+
+ADD . volcano
+
+# Build plugin
+RUN cd volcano && CC=/usr/local/musl/bin/musl-gcc CGO_ENABLED=1 \
+    go build -buildmode=plugin -ldflags '-linkmode=external' \
+    -o example/hypernode-provider/example-provider.so example/hypernode-provider/example_provider.go
+
+# Build vc controller base manager image with plugin enabled
+RUN cd volcano && SUPPORT_PLUGINS=yes make vc-controller-manager
+
+# Build vc controller manager image with plugin
+FROM alpine:latest
+COPY --from=builder /go/src/volcano.sh/volcano/_output/bin/vc-controller-manager /vc-controller-manager
+COPY --from=builder /go/src/volcano.sh/volcano/example/hypernode-provider/example-provider.so /
+ENTRYPOINT ["/vc-controller-manager"]

--- a/example/hypernode-provider/README.md
+++ b/example/hypernode-provider/README.md
@@ -1,0 +1,19 @@
+# Overview
+
+As stated in the [network topology aware scheduling doc](https://github.com/volcano-sh/volcano/blob/master/docs/design/Network%20Topology%20Aware%20Scheduling.md#network-topology-generation-and-update), datacenter's network topology architectures are different, besides create and update hyperNode CRDs manually, Volcano should also support a method that auto-discovery the network topology and update the hyperNode CRDs automatically, this needs the cooperation with under-layer hardware vendors, Volcano controller supports the basic hyperNodes reconcile framework, and expose an interface which can interactive with the hardware vendors, the vendor behaves as a hyperNode provider and reconcile hyperNodes such as creating/updating/reporting healthy status, through which Volcano can adapt any hardware vendors with auto-discovery network topology tools supported, and vendors just need to focus on the auto-discovery mechanism while Volcano supports a basic framework and integrate them with an extensible way. This is similar to the [cloud provider mechanism](https://github.com/kubernetes/cloud-provider) in kubernetes.
+
+# How to use
+
+## Write your provider
+Write your codes locally and implement the `Plugin` interface in file `pkg/controllers/hypernode/provider/interface.go`, there are two critical params that you need to concern:
+`eventCh chan<- Event`: Vendors should send the hyperNode create/update/delete event to this channel, and Volcano controller will communicate to API Server to store them.
+`replyCh <-chan Reply`: Volcano will reply errors to vendor providers through this channel when an unexpected error occurs when communicating with the API Server and the retry does not succeed, providers should be aware of that and should resend the event or perform fault-tolerant processing.
+
+There is an example in `example_provider.go` at current directory demonstrated how to write a provider.
+
+## Build the provider with volcano controller
+
+You should execute the following command in volcano directory to build the provider.
+```shell
+docker build -t volcanosh/vc-controller-manager:provider -f example/hypernode-provider/Dockerfile .
+```

--- a/example/hypernode-provider/example_provider.go
+++ b/example/hypernode-provider/example_provider.go
@@ -1,0 +1,112 @@
+/*
+Copyright 2025 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"strconv"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2"
+	"volcano.sh/apis/pkg/apis/topology/v1alpha1"
+	topologyinformerv1alpha1 "volcano.sh/apis/pkg/client/informers/externalversions/topology/v1alpha1"
+
+	"volcano.sh/volcano/pkg/controllers/hypernode/provider"
+)
+
+func New() provider.Plugin {
+	return &exampleProvider{
+		stopChan: make(chan struct{}),
+	}
+}
+
+// exampleProvider is an example provider of hyperNodes.
+type exampleProvider struct {
+	stopChan          chan struct{}
+	hyperNodeInformer topologyinformerv1alpha1.HyperNodeInformer
+}
+
+// Name returns the name of the vendor.
+func (e *exampleProvider) Name() string {
+	return "example-provider"
+}
+
+// Start starts the vendor provider.
+func (e *exampleProvider) Start(eventCh chan<- provider.Event, replyCh <-chan provider.Reply, informer topologyinformerv1alpha1.HyperNodeInformer) error {
+	e.hyperNodeInformer = informer
+	go e.receiveReply(replyCh)
+	go e.sendEvent(eventCh)
+	return nil
+}
+
+// Stop stops the provider.
+func (e *exampleProvider) Stop() error {
+	klog.InfoS("exampleProvider stopped")
+	close(e.stopChan)
+	return nil
+}
+
+func (e *exampleProvider) sendEvent(eventCh chan<- provider.Event) {
+	i := 0
+	for {
+		select {
+		case <-e.stopChan:
+			klog.InfoS("Stop signal received, exiting sendEvent")
+			return
+		default:
+			hn := v1alpha1.HyperNode{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "hypernode-" + strconv.Itoa(i),
+				},
+				Spec: v1alpha1.HyperNodeSpec{
+					Tier: 1,
+					Members: []v1alpha1.MemberSpec{
+						{
+							Type: v1alpha1.MemberTypeNode,
+							Selector: v1alpha1.MemberSelector{
+								ExactMatch: &v1alpha1.ExactMatch{
+									Name: "node-" + strconv.Itoa(i),
+								},
+							},
+						},
+					},
+				},
+			}
+			event := provider.Event{Type: provider.EventAdd, HyperNodeName: hn.Name, HyperNode: hn}
+			eventCh <- event
+			klog.InfoS("Successfully sent add event", "event", event.Type, "hyperNodeName", hn.Name)
+			time.Sleep(5 * time.Second) // analog sending interval
+			i++
+			if i == 3 {
+				return
+			}
+		}
+	}
+}
+
+func (e *exampleProvider) receiveReply(replyCh <-chan provider.Reply) {
+	for {
+		select {
+		case reply, ok := <-replyCh:
+			if !ok {
+				klog.InfoS("Reply channel closed, exiting receiveReply")
+				return
+			}
+			klog.ErrorS(reply.Error, "Failed to process hyperNode event", "hyperNodeName", reply.HyperNodeName)
+		}
+	}
+}

--- a/installer/helm/chart/volcano/templates/controllers.yaml
+++ b/installer/helm/chart/volcano/templates/controllers.yaml
@@ -84,6 +84,9 @@ rules:
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]
     verbs: ["get", "create", "update", "watch"]
+  - apiGroups: ["topology.volcano.sh"]
+    resources: ["hypernodes", "hypernodes/status"]
+    verbs: ["list", "watch", "get", "create", "delete", "update", "patch"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/installer/volcano-development.yaml
+++ b/installer/volcano-development.yaml
@@ -4410,6 +4410,9 @@ rules:
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]
     verbs: ["get", "create", "update", "watch"]
+  - apiGroups: ["topology.volcano.sh"]
+    resources: ["hypernodes", "hypernodes/status"]
+    verbs: ["list", "watch", "get", "create", "delete", "update", "patch"]
 ---
 # Source: volcano/templates/controllers.yaml
 kind: ClusterRoleBinding

--- a/pkg/controllers/framework/interface.go
+++ b/pkg/controllers/framework/interface.go
@@ -43,6 +43,8 @@ type ControllerOption struct {
 	// Config holds the common attributes that can be passed to a Kubernetes client
 	// and controllers registered by the users can use it.
 	Config *rest.Config
+	// HyperNodeProviderDir specifies the directory where the hyperNode provider plugins are stored.
+	HyperNodeProviderDir string
 }
 
 // Controller is the interface of all controllers.

--- a/pkg/controllers/hypernode/hypernode_controller.go
+++ b/pkg/controllers/hypernode/hypernode_controller.go
@@ -1,0 +1,74 @@
+/*
+Copyright 2025 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hypernode
+
+import (
+	"k8s.io/klog/v2"
+
+	vcclientset "volcano.sh/apis/pkg/client/clientset/versioned"
+	vcinformer "volcano.sh/apis/pkg/client/informers/externalversions"
+	topologyinformerv1alpha1 "volcano.sh/apis/pkg/client/informers/externalversions/topology/v1alpha1"
+	topologylisterv1alpha1 "volcano.sh/apis/pkg/client/listers/topology/v1alpha1"
+
+	"volcano.sh/volcano/pkg/controllers/framework"
+	"volcano.sh/volcano/pkg/controllers/hypernode/provider"
+)
+
+func init() {
+	framework.RegisterController(&hyperNodeController{})
+}
+
+const (
+	name = "hyperNode-controller"
+)
+
+type hyperNodeController struct {
+	vcClient          vcclientset.Interface
+	vcInformerFactory vcinformer.SharedInformerFactory
+	hyperNodeInformer topologyinformerv1alpha1.HyperNodeInformer
+	hyperNodeLister   topologylisterv1alpha1.HyperNodeLister
+	provider          provider.Provider
+}
+
+// Run starts the hyperNode controller.
+func (hn *hyperNodeController) Run(stopCh <-chan struct{}) {
+	hn.vcInformerFactory.Start(stopCh)
+	for informerType, ok := range hn.vcInformerFactory.WaitForCacheSync(stopCh) {
+		if !ok {
+			klog.ErrorS(nil, "Failed to sync cache", "type", informerType)
+			return
+		}
+	}
+
+	go hn.provider.Provision(stopCh)
+}
+
+// Name returns the name of the hyperNode controller.
+func (hn *hyperNodeController) Name() string {
+	return name
+}
+
+// Initialize initializes the hyperNode controller.
+func (hn *hyperNodeController) Initialize(opt *framework.ControllerOption) error {
+	hn.vcClient = opt.VolcanoClient
+	factory := opt.VCSharedInformerFactory
+	hn.vcInformerFactory = factory
+	hn.hyperNodeInformer = factory.Topology().V1alpha1().HyperNodes()
+	hn.hyperNodeLister = hn.hyperNodeInformer.Lister()
+	hn.provider = provider.NewProvider(hn.vcClient, factory, opt.HyperNodeProviderDir)
+	return nil
+}

--- a/pkg/controllers/hypernode/hypernode_controller_test.go
+++ b/pkg/controllers/hypernode/hypernode_controller_test.go
@@ -1,0 +1,34 @@
+package hypernode
+
+import (
+	"testing"
+	"time"
+
+	vcclientset "volcano.sh/apis/pkg/client/clientset/versioned/fake"
+	vcinformer "volcano.sh/apis/pkg/client/informers/externalversions"
+	"volcano.sh/volcano/pkg/controllers/hypernode/provider"
+)
+
+func TestHyperNodeController_Run(t *testing.T) {
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+
+	fakeClient := vcclientset.NewSimpleClientset()
+	informerFactory := vcinformer.NewSharedInformerFactory(fakeClient, 0)
+
+	controller := &hyperNodeController{
+		vcClient:          fakeClient,
+		vcInformerFactory: informerFactory,
+		hyperNodeInformer: informerFactory.Topology().V1alpha1().HyperNodes(),
+		hyperNodeLister:   informerFactory.Topology().V1alpha1().HyperNodes().Lister(),
+		provider:          provider.NewProvider(fakeClient, informerFactory, ""),
+	}
+
+	go controller.Run(stopCh)
+	time.Sleep(1 * time.Second)
+	for informerType, ok := range informerFactory.WaitForCacheSync(stopCh) {
+		if !ok {
+			t.Errorf("Failed to sync cache for informer type: %s", informerType)
+		}
+	}
+}

--- a/pkg/controllers/hypernode/provider/interface.go
+++ b/pkg/controllers/hypernode/provider/interface.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2025 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package provider
+
+import (
+	topologyv1alpha1 "volcano.sh/apis/pkg/apis/topology/v1alpha1"
+	topologyapplyv1alpha1 "volcano.sh/apis/pkg/client/applyconfiguration/topology/v1alpha1"
+	topologyinformerv1alpha1 "volcano.sh/apis/pkg/client/informers/externalversions/topology/v1alpha1"
+)
+
+type PluginBuilder = func() Plugin
+
+// EventType defines the event type.
+type EventType string
+
+const (
+	// EventAdd is the event type for adding hyperNode.
+	EventAdd EventType = "Add"
+	// EventUpdate is the event type for updating hyperNode.
+	EventUpdate EventType = "Update"
+	// EventDelete is the event type for deleting hyperNode.
+	EventDelete EventType = "Delete"
+)
+
+// Event defines the event from hyperNode provider.
+type Event struct {
+	// Type is the event type.
+	Type EventType
+	// HyperNodeName is the name of the hyperNode event.
+	HyperNodeName string
+	// HyperNode is the hyperNode object to add.
+	HyperNode topologyv1alpha1.HyperNode
+	// Patch is the hyperNode apply configuration, only used for update event.
+	Patch topologyapplyv1alpha1.HyperNodeApplyConfiguration
+}
+
+// Reply is the reply message to hyperNode provider when processed hyperNode event failed,
+// and vendor should be aware of that and retry or som.
+type Reply struct {
+	// HyperNodeName is the name of the hyperNode.
+	HyperNodeName string
+	// Error is the error message of hyperNode event processing.
+	Error error
+}
+
+// Plugin is the interface for the hyperNode provider, vendors should implement this
+// and hyperNode controller call the plugin to populate hyperNodes.
+type Plugin interface {
+	// Name is the name of the plugin.
+	Name() string
+	// Start starts the plugin.
+	Start(eventCh chan<- Event, replyCh <-chan Reply, informer topologyinformerv1alpha1.HyperNodeInformer) error
+	// Stop stops the plugin.
+	Stop() error
+}

--- a/pkg/controllers/hypernode/provider/provider.go
+++ b/pkg/controllers/hypernode/provider/provider.go
@@ -1,0 +1,242 @@
+/*
+Copyright 2025 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package provider
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"plugin"
+	"time"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/util/retry"
+	"k8s.io/klog/v2"
+
+	vcclientset "volcano.sh/apis/pkg/client/clientset/versioned"
+	vcinformer "volcano.sh/apis/pkg/client/informers/externalversions"
+)
+
+// Provider is the interface for the hyperNode provider.
+type Provider interface {
+	Provision(stopCh <-chan struct{})
+}
+
+var backoff = wait.Backoff{
+	Duration: time.Second,
+	Factor:   1,
+	Jitter:   0.1,
+	Steps:    20,
+}
+
+type provider struct {
+	eventCh        chan Event
+	replyCh        chan Reply
+	vcClient       vcclientset.Interface
+	factory        vcinformer.SharedInformerFactory
+	pluginBuilders map[string]PluginBuilder
+	pluginDir      string
+}
+
+// NewProvider creates a new hyperNode provider.
+func NewProvider(client vcclientset.Interface, factory vcinformer.SharedInformerFactory, pluginDir string) Provider {
+	p := &provider{
+		vcClient:       client,
+		factory:        factory,
+		eventCh:        make(chan Event),
+		replyCh:        make(chan Reply),
+		pluginBuilders: make(map[string]PluginBuilder),
+		pluginDir:      pluginDir,
+	}
+	if err := p.loadProvider(pluginDir); err != nil {
+		klog.ErrorS(err, "Failed to load hyperNode provider")
+	}
+	return p
+}
+
+func (p *provider) loadProvider(dir string) error {
+	pluginPaths, _ := filepath.Glob(fmt.Sprintf("%s/*.so", dir))
+	for _, pluginPath := range pluginPaths {
+		klog.InfoS("Loading provider plugin...", "", "path", pluginPath)
+		pb, err := loadPlugin(pluginPath)
+		if err != nil {
+			return err
+		}
+		plugin := pb()
+		//pluginName := getPluginName(pluginPath)
+		p.RegisterPlugin(plugin.Name(), pb)
+		klog.V(2).Infof("hyperNode provider %s loaded", plugin.Name())
+	}
+
+	return nil
+}
+
+func loadPlugin(pluginPath string) (PluginBuilder, error) {
+	plug, err := plugin.Open(pluginPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open plugin, err: %v, path: %v", err, pluginPath)
+	}
+
+	symBuilder, err := plug.Lookup("New")
+	if err != nil {
+		return nil, fmt.Errorf("failed to look up New method: %v", err)
+	}
+
+	builder, ok := symBuilder.(PluginBuilder)
+	if !ok {
+		return nil, fmt.Errorf("unexpected plugin: %s, failed to convert Plugin", pluginPath)
+	}
+
+	return builder, nil
+}
+
+// RegisterPlugin registers a plugin as part of the provider.
+func (p *provider) RegisterPlugin(name string, pb PluginBuilder) {
+	if _, ok := p.pluginBuilders[name]; ok {
+		klog.ErrorS(nil, "Plugin already registered", "name", name)
+		return
+	}
+	p.pluginBuilders[name] = pb
+	klog.InfoS("Successfully registered plugin", "name", name)
+}
+
+// Provision starts the hyperNode provider.
+func (p *provider) Provision(stopCh <-chan struct{}) {
+	for _, pb := range p.pluginBuilders {
+		plugin := pb()
+		if err := plugin.Start(p.eventCh, p.replyCh, p.factory.Topology().V1alpha1().HyperNodes()); err != nil {
+			klog.ErrorS(err, "Failed to load plugin", "name", plugin.Name())
+			return
+		} else {
+			klog.InfoS("Successfully loaded plugin", "name", plugin.Name())
+		}
+	}
+
+	go p.handleEvents(stopCh)
+
+	<-stopCh
+	p.stop()
+}
+
+func (p *provider) stop() {
+	for _, pb := range p.pluginBuilders {
+		plugin := pb()
+		if err := plugin.Stop(); err != nil {
+			klog.ErrorS(err, "Failed to stop plugin", "name", plugin.Name())
+		}
+	}
+	close(p.replyCh)
+}
+
+func (p *provider) handleEvents(stop <-chan struct{}) {
+	for {
+		select {
+		case event := <-p.eventCh:
+			name := event.HyperNodeName
+			klog.InfoS("Received event", "type", event.Type, "name", name)
+			switch event.Type {
+			case EventAdd:
+				klog.InfoS("Handling hyperNode add event", "name", name)
+				go p.handleHyperNodeAdd(event)
+			case EventUpdate:
+				klog.InfoS("Handling hyperNode update event", "name", name)
+				go p.handleHyperNodeUpdate(event)
+			case EventDelete:
+				klog.InfoS("Handling hyperNode delete event", "name", name)
+				go p.handleNodeDeleted(event)
+			default:
+				klog.ErrorS(nil, "Unknown event type", "type", event.Type)
+			}
+		case <-stop:
+			return
+		}
+	}
+}
+
+func (p *provider) handleHyperNodeAdd(event Event) {
+	hyperNode := event.HyperNode
+	err := retry.OnError(
+		backoff,
+		func(err error) bool {
+			return !apierrors.IsAlreadyExists(err)
+		},
+		func() error {
+			_, err := p.vcClient.TopologyV1alpha1().HyperNodes().Create(context.Background(), &hyperNode, metav1.CreateOptions{})
+			return err
+		},
+	)
+
+	if err != nil {
+		klog.ErrorS(err, "Failed to add HyperNode after retries", "name", hyperNode.Name)
+		p.replyCh <- Reply{
+			HyperNodeName: hyperNode.Name,
+			Error:         err,
+		}
+		return
+	}
+	klog.InfoS("Successfully added hyperNode", "name", hyperNode.Name)
+}
+
+func (p *provider) handleHyperNodeUpdate(event Event) {
+	hyperNode := event.HyperNode
+	err := retry.OnError(
+		backoff,
+		func(err error) bool {
+			return true
+		},
+		func() error {
+			_, err := p.vcClient.TopologyV1alpha1().HyperNodes().ApplyStatus(context.Background(), &event.Patch, metav1.ApplyOptions{})
+			return err
+		},
+	)
+
+	if err != nil {
+		klog.ErrorS(err, "Failed to update HyperNode after retries", "name", hyperNode.Name)
+		p.replyCh <- Reply{
+			HyperNodeName: hyperNode.Name,
+			Error:         err,
+		}
+		return
+	}
+	klog.InfoS("Successfully updated hyperNode", "name", hyperNode.Name)
+}
+
+func (p *provider) handleNodeDeleted(event Event) {
+	name := event.HyperNodeName
+	err := retry.OnError(
+		backoff,
+		func(err error) bool {
+			return !apierrors.IsNotFound(err)
+		},
+		func() error {
+			err := p.vcClient.TopologyV1alpha1().HyperNodes().Delete(context.Background(), name, metav1.DeleteOptions{})
+			return err
+		},
+	)
+
+	if err != nil {
+		klog.ErrorS(err, "Failed to delete HyperNode after retries", "name", name)
+		p.replyCh <- Reply{
+			HyperNodeName: name,
+			Error:         err,
+		}
+		return
+	}
+	klog.InfoS("Successfully deleted HyperNode", "name", name)
+}

--- a/pkg/controllers/hypernode/provider/provider_test.go
+++ b/pkg/controllers/hypernode/provider/provider_test.go
@@ -1,0 +1,116 @@
+package provider
+
+import (
+	"context"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	"volcano.sh/apis/pkg/apis/topology/v1alpha1"
+	topologyv1alpha1 "volcano.sh/apis/pkg/apis/topology/v1alpha1"
+	topologyapplyv1alpha1 "volcano.sh/apis/pkg/client/applyconfiguration/topology/v1alpha1"
+	fakeclient "volcano.sh/apis/pkg/client/clientset/versioned/fake"
+	"volcano.sh/apis/pkg/client/informers/externalversions"
+)
+
+func Test_provider_Provision_Add_And_Delete_Event(t *testing.T) {
+	eventCh := make(chan Event)
+	client := fakeclient.NewSimpleClientset()
+	factory := externalversions.NewSharedInformerFactory(client, 0)
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	p := &provider{
+		eventCh:  eventCh,
+		replyCh:  make(chan Reply),
+		vcClient: client,
+		factory:  factory,
+	}
+	go p.Provision(stopCh)
+	// add event
+	add := addEvent()
+	delete := deleteEvent()
+	eventCh <- add
+	err := wait.PollUntilContextTimeout(context.TODO(), 1*time.Second, 10*time.Second, true, func(ctx context.Context) (bool, error) {
+		_, err := client.TopologyV1alpha1().HyperNodes().Get(ctx, add.HyperNodeName, metav1.GetOptions{})
+		if err != nil {
+			return false, nil
+		}
+		return true, nil
+	})
+	assert.NoError(t, err)
+
+	// update event
+	update := updateEvent()
+	eventCh <- update
+	err = wait.PollUntilContextTimeout(context.TODO(), 1*time.Second, 10*time.Second, true, func(ctx context.Context) (bool, error) {
+		hn, err := client.TopologyV1alpha1().HyperNodes().Get(ctx, update.HyperNodeName, metav1.GetOptions{})
+		if err != nil {
+			return false, nil
+		}
+		if !reflect.DeepEqual(hn.Spec, expectedHyperNode().Spec) {
+			return false, nil
+		}
+		return true, nil
+	})
+	assert.NoError(t, err)
+
+	// delete event
+	eventCh <- delete
+	err = wait.PollUntilContextTimeout(context.TODO(), 1*time.Second, 10*time.Second, true, func(ctx context.Context) (bool, error) {
+		_, err := client.TopologyV1alpha1().HyperNodes().Get(ctx, delete.HyperNodeName, metav1.GetOptions{})
+		if errors.IsNotFound(err) {
+
+			return true, nil
+		}
+		return false, nil
+	})
+	assert.NoError(t, err)
+}
+
+func addEvent() Event {
+	return Event{
+		Type:          "Add",
+		HyperNodeName: "hn-1",
+		HyperNode: topologyv1alpha1.HyperNode{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "hn-1",
+			},
+			Spec: v1alpha1.HyperNodeSpec{
+				Tier: 1,
+			},
+		},
+	}
+}
+
+func deleteEvent() Event {
+	return Event{
+		Type:          "Delete",
+		HyperNodeName: "hn-1",
+	}
+}
+
+func updateEvent() Event {
+	patch := *topologyapplyv1alpha1.HyperNode("hn-1").WithSpec(topologyapplyv1alpha1.HyperNodeSpec().WithTier(2))
+	return Event{
+		Type:          "Update",
+		HyperNodeName: "hn-1",
+		HyperNode:     expectedHyperNode(),
+		Patch:         patch,
+	}
+}
+
+func expectedHyperNode() v1alpha1.HyperNode {
+	return topologyv1alpha1.HyperNode{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "hn-1",
+		},
+		Spec: v1alpha1.HyperNodeSpec{
+			Tier: 2,
+		},
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?
/kind feature
/area controllers


#### What this PR does / why we need it:
Add hyperNode controller provider and vendors can register plugins to add/update/delete hyperNodes by auto discovering network topology of their own datacenters.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Notice that do not add `Fixes` if the issue is associated with multiple PRs.
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
Vendors should register their own plugins and integrate with vc controller to reconcile hyperNodes 
```