### PR TITLE
Correct step order to enable caching in E2E workflows

### DIFF
--- a/.github/workflows/e2e_dra.yml
+++ b/.github/workflows/e2e_dra.yml
@@ -24,6 +24,8 @@ jobs:
           tar -xf musl-1.2.1.tar.gz && cd musl-1.2.1
           ./configure
           make && sudo make install
+      - name: Checkout code
+        uses: actions/checkout@v3
       - uses: actions/cache@v4
         with:
           path: ~/go/pkg/mod
@@ -33,8 +35,6 @@ jobs:
         run: |
           GO111MODULE="on" go install sigs.k8s.io/kind@v0.29.0
           curl -LO https://dl.k8s.io/release/v1.32.0/bin/linux/amd64/kubectl && sudo install kubectl /usr/local/bin/kubectl
-      - name: Checkout code
-        uses: actions/checkout@v3
 
       - name: Run E2E Tests
         run: |

--- a/.github/workflows/e2e_parallel_jobs.yaml
+++ b/.github/workflows/e2e_parallel_jobs.yaml
@@ -28,6 +28,8 @@ jobs:
           tar -xf musl-1.2.1.tar.gz && cd musl-1.2.1
           ./configure
           make && sudo make install
+      - name: Checkout code
+        uses: actions/checkout@v3
       - uses: actions/cache@v4
         with:
           path: ~/go/pkg/mod
@@ -37,8 +39,6 @@ jobs:
         run: |
           GO111MODULE="on" go install sigs.k8s.io/kind@v0.29.0
           curl -LO https://dl.k8s.io/release/v1.32.0/bin/linux/amd64/kubectl && sudo install kubectl /usr/local/bin/kubectl
-      - name: Checkout code
-        uses: actions/checkout@v3
 
       - name: Run E2E Tests
         run: |

--- a/.github/workflows/e2e_scheduling_actions.yaml
+++ b/.github/workflows/e2e_scheduling_actions.yaml
@@ -24,6 +24,8 @@ jobs:
           tar -xf musl-1.2.1.tar.gz && cd musl-1.2.1
           ./configure
           make && sudo make install
+      - name: Checkout code
+        uses: actions/checkout@v3
       - uses: actions/cache@v4
         with:
           path: ~/go/pkg/mod
@@ -33,8 +35,6 @@ jobs:
         run: |
           GO111MODULE="on" go install sigs.k8s.io/kind@v0.29.0
           curl -LO https://dl.k8s.io/release/v1.32.0/bin/linux/amd64/kubectl && sudo install kubectl /usr/local/bin/kubectl
-      - name: Checkout code
-        uses: actions/checkout@v3
 
       - name: Run E2E Tests
         run: |

--- a/.github/workflows/e2e_scheduling_basic.yaml
+++ b/.github/workflows/e2e_scheduling_basic.yaml
@@ -24,6 +24,8 @@ jobs:
           tar -xf musl-1.2.1.tar.gz && cd musl-1.2.1
           ./configure
           make && sudo make install
+      - name: Checkout code
+        uses: actions/checkout@v3
       - uses: actions/cache@v4
         with:
           path: ~/go/pkg/mod
@@ -33,8 +35,6 @@ jobs:
         run: |
           GO111MODULE="on" go install sigs.k8s.io/kind@v0.29.0
           curl -LO https://dl.k8s.io/release/v1.32.0/bin/linux/amd64/kubectl && sudo install kubectl /usr/local/bin/kubectl
-      - name: Checkout code
-        uses: actions/checkout@v3
 
       - name: Run E2E Tests
         run: |

--- a/.github/workflows/e2e_vcctl.yaml
+++ b/.github/workflows/e2e_vcctl.yaml
@@ -24,6 +24,8 @@ jobs:
           tar -xf musl-1.2.1.tar.gz && cd musl-1.2.1
           ./configure
           make && sudo make install
+      - name: Checkout code
+        uses: actions/checkout@v3
       - uses: actions/cache@v4
         with:
           path: ~/go/pkg/mod
@@ -33,8 +35,6 @@ jobs:
         run: |
           GO111MODULE="on" go install sigs.k8s.io/kind@v0.29.0
           curl -LO https://dl.k8s.io/release/v1.32.0/bin/linux/amd64/kubectl && sudo install kubectl /usr/local/bin/kubectl
-      - name: Checkout code
-        uses: actions/checkout@v3
 
       - name: Run E2E Tests
         run: |


### PR DESCRIPTION
This PR fixes a bug in the E2E workflows where Go module caching was ineffective.

The `actions/cache` step was running before `actions/checkout`, so the cache key could not be generated from the `go.sum` file. This change reorders the steps, which will properly enable caching and improve the performance of the E2E jobs.