### PR TITLE
fix: rolling restart admission webhooks after helm upgrade

### DIFF
--- a/installer/helm/chart/volcano/templates/admission.yaml
+++ b/installer/helm/chart/volcano/templates/admission.yaml
@@ -100,6 +100,8 @@ spec:
       app: volcano-admission
   template:
     metadata:
+      annotations:
+        rollme/helm-revision: {{ .Release.Revision }}
       labels:
         app: volcano-admission
         {{- if or (.Values.custom.admission_podLabels) (.Values.custom.common_labels) }}


### PR DESCRIPTION
#### What type of PR is this?

fix

#### What this PR does / why we need it:

When we're creating VolcanoJobs, we've seen errors like below

> error occurred: failed calling webhook \"mutatejob.volcano.sh\": failed to call webhook: Post \"https://volcano-admission-service.volcano-system.svc:443/jobs/mutate?timeout=10s\": tls: failed to verify certificate: x509: certificate signed by unknown authority (possibly because of \"crypto/rsa: verification error\" while trying to verify candidate authority certificate \"volcano-admission-service.volcano-system.svc\"

I think the reason is as follows:
Every time the volcano helm chart gets upgraded, it generates a new tls certificate and the secret is [updated with the new certificate](https://github.com/volcano-sh/volcano/blob/v1.12.1/installer/dockerfile/webhook-manager/gen-admission-secret.sh#L123-L124). When we're running the admission webhook with 5 replicas and let's say at `t0` they're started with the initial certificate `c0`, a helm upgrade at `t1` would result in a new certificate `c1` in the secret. So any newly started pod (e.g., `p4`) fetches the new certificate `c1` while the rest pods `p0-p3` are still running with the old certificate `c0`.

Long story short I think the admission webhook deployment needs a restart after the certificate is updated, however the certificate is only generated in the `admission-init` job, so I can't annotate the pods with the certificate checksum.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```