### PR TITLE
Automated cherry pick of #4281: Include only master and worker replicas in WORLD_SIZE

### DIFF
--- a/pkg/controllers/job/plugins/distributed-framework/pytorch/pytorch.go
+++ b/pkg/controllers/job/plugins/distributed-framework/pytorch/pytorch.go
@@ -120,7 +120,9 @@ func (pp *pytorchPlugin) OnPodCreate(pod *v1.Pod, job *batch.Job) error {
 func (pp *pytorchPlugin) getTotalReplicas(job *batch.Job) int32 {
 	jobReplicas := int32(0)
 	for _, task := range job.Spec.Tasks {
-		jobReplicas += task.Replicas
+		if task.Name == pp.masterName || task.Name == pp.workerName {
+			jobReplicas += task.Replicas
+		}
 	}
 
 	return jobReplicas

--- a/pkg/controllers/job/plugins/distributed-framework/pytorch/pytorch_test.go
+++ b/pkg/controllers/job/plugins/distributed-framework/pytorch/pytorch_test.go
@@ -182,6 +182,11 @@ func TestPytorch(t *testing.T) {
 							Replicas: 2,
 							Template: v1.PodTemplateSpec{},
 						},
+						{
+							Name:     "extra",
+							Replicas: 2,
+							Template: v1.PodTemplateSpec{},
+						},
 					},
 				},
 			},
@@ -242,6 +247,11 @@ func TestPytorch(t *testing.T) {
 							Replicas: 2,
 							Template: v1.PodTemplateSpec{},
 						},
+						{
+							Name:     "extra",
+							Replicas: 2,
+							Template: v1.PodTemplateSpec{},
+						},
 					},
 				},
 			},
@@ -299,6 +309,11 @@ func TestPytorch(t *testing.T) {
 						},
 						{
 							Name:     "worker",
+							Replicas: 2,
+							Template: v1.PodTemplateSpec{},
+						},
+						{
+							Name:     "extra",
 							Replicas: 2,
 							Template: v1.PodTemplateSpec{},
 						},


### PR DESCRIPTION
Cherry pick of #4281 on release-1.11.

#4281: Include only master and worker replicas in WORLD_SIZE
For details on the cherry pick process, see the [cherry picks](https://github.com/volcano-sh/volcano/tree/master/docs/development/cherry-picks.md) page.
```release-note
NONE
```