### PR TITLE
Add unit tests for CNI and eBPF API types

### DIFF
--- a/pkg/networkqos/api/cni_test.go
+++ b/pkg/networkqos/api/cni_test.go
@@ -1,0 +1,84 @@
+package api
+
+import (
+	"encoding/json"
+	"net"
+	"reflect"
+	"testing"
+
+	"github.com/containernetworking/cni/pkg/types"
+)
+
+func TestNetConfJSONRoundTrip(t *testing.T) {
+	original := NetConf{
+		NetConf: types.NetConf{
+			CNIVersion: "0.4.0",
+			Name:       "volcano-net",
+			Type:       "bridge",
+		},
+		Args: map[string]string{
+			"foo": "bar",
+			"baz": "qux",
+		},
+	}
+
+	data, err := json.Marshal(original)
+	if err != nil {
+		t.Fatalf("failed to marshal NetConf: %v", err)
+	}
+
+	var parsed NetConf
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("failed to unmarshal NetConf: %v", err)
+	}
+
+	if parsed.CNIVersion != original.CNIVersion {
+		t.Errorf("CNIVersion mismatch: got %q, want %q", parsed.CNIVersion, original.CNIVersion)
+	}
+	if parsed.Name != original.Name {
+		t.Errorf("Name mismatch: got %q, want %q", parsed.Name, original.Name)
+	}
+	if parsed.Type != original.Type {
+		t.Errorf("Type mismatch: got %q, want %q", parsed.Type, original.Type)
+	}
+
+	if !reflect.DeepEqual(parsed.Args, original.Args) {
+		t.Errorf("Args mismatch: got %#v, want %#v", parsed.Args, original.Args)
+	}
+}
+
+func TestK8sArgsFieldAssignment(t *testing.T) {
+	ip := net.ParseIP("10.1.2.3")
+	if ip == nil {
+		t.Fatal("failed to parse IP")
+	}
+
+	a := K8sArgs{}
+	a.IP = ip
+	a.K8S_POD_NAME = types.UnmarshallableString("mypod")
+	a.K8S_POD_NAMESPACE = types.UnmarshallableString("myns")
+	a.K8S_POD_INFRA_CONTAINER_ID = types.UnmarshallableString("container123")
+	a.K8S_POD_UID = types.UnmarshallableString("uid-abc")
+	a.K8S_POD_RUNTIME = types.UnmarshallableString("docker")
+	a.SECURE_CONTAINER = types.UnmarshallableString("deprecated")
+
+	// Verify IP
+	if !a.IP.Equal(ip) {
+		t.Errorf("IP mismatch: got %q, want %q", a.IP, ip)
+	}
+
+	// Verify each UnmarshallableString
+	fields := map[string]types.UnmarshallableString{
+		"K8S_POD_NAME":               a.K8S_POD_NAME,
+		"K8S_POD_NAMESPACE":          a.K8S_POD_NAMESPACE,
+		"K8S_POD_INFRA_CONTAINER_ID": a.K8S_POD_INFRA_CONTAINER_ID,
+		"K8S_POD_UID":                a.K8S_POD_UID,
+		"K8S_POD_RUNTIME":            a.K8S_POD_RUNTIME,
+		"SECURE_CONTAINER":           a.SECURE_CONTAINER,
+	}
+	for name, val := range fields {
+		if string(val) == "" {
+			t.Errorf("%s was not set correctly", name)
+		}
+	}
+}

--- a/pkg/networkqos/api/ebpf_map_test.go
+++ b/pkg/networkqos/api/ebpf_map_test.go
@@ -1,0 +1,114 @@
+package api
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+)
+
+func TestEbpfNetThrottlingConfGetResultJSONRoundTrip(t *testing.T) {
+	original := EbpfNetThrottlingConfGetResult{
+		WaterLine: "100mbps",
+		Interval:  30,
+		LowRate:   "10mbps",
+		HighRate:  "50mbps",
+	}
+
+	data, err := json.Marshal(original)
+	if err != nil {
+		t.Fatalf("failed to marshal EbpfNetThrottlingConfGetResult: %v", err)
+	}
+
+	var parsed EbpfNetThrottlingConfGetResult
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("failed to unmarshal EbpfNetThrottlingConfGetResult: %v", err)
+	}
+
+	if !reflect.DeepEqual(parsed, original) {
+		t.Errorf("roundtrip mismatch:\ngot  %#v\nwant %#v", parsed, original)
+	}
+}
+
+func TestEbpfNetThrottlingConfigJSONRoundTrip(t *testing.T) {
+	original := EbpfNetThrottlingConfig{
+		WaterLine: 100,
+		Interval:  60,
+		LowRate:   20,
+		HighRate:  80,
+	}
+
+	data, err := json.Marshal(original)
+	if err != nil {
+		t.Fatalf("failed to marshal EbpfNetThrottlingConfig: %v", err)
+	}
+
+	var parsed EbpfNetThrottlingConfig
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("failed to unmarshal EbpfNetThrottlingConfig: %v", err)
+	}
+
+	if !reflect.DeepEqual(parsed, original) {
+		t.Errorf("roundtrip mismatch:\ngot  %#v\nwant %#v", parsed, original)
+	}
+}
+
+func TestEbpfNetThrottlingStatusJSONRoundTrip(t *testing.T) {
+	original := EbpfNetThrottlingStatus{
+		CheckTimes:      5,
+		HighTimes:       2,
+		LowTimes:        3,
+		OnlinePKTs:      1000,
+		OfflinePKTs:     500,
+		OfflinePrio:     1,
+		RatePast:        45,
+		OfflineRatePast: 15,
+	}
+
+	data, err := json.Marshal(original)
+	if err != nil {
+		t.Fatalf("failed to marshal EbpfNetThrottlingStatus: %v", err)
+	}
+
+	var parsed EbpfNetThrottlingStatus
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("failed to unmarshal EbpfNetThrottlingStatus: %v", err)
+	}
+
+	if !reflect.DeepEqual(parsed, original) {
+		t.Errorf("roundtrip mismatch:\ngot  %#v\nwant %#v", parsed, original)
+	}
+}
+
+func TestEbpfNetThrottlingJSONRoundTrip(t *testing.T) {
+	original := EbpfNetThrottling{
+		TLast:         12345,
+		Rate:          75,
+		TXBytes:       2048,
+		OnlineTXBytes: 4096,
+		TStart:        67890,
+		EbpfNetThrottlingStatus: EbpfNetThrottlingStatus{
+			CheckTimes:      10,
+			HighTimes:       4,
+			LowTimes:        6,
+			OnlinePKTs:      2000,
+			OfflinePKTs:     1000,
+			OfflinePrio:     2,
+			RatePast:        55,
+			OfflineRatePast: 25,
+		},
+	}
+
+	data, err := json.Marshal(original)
+	if err != nil {
+		t.Fatalf("failed to marshal EbpfNetThrottling: %v", err)
+	}
+
+	var parsed EbpfNetThrottling
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("failed to unmarshal EbpfNetThrottling: %v", err)
+	}
+
+	if !reflect.DeepEqual(parsed, original) {
+		t.Errorf("roundtrip mismatch:\ngot  %#v\nwant %#v", parsed, original)
+	}
+}


### PR DESCRIPTION
This PR introduces unit tests for the data structures within the `pkg/networkqos/api` package.

The tests verify the correctness of JSON serialization and deserialization for the API models using a round-trip strategy. This ensures the types in `cni.go` and `ebpf_map.go` behave as expected and prevents future regressions.