### PR TITLE
fix#4497: hypernode update bug

### DIFF
--- a/pkg/controllers/hypernode/utils/utils.go
+++ b/pkg/controllers/hypernode/utils/utils.go
@@ -64,6 +64,7 @@ func UpdateHyperNode(vcClient vcclientset.Interface, lister v1alpha1.HyperNodeLi
 		}
 
 		_, err = vcClient.TopologyV1alpha1().HyperNodes().Update(context.Background(), current, metav1.UpdateOptions{})
+		_, err = vcClient.TopologyV1alpha1().HyperNodes().UpdateStatus(context.Background(), current, metav1.UpdateOptions{})
 		return err
 	})
 }

--- a/pkg/controllers/hypernode/utils/utils.go
+++ b/pkg/controllers/hypernode/utils/utils.go
@@ -63,7 +63,7 @@ func UpdateHyperNode(vcClient vcclientset.Interface, lister v1alpha1.HyperNodeLi
 			current.Annotations[k] = v
 		}
 
-		_, err = vcClient.TopologyV1alpha1().HyperNodes().UpdateStatus(context.Background(), current, metav1.UpdateOptions{})
+		_, err = vcClient.TopologyV1alpha1().HyperNodes().Update(context.Background(), current, metav1.UpdateOptions{})
 		return err
 	})
 }


### PR DESCRIPTION
#### What type of PR is this?
fix
#### What this PR does / why we need it:
Hypernode controller will ignore updating spec, as it only calls UpdateStatus() to update hypernode. When I test the function of autoupdate, hypernode spec will never be updated since it's created. So we should add Update() call.
#### Which issue(s) this PR fixes:
#4497 
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Notice that do not add `Fixes` if the issue is associated with multiple PRs.
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```