### PR TITLE
Add sra policy for ResourceStrategyFit Plugin

### DIFF
--- a/docs/design/proportional.md
+++ b/docs/design/proportional.md
@@ -29,14 +29,16 @@ Firstly set the proportion binding in volcano-scheduler.conf:
 actions: "enqueue, allocate, backfill"
 tiers:
 - plugins:
-  - name: predicates
+  - name: resource-strategy-fit
     arguments:
-      predicate.ProportionalEnable: true
-      predicate.resources: nvidia.com/gpu,nvidia.com/v100-sxm2-16gb
-      predicate.resources.nvidia.com/gpu.cpu: 8
-      predicate.resources.nvidia.com/gpu.memory: 8
-      predicate.resources.nvidia.com/v100-sxm2-16gb.cpu: 16
-      predicate.resources.nvidia.com/v100-sxm2-16gb.memory: 16
+      sra:
+        policy: proportional
+        resources: nvidia.com/gpu,nvidia.com/v100-sxm2-16gb
+        proportional:
+          nvidia.com/gpu.cpu: 8
+          nvidia.com/gpu.memory: 8
+          nvidia.com/v100-sxm2-16gb.cpu: 16
+          nvidia.com/v100-sxm2-16gb.memory: 16
 ```
 
 The proportion is GPU:CPU:MEMORY=1:8:8, and let the test scenario just as above:
@@ -50,8 +52,8 @@ Job | Pod | Resource | Node | NodeAllocatable | NodeIdle
 default/single-1000-0 | single-1000-0 | cpu 8, memory 8G, nvidia.com/gpu 0 | nodeC0-0 | cpu 74, memory 128G, nvidia.com/gpu 8 | cpu 66, memory 120G, nvidia.com/gpu 8 |
 default/single-1000-1 | single-1000-1 | cpu 8, memory 8G, nvidia.com/gpu 0 | - | - | - |
 
-After job single-1000-0 is scheduled, the Idel resouce is 8GPUs, 66CPUs, 120G memory. During the predicate phase, this plugin caculates the resource left if job single-1000-1 is scheduled`(node.Idel.CPU - task.Resreq.CPU < node.Idel.GPU * cpuRatio ||
-node.Idel.Memory - task.Resreq.Memory < node.Idel.GPU * memoryRatio)`; the result is 8GPUs, 58CPUs, 112G memory, that unsatisfies the 1:8:8 proportion. Therefore nodeC0-0 is removed from the predicateNodes, and NodeIdle remains 8GPUs, 66CPUs, 120G memory. 
+After job single-1000-0 is scheduled, the Idle resource is 8GPUs, 66CPUs, 120G memory. During the predicate phase, this plugin calculates the resource left if job single-1000-1 is scheduled`(node.Idle.CPU - task.Resreq.CPU < node.Idle.GPU * cpuRatio ||
+node.Idle.Memory - task.Resreq.Memory < node.Idle.GPU * memoryRatio)`; the result is 8GPUs, 58CPUs, 112G memory, that unsatisfied the 1:8:8 proportion. Therefore, nodeC0-0 is removed from the predicateNodes, and NodeIdle remains 8GPUs, 66CPUs, 120G memory.
 
 
 

--- a/docs/design/resource-strategy-fit-scheduling.md
+++ b/docs/design/resource-strategy-fit-scheduling.md
@@ -2,15 +2,23 @@
 
 ## Summary
 
-The native k8s ResourceStrategyFit plug-in can only adopt one type of strategy for all resources, such as MostRequestedPriority and LeastRequestedPriority. However, in industrial practice, this design is not applicable in some scenarios. For example: in AI scenarios, we usually disperse CPU tasks in CPU machine groups to reduce hot spots. GPU tasks are gathered in GPU machine groups to reduce GPU fragmentation. Therefore, we need to expand a scheduling strategy to meet the needs of this scenario.
+At present, there are few scheduling strategies for resource types. When users want to schedule according to resource types in some special scenarios, there is a lack of refined strategies to choose from. This plugin attempts to improve this part of the strategy to cover more application scenarios for users.
 
 ## Motivation
 
-- Different resource types can be configured with different aggregation or dispersion strategies, and weights can be used to distinguish priorities
+- **resourceStrategyFit**: The native k8s NodeResourcesFit plug-in can only adopt one type of strategy for all resources, such as MostRequestedPriority and LeastRequestedPriority. However, in industrial practice, this design is not applicable in some scenarios. For example: in AI scenarios, we usually disperse CPU tasks in CPU machine groups to reduce hot spots. GPU tasks are gathered in GPU machine groups to reduce GPU fragmentation. Therefore, we need to expand a scheduling strategy to meet the needs of this scenario.
+
+- **sra.retention**: In a cluster where GPU nodes and CPU nodes are deployed together, there is a risk that a task submitted to the cluster, which does not require GPU resources, may be scheduled to a GPU node. This can lead to inefficient resource utilization, as a job requiring both CPU and GPU resources might be pending due to insufficient CPU resources on the GPU node. This scenario is not ideal, as it can result in under utilization of resources and potential delays in job execution. Therefore, sra is proposed to avoid nodes with critical resources (such as GPUs) for certain CPU jobs and to improve overall resource utilization.
+
+- **sra.proportional**: In a cluster where CPU tasks and GPU tasks are mixed, sometimes some CPU tasks are scheduled to GPU nodes, resulting in some GPU tasks being in a long-term Pending state due to lack of CPU resources. In this regard, we may specify a 'primary' resource(e.g., GPU in deep learning), and preserve the amount of associated 'secondary' resources by a pre-set proportion. This policy will play a role in the predicate stage, and is committed to ensuring that the idle resources of the node will meet the secondary resources required by the scare resources of the node according to the proportion.
 
 ### Goals
 
-- Different types of resources can be configured with different strategies to prioritize them in the form of weights
+- Different types of resources can be configured with different strategies to prioritize them in the form of weights.
+
+- Different resources can be configured with different weights, which are used to indicate the scarcity of resources.
+
+- Different resources can set the proportion of secondary resources to ensure that the idle secondary resources on the node are sufficient.
 
 ### Non-Goals
 
@@ -18,34 +26,43 @@ The native k8s ResourceStrategyFit plug-in can only adopt one type of strategy f
 
 ## Proposal
 
-Extend one plug-ins to meet the above needs
+Extend one plugin (ResourceStrategyFit) to meet the above needs
+- **ResourceStrategyFit**: Provide users with **MostAllocated** and **LeastAllocated** these two ways to facilitate the user to decide whether the task should be distributed or aggregated according to the different needs of the task.
 
-- ResourceStrategyFit
+- **sra.retention**: Provide users the way of weight to avoid common task being scheduled to the presence of scare resource nodes, thereby improving the utilization of scare resources.
+
+- **sra.proportional**: Provide users with the way of proportion to avoid common task being scheduled to the presence of scare resource nodes, thereby improving the utilization of scare resources.
 
 ## User Story
 
 ### Story1
 - Users expect different resource allocation strategies to be applied based on resource types. For example, in PyTorch jobs, the master pod (which uses CPU) should be distributed to avoid node hotspots, while worker pods (which use GPU) should be aggregated to minimize resource fragmentation.
 
+### Story2
+- Users expect that there should be no ordinary tasks on scarce resource nodes. For example, in a cluster where CPU tasks and GPU tasks are mixed, CPU tasks should be avoided being scheduled to GPU nodes.
+
+### Story3
+- Users expect to ensure that the idle secondary resources on the nodes are sufficient after setting the proportion of secondary resources for scare resources.
+
 ## Design Details
 
 ### ResourceStrategyFit
 
 config：
-```
-actions: "enqueue, allocate, backfill, reclaim, preempt"
-tiers:
-- plugins:
- - name: resource-strategy-fit
-    arguments:
-      resourceStrategyFitWeight: 10
-      resources:
-        nvidia.com/gpu:
-          type: MostAllocated
-          weight: 2
-        cpu:
-          type: LeastAllocated
-          weight: 1
+```yaml
+  actions: "enqueue, allocate, backfill, reclaim, preempt"
+  tiers:
+  - plugins:
+    - name: resource-strategy-fit
+      arguments:
+        resourceStrategyFitWeight: 10
+        resources:
+          nvidia.com/gpu:
+            type: MostAllocated
+            weight: 2
+          cpu:
+            type: LeastAllocated
+            weight: 1
 ```
 config description：
 
