### PR TITLE
fix high-priority jobs reclaiming resources and excessively killing l…

### DIFF
--- a/docs/design/session-persisted-state.md
+++ b/docs/design/session-persisted-state.md
@@ -1,0 +1,138 @@
+# Volcano Scheduler: Task State Persistence Across Sessions 
+
+
+## Background
+
+Under heavy preemption/reclaim, high-priority jobs could reclaim resources too aggressively, leading to excessive evictions (“overkill”) of low-priority jobs and instability. Pipelined tasks (pre-allocated but not bound) lost state across sessions, causing duplicate decisions, mis-accounting, and oscillations. Plugins could observe inconsistent resource accounting during rapid pipeline → allocate → unallocate transitions.
+
+## Goals
+
+- Preserve and reconcile pipelined state across scheduler sessions.
+- Reduce unnecessary evictions and duplicate work.
+- Make allocation deterministic for pipelined tasks.
+- Prevent negative/invalid plugin accounting under churn.
+- Improve resiliency against concurrent state changes in the Kubernetes API.
+
+## Non-Goals
+
+- Redesign Volcano’s event model or plugin API.
+- Introduce new CRDs or controllers.
+- Change gang scheduling semantics.
+
+---
+
+## High-Level Design
+
+### Persist pipelined state on Pods (annotations)
+
+```go
+// pkg/scheduler/api/helpers.go
+const (
+  VolcanoPipelinedStatusAnnotation   = "volcano.sh/pipelined-status"
+  VolcanoPipelinedNodeAnnotation     = "volcano.sh/pipelined-node"
+  VolcanoEvictionOccurredAnnotation  = "volcano.sh/eviction-occurred"
+)
+```
+
+- On pipeline: set `pipelined-status=true` and `pipelined-node=<name>`.
+- On allocate (final bind): clear pipeline annotations.
+- On unallocate originating from a pipelined state: restore `pipelined-*` instead of resetting to `Pending`.
+- During reclaim: record `eviction-occurred=true` when victims are chosen.
+
+### Deterministic allocation for pipelined tasks
+
+- If a task is already pipelined to a node and the node becomes available, allocate via a fast path that avoids duplicate node ops and stale pipeline state.
+- Predicate helper recognizes pipelined tasks to the same node and short-circuits checks to prevent redundant work.
+
+### Harden plugins and resource comparisons
+
+- DRF, Capacity, Proportion plugins guard against underflow/negative deallocations and improve logs.
+- Resource comparisons (`LessEqualWithDimension`) ignore dimensions not configured for a queue (e.g., GPU scalar), avoiding spurious failures.
+
+### Safer cache/binder and framework updates
+
+- Binder: treat “already bound to same node” as success; if bound elsewhere, fail and clear annotations.
+- Annotation updates via a single abstraction to avoid GET/UPDATE drift; prefer PATCH.
+- Session/Statement ensure plugin callbacks are invoked exactly once on final allocation.
+
+---
+
+## Detailed Changes and Rationale
+
+### Actions
+
+**Allocate**
+- Add fast path to bind already-pipelined tasks once resources are free on the pipelined node.
+- Filter nil nodes, add defensive checks, and prevent duplicate AddTask on nodes for pipelined → final allocation.
+- Predicate: if task is pipelined to the node, skip full resource check; if the task moved, release stale pipelined accounting.
+
+**Reclaim**
+- When selecting victims, set `EvictionOccurred` and propagate via annotations; improves traceability and reduces unnecessary follow-on evictions.
+
+### Framework (Session/Statement)
+
+- On pipeline/unpipeline/allocate, set/clear pipelined annotations through a **single** annotations updater.
+- Unallocate from a pipelined origin restores pipelined status and avoids double deallocation & node removal.
+- Add `Operation.String()` helper and targeted annotations update to avoid clobbering third‑party annotations.
+
+### Cache/Binder
+
+- Binder checks current binding:
+  - If already bound to target node → succeed & clear pipeline annotations.
+  - If bound to a different node → error and clear pipeline annotations for consistency.
+- Add retry for conflict-prone updates (Unschedulable condition, nominated node).
+- Expose `GetStatusUpdater` and `UpdatePodAnnotations` for annotations‑only writes.
+
+### API / Helpers
+
+- `getTaskStatus` prefers annotations-derived `Pipelined` over Pod phase for accuracy across sessions.
+- `NewTaskInfo` restores pipelined node and eviction flag; includes `Pipelined` in readiness/allocated counts.
+- Helpers to set/clear/read pipelined annotations.
+
+### Plugins
+
+- **DRF/Capacity/Proportion:** guard deallocation to never subtract more than allocated, protect ancestor totals, and clarify logs.
+- **Capacity:** relax strict root queue capability/deserved/guarantee enforcement; enforce only on non-root queues.
+
+### Resources
+
+- `LessEqualWithDimension`: ignore dimensions with zero/undefined config in the queue (e.g., GPUs not configured), keeping CPU/memory scheduling unblocked.
+
+### Utils
+
+- `predicate_helper.go`: early exit on matching pipelined node; avoid re-alloc attempts to nodes where the same task is present in another status.
+
+---
+
+## Behavioral Impact
+
+- **Stability:** pipelined tasks resume correctly after session reopen; fewer duplicate pipeline/allocate loops.
+- **Efficiency:** reduced overkill in reclaim; fewer unnecessary evictions.
+- **Correctness:** plugins avoid underflow and negatives under churn.
+- **Compatibility:** queues without GPU dimensions schedule CPU/memory workloads without scalar-related blocks.
+
+---
+
+## Backward Compatibility
+
+- New annotations are additive and benign for older components.
+- Plugin changes are defensive (no behavior breaks).
+- Capacity plugin’s relaxed root semantics may affect deployments depending on strict root validation—documented below.
+
+
+## Risks and Mitigations
+
+- **Plugin accounting drift:** If AllocateFunc is skipped for pipelined tasks, plugins may under-account.
+  - *Mitigation:* Ensure AllocateFunc executes exactly once on final allocation (even for pipelined tasks). Only skip if a future PipelineFunc provides equivalent accounting.
+- **API write amplification:** Frequent annotation updates on large clusters.
+  - *Mitigation:* Batch/coalesce updates and switch to PATCH; avoid writes when values unchanged.
+- **Get → Bind races:** Still possible in extreme churn.
+  - *Mitigation:* Binder clears annotations on success/failure; consider binding preconditions or further retries.
+
+---
+
+## TL;DR
+
+- Persist pipelined state via Pod annotations and reconcile on allocate/unallocate; reclaim propagates eviction context.
+- Plugins are hardened against deallocation underflow; resource dimensionality checks are queue-aware; root queue constraints are eased.
+- Next steps: keep AllocateFunc for pipelined allocations, switch annotations to PATCH, and add metrics + tests for pipeline fast-path.

