### PR TITLE
Optimize queueAllocatable calculation by excluding allocated resources from unschedulable nodes

### DIFF
--- a/pkg/scheduler/framework/session.go
+++ b/pkg/scheduler/framework/session.go
@@ -219,7 +219,7 @@ func openSession(cache cache.Cache) *Session {
 	ssn.NamespaceInfo = snapshot.NamespaceInfo
 	// calculate all nodes' resource only once in each schedule cycle, other plugins can clone it when need
 	for _, n := range ssn.Nodes {
-		if isNodeUnschedulable(n.Node) || isNodeNotReady(n.Node) {
+		if util.IsNodeUnschedulable(n.Node) || util.IsNodeNotReady(n.Node) {
 			klog.V(3).Infof("node %s is not ready or unschedulable, need to continue", n.Name)
 			continue
 		}

--- a/pkg/scheduler/framework/util.go
+++ b/pkg/scheduler/framework/util.go
@@ -262,22 +262,3 @@ func (nl *NodeLister) List() ([]*v1.Node, error) {
 	}
 	return nodes, nil
 }
-
-func isNodeUnschedulable(node *v1.Node) bool {
-	if node == nil {
-		return true
-	}
-	return node.Spec.Unschedulable
-}
-
-func isNodeNotReady(node *v1.Node) bool {
-	if node == nil {
-		return true
-	}
-	for _, cond := range node.Status.Conditions {
-		if cond.Type == v1.NodeReady {
-			return cond.Status != v1.ConditionTrue
-		}
-	}
-	return true
-}

--- a/pkg/scheduler/framework/util_test.go
+++ b/pkg/scheduler/framework/util_test.go
@@ -5,6 +5,8 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"volcano.sh/volcano/pkg/scheduler/util"
 )
 
 func makeNode(unschedulable bool, readyCondition v1.ConditionStatus, nodeIsNil bool) *v1.Node {
@@ -59,7 +61,7 @@ func TestIsNodeUnschedulable(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			node := makeNode(tt.input, v1.ConditionTrue, tt.nodeIsNil)
-			result := isNodeUnschedulable(node)
+			result := util.IsNodeUnschedulable(node)
 			if result != tt.expected {
 				t.Errorf("expected %v, got %v", tt.expected, result)
 			}
@@ -82,8 +84,8 @@ func TestIsNodeNotReady(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			node := makeNode(false, tt.ready, false)
-			result := isNodeNotReady(node)
+			node := makeNode(false, tt.ready, tt.nodeIsNil)
+			result := util.IsNodeNotReady(node)
 			if result != tt.expected {
 				t.Errorf("expected %v, got %v", tt.expected, result)
 			}
@@ -92,7 +94,7 @@ func TestIsNodeNotReady(t *testing.T) {
 
 	t.Run("No NodeReady condition", func(t *testing.T) {
 		node := makeNodeWithoutReady()
-		result := isNodeNotReady(node)
+		result := util.IsNodeNotReady(node)
 		if result != true {
 			t.Errorf("expected true when no NodeReady condition, got %v", result)
 		}

--- a/pkg/scheduler/plugins/capacity/capacity.go
+++ b/pkg/scheduler/plugins/capacity/capacity.go
@@ -32,6 +32,7 @@ import (
 	"volcano.sh/volcano/pkg/scheduler/framework"
 	"volcano.sh/volcano/pkg/scheduler/metrics"
 	"volcano.sh/volcano/pkg/scheduler/plugins/util"
+	schedutil "volcano.sh/volcano/pkg/scheduler/util"
 )
 
 const (
@@ -61,9 +62,10 @@ type queueAttr struct {
 	ancestors []api.QueueID
 	children  map[api.QueueID]*queueAttr
 
-	deserved  *api.Resource
-	allocated *api.Resource
-	request   *api.Resource
+	deserved                               *api.Resource
+	allocated                              *api.Resource
+	allocatedWithoutSchedulingDisabledNode *api.Resource
+	request                                *api.Resource
 	// elastic represents the sum of job's elastic resource, job's elastic = job.allocated - job.minAvailable
 	elastic *api.Resource
 	// inqueue represents the resource request of the inqueue job
@@ -373,6 +375,21 @@ func (cp *capacityPlugin) OnSessionClose(ssn *framework.Session) {
 	cp.queueOpts = nil
 }
 
+// addAllocatedFromSchedulableNode tracks resources allocated on schedulable and ready nodes
+// This helper function is used by both buildQueueAttrs and buildHierarchicalQueueAttrs
+func (cp *capacityPlugin) addAllocatedFromSchedulableNode(attr *queueAttr, task *api.TaskInfo, ssn *framework.Session) {
+	// Check if the node is schedulable and ready
+	if node, found := ssn.Nodes[task.NodeName]; found {
+		if !schedutil.IsNodeUnschedulable(node.Node) && !schedutil.IsNodeNotReady(node.Node) {
+			// Node is schedulable and ready, count it
+			if attr.allocatedWithoutSchedulingDisabledNode == nil {
+				attr.allocatedWithoutSchedulingDisabledNode = api.EmptyResource()
+			}
+			attr.allocatedWithoutSchedulingDisabledNode.Add(task.Resreq)
+		}
+	}
+}
+
 func (cp *capacityPlugin) buildQueueAttrs(ssn *framework.Session) {
 	for _, queue := range ssn.Queues {
 		if len(queue.Queue.Spec.Guarantee.Resource) == 0 {
@@ -428,6 +445,7 @@ func (cp *capacityPlugin) buildQueueAttrs(ssn *framework.Session) {
 				for _, t := range tasks {
 					attr.allocated.Add(t.Resreq)
 					attr.request.Add(t.Resreq)
+					cp.addAllocatedFromSchedulableNode(attr, t, ssn)
 				}
 			} else if status == api.Pending {
 				for _, t := range tasks {
@@ -556,12 +574,17 @@ func (cp *capacityPlugin) buildHierarchicalQueueAttrs(ssn *framework.Session) bo
 		oldRequest := attr.request.Clone()
 		oldInqueue := attr.inqueue.Clone()
 		oldElastic := attr.elastic.Clone()
+		oldAllocatedOnSchedulableNodes := api.EmptyResource()
+		if attr.allocatedWithoutSchedulingDisabledNode != nil {
+			oldAllocatedOnSchedulableNodes = attr.allocatedWithoutSchedulingDisabledNode.Clone()
+		}
 
 		for status, tasks := range job.TaskStatusIndex {
 			if api.AllocatedStatus(status) {
 				for _, t := range tasks {
 					attr.allocated.Add(t.Resreq)
 					attr.request.Add(t.Resreq)
+					cp.addAllocatedFromSchedulableNode(attr, t, ssn)
 				}
 			} else if status == api.Pending {
 				for _, t := range tasks {
@@ -591,6 +614,17 @@ func (cp *capacityPlugin) buildHierarchicalQueueAttrs(ssn *framework.Session) bo
 			ancestorAttr.request.Add(attr.request.Clone().Sub(oldRequest))
 			ancestorAttr.inqueue.Add(attr.inqueue.Clone().Sub(oldInqueue))
 			ancestorAttr.elastic.Add(attr.elastic.Clone().Sub(oldElastic))
+
+			// Also update allocatedWithoutSchedulingDisabledNode for ancestors
+			if attr.allocatedWithoutSchedulingDisabledNode != nil {
+				newAllocatedOnSchedulableNodes := attr.allocatedWithoutSchedulingDisabledNode.Clone().Sub(oldAllocatedOnSchedulableNodes)
+				if !newAllocatedOnSchedulableNodes.IsEmpty() {
+					if ancestorAttr.allocatedWithoutSchedulingDisabledNode == nil {
+						ancestorAttr.allocatedWithoutSchedulingDisabledNode = api.EmptyResource()
+					}
+					ancestorAttr.allocatedWithoutSchedulingDisabledNode.Add(newAllocatedOnSchedulableNodes)
+				}
+			}
 		}
 
 		klog.V(5).Infof("Queue %s allocated <%s> request <%s> inqueue <%s> elastic <%s>",
@@ -853,11 +887,17 @@ func (cp *capacityPlugin) queueAllocatable(queue *api.QueueInfo, candidate *api.
 }
 
 func queueAllocatable(attr *queueAttr, candidate *api.TaskInfo, queue *api.QueueInfo) bool {
-	futureUsed := attr.allocated.Clone().Add(candidate.Resreq)
+	// Initialize allocatedWithoutSchedulingDisabledNode if it's nil
+	allocatedOnSchedulableNodes := attr.allocatedWithoutSchedulingDisabledNode
+	if allocatedOnSchedulableNodes == nil {
+		allocatedOnSchedulableNodes = api.EmptyResource()
+	}
+
+	futureUsed := allocatedOnSchedulableNodes.Clone().Add(candidate.Resreq)
 	allocatable := futureUsed.LessEqualWithDimension(attr.realCapability, candidate.Resreq)
 	if !allocatable {
-		klog.V(3).Infof("Queue <%v>: realCapability <%v>, allocated <%v>; Candidate <%v>: resource request <%v>",
-			queue.Name, attr.realCapability, attr.allocated, candidate.Name, candidate.Resreq)
+		klog.V(3).Infof("Queue <%v>: realCapability <%v>, allocated <%v>, allocatedOnSchedulableNodes <%v>; Candidate <%v>: resource request <%v>",
+			queue.Name, attr.realCapability, attr.allocated, allocatedOnSchedulableNodes, candidate.Name, candidate.Resreq)
 	}
 
 	return allocatable
@@ -963,6 +1003,11 @@ func (qa *queueAttr) Clone() *queueAttr {
 		realCapability: qa.realCapability.Clone(),
 		guarantee:      qa.guarantee.Clone(),
 		children:       make(map[api.QueueID]*queueAttr),
+	}
+
+	// Clone the new field for allocated resources on schedulable nodes
+	if qa.allocatedWithoutSchedulingDisabledNode != nil {
+		cloned.allocatedWithoutSchedulingDisabledNode = qa.allocatedWithoutSchedulingDisabledNode.Clone()
 	}
 
 	if len(qa.ancestors) > 0 {

--- a/pkg/scheduler/util/node_utils.go
+++ b/pkg/scheduler/util/node_utils.go
@@ -1,0 +1,48 @@
+/*
+Copyright 2025 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	v1 "k8s.io/api/core/v1"
+)
+
+// IsNodeUnschedulable checks if a node is marked as unschedulable
+func IsNodeUnschedulable(node *v1.Node) bool {
+	if node == nil {
+		return true
+	}
+	return node.Spec.Unschedulable
+}
+
+// IsNodeNotReady checks if a node is in NotReady state
+func IsNodeNotReady(node *v1.Node) bool {
+	if node == nil {
+		return true
+	}
+	for _, condition := range node.Status.Conditions {
+		if condition.Type == v1.NodeReady {
+			return condition.Status != v1.ConditionTrue
+		}
+	}
+	// If no Ready condition found, consider it as NotReady
+	return true
+}
+
+// IsNodeSchedulingDisabled checks if a node is either unschedulable or not ready
+func IsNodeSchedulingDisabled(node *v1.Node) bool {
+	return IsNodeUnschedulable(node) || IsNodeNotReady(node)
+}


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/kind cleanup

#### What this PR does / why we need it:
This PR optimizes the calculation of `queueAllocatable` by excluding allocated resources that come from nodes marked as unschedulable.  
Without this fix, queue-level resource accounting may include unusable allocations, leading to inaccurate scheduling decisions and potential over-commit.

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:
- The change ensures that only allocatable resources from schedulable nodes are considered.  
- Helps improve fairness and accuracy in queue-level resource management.  
- No functional impact expected on already scheduled workloads, only more accurate accounting.

#### Does this PR introduce a user-facing change?
```release-note
Optimize queueAllocatable calculation by excluding allocated resources from unschedulable nodes.
This prevents incorrect resource accounting and improves scheduling accuracy.