@@ -71,8 +88,137 @@ node score:
 ```
 finalScoreNode = [(weight1 * resource1) + (weight2 * resource2) + … + (weightN* resourceN)] /(weight1+weight2+ … +weightN)
 ```
+### Scarce Resource Avoidance (SRA)
+#### Policy
+At present, the following two policies are supported:
+- `retention`: Give each scarce resource a weight. Higher weight means more scarce. Jobs that don’t need the scarce resource will try to stay off nodes that have it, so the scarce resource can be retained.
+- `proportional`: By specifying 'primary' scarce resources (e.g. GPU in deep learning) and preserve the amount of associated 'secondary' resources by a pre-set proportion.
+
+#### Solution
+##### retention
+1. In retention policy, arguments `sra.resources` is provided to configure important resources in the cluster.
+2. Based on the significance of different resources, `sra.retention.[ResourceName]` can assign varying weights for resource allocation. A higher weight signifies greater importance, and tasks that do not require this resource will, to the extent possible, be scheduled away from nodes with such resources
+3. For all tasks, user can set `sra.resources` and `sra.retention.[ResourceName]` field in `resource-strategy-fit` arguments via `volcano-scheduler-configmap` in following format:
+
+```yaml
+  actions: "enqueue, reclaim, allocate, backfill, preempt"
+  tiers:
+  - plugins:
+    - name: resource-strategy-fit
+      arguments:
+        sra.policy: retention
+        sra.resources: nvidia.com/t4, nvidia.com/a10
+        sra.retention.weight: 2
+        sra.retention.nvidia.com/t4: 1
+        sra.retention.nvidia.com/a10: 1
+```
+
+4. `retention` policy will affect the score result of node order. The higher the node score is, the higher the priority is. The score result of retention policy is calculated as follows :
+```
+node resources items don't meet task request, retentionScore = 0
+node resources items meet task request,       retentionScore = MaxNodeScore * retentionWeight * (weight_1 + weight_2 + ··· + weight_n) / weightSum
+```
+> `retentionScore`: the node score of retention policy. \
+> `MaxNodeScore`: the maximum score of node. default is 100. \
+> `retentionWeight`: the weight of retention policy. \
+> `weightSum`: the sum of all retention resources weights. \
+> `weight_x`: the weight of the xth retention resource that does not exist on the node.
+
+   1. Now, we have tasks:
+
+      | Task Name  | Task request resource                                        |
+      |------------|--------------------------------------------------------------|
+      | cpu-task-0 | `{cpu: 2, memory: 4Gi}`                                      |
+      | gpu-task-0 | `{cpu: 2, memory: 4Gi, nvidia.com/t4: 2}`                    |
+      | gpu-task-1 | `{cpu: 2, memory: 4Gi, nvidia.com/t4: 1, nvidia.com/a10: 2}` | 
+   
+   2. Suppose there are 3 nodes available in cluster:
+
+      | Node Name | Resource capacity on node                                       |
+      |-----------|-----------------------------------------------------------------|
+      | node1     | `{cpu: 32, memory: 64Gi}`                                       | 
+      | node2     | `{cpu: 16, memory: 32Gi, nvidia.com/t4: 10}`                    | 
+      | node3     | `{cpu: 16, memory: 32Gi, nvidia.com/t4: 5, nvidia.com/a10: 10}` |
+
+   3. Through the retention policy we will get the following results:
+   
+      | Task       | Node  | Score result (retention) | Notes                                                        |
+      |------------|-------|--------------------------|--------------------------------------------------------------|
+      | cpu-task-0 | node1 | 200                      | node resources meet the task request and no scarce resources |
+      | cpu-task-0 | node2 | 100                      | node resources meet the task request but have t4             |
+      | cpu-task-0 | node3 | 0                        | node resources meet the task request but have t4, a10        |
+      | gpu-task-0 | node1 | 0                        | node resources don't meet the task request                   |
+      | gpu-task-0 | node2 | 100                      | node resources meet the task request and have t4             |
+      | gpu-task-0 | node3 | 0                        | node resources meet the task request but have a10            |
+      | gpu-task-1 | node1 | 0                        | node resources don't meet the task request                   |
+      | gpu-task-1 | node2 | 0                        | node resources don't meet the task request                   |
+      | gpu-task-1 | node3 | 0                        | node resources meet the task request and have t4, a10        |
+
+##### proportional
+
+![](./images/proportional-diagram.png)
+
+Firstly set the proportion binding in volcano-scheduler.conf:
+
+```yaml
+  actions: "enqueue, reclaim, allocate, backfill, preempt"
+  tiers:
+  - plugins:
+    - name: resource-strategy-fit
+      arguments:
+        sra:
+          policy: proportional
+          resources: nvidia.com/gpu,nvidia.com/v100-sxm2-16gb
+          proportional:
+            nvidia.com/gpu.cpu: 8
+            nvidia.com/gpu.memory: 8
+            nvidia.com/v100-sxm2-16gb.cpu: 16
+            nvidia.com/v100-sxm2-16gb.memory: 16
+```
+
+The proportion is GPU:CPU:MEMORY=1:8:8, and let the test scenario just as above:
+
+| Node     | NodeAllocatable                       | NodeIdle                              |
+|----------|---------------------------------------|---------------------------------------|
+| nodeC0-0 | cpu 74, memory 128G, nvidia.com/gpu 8 | cpu 74, memory 128G, nvidia.com/gpu 8 |
+
+| Job                   | Pod           | Resource                           | Node     | NodeAllocatable                       | NodeIdle                              |
+|-----------------------|---------------|------------------------------------|----------|---------------------------------------|---------------------------------------|
+| default/single-1000-0 | single-1000-0 | cpu 8, memory 8G, nvidia.com/gpu 0 | nodeC0-0 | cpu 74, memory 128G, nvidia.com/gpu 8 | cpu 66, memory 120G, nvidia.com/gpu 8 |
+| default/single-1000-1 | single-1000-1 | cpu 8, memory 8G, nvidia.com/gpu 0 | -        | -                                     | -                                     |
+
+After job single-1000-0 is scheduled, the Idle resource is 8GPUs, 66CPUs, 120G memory. During the predicate phase, this plugin calculates the resource left if job single-1000-1 is scheduled`(node.Idle.CPU - task.Resreq.CPU < node.Idle.GPU * cpuRatio ||
+node.Idle.Memory - task.Resreq.Memory < node.Idle.GPU * memoryRatio)`; the result is 8GPUs, 58CPUs, 112G memory, that unsatisfied the 1:8:8 proportion. Therefore, nodeC0-0 is removed from the predicateNodes, and NodeIdle remains 8GPUs, 66CPUs, 120G memory.
+
+For more details, please refer to: [proportional design](./proportional.md)
 
 ## Alternatives
 
 ### Binpack VS ResourceStrategyFit
 If you want to use the clustering strategy for all resource types, you can choose the Binpack plugin. If you need to configure different clustering or scattering strategies for different resource types, you can choose the ResourceStrategyFit plugin. ResourceStrategyFit can also achieve the same results as Binpack by adjusting configuration parameters.
