### PR TITLE
Check queue spec to ensure the rationality of resource size

### DIFF
--- a/pkg/webhooks/admission/queues/validate/validate_queue.go
+++ b/pkg/webhooks/admission/queues/validate/validate_queue.go
@@ -21,6 +21,8 @@ import (
 	"strconv"
 	"strings"
 
+	"volcano.sh/volcano/pkg/scheduler/api"
+
 	admissionv1 "k8s.io/api/admission/v1"
 	whv1 "k8s.io/api/admissionregistration/v1"
 	v1 "k8s.io/api/core/v1"
@@ -116,6 +118,7 @@ func validateQueue(queue *schedulingv1beta1.Queue) error {
 
 	errs = append(errs, validateStateOfQueue(queue.Status.State, resourcePath.Child("spec").Child("state"))...)
 	errs = append(errs, validateWeightOfQueue(queue.Spec.Weight, resourcePath.Child("spec").Child("weight"))...)
+	errs = append(errs, validateResourceOfQueue(queue.Spec, resourcePath.Child("spec"))...)
 	errs = append(errs, validateHierarchicalAttributes(queue, resourcePath.Child("metadata").Child("annotations"))...)
 
 	if len(errs) > 0 {
@@ -209,6 +212,33 @@ func validateWeightOfQueue(value int32, fldPath *field.Path) field.ErrorList {
 		return errs
 	}
 	return append(errs, field.Invalid(fldPath, value, "queue weight must be a positive integer"))
+}
+
+func validateResourceOfQueue(resource schedulingv1beta1.QueueSpec, fldPath *field.Path) field.ErrorList {
+	errs := field.ErrorList{}
+	capabilityResource := api.NewResource(resource.Capability)
+	deservedResource := api.NewResource(resource.Deserved)
+	guaranteeResource := api.NewResource(resource.Guarantee.Resource)
+
+	if len(resource.Capability) != 0 &&
+		capabilityResource.LessPartly(deservedResource, api.Zero) {
+		return append(errs, field.Invalid(fldPath.Child("deserved"),
+			deservedResource.String(), "deserved should less equal than capability"))
+	}
+
+	if len(resource.Capability) != 0 &&
+		capabilityResource.LessPartly(guaranteeResource, api.Zero) {
+		return append(errs, field.Invalid(fldPath.Child("guarantee"),
+			guaranteeResource.String(), "guarantee should less equal than capability"))
+	}
+
+	if len(resource.Deserved) != 0 &&
+		deservedResource.LessPartly(guaranteeResource, api.Zero) {
+		return append(errs, field.Invalid(fldPath.Child("guarantee"),
+			guaranteeResource.String(), "guarantee should less equal than deserved"))
+	}
+
+	return errs
 }
 
 func validateQueueDeleting(queueName string) error {

--- a/pkg/webhooks/admission/queues/validate/validate_queue_test.go
+++ b/pkg/webhooks/admission/queues/validate/validate_queue_test.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"testing"
+	"volcano.sh/volcano/pkg/scheduler/api"
 
 	admissionv1 "k8s.io/api/admission/v1"
 	v1 "k8s.io/api/core/v1"
@@ -189,6 +190,130 @@ func TestAdmitQueues(t *testing.T) {
 	if err != nil {
 		t.Errorf("Marshal queue with negative weight failed for %v.", err)
 
+	}
+
+	resourceNotSet := schedulingv1beta1.Queue{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "resource-not-set",
+		},
+		Spec: schedulingv1beta1.QueueSpec{
+			Weight: 1,
+		},
+	}
+
+	resourceNotSetJSON, err := json.Marshal(resourceNotSet)
+	if err != nil {
+		t.Errorf("Marshal resourceNotSet failed for %v.", err)
+
+	}
+
+	onlyDeservedSet := schedulingv1beta1.Queue{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "only-deserved-set",
+		},
+		Spec: schedulingv1beta1.QueueSpec{
+			Weight: 1,
+			Deserved: map[v1.ResourceName]resource.Quantity{
+				v1.ResourceCPU:    resource.MustParse("1"),
+				v1.ResourceMemory: resource.MustParse("1Gi"),
+			},
+		},
+	}
+
+	onlyDeservedSetJSON, err := json.Marshal(onlyDeservedSet)
+	if err != nil {
+		t.Errorf("Marshal onlyDeservedSet failed for %v.", err)
+
+	}
+
+	onlyGuaranteeSet := schedulingv1beta1.Queue{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "only-deserved-set",
+		},
+		Spec: schedulingv1beta1.QueueSpec{
+			Weight: 1,
+			Guarantee: schedulingv1beta1.Guarantee{
+				Resource: map[v1.ResourceName]resource.Quantity{
+					v1.ResourceCPU:    resource.MustParse("1"),
+					v1.ResourceMemory: resource.MustParse("1Gi"),
+				},
+			},
+		},
+	}
+
+	onlyGuaranteeSetJSON, err := json.Marshal(onlyGuaranteeSet)
+	if err != nil {
+		t.Errorf("Marshal onlyGuaranteeSet failed for %v.", err)
+	}
+
+	capabilityLessDeserved := schedulingv1beta1.Queue{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "capability-less-deserved",
+		},
+		Spec: schedulingv1beta1.QueueSpec{
+			Weight: 1,
+			Capability: map[v1.ResourceName]resource.Quantity{
+				v1.ResourceCPU:    resource.MustParse("1"),
+				v1.ResourceMemory: resource.MustParse("1Gi"),
+			},
+			Deserved: map[v1.ResourceName]resource.Quantity{
+				v1.ResourceCPU:    resource.MustParse("2"),
+				v1.ResourceMemory: resource.MustParse("1Gi"),
+			},
+		},
+	}
+
+	capabilityLessDeservedJSON, err := json.Marshal(capabilityLessDeserved)
+	if err != nil {
+		t.Errorf("Marshal capabilityLessDeserved failed for %v.", err)
+	}
+
+	deservedLessGuarantee := schedulingv1beta1.Queue{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "deserved-less-guarantee",
+		},
+		Spec: schedulingv1beta1.QueueSpec{
+			Weight: 1,
+			Deserved: map[v1.ResourceName]resource.Quantity{
+				v1.ResourceCPU:    resource.MustParse("2"),
+				v1.ResourceMemory: resource.MustParse("1Gi"),
+			},
+			Guarantee: schedulingv1beta1.Guarantee{
+				Resource: map[v1.ResourceName]resource.Quantity{
+					v1.ResourceCPU:    resource.MustParse("2"),
+					v1.ResourceMemory: resource.MustParse("3Gi"),
+				},
+			},
+		},
+	}
+
+	deservedLessGuaranteeJSON, err := json.Marshal(deservedLessGuarantee)
+	if err != nil {
+		t.Errorf("Marshal deservedLessGuarantee failed for %v.", err)
+	}
+
+	capabilityLessGuarantee := schedulingv1beta1.Queue{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "capability-less-guarantee",
+		},
+		Spec: schedulingv1beta1.QueueSpec{
+			Weight: 1,
+			Capability: map[v1.ResourceName]resource.Quantity{
+				v1.ResourceCPU:    resource.MustParse("1"),
+				v1.ResourceMemory: resource.MustParse("1Gi"),
+			},
+			Guarantee: schedulingv1beta1.Guarantee{
+				Resource: map[v1.ResourceName]resource.Quantity{
+					v1.ResourceCPU:    resource.MustParse("2"),
+					v1.ResourceMemory: resource.MustParse("3Gi"),
+				},
+			},
+		},
+	}
+
+	capabilityLessGuaranteeJSON, err := json.Marshal(capabilityLessGuarantee)
+	if err != nil {
+		t.Errorf("Marshal capabilityLessGuarantee failed for %v.", err)
 	}
 
 	hierarchyWeightsDontMatch := schedulingv1beta1.Queue{
@@ -815,7 +940,207 @@ func TestAdmitQueues(t *testing.T) {
 				},
 			},
 		},
