### PR TITLE
Fix the bug that the owner's pg name was not effective

### DIFF
--- a/pkg/controllers/podgroup/pg_controller_handler.go
+++ b/pkg/controllers/podgroup/pg_controller_handler.go
@@ -264,7 +264,7 @@ func (pg *pgcontroller) getMinMemberFromUpperRes(upperAnnotations map[string]str
 func (pg *pgcontroller) inheritUpperAnnotations(upperAnnotations map[string]string, obj *scheduling.PodGroup) {
 	if pg.inheritOwnerAnnotations {
 		for k, v := range upperAnnotations {
-			if strings.HasPrefix(k, scheduling.AnnotationPrefix) {
+			if strings.HasPrefix(k, scheduling.GroupName) {
 				obj.Annotations[k] = v
 			}
 		}


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
#### What this PR does / why we need it:
In the quick start documentation, it is mentioned that we can customize the podgroup name by adding annotations to objects such as `Deployment` and `StatefulSet`. However, this approach did not take effect.
```
apiVersion: apps/v1
kind: Deployment
metadata:
  name: my-app-deployment
  annotations:
    # 对成组调度至关重要：此注解告知Volcano将此Deployment视为一个组，
    # 要求至少2个Pod能够一起调度，然后才会启动任何Pod。
    scheduling.volcano.sh/group-min-member: "2"
    # 可选：您也可以为此Deployment创建的PodGroup指定一个特定的Volcano队列。
    # scheduling.volcano.sh/queue-name: "my-deployment-queue"
  labels:
    app: my-app

```



#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Notice that do not add `Fixes` if the issue is associated with multiple PRs.
-->
Fixes #4423

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
None
```