### PR TITLE
[Cherry-pick v1.11] Fix: remove controller-manager metrics that should not be introduced 

### DIFF
--- a/.github/workflows/e2e_spark.yaml
+++ b/.github/workflows/e2e_spark.yaml
@@ -10,7 +10,7 @@ on:
 jobs:
   k8s-integration-tests:
     name: "E2E about Spark Integration test"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
     - name: Free Disk Space (Ubuntu)
       uses: jlumbroso/free-disk-space@main

--- a/.github/workflows/licenses_lint.yaml
+++ b/.github/workflows/licenses_lint.yaml
@@ -11,7 +11,7 @@ jobs:
   licenses-lint:
     name: Licenses Lint
     timeout-minutes: 40
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Install Go
         uses: actions/setup-go@v4

--- a/pkg/controllers/job/state/metrics.go
+++ b/pkg/controllers/job/state/metrics.go
@@ -4,13 +4,13 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 
-	"volcano.sh/volcano/pkg/scheduler/metrics"
+	"volcano.sh/volcano/pkg/controllers/util"
 )
 
 var (
 	jobCompletedPhaseCount = promauto.NewCounterVec(
 		prometheus.CounterOpts{
-			Subsystem: metrics.VolcanoNamespace,
+			Subsystem: util.VolcanoSubSystemName,
 			Name:      "job_completed_phase_count",
 			Help:      "Number of job completed phase",
 		}, []string{"job_name", "queue_name"},
@@ -18,7 +18,7 @@ var (
 
 	jobFailedPhaseCount = promauto.NewCounterVec(
 		prometheus.CounterOpts{
-			Subsystem: metrics.VolcanoNamespace,
+			Subsystem: util.VolcanoSubSystemName,
 			Name:      "job_failed_phase_count",
 			Help:      "Number of job failed phase",
 		}, []string{"job_name", "queue_name"},

--- a/pkg/controllers/metrics/queue.go
+++ b/pkg/controllers/metrics/queue.go
@@ -5,13 +5,13 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 
 	"volcano.sh/apis/pkg/apis/scheduling/v1beta1"
-	"volcano.sh/volcano/pkg/scheduler/metrics"
+	"volcano.sh/volcano/pkg/controllers/util"
 )
 
 var (
 	queuePodGroupInqueue = promauto.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Subsystem: metrics.VolcanoNamespace,
+			Subsystem: util.VolcanoSubSystemName,
 			Name:      "queue_pod_group_inqueue_count",
 			Help:      "The number of Inqueue PodGroup in this queue",
 		}, []string{"queue_name"},
@@ -19,7 +19,7 @@ var (
 
 	queuePodGroupPending = promauto.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Subsystem: metrics.VolcanoNamespace,
+			Subsystem: util.VolcanoSubSystemName,
 			Name:      "queue_pod_group_pending_count",
 			Help:      "The number of Pending PodGroup in this queue",
 		}, []string{"queue_name"},
@@ -27,7 +27,7 @@ var (
 
 	queuePodGroupRunning = promauto.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Subsystem: metrics.VolcanoNamespace,
+			Subsystem: util.VolcanoSubSystemName,
 			Name:      "queue_pod_group_running_count",
 			Help:      "The number of Running PodGroup in this queue",
 		}, []string{"queue_name"},
@@ -35,7 +35,7 @@ var (
 
 	queuePodGroupUnknown = promauto.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Subsystem: metrics.VolcanoNamespace,
+			Subsystem: util.VolcanoSubSystemName,
 			Name:      "queue_pod_group_unknown_count",
 			Help:      "The number of Unknown PodGroup in this queue",
 		}, []string{"queue_name"},
@@ -43,7 +43,7 @@ var (
 
 	queuePodGroupCompleted = promauto.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Subsystem: metrics.VolcanoNamespace,
+			Subsystem: util.VolcanoSubSystemName,
 			Name:      "queue_pod_group_completed_count",
 			Help:      "The number of Completed PodGroup in this queue",
 		}, []string{"queue_name"},

--- a/pkg/controllers/util/const.go
+++ b/pkg/controllers/util/const.go
@@ -1,0 +1,22 @@
+/*
+Copyright 2025 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+const (
+	// VolcanoSubSystemName - subsystem name in prometheus used by volcano
+	VolcanoSubSystemName = "volcano"
+)


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Cherry pick #4201  to release v1.11

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Notice that do not add `Fixes` if the issue is associated with multiple PRs.
-->
Fixes #4200 

#### Special notes for your reviewer:

@JesseStutler  @Monokaix 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
 remove controller-manager metrics that should not be introduced 
```