### PR TITLE
add SkipNodeSupportCheck to agent

### DIFF
--- a/pkg/agent/config/api/types.go
+++ b/pkg/agent/config/api/types.go
@@ -99,6 +99,8 @@ type OverSubscription struct {
 	Enable *bool `json:"enable,omitempty"`
 	// OverSubscriptionTypes defines over subscription types, such as cpu,memory.
 	OverSubscriptionTypes *string `json:"overSubscriptionTypes,omitempty"`
+	// SkipNodeSupportCheck defines whether skip node label check when enable overSubscription.
+	SkipNodeSupportCheck *bool `json:"skipNodeSupportCheck,omitempty"`
 }
 
 type Evicting struct {

--- a/pkg/agent/config/configmgr.go
+++ b/pkg/agent/config/configmgr.go
@@ -118,7 +118,7 @@ func (m *ConfigManager) updateConfigMap(cm *corev1.ConfigMap) error {
 
 	changed := false
 	if c.GlobalConfig == nil {
-		return fmt.Errorf("empty glaobal config")
+		return fmt.Errorf("empty global config")
 	}
 	if c.GlobalConfig.OverSubscriptionConfig == nil {
 		changed = true

--- a/pkg/agent/config/utils/utils.go
+++ b/pkg/agent/config/utils/utils.go
@@ -164,7 +164,8 @@ func MergerCfg(fullConfig *api.VolcanoAgentConfig, node *corev1.Node) (*api.Colo
 		return mergedCfg, err
 	}
 
-	enableOverSubscription := utilpointer.Bool(utilnode.IsNodeSupportOverSubscription(node))
+	enableOverSubscription := utilpointer.Bool(utilnode.IsNodeSupportOverSubscription(node) ||
+		(mergedCfg.OverSubscriptionConfig.SkipNodeSupportCheck != nil && *mergedCfg.OverSubscriptionConfig.SkipNodeSupportCheck))
 	mergedCfg.NodeLabelConfig.NodeColocationEnable = utilpointer.Bool(utilnode.IsNodeSupportColocation(node) || *enableOverSubscription)
 	mergedCfg.NodeLabelConfig.NodeOverSubscriptionEnable = enableOverSubscription
 

--- a/pkg/agent/config/utils/utils_test.go
+++ b/pkg/agent/config/utils/utils_test.go
@@ -193,6 +193,24 @@ func TestMergerCfg(t *testing.T) {
 			wantCfg: withLabelSelector(DefaultColocationConfig()),
 			wantErr: true,
 		},
+		{
+			name: "set SkipNodeSupportCheck to true",
+			volcanoCfg: &api.VolcanoAgentConfig{
+				GlobalConfig: &api.ColocationConfig{
+					OverSubscriptionConfig: &api.OverSubscription{
+						Enable:               utilpointer.Bool(true),
+						SkipNodeSupportCheck: utilpointer.Bool(true),
+					},
+				},
+			},
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{},
+				},
+			},
+			wantCfg: enableNodeOverSubscription(enableNodeColocation(DefaultColocationConfig())),
+			wantErr: false,
+		},
 	}
 
 	for _, tc := range tests {

--- a/pkg/agent/config/utils/utils_test.go
+++ b/pkg/agent/config/utils/utils_test.go
@@ -208,7 +208,12 @@ func TestMergerCfg(t *testing.T) {
 					Labels: map[string]string{},
 				},
 			},
-			wantCfg: enableNodeOverSubscription(enableNodeColocation(DefaultColocationConfig())),
+			wantCfg: withNewOverSubscription(enableNodeOverSubscription(enableNodeColocation(DefaultColocationConfig())),
+				&api.OverSubscription{
+					Enable:                utilpointer.Bool(true),
+					SkipNodeSupportCheck:  utilpointer.Bool(true),
+					OverSubscriptionTypes: utilpointer.String("cpu,memory"),
+				}),
 			wantErr: false,
 		},
 	}

--- a/pkg/agent/events/probes/nodemonitor/node_monitor.go
+++ b/pkg/agent/events/probes/nodemonitor/node_monitor.go
@@ -160,6 +160,8 @@ func (m *monitor) detect() {
 	if !allResourcesAreLowUsage {
 		return
 	}
+
+	klog.InfoS("All resource usages are below the low watermark, resuming scheduling.")
 	if err := m.RecoverSchedule(); err != nil {
 		klog.ErrorS(err, "Failed to recover schedule")
 	}


### PR DESCRIPTION
#### What type of PR is this?
/kind feature
#### What this PR does / why we need it:
This change introduces a SkipNodeSupportCheck configuration in the agent, allowing users to bypass node label checks related to oversubscription and colocation features. This is useful in environments where such labels are not present or enforced.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Notice that do not add `Fixes` if the issue is associated with multiple PRs.
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```