### PR TITLE
Fix bump version script

### DIFF
--- a/hack/bump-version.sh
+++ b/hack/bump-version.sh
@@ -193,7 +193,7 @@ echo "${NEW_VERSION}" > "${RELEASE_VERSION_FILE}"
 echo "+++ Updating ${CHART_YAML}"
 if [[ -f "${CHART_YAML}" ]]; then
     sed -i.bak "s/^version: .*/version: \"${CHART_VERSION}\"/" "${CHART_YAML}"
-    sed -i.bak "s/^appVersion: .*/appVersion: \"${NEW_VERSION}\"/" "${CHART_YAML}"
+    sed -i.bak "s/^appVersion: .*/appVersion: \"${CHART_VERSION}\"/" "${CHART_YAML}"
     rm -f "${CHART_YAML}.bak"
 fi
 
@@ -234,7 +234,7 @@ fi
 # Commit changes
 echo "+++ Committing changes"
 git add .
-git commit -m "chore: bump version to ${NEW_VERSION}
+git commit -s -m "chore: bump version to ${NEW_VERSION}
 
 - Update .release-version to ${NEW_VERSION}
 - Update Chart version to ${CHART_VERSION}


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
1.  bump version missed to use `git commit -s` to sign commit, it will cause the auto PR's CI failed
2. The chart's `appVersion` does not need a `v` prefix, therefore needs to modify the script

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Notice that do not add `Fixes` if the issue is associated with multiple PRs.
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```