### PR TITLE
Add support for skipping handler registration and QoS manager initialization based on configuration in Volcano Agent

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,6 +99,9 @@ images:
 		docker buildx build -t "${IMAGE_PREFIX}/vc-$$name:$(TAG)" . -f ./installer/dockerfile/$$name/Dockerfile --output=type=${BUILDX_OUTPUT_TYPE} --platform ${DOCKER_PLATFORMS} --build-arg APK_MIRROR=${APK_MIRROR} --build-arg OPEN_EULER_IMAGE_TAG=${OPEN_EULER_IMAGE_TAG}; \
 	done
 
+vc-agent-image:
+	docker buildx build -t "${IMAGE_PREFIX}/vc-agent:$(TAG)" . -f ./installer/dockerfile/agent/Dockerfile --output=type=${BUILDX_OUTPUT_TYPE} --platform ${DOCKER_PLATFORMS} --build-arg APK_MIRROR=${APK_MIRROR} --build-arg OPEN_EULER_IMAGE_TAG=${OPEN_EULER_IMAGE_TAG}
+
 generate-code:
 	./hack/update-gencode.sh
 

--- a/pkg/agent/healthcheck/healthcheck.go
+++ b/pkg/agent/healthcheck/healthcheck.go
@@ -39,13 +39,15 @@ func NewHealthChecker(networkQoSMgr networkqos.NetworkQoSManager) HealthChecker 
 }
 
 func (c *healthChecker) HealthCheck(w http.ResponseWriter, r *http.Request) {
-	if err := c.networkQoSMgr.HealthCheck(); err != nil {
-		w.WriteHeader(http.StatusInternalServerError)
-		if _, writeErr := w.Write([]byte(err.Error())); writeErr != nil {
-			klog.ErrorS(writeErr, "Failed to check network qos")
+	if c.networkQoSMgr != nil {
+		if err := c.networkQoSMgr.HealthCheck(); err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			if _, writeErr := w.Write([]byte(err.Error())); writeErr != nil {
+				klog.ErrorS(writeErr, "Failed to check network qos")
+			}
+			klog.ErrorS(err, "Failed to check volcano-agent")
+			return
 		}
-		klog.ErrorS(err, "Failed to check volcano-agent")
-		return
 	}
 
 	w.WriteHeader(http.StatusOK)


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
This PR adds support for skipping handler registration and QoS manager initialization based on configuration in Volcano Agent, which is needed when the user only need a set of feature, and cannot enable some feature as they cannot run it on specified OS.

1. If a feature is not listed in supported-features, skip the registration of its corresponding handler.
2. If networkQoS is not in supported-features, skip the initialization of the QoS manager.
3. If the QoS manager is not initialized, skip its health check.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Notice that do not add `Fixes` if the issue is associated with multiple PRs.
-->
Fixes #

#### Special notes for your reviewer:
test:
when the supported-features=OverSubscription,Eviction
![image](https://github.com/user-attachments/assets/415036e3-d224-4bdd-a128-1c11766d2ee3)
the initialization of network QoS manager will be skipped
![image](https://github.com/user-attachments/assets/2edb4d84-e835-48d3-a4cd-c042988f3b54)
meanwhile the health check can pass
![image](https://github.com/user-attachments/assets/0c398fb2-d84f-45d4-9a32-ff85888f205b)
and unrelated handler will be skip
![image](https://github.com/user-attachments/assets/6a72b15d-c5c9-49ee-872e-aff9fe64be17)

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```