### PR TITLE
[Security] Add a switch to control whether enable pprof in scheduler

### DIFF
--- a/cmd/scheduler/app/options/options.go
+++ b/cmd/scheduler/app/options/options.go
@@ -67,6 +67,7 @@ type ServerOption struct {
 	DefaultQueue        string
 	PrintVersion        bool
 	EnableMetrics       bool
+	EnablePprof         bool
 	ListenAddress       string
 	EnablePriorityClass bool
 	EnableCSIStorage    bool
@@ -141,6 +142,7 @@ func (s *ServerOption) AddFlags(fs *pflag.FlagSet) {
 		"Enable tracking of available storage capacity that CSI drivers provide; it is false by default")
 	fs.BoolVar(&s.EnableHealthz, "enable-healthz", false, "Enable the health check; it is false by default")
 	fs.BoolVar(&s.EnableMetrics, "enable-metrics", false, "Enable the metrics function; it is false by default")
+	fs.BoolVar(&s.EnablePprof, "enable-pprof", false, "Enable the pprof endpoint; it is false by default")
 	fs.StringSliceVar(&s.NodeSelector, "node-selector", nil, "volcano only work with the labeled node, like: --node-selector=volcano.sh/role:train --node-selector=volcano.sh/role:serving")
 	fs.BoolVar(&s.EnableCacheDumper, "cache-dumper", true, "Enable the cache dumper, it's true by default")
 	fs.StringVar(&s.CacheDumpFileDir, "cache-dump-dir", "/tmp", "The target dir where the json file put at when dump cache info to json file")

--- a/cmd/scheduler/app/server.go
+++ b/cmd/scheduler/app/server.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"net/http/pprof"
 	"os"
 
 	"volcano.sh/apis/pkg/apis/helpers"
@@ -69,11 +70,8 @@ func Run(opt *options.ServerOption) error {
 		panic(err)
 	}
 
-	if opt.EnableMetrics {
-		go func() {
-			http.Handle("/metrics", commonutil.PromHandler())
-			klog.Fatalf("Prometheus Http Server failed %s", http.ListenAndServe(opt.ListenAddress, nil))
-		}()
+	if opt.EnableMetrics || opt.EnablePprof {
+		go startMetricsServer(opt)
 	}
 
 	if opt.EnableHealthz {
@@ -141,4 +139,29 @@ func Run(opt *options.ServerOption) error {
 		},
 	})
 	return fmt.Errorf("lost lease")
+}
+
+func startMetricsServer(opt *options.ServerOption) {
+	mux := http.NewServeMux()
+
+	if opt.EnableMetrics {
+		mux.Handle("/metrics", commonutil.PromHandler())
+	}
+
+	if opt.EnablePprof {
+		mux.HandleFunc("/debug/pprof/", pprof.Index)
+		mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+		mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
+		mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+		mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
+	}
+
+	server := &http.Server{
+		Addr:    opt.ListenAddress,
+		Handler: mux,
+	}
+
+	if err := server.ListenAndServe(); err != nil {
+		klog.Errorf("start metrics/pprof http server failed: %v", err)
+	}
 }

--- a/cmd/scheduler/main.go
+++ b/cmd/scheduler/main.go
@@ -29,9 +29,6 @@ import (
 	componentbaseoptions "k8s.io/component-base/config/options"
 	"k8s.io/klog/v2"
 
-	// init pprof server
-	_ "net/http/pprof"
-
 	"volcano.sh/volcano/cmd/scheduler/app"
 	"volcano.sh/volcano/cmd/scheduler/app/options"
 	commonutil "volcano.sh/volcano/pkg/util"

--- a/installer/helm/chart/volcano/templates/scheduler.yaml
+++ b/installer/helm/chart/volcano/templates/scheduler.yaml
@@ -185,6 +185,9 @@ spec:
             {{- if .Values.custom.scheduler_metrics_enable }}
             - --enable-metrics=true
             {{- end }}
+            {{- if .Values.custom.scheduler_pprof_enable }}
+            - --enable-pprof=true
+            {{- end }}
             - --leader-elect={{ .Values.custom.leader_elect_enable }}
             {{- if .Values.custom.leader_elect_enable }}
             - --leader-elect-resource-namespace={{ .Release.Namespace }}

--- a/installer/helm/chart/volcano/values.yaml
+++ b/installer/helm/chart/volcano/values.yaml
@@ -21,6 +21,7 @@ custom:
   scheduler_enable: true
   scheduler_replicas: 1
   scheduler_metrics_enable: true
+  scheduler_pprof_enable: false
   scheduler_plugins_dir: ""
   scheduler_name: ~
   leader_elect_enable: false


### PR DESCRIPTION
#### What type of PR is this?
Related with #4170, add a switch to control whether enable pprof in scheduler


#### What this PR does / why we need it:
Currently in cmd/scheduler/main.go,` _ "net/http/pprof"` is imposed, which causes some handlers in the pprof package, such as `/debug/pprof`, to be registered to `DefaultServeMux` by default without a switch to control whether they are registered, posing a potential security risk. Currently, the registration of metrics handlers and pprof handlers has been unified, and to avoid third-party packages directly registering handlers to DefaultServeMux, a new ServeMux has been created to register the handlers, and then listen.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Notice that do not add `Fixes` if the issue is associated with multiple PRs.
-->
Related with #4170

#### Special notes for your reviewer:
NONE

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```