### PR TITLE
feat: add graceful shutdown server for webhook manager.

### DIFF
--- a/cmd/webhook-manager/app/options/options.go
+++ b/cmd/webhook-manager/app/options/options.go
@@ -19,6 +19,7 @@ package options
 import (
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/spf13/pflag"
 
@@ -26,31 +27,33 @@ import (
 )
 
 const (
-	defaultSchedulerName    = "volcano"
-	defaultQPS              = 50.0
-	defaultBurst            = 100
-	defaultEnabledAdmission = "/jobs/mutate,/jobs/validate,/podgroups/mutate,/pods/validate,/pods/mutate,/queues/mutate,/queues/validate"
-	defaultHealthzAddress   = ":11251"
+	defaultSchedulerName        = "volcano"
+	defaultQPS                  = 50.0
+	defaultBurst                = 100
+	defaultEnabledAdmission     = "/jobs/mutate,/jobs/validate,/podgroups/mutate,/pods/validate,/pods/mutate,/queues/mutate,/queues/validate"
+	defaultHealthzAddress       = ":11251"
+	defaultGracefulShutdownTime = time.Second * 30
 )
 
 // Config admission-controller server config.
 type Config struct {
-	KubeClientOptions kube.ClientOptions
-	CertFile          string
-	KeyFile           string
-	CaCertFile        string
-	CertData          []byte
-	KeyData           []byte
-	CaCertData        []byte
-	ListenAddress     string
-	Port              int
-	PrintVersion      bool
-	WebhookName       string
-	WebhookNamespace  string
-	SchedulerNames    []string
-	WebhookURL        string
-	ConfigPath        string
-	EnabledAdmission  string
+	KubeClientOptions    kube.ClientOptions
+	CertFile             string
+	KeyFile              string
+	CaCertFile           string
+	CertData             []byte
+	KeyData              []byte
+	CaCertData           []byte
+	ListenAddress        string
+	Port                 int
+	PrintVersion         bool
+	WebhookName          string
+	WebhookNamespace     string
+	SchedulerNames       []string
+	WebhookURL           string
+	ConfigPath           string
+	EnabledAdmission     string
+	GracefulShutdownTime time.Duration
 
 	EnableHealthz bool
 	// HealthzBindAddress is the IP address and port for the health check server to serve on
@@ -88,6 +91,7 @@ func (c *Config) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&c.ConfigPath, "admission-conf", "", "The configmap file of this webhook")
 	fs.BoolVar(&c.EnableHealthz, "enable-healthz", false, "Enable the health check; it is false by default")
 	fs.StringVar(&c.HealthzBindAddress, "healthz-address", defaultHealthzAddress, "The address to listen on for the health check server.")
+	fs.DurationVar(&c.GracefulShutdownTime, "graceful-shutdown-time", defaultGracefulShutdownTime, "The duration to wait during graceful shutdown before forcing termination.")
 }
 
 // CheckPortOrDie check valid port range.

--- a/cmd/webhook-manager/app/options/options_test.go
+++ b/cmd/webhook-manager/app/options/options_test.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2025 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package options
+
+import (
+	"testing"
+
+	"github.com/spf13/pflag"
+	"k8s.io/apimachinery/pkg/api/equality"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+
+	"volcano.sh/volcano/pkg/kube"
+)
+
+func TestAddFlags(t *testing.T) {
+	fs := pflag.NewFlagSet("addflagstest", pflag.ExitOnError)
+	s := NewConfig()
+	s.AddFlags(fs)
+	utilfeature.DefaultMutableFeatureGate.AddFlag(fs)
+
+	args := []string{
+		"--master=127.0.0.1",
+		"--kube-api-burst=200",
+	}
+	fs.Parse(args)
+
+	// This is a snapshot of expected options parsed by args.
+	expected := &Config{
+		KubeClientOptions: kube.ClientOptions{
+			Master:     "127.0.0.1",
+			KubeConfig: "",
+			QPS:        defaultQPS,
+			Burst:      200,
+		},
+		ListenAddress:        "",
+		Port:                 8443,
+		PrintVersion:         false,
+		WebhookName:          "",
+		WebhookNamespace:     "",
+		SchedulerNames:       []string{defaultSchedulerName},
+		WebhookURL:           "",
+		ConfigPath:           "",
+		EnabledAdmission:     defaultEnabledAdmission,
+		GracefulShutdownTime: defaultGracefulShutdownTime,
+		EnableHealthz:        false,
+		HealthzBindAddress:   defaultHealthzAddress,
+	}
+
+	if !equality.Semantic.DeepEqual(expected, s) {
+		t.Errorf("Got different run options than expected.\nGot: %+v\nExpected: %+v\n", s, expected)
+	}
+}

--- a/pkg/webhooks/config/config.go
+++ b/pkg/webhooks/config/config.go
@@ -78,7 +78,7 @@ func LoadAdmissionConf(confPath string) *AdmissionConfiguration {
 }
 
 // WatchAdmissionConf listen the changes of the configuration file
-func WatchAdmissionConf(path string, stopCh chan os.Signal) {
+func WatchAdmissionConf(path string, stopCh <-chan struct{}) {
 	dirPath := filepath.Dir(path)
 	fileWatcher, err := filewatcher.NewFileWatcher(dirPath)
 	if err != nil {


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
Volcano webhook provides callback process for kubernetes resource mutation and validation. As an HTTP server, it need support graceful shutdown to ensure proper behavior during kubernetes rolling upgrades or when the webhook pod is deleted. Kubelet sends a SIGTERM signal to the container. The webhook should handle this signal by performing a graceful shutdown. However, calling http.Server.Close immediately closes all active net.Listeners and any connections in the StateNew, StateActive, or StateIdle states. For a graceful shutdown, we should use Server.Shutdown, which first closes all open listeners, then closes all idle connections, and finally waits indefinitely for active connections to become idle before shutting down.

Second, regarding the stop channel returned from signal handling: if multiple handlers are waiting on different channels, only one of them will be triggered. Therefore, we must use `signals.SetupSignalContext()` to handle signals, as it will close the signal channel, allowing multiple handlers to be triggered simultaneously.



#### Special notes for your reviewer:
@hwdef 

#### Does this PR introduce a user-facing change?
None