### PR TITLE
feat: add extra args to scheduler deployment args

### DIFF
--- a/installer/helm/chart/volcano/templates/scheduler.yaml
+++ b/installer/helm/chart/volcano/templates/scheduler.yaml
@@ -230,6 +230,9 @@ spec:
             - --ignored-provisioners={{ .Values.custom.ignored_provisioners}}
             {{- end}}
             - -v={{.Values.custom.scheduler_log_level}}
+            {{- range .Values.custom.scheduler_extra_args }}
+            - {{ . }}
+            {{- end }}
             - 2>&1
           env:
             - name: DEBUG_SOCKET_DIR


### PR DESCRIPTION
#### What type of PR is this?
helm chart update

#### What this PR does / why we need it:
This PR allows users to specify extra arguments to scheduler, for example `--default-queue`

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
add scheduler_extra_args to the custom section in the helm chart
```