### PR TITLE
fix: the problem that the pending tasks cannot be scheduled during the backfill action

### DIFF
--- a/pkg/scheduler/actions/backfill/backfill.go
+++ b/pkg/scheduler/actions/backfill/backfill.go
@@ -71,13 +71,13 @@ func (backfill *Action) Execute(ssn *framework.Session) {
 				fe.SetNodeError(ni.Name, err)
 			}
 			job.NodesFitErrors[task.UID] = fe
-			break
+			continue
 		}
 
 		predicateNodes, fitErrors := ph.PredicateNodes(task, ssn.NodeList, predicateFunc, backfill.enablePredicateErrorCache)
 		if len(predicateNodes) == 0 {
 			job.NodesFitErrors[task.UID] = fitErrors
-			break
+			continue
 		}
 
 		node := predicateNodes[0]


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:
/kind bug

Optionally add one of the following areas, help us further classify and filter PRs:
/area scheduling
-->

#### What this PR does / why we need it:
During the backfill action, in the loop of pending tasks, if a previous task fails to match a node or an exception occurs when calling the PrePredicateFn method, all subsequent tasks will stop being scheduled.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Notice that do not add `Fixes` if the issue is associated with multiple PRs.
-->
Fixes #4028

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```