### PR TITLE
[cherry-pick for 1.12]Fix incorrect definition of ReleaseNameEnvKey

### DIFF
--- a/pkg/controllers/hypernode/config/loader.go
+++ b/pkg/controllers/hypernode/config/loader.go
@@ -32,7 +32,7 @@ type Loader interface {
 
 const (
 	NamespaceEnvKey    = "KUBE_POD_NAMESPACE"
-	ReleaseNameEnvKey  = "RELEASE_NAME"
+	ReleaseNameEnvKey  = "HELM_RELEASE_NAME"
 	DefaultReleaseName = "volcano"
 
 	DefaultNamespace = "volcano-system"


### PR DESCRIPTION
(cherry picked from commit f2c0abe79d56c3ecfa7bef464a9c55a3dd4b240f)

#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
Fix incorrect definition of `ReleaseNameEnvKey`

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Notice that do not add `Fixes` if the issue is associated with multiple PRs.
-->
Fixes #4485

#### Special notes for your reviewer:
@Monokaix @JesseStutler 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```