### PR TITLE
inherit non-existent scalar resources from the parent queue

### DIFF
--- a/pkg/scheduler/plugins/capacity/capacity.go
+++ b/pkg/scheduler/plugins/capacity/capacity.go
@@ -774,6 +774,19 @@ func (cp *capacityPlugin) checkHierarchicalQueue(attr *queueAttr) error {
 		if childAttr.capability.Memory <= 0 {
 			childAttr.capability.Memory = attr.capability.Memory
 		}
+
+		// Inherit scalar resources from parent if child's scalar resources is nil or some fields are not set
+		if attr.capability.ScalarResources != nil {
+			if childAttr.capability.ScalarResources == nil {
+				childAttr.capability.ScalarResources = make(map[v1.ResourceName]float64)
+			}
+			for k, v := range attr.capability.ScalarResources {
+				if _, exists := childAttr.capability.ScalarResources[k]; !exists {
+					childAttr.capability.ScalarResources[k] = v
+				}
+			}
+		}
+
 		// Check if the parent queue's capability is less than the child queue's capability
 		if attr.capability.LessPartly(childAttr.capability, api.Zero) {
 			return fmt.Errorf("queue <%s> capability <%s> is less than its child queue <%s> capability <%s>",

--- a/pkg/scheduler/plugins/capacity/capacity_test.go
+++ b/pkg/scheduler/plugins/capacity/capacity_test.go
@@ -472,6 +472,20 @@ func Test_capacityPlugin_OnSessionOpenWithHierarchy(t *testing.T) {
 	// queue
 	queue10 := buildQueueWithParents("q10", "root", nil, api.BuildResourceList("10", "4Gi", []api.ScalarResource{}...))
 
+	// resources for test case 11
+	// queue
+	case11_queue1 := buildQueueWithParents("case11_queue1", "root", nil, nil)                                                                                                         // 指定部分 scalar resources
+	case11_queue11 := buildQueueWithParents("case11_queue11", "case11_queue1", nil, api.BuildResourceList("4", "4Gi", []api.ScalarResource{{Name: "nvidia.com/gpu", Value: "4"}}...)) // 指定部分 scalar resources
+	case11_queue12 := buildQueueWithParents("case11_queue12", "case11_queue1", nil, api.BuildResourceList("4", "4Gi", []api.ScalarResource{{Name: "nvidia.com/gpu", Value: "4"}}...)) // 指定部分 scalar resources
+
+	// podgroup
+	pg14 := util.BuildPodGroup("pg14", "ns1", "case11_queue11", 1, nil, schedulingv1beta1.PodGroupInqueue)
+	pg15 := util.BuildPodGroup("pg15", "ns1", "case11_queue12", 1, nil, schedulingv1beta1.PodGroupInqueue)
+
+	// pod
+	p14 := util.BuildPod("ns1", "p14", "", corev1.PodPending, api.BuildResourceList("1", "1Gi", []api.ScalarResource{{Name: "nvidia.com/gpu", Value: "4"}}...), "pg14", make(map[string]string), map[string]string{})
+	p15 := util.BuildPod("ns1", "p15", "", corev1.PodPending, api.BuildResourceList("1", "1Gi", []api.ScalarResource{{Name: "nvidia.com/gpu", Value: "4"}}...), "pg15", make(map[string]string), map[string]string{})
+
 	tests := []uthelper.TestCommonStruct{
 		{
 			Name:      "case0: Pod allocatable when queue is leaf queue",
@@ -589,6 +603,19 @@ func Test_capacityPlugin_OnSessionOpenWithHierarchy(t *testing.T) {
 			Plugins: plugins,
 			Nodes:   []*corev1.Node{n1},
 			Queues:  []*schedulingv1beta1.Queue{root1, queue10},
+		},
+		{
+			Name:      "case11: If the capability scalar resources is not specified, the value should be inherited from parent queue",
+			Plugins:   plugins,
+			Pods:      []*corev1.Pod{p14, p15},
+			Nodes:     []*corev1.Node{n2},
+			PodGroups: []*schedulingv1beta1.PodGroup{pg14, pg15},
+			Queues:    []*schedulingv1beta1.Queue{root, case11_queue1, case11_queue11, case11_queue12},
+			ExpectBindMap: map[string]string{
+				"ns1/p14": "n2",
+				"ns1/p15": "n2",
+			},
+			ExpectBindsNum: 2,
 		},
 	}
 


### PR DESCRIPTION
#### What type of PR is this?

fix

#### What this PR does / why we need it:

non-existent scalar resources of capacity do not inherit from the parent queue, only memory and cpu resource of capacity inherit from parent.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Notice that do not add `Fixes` if the issue is associated with multiple PRs.
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```