+
+## Best Practices
+### AI scenario
+In some AI scenarios, CPU tasks are usually dispersed into CPU machine groups to reduce hot spots. GPU tasks are gathered in the GPU machine group to reduce GPU fragmentation. At the same time, it is also necessary to avoid the situation that CPU tasks are assigned to GPU nodes, resulting in long-term waiting of GPU tasks due to insufficient CPU or MEM resources of nodes. In this scenario, we can combine **resourceStrategyFit** and **sra policy** to deal with this scenario. The corresponding example configuration is as follows:
+
+```yaml
+  actions: "enqueue, allocate, backfill, reclaim, preempt"
+  tiers:
+    - plugins:
+      - name: resource-strategy-fit
+        arguments:
+          resourceStrategyFitWeight: 10
+          resources:
+            nvidia.com/gpu:
+              type: MostAllocated
+              weight: 2
+            cpu:
+              type: LeastAllocated
+              weight: 1
+          sra:
+            policy: retention
+            resources: nvidia.com/gpu
+            retention:
+              weight: 10
+              nvidia.com/gpu: 1
+```

--- a/pkg/scheduler/plugins/predicates/predicates.go
+++ b/pkg/scheduler/plugins/predicates/predicates.go
@@ -26,7 +26,6 @@ import (
 	"fmt"
 	"maps"
 	"slices"
-	"strings"
 	"sync"
 
 	v1 "k8s.io/api/core/v1"
@@ -51,6 +50,7 @@ import (
 	"volcano.sh/volcano/pkg/scheduler/cache"
 	vbcap "volcano.sh/volcano/pkg/scheduler/capabilities/volumebinding"
 	"volcano.sh/volcano/pkg/scheduler/framework"
+	"volcano.sh/volcano/pkg/scheduler/plugins/util"
 	"volcano.sh/volcano/pkg/scheduler/plugins/util/k8s"
 	"volcano.sh/volcano/pkg/scheduler/plugins/util/nodescore"
 )
@@ -88,13 +88,6 @@ const (
 
 	// CachePredicate control cache predicate feature
 	CachePredicate = "predicate.CacheEnable"
-
-	// ProportionalPredicate is the key for enabling Proportional Predicate in YAML
-	ProportionalPredicate = "predicate.ProportionalEnable"
-	// ProportionalResource is the key for additional resource key name
-	ProportionalResource = "predicate.resources"
-	// ProportionalResourcesPrefix is the key prefix for additional resource key name
-	ProportionalResourcesPrefix = ProportionalResource + "."
 )
 
 var (
@@ -120,11 +113,6 @@ func (pp *predicatesPlugin) Name() string {
 	return PluginName
 }
 
-type baseResource struct {
-	CPU    float64
-	Memory float64
-}
-
 type predicateEnable struct {
 	nodeAffinityEnable              bool
 	nodePortEnable                  bool
@@ -134,10 +122,8 @@ type predicateEnable struct {
 	volumeZoneEnable                bool
 	podTopologySpreadEnable         bool
 	cacheEnable                     bool
-	proportionalEnable              bool
 	volumeBindingEnable             bool
 	dynamicResourceAllocationEnable bool
-	proportional                    map[v1.ResourceName]baseResource
 }
 
 // bind context extension information of predicates
@@ -170,10 +156,6 @@ func enablePredicate(args framework.Arguments) predicateEnable {
 	         predicate.GPUSharingEnable: true
 	         predicate.GPUNumberEnable: true
 	         predicate.CacheEnable: true
-	         predicate.ProportionalEnable: true
-	         predicate.resources: nvidia.com/gpu
-	         predicate.resources.nvidia.com/gpu.cpu: 4
-	         predicate.resources.nvidia.com/gpu.memory: 8
 	     - name: proportion
 	     - name: nodeorder
 	*/
@@ -187,7 +169,6 @@ func enablePredicate(args framework.Arguments) predicateEnable {
 		volumeZoneEnable:                true,
 		podTopologySpreadEnable:         true,
 		cacheEnable:                     false,
-		proportionalEnable:              false,
 		volumeBindingEnable:             true,
 		dynamicResourceAllocationEnable: false,
 	}
@@ -203,41 +184,7 @@ func enablePredicate(args framework.Arguments) predicateEnable {
 	args.GetBool(&predicate.podTopologySpreadEnable, PodTopologySpreadEnable)
 	args.GetBool(&predicate.volumeBindingEnable, VolumeBindingEnable)
 	args.GetBool(&predicate.dynamicResourceAllocationEnable, DynamicResourceAllocationEnable)
-
 	args.GetBool(&predicate.cacheEnable, CachePredicate)
-	// Checks whether predicate.ProportionalEnable is provided or not, if given, modifies the value in predicateEnable struct.
-	args.GetBool(&predicate.proportionalEnable, ProportionalPredicate)
-	resourcesProportional := make(map[v1.ResourceName]baseResource)
-	resourcesStr, ok := args[ProportionalResource].(string)
-	if !ok {
-		resourcesStr = ""
-	}
-	resources := strings.Split(resourcesStr, ",")
-	for _, resource := range resources {
-		resource = strings.TrimSpace(resource)
-		if resource == "" {
-			continue
-		}
-		// proportional.resources.[ResourceName]
-		cpuResourceKey := ProportionalResourcesPrefix + resource + ".cpu"
-		cpuResourceRate := 1.0
-		args.GetFloat64(&cpuResourceRate, cpuResourceKey)
-		if cpuResourceRate < 0 {
-			cpuResourceRate = 1.0
-		}
-		memoryResourceKey := ProportionalResourcesPrefix + resource + ".memory"
-		memoryResourceRate := 1.0
-		args.GetFloat64(&memoryResourceRate, memoryResourceKey)
-		if memoryResourceRate < 0 {
-			memoryResourceRate = 1.0
-		}
-		r := baseResource{
-			CPU:    cpuResourceRate,
-			Memory: memoryResourceRate,
-		}
-		resourcesProportional[v1.ResourceName(resource)] = r
-	}
-	predicate.proportional = resourcesProportional
 
 	return predicate
 }
@@ -514,7 +461,7 @@ func (pp *predicatesPlugin) OnSessionOpen(ssn *framework.Session) {
 			nodeUnscheduleStatus := api.ConvertPredicateStatus(status)
 			if nodeUnscheduleStatus.Code != api.Success {
 				predicateStatus = append(predicateStatus, nodeUnscheduleStatus)
-				if ShouldAbort(nodeUnscheduleStatus) {
+				if util.ShouldAbort(nodeUnscheduleStatus) {
 					return predicateStatus, false, fmt.Errorf("plugin %s predicates failed %s", nodeUnscheduleFilter.Name(), status.Message())
 				}
 			}
@@ -525,7 +472,7 @@ func (pp *predicatesPlugin) OnSessionOpen(ssn *framework.Session) {
 				nodeAffinityStatus := api.ConvertPredicateStatus(status)
 				if nodeAffinityStatus.Code != api.Success {
 					predicateStatus = append(predicateStatus, nodeAffinityStatus)
-					if ShouldAbort(nodeAffinityStatus) {
+					if util.ShouldAbort(nodeAffinityStatus) {
 						return predicateStatus, false, fmt.Errorf("plugin %s predicates failed %s", nodeAffinityFilter.Name(), status.Message())
 					}
 				}
@@ -537,7 +484,7 @@ func (pp *predicatesPlugin) OnSessionOpen(ssn *framework.Session) {
 				tolerationStatus := api.ConvertPredicateStatus(status)
 				if tolerationStatus.Code != api.Success {
 					predicateStatus = append(predicateStatus, tolerationStatus)
-					if ShouldAbort(tolerationStatus) {
+					if util.ShouldAbort(tolerationStatus) {
 						return predicateStatus, false, fmt.Errorf("plugin %s predicates failed %s", tolerationFilter.Name(), status.Message())
 					}
 				}
@@ -580,7 +527,7 @@ func (pp *predicatesPlugin) OnSessionOpen(ssn *framework.Session) {
 				nodePortStatus := api.ConvertPredicateStatus(status)
 				if nodePortStatus.Code != api.Success {
 					predicateStatus = append(predicateStatus, nodePortStatus)
-					if ShouldAbort(nodePortStatus) {
+					if util.ShouldAbort(nodePortStatus) {
 						return api.NewFitErrWithStatus(task, node, predicateStatus...)
 					}
 				}
@@ -595,7 +542,7 @@ func (pp *predicatesPlugin) OnSessionOpen(ssn *framework.Session) {
 				podAffinityStatus := api.ConvertPredicateStatus(status)
 				if podAffinityStatus.Code != api.Success {
 					predicateStatus = append(predicateStatus, podAffinityStatus)
-					if ShouldAbort(podAffinityStatus) {
+					if util.ShouldAbort(podAffinityStatus) {
 						return api.NewFitErrWithStatus(task, node, predicateStatus...)
 					}
 				}
@@ -608,7 +555,7 @@ func (pp *predicatesPlugin) OnSessionOpen(ssn *framework.Session) {
 			nodeVolumeStatus := api.ConvertPredicateStatus(status)
 			if nodeVolumeStatus.Code != api.Success {
 				predicateStatus = append(predicateStatus, nodeVolumeStatus)
-				if ShouldAbort(nodeVolumeStatus) {
+				if util.ShouldAbort(nodeVolumeStatus) {
 					return api.NewFitErrWithStatus(task, node, predicateStatus...)
 				}
 			}
@@ -620,7 +567,7 @@ func (pp *predicatesPlugin) OnSessionOpen(ssn *framework.Session) {
 			volumeZoneStatus := api.ConvertPredicateStatus(status)
 			if volumeZoneStatus.Code != api.Success {
 				predicateStatus = append(predicateStatus, volumeZoneStatus)
-				if ShouldAbort(volumeZoneStatus) {
+				if util.ShouldAbort(volumeZoneStatus) {
 					return api.NewFitErrWithStatus(task, node, predicateStatus...)
 				}
 			}
@@ -634,24 +581,11 @@ func (pp *predicatesPlugin) OnSessionOpen(ssn *framework.Session) {
 				podTopologyStatus := api.ConvertPredicateStatus(status)
 				if podTopologyStatus.Code != api.Success {
 					predicateStatus = append(predicateStatus, podTopologyStatus)
-					if ShouldAbort(podTopologyStatus) {
+					if util.ShouldAbort(podTopologyStatus) {
 						return api.NewFitErrWithStatus(task, node, predicateStatus...)
 					}
 				}
 			}
-		}
-
-		if predicate.proportionalEnable {
-			// Check ProportionalPredicate
-			proportionalStatus, _ := checkNodeResourceIsProportional(task, node, predicate.proportional)
-			if proportionalStatus.Code != api.Success {
-				predicateStatus = append(predicateStatus, proportionalStatus)
-				if ShouldAbort(proportionalStatus) {
-					return api.NewFitErrWithStatus(task, node, predicateStatus...)
-				}
-			}
-			klog.V(4).Infof("checkNodeResourceIsProportional predicates Task <%s/%s> on Node <%s>: fit %v",
-				task.Namespace, task.Name, node.Name, fit)
 		}
 
 		// Check VolumeBinding
@@ -662,7 +596,7 @@ func (pp *predicatesPlugin) OnSessionOpen(ssn *framework.Session) {
 				volumeBindingStatus := api.ConvertPredicateStatus(status)
 				if volumeBindingStatus.Code != api.Success {
 					predicateStatus = append(predicateStatus, volumeBindingStatus)
-					if ShouldAbort(volumeBindingStatus) {
+					if util.ShouldAbort(volumeBindingStatus) {
 						return api.NewFitErrWithStatus(task, node, predicateStatus...)
 					}
 				}
@@ -677,7 +611,7 @@ func (pp *predicatesPlugin) OnSessionOpen(ssn *framework.Session) {
 				dynamicResourceAllocationStatus := api.ConvertPredicateStatus(status)
 				if dynamicResourceAllocationStatus.Code != api.Success {
 					predicateStatus = append(predicateStatus, dynamicResourceAllocationStatus)
-					if ShouldAbort(dynamicResourceAllocationStatus) {
+					if util.ShouldAbort(dynamicResourceAllocationStatus) {
 						return api.NewFitErrWithStatus(task, node, predicateStatus...)
 					}
 				}
@@ -894,25 +828,6 @@ func (pp *predicatesPlugin) SetupBindContextExtension(ssn *framework.Session, bi
 	}
 
 	bindCtx.Extensions[pp.Name()] = &bindContextExtension{State: ssn.GetCycleState(bindCtx.TaskInfo.UID)}
-}
-
-// ShouldAbort determines if the given status indicates that execution should be aborted.
-// It checks if the status code corresponds to any of the following conditions:
-// - UnschedulableAndUnresolvable: Indicates the task cannot be scheduled and resolved.
-// - Error: Represents an error state that prevents further execution.
-// - Wait: Suggests that the process should pause and not proceed further.
-// - Skip: Indicates that the operation should be skipped entirely.
-//
-// Parameters:
-// - status (*api.Status): The status object to evaluate.
-//
-// Returns:
-// - bool: True if the status code matches any of the abort conditions; false otherwise.
-func ShouldAbort(status *api.Status) bool {
-	return status.Code == api.UnschedulableAndUnresolvable ||
-		status.Code == api.Error ||
-		status.Code == api.Wait ||
-		status.Code == api.Skip
 }
 
 func handleSkipPredicatePlugin(state *k8sframework.CycleState, pluginName string) bool {

--- a/pkg/scheduler/plugins/resource-strategy-fit/proportional.go
+++ b/pkg/scheduler/plugins/resource-strategy-fit/proportional.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 The Volcano Authors.
+Copyright 2025 The Volcano Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,21 +14,67 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package predicates
+package resourcestrategyfit
 
 import (
 	"fmt"
+	"strings"
 
 	v1 "k8s.io/api/core/v1"
 
 	"volcano.sh/volcano/pkg/scheduler/api"
 )
 
+const (
+	// ProportionalPolicy indicates name of sra policy.
+	ProportionalPolicy = "proportional"
+)
+
+type baseResource struct {
+	CPU    float64
+	Memory float64
+}
+
+func calculateProportionalResources(resources []string, cfg sraConfig) map[v1.ResourceName]baseResource {
+	resourcesProportional := make(map[v1.ResourceName]baseResource)
+
+	for _, resource := range resources {
+		resource = strings.TrimSpace(resource)
+		if resource == "" {
+			continue
+		}
+		// proportional.resources.[ResourceName]
+		cpuResourceKey := resource + ".cpu"
+		cpuResourceRate := 1.0
+		if v, ok := cfg.Proportional[cpuResourceKey]; ok {
+			cpuResourceRate = v
+		}
+		if cpuResourceRate < 0 {
+			cpuResourceRate = 1.0
+		}
+		memoryResourceKey := resource + ".memory"
+		memoryResourceRate := 1.0
+		if v, ok := cfg.Proportional[memoryResourceKey]; ok {
+			memoryResourceRate = v
+		}
+		if memoryResourceRate < 0 {
+			memoryResourceRate = 1.0
+		}
+		r := baseResource{
+			CPU:    cpuResourceRate,
+			Memory: memoryResourceRate,
+		}
+		resourcesProportional[v1.ResourceName(resource)] = r
+	}
+
+	return resourcesProportional
+}
+
 // checkNodeResourceIsProportional checks if a gpu:cpu:memory is Proportional
 func checkNodeResourceIsProportional(task *api.TaskInfo, node *api.NodeInfo, proportional map[v1.ResourceName]baseResource) (*api.Status, error) {
 	status := &api.Status{
 		Code:   api.Success,
-		Plugin: ProportionalPredicate,
+		Plugin: PluginName,
 	}
 	for resourceName := range proportional {
 		if value, found := task.Resreq.ScalarResources[resourceName]; found && value > 0 {

--- a/pkg/scheduler/plugins/resource-strategy-fit/proportional_test.go
+++ b/pkg/scheduler/plugins/resource-strategy-fit/proportional_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 The Volcano Authors.
+Copyright 2025 The Volcano Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package predicates
+package resourcestrategyfit
 
 import (
 	"testing"

--- a/pkg/scheduler/plugins/resource-strategy-fit/retention.go
+++ b/pkg/scheduler/plugins/resource-strategy-fit/retention.go
@@ -1,0 +1,151 @@
+/*
+Copyright 2025 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resourcestrategyfit
+
+import (
+	"fmt"
+	"strings"
+
+	v1 "k8s.io/api/core/v1"
+
+	"k8s.io/klog/v2"
+	k8sFramework "k8s.io/kubernetes/pkg/scheduler/framework"
+
+	"volcano.sh/volcano/pkg/scheduler/api"
+)
+
+const (
+	// RetentionPolicy indicates name of sra policy.
+	RetentionPolicy = "retention"
+)
+
+type retentionWeight struct {
+	Weight             int
+	Resources          map[v1.ResourceName]int
+	ResourcesWeightSum int
+}
+
+func (w *retentionWeight) String() string {
+	length := 1
+	if extendLength := len(w.Resources); extendLength == 0 {
+		length++
+	} else {
+		length += extendLength
+	}
+
+	msg := make([]string, 0, length)
+	msg = append(msg,
+		fmt.Sprintf(resourceFmt, SraRetentionWeight, w.Weight),
+	)
+
+	if len(w.Resources) == 0 {
+		msg = append(msg, "no extend resources.")
+	} else {
+		for name, weight := range w.Resources {
+			msg = append(msg, fmt.Sprintf(resourceFmt, name, weight))
+		}
+	}
+
+	return strings.Join(msg, ", ")
+}
+
+func calculateRetentionWeight(resources []string, cfg sraConfig) retentionWeight {
+	// Values are initialized to 1.
+	weight := retentionWeight{
+		Weight:             1,
+		Resources:          make(map[v1.ResourceName]int),
+		ResourcesWeightSum: 0,
+	}
+
+	// Checks whether sra retention weight is provided or not, if given, modifies the value in weight struct.
+	if v, ok := cfg.Retention["weight"]; ok {
+		weight.Weight = v
+	}
+
+	for _, resource := range resources {
+		resource = strings.TrimSpace(resource)
+		if resource == "" {
+			continue
+		}
+
+		resourceWeight := 1
+		if v, ok := cfg.Retention[resource]; ok {
+			resourceWeight = v
+		}
+		if resourceWeight < 0 {
+			resourceWeight = 1
+		}
+		weight.Resources[v1.ResourceName(resource)] = resourceWeight
+		weight.ResourcesWeightSum += resourceWeight
+	}
+
+	return weight
+}
+
+// retentionScore use the best fit polices during scheduling.
+// Goals:
+// - Schedule Tasks using BestFit Policy using retention policy
+// - Improve the utilization of scarce resources on the cluster
+func retentionScore(task *api.TaskInfo, node *api.NodeInfo, retention retentionWeight) float64 {
+	requested := task.Resreq
+	allocatable := node.Allocatable
+
+	// check if the node has the requested resource item
+	for _, resource := range requested.ResourceNames() {
+		resourceCapacity := allocatable.Get(resource)
+
+		if resourceCapacity == 0 {
+			// node resources can't meet the task request, so it can be disregarded.
+			klog.V(4).Infof("task %s/%s doesn't need to consider node %s, because node allocatable: %v , task need: %v",
+				task.Namespace, task.Name, node.Name, allocatable, requested)
+			return 0
+		}
+	}
+
+	score, err := resourceRetentionScore(retention.Resources, allocatable)
+	if err != nil {
+		klog.V(4).Infof("task %s/%s cannot sra node %s, node allocatable: %v , task need: %v , error: %s",
+			task.Namespace, task.Name, node.Name, allocatable, requested, err.Error())
+		return 0
+	}
+	klog.V(5).Infof("task %s/%s on node %s , node allocatable: %s, task need: %v, score %v",
+		task.Namespace, task.Name, node.Name, allocatable, requested, score)
+
+	// mapping the result from [0, weightSum] to [0, MaxNodeScore]
+	if retention.ResourcesWeightSum > 0 {
+		score /= float64(retention.ResourcesWeightSum)
+		score = 1.0 - score
+	}
+	score *= float64(k8sFramework.MaxNodeScore * int64(retention.Weight))
+
+	return score
+}
+
+// resourceRetentionScore calculate the retention score for resource with provided info
+func resourceRetentionScore(resources map[v1.ResourceName]int, capacity *api.Resource) (float64, error) {
+	score := 0.0
+
+	for resource, weight := range resources {
+		resourceCapacity := capacity.Get(resource)
+
+		if resourceCapacity > 0 {
+			score += float64(weight)
+		}
+	}
+
+	return score, nil
+}

--- a/pkg/scheduler/plugins/resource-strategy-fit/retention_test.go
+++ b/pkg/scheduler/plugins/resource-strategy-fit/retention_test.go
@@ -1,0 +1,385 @@
+/*
+Copyright 2025 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resourcestrategyfit
+
+import (
+	"fmt"
+	"math"
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+
+	schedulingv1 "volcano.sh/apis/pkg/apis/scheduling/v1beta1"
+	"volcano.sh/volcano/pkg/scheduler/api"
+	"volcano.sh/volcano/pkg/scheduler/conf"
+	"volcano.sh/volcano/pkg/scheduler/framework"
+	"volcano.sh/volcano/pkg/scheduler/uthelper"
+	"volcano.sh/volcano/pkg/scheduler/util"
+)
+
+func TestArguments(t *testing.T) {
+	framework.RegisterPluginBuilder(PluginName, New)
+	defer framework.CleanupPluginBuilders()
+
+	arguments := framework.Arguments{
+		"sra": map[string]interface{}{
+			"policy":    "retention",
+			"resources": "nvidia.com/t4, nvidia.com/a10",
+			"retention": map[string]interface{}{
+				"weight":         3,
+				"nvidia.com/t4":  1,
+				"nvidia.com/a10": 2,
+			},
+			"proportional": map[string]interface{}{
+				"nvidia.com/t4.cpu":     3,
+				"nvidia.com/t4.memory":  6,
+				"nvidia.com/a10.cpu":    4,
+				"nvidia.com/a10.memory": 8,
+			},
+		},
+	}
+
+	builder, ok := framework.GetPluginBuilder(PluginName)
+	if !ok {
+		t.Fatalf("should have plugin named %s", PluginName)
+	}
+
+	plugin := builder(arguments)
+	rsf, ok := plugin.(*resourceStrategyFitPlugin)
+	if !ok {
+		t.Fatalf("plugin should be %T, but not %T", rsf, plugin)
+	}
+
+	if rsf.sraPolicy.Policy != RetentionPolicy {
+		t.Errorf("sra.policy should be retention, but not %s", rsf.sraPolicy.Policy)
+	}
+
+	retention := rsf.sraPolicy.Retention
+	if retention.Weight != 3 {
+		t.Errorf("sra.retention weight should be 3, but not %v", retention.Weight)
+	}
+	if retention.ResourcesWeightSum != 3 {
+		t.Errorf("the sum of resource weights of retention policy should be 3, but not %v", retention.ResourcesWeightSum)
+	}
+	for name, weight := range retention.Resources {
+		switch name {
+		case "nvidia.com/t4":
+			if weight != 1 {
+				t.Errorf("nvidia.com/t4 should be 1, but not %v", weight)
+			}
+		case "nvidia.com/a10":
+			if weight != 2 {
+				t.Errorf("nvidia.com/a10 should be 2, but not %v", weight)
+			}
+		default:
+			t.Errorf("resource %s with weight %d should not appear", name, weight)
+		}
+	}
+
+	proportional := rsf.sraPolicy.Proportional
+	for name, weight := range proportional {
+		switch name {
+		case "nvidia.com/t4.cpu":
+			if weight.CPU != 3 {
+				t.Errorf("nvidia.com/t4.cpu should be 3, but not %v", weight)
+			}
+			if weight.Memory != 6 {
+				t.Errorf("nvidia.com/t4.memory should be 6, but not %v", weight)
+			}
+		case "nvidia.com/a10.cpu":
+			if weight.CPU != 4 {
+				t.Errorf("nvidia.com/a10.cpu should be 4, but not %v", weight)
+			}
+			if weight.Memory != 8 {
+				t.Errorf("nvidia.com/a10.memory should be 8, but not %v", weight)
+			}
+		}
+	}
+}
+
+func TestNode(t *testing.T) {
+	GPUT4 := v1.ResourceName("nvidia.com/t4")
+	GPUA10 := v1.ResourceName("nvidia.com/a10")
+
+	p1 := util.BuildPod("c1", "p1", "", v1.PodPending, api.BuildResourceList("1", "1Gi"), "pg1", make(map[string]string), make(map[string]string))
+	p2 := util.BuildPod("c1", "p2", "", v1.PodPending, api.BuildResourceList("1.5", "0Gi"), "pg1", make(map[string]string), make(map[string]string))
+	addResource(p2.Spec.Containers[0].Resources.Requests, GPUT4, "2")
+	p3 := util.BuildPod("c1", "p3", "", v1.PodPending, api.BuildResourceList("2", "4Gi"), "pg1", make(map[string]string), make(map[string]string))
+	addResource(p3.Spec.Containers[0].Resources.Requests, GPUA10, "2")
+	p4 := util.BuildPod("c1", "p4", "", v1.PodPending, api.BuildResourceList("3", "4Gi"), "pg1", make(map[string]string), make(map[string]string))
+	addResource(p4.Spec.Containers[0].Resources.Requests, GPUT4, "1")
+	addResource(p4.Spec.Containers[0].Resources.Requests, GPUA10, "3")
+
+	n1 := util.BuildNode("n1", api.BuildResourceList("32", "64Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), make(map[string]string))
+	n2 := util.BuildNode("n2", api.BuildResourceList("8", "16Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), make(map[string]string))
+	addResource(n2.Status.Allocatable, GPUT4, "16")
+	n3 := util.BuildNode("n3", api.BuildResourceList("8", "16Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), make(map[string]string))
+	addResource(n3.Status.Allocatable, GPUA10, "16")
+	n4 := util.BuildNode("n4", api.BuildResourceList("8", "16Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), make(map[string]string))
+	addResource(n4.Status.Allocatable, GPUT4, "8")
+	addResource(n4.Status.Allocatable, GPUA10, "16")
+
+	pg1 := util.BuildPodGroup("pg1", "c1", "c1", 0, nil, "")
+	queue1 := util.BuildQueue("c1", 1, nil)
+
+	tests := []struct {
+		uthelper.TestCommonStruct
+		arguments framework.Arguments
+		expected  map[string]map[string]float64
+	}{
+		{
+			TestCommonStruct: uthelper.TestCommonStruct{
+				Name:      "case1: single job score result in multi-GPU resource",
+				Plugins:   map[string]framework.PluginBuilder{PluginName: New},
+				PodGroups: []*schedulingv1.PodGroup{pg1},
+				Queues:    []*schedulingv1.Queue{queue1},
+				Pods:      []*v1.Pod{p1, p2, p3, p4},
+				Nodes:     []*v1.Node{n1, n2, n3, n4},
+			},
+			arguments: framework.Arguments{
+				"resourceStrategyFitWeight": 0,
+				"sra": map[string]interface{}{
+					"policy":    "retention",
+					"resources": "nvidia.com/t4, nvidia.com/a10",
+					"retention": map[string]interface{}{
+						"weight":         5,
+						"nvidia.com/t4":  2,
+						"nvidia.com/a10": 3,
+					},
+				},
+			},
+			expected: map[string]map[string]float64{
+				"c1/p1": {
+					"n1": 500,
+					"n2": 300,
+					"n3": 200,
+					"n4": 0,
+				},
+				"c1/p2": {
+					"n1": 0,
+					"n2": 300,
+					"n3": 0,
+					"n4": 0,
+				},
+				"c1/p3": {
+					"n1": 0,
+					"n2": 0,
+					"n3": 200,
+					"n4": 0,
+				},
+				"c1/p4": {
+					"n1": 0,
+					"n2": 0,
+					"n3": 0,
+					"n4": 0,
+				},
+			},
+		},
+		{
+			TestCommonStruct: uthelper.TestCommonStruct{
+				Name:      "case2: single job score result in single GPU resource",
+				Plugins:   map[string]framework.PluginBuilder{PluginName: New},
+				PodGroups: []*schedulingv1.PodGroup{pg1},
+				Queues:    []*schedulingv1.Queue{queue1},
+				Pods:      []*v1.Pod{p1, p2, p3, p4},
+				Nodes:     []*v1.Node{n1, n2, n3, n4},
+			},
+			arguments: framework.Arguments{
+				"resourceStrategyFitWeight": 0,
+				"sra": map[string]interface{}{
+					"policy":    "retention",
+					"resources": "nvidia.com/t4",
+					"retention": map[string]interface{}{
+						"weight":        5,
+						"nvidia.com/t4": 2,
+					},
+				},
+			},
+			expected: map[string]map[string]float64{
+				"c1/p1": {
+					"n1": 500,
+					"n2": 0,
+					"n3": 500,
+					"n4": 0,
+				},
+				"c1/p2": {
+					"n1": 0,
+					"n2": 0,
+					"n3": 0,
+					"n4": 0,
+				},
+				"c1/p3": {
+					"n1": 0,
+					"n2": 0,
+					"n3": 500,
+					"n4": 0,
+				},
+				"c1/p4": {
+					"n1": 0,
+					"n2": 0,
+					"n3": 0,
+					"n4": 0,
+				},
+			},
+		},
+		{
+			TestCommonStruct: uthelper.TestCommonStruct{
+				Name:      "case3: single job score result with retention policy and resourceStrategyFit",
+				Plugins:   map[string]framework.PluginBuilder{PluginName: New},
+				PodGroups: []*schedulingv1.PodGroup{pg1},
+				Queues:    []*schedulingv1.Queue{queue1},
+				Pods:      []*v1.Pod{p1, p2, p3, p4},
+				Nodes:     []*v1.Node{n1, n2, n3, n4},
+			},
+			arguments: framework.Arguments{
+				"resourceStrategyFitWeight": 8,
+				"resources": map[string]interface{}{
+					"nvidia.com/t4": map[string]interface{}{
+						"type":   "MostAllocated",
+						"weight": 3,
+					},
+					"cpu": map[string]interface{}{
+						"type":   "LeastAllocated",
+						"weight": 1,
+					},
+				},
+				"sra": map[string]interface{}{
+					"policy":    "retention",
+					"resources": "nvidia.com/t4",
+					"retention": map[string]interface{}{
+						"weight":        0,
+						"nvidia.com/t4": 2,
+					},
+				},
+			},
+			expected: map[string]map[string]float64{
+				"c1/p1": {
+					"n1": 775,
+					"n2": 700,
+					"n3": 700,
+					"n4": 700,
+				},
+				"c1/p2": {
+					"n1": 190.625,
+					"n2": 237.5,
+					"n3": 162.5,
+					"n4": 312.5,
+				},
+				"c1/p3": {
+					"n1": 750,
+					"n2": 600,
+					"n3": 600,
+					"n4": 600,
+				},
+				"c1/p4": {
+					"n1": 181.25,
+					"n2": 162.5,
+					"n3": 125,
+					"n4": 200,
+				},
+			},
+		},
+		{
+			TestCommonStruct: uthelper.TestCommonStruct{
+				Name:      "case4: single job score result with retention policy and resourceStrategyFit",
+				Plugins:   map[string]framework.PluginBuilder{PluginName: New},
+				PodGroups: []*schedulingv1.PodGroup{pg1},
+				Queues:    []*schedulingv1.Queue{queue1},
+				Pods:      []*v1.Pod{p1, p2, p3, p4},
+				Nodes:     []*v1.Node{n1, n2, n3, n4},
+			},
+			arguments: framework.Arguments{
+				"resourceStrategyFitWeight": 8,
+				"resources": map[string]interface{}{
+					"nvidia.com/t4": map[string]interface{}{
+						"type":   "MostAllocated",
+						"weight": 3,
+					},
+					"cpu": map[string]interface{}{
+						"type":   "LeastAllocated",
+						"weight": 1,
+					},
+				},
+				"sra": map[string]interface{}{
+					"policy":    "retention",
+					"resources": "nvidia.com/t4",
+					"retention": map[string]interface{}{
+						"weight":        5,
+						"nvidia.com/t4": 2,
+					},
+				},
+			},
+			expected: map[string]map[string]float64{
+				"c1/p1": {
+					"n1": 1275,
+					"n2": 700,
+					"n3": 1200,
+					"n4": 700,
+				},
+				"c1/p2": {
+					"n1": 190.625,
+					"n2": 237.5,
+					"n3": 162.5,
+					"n4": 312.5,
+				},
+				"c1/p3": {
+					"n1": 750,
+					"n2": 600,
+					"n3": 1100,
+					"n4": 600,
+				},
+				"c1/p4": {
+					"n1": 181.25,
+					"n2": 162.5,
+					"n3": 125,
+					"n4": 200,
+				},
+			},
+		},
+	}
+
+	trueValue := true
+	for i, test := range tests {
+		tiers := []conf.Tier{
+			{
+				Plugins: []conf.PluginOption{
+					{
+						Name:             PluginName,
+						EnabledNodeOrder: &trueValue,
+						Arguments:        test.arguments,
+					},
+				},
+			},
+		}
+		ssn := test.RegisterSession(tiers, nil)
+		for _, job := range ssn.Jobs {
+			for _, task := range job.Tasks {
+				taskID := fmt.Sprintf("%s/%s", task.Namespace, task.Name)
+				for _, node := range ssn.Nodes {
+					score, err := ssn.NodeOrderFn(task, node)
+					if err != nil {
+						t.Errorf("case%d: task %s on node %s has err %v", i+1, taskID, node.Name, err)
+						continue
+					}
+					if expectScore := test.expected[taskID][node.Name]; math.Abs(expectScore-score) > eps {
+						t.Errorf("case%d: task %s on node %s expect have score %v, but get %v", i+1, taskID, node.Name, expectScore, score)
+					}
+				}
+			}
+		}
+	}
+}

--- a/pkg/scheduler/plugins/util/util.go
+++ b/pkg/scheduler/plugins/util/util.go
@@ -137,3 +137,22 @@ func GetInqueueResource(job *api.JobInfo, allocated *api.Resource) *api.Resource
 	}
 	return inqueue
 }
+
+// ShouldAbort determines if the given status indicates that execution should be aborted.
+// It checks if the status code corresponds to any of the following conditions:
+// - UnschedulableAndUnresolvable: Indicates the task cannot be scheduled and resolved.
+// - Error: Represents an error state that prevents further execution.
+// - Wait: Suggests that the process should pause and not proceed further.
+// - Skip: Indicates that the operation should be skipped entirely.
+//
+// Parameters:
+// - status (*api.Status): The status object to evaluate.
+//
+// Returns:
+// - bool: True if the status code matches any of the abort conditions; false otherwise.
+func ShouldAbort(status *api.Status) bool {
+	return status.Code == api.UnschedulableAndUnresolvable ||
+		status.Code == api.Error ||
+		status.Code == api.Wait ||
+		status.Code == api.Skip
+}


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
Prevent task starvation for those requesting critical resources, enhance the utilization of important resources, and thereby achieve more effective task scheduling strategies.
To keep the `predicates` plugin clean, the processing logic of `predicates.proportional` is moved to the `resource-strategy-fit` plugin.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Notice that do not add `Fixes` if the issue is associated with multiple PRs.
-->
Fixes  https://github.com/volcano-sh/volcano/issues/4244

#### Special notes for your reviewer:
_No additional assistance messages_

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
1. Support users to avoid scarce resource nodes when scheduling tasks that do not require scarce resources.
2. Move the processing logic of `predicates.proportional` to the `resource-strategy-fit `plugin and adjust the previous configuration.
```