### PR TITLE
fix: Volcano scheduler panic when scheduling Pods with delayed binding PVCs

### DIFF
--- a/pkg/scheduler/capabilities/volumebinding/binder.go
+++ b/pkg/scheduler/capabilities/volumebinding/binder.go
@@ -977,6 +977,12 @@ func (b *volumeBinder) revertAssumedPVCs(claims []*v1.PersistentVolumeClaim) {
 // hasEnoughCapacity checks whether the provisioner has enough capacity left for a new volume of the given size
 // that is available from the node. This function returns the node capacity based on the PVC's storage class.
 func (b *volumeBinder) hasEnoughCapacity(logger klog.Logger, provisioner string, claim *v1.PersistentVolumeClaim, storageClass *storagev1.StorageClass, node *v1.Node) (bool, *storagev1beta1.CSIStorageCapacity, error) {
+	// This is an optional feature. If disabled, we assume that
+	// there is enough storage.
+	if !b.capacityCheckEnabled {
+		return true, nil, nil
+	}
+
 	quantity, ok := claim.Spec.Resources.Requests[v1.ResourceStorage]
 	if !ok {
 		// No capacity to check for.

--- a/pkg/scheduler/capabilities/volumebinding/binder_test.go
+++ b/pkg/scheduler/capabilities/volumebinding/binder_test.go
@@ -25,7 +25,6 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
-
 	v1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	storagev1beta1 "k8s.io/api/storage/v1beta1"
@@ -2356,5 +2355,22 @@ func TestCapacity(t *testing.T) {
 				t.Run(name, func(t *testing.T) { run(t, scenario, optIn) })
 			}
 		})
+	}
+}
+
+func TestBinderWithCapacityCheckDisabled(t *testing.T) {
+	logger, ctx := ktesting.NewTestContext(t)
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	binder := &volumeBinder{
+		capacityCheckEnabled: false,
+	}
+	sufficient, _, err := binder.hasEnoughCapacity(logger, "", nil, nil, nil)
+	if err != nil {
+		t.Errorf("returned error: %v", err)
+	}
+	if !sufficient {
+		t.Error("expected sufficient, got insufficient")
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?
bugfix

#### What this PR does / why we need it:
volcano-scheduler with the startup argument `--csi-storage=false`(the argument defaults false), will panic when scheduling Pods with delayed binding PVCs.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Notice that do not add `Fixes` if the issue is associated with multiple PRs.
-->
Fixes #4480

#### Special notes for your reviewer:
@JesseStutler 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```