### PR TITLE
fix: panic when total guarantee of child queue exceeds capacity of parent

### DIFF
--- a/pkg/scheduler/plugins/capacity/capacity.go
+++ b/pkg/scheduler/plugins/capacity/capacity.go
@@ -670,7 +670,7 @@ func (cp *capacityPlugin) checkHierarchicalQueue(attr *queueAttr) error {
 	}
 
 	for _, childAttr := range attr.children {
-		realCapability := attr.realCapability.Clone().Sub(totalGuarantee).Add(childAttr.guarantee)
+		realCapability := api.ExceededPart(attr.realCapability, totalGuarantee).Add(childAttr.guarantee)
 		if childAttr.capability == nil {
 			childAttr.realCapability = realCapability
 		} else {

--- a/pkg/scheduler/plugins/capacity/capacity_test.go
+++ b/pkg/scheduler/plugins/capacity/capacity_test.go
@@ -17,11 +17,11 @@ limitations under the License.
 package capacity
 
 import (
-	"k8s.io/apimachinery/pkg/api/resource"
 	"os"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	schedulingv1beta1 "volcano.sh/apis/pkg/apis/scheduling/v1beta1"
 
 	"volcano.sh/apis/pkg/apis/scheduling"


### PR DESCRIPTION
fix panic when total guarantee of child queue exceeds capacity of parent
#4104 