### PR TITLE
 Support for configurable extended resource names in volcano agent

### DIFF
--- a/cmd/agent/app/app.go
+++ b/cmd/agent/app/app.go
@@ -34,6 +34,7 @@ import (
 
 	"volcano.sh/apis/pkg/apis/helpers"
 	"volcano.sh/volcano/cmd/agent/app/options"
+	"volcano.sh/volcano/pkg/agent/apis"
 	"volcano.sh/volcano/pkg/agent/healthcheck"
 	"volcano.sh/volcano/pkg/agent/utils"
 	"volcano.sh/volcano/pkg/config"
@@ -47,6 +48,16 @@ func NewConfiguration(opts *options.VolcanoAgentOptions) (*config.Configuration,
 	if err := opts.ApplyTo(conf); err != nil {
 		return conf, err
 	}
+
+	if conf.GenericConfiguration.ExtendResourceCPU != "" {
+		apis.SetExtendResourceCPU(conf.GenericConfiguration.ExtendResourceCPU)
+	}
+
+	if conf.GenericConfiguration.ExtendResourceMemory != "" {
+		apis.SetExtendResourceMemory(conf.GenericConfiguration.ExtendResourceMemory)
+	}
+
+	klog.InfoS("Set extend resource", "cpu", apis.ExtendResourceCPU, "memory", apis.ExtendResourceMemory)
 
 	kubeConfig, err := restclient.InClusterConfig()
 	if err != nil {

--- a/cmd/agent/app/options/options.go
+++ b/cmd/agent/app/options/options.go
@@ -62,6 +62,12 @@ type VolcanoAgentOptions struct {
 
 	// IncludeSystemUsage determines whether considering system usage when calculate overSubscription resource and evict.
 	IncludeSystemUsage bool
+
+	// ExtendResourceCPU is the extend resource cpu, which is used to calculate overSubscription resources.
+	ExtendResourceCPU string
+
+	// ExtendResourceMemory is the extend resource memory, which is used to calculate overSubscription resources.
+	ExtendResourceMemory string
 }
 
 func NewVolcanoAgentOptions() *VolcanoAgentOptions {
@@ -81,6 +87,8 @@ func (options *VolcanoAgentOptions) AddFlags(c *cobra.Command) {
 	// TODO: put in configMap.
 	c.Flags().IntVar(&options.OverSubscriptionRatio, "oversubscription-ratio", defaultOverSubscriptionRatio, "The oversubscription ratio determines how many idle resources can be oversold")
 	c.Flags().BoolVar(&options.IncludeSystemUsage, "include-system-usage", false, "It determines whether considering system usage when calculate overSubscription resource and evict.")
+	c.Flags().StringVar(&options.ExtendResourceCPU, "extend-resource-cpu", "", "The extended cpu resource name, which is used to calculate oversubscription resources, default to kubernetes.io/cpu")
+	c.Flags().StringVar(&options.ExtendResourceMemory, "extend-resource-memory", "", "The extended memory resource name, which is used to calculate oversubscription resources, default to kubernetes.io/memory")
 }
 
 func (options *VolcanoAgentOptions) Validate() error {
@@ -101,5 +109,7 @@ func (options *VolcanoAgentOptions) ApplyTo(cfg *config.Configuration) error {
 	cfg.GenericConfiguration.OverSubscriptionPolicy = options.OverSubscriptionPolicy
 	cfg.GenericConfiguration.OverSubscriptionRatio = options.OverSubscriptionRatio
 	cfg.GenericConfiguration.IncludeSystemUsage = options.IncludeSystemUsage
+	cfg.GenericConfiguration.ExtendResourceCPU = options.ExtendResourceCPU
+	cfg.GenericConfiguration.ExtendResourceMemory = options.ExtendResourceMemory
 	return nil
 }

--- a/cmd/agent/app/options/options.go
+++ b/cmd/agent/app/options/options.go
@@ -87,8 +87,8 @@ func (options *VolcanoAgentOptions) AddFlags(c *cobra.Command) {
 	// TODO: put in configMap.
 	c.Flags().IntVar(&options.OverSubscriptionRatio, "oversubscription-ratio", defaultOverSubscriptionRatio, "The oversubscription ratio determines how many idle resources can be oversold")
 	c.Flags().BoolVar(&options.IncludeSystemUsage, "include-system-usage", false, "It determines whether considering system usage when calculate overSubscription resource and evict.")
-	c.Flags().StringVar(&options.ExtendResourceCPU, "extend-resource-cpu", "", "The extended cpu resource name, which is used to calculate oversubscription resources, default to kubernetes.io/cpu")
-	c.Flags().StringVar(&options.ExtendResourceMemory, "extend-resource-memory", "", "The extended memory resource name, which is used to calculate oversubscription resources, default to kubernetes.io/memory")
+	c.Flags().StringVar(&options.ExtendResourceCPU, "extend-resource-cpu", "", "The extended cpu resource name, which is used to calculate oversubscription resources, default to kubernetes.io/batch-cpu")
+	c.Flags().StringVar(&options.ExtendResourceMemory, "extend-resource-memory", "", "The extended memory resource name, which is used to calculate oversubscription resources, default to kubernetes.io/batch-memory")
 }
 
 func (options *VolcanoAgentOptions) Validate() error {

--- a/pkg/agent/apis/types.go
+++ b/pkg/agent/apis/types.go
@@ -65,16 +65,39 @@ const (
 	// ResourceDefaultPrefix is the extended resource prefix.
 	ResourceDefaultPrefix = "kubernetes.io/"
 
-	ExtendResourceCPU    = ResourceDefaultPrefix + "batch-cpu"
-	ExtendResourceMemory = ResourceDefaultPrefix + "batch-memory"
-
 	// ColocationPolicyKey is the label key of node custom colocation policy.
 	ColocationPolicyKey = "colocation-policy"
 )
 
+var (
+	ExtendResourceCPU    = ResourceDefaultPrefix + "batch-cpu"
+	ExtendResourceMemory = ResourceDefaultPrefix + "batch-memory"
+)
+
+func SetExtendResourceCPU(val string) {
+	ExtendResourceCPU = val
+}
+func GetExtendResourceCPU() corev1.ResourceName {
+	return corev1.ResourceName(ExtendResourceCPU)
+}
+func SetExtendResourceMemory(val string) {
+	ExtendResourceMemory = val
+}
+func GetExtendResourceMemory() corev1.ResourceName {
+	return corev1.ResourceName(ExtendResourceMemory)
+}
+
 var OverSubscriptionResourceTypes = []corev1.ResourceName{corev1.ResourceCPU, corev1.ResourceMemory}
 
-var OverSubscriptionResourceTypesIncludeExtendResources = []corev1.ResourceName{corev1.ResourceCPU, corev1.ResourceMemory, ExtendResourceCPU, ExtendResourceMemory}
+// GetOverSubscriptionResourceTypesIncludeExtendResources returns oversubscription resource types including extend resources.
+func GetOverSubscriptionResourceTypesIncludeExtendResources() []corev1.ResourceName {
+	return []corev1.ResourceName{
+		corev1.ResourceCPU,
+		corev1.ResourceMemory,
+		GetExtendResourceCPU(),
+		GetExtendResourceMemory(),
+	}
+}
 
 // Resource mapping resource type and usage.
 type Resource map[corev1.ResourceName]int64

--- a/pkg/agent/events/handlers/oversubscription/resource_reporter_test.go
+++ b/pkg/agent/events/handlers/oversubscription/resource_reporter_test.go
@@ -216,10 +216,10 @@ func Test_reporter_Handle(t *testing.T) {
 				node, err := makeNode()
 				assert.NoError(t, err)
 				node.Status.Capacity = map[v1.ResourceName]resource.Quantity{}
-				node.Status.Capacity[apis.ExtendResourceCPU] = *resource.NewQuantity(1000, resource.DecimalSI)
-				node.Status.Capacity[apis.ExtendResourceMemory] = *resource.NewQuantity(2000, resource.BinarySI)
-				node.Status.Allocatable[apis.ExtendResourceCPU] = *resource.NewQuantity(1000, resource.DecimalSI)
-				node.Status.Allocatable[apis.ExtendResourceMemory] = *resource.NewQuantity(2000, resource.BinarySI)
+				node.Status.Capacity[apis.GetExtendResourceCPU()] = *resource.NewQuantity(1000, resource.DecimalSI)
+				node.Status.Capacity[apis.GetExtendResourceMemory()] = *resource.NewQuantity(2000, resource.BinarySI)
+				node.Status.Allocatable[apis.GetExtendResourceCPU()] = *resource.NewQuantity(1000, resource.DecimalSI)
+				node.Status.Allocatable[apis.GetExtendResourceMemory()] = *resource.NewQuantity(2000, resource.BinarySI)
 				return node
 			},
 		},

--- a/pkg/agent/oversubscription/policy/extend/extend.go
+++ b/pkg/agent/oversubscription/policy/extend/extend.go
@@ -48,6 +48,16 @@ type extendResource struct {
 }
 
 func NewExtendResource(config *config.Configuration, mgr *metriccollect.MetricCollectorManager, evictor eviction.Eviction, queue *queue.SqQueue, collectorName string) policy.Interface {
+	if config.GenericConfiguration.ExtendResourceCPU != "" {
+		apis.SetExtendResourceCPU(config.GenericConfiguration.ExtendResourceCPU)
+	}
+
+	if config.GenericConfiguration.ExtendResourceMemory != "" {
+		apis.SetExtendResourceMemory(config.GenericConfiguration.ExtendResourceMemory)
+	}
+
+	klog.InfoS("Using extend resource policy with default values", "cpu", apis.ExtendResourceCPU, "memory", apis.ExtendResourceMemory)
+
 	return &extendResource{
 		config:      config,
 		getPodsFunc: config.GetActivePods,

--- a/pkg/agent/oversubscription/policy/extend/extend.go
+++ b/pkg/agent/oversubscription/policy/extend/extend.go
@@ -48,16 +48,6 @@ type extendResource struct {
 }
 
 func NewExtendResource(config *config.Configuration, mgr *metriccollect.MetricCollectorManager, evictor eviction.Eviction, queue *queue.SqQueue, collectorName string) policy.Interface {
-	if config.GenericConfiguration.ExtendResourceCPU != "" {
-		apis.SetExtendResourceCPU(config.GenericConfiguration.ExtendResourceCPU)
-	}
-
-	if config.GenericConfiguration.ExtendResourceMemory != "" {
-		apis.SetExtendResourceMemory(config.GenericConfiguration.ExtendResourceMemory)
-	}
-
-	klog.InfoS("Using extend resource policy with default values", "cpu", apis.ExtendResourceCPU, "memory", apis.ExtendResourceMemory)
-
 	return &extendResource{
 		config:      config,
 		getPodsFunc: config.GetActivePods,

--- a/pkg/agent/utils/node/patcher.go
+++ b/pkg/agent/utils/node/patcher.go
@@ -77,11 +77,11 @@ func updateNodeOverSoldStatus(res apis.Resource) Modifier {
 		for k, v := range res {
 			switch k {
 			case v1.ResourceCPU:
-				node.Status.Allocatable[apis.ExtendResourceCPU] = *resource.NewQuantity(v, resource.DecimalSI)
-				node.Status.Capacity[apis.ExtendResourceCPU] = *resource.NewQuantity(v, resource.DecimalSI)
+				node.Status.Allocatable[apis.GetExtendResourceCPU()] = *resource.NewQuantity(v, resource.DecimalSI)
+				node.Status.Capacity[apis.GetExtendResourceCPU()] = *resource.NewQuantity(v, resource.DecimalSI)
 			case v1.ResourceMemory:
-				node.Status.Allocatable[apis.ExtendResourceMemory] = *resource.NewQuantity(v, resource.BinarySI)
-				node.Status.Capacity[apis.ExtendResourceMemory] = *resource.NewQuantity(v, resource.BinarySI)
+				node.Status.Allocatable[apis.GetExtendResourceMemory()] = *resource.NewQuantity(v, resource.BinarySI)
+				node.Status.Capacity[apis.GetExtendResourceMemory()] = *resource.NewQuantity(v, resource.BinarySI)
 			default:
 				klog.ErrorS(nil, "Unsupported resource", "resType", k)
 			}
@@ -91,10 +91,10 @@ func updateNodeOverSoldStatus(res apis.Resource) Modifier {
 
 func deleteNodeOverSoldStatus() Modifier {
 	return func(node *v1.Node) {
-		delete(node.Status.Capacity, apis.ExtendResourceCPU)
-		delete(node.Status.Capacity, apis.ExtendResourceMemory)
-		delete(node.Status.Allocatable, apis.ExtendResourceCPU)
-		delete(node.Status.Allocatable, apis.ExtendResourceMemory)
+		delete(node.Status.Capacity, apis.GetExtendResourceCPU())
+		delete(node.Status.Capacity, apis.GetExtendResourceMemory())
+		delete(node.Status.Allocatable, apis.GetExtendResourceCPU())
+		delete(node.Status.Allocatable, apis.GetExtendResourceMemory())
 	}
 }
 
@@ -152,7 +152,7 @@ func UpdateNodeExtendResource(config *config.Configuration, res apis.Resource) e
 func needUpdate(curNode, newNode *v1.Node) bool {
 	return !equality.Semantic.DeepEqual(curNode.Annotations, newNode.Annotations) ||
 		!equality.Semantic.DeepEqual(curNode.Labels, newNode.Labels) ||
-		!equality.Semantic.DeepEqual(curNode.Status.Allocatable[apis.ExtendResourceCPU], newNode.Status.Allocatable[apis.ExtendResourceCPU]) ||
-		!equality.Semantic.DeepEqual(curNode.Status.Capacity[apis.ExtendResourceMemory], newNode.Status.Capacity[apis.ExtendResourceMemory]) ||
+		!equality.Semantic.DeepEqual(curNode.Status.Allocatable[apis.GetExtendResourceCPU()], newNode.Status.Allocatable[apis.GetExtendResourceCPU()]) ||
+		!equality.Semantic.DeepEqual(curNode.Status.Capacity[apis.GetExtendResourceMemory()], newNode.Status.Capacity[apis.GetExtendResourceMemory()]) ||
 		!equality.Semantic.DeepEqual(curNode.Spec.Taints, newNode.Spec.Taints)
 }

--- a/pkg/agent/utils/node/patcher_test.go
+++ b/pkg/agent/utils/node/patcher_test.go
@@ -61,11 +61,11 @@ func Test_updater_Update(t *testing.T) {
 			expectedNode: &v1.Node{
 				ObjectMeta: metav1.ObjectMeta{Name: "test-node"},
 				Status: v1.NodeStatus{Allocatable: map[v1.ResourceName]resource.Quantity{
-					apis.ExtendResourceCPU:    *resource.NewQuantity(100, resource.DecimalSI),
-					apis.ExtendResourceMemory: *resource.NewQuantity(100, resource.BinarySI),
+					apis.GetExtendResourceCPU():    *resource.NewQuantity(100, resource.DecimalSI),
+					apis.GetExtendResourceMemory(): *resource.NewQuantity(100, resource.BinarySI),
 				}, Capacity: map[v1.ResourceName]resource.Quantity{
-					apis.ExtendResourceCPU:    *resource.NewQuantity(100, resource.DecimalSI),
-					apis.ExtendResourceMemory: *resource.NewQuantity(100, resource.BinarySI),
+					apis.GetExtendResourceCPU():    *resource.NewQuantity(100, resource.DecimalSI),
+					apis.GetExtendResourceMemory(): *resource.NewQuantity(100, resource.BinarySI),
 				}}},
 			nodeModifiers: []Modifier{updateNodeOverSoldStatus(apis.Resource{
 				v1.ResourceCPU:    100,

--- a/pkg/agent/utils/node/resource.go
+++ b/pkg/agent/utils/node/resource.go
@@ -42,11 +42,11 @@ func IsOverused(resName v1.ResourceName, resList *ResourceList) bool {
 
 func UseExtendResource(resName v1.ResourceName, resList *ResourceList) bool {
 	if resName == v1.ResourceCPU {
-		cpuReq, cpuExists := (*resList).TotalPodsRequest[apis.ExtendResourceCPU]
+		cpuReq, cpuExists := (*resList).TotalPodsRequest[apis.GetExtendResourceCPU()]
 		return cpuExists && !cpuReq.IsZero()
 	}
 	if resName == v1.ResourceMemory {
-		memReq, memoryExists := (*resList).TotalPodsRequest[apis.ExtendResourceMemory]
+		memReq, memoryExists := (*resList).TotalPodsRequest[apis.GetExtendResourceMemory()]
 		return memoryExists && !memReq.IsZero()
 	}
 	return false
@@ -90,11 +90,11 @@ func GetNodeStatusOverSubscription(node *v1.Node) apis.Resource {
 		return resources
 	}
 
-	if value, found := node.Status.Capacity[apis.ExtendResourceCPU]; found {
+	if value, found := node.Status.Capacity[apis.GetExtendResourceCPU()]; found {
 		resources[v1.ResourceCPU] = value.Value()
 	}
 
-	if value, found := node.Status.Capacity[apis.ExtendResourceMemory]; found {
+	if value, found := node.Status.Capacity[apis.GetExtendResourceMemory()]; found {
 		resources[v1.ResourceMemory] = value.Value()
 	}
 	return resources
@@ -148,7 +148,7 @@ func GetLatestPodsAndResList(node *v1.Node, getPodFunc utilpod.ActivePods, resTy
 func getResourceList(node *v1.Node, pods []*v1.Pod) *ResourceList {
 	resList := new(ResourceList)
 	fns := []utilpod.FilterPodsFunc{utilpod.IncludeOversoldPodFn(true), utilpod.IncludeGuaranteedPodsFn(true)}
-	resList.TotalPodsRequest = utilpod.GetTotalRequest(pods, fns, apis.OverSubscriptionResourceTypesIncludeExtendResources)
+	resList.TotalPodsRequest = utilpod.GetTotalRequest(pods, fns, apis.GetOverSubscriptionResourceTypesIncludeExtendResources())
 	resList.TotalNodeRes = GetTotalNodeResource(node, false)
 	return resList
 }

--- a/pkg/agent/utils/pod/resources.go
+++ b/pkg/agent/utils/pod/resources.go
@@ -59,7 +59,7 @@ func CalculateExtendResources(pod *v1.Pod) []Resources {
 	for _, c := range pod.Spec.Containers {
 		id := findContainerIDByName(pod, c.Name)
 		// set cpu share.
-		cpuReq, ok := c.Resources.Requests[apis.ExtendResourceCPU]
+		cpuReq, ok := c.Resources.Requests[apis.GetExtendResourceCPU()]
 		if ok && !cpuReq.IsZero() {
 			cpuShares := int64(milliCPUToShares(cpuReq.Value()))
 			containerRes = append(containerRes, Resources{CgroupSubSystem: cgroup.CgroupCpuSubsystem, ContainerID: id, SubPath: cgroup.CPUShareFileName, Value: cpuShares})
@@ -67,7 +67,7 @@ func CalculateExtendResources(pod *v1.Pod) []Resources {
 		}
 
 		// set cpu quota.
-		cpuLimits, ok := c.Resources.Limits[apis.ExtendResourceCPU]
+		cpuLimits, ok := c.Resources.Limits[apis.GetExtendResourceCPU()]
 		if ok && !cpuLimits.IsZero() {
 			cpuQuota := milliCPUToQuota(cpuLimits.Value(), quotaPeriod)
 			containerRes = append(containerRes, Resources{CgroupSubSystem: cgroup.CgroupCpuSubsystem, ContainerID: id, SubPath: cgroup.CPUQuotaTotalFile, Value: cpuQuota})
@@ -77,7 +77,7 @@ func CalculateExtendResources(pod *v1.Pod) []Resources {
 		}
 
 		// set memory limit.
-		memoryLimit, ok := c.Resources.Limits[apis.ExtendResourceMemory]
+		memoryLimit, ok := c.Resources.Limits[apis.GetExtendResourceMemory()]
 		if ok && !memoryLimit.IsZero() {
 			containerRes = append(containerRes, Resources{CgroupSubSystem: cgroup.CgroupMemorySubsystem, ContainerID: id, SubPath: cgroup.MemoryLimitFile, Value: memoryLimit.Value()})
 			memoryLimitsTotal += memoryLimit.Value()

--- a/pkg/agent/utils/testing/pod.go
+++ b/pkg/agent/utils/testing/pod.go
@@ -93,12 +93,12 @@ func MakePodWithExtendResources(name string, cpuRequest, memoryRequest int64, qo
 			Containers: []v1.Container{{
 				Resources: v1.ResourceRequirements{
 					Limits: v1.ResourceList{
-						apis.ExtendResourceCPU:    *resource.NewQuantity(cpuRequest, resource.DecimalSI),
-						apis.ExtendResourceMemory: *resource.NewQuantity(memoryRequest, resource.DecimalSI),
+						apis.GetExtendResourceCPU():    *resource.NewQuantity(cpuRequest, resource.DecimalSI),
+						apis.GetExtendResourceMemory(): *resource.NewQuantity(memoryRequest, resource.DecimalSI),
 					},
 					Requests: v1.ResourceList{
-						apis.ExtendResourceCPU:    *resource.NewQuantity(cpuRequest, resource.DecimalSI),
-						apis.ExtendResourceMemory: *resource.NewQuantity(memoryRequest, resource.DecimalSI),
+						apis.GetExtendResourceCPU():    *resource.NewQuantity(cpuRequest, resource.DecimalSI),
+						apis.GetExtendResourceMemory(): *resource.NewQuantity(memoryRequest, resource.DecimalSI),
 					},
 				}},
 			}},

--- a/pkg/config/generic.go
+++ b/pkg/config/generic.go
@@ -74,4 +74,10 @@ type VolcanoAgentConfiguration struct {
 
 	// IncludeSystemUsage determines whether considering system usage when calculate overSubscription resource and evict.
 	IncludeSystemUsage bool
+
+	// ExtendResourceCPU is the extend resource cpu, which is used to calculate overSubscription resources.
+	ExtendResourceCPU string
+
+	// ExtendResourceMemory is the extend resource memory, which is used to calculate overSubscription resources.
+	ExtendResourceMemory string
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
This PR adds support for configurable extended resource names. Users can now specify custom resource names via the --extend-resource-cpu and --extend-resource-memory options.

By default, the resource names are:

kubernetes.io/batch-cpu

kubernetes.io/batch-memory

This enhancement provides greater flexibility for integration with different resource models or scheduling systems.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Notice that do not add `Fixes` if the issue is associated with multiple PRs.
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
added 2 options in volcano agent: extend-resource-cpu, and extend-resource-memory
```