--- a/pkg/scheduler/api/job_info_test.go
+++ b/pkg/scheduler/api/job_info_test.go
@@ -343,9 +343,9 @@ func TestJobInfo(t *testing.T) {
 				newTaskFunc("running-unbesteffort-task-1", "job-1", Running, NewResource(v1.ResourceList{"cpu": resource.MustParse("100m")})),
 			},
 			expectedPendingBestEffortTaskNum: 1,
-			expectedIsReady:                  false,
+			expectedIsReady:                  true,
 			expectedIsPipelined:              true,
-			expectedIsStarving:               true,
+			expectedIsStarving:               false,
 		},
 
 		{

--- a/pkg/scheduler/cache/cache.go
+++ b/pkg/scheduler/cache/cache.go
@@ -18,6 +18,7 @@ package cache
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"strconv"
@@ -31,6 +32,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -208,6 +210,39 @@ func (db *DefaultBinder) Bind(kubeClient kubernetes.Interface, tasks []*scheduli
 	errMsg := make(map[schedulingapi.TaskID]string)
 	for _, task := range tasks {
 		p := task.Pod
+		// Check if pod is already bound to avoid conflicts
+		currentPod, err := db.kubeclient.CoreV1().Pods(p.Namespace).Get(context.TODO(), p.Name, metav1.GetOptions{})
+		if err != nil {
+			klog.Errorf("Failed to get current pod <%v/%v> status before binding: %v", p.Namespace, p.Name, err)
+			errMsg[task.UID] = err.Error()
+			continue
+		}
+
+		// If pod is already assigned to a node
+		if len(currentPod.Spec.NodeName) > 0 {
+			if currentPod.Spec.NodeName == task.NodeName {
+				// Pod is already bound to the correct node, consider it successful
+				klog.V(3).Infof("Pod <%v/%v> is already bound to target node <%s>, skipping bind",
+					p.Namespace, p.Name, task.NodeName)
+				metrics.UpdateTaskScheduleDuration(metrics.Duration(p.CreationTimestamp.Time))
+
+				// Clear pipelined annotations even when already bound to correct node
+				db.clearPipelinedAnnotations(p)
+				continue
+			} else {
+				// Pod is bound to a different node, this is an error
+				errorMsg := fmt.Sprintf("pod is already assigned to node %s, cannot bind to %s",
+					currentPod.Spec.NodeName, task.NodeName)
+				klog.Errorf("Failed to bind pod <%v/%v>: %s", p.Namespace, p.Name, errorMsg)
+				errMsg[task.UID] = errorMsg
+
+				// Clear pipelined annotations even when binding fails due to node conflict
+				db.clearPipelinedAnnotations(p)
+				continue
+			}
+		}
+
+		// Pod is not bound, proceed with normal binding
 		if err := db.kubeclient.CoreV1().Pods(p.Namespace).Bind(context.TODO(),
 			&v1.Binding{
 				ObjectMeta: metav1.ObjectMeta{Namespace: p.Namespace, Name: p.Name, UID: p.UID, Annotations: p.Annotations},
@@ -225,6 +260,47 @@ func (db *DefaultBinder) Bind(kubeClient kubernetes.Interface, tasks []*scheduli
 	}
 
 	return errMsg
+}
+
+// clearPipelinedAnnotations removes pipelined annotations from pod after successful binding
+func (db *DefaultBinder) clearPipelinedAnnotations(pod *v1.Pod) {
+	// Get the latest pod version to avoid conflicts
+	currentPod, err := db.kubeclient.CoreV1().Pods(pod.Namespace).Get(context.TODO(), pod.Name, metav1.GetOptions{})
+	if err != nil {
+		klog.Errorf("Failed to get pod <%v/%v> for clearing annotations: %v", pod.Namespace, pod.Name, err)
+		return
+	}
+
+	// Check if pipelined annotations exist
+	if currentPod.Annotations == nil {
+		return
+	}
+
+	// Check if any pipelined annotations exist before proceeding
+	hasAnnotations := false
+	for _, key := range []string{schedulingapi.VolcanoPipelinedStatusAnnotation, schedulingapi.VolcanoPipelinedNodeAnnotation, schedulingapi.VolcanoEvictionOccurredAnnotation} {
+		if _, exists := currentPod.Annotations[key]; exists {
+			hasAnnotations = true
+			break
+		}
+	}
+
+	if !hasAnnotations {
+		return
+	}
+
+	podCopy := currentPod.DeepCopy()
+	// Reuse existing function to clear pipelined annotations
+	schedulingapi.ClearPipelinedAnnotations(podCopy)
+
+	// Update annotations to Kubernetes API
+	if _, err := db.kubeclient.CoreV1().Pods(podCopy.Namespace).Update(context.TODO(), podCopy, metav1.UpdateOptions{}); err != nil {
+		klog.Errorf("Failed to update pod <%v/%v> annotations after clearing pipelined annotations: %v",
+			podCopy.Namespace, podCopy.Name, err)
+	} else {
+		klog.V(3).Infof("Successfully cleared pipelined annotations from pod <%v/%v>",
+			podCopy.Namespace, podCopy.Name)
+	}
 }
 
 // NewDefaultBinder create binder with kube client and event recorder, support fake binder if passed fake client and fake event recorder
@@ -324,6 +400,30 @@ func podNominatedNodeNameNeedUpdate(status *v1.PodStatus, nodeName string) bool 
 // UpdatePodStatus will Update pod status
 func (su *defaultStatusUpdater) UpdatePodStatus(pod *v1.Pod) (*v1.Pod, error) {
 	return su.kubeclient.CoreV1().Pods(pod.Namespace).UpdateStatus(context.TODO(), pod, metav1.UpdateOptions{})
+}
+
+// UpdatePodAnnotations will Update pod annotations
+func (su *defaultStatusUpdater) UpdatePodAnnotations(pod *v1.Pod) (*v1.Pod, error) {
+	// Use strategic merge patch to update only annotations
+	if pod == nil {
+		return nil, fmt.Errorf("nil pod passed to UpdatePodAnnotations")
+	}
+	patchObj := map[string]interface{}{
+		"metadata": map[string]interface{}{
+			"annotations": pod.Annotations,
+		},
+	}
+	patchBytes, err := json.Marshal(patchObj)
+	if err != nil {
+		return nil, err
+	}
+	return su.kubeclient.CoreV1().Pods(pod.Namespace).Patch(
+		context.TODO(),
+		pod.Name,
+		types.StrategicMergePatchType,
+		patchBytes,
+		metav1.PatchOptions{},
+	)
 }
 
 // UpdatePodGroup will Update PodGroup
@@ -1238,6 +1338,36 @@ func (sc *SchedulerCache) AddBindTask(bindContext *BindContext) error {
 	}
 	task.NumaInfo = bindContext.TaskInfo.NumaInfo.Clone()
 
+	// Handle task node conflict: if task is already assigned to any node, clean up the old assignment first
+	if len(task.NodeName) > 0 {
+		if task.NodeName != bindContext.TaskInfo.NodeName {
+			klog.V(4).Infof("Task <%s> is already assigned to node <%s>, but trying to bind to <%s>. Cleaning up old assignment.",
+				task.Name, task.NodeName, bindContext.TaskInfo.NodeName)
+
+			// Find and remove task from old node
+			if oldNode, found := sc.Nodes[task.NodeName]; found {
+				if removeErr := oldNode.RemoveTask(task); removeErr != nil {
+					klog.Warningf("Failed to remove task <%s> from old node <%s>: %v", task.Name, task.NodeName, removeErr)
+				}
+			}
+
+			// Clear the old NodeName to allow binding to new node
+			task.NodeName = ""
+		} else {
+			// Task is already assigned to the same node we're trying to bind to
+			klog.V(4).Infof("Task <%s> is already assigned to target node <%s>. Cleaning up existing assignment to allow re-binding.",
+				task.Name, task.NodeName)
+
+			// Remove task from the target node first to allow re-adding it
+			if removeErr := node.RemoveTask(task); removeErr != nil {
+				klog.Warningf("Failed to remove existing task <%s> from target node <%s>: %v", task.Name, task.NodeName, removeErr)
+			}
+
+			// Clear the NodeName to allow binding
+			task.NodeName = ""
+		}
+	}
+
 	// Add task to the node.
 	if err := node.AddTask(task); err != nil {
 		// After failing to update task to a node we need to revert task status from Releasing,
@@ -1462,6 +1592,11 @@ func (sc *SchedulerCache) Snapshot() *schedulingapi.ClusterInfo {
 
 func (sc *SchedulerCache) SharedDRAManager() k8sframework.SharedDRAManager {
 	return sc.sharedDRAManager
+}
+
+// GetStatusUpdater returns the status updater
+func (sc *SchedulerCache) GetStatusUpdater() StatusUpdater {
+	return sc.StatusUpdater
 }
 
 // String returns information about the cache in a string format

--- a/pkg/scheduler/cache/cache_test.go
+++ b/pkg/scheduler/cache/cache_test.go
@@ -203,8 +203,14 @@ func TestSchedulerCache_Bind_NodeWithInsufficientResources(t *testing.T) {
 	if err != nil {
 		t.Errorf("expected to find task after failed bind")
 	}
-	if !equality.Semantic.DeepEqual(taskBeforeBind, taskAfterBind) {
-		t.Errorf("expected task to remain the same after failed bind: \n %#v\n %#v", taskBeforeBind, taskAfterBind)
+
+	// After the commit c1f5ade2588918ea29d374c63b9ec688b0b69f2c, the NodeName is cleared during binding attempt
+	// to handle task node conflicts, even when binding fails due to insufficient resources
+	expectedTask := taskBeforeBind.Clone()
+	expectedTask.NodeName = "" // NodeName is cleared as part of the new conflict resolution logic
+
+	if !equality.Semantic.DeepEqual(expectedTask, taskAfterBind) {
+		t.Errorf("expected task after failed bind: \n %#v\n got: %#v", expectedTask, taskAfterBind)
 	}
 
 	nodeAfterBind := cache.Nodes["n1"].Clone()

--- a/pkg/scheduler/cache/interface.go
+++ b/pkg/scheduler/cache/interface.go
@@ -92,6 +92,9 @@ type Cache interface {
 
 	// SharedDRAManager returns the shared DRAManager
 	SharedDRAManager() framework.SharedDRAManager
+
+	// GetStatusUpdater returns the status updater
+	GetStatusUpdater() StatusUpdater
 }
 
 // Binder interface for binding task and hostname
@@ -107,6 +110,7 @@ type Evictor interface {
 // StatusUpdater updates pod with given PodCondition
 type StatusUpdater interface {
 	UpdatePodStatus(pod *v1.Pod) (*v1.Pod, error)
+	UpdatePodAnnotations(pod *v1.Pod) (*v1.Pod, error)
 	UpdatePodGroup(pg *api.PodGroup) (*api.PodGroup, error)
 	UpdateQueueStatus(queue *api.QueueInfo) error
 }

--- a/pkg/scheduler/util/test_utils.go
+++ b/pkg/scheduler/util/test_utils.go
@@ -556,6 +556,12 @@ func (ftsu *FakeStatusUpdater) UpdatePodStatus(pod *v1.Pod) (*v1.Pod, error) {
 	return pod, nil
 }
 
+// UpdatePodAnnotations is an empty function
+func (ftsu *FakeStatusUpdater) UpdatePodAnnotations(pod *v1.Pod) (*v1.Pod, error) {
+	// Directly return the pod and do nothing here
+	return pod, nil
+}
+
 // UpdatePodGroup is an empty function
 func (ftsu *FakeStatusUpdater) UpdatePodGroup(pg *api.PodGroup) (*api.PodGroup, error) {
 	// Directly return the pg and do nothing here


### PR DESCRIPTION
#### What type of PR is this?
/kind bug  
/kind fix  

#### What this PR does / why we need it:
This PR fixes an issue where **high-priority jobs reclaim resources from low-priority jobs** but cause **excessive killing of pods**.  
The change ensures that resource reclamation is performed more precisely, avoiding unnecessary pod evictions and improving overall job scheduling stability.  

#### Which issue(s) this PR fixes:
Fixes #<issue number>  

#### Special notes for your reviewer:
- Verify the correctness of task state transitions after reclaim.  
- Ensure compatibility with existing predicate and allocate actions.  
- Additional testing on mixed-priority workloads is recommended.  

#### Does this PR introduce a user-facing change?
```release-note
Fix high-priority jobs reclaiming resources and excessively killing low-priority jobs.
Improved reclaim logic to prevent overkill of low-priority jobs.
