### PR TITLE
WORLD_SIZE calculation for PyTorch Jobs

### DIFF
--- a/pkg/controllers/job/plugins/distributed-framework/pytorch/pytorch.go
+++ b/pkg/controllers/job/plugins/distributed-framework/pytorch/pytorch.go
@@ -120,7 +120,9 @@ func (pp *pytorchPlugin) OnPodCreate(pod *v1.Pod, job *batch.Job) error {
 func (pp *pytorchPlugin) getTotalReplicas(job *batch.Job) int32 {
 	jobReplicas := int32(0)
 	for _, task := range job.Spec.Tasks {
-		jobReplicas += task.Replicas
+		if task.Name == pp.masterName || task.Name == pp.workerName {
+			jobReplicas += task.Replicas
+		}
 	}
 
 	return jobReplicas

--- a/pkg/controllers/job/plugins/distributed-framework/pytorch/pytorch_test.go
+++ b/pkg/controllers/job/plugins/distributed-framework/pytorch/pytorch_test.go
@@ -182,6 +182,11 @@ func TestPytorch(t *testing.T) {
 							Replicas: 2,
 							Template: v1.PodTemplateSpec{},
 						},
+						{
+							Name:     "extra",
+							Replicas: 2,
+							Template: v1.PodTemplateSpec{},
+						},
 					},
 				},
 			},
@@ -242,6 +247,11 @@ func TestPytorch(t *testing.T) {
 							Replicas: 2,
 							Template: v1.PodTemplateSpec{},
 						},
+						{
+							Name:     "extra",
+							Replicas: 2,
+							Template: v1.PodTemplateSpec{},
+						},
 					},
 				},
 			},
@@ -299,6 +309,11 @@ func TestPytorch(t *testing.T) {
 						},
 						{
 							Name:     "worker",
+							Replicas: 2,
+							Template: v1.PodTemplateSpec{},
+						},
+						{
+							Name:     "extra",
 							Replicas: 2,
 							Template: v1.PodTemplateSpec{},
 						},


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
The WORLD_SIZE calculation for PyTorch Jobs includes any extra tasks apart from Master and Worker are also included. This is resulting in Failures.
**Expected** : 
WORLD_SIZE should include only tasks that are from Master and Worker

#### Which issue(s) this PR fixes:
Fixes https://github.com/volcano-sh/volcano/issues/4238
Fixes https://github.com/volcano-sh/volcano/issues/4166

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```