### PR TITLE
backfill: consider the nominated node first before iterating over all nodes

### DIFF
--- a/pkg/scheduler/actions/backfill/backfill.go
+++ b/pkg/scheduler/actions/backfill/backfill.go
@@ -73,7 +73,7 @@ func (backfill *Action) Execute(ssn *framework.Session) {
 			continue
 		}
 
-		predicateNodes, fitErrors := ph.PredicateNodes(task, ssn.NodeList, predicateFunc, backfill.enablePredicateErrorCache)
+		predicateNodes, fitErrors := util.PredicateNodes(ssn.Nodes, task, ssn.NodeList, ph, predicateFunc, backfill.enablePredicateErrorCache, false)
 		if len(predicateNodes) == 0 {
 			job.NodesFitErrors[task.UID] = fitErrors
 			continue


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
backfill: consider the nominated node first before iterating over all nodes

"NominatedNodeName" can potentially be set in a previous scheduling cycle as a result of preemption.
This node is likely the only candidate that will fit the pod, and hence we try it first before iterating over all nodes.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Notice that do not add `Fixes` if the issue is associated with multiple PRs.
-->
Ref https://github.com/volcano-sh/volcano/issues/3491 #4079

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```