### PR TITLE
Remove pod mutate webhook by default

### DIFF
--- a/installer/helm/chart/volcano/values.yaml
+++ b/installer/helm/chart/volcano/values.yaml
@@ -33,7 +33,7 @@ custom:
   scheduler_kube_api_burst: 2000
   scheduler_schedule_period: 1s
   scheduler_node_worker_threads: 20
-  enabled_admissions: "/jobs/mutate,/jobs/validate,/podgroups/mutate,/pods/validate,/pods/mutate,/queues/mutate,/queues/validate"
+  enabled_admissions: "/jobs/mutate,/jobs/validate,/podgroups/mutate,/pods/validate,/queues/mutate,/queues/validate"
   colocation_enable: false
 
 # Override the configuration for admission or scheduler.

--- a/installer/volcano-development.yaml
+++ b/installer/volcano-development.yaml
@@ -135,7 +135,7 @@ spec:
       priorityClassName: system-cluster-critical
       containers:
         - args:
-            - --enabled-admission=/jobs/mutate,/jobs/validate,/podgroups/mutate,/pods/validate,/pods/mutate,/queues/mutate,/queues/validate
+            - --enabled-admission=/jobs/mutate,/jobs/validate,/podgroups/mutate,/pods/validate,/queues/mutate,/queues/validate
             - --tls-cert-file=/admission.local.config/certificates/tls.crt
             - --tls-private-key-file=/admission.local.config/certificates/tls.key
             - --ca-cert-file=/admission.local.config/certificates/ca.crt
@@ -5135,45 +5135,6 @@ spec:
         type: object
     served: true
     storage: true
----
-# Source: volcano/templates/webhooks.yaml
-apiVersion: admissionregistration.k8s.io/v1
-kind: MutatingWebhookConfiguration
-metadata:
-  name: volcano-admission-service-pods-mutate
-webhooks:
-  - admissionReviewVersions:
-      - v1
-    clientConfig:
-      service:
-        name: volcano-admission-service
-        namespace: volcano-system
-        path: /pods/mutate
-        port: 443
-    failurePolicy: Fail
-    matchPolicy: Equivalent
-    name: mutatepod.volcano.sh
-    namespaceSelector:
-      matchExpressions:
-        - key: kubernetes.io/metadata.name
-          operator: NotIn
-          values:
-            - volcano-system
-            - kube-system
-    objectSelector: {}
-    reinvocationPolicy: Never
-    rules:
-      - apiGroups:
-          - ""
-        apiVersions:
-          - v1
-        operations:
-          - CREATE
-        resources:
-          - pods
-        scope: '*'
-    sideEffects: NoneOnDryRun
-    timeoutSeconds: 10
 ---
 # Source: volcano/templates/webhooks.yaml
 apiVersion: admissionregistration.k8s.io/v1


### PR DESCRIPTION
#### What type of PR is this?
/area performance
#### What this PR does / why we need it:
Remove pod mutate webhook by default. The pod mutating webhook is only used in multi scheduler scenario, it's a normal case and not recommended, we should disable it by default and users can enable it when needed.
This can improve performance in large scale case.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Notice that do not add `Fixes` if the issue is associated with multiple PRs.
-->
Fixes #

#### Special notes for your reviewer:
multi scheduler issue: https://github.com/volcano-sh/volcano/pull/1576
Part of performance improvement issus: https://github.com/volcano-sh/volcano/issues/3852
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
The pod mutating webhook is disabled by default to Improve performance
```