### PR TITLE
fix: scheduler leader elect namespace not take effect

### DIFF
--- a/cmd/scheduler/app/options/options.go
+++ b/cmd/scheduler/app/options/options.go
@@ -113,7 +113,7 @@ func (s *ServerOption) AddFlags(fs *pflag.FlagSet) {
 		"File containing the default x509 Certificate for HTTPS. (CA cert, if any, concatenated "+
 		"after server cert).")
 	fs.StringVar(&s.KeyFile, "tls-private-key-file", s.KeyFile, "File containing the default x509 private key matching --tls-cert-file.")
-	fs.StringVar(&s.LockObjectNamespace, "lock-object-namespace", defaultLockObjectNamespace, "Define the namespace of the lock object; it is volcano-system by default.")
+	fs.StringVar(&s.LockObjectNamespace, "lock-object-namespace", "", "Define the namespace of the lock object; it is volcano-system by default.")
 	fs.MarkDeprecated("lock-object-namespace", "This flag is deprecated and will be removed in a future release. Please use --leader-elect-resource-namespace instead.")
 	// volcano scheduler will ignore pods with scheduler names other than specified with the option
 	fs.StringArrayVar(&s.SchedulerNames, "scheduler-name", []string{defaultSchedulerName}, "vc-scheduler will handle pods whose .spec.SchedulerName is same as scheduler-name")

--- a/cmd/scheduler/app/options/options_test.go
+++ b/cmd/scheduler/app/options/options_test.go
@@ -66,9 +66,8 @@ func TestAddFlags(t *testing.T) {
 			ResourceLock:      resourcelock.LeasesResourceLock,
 			ResourceNamespace: defaultLockObjectNamespace,
 		},
-		LockObjectNamespace: defaultLockObjectNamespace,
-		DefaultQueue:        defaultQueue,
-		ListenAddress:       defaultListenAddress,
+		DefaultQueue:  defaultQueue,
+		ListenAddress: defaultListenAddress,
 		KubeClientOptions: kube.ClientOptions{
 			Master:     "",
 			KubeConfig: "",


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
#### What this PR does / why we need it:
For volcano-scheduler, --leader-elect-namespace flag do not take effect. The same as https://github.com/volcano-sh/volcano/pull/3975.
#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:
cc @Monokaix 

#### Does this PR introduce a user-facing change?
