### PR TITLE
:sparkles: Task rank and node ip aware scheduling policy 

### DIFF
--- a/pkg/features/volcano_features.go
+++ b/pkg/features/volcano_features.go
@@ -43,6 +43,9 @@ const (
 
 	// ResourceTopology supports resources like cpu/memory topology aware.
 	ResourceTopology featuregate.Feature = "ResourceTopology"
+
+	// NodeIPAware supports node ip aware scheduling.
+	NodeIPAware featuregate.Feature = "NodeIPAware"
 )
 
 func init() {
@@ -58,4 +61,5 @@ var defaultVolcanoFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec
 	// CSIStorage is explicitly set to false by default.
 	CSIStorage:       {Default: false, PreRelease: featuregate.Alpha},
 	ResourceTopology: {Default: true, PreRelease: featuregate.Alpha},
+	NodeIPAware:      {Default: false, PreRelease: featuregate.Alpha},
 }

--- a/pkg/scheduler/api/job_info.go
+++ b/pkg/scheduler/api/job_info.go
@@ -237,6 +237,21 @@ func (ti *TaskInfo) ClearLastTxContext() {
 	ti.LastTransaction = nil
 }
 
+func (ti *TaskInfo) GetRank() string {
+	if ti == nil || ti.Pod == nil {
+		return ""
+	}
+	for _, c := range ti.Pod.Spec.Containers {
+		for _, env := range c.Env {
+			if env.Name == "RANK" {
+				klog.V(4).Infof(" pod %v/%v get rank %v", ti.Namespace, ti.Name, env.Value)
+				return env.Value
+			}
+		}
+	}
+	return ""
+}
+
 // Return if the pod of a task is scheduling gated by checking if length of sch gates is zero
 // When the Pod is not yet created or sch gates field not set, return false
 func calSchedulingGated(pod *v1.Pod) bool {

--- a/pkg/scheduler/plugins/network-topology-aware/network_topology_aware.go
+++ b/pkg/scheduler/plugins/network-topology-aware/network_topology_aware.go
@@ -17,8 +17,14 @@ limitations under the License.
 package networktopologyaware
 
 import (
+	"fmt"
+	"net"
+
+	v1 "k8s.io/api/core/v1"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/klog/v2"
 
+	"volcano.sh/volcano/pkg/features"
 	"volcano.sh/volcano/pkg/scheduler/api"
 	"volcano.sh/volcano/pkg/scheduler/framework"
 	"volcano.sh/volcano/pkg/scheduler/util"
@@ -30,12 +36,14 @@ const (
 	BaseScore             = 100.0
 	ZeroScore             = 0.0
 	NetworkTopologyWeight = "weight"
+	HighPriorityIPScore   = "highPriorityIPScore"
 )
 
 type networkTopologyAwarePlugin struct {
 	// Arguments given for the plugin
-	pluginArguments framework.Arguments
-	weight          int
+	pluginArguments     framework.Arguments
+	weight              int
+	highPriorityIPScore float64
 	*hyperNodesTier
 }
 
@@ -55,9 +63,10 @@ func (h *hyperNodesTier) init(hyperNodesSetByTier []int) {
 // New function returns prioritizePlugin object
 func New(arguments framework.Arguments) framework.Plugin {
 	return &networkTopologyAwarePlugin{
-		pluginArguments: arguments,
-		hyperNodesTier:  &hyperNodesTier{},
-		weight:          calculateWeight(arguments),
+		pluginArguments:     arguments,
+		hyperNodesTier:      &hyperNodesTier{},
+		weight:              calculateWeight(arguments),
+		highPriorityIPScore: calculateHighPriorityIPScore(arguments),
 	}
 }
 
@@ -76,6 +85,21 @@ func calculateWeight(args framework.Arguments) int {
 	*/
 	weight := 1
 	args.GetInt(&weight, NetworkTopologyWeight)
+	return weight
+}
+
+func calculateHighPriorityIPScore(args framework.Arguments) float64 {
+	/*
+		   The arguments of the networktopologyaware plugin can refer to the following configuration:
+		   tiers:
+		   - plugins:
+		     - name: network-topology-aware
+		       arguments:
+		         weight: 10
+				 high
+	*/
+	weight := 0.0
+	args.GetFloat64(&weight, NetworkTopologyWeight)
 	return weight
 }
 
@@ -124,16 +148,16 @@ func (nta *networkTopologyAwarePlugin) OnSessionOpen(ssn *framework.Session) {
 		taskJob := ssn.Jobs[task.Job]
 		hardMode, _ := taskJob.IsHardTopologyMode()
 		if hardMode {
-			return nodeScores, nil
+			return nta.scoreNodeByIP(nodes)
 		}
 
 		jobAllocatedHyperNode := task.JobAllocatedHyperNode
 		if jobAllocatedHyperNode == "" {
-			return nodeScores, nil
+			return nta.scoreNodeByIP(nodes)
 		}
 		// Calculate score based on LCAHyperNode tier.
 		var maxScore float64 = -1
-		scoreToNodes := map[float64][]string{}
+		scoreToNodes := map[float64][]*api.NodeInfo{}
 		for _, node := range nodes {
 			hyperNode := util.FindHyperNodeForNode(node.Name, ssn.RealNodesList, ssn.HyperNodesTiers, ssn.HyperNodesSetByTier)
 			score := nta.networkTopologyAwareScore(hyperNode, jobAllocatedHyperNode, ssn.HyperNodes)
@@ -141,17 +165,28 @@ func (nta *networkTopologyAwarePlugin) OnSessionOpen(ssn *framework.Session) {
 			nodeScores[node.Name] = score
 			if score >= maxScore {
 				maxScore = score
-				scoreToNodes[maxScore] = append(scoreToNodes[maxScore], node.Name)
+				scoreToNodes[maxScore] = append(scoreToNodes[maxScore], node)
 			}
 		}
 		// Calculate score based on the number of tasks scheduled for the job when max score of node has more than one.
 		if len(scoreToNodes[maxScore]) > 1 {
 			candidateNodes := scoreToNodes[maxScore]
 			for _, node := range candidateNodes {
-				hyperNode := util.FindHyperNodeForNode(node, ssn.RealNodesList, ssn.HyperNodesTiers, ssn.HyperNodesSetByTier)
+				hyperNode := util.FindHyperNodeForNode(node.Name, ssn.RealNodesList, ssn.HyperNodesTiers, ssn.HyperNodesSetByTier)
 				taskNumScore := nta.scoreWithTaskNum(hyperNode, taskJob, ssn.RealNodesList)
 				taskNumScore *= float64(nta.weight)
-				nodeScores[node] += taskNumScore
+				nodeScores[node.Name] += taskNumScore
+				if nodeScores[node.Name] >= maxScore {
+					maxScore = nodeScores[node.Name]
+					scoreToNodes[maxScore] = append(scoreToNodes[maxScore], node)
+				}
+			}
+			// Prioritize nodes within the same LEAF HyperNode, then select the one with the lowest IP address among them.
+			if len(scoreToNodes[maxScore]) > 1 {
+				tmpScore, _ := nta.scoreNodeByIP(scoreToNodes[maxScore])
+				for k, v := range tmpScore {
+					nodeScores[k] += v
+				}
 			}
 		}
 
@@ -210,4 +245,60 @@ func scoreHyperNodeWithTaskNum(taskNum int, allTaskNum int) float64 {
 		return ZeroScore
 	}
 	return float64(taskNum) / float64(allTaskNum)
+}
+
+func GetInternalIP(node *v1.Node) string {
+	for _, address := range node.Status.Addresses {
+		if address.Type == v1.NodeInternalIP {
+			return address.Address
+		}
+	}
+	return ""
+}
+
+func IPToUint32(ipStr string) (uint32, error) {
+	ip := net.ParseIP(ipStr)
+	if ip == nil {
+		return 0, fmt.Errorf("invalid IP address: %s", ipStr)
+	}
+
+	ipv4 := ip.To4()
+	if ipv4 == nil {
+		return 0, fmt.Errorf("%s is not an IPv4 address", ipStr)
+	}
+	return uint32(ipv4[0])<<24 | uint32(ipv4[1])<<16 |
+		uint32(ipv4[2])<<8 | uint32(ipv4[3]), nil
+}
+
+func (nta *networkTopologyAwarePlugin) scoreNodeByIP(nodes []*api.NodeInfo) (map[string]float64, error) {
+	if !utilfeature.DefaultFeatureGate.Enabled(features.NodeIPAware) {
+		klog.V(4).Info("NodeIPAware feature is not enabled, skip scoring by IP")
+		return nil, nil
+	}
+	klog.V(4).Info("Scoring nodes by IP")
+	var minIP uint32
+	minName := ""
+	for _, node := range nodes {
+		ipStr := GetInternalIP(node.Node)
+		if ipStr == "" {
+			klog.V(4).Infof("node %s has no internal IP", node.Name)
+			continue
+		}
+
+		ip, err := IPToUint32(ipStr)
+		if err != nil {
+			klog.Error(err)
+			continue
+		}
+
+		if ip < minIP {
+			minIP = ip
+			minName = node.Name
+		}
+	}
+
+	score := make(map[string]float64)
+	// just set minName with highPriorityIPScore and others with zero score
+	score[minName] = nta.highPriorityIPScore
+	return score, nil
 }

--- a/pkg/scheduler/plugins/priority/priority_test.go
+++ b/pkg/scheduler/plugins/priority/priority_test.go
@@ -19,8 +19,10 @@ package priority
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
 	schedulingv1 "k8s.io/api/scheduling/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	vcapisv1 "volcano.sh/apis/pkg/apis/scheduling/v1beta1"
 	"volcano.sh/volcano/cmd/scheduler/app/options"
@@ -148,6 +150,176 @@ func TestPreempt(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
+		})
+	}
+}
+
+// Helper function to create TaskInfo with specific parameters
+func createTask(name, namespace, rankValue string, suffixes ...string) *api.TaskInfo {
+	podName := name
+	if len(suffixes) > 0 {
+		name = name + suffixes[0]
+		podName = name
+	}
+
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      podName,
+			Namespace: namespace,
+		},
+	}
+
+	if rankValue != "" {
+		pod.Spec.Containers = []v1.Container{
+			{
+				Env: []v1.EnvVar{
+					{
+						Name:  "RANK",
+						Value: rankValue,
+					},
+				},
+			},
+		}
+	}
+
+	return &api.TaskInfo{
+		Name:      name,
+		Namespace: namespace,
+		Pod:       pod,
+	}
+}
+
+// TestTaskOrderByRank tests ranking comparison logic
+func TestTaskOrderByRank(t *testing.T) {
+	// Test cases for rank comparison
+	testCases := []struct {
+		name     string
+		a        *api.TaskInfo
+		b        *api.TaskInfo
+		expected int
+	}{
+		{
+			name:     "Both have valid numeric ranks - a < b",
+			a:        createTask("task1", "ns", "5"),
+			b:        createTask("task2", "ns", "10"),
+			expected: -1,
+		},
+		{
+			name:     "Valid vs invalid rank",
+			a:        createTask("task1", "ns", "5"),
+			b:        createTask("task2", "ns", "invalid"),
+			expected: 1,
+		},
+		{
+			name:     "No ranks specified",
+			a:        createTask("task1", "ns", ""),
+			b:        createTask("task2", "ns", ""),
+			expected: 0,
+		},
+		{
+			name:     "Mixed valid and empty ranks",
+			a:        createTask("task1", "ns", "3"),
+			b:        createTask("task2", "ns", ""),
+			expected: 1,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := taskOrderByRank(tc.a, tc.b)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+// TestTaskOrderByNameSuffix tests name suffix comparison logic
+func TestTaskOrderByNameSuffix(t *testing.T) {
+	testCases := []struct {
+		name     string
+		a        *api.TaskInfo
+		b        *api.TaskInfo
+		expected int
+	}{
+		{
+			name:     "A has launcher suffix",
+			a:        createTask("task", "ns", "", "-launcher"),
+			b:        createTask("task", "ns", "", "-worker-0"),
+			expected: -1,
+		},
+		{
+			name:     "B has master-0 suffix",
+			a:        createTask("task", "ns", "", "-worker-1"),
+			b:        createTask("task", "ns", "", "-master-0"),
+			expected: 1,
+		},
+		{
+			name:     "Both have numeric suffixes",
+			a:        createTask("task", "ns", "", "-worker-0"),
+			b:        createTask("task", "ns", "", "-worker-1"),
+			expected: -1,
+		},
+		{
+			name:     "Complex numeric comparison",
+			a:        createTask("task", "ns", "", "-worker-10"),
+			b:        createTask("task", "ns", "", "-worker-2"),
+			expected: 1,
+		},
+		{
+			name:     "No numeric suffixes",
+			a:        createTask("task", "ns", "", "-worker"),
+			b:        createTask("task", "ns", "", "-worker"),
+			expected: 0,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := taskOrderByNameSuffix(tc.a, tc.b)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+// TestCompareNumberStr tests numeric string comparison
+func TestCompareNumberStr(t *testing.T) {
+	testCases := []struct {
+		name     string
+		a        string
+		b        string
+		expected int
+	}{
+		{"Valid numbers", "5", "10", -1},
+		{"Invalid vs valid", "abc", "5", -1},
+		{"Valid vs invalid", "5", "abc", 1},
+		{"Both invalid", "foo", "bar", 0},
+		{"Empty strings", "", "", 0},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := compareNumberStr(tc.a, tc.b)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+// TestExtractTrailingNumber tests number extraction from names
+func TestExtractTrailingNumber(t *testing.T) {
+	testCases := []struct {
+		input    string
+		expected string
+	}{
+		{"worker-23", "23"},
+		{"master-0", "0"},
+		{"launcher", ""},
+		{"worker-1-2", "2"},
+		{"invalid-format", ""},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.input, func(t *testing.T) {
+			result := extractTrailingNumber(tc.input)
+			assert.Equal(t, tc.expected, result)
 		})
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?
Task rank and node IP aware scheduling policy 
#### What this PR does / why we need it:
Add TaskOrderFunc And NodeScoreFunc to networkTopologyAwarePlugin.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Notice that do not add `Fixes` if the issue is associated with multiple PRs.
-->
Fixes https://github.com/volcano-sh/volcano/issues/4233

#### Special notes for your reviewer:



We have nearly identical scheduling requirements in our production environment. Our internal scheduler already implements similar functionality, operating under the following key assumption:

Nodes within different LEAF HyperNodes reside in distinct IP ranges, while Nodes within the same LEAF HyperNode are in the same, contiguous IP range.

![image](https://github.com/user-attachments/assets/e21a8e72-e2b0-4462-b1ad-2780038945ac)

For example, as illustrated above:

- Nodes under s1: node1 has IP 10.116.200.150, node2 has 10.116.200.151, and node3 has 10.116.200.153.
- Nodes under s2: node4 has IP 10.116.200.200, and node5 has 10.116.200.201.

Our implementation only requires extending the Network Topology Aware plugin and doesn't necessitate any changes for user tasks.

 https://github.com/volcano-sh/volcano/pull/4345  should be merged first.
As the picture shows , when pod1 is assigned to node1,  pod2 should select the node that is within the same hypernode of node1.  Then pod2 will select node2 or node3 who has the lowest IP.

#### Does this PR introduce a user-facing change?
NONE
```release-note

```