### PR TITLE
Integrate with leaderworkerset: Volcano controller doesn't need to create podgroup for statefulset if statefulset pods have associated podgroup

### DIFF
--- a/pkg/controllers/podgroup/pg_controller_handler.go
+++ b/pkg/controllers/podgroup/pg_controller_handler.go
@@ -148,6 +148,12 @@ func (pg *pgcontroller) addStatefulSet(obj interface{}) {
 				klog.V(4).Infof("Pod %s field SchedulerName is not matched", klog.KObj(pod))
 				return
 			}
+			// If the pod is already associated with a podgroup, skip creating a new one. This scenario is applicable to LeaderWorkerSet,
+			// which will create podgroups by itself, and Volcano does not need to create a podgroup for statefulset.
+			if pgName := pod.Annotations[scheduling.KubeGroupNameAnnotationKey]; pgName != "" {
+				klog.V(4).Infof("Pod %s is already associated with a podgroup %s", klog.KObj(pod), pgName)
+				return
+			}
 			err := pg.createNormalPodPGIfNotExist(pod)
 			if err != nil {
 				klog.Errorf("Failed to create PodGroup for pod <%s/%s>: %v", pod.Namespace, pod.Name, err)


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
Currently, volcano will list/watch statefulsets and create pg for the statefulset if it doesn't have a related one. But in leaderWorkerSet scenario, lws uses statefulset as the basic resource:
<img width="840" height="687" alt="image" src="https://github.com/user-attachments/assets/c0ef99dc-a6a4-4098-bf7a-40666b0afe06" />
Leader has a statefulset and workers have their own statefulsets, as in the pic shown above, 4 replicas lws will create 5 pgs(5 statefulsets). But now we want to schedule 1 replica as a group( means 1 leader pod + (size-1) worker pods), just like the red box in the picture, we only need to create 4 pgs instead. Therefore we need to add a judgement in addStatefulset, if the pods already have pg annotation, skip creating pg

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Notice that do not add `Fixes` if the issue is associated with multiple PRs.
-->
Related https://github.com/kubernetes-sigs/lws/pull/496

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```