### PR TITLE
Replace queue status update by using ApplyStatus method

### DIFF
--- a/config/crd/volcano/bases/scheduling.volcano.sh_queues.yaml
+++ b/config/crd/volcano/bases/scheduling.volcano.sh_queues.yaml
@@ -211,8 +211,6 @@ spec:
                 description: The number of 'Unknown' PodGroup in this queue.
                 format: int32
                 type: integer
-            required:
-            - allocated
             type: object
         type: object
     served: true

--- a/go.mod
+++ b/go.mod
@@ -46,7 +46,7 @@ require (
 	sigs.k8s.io/controller-runtime v0.13.0
 	sigs.k8s.io/yaml v1.4.0
 	stathat.com/c/consistent v1.0.0
-	volcano.sh/apis v1.11.1-0.20250321094701-ffd8b8db3944
+	volcano.sh/apis v1.11.1-0.20250326062604-2d1b261f52f1
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -511,5 +511,5 @@ sigs.k8s.io/yaml v1.4.0 h1:Mk1wCc2gy/F0THH0TAp1QYyJNzRm2KCLy3o5ASXVI5E=
 sigs.k8s.io/yaml v1.4.0/go.mod h1:Ejl7/uTz7PSA4eKMyQCUTnhZYNmLIl+5c2lQPGR2BPY=
 stathat.com/c/consistent v1.0.0 h1:ezyc51EGcRPJUxfHGSgJjWzJdj3NiMU9pNfLNGiXV0c=
 stathat.com/c/consistent v1.0.0/go.mod h1:QkzMWzcbB+yQBL2AttO6sgsQS/JSTapcDISJalmCDS0=
-volcano.sh/apis v1.11.1-0.20250321094701-ffd8b8db3944 h1:Y/HflNDbCeLOjtdsyFpgjuL/iax3p+hDyGV5TML0Fhk=
-volcano.sh/apis v1.11.1-0.20250321094701-ffd8b8db3944/go.mod h1:0XNNnIOevJSYNiXRmwhXUrYCcCcWcBeTY0nxrlkk03A=
+volcano.sh/apis v1.11.1-0.20250326062604-2d1b261f52f1 h1:fvtSPUgw7XlmqvvFH9AGCZfR9KXo6qFeWee2PoechIw=
+volcano.sh/apis v1.11.1-0.20250326062604-2d1b261f52f1/go.mod h1:0XNNnIOevJSYNiXRmwhXUrYCcCcWcBeTY0nxrlkk03A=

--- a/installer/helm/chart/volcano/crd/bases/scheduling.volcano.sh_queues.yaml
+++ b/installer/helm/chart/volcano/crd/bases/scheduling.volcano.sh_queues.yaml
@@ -210,8 +210,6 @@ spec:
                 description: The number of 'Unknown' PodGroup in this queue.
                 format: int32
                 type: integer
-            required:
-            - allocated
             type: object
         type: object
     served: true

--- a/installer/helm/chart/volcano/templates/scheduler.yaml
+++ b/installer/helm/chart/volcano/templates/scheduler.yaml
@@ -90,7 +90,7 @@ rules:
     verbs: ["get", "list", "watch", "create", "delete", "update"]
   - apiGroups: ["scheduling.incubator.k8s.io", "scheduling.volcano.sh"]
     resources: ["queues/status"]
-    verbs: ["update"]
+    verbs: ["patch"]
   - apiGroups: ["scheduling.incubator.k8s.io", "scheduling.volcano.sh"]
     resources: ["podgroups"]
     verbs: ["list", "watch", "update"]

--- a/installer/volcano-development.yaml
+++ b/installer/volcano-development.yaml
@@ -4594,7 +4594,7 @@ rules:
     verbs: ["get", "list", "watch", "create", "delete", "update"]
   - apiGroups: ["scheduling.incubator.k8s.io", "scheduling.volcano.sh"]
     resources: ["queues/status"]
-    verbs: ["update"]
+    verbs: ["patch"]
   - apiGroups: ["scheduling.incubator.k8s.io", "scheduling.volcano.sh"]
     resources: ["podgroups"]
     verbs: ["list", "watch", "update"]
@@ -5074,8 +5074,6 @@ spec:
                 description: The number of 'Unknown' PodGroup in this queue.
                 format: int32
                 type: integer
-            required:
-            - allocated
             type: object
         type: object
     served: true

--- a/pkg/scheduler/framework/session.go
+++ b/pkg/scheduler/framework/session.go
@@ -35,6 +35,7 @@ import (
 	"volcano.sh/apis/pkg/apis/scheduling"
 	schedulingscheme "volcano.sh/apis/pkg/apis/scheduling/scheme"
 	vcv1beta1 "volcano.sh/apis/pkg/apis/scheduling/v1beta1"
+	v1beta1apply "volcano.sh/apis/pkg/client/applyconfiguration/scheduling/v1beta1"
 	vcclient "volcano.sh/apis/pkg/client/clientset/versioned"
 	"volcano.sh/volcano/pkg/scheduler/api"
 	"volcano.sh/volcano/pkg/scheduler/cache"
@@ -285,8 +286,9 @@ func updateRootQueueResources(ssn *Session, allocated v1.ResourceList) {
 	}
 
 	if !equality.Semantic.DeepEqual(queue.Status.Allocated, allocated) {
-		queue.Status.Allocated = allocated
-		_, err = ssn.VCClient().SchedulingV1beta1().Queues().UpdateStatus(context.TODO(), queue, metav1.UpdateOptions{})
+		queueStatusApply := v1beta1apply.QueueStatus().WithAllocated(allocated)
+		queueApply := v1beta1apply.Queue(queue.Name).WithStatus(queueStatusApply)
+		_, err = ssn.VCClient().SchedulingV1beta1().Queues().ApplyStatus(context.TODO(), queueApply, metav1.ApplyOptions{FieldManager: util.DefaultComponentName})
 		if err != nil {
 			klog.Errorf("failed to update root queue status: %s", err.Error())
 			return

--- a/pkg/scheduler/util/scheduler_helper.go
+++ b/pkg/scheduler/util/scheduler_helper.go
@@ -34,7 +34,11 @@ import (
 	"volcano.sh/volcano/pkg/scheduler/api"
 )
 
-const baselinePercentageOfNodesToFind = 50
+const (
+	baselinePercentageOfNodesToFind = 50
+
+	DefaultComponentName = "vc-scheduler"
+)
 
 var lastProcessedNodeIndex int
 


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
Currently, the vc-controller must specify the allocated field to update the status because allocated is not optional. The scheduler also updates allocated, which may potentially lead to conflicts, causing the queue to not open:
https://github.com/volcano-sh/volcano/blob/1ae9a84e16bb327aa54420863cba3c4588e6e325/pkg/controllers/queue/queue_controller_action.go#L101-L107

Therefore, the fields updated by the scheduler and controller cannot conflict. The scheduler is only responsible for updating the allocated field in status, and the controller is only responsible for updating the state field in status. Currently, the controller has used ApplyStatus to update the state. For consistency, the scheduler also uses AppyStatus and declares the fields it manages.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Notice that do not add `Fixes` if the issue is associated with multiple PRs.
-->
Fixes #4139 

#### Special notes for your reviewer:
#### Validation
Queue can successfully open and update allocated in status:
![eaa8209ac3950a97cd0f52392743c1f](https://github.com/user-attachments/assets/5d541b42-ed44-4d98-8202-eff999226518)
![5262a5dae07bd51dd01cc9c27aa834c](https://github.com/user-attachments/assets/de186469-fe95-4038-ade4-7cc2aff5b47e)
![bd450ffe124c27099be5ad03bd6a824](https://github.com/user-attachments/assets/8cd910d2-1480-46e2-b0eb-9bf8135bc354)


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```