### PR TITLE
Add resync-period flag for k8s native informers

### DIFF
--- a/cmd/scheduler/app/options/options.go
+++ b/cmd/scheduler/app/options/options.go
@@ -32,6 +32,7 @@ import (
 const (
 	defaultSchedulerName   = "volcano"
 	defaultSchedulerPeriod = time.Second
+	defaultResyncPeriod    = 0
 	defaultQueue           = "default"
 	defaultListenAddress   = ":8080"
 	defaultHealthzAddress  = ":11251"
@@ -60,6 +61,7 @@ type ServerOption struct {
 	SchedulerNames    []string
 	SchedulerConf     string
 	SchedulePeriod    time.Duration
+	ResyncPeriod      time.Duration
 	// leaderElection defines the configuration of leader election.
 	LeaderElection config.LeaderElectionConfiguration
 	// Deprecated: use ResourceNamespace instead.
@@ -119,6 +121,7 @@ func (s *ServerOption) AddFlags(fs *pflag.FlagSet) {
 	fs.StringArrayVar(&s.SchedulerNames, "scheduler-name", []string{defaultSchedulerName}, "vc-scheduler will handle pods whose .spec.SchedulerName is same as scheduler-name")
 	fs.StringVar(&s.SchedulerConf, "scheduler-conf", "", "The absolute path of scheduler configuration file")
 	fs.DurationVar(&s.SchedulePeriod, "schedule-period", defaultSchedulerPeriod, "The period between each scheduling cycle")
+	fs.DurationVar(&s.ResyncPeriod, "resync-period", defaultResyncPeriod, "The default resync period for k8s native informer factory")
 	fs.StringVar(&s.DefaultQueue, "default-queue", defaultQueue, "The default queue name of the job")
 	fs.BoolVar(&s.PrintVersion, "version", false, "Show version and quit")
 	fs.StringVar(&s.ListenAddress, "listen-address", defaultListenAddress, "The address to listen on for HTTP requests.")

--- a/cmd/scheduler/app/options/options_test.go
+++ b/cmd/scheduler/app/options/options_test.go
@@ -45,6 +45,7 @@ func TestAddFlags(t *testing.T) {
 
 	args := []string{
 		"--schedule-period=5m",
+		"--resync-period=0",
 		"--priority-class=false",
 		"--cache-dumper=false",
 		"--leader-elect-lease-duration=60s",
@@ -58,6 +59,7 @@ func TestAddFlags(t *testing.T) {
 	expected := &ServerOption{
 		SchedulerNames: []string{defaultSchedulerName},
 		SchedulePeriod: 5 * time.Minute,
+		ResyncPeriod:   0,
 		LeaderElection: config.LeaderElectionConfiguration{
 			LeaderElect:       true,
 			LeaseDuration:     metav1.Duration{Duration: 60 * time.Second},

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -67,7 +67,7 @@ func NewScheduler(config *rest.Config, opt *options.ServerOption) (*Scheduler, e
 		}
 	}
 
-	cache := schedcache.New(config, opt.SchedulerNames, opt.DefaultQueue, opt.NodeSelector, opt.NodeWorkerThreads, opt.IgnoredCSIProvisioners)
+	cache := schedcache.New(config, opt.SchedulerNames, opt.DefaultQueue, opt.NodeSelector, opt.NodeWorkerThreads, opt.IgnoredCSIProvisioners, opt.ResyncPeriod)
 	scheduler := &Scheduler{
 		schedulerConf:  opt.SchedulerConf,
 		fileWatcher:    watcher,


### PR DESCRIPTION
This is to optionally help with cache inconsistencies

#### What type of PR is this?
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind failing-test
/kind flake

Optionally add one of the following areas, help us further classify and filter PRs:
/area scheduling
/area controllers
/area cli
/area dependency
/area webhooks
/area deploy
/area documentation
/area performance
/area test
-->
/kind feature
#### What this PR does / why we need it:
- Add resync-period flag for k8s native informers
- This is to optionally help with cache inconsistencies


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Notice that do not add `Fixes` if the issue is associated with multiple PRs.
-->
Fixes # https://github.com/volcano-sh/volcano/issues/4046

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```