### PR TITLE
Support the allocation callback function provided by the extender.

### DIFF
--- a/pkg/scheduler/plugins/extender/argument.go
+++ b/pkg/scheduler/plugins/extender/argument.go
@@ -71,3 +71,11 @@ type JobReadyRequest struct {
 type JobReadyResponse struct {
 	Status bool `json:"status"`
 }
+
+type EventHandlerRequest struct {
+	Task *api.TaskInfo `json:"task"`
+}
+
+type EventHandlerResponse struct {
+	ErrorMessage string `json:"errorMessage"`
+}


### PR DESCRIPTION
#### What type of PR is this?

#### What this PR does / why we need it:
Similar to plugins such as `Predicate` and `Prioritize`, `AllocateFunc` and `DeallocateFunc` should also be configurable.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Notice that do not add `Fixes` if the issue is associated with multiple PRs.
-->
Fixes #4376

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
Added support for registering `AllocateFunc` and `DeallocateFunc` in the extender by calling `ssn.AddEventHandler`.
```