### PR TITLE
feat: add detail msg for pg event

### DIFF
--- a/pkg/scheduler/plugins/proportion/proportion.go
+++ b/pkg/scheduler/plugins/proportion/proportion.go
@@ -319,7 +319,7 @@ func (pp *proportionPlugin) OnSessionOpen(ssn *framework.Session) {
 
 		attr := pp.queueOpts[queue.UID]
 		futureUsed := attr.allocated.Clone().Add(candidate.Resreq)
-		allocatable := futureUsed.LessEqualWithDimension(attr.deserved, candidate.Resreq)
+		allocatable, _ := futureUsed.LessEqualWithDimensionAndResourcesName(attr.deserved, candidate.Resreq)
 		if !allocatable {
 			klog.V(3).Infof("Queue <%v>: deserved <%v>, allocated <%v>; Candidate <%v>: resource request <%v>",
 				queue.Name, attr.deserved, attr.allocated, candidate.Name, candidate.Resreq)
@@ -345,7 +345,7 @@ func (pp *proportionPlugin) OnSessionOpen(ssn *framework.Session) {
 		}
 
 		futureUsed := attr.allocated.Clone().Add(candidate.Resreq)
-		allocatable := futureUsed.LessEqualWithDimension(attr.deserved, candidate.Resreq)
+		allocatable, _ := futureUsed.LessEqualWithDimensionAndResourcesName(attr.deserved, candidate.Resreq)
 		if !allocatable {
 			klog.V(3).Infof("Queue <%v>: deserved <%v>, allocated <%v>; Candidate <%v>: resource request <%v>",
 				queue.Name, attr.deserved, attr.allocated, candidate.Name, candidate.Resreq)
@@ -402,7 +402,7 @@ func (pp *proportionPlugin) OnSessionOpen(ssn *framework.Session) {
 		// The queue resource quota limit has not reached
 		r := minReq.Clone().Add(attr.allocated).Add(attr.inqueue).Sub(attr.elastic)
 
-		inqueue := r.LessEqualWithDimension(attr.realCapability, minReq)
+		inqueue, resourceNames := r.LessEqualWithDimensionAndResourcesName(attr.realCapability, minReq)
 		klog.V(5).Infof("job %s inqueue %v", job.Name, inqueue)
 		if inqueue {
 			// deduct the resources of scheduling gated tasks in a job when calculating inqueued resources
@@ -410,7 +410,7 @@ func (pp *proportionPlugin) OnSessionOpen(ssn *framework.Session) {
 			attr.inqueue.Add(job.DeductSchGatedResources(minReq))
 			return util.Permit
 		}
-		ssn.RecordPodGroupEvent(job.PodGroup, v1.EventTypeNormal, string(scheduling.PodGroupUnschedulableType), "queue resource quota insufficient")
+		ssn.RecordPodGroupEvent(job.PodGroup, v1.EventTypeNormal, string(scheduling.PodGroupUnschedulableType), util.FormatResourceNames("queue resource quota insufficient", "insufficient", resourceNames))
 		return util.Reject
 	})
 

--- a/pkg/scheduler/plugins/util/util.go
+++ b/pkg/scheduler/plugins/util/util.go
@@ -23,6 +23,7 @@ limitations under the License.
 package util
 
 import (
+	"fmt"
 	"strings"
 
 	v1 "k8s.io/api/core/v1"
@@ -136,4 +137,18 @@ func GetInqueueResource(job *api.JobInfo, allocated *api.Resource) *api.Resource
 		}
 	}
 	return inqueue
+}
+
+// FormatResourceNames formats a list of resource names into a human-readable string.
+func FormatResourceNames(prefix, verb string, resourceNames []string) string {
+	if len(resourceNames) == 0 {
+		return prefix
+	}
+
+	var parts []string
+	for _, name := range resourceNames {
+		parts = append(parts, fmt.Sprintf("%s %s", verb, name))
+	}
+
+	return fmt.Sprintf("%s: %s", prefix, strings.Join(parts, ", "))
 }


### PR DESCRIPTION
#### What type of PR is this?
Just as I mentioned in #4311, now event in podgroup is not detailed. Many times, we may have to adjust vc-scheduler to 5 and watch scheduler's log to locate the problem. This PR supplements the event information to help us quickly locate the resource name when one of the resource is insufficient or overused, like kube-scheduler.

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

Fixes #https://github.com/volcano-sh/volcano/issues/4311

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```