### PR TITLE
Add error msg when check hierarchical queue fail

### DIFF
--- a/pkg/scheduler/plugins/capacity/capacity.go
+++ b/pkg/scheduler/plugins/capacity/capacity.go
@@ -661,7 +661,8 @@ func (cp *capacityPlugin) checkHierarchicalQueue(attr *queueAttr) error {
 		}
 		// Check if the parent queue's capability is less than the child queue's capability
 		if attr.capability.LessPartly(childAttr.capability, api.Zero) {
-			return fmt.Errorf("queue <%s> capability is less than its child queue <%s>", attr.name, childAttr.name)
+			return fmt.Errorf("queue <%s> capability <%s> is less than its child queue <%s> capability <%s>",
+				attr.name, attr.capability, childAttr.name, childAttr.capability)
 		}
 	}
 
@@ -688,12 +689,14 @@ func (cp *capacityPlugin) checkHierarchicalQueue(attr *queueAttr) error {
 
 	// Check if the parent queue's deserved resources are less than the total deserved resources of child queues
 	if attr.deserved.LessPartly(totalDeserved, api.Zero) {
-		return fmt.Errorf("deserved resources of queue <%s> are less than the sum of its child queues' deserved resources", attr.name)
+		return fmt.Errorf("queue <%s> deserved resources <%s> are less than the sum of its child queues' deserved resources <%s>",
+			attr.name, attr.deserved, totalDeserved)
 	}
 
 	// Check if the parent queue's guarantee resources are less than the total guarantee resources of child queues
 	if attr.guarantee.LessPartly(totalGuarantee, api.Zero) {
-		return fmt.Errorf("guarantee resources of queue <%s> are less than the sum of its child queues' guarantee resources", attr.name)
+		return fmt.Errorf("queue <%s> guarantee resources <%s> are less than the sum of its child queues' guarantee resources <%s>",
+			attr.name, attr.guarantee, totalGuarantee)
 	}
 
 	for _, childAttr := range attr.children {


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
When encountering a hierarchical queue error, user can quickly identify which resource item fails to meet the requirements.

The current error log lacks sufficient information to pinpoint the issue:
![image](https://github.com/user-attachments/assets/a34444ff-1f31-45b9-88c1-79443a8bdab3)

After applying this patch, user will obtain the following information:
![image](https://github.com/user-attachments/assets/5c81167a-ca66-4522-be1d-16af7156667b)

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Notice that do not add `Fixes` if the issue is associated with multiple PRs.
-->
_The relevant issue has not been submitted as of yet_

#### Special notes for your reviewer:
_No additional assistance information is available at present._

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
1. More information is added to the check of hierarchical queue to aid in problem identification.
```