### PR TITLE
Only refresh podgroup to running when pods are scheduled

### DIFF
--- a/pkg/scheduler/actions/allocate/allocate_test.go
+++ b/pkg/scheduler/actions/allocate/allocate_test.go
@@ -1738,8 +1738,8 @@ func TestAllocateWithPVC(t *testing.T) {
 			PVs:                []*v1.PersistentVolume{pv1, pv2},
 			PVCs:               []*v1.PersistentVolumeClaim{pvc1, pvc2},
 			IgnoreProvisioners: ignoreProvisioners,
-			ExpectStatus: map[api.JobID]scheduling.PodGroupPhase{
-				"c1/pg1": scheduling.PodGroupRunning,
+			ExpectTaskStatusNums: map[api.JobID]map[api.TaskStatus]int{
+				"c1/pg1": {api.Binding: 2},
 			},
 		},
 	}
@@ -1829,8 +1829,8 @@ func TestAllocateWithDRA(t *testing.T) {
 			Nodes: []*v1.Node{
 				util.BuildNode("n1", api.BuildResourceList("2", "4Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), make(map[string]string)),
 			},
-			ExpectStatus: map[api.JobID]scheduling.PodGroupPhase{
-				"c1/pg1": scheduling.PodGroupRunning,
+			ExpectTaskStatusNums: map[api.JobID]map[api.TaskStatus]int{
+				"c1/pg1": {api.Binding: 1},
 			},
 			ExpectBindMap: map[string]string{
 				"c1/p1": "n1",

--- a/pkg/scheduler/api/helpers.go
+++ b/pkg/scheduler/api/helpers.go
@@ -90,6 +90,16 @@ func CompletedStatus(status TaskStatus) bool {
 	}
 }
 
+// ScheduledStatus checks whether the tasks are running, bound, failed or succeeded
+func ScheduledStatus(status TaskStatus) bool {
+	switch status {
+	case Running, Bound, Failed, Succeeded:
+		return true
+	default:
+		return false
+	}
+}
+
 // MergeErrors is used to merge multiple errors into single error
 func MergeErrors(errs ...error) error {
 	msg := "errors: "

--- a/pkg/scheduler/framework/session.go
+++ b/pkg/scheduler/framework/session.go
@@ -353,6 +353,38 @@ func closeSession(ssn *Session) {
 	klog.V(3).Infof("Close Session %v", ssn.UID)
 }
 
+func getPodGroupPhase(jobInfo *api.JobInfo, unschedulable bool) scheduling.PodGroupPhase {
+	// If running tasks && unschedulable, unknown phase
+	if len(jobInfo.TaskStatusIndex[api.Running]) != 0 && unschedulable {
+		return scheduling.PodGroupUnknown
+	}
+
+	scheduled := 0
+	completed := 0
+	for s, tasks := range jobInfo.TaskStatusIndex {
+		if api.ScheduledStatus(s) {
+			scheduled += len(tasks)
+		}
+		if api.CompletedStatus(s) {
+			completed += len(tasks)
+		}
+	}
+
+	if int32(scheduled) >= jobInfo.PodGroup.Spec.MinMember {
+		// If all scheduled tasks are completed, then the podgroup is completed
+		if scheduled == completed {
+			return scheduling.PodGroupCompleted
+		}
+		return scheduling.PodGroupRunning
+	}
+
+	if jobInfo.PodGroup.Status.Phase != scheduling.PodGroupInqueue {
+		return scheduling.PodGroupPending
+	}
+
+	return jobInfo.PodGroup.Status.Phase
+}
+
 func jobStatus(ssn *Session, jobInfo *api.JobInfo) scheduling.PodGroupStatus {
 	status := jobInfo.PodGroup.Status
 
@@ -366,29 +398,7 @@ func jobStatus(ssn *Session, jobInfo *api.JobInfo) scheduling.PodGroupStatus {
 		}
 	}
 
-	// If running tasks && unschedulable, unknown phase
-	if len(jobInfo.TaskStatusIndex[api.Running]) != 0 && unschedulable {
-		status.Phase = scheduling.PodGroupUnknown
-	} else {
-		allocated := 0
-		for status, tasks := range jobInfo.TaskStatusIndex {
-			if api.AllocatedStatus(status) || api.CompletedStatus(status) {
-				allocated += len(tasks)
-			}
-		}
-
-		// If there're enough allocated resource, it's running
-		if int32(allocated) >= jobInfo.PodGroup.Spec.MinMember {
-			status.Phase = scheduling.PodGroupRunning
-			// If all allocated tasks is succeeded or failed, it's completed
-			if len(jobInfo.TaskStatusIndex[api.Succeeded])+len(jobInfo.TaskStatusIndex[api.Failed]) == allocated {
-				status.Phase = scheduling.PodGroupCompleted
-			}
-		} else if jobInfo.PodGroup.Status.Phase != scheduling.PodGroupInqueue {
-			status.Phase = scheduling.PodGroupPending
-		}
-	}
-
+	status.Phase = getPodGroupPhase(jobInfo, unschedulable)
 	status.Running = int32(len(jobInfo.TaskStatusIndex[api.Running]))
 	status.Failed = int32(len(jobInfo.TaskStatusIndex[api.Failed]))
 	status.Succeeded = int32(len(jobInfo.TaskStatusIndex[api.Succeeded]))


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
When pod bind/preBind fails, the pod has been resynced, but the pg remains in running state, which may confuse users.Now only the number of scheduled pods( Bound/Running) exceed the minAvailable will refresh the podgroup to Running, allocated/binding in session currently will not be counted

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Notice that do not add `Fixes` if the issue is associated with multiple PRs.
-->
Fixes # https://github.com/volcano-sh/volcano/issues/4383

#### Special notes for your reviewer:


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
Now only the number of scheduled pods(Bound/Running) exceed the minAvailable will refresh the podgroup to Running, allocated/binding pods recorded in session currently will not be counted
```