### PR TITLE
Fix panic while queues' total guarantee  exceed the total resource of the cluster in some situations.

### DIFF
--- a/pkg/scheduler/plugins/proportion/proportion.go
+++ b/pkg/scheduler/plugins/proportion/proportion.go
@@ -234,7 +234,7 @@ func (pp *proportionPlugin) OnSessionOpen(ssn *framework.Session) {
 			metrics.UpdateQueueDeserved(attr.name, attr.deserved.MilliCPU, attr.deserved.Memory, attr.deserved.ScalarResources)
 		}
 
-		remaining.Sub(increasedDeserved).Add(decreasedDeserved)
+		remaining = api.ExceededPart(remaining.Clone().Add(decreasedDeserved), increasedDeserved)
 		klog.V(4).Infof("Remaining resource is  <%s>", remaining)
 		if remaining.IsEmpty() || equality.Semantic.DeepEqual(remaining, oldRemaining) {
 			klog.V(4).Infof("Exiting when remaining is empty or no queue has more resource request:  <%v>", remaining)


### PR DESCRIPTION
Fix the panic while executing the proportion plugin in a cluster where node information synchronization is very slow, which can cause the `totalResource` have been calculated too small and make the `Resource.Sub` method  assertion failed, lead to continuous panic. See Issue #4261 for more infomation.

#### What type of PR is this?
kind/ bug

#### What this PR/ why we need it:

Handle the situation that `remaining` is less than the `decreasedDeserved`,  to prevent panic and enhance code robustness.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Notice that do not add `Fixes` if the issue is associated with multiple PRs.
-->
Fixes #4261 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "N in the release-note block below.
If yes, a release note is required.
-->
```release-note
N
```