### PR TITLE
cleanup residual useless victims code in preempt action

### DIFF
--- a/pkg/scheduler/actions/preempt/preempt.go
+++ b/pkg/scheduler/actions/preempt/preempt.go
@@ -218,9 +218,6 @@ func (pmpt *Action) Execute(ssn *framework.Session) {
 			}
 		}
 	}
-
-	// call victimTasksFn to evict tasks
-	victimTasks(ssn)
 }
 
 func (pmpt *Action) UnInitialize() {}
@@ -344,18 +341,4 @@ func (pmpt *Action) taskEligibleToPreempt(preemptor *api.TaskInfo) error {
 	}
 
 	return nil
-}
-
-func victimTasks(ssn *framework.Session) {
-	stmt := framework.NewStatement(ssn)
-	tasks := make([]*api.TaskInfo, 0)
-	victimTasksMap := ssn.VictimTasks(tasks)
-	for victim := range victimTasksMap {
-		if err := stmt.Evict(victim.Clone(), "evict"); err != nil {
-			klog.Errorf("Failed to evict Task <%s/%s>: %v",
-				victim.Namespace, victim.Name, err)
-			continue
-		}
-	}
-	stmt.Commit()
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
Victims filter is only used in shuffle action, preempt action needs to use preemptable to filter preemptees. These residual codes are useless, cause the logic here:
https://github.com/volcano-sh/volcano/blob/0403a8849afa05cf9b6e2f42553c4f5433f27092/pkg/scheduler/actions/preempt/preempt.go#L351
Only init an empty slice, so the plugin needs to retrieve tasks from the session again, I think the implementation is wrong here. The extension points VictimTasksFns should only be used in shuffle action

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Notice that do not add `Fixes` if the issue is associated with multiple PRs.
-->
Fixes #4137 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
Cleanup residual useless victims code in preempt action, users of tdm need to enable shuffle action when upgrading to new version
```