### PR TITLE
Prevent pod scheduling when reclaim

### DIFF
--- a/pkg/scheduler/actions/preempt/preempt.go
+++ b/pkg/scheduler/actions/preempt/preempt.go
@@ -314,7 +314,7 @@ func (pmpt *Action) preempt(
 		klog.V(3).Infof("Preempted <%v> for Task <%s/%s> requested <%v>.",
 			preempted, preemptor.Namespace, preemptor.Name, preemptor.InitResreq)
 
-		// If preemptor's queue is overused, it means preemptor can not be allocated. So no need care about the node idle resource
+		// If preemptor's queue is not allocatable, it means preemptor cannot be allocated. So no need care about the node idle resource
 		if ssn.Allocatable(currentQueue, preemptor) && preemptor.InitResreq.LessEqual(node.FutureIdle(), api.Zero) {
 			if err := stmt.Pipeline(preemptor, node.Name, evictionOccurred); err != nil {
 				klog.Errorf("Failed to pipeline Task <%s/%s> on Node <%s>",

--- a/pkg/scheduler/plugins/proportion/proportion.go
+++ b/pkg/scheduler/plugins/proportion/proportion.go
@@ -299,8 +299,12 @@ func (pp *proportionPlugin) OnSessionOpen(ssn *framework.Session) {
 	})
 
 	queueAllocatable := func(queue *api.QueueInfo, candidate *api.TaskInfo) bool {
-		attr := pp.queueOpts[queue.UID]
+		if queue.Queue.Status.State != scheduling.QueueStateOpen {
+			klog.V(3).Infof("Queue <%s> current state: %s, is not in open state, can not allocate task <%s>.", queue.Name, queue.Queue.Status.State, candidate.Name)
+			return false
+		}
 
+		attr := pp.queueOpts[queue.UID]
 		futureUsed := attr.allocated.Clone().Add(candidate.Resreq)
 		allocatable := futureUsed.LessEqualWithDimension(attr.deserved, candidate.Resreq)
 		if !allocatable {
@@ -312,10 +316,6 @@ func (pp *proportionPlugin) OnSessionOpen(ssn *framework.Session) {
 	}
 
 	ssn.AddAllocatableFn(pp.Name(), func(queue *api.QueueInfo, candidate *api.TaskInfo) bool {
-		if queue.Queue.Status.State != scheduling.QueueStateOpen {
-			klog.V(4).Infof("Queue <%s> is not in open state, can not allocate task <%s>.", queue.Name, candidate.Name)
-			return false
-		}
 		return queueAllocatable(queue, candidate)
 	})
 	ssn.AddPreemptiveFn(pp.Name(), func(obj interface{}, candidate interface{}) bool {
@@ -331,7 +331,7 @@ func (pp *proportionPlugin) OnSessionOpen(ssn *framework.Session) {
 		queue := ssn.Queues[queueID]
 		// If the queue is not open, do not enqueue
 		if queue.Queue.Status.State != scheduling.QueueStateOpen {
-			klog.V(4).Infof("Queue <%s> is not open state, reject job <%s/%s>.", queue.Name, job.Namespace, job.Name)
+			klog.V(3).Infof("Queue <%s> current state: %s, is not open state, reject job <%s/%s>.", queue.Name, queue.Queue.Status.State, job.Namespace, job.Name)
 			return util.Reject
 		}
 		// If no capability is set, always enqueue the job.


### PR DESCRIPTION
#### What type of PR is this?
/kind feature
#### What this PR does / why we need it:
see https://github.com/volcano-sh/volcano/issues/4189
Supplementary implementation of https://github.com/volcano-sh/volcano/pull/4263 and https://github.com/volcano-sh/volcano/pull/4274
In allocate, preempt, reclaim actions, we all need to prevent pod be scheduled when queue is not open.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Notice that do not add `Fixes` if the issue is associated with multiple PRs.
-->
Fixes #4189

#### Special notes for your reviewer:
There is no check in `backfill` action, as there is no queue logic so far, it's too heavy to add new callback for this feature, we can assume that it's a corner case.
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```