### PR TITLE
Set root queue capability through helm

### DIFF
--- a/installer/helm/chart/volcano/templates/root_queue.yaml
+++ b/installer/helm/chart/volcano/templates/root_queue.yaml
@@ -1,0 +1,9 @@
+apiVersion: scheduling.volcano.sh/v1beta1
+kind: Queue
+metadata:
+  name: root
+spec:
+  capability:
+    {{- toYaml .Values.custom.root_queue.capability | nindent 4 }}
+  reclaimable: {{ .Values.custom.root_queue.reclaimable | default false }}
+  weight: {{ .Values.custom.root_queue.weight | default 1 }}

--- a/installer/helm/chart/volcano/values.yaml
+++ b/installer/helm/chart/volcano/values.yaml
@@ -224,6 +224,12 @@ custom:
       drop: [ "ALL" ]
     allowPrivilegeEscalation: false
 
+  # Specify root Queue capability
+  root_queue:
+    capability: ~
+    reclaimable: false
+    weight: 1
+
   # Specify agent cni config path.
   agent_cni_config_path: /etc/cni/net.d/cni.conflist
 


### PR DESCRIPTION
When the hierarchy plugin is enabled, the capability check can fail:
https://github.com/volcano-sh/volcano/issues/4350
It will pass now, if the capability is set properly: https://github.com/volcano-sh/volcano/pull/4354
We should be able to set this value for the root queue through helm too.

#### What type of PR is this?
The PR adds a helm value that will render the rootQueue capability if provided.

#### What this PR does / why we need it:
Minor change in the helm chart.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Notice that do not add `Fixes` if the issue is associated with multiple PRs.
-->
Fixes https://github.com/volcano-sh/volcano/issues/4496

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
New helm value for root queue capabilty settings.
```