### PR TITLE
Remove podgroup mutating webhook by default

### DIFF
--- a/installer/helm/chart/volcano/values.yaml
+++ b/installer/helm/chart/volcano/values.yaml
@@ -33,7 +33,7 @@ custom:
   scheduler_kube_api_burst: 2000
   scheduler_schedule_period: 1s
   scheduler_node_worker_threads: 20
-  enabled_admissions: "/jobs/mutate,/jobs/validate,/podgroups/mutate,/pods/validate,/queues/mutate,/queues/validate"
+  enabled_admissions: "/jobs/mutate,/jobs/validate,/pods/validate,/queues/mutate,/queues/validate"
   colocation_enable: false
 
 # Override the configuration for admission or scheduler.

--- a/installer/volcano-development.yaml
+++ b/installer/volcano-development.yaml
@@ -135,7 +135,7 @@ spec:
       priorityClassName: system-cluster-critical
       containers:
         - args:
-            - --enabled-admission=/jobs/mutate,/jobs/validate,/podgroups/mutate,/pods/validate,/queues/mutate,/queues/validate
+            - --enabled-admission=/jobs/mutate,/jobs/validate,/pods/validate,/queues/mutate,/queues/validate
             - --tls-cert-file=/admission.local.config/certificates/tls.crt
             - --tls-private-key-file=/admission.local.config/certificates/tls.key
             - --ca-cert-file=/admission.local.config/certificates/ca.crt
@@ -5171,45 +5171,6 @@ webhooks:
           - CREATE
         resources:
           - queues
-        scope: '*'
-    sideEffects: NoneOnDryRun
-    timeoutSeconds: 10
----
-# Source: volcano/templates/webhooks.yaml
-apiVersion: admissionregistration.k8s.io/v1
-kind: MutatingWebhookConfiguration
-metadata:
-  name: volcano-admission-service-podgroups-mutate
-webhooks:
-  - admissionReviewVersions:
-      - v1
-    clientConfig:
-      service:
-        name: volcano-admission-service
-        namespace: volcano-system
-        path: /podgroups/mutate
-        port: 443
-    failurePolicy: Fail
-    matchPolicy: Equivalent
-    name: mutatepodgroup.volcano.sh
-    namespaceSelector:
-      matchExpressions:
-        - key: kubernetes.io/metadata.name
-          operator: NotIn
-          values:
-            - volcano-system
-            - kube-system
-    objectSelector: {}
-    reinvocationPolicy: Never
-    rules:
-      - apiGroups:
-          - scheduling.volcano.sh
-        apiVersions:
-          - v1beta1
-        operations:
-          - CREATE
-        resources:
-          - podgroups
         scope: '*'
     sideEffects: NoneOnDryRun
     timeoutSeconds: 10

--- a/pkg/webhooks/admission/podgroups/mutate/mutate_podgroup_test.go
+++ b/pkg/webhooks/admission/podgroups/mutate/mutate_podgroup_test.go
@@ -1,0 +1,122 @@
+package mutate
+
+import (
+	"context"
+	"encoding/json"
+	"reflect"
+	"testing"
+	"volcano.sh/volcano/pkg/webhooks/router"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+
+	schedulingv1beta1 "volcano.sh/apis/pkg/apis/scheduling/v1beta1"
+)
+
+func Test_createPodGroupPatch(t *testing.T) {
+	tests := []struct {
+		name          string
+		podgroup      *schedulingv1beta1.PodGroup
+		nsAnnotations map[string]string
+		wantPatch     []patchOperation
+		wantErr       bool
+	}{
+		{
+			name: "podgroup with non-default queue",
+			podgroup: &schedulingv1beta1.PodGroup{
+				Spec: schedulingv1beta1.PodGroupSpec{
+					Queue: "custom-queue",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "test-ns",
+				},
+			},
+			nsAnnotations: nil,
+			wantPatch:     nil,
+			wantErr:       false,
+		},
+		{
+			name: "podgroup with default queue and namespace with queue annotation",
+			podgroup: &schedulingv1beta1.PodGroup{
+				Spec: schedulingv1beta1.PodGroupSpec{
+					Queue: schedulingv1beta1.DefaultQueue,
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "test-ns",
+				},
+			},
+			nsAnnotations: map[string]string{
+				schedulingv1beta1.QueueNameAnnotationKey: "ns-queue",
+			},
+			wantPatch: []patchOperation{
+				{
+					Op:    "add",
+					Path:  "/spec/queue",
+					Value: "ns-queue",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "podgroup with default queue and namespace without queue annotation",
+			podgroup: &schedulingv1beta1.PodGroup{
+				Spec: schedulingv1beta1.PodGroupSpec{
+					Queue: schedulingv1beta1.DefaultQueue,
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "test-ns",
+				},
+			},
+			nsAnnotations: map[string]string{},
+			wantPatch:     nil,
+			wantErr:       false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Setup fake client
+			client := fake.NewSimpleClientset()
+			if tt.nsAnnotations != nil {
+				ns := &corev1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        "test-ns",
+						Annotations: tt.nsAnnotations,
+					},
+				}
+				_, err := client.CoreV1().Namespaces().Create(context.TODO(), ns, metav1.CreateOptions{})
+				if err != nil {
+					t.Fatalf("Failed to create test namespace: %v", err)
+				}
+			}
+
+			config = &router.AdmissionServiceConfig{
+				KubeClient: client,
+			}
+
+			got, err := createPodGroupPatch(tt.podgroup)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("createPodGroupPatch() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if tt.wantPatch == nil {
+				if got != nil {
+					t.Errorf("createPodGroupPatch() got = %v, want nil", string(got))
+				}
+				return
+			}
+
+			var gotPatch []patchOperation
+			if err := json.Unmarshal(got, &gotPatch); err != nil {
+				t.Errorf("Failed to unmarshal patch: %v", err)
+				return
+			}
+
+			if !reflect.DeepEqual(gotPatch, tt.wantPatch) {
+				t.Errorf("createPodGroupPatch() got = %v, want %v", gotPatch, tt.wantPatch)
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?
Part of https://github.com/volcano-sh/volcano/issues/4127
#### What this PR does / why we need it:
The origin issue is not a common case, disable it by default.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Notice that do not add `Fixes` if the issue is associated with multiple PRs.
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
The podGroup mutating webhook is disabled by default
```