### PR TITLE
[Cherry-pick network-topology] Add http response body size limit

### DIFF
--- a/pkg/scheduler/metrics/source/metrics_client_elasticsearch.go
+++ b/pkg/scheduler/metrics/source/metrics_client_elasticsearch.go
@@ -36,6 +36,9 @@ const (
 	esCPUUsageField = "host.cpu.usage"
 	// esMemUsageField is the field name of mem usage in the document
 	esMemUsageField = "system.memory.actual.used.pct"
+
+	// 1MB
+	maxBodySize = 1 << 20
 )
 
 type ElasticsearchMetricsClient struct {
@@ -156,6 +159,7 @@ func (e *ElasticsearchMetricsClient) NodeMetricsAvg(ctx context.Context, nodeNam
 			}
 		} `json:"aggregations"`
 	}
+	res.Body = http.MaxBytesReader(nil, res.Body, maxBodySize)
 	if err := json.NewDecoder(res.Body).Decode(&r); err != nil {
 		return nil, err
 	}

--- a/pkg/scheduler/plugins/extender/extender.go
+++ b/pkg/scheduler/plugins/extender/extender.go
@@ -60,6 +60,9 @@ const (
 	ExtenderJobReadyVerb = "extender.jobReadyVerb"
 	// ExtenderIgnorable indicates whether the extender can ignore unexpected errors
 	ExtenderIgnorable = "extender.ignorable"
+
+	// 10MB
+	maxBodySize = 10 << 20
 )
 
 type extenderConfig struct {
@@ -322,6 +325,7 @@ func (ep *extenderPlugin) send(action string, args interface{}, result interface
 	}
 
 	if result != nil {
+		resp.Body = http.MaxBytesReader(nil, resp.Body, maxBodySize)
 		return json.NewDecoder(resp.Body).Decode(result)
 	}
 	return nil

--- a/pkg/scheduler/plugins/extender/extender_test.go
+++ b/pkg/scheduler/plugins/extender/extender_test.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2025 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package extender
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"volcano.sh/volcano/pkg/scheduler/api"
+)
+
+func TestMaxBodySizeLimit2(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		response := strings.Repeat("a", maxBodySize+1)
+		w.Write([]byte(`{"padding":"` + response + `"}`))
+	}))
+	defer server.Close()
+
+	plugin := &extenderPlugin{
+		client: http.Client{},
+		config: &extenderConfig{
+			urlPrefix: server.URL,
+		},
+	}
+
+	var result map[string]interface{}
+	err := plugin.send("test", &PredicateRequest{Task: &api.TaskInfo{}, Node: &api.NodeInfo{}}, &result)
+
+	if err == nil {
+		t.Error("Expected error due to request body size limit, but got nil")
+	} else if !strings.Contains(err.Error(), "http: request body too large") {
+		t.Errorf("Expected 'http: request body too large' error, got: %v", err)
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?
/area security

#### What this PR does / why we need it:
Cherry-pick 76285a04ad6a4b93fbca89be655101962f05fc29

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Notice that do not add `Fixes` if the issue is associated with multiple PRs.
-->
Cherry-pick 76285a04ad6a4b93fbca89be655101962f05fc29

#### Special notes for your reviewer:
NONE

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```