### PR TITLE
Fix the issue where SelectBestNode returns nil when plugin scores are…

### DIFF
--- a/pkg/scheduler/util/scheduler_helper.go
+++ b/pkg/scheduler/util/scheduler_helper.go
@@ -193,7 +193,7 @@ func SortNodes(nodeScores map[float64][]*api.NodeInfo) []*api.NodeInfo {
 // SelectBestNodeAndScore returns the best node whose score is highest and the highest score, pick one randomly if there are many nodes with same score.
 func SelectBestNodeAndScore(nodeScores map[float64][]*api.NodeInfo) (*api.NodeInfo, float64) {
 	var bestNodes []*api.NodeInfo
-	maxScore := -1.0
+	var maxScore = math.Inf(-1)
 	for score, nodes := range nodeScores {
 		if score > maxScore {
 			maxScore = score
@@ -211,7 +211,7 @@ func SelectBestNodeAndScore(nodeScores map[float64][]*api.NodeInfo) (*api.NodeIn
 // SelectBestHyperNode return the best hyperNode name whose score is highest, pick one randomly if there are many hyperNodes with same score.
 func SelectBestHyperNode(hyperNodeScores map[float64][]string) string {
 	var bestHyperNodes []string
-	maxScore := -1.0
+	var maxScore = math.Inf(-1)
 	for score, hyperNodes := range hyperNodeScores {
 		if score > maxScore {
 			maxScore = score

--- a/pkg/scheduler/util/scheduler_helper_test.go
+++ b/pkg/scheduler/util/scheduler_helper_test.go
@@ -55,6 +55,15 @@ func TestSelectBestNode(t *testing.T) {
 			NodeScores:    map[float64][]*api.NodeInfo{},
 			ExpectedNodes: []*api.NodeInfo{nil},
 		},
+		{
+			NodeScores: map[float64][]*api.NodeInfo{
+				-5.0:  {&api.NodeInfo{Name: "node1"}, &api.NodeInfo{Name: "node2"}},
+				-10.0: {&api.NodeInfo{Name: "node3"}},
+				-8.0:  {&api.NodeInfo{Name: "node4"}, &api.NodeInfo{Name: "node5"}},
+			},
+			ExpectedNodes: []*api.NodeInfo{{Name: "node1"}, {Name: "node2"}},
+			ExpectedScore: -5.0,
+		},
 	}
 
 	oneOf := func(node *api.NodeInfo, nodes []*api.NodeInfo) bool {


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
#### What this PR does / why we need it:
This PR primarily strengthens the scheduler's node selection logic by initializing the score to negative infinity. This ensures that even when plugin scores are negative, the scheduler can still return the best node based on the scores, instead of returning nil.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Notice that do not add `Fixes` if the issue is associated with multiple PRs.
-->
Fixes # https://github.com/volcano-sh/volcano/issues/4444

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```