### PR TITLE
Add detailed metrics for preemption and reclaim events

### DIFF
--- a/docs/design/metrics.md
+++ b/docs/design/metrics.md
@@ -32,8 +32,10 @@ This metrics describe internal state of volcano.
 | `schedule_attempts_total`              | Counter         | `result`=&lt;result&gt;                                           | The number of attempts to schedule pods       |
 | `pod_preemption_victims`               | Gauge           | None                                                              | The number of selected preemption victims     |
 | `total_preemption_attempts`            | Counter         | None                                                              | Total preemption attempts in the cluster      |
+| `preemption_events_total`              | Counter         | `preemptor_namespace`, `preemptor_name`, `victim_namespace`, `victim_name`, `node_name`, `queue` | Total number of preemption events, labeled by preemptor pod, victim pod, node, and queue |
 | `unschedule_task_count`                | Gauge           | `job_id`=&lt;job_id&gt;                                           | The number of tasks failed to schedule        |
 | `unschedule_job_counts`                | Gauge           | None                                                              | The number of jobs could not be scheduled     |
+| `reclaim_events_total`                 | Counter         | `reclaimer_namespace`, `reclaimer_name`, `victim_namespace`, `victim_name`, `node_name`, `reclaimer_queue`, `victim_queue` | Total number of reclaim events, labeled by reclaimer pod, victim pod, node, and queues |
 | `queue_allocated_milli_cpu`            | Gauge           | `queue_name`=&lt;queue_name&gt;                                   | Allocated CPU count for one queue             |
 | `queue_allocated_memory_bytes`         | Gauge           | `queue_name`=&lt;queue_name&gt;                                   | Allocated memory for one queue                |
 | `queue_allocated_scalar_resources`     | Gauge           | `queue_name`=&lt;queue_name&gt;, `resource`=&lt;resource_name&gt; | Allocated scalar resource for one queue       |

--- a/pkg/scheduler/actions/preempt/preempt.go
+++ b/pkg/scheduler/actions/preempt/preempt.go
@@ -358,6 +358,8 @@ func (pmpt *Action) normalPreempt(
 					preemptee.Namespace, preemptee.Name, preemptor.Namespace, preemptor.Name, err)
 				continue
 			}
+			// Record the fine-grained preemption event
+			metrics.RecordPreemptionEvent(preemptor, preemptee, node.Name, currentQueue.Name)
 			preempted.Add(preemptee.Resreq)
 		}
 

--- a/pkg/scheduler/actions/reclaim/reclaim.go
+++ b/pkg/scheduler/actions/reclaim/reclaim.go
@@ -197,6 +197,18 @@ func (ra *Action) Execute(ssn *framework.Session) {
 						reclaimee.Namespace, reclaimee.Name, task.Namespace, task.Name, err)
 					continue
 				}
+				// Record the fine-grained reclaim event
+				if victimJob, ok := ssn.Jobs[reclaimee.Job]; ok {
+					if victimQ, found := ssn.Queues[victimJob.Queue]; found {
+						metrics.RecordReclaimEvent(
+							task,
+							reclaimee,
+							n.Name,
+							queue.Name,
+							victimQ.Name,
+						)
+					}
+				}
 				reclaimed.Add(reclaimee.Resreq)
 				// If reclaimed enough resources, break loop to avoid Sub panic.
 				if resreq.LessEqual(reclaimed, api.Zero) {

--- a/pkg/scheduler/metrics/metrics.go
+++ b/pkg/scheduler/metrics/metrics.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto" // auto-registry collectors in default registry
+	"volcano.sh/volcano/pkg/scheduler/api"
 )
 
 const (
@@ -131,6 +132,26 @@ var (
 		},
 	)
 
+	// Preemption events: one for each successful eviction, labeled by preemptor pod, victim pod, node, and queue
+	preemptionEvents = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Subsystem: VolcanoSubSystemName,
+			Name:      "preemption_events_total",
+			Help:      "Total number of preemption events, labeled by preemptor pod, victim pod, node, and queue",
+		},
+		[]string{"preemptor_namespace", "preemptor_name", "victim_namespace", "victim_name", "node_name", "queue"},
+	)
+
+	// Reclaim events: one for each successful eviction, labeled by reclaimer pod, victim pod, node, and queues
+	reclaimEvents = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Subsystem: VolcanoSubSystemName,
+			Name:      "reclaim_events_total",
+			Help:      "Total number of reclaim events, labeled by reclaimer pod, victim pod, node, and queues",
+		},
+		[]string{"reclaimer_namespace", "reclaimer_name", "victim_namespace", "victim_name", "node_name", "reclaimer_queue", "victim_queue"},
+	)
+
 	unscheduleTaskCount = promauto.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Subsystem: VolcanoSubSystemName,
@@ -207,6 +228,31 @@ func UpdateUnscheduleTaskCount(jobID string, taskCount int) {
 // UpdateUnscheduleJobCount records total number of unscheduleable jobs
 func UpdateUnscheduleJobCount(jobCount int) {
 	unscheduleJobCount.Set(float64(jobCount))
+}
+
+// RecordPreemptionEvent records a successful preemption eviction.
+func RecordPreemptionEvent(preemptor, victim *api.TaskInfo, nodeName, queueName string) {
+	preemptionEvents.WithLabelValues(
+		preemptor.Pod.Namespace,
+		preemptor.Pod.Name,
+		victim.Pod.Namespace,
+		victim.Pod.Name,
+		nodeName,
+		queueName,
+	).Inc()
+}
+
+// RecordReclaimEvent records a successful reclaim eviction.
+func RecordReclaimEvent(reclaimer, victim *api.TaskInfo, nodeName, reclaimerQueue, victimQueue string) {
+	reclaimEvents.WithLabelValues(
+		reclaimer.Pod.Namespace,
+		reclaimer.Pod.Name,
+		victim.Pod.Namespace,
+		victim.Pod.Name,
+		nodeName,
+		reclaimerQueue,
+		victimQueue,
+	).Inc()
 }
 
 // DurationInMicroseconds gets the time in microseconds.


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
This PR introduces new, detailed Prometheus metrics to provide visibility into the scheduler's preemption and reclamation actions. Currently, it's difficult to determine which specific pods are being evicted, on which nodes, and by which jobs.

This change adds two new counters that record every successful preemption and reclaim event, labeled with the names of the pods, nodes, and queues involved. This directly addresses the need for finer-grained observability to monitor and debug queue behavior effectively.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Notice that do not add `Fixes` if the issue is associated with multiple PRs.
-->
Fixes #4040 

#### Special notes for your reviewer:
- Two new CounterVecs have been added in pkg/scheduler/metrics/metrics.go.
- Helper functions RecordPreemptionEvent and RecordReclaimEvent hook into preempt.go and reclaim.go immediately after successful evictions, emitting one metric per pod eviction.
- Documentation in docs/design/metrics.md has been updated to describe the new metrics.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
Adds new Prometheus metrics, `volcano_preemption_events_total` and `volcano_reclaim_events_total`, to provide detailed, pod-level visibility into preemption and reclamation events.
```