### PR TITLE
When some scalar resources are 0 in deserved, hierarychical queues validation can not pass

### DIFF
--- a/pkg/scheduler/api/helpers/helpers.go
+++ b/pkg/scheduler/api/helpers/helpers.go
@@ -56,14 +56,14 @@ func Max(l, r *api.Resource) *api.Resource {
 	res.ScalarResources = map[v1.ResourceName]float64{}
 	if l.ScalarResources != nil {
 		for lName, lQuant := range l.ScalarResources {
-			if lQuant > 0 {
+			if lQuant >= 0 {
 				res.ScalarResources[lName] = lQuant
 			}
 		}
 	}
 	if r.ScalarResources != nil {
 		for rName, rQuant := range r.ScalarResources {
-			if rQuant > 0 {
+			if rQuant >= 0 {
 				maxQuant := math.Max(rQuant, res.ScalarResources[rName])
 				res.ScalarResources[rName] = maxQuant
 			}

--- a/pkg/scheduler/plugins/capacity/capacity.go
+++ b/pkg/scheduler/plugins/capacity/capacity.go
@@ -671,7 +671,8 @@ func (cp *capacityPlugin) checkHierarchicalQueue(attr *queueAttr) error {
 		}
 		// Check if the parent queue's capability is less than the child queue's capability
 		if attr.capability.LessPartly(childAttr.capability, api.Zero) {
-			return fmt.Errorf("queue <%s> capability is less than its child queue <%s>", attr.name, childAttr.name)
+			return fmt.Errorf("queue <%s> capability <%s> is less than its child queue <%s> capability <%s>",
+				attr.name, attr.capability, childAttr.name, childAttr.capability)
 		}
 	}
 
@@ -697,12 +698,14 @@ func (cp *capacityPlugin) checkHierarchicalQueue(attr *queueAttr) error {
 
 	// Check if the parent queue's deserved resources are less than the total deserved resources of child queues
 	if attr.deserved.LessPartly(totalDeserved, api.Zero) {
-		return fmt.Errorf("deserved resources of queue <%s> are less than the sum of its child queues' deserved resources", attr.name)
+		return fmt.Errorf("queue <%s> deserved resources <%s> are less than the sum of its child queues' deserved resources <%s>",
+			attr.name, attr.deserved, totalDeserved)
 	}
 
 	// Check if the parent queue's guarantee resources are less than the total guarantee resources of child queues
 	if attr.guarantee.LessPartly(totalGuarantee, api.Zero) {
-		return fmt.Errorf("guarantee resources of queue <%s> are less than the sum of its child queues' guarantee resources", attr.name)
+		return fmt.Errorf("queue <%s> guarantee resources <%s> are less than the sum of its child queues' guarantee resources <%s>",
+			attr.name, attr.guarantee, totalGuarantee)
 	}
 
 	for _, childAttr := range attr.children {


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
Currently, during the hierarchical queue validation process, if a user sets some scalar resources in the queue's deserved with a value of 0 (for example, configuring hugepages-1Gi: 0), the hierarchical queue validation will fail. The main reason for this is:
https://github.com/volcano-sh/volcano/blob/6e2959db6b8e2b4dcd5d81594381014fa87dd9b5/pkg/scheduler/plugins/capacity/capacity.go#L694
In `helpers.Max`, if the scalar resource is 0, the copied `res` will not carry that scalar resource. For example, it will not include `hugepages-1Gi`. 
https://github.com/volcano-sh/volcano/blob/6e2959db6b8e2b4dcd5d81594381014fa87dd9b5/pkg/scheduler/api/helpers/helpers.go#L59

Later, when determining `LessPartly`, `totalDeserved` actually includes the configuration with `hugepages-1Gi:0`. When `LessPartly` is evaluated, if the right has the resource but the left does not, it returns `true`, leading to an error:
https://github.com/volcano-sh/volcano/blob/6e2959db6b8e2b4dcd5d81594381014fa87dd9b5/pkg/scheduler/plugins/capacity/capacity.go#L698-L701
To minimize the impact, it is most appropriate to change the condition in `helper.Max` to `>= 0`.

At the same time, Cherry-pick #4280, to better print the queue information and show why the Check is failing

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Notice that do not add `Fixes` if the issue is associated with multiple PRs.
-->
Fixes #4346 

#### Special notes for your reviewer:
NONE
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
User can configure scalar resource to 0 in deserved of queue
```