### PR TITLE
feat: Enable Automated & Scheduled Image Vulnerability Scanning with Trivy

### DIFF
--- a/.github/workflows/scan_image.yml
+++ b/.github/workflows/scan_image.yml
@@ -1,0 +1,79 @@
+name: Scan images
+on:
+  push:
+    branches:
+      - master
+  schedule:
+    - cron: '0 0 * * *' # Daily at midnight UTC
+
+jobs:
+  build-and-scan:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: 1.23.x 
+      
+      - name: Build Docker images
+        run: |
+          make TAG=latest images
+
+      - name: Scan volcano-scheduler image
+        uses: aquasecurity/trivy-action@0.31.0
+        with:
+          image-ref: volcanosh/vc-scheduler:latest
+          format: sarif
+          output: trivy-scheduler.sarif
+          ignore-unfixed: true
+
+      - name: Upload volcano-scheduler report
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: trivy-scheduler.sarif
+          category: volcano-scheduler
+
+      - name: Scan volcano-controller-manager image
+        uses: aquasecurity/trivy-action@0.31.0
+        with:
+          image-ref: volcanosh/vc-controller-manager:latest
+          format: sarif
+          output: trivy-controller-manager.sarif
+          ignore-unfixed: true
+
+      - name: Upload volcano-controller-manager report
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: trivy-controller-manager.sarif
+          category: volcano-controller-manager
+
+      - name: Scan volcano-webhook-manager image
+        uses: aquasecurity/trivy-action@0.31.0
+        with:
+          image-ref: volcanosh/vc-webhook-manager:latest
+          format: sarif
+          output: trivy-webhook-manager.sarif
+          ignore-unfixed: true
+
+      - name: Upload volcano-webhook-manager report
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: trivy-webhook-manager.sarif
+          category: volcano-webhook-manager
+
+      - name: Scan volcano-agent image
+        uses: aquasecurity/trivy-action@0.31.0
+        with:
+          image-ref: volcanosh/vc-agent:latest
+          format: sarif
+          output: trivy-agent.sarif
+          ignore-unfixed: true
+
+      - name: Upload volcano-agent report
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: trivy-agent.sarif
+          category: volcano-agent


### PR DESCRIPTION
#### What type of PR is this?
Feature
#### What this PR does / why we need it:
As discussed here #4358 
Adds action to scan images of different volcano components using Trivy for checking vulnerabilities
1. Triggers when a merge happens
2. Triggers daily
This is one of the triggered scans - [eg](https://github.com/vaidikcode/volcano/actions/runs/15818457257/job/44581895364)
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Notice that do not add `Fixes` if the issue is associated with multiple PRs.
-->
Fixes #4358 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```