### PR TITLE
fix bugs for queue status can not update when use capacity plugin

### DIFF
--- a/installer/helm/chart/volcano/templates/scheduler.yaml
+++ b/installer/helm/chart/volcano/templates/scheduler.yaml
@@ -91,7 +91,7 @@ rules:
     verbs: ["get", "list", "watch", "create", "delete", "update"]
   - apiGroups: ["scheduling.incubator.k8s.io", "scheduling.volcano.sh"]
     resources: ["queues/status"]
-    verbs: ["update"]
+    verbs: ["update", "patch"]
   - apiGroups: ["scheduling.incubator.k8s.io", "scheduling.volcano.sh"]
     resources: ["podgroups"]
     verbs: ["list", "watch", "update"]


### PR DESCRIPTION
#### What type of PR is this?
Bug fix

#### What this PR does / why we need it:
Queue Status Not Updating on volcano v1.11.2

![image](https://github.com/user-attachments/assets/483f0867-3ee0-4c96-8611-c514d5c2efb1)


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
None
