### PR TITLE
Fix panic while `vcctl queue list` after podgroups' queue was deleted

### DIFF
--- a/pkg/cli/queue/list.go
+++ b/pkg/cli/queue/list.go
@@ -104,6 +104,10 @@ func ListQueue(ctx context.Context) error {
 	}
 
 	for _, pg := range pgList.Items {
+		_, ok := queueStats[pg.Spec.Queue]
+		if !ok {
+			continue
+		}
 		queueStats[pg.Spec.Queue].StatPodGroupCountsForQueue(&pg)
 	}
 


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
When using `vcctl queue list` for querying queues, if a podgroup's queue does not exist, ignore it. To prevent panic and display the result correctly.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Notice that do not add `Fixes` if the issue is associated with multiple PRs.
-->
Fixes #4427 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```