### PR TITLE
Automated cherry pick of #4422: Move kube-scheduler related metrics initilization to server.go to avoid panic

### DIFF
--- a/cmd/scheduler/app/server.go
+++ b/cmd/scheduler/app/server.go
@@ -28,6 +28,7 @@ import (
 	"volcano.sh/volcano/pkg/kube"
 	"volcano.sh/volcano/pkg/scheduler"
 	"volcano.sh/volcano/pkg/scheduler/framework"
+	"volcano.sh/volcano/pkg/scheduler/metrics"
 	"volcano.sh/volcano/pkg/signals"
 	commonutil "volcano.sh/volcano/pkg/util"
 
@@ -70,6 +71,7 @@ func Run(opt *options.ServerOption) error {
 	}
 
 	if opt.EnableMetrics || opt.EnablePprof {
+		metrics.InitKubeSchedulerRelatedMetrics()
 		go startMetricsServer(opt)
 	}
 

--- a/pkg/scheduler/metrics/metrics.go
+++ b/pkg/scheduler/metrics/metrics.go
@@ -21,6 +21,8 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto" // auto-registry collectors in default registry
+	"k8s.io/component-base/metrics"
+	k8smetrics "k8s.io/kubernetes/pkg/scheduler/metrics"
 )
 
 const (
@@ -147,6 +149,19 @@ var (
 		},
 	)
 )
