### PR TITLE
Use Job Execution Time as a Tie-Breaker in Reclaim Logic

### DIFF
--- a/pkg/scheduler/framework/session_plugins.go
+++ b/pkg/scheduler/framework/session_plugins.go
@@ -232,13 +232,17 @@ func (ssn *Session) Reclaimable(reclaimer *api.TaskInfo, reclaimees []*api.TaskI
 func getJobStartTime(job *api.JobInfo) time.Time {
 	var minStart time.Time
 	for _, task := range job.Tasks {
-		// Skip tasks that haven't started
-		if task.StartTimestamp.IsZero() {
+		// Safely handle nil pointers
+		if task.Pod == nil || task.Pod.Status.StartTime == nil {
 			continue
 		}
+
+		// Get the actual start time
+		startTime := task.Pod.Status.StartTime.Time
+
 		// Find the earliest start time
-		if minStart.IsZero() || task.StartTimestamp.Before(minStart) {
-			minStart = task.StartTimestamp
+		if minStart.IsZero() || startTime.Before(minStart) {
+			minStart = startTime
 		}
 	}
 	return minStart


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
This PR enhances the scheduler's reclaim logic to consider the execution duration of a job. Currently, when selecting a victim from jobs of the same priority, the scheduler doesn't account for how long a job has been running. This can lead to the termination of valuable, long-running jobs.

This change introduces job execution time as a tie-breaker. When jobs have the same priority, the one that has been running for the shortest duration is selected for reclamation first, thus protecting long-running HPC workloads.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Notice that do not add `Fixes` if the issue is associated with multiple PRs.
-->
Fixes #4175 

#### Special notes for your reviewer:
The core logic is modified within the BuildVictimsPriorityQueue function in pkg/scheduler/framework/session_plugins.go.

The new sorting hierarchy is as follows:

- Intra-job task ordering
- Cross-queue victim ordering
- Job Priority (primary criterion)
- Job execution time (new tie-breaker)
- Job UID (final stable tie-breaker)

ScheduleStartTimestamp is used as the proxy for execution time, as it's the most accurate timestamp readily available on the JobInfo struct.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```