### PR TITLE
fix: remove hostpath mount in volcano-scheduler

### DIFF
--- a/installer/helm/chart/volcano/templates/scheduler.yaml
+++ b/installer/helm/chart/volcano/templates/scheduler.yaml
@@ -224,8 +224,7 @@ spec:
           configMap:
             name: {{ .Release.Name }}-scheduler-configmap
         - name: klog-sock
-          hostPath:
-            path: /tmp/klog-socks
+          emptyDir: {}
 ---
 apiVersion: v1
 kind: Service

--- a/installer/volcano-development.yaml
+++ b/installer/volcano-development.yaml
@@ -4661,8 +4661,7 @@ spec:
           configMap:
             name: volcano-scheduler-configmap
         - name: klog-sock
-          hostPath:
-            path: /tmp/klog-socks
+          emptyDir: {}
 ---
 # Source: volcano/templates/scheduling_v1beta1_podgroup.yaml
 apiVersion: apiextensions.k8s.io/v1


### PR DESCRIPTION
#### What type of PR is this?

Bugfix

#### What this PR does / why we need it:

`hostPath` should be avoided unless absolutely necessary:
https://kubernetes.io/docs/concepts/storage/volumes/#hostpath

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Notice that do not add `Fixes` if the issue is associated with multiple PRs.
-->
Fixes #3298

#### Special notes for your reviewer:
Previous PR: https://github.com/volcano-sh/volcano/pull/3303 which this supersedes 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
fix: remove hostpath mount in volcano-scheduler
```