### PR TITLE
Skip retry count on manual resume

### DIFF
--- a/pkg/controllers/job/state/aborted.go
+++ b/pkg/controllers/job/state/aborted.go
@@ -31,7 +31,6 @@ func (as *abortedState) Execute(action Action) error {
 	case v1alpha1.ResumeJobAction:
 		return KillJob(as.job, PodRetainPhaseSoft, func(status *vcbatch.JobStatus) bool {
 			status.State.Phase = vcbatch.Restarting
-			status.RetryCount++
 			return true
 		})
 	default:


### PR DESCRIPTION
#### What type of PR is this?
Fix

#### What this PR does / why we need it:
This change prevents user‑initiated resume actions from counting toward the job’s retry limit. Previously, every ResumeJobAction incremented status.RetryCount, causing a job to immediately fail once it hit MaxRetry even if no real error had occurred. Now, manual resumes transition the job to Restarting without altering RetryCount.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Notice that do not add `Fixes` if the issue is associated with multiple PRs.
-->
Fixes #3067 

#### Special notes for your reviewer:
Only aborted.go was modified (the single-line removal of status.RetryCount++ in the ResumeJobAction handler).

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NA
```