### PR TITLE
Fix the issue of failed within queue preemption

### DIFF
--- a/pkg/scheduler/framework/statement.go
+++ b/pkg/scheduler/framework/statement.go
@@ -433,6 +433,15 @@ func (s *Statement) Commit() {
 	}
 }
 
+// Merge operations
+func (s *Statement) Merge(ss *Statement) {
+	if ss == nil {
+		return
+	}
+	klog.V(3).Info("Merging operations ...")
+	s.operations = append(s.operations, ss.operations...)
+}
+
 func (s *Statement) SaveOperations() *Statement {
 	s.outputOperations("Save operations: ", 4)
 


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
#### What this PR does / why we need it:
The current task preemption within the queue has some issues: when the conditions for within-queue preemption are met, but the cluster resources are insufficient, `predicateNodes` becomes empty, which prevents preemption from proceeding.

```
func (pmpt *Action) preempt(
	ssn *framework.Session,
	stmt *framework.Statement,
	preemptor *api.TaskInfo,
	filter func(*api.TaskInfo) bool,
	predicateHelper util.PredicateHelper,
) (bool, error) {
	// Check whether the task is eligible to preempt others, e.g., check preemptionPolicy is `Never` or not
	if err := pmpt.taskEligibleToPreempt(preemptor); err != nil {
		return false, err
	}

	if err := ssn.PrePredicateFn(preemptor); err != nil {
		return false, fmt.Errorf("PrePredicate for task %s/%s failed for: %v", preemptor.Namespace, preemptor.Name, err)
	}

	// we should filter out those nodes that are UnschedulableAndUnresolvable status got in allocate action
	allNodes := ssn.FilterOutUnschedulableAndUnresolvableNodesForTask(preemptor)
	predicateNodes, _ := predicateHelper.PredicateNodes(preemptor, allNodes, ssn.PredicateForPreemptAction, pmpt.enablePredicateErrorCache)


```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Notice that do not add `Fixes` if the issue is associated with multiple PRs.
-->
Fixes #4447

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
None
```