+
+// InitKubeSchedulerRelatedMetrics is used to init metrics global variables in k8s.io/kubernetes/pkg/scheduler/metrics/metrics.go.
+// We don't use InitMetrics() to init all global variables because currently only "Goroutines" is required when calling kube-scheduler
+// related plugins. And there is no need to export these metrics, therefore currently initialization is enough.
+func InitKubeSchedulerRelatedMetrics() {
+	k8smetrics.Goroutines = metrics.NewGaugeVec(
+		&metrics.GaugeOpts{
+			Subsystem:      VolcanoSubSystemName,
+			Name:           "goroutines",
+			Help:           "Number of running goroutines split by the work they do such as binding.",
+			StabilityLevel: metrics.ALPHA,
+		}, []string{"operation"})
+}
 
 // UpdatePluginDuration updates latency for every plugin
 func UpdatePluginDuration(pluginName, onSessionStatus string, duration time.Duration) {

--- a/pkg/scheduler/plugins/nodeorder/nodeorder_test.go
+++ b/pkg/scheduler/plugins/nodeorder/nodeorder_test.go
@@ -1,0 +1,141 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nodeorder
+
+import (
+	"os"
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	k8smetrics "k8s.io/kubernetes/pkg/scheduler/metrics"
+
+	schedulingv1 "volcano.sh/apis/pkg/apis/scheduling/v1beta1"
+	"volcano.sh/volcano/cmd/scheduler/app/options"
+	"volcano.sh/volcano/pkg/scheduler/actions/allocate"
+	"volcano.sh/volcano/pkg/scheduler/api"
+	"volcano.sh/volcano/pkg/scheduler/conf"
+	"volcano.sh/volcano/pkg/scheduler/framework"
+	"volcano.sh/volcano/pkg/scheduler/plugins/gang"
+	"volcano.sh/volcano/pkg/scheduler/uthelper"
+	"volcano.sh/volcano/pkg/scheduler/util"
+)
+
+func TestMain(m *testing.M) {
+	options.Default()
+	k8smetrics.Register()
+	os.Exit(m.Run())
+}
+
+type nodeOrderTestCase struct {
+	uthelper.TestCommonStruct
+	LeastRequestedWeight int
+	MostRequestedWeight  int
+}
+
+func TestNodeOrderPlugin(t *testing.T) {
+	plugins := map[string]framework.PluginBuilder{
+		PluginName:      New,
+		gang.PluginName: gang.New,
+	}
+
+	tests := []nodeOrderTestCase{
+		{
+			TestCommonStruct: uthelper.TestCommonStruct{
+				Name: "leastAllocated strategy",
+				PodGroups: []*schedulingv1.PodGroup{
+					util.BuildPodGroup("pg1", "c1", "c1", 0, nil, schedulingv1.PodGroupInqueue),
+				},
+				Pods: []*v1.Pod{
+					util.BuildPod("c1", "p1", "", v1.PodPending, api.BuildResourceList("1", "1G"), "pg1", make(map[string]string), make(map[string]string)),
+				},
+				Nodes: []*v1.Node{
+					util.BuildNode("n1", api.BuildResourceList("2", "4Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), make(map[string]string)),
+					util.BuildNode("n2", api.BuildResourceList("4", "8Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), make(map[string]string)),
+				},
+				Queues: []*schedulingv1.Queue{
+					util.BuildQueue("c1", 1, nil),
+				},
+				ExpectBindsNum: 1,
+				ExpectBindMap: map[string]string{
+					"c1/p1": "n2",
+				},
+			},
+			LeastRequestedWeight: 1,
+			MostRequestedWeight:  0,
+		},
+		{
+			TestCommonStruct: uthelper.TestCommonStruct{
+				Name: "mostAllocated strategy",
+				PodGroups: []*schedulingv1.PodGroup{
+					util.BuildPodGroup("pg1", "c1", "c1", 0, nil, schedulingv1.PodGroupInqueue),
+				},
+				Pods: []*v1.Pod{
+					util.BuildPod("c1", "p1", "", v1.PodPending, api.BuildResourceList("1", "1G"), "pg1", make(map[string]string), make(map[string]string)),
+				},
+				Nodes: []*v1.Node{
+					util.BuildNode("n1", api.BuildResourceList("2", "4Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), make(map[string]string)),
+					util.BuildNode("n2", api.BuildResourceList("4", "8Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), make(map[string]string)),
+				},
+				Queues: []*schedulingv1.Queue{
+					util.BuildQueue("c1", 1, nil),
+				},
+				ExpectBindsNum: 1,
+				ExpectBindMap: map[string]string{
+					"c1/p1": "n1",
+				},
+			},
+			LeastRequestedWeight: 0,
+			MostRequestedWeight:  1,
+		},
+	}
+
+	trueValue := true
+
+	for i, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			tiers := []conf.Tier{
+				{
+					Plugins: []conf.PluginOption{
+						{
+							Name:            gang.PluginName,
+							EnabledJobReady: &trueValue,
+						},
+						{
+							Name:             PluginName,
+							EnabledNodeOrder: &trueValue,
+							Arguments: framework.Arguments{
+								LeastRequestedWeight: test.LeastRequestedWeight,
+								MostRequestedWeight:  test.MostRequestedWeight,
+							},
+						},
+					},
+				},
+			}
+
+			test.Plugins = plugins
+			test.RegisterSession(tiers, nil)
+			defer test.Close()
+
+			action := allocate.New()
+			test.Run([]framework.Action{action})
+
+			if err := test.CheckAll(i); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}

--- a/pkg/scheduler/plugins/predicates/predicates.go
+++ b/pkg/scheduler/plugins/predicates/predicates.go
@@ -41,7 +41,6 @@ import (
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/podtopologyspread"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/tainttoleration"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/volumezone"
-	"k8s.io/kubernetes/pkg/scheduler/metrics"
 
 	"volcano.sh/volcano/pkg/scheduler/api"
 	"volcano.sh/volcano/pkg/scheduler/cache"
@@ -405,7 +404,6 @@ func (pp *predicatesPlugin) OnSessionOpen(ssn *framework.Session) {
 		// It is safe here to directly use the state to run plugins because we have already initialized the cycle state
 		// for each pending pod when open session and will not meet nil state
 		state := ssn.GetCycleState(task.UID)
-		metrics.Register()
 		// Check NodePorts
 		if predicate.nodePortEnable {
 			_, status := nodePortFilter.PreFilter(context.TODO(), state, task.Pod)

--- a/pkg/scheduler/uthelper/helper.go
+++ b/pkg/scheduler/uthelper/helper.go
@@ -37,8 +37,13 @@ import (
 	"volcano.sh/volcano/pkg/scheduler/cache"
 	"volcano.sh/volcano/pkg/scheduler/conf"
 	"volcano.sh/volcano/pkg/scheduler/framework"
+	"volcano.sh/volcano/pkg/scheduler/metrics"
 	"volcano.sh/volcano/pkg/scheduler/util"
 )
+
+func init() {
+	metrics.InitKubeSchedulerRelatedMetrics()
+}
 
 // RegisterPlugins plugins
 func RegisterPlugins(plugins map[string]framework.PluginBuilder) {


### PR DESCRIPTION
Cherry pick of #4422 on release-1.12.

#4422: Move kube-scheduler related metrics initilization to server.go to avoid panic
For details on the cherry pick process, see the [cherry picks](https://github.com/volcano-sh/volcano/tree/master/docs/development/cherry-picks.md) page.
```release-note
NONE
```