### PR TITLE
Update volcano author header based on kube-batch

### DIFF
--- a/pkg/scheduler/actions/allocate/allocate_test.go
+++ b/pkg/scheduler/actions/allocate/allocate_test.go
@@ -1,6 +1,6 @@
 /*
 Copyright 2017 The Kubernetes Authors.
-
+Copyright 2018-2025 The Volcano Authors.
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/pkg/scheduler/actions/backfill/backfill.go
+++ b/pkg/scheduler/actions/backfill/backfill.go
@@ -1,6 +1,6 @@
 /*
 Copyright 2018 The Kubernetes Authors.
-
+Copyright 2018-2025 The Volcano Authors.
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/pkg/scheduler/actions/factory.go
+++ b/pkg/scheduler/actions/factory.go
@@ -1,6 +1,6 @@
 /*
 Copyright 2019 The Kubernetes Authors.
-
+Copyright 2018-2022 The Volcano Authors.
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/pkg/scheduler/actions/preempt/preempt.go
+++ b/pkg/scheduler/actions/preempt/preempt.go
@@ -1,6 +1,6 @@
 /*
 Copyright 2018 The Kubernetes Authors.
-
+Copyright 2018-2025 The Volcano Authors.
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/pkg/scheduler/actions/preempt/preempt_test.go
+++ b/pkg/scheduler/actions/preempt/preempt_test.go
@@ -1,6 +1,6 @@
 /*
 Copyright 2018 The Kubernetes Authors.
-
+Copyright 2018-2025 The Volcano Authors.
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/pkg/scheduler/actions/reclaim/reclaim.go
+++ b/pkg/scheduler/actions/reclaim/reclaim.go
@@ -1,6 +1,6 @@
 /*
 Copyright 2018 The Kubernetes Authors.
-
+Copyright 2018-2025 The Volcano Authors.
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/pkg/scheduler/actions/reclaim/reclaim_test.go
+++ b/pkg/scheduler/actions/reclaim/reclaim_test.go
@@ -1,6 +1,6 @@
 /*
 Copyright 2018 The Kubernetes Authors.
-
+Copyright 2019-2025 The Volcano Authors.
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/pkg/scheduler/api/cluster_info.go
+++ b/pkg/scheduler/api/cluster_info.go
@@ -1,6 +1,6 @@
 /*
 Copyright 2017 The Kubernetes Authors.
-
+Copyright 2017-2025 The Volcano Authors.
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/pkg/scheduler/api/helpers.go
+++ b/pkg/scheduler/api/helpers.go
@@ -1,6 +1,6 @@
 /*
 Copyright 2017 The Kubernetes Authors.
-
+Copyright 2017-2024 The Volcano Authors.
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/pkg/scheduler/api/helpers/helpers.go
+++ b/pkg/scheduler/api/helpers/helpers.go
@@ -1,6 +1,6 @@
 /*
 Copyright 2018 The Kubernetes Authors.
-
+Copyright 2018-2021 The Volcano Authors.
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/pkg/scheduler/api/job_info.go
+++ b/pkg/scheduler/api/job_info.go
@@ -1,6 +1,6 @@
 /*
 Copyright 2017 The Kubernetes Authors.
-
+Copyright 2017-2025 The Volcano Authors.
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/pkg/scheduler/api/job_info_test.go
+++ b/pkg/scheduler/api/job_info_test.go
@@ -1,6 +1,6 @@
 /*
 Copyright 2017 The Kubernetes Authors.
-
+Copyright 2018-2025 The Volcano Authors.
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/pkg/scheduler/api/pod_group_info.go
+++ b/pkg/scheduler/api/pod_group_info.go
@@ -1,6 +1,6 @@
 /*
 Copyright 2019 The Kubernetes Authors.
-
+Copyright 2019-2021 The Volcano Authors.
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/pkg/scheduler/api/pod_info.go
+++ b/pkg/scheduler/api/pod_info.go
@@ -1,6 +1,6 @@
 /*
 Copyright 2019 The Kubernetes Authors.
-
+Copyright 2019-2025 The Volcano Authors.
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/pkg/scheduler/api/pod_info_test.go
+++ b/pkg/scheduler/api/pod_info_test.go
@@ -1,6 +1,6 @@
 /*
 Copyright 2019 The Kubernetes Authors.
-
+Copyright 2019-2024 The Volcano Authors.
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/pkg/scheduler/api/queue_info.go
+++ b/pkg/scheduler/api/queue_info.go
@@ -1,6 +1,6 @@
 /*
 Copyright 2018 The Kubernetes Authors.
-
+Copyright 2018-2021 The Volcano Authors.
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/pkg/scheduler/api/resource_info.go
+++ b/pkg/scheduler/api/resource_info.go
@@ -1,6 +1,6 @@
 /*
 Copyright 2017 The Kubernetes Authors.
-
+Copyright 2017-2024 The Volcano Authors.
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/pkg/scheduler/api/resource_info_test.go
+++ b/pkg/scheduler/api/resource_info_test.go
@@ -1,6 +1,6 @@
 /*
 Copyright 2019 The Kubernetes Authors.
-
+Copyright 2019-2024 The Volcano Authors.
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/pkg/scheduler/api/test_utils.go
+++ b/pkg/scheduler/api/test_utils.go
@@ -1,6 +1,6 @@
 /*
 Copyright 2018 The Kubernetes Authors.
-
+Copyright 2018-2025 The Volcano Authors.
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/pkg/scheduler/api/types.go
+++ b/pkg/scheduler/api/types.go
@@ -1,6 +1,6 @@
 /*
 Copyright 2018 The Kubernetes Authors.
-
+Copyright 2018-2025 The Volcano Authors.
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/pkg/scheduler/cache/cache_test.go
+++ b/pkg/scheduler/cache/cache_test.go
@@ -1,6 +1,6 @@
 /*
 Copyright 2017 The Kubernetes Authors.
-
+Copyright 2018-2025 The Volcano Authors.
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/pkg/scheduler/cache/event_handlers.go
+++ b/pkg/scheduler/cache/event_handlers.go
@@ -1,6 +1,6 @@
 /*
 Copyright 2017 The Kubernetes Authors.
-
+Copyright 2018-2025 The Volcano Authors.
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/pkg/scheduler/cache/interface.go
+++ b/pkg/scheduler/cache/interface.go
@@ -1,6 +1,6 @@
 /*
 Copyright 2017 The Kubernetes Authors.
-
+Copyright 2017-2025 The Volcano Authors.
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/pkg/scheduler/conf/scheduler_conf.go
+++ b/pkg/scheduler/conf/scheduler_conf.go
@@ -1,6 +1,6 @@
 /*
 Copyright 2018 The Kubernetes Authors.
-
+Copyright 2019-2025 The Volcano Authors.
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/pkg/scheduler/framework/arguments.go
+++ b/pkg/scheduler/framework/arguments.go
@@ -1,6 +1,6 @@
 /*
 Copyright 2019 The Kubernetes Authors.
-
+Copyright 2019-2025 The Volcano Authors.
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/pkg/scheduler/framework/arguments_test.go
+++ b/pkg/scheduler/framework/arguments_test.go
@@ -1,6 +1,6 @@
 /*
 Copyright 2019 The Kubernetes Authors.
-
+Copyright 2019-2024 The Volcano Authors.
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/pkg/scheduler/framework/event.go
+++ b/pkg/scheduler/framework/event.go
@@ -1,6 +1,6 @@
 /*
 Copyright 2018 The Kubernetes Authors.
-
+Copyright 2018-2024 The Volcano Authors.
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/pkg/scheduler/framework/framework.go
+++ b/pkg/scheduler/framework/framework.go
@@ -1,6 +1,6 @@
 /*
 Copyright 2018 The Kubernetes Authors.
-
+Copyright 2018-2023 The Volcano Authors.
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/pkg/scheduler/framework/interface.go
+++ b/pkg/scheduler/framework/interface.go
@@ -1,6 +1,6 @@
 /*
 Copyright 2017 The Kubernetes Authors.
-
+Copyright 2017-2025 The Volcano Authors.
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/pkg/scheduler/framework/plugins.go
+++ b/pkg/scheduler/framework/plugins.go
@@ -1,6 +1,6 @@
 /*
 Copyright 2018 The Kubernetes Authors.
-
+Copyright 2018-2023 The Volcano Authors.
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/pkg/scheduler/framework/session.go
+++ b/pkg/scheduler/framework/session.go
@@ -1,6 +1,6 @@
 /*
 Copyright 2018 The Kubernetes Authors.
-
+Copyright 2018-2025 The Volcano Authors.
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/pkg/scheduler/framework/session_plugins.go
+++ b/pkg/scheduler/framework/session_plugins.go
@@ -1,6 +1,6 @@
 /*
 Copyright 2018 The Kubernetes Authors.
-
+Copyright 2019-2025 The Volcano Authors.
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/pkg/scheduler/framework/statement.go
+++ b/pkg/scheduler/framework/statement.go
@@ -1,6 +1,6 @@
 /*
 Copyright 2018 The Kubernetes Authors.
-
+Copyright 2018-2025 The Volcano Authors.
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/pkg/scheduler/plugins/conformance/conformance.go
+++ b/pkg/scheduler/plugins/conformance/conformance.go
@@ -1,6 +1,6 @@
 /*
 Copyright 2018 The Kubernetes Authors.
-
+Copyright 2019-2021 The Volcano Authors.
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/pkg/scheduler/plugins/defaults.go
+++ b/pkg/scheduler/plugins/defaults.go
@@ -1,6 +1,6 @@
 /*
 Copyright 2019 The Kubernetes Authors.
-
+Copyright 2019-2025 The Volcano Authors.
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/pkg/scheduler/plugins/drf/drf.go
+++ b/pkg/scheduler/plugins/drf/drf.go
@@ -1,6 +1,6 @@
 /*
 Copyright 2018 The Kubernetes Authors.
-
+Copyright 2018-2025 The Volcano Authors.
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/pkg/scheduler/plugins/factory.go
+++ b/pkg/scheduler/plugins/factory.go
@@ -1,6 +1,6 @@
 /*
 Copyright 2019 The Kubernetes Authors.
-
+Copyright 2018-2025 The Volcano Authors.
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/pkg/scheduler/plugins/gang/gang.go
+++ b/pkg/scheduler/plugins/gang/gang.go
@@ -1,6 +1,6 @@
 /*
 Copyright 2018 The Kubernetes Authors.
-
+Copyright 2018-2025 The Volcano Authors.
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/pkg/scheduler/plugins/nodeorder/nodeorder.go
+++ b/pkg/scheduler/plugins/nodeorder/nodeorder.go
@@ -1,6 +1,6 @@
 /*
 Copyright 2019 The Kubernetes Authors.
-
+Copyright 2019-2025 The Volcano Authors.
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/pkg/scheduler/plugins/predicates/predicates.go
+++ b/pkg/scheduler/plugins/predicates/predicates.go
@@ -1,6 +1,6 @@
 /*
 Copyright 2018 The Kubernetes Authors.
-
+Copyright 2018-2025 The Volcano Authors.
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/pkg/scheduler/plugins/priority/priority.go
+++ b/pkg/scheduler/plugins/priority/priority.go
@@ -1,6 +1,6 @@
 /*
 Copyright 2018 The Kubernetes Authors.
-
+Copyright 2018-2023 The Volcano Authors.
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/pkg/scheduler/plugins/proportion/proportion.go
+++ b/pkg/scheduler/plugins/proportion/proportion.go
@@ -1,6 +1,6 @@
 /*
 Copyright 2018 The Kubernetes Authors.
-
+Copyright 2018-2025 The Volcano Authors.
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/pkg/scheduler/plugins/util/util.go
+++ b/pkg/scheduler/plugins/util/util.go
@@ -1,6 +1,6 @@
 /*
 Copyright 2019 The Kubernetes Authors.
-
+Copyright 2019-2024 The Volcano Authors.
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -1,6 +1,6 @@
 /*
 Copyright 2017 The Kubernetes Authors.
-
+Copyright 2018-2025 The Volcano Authors.
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/pkg/scheduler/util.go
+++ b/pkg/scheduler/util.go
@@ -1,6 +1,6 @@
 /*
 Copyright 2018 The Kubernetes Authors.
-
+Copyright 2018-2025 The Volcano Authors.
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/pkg/scheduler/util/priority_queue.go
+++ b/pkg/scheduler/util/priority_queue.go
@@ -1,6 +1,6 @@
 /*
 Copyright 2017 The Kubernetes Authors.
-
+Copyright 2018-2025 The Volcano Authors.
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/pkg/scheduler/util/scheduler_helper.go
+++ b/pkg/scheduler/util/scheduler_helper.go
@@ -1,6 +1,6 @@
 /*
 Copyright 2019 The Kubernetes Authors.
-
+Copyright 2019-2025 The Volcano Authors.
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/pkg/scheduler/util/scheduler_helper_test.go
+++ b/pkg/scheduler/util/scheduler_helper_test.go
@@ -1,6 +1,6 @@
 /*
 Copyright 2019 The Kubernetes Authors.
-
+Copyright 2019-2025 The Volcano Authors.
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/pkg/scheduler/util/test_utils.go
+++ b/pkg/scheduler/util/test_utils.go
@@ -1,6 +1,6 @@
 /*
 Copyright 2019 The Kubernetes Authors.
-
+Copyright 2019-2025 The Volcano Authors.
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/pkg/scheduler/util_test.go
+++ b/pkg/scheduler/util_test.go
@@ -1,6 +1,6 @@
 /*
 Copyright 2019 The Kubernetes Authors.
-
+Copyright 2019-2025 The Volcano Authors.
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at


### PR DESCRIPTION
#### What type of PR is this?
/kind documentation

#### What this PR does / why we need it:
As we all know, Volcano is the successor of the archived project kube-batch. It was initiated by the same maintainers of kube-batch. Volcano has made many iterations and modifications based on Kube-batch, but some files are still the Kubernetes Author. We also need to add Volcano author for these files.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Notice that do not add `Fixes` if the issue is associated with multiple PRs.
-->
NONE

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```