### PR TITLE
fix: add miss queue state check in allocatable action

### DIFF
--- a/pkg/scheduler/plugins/capacity/capacity.go
+++ b/pkg/scheduler/plugins/capacity/capacity.go
@@ -162,6 +162,10 @@ func (cp *capacityPlugin) OnSessionOpen(ssn *framework.Session) {
 	})
 
 	ssn.AddAllocatableFn(cp.Name(), func(queue *api.QueueInfo, candidate *api.TaskInfo) bool {
+		if queue.Queue.Status.State != scheduling.QueueStateOpen {
+			klog.V(4).Infof("Queue <%s> is not in open state, can not allocate task <%s>.", queue.Name, candidate.Name)
+			return false
+		}
 		if !readyToSchedule {
 			klog.V(3).Infof("Capacity plugin failed to check queue's hierarchical structure!")
 			return false
@@ -190,6 +194,7 @@ func (cp *capacityPlugin) OnSessionOpen(ssn *framework.Session) {
 		queue := ssn.Queues[queueID]
 		// If the queue is not open, do not enqueue
 		if queue.Queue.Status.State != scheduling.QueueStateOpen {
+			klog.V(4).Infof("Queue <%s> is not open state, reject job <%s/%s>.", queue.Name, job.Namespace, job.Name)
 			return util.Reject
 		}
 		// If no capability is set, always enqueue the job.

--- a/pkg/scheduler/plugins/capacity/capacity_test.go
+++ b/pkg/scheduler/plugins/capacity/capacity_test.go
@@ -330,7 +330,7 @@ func TestEnqueueAndAllocatable(t *testing.T) {
 			ExpectBindMap:  map[string]string{},
 		},
 		{
-			Name:           "case4: queue with  non-open state, can not enqueue",
+			Name:           "case4: queue with non-open state, can not enqueue",
 			Plugins:        plugins,
 			Pods:           []*corev1.Pod{p6},
 			Nodes:          []*corev1.Node{n1, n2},


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
#### What this PR does / why we need it:
- add miss queue state check in `allocatble` action
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Notice that do not add `Fixes` if the issue is associated with multiple PRs.
-->
Fixes https://github.com/volcano-sh/volcano/issues/4189

follow-up this comment: https://github.com/volcano-sh/volcano/pull/4263#discussion_r2083889569

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
None
```