-
+		{
+			Name: "Create queue without resource",
+			AR: admissionv1.AdmissionReview{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "AdmissionReview",
+					APIVersion: "admission.k8s.io/v1beta1",
+				},
+				Request: &admissionv1.AdmissionRequest{
+					Kind: metav1.GroupVersionKind{
+						Group:   "scheduling.volcano.sh",
+						Version: "v1beta1",
+						Kind:    "Queue",
+					},
+					Resource: metav1.GroupVersionResource{
+						Group:    "scheduling.volcano.sh",
+						Version:  "v1beta1",
+						Resource: "queues",
+					},
+					Name:      "default",
+					Operation: "CREATE",
+					Object: runtime.RawExtension{
+						Raw: resourceNotSetJSON,
+					},
+				},
+			},
+			reviewResponse: &admissionv1.AdmissionResponse{
+				Allowed: true,
+			},
+		},
+		{
+			Name: "Create queue with deserved resource",
+			AR: admissionv1.AdmissionReview{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "AdmissionReview",
+					APIVersion: "admission.k8s.io/v1beta1",
+				},
+				Request: &admissionv1.AdmissionRequest{
+					Kind: metav1.GroupVersionKind{
+						Group:   "scheduling.volcano.sh",
+						Version: "v1beta1",
+						Kind:    "Queue",
+					},
+					Resource: metav1.GroupVersionResource{
+						Group:    "scheduling.volcano.sh",
+						Version:  "v1beta1",
+						Resource: "queues",
+					},
+					Name:      "default",
+					Operation: "CREATE",
+					Object: runtime.RawExtension{
+						Raw: onlyDeservedSetJSON,
+					},
+				},
+			},
+			reviewResponse: &admissionv1.AdmissionResponse{
+				Allowed: true,
+			},
+		},
+		{
+			Name: "Create queue with guarantee resource",
+			AR: admissionv1.AdmissionReview{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "AdmissionReview",
+					APIVersion: "admission.k8s.io/v1beta1",
+				},
+				Request: &admissionv1.AdmissionRequest{
+					Kind: metav1.GroupVersionKind{
+						Group:   "scheduling.volcano.sh",
+						Version: "v1beta1",
+						Kind:    "Queue",
+					},
+					Resource: metav1.GroupVersionResource{
+						Group:    "scheduling.volcano.sh",
+						Version:  "v1beta1",
+						Resource: "queues",
+					},
+					Name:      "default",
+					Operation: "CREATE",
+					Object: runtime.RawExtension{
+						Raw: onlyGuaranteeSetJSON,
+					},
+				},
+			},
+			reviewResponse: &admissionv1.AdmissionResponse{
+				Allowed: true,
+			},
+		},
+		{
+			Name: "Create queue with capability less deserved",
+			AR: admissionv1.AdmissionReview{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "AdmissionReview",
+					APIVersion: "admission.k8s.io/v1beta1",
+				},
+				Request: &admissionv1.AdmissionRequest{
+					Kind: metav1.GroupVersionKind{
+						Group:   "scheduling.volcano.sh",
+						Version: "v1beta1",
+						Kind:    "Queue",
+					},
+					Resource: metav1.GroupVersionResource{
+						Group:    "scheduling.volcano.sh",
+						Version:  "v1beta1",
+						Resource: "queues",
+					},
+					Name:      "default",
+					Operation: "CREATE",
+					Object: runtime.RawExtension{
+						Raw: capabilityLessDeservedJSON,
+					},
+				},
+			},
+			reviewResponse: &admissionv1.AdmissionResponse{
+				Allowed: false,
+				Result: &metav1.Status{
+					Message: field.Invalid(field.NewPath("requestBody").Child("spec").Child("deserved"),
+						api.NewResource(
+							v1.ResourceList{
+								v1.ResourceCPU:    resource.MustParse("2"),
+								v1.ResourceMemory: resource.MustParse("1Gi"),
+							}).String(),
+						"deserved should less equal than capability").Error(),
+				},
+			},
+		},
+		{
+			Name: "Create queue with capability less guarantee",
+			AR: admissionv1.AdmissionReview{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "AdmissionReview",
+					APIVersion: "admission.k8s.io/v1beta1",
+				},
+				Request: &admissionv1.AdmissionRequest{
+					Kind: metav1.GroupVersionKind{
+						Group:   "scheduling.volcano.sh",
+						Version: "v1beta1",
+						Kind:    "Queue",
+					},
+					Resource: metav1.GroupVersionResource{
+						Group:    "scheduling.volcano.sh",
+						Version:  "v1beta1",
+						Resource: "queues",
+					},
+					Name:      "default",
+					Operation: "CREATE",
+					Object: runtime.RawExtension{
+						Raw: capabilityLessGuaranteeJSON,
+					},
+				},
+			},
+			reviewResponse: &admissionv1.AdmissionResponse{
+				Allowed: false,
+				Result: &metav1.Status{
+					Message: field.Invalid(field.NewPath("requestBody").Child("spec").Child("guarantee"),
+						api.NewResource(
+							v1.ResourceList{
+								v1.ResourceCPU:    resource.MustParse("2"),
+								v1.ResourceMemory: resource.MustParse("3Gi"),
+							}).String(),
+						"guarantee should less equal than capability").Error(),
+				},
+			},
+		},
+		{
+			Name: "Create queue with deserved less guarantee",
+			AR: admissionv1.AdmissionReview{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "AdmissionReview",
+					APIVersion: "admission.k8s.io/v1beta1",
+				},
+				Request: &admissionv1.AdmissionRequest{
+					Kind: metav1.GroupVersionKind{
+						Group:   "scheduling.volcano.sh",
+						Version: "v1beta1",
+						Kind:    "Queue",
+					},
+					Resource: metav1.GroupVersionResource{
+						Group:    "scheduling.volcano.sh",
+						Version:  "v1beta1",
+						Resource: "queues",
+					},
+					Name:      "default",
+					Operation: "CREATE",
+					Object: runtime.RawExtension{
+						Raw: deservedLessGuaranteeJSON,
+					},
+				},
+			},
+			reviewResponse: &admissionv1.AdmissionResponse{
+				Allowed: false,
+				Result: &metav1.Status{
+					Message: field.Invalid(field.NewPath("requestBody").Child("spec").Child("guarantee"),
+						api.NewResource(
+							v1.ResourceList{
+								v1.ResourceCPU:    resource.MustParse("2"),
+								v1.ResourceMemory: resource.MustParse("3Gi"),
+							}).String(),
+						"guarantee should less equal than deserved").Error(),
+				},
+			},
+		},
 		{
 			Name: "Abnormal Case Hierarchy And Weights Do Not Match",
 			AR: admissionv1.AdmissionReview{


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
#### What this PR does / why we need it:
Check the size relationship of queue resource items.

1. Let the problem be exposed to the user earlier, rather than discovered when the task is submitted.
2. Prevent the existence of unreasonable queues.
3. Facilitate the user to understand the correct configuration of the queue.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Notice that do not add `Fixes` if the issue is associated with multiple PRs.
-->
Fixes # https://github.com/volcano-sh/volcano/issues/4292

#### Special notes for your reviewer:
_No more help info now._

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```