### PR TITLE
feat: Add dequeue strategies support for queue scheduling

### DIFF
--- a/config/crd/volcano/bases/scheduling.volcano.sh_queues.yaml
+++ b/config/crd/volcano/bases/scheduling.volcano.sh_queues.yaml
@@ -96,6 +96,7 @@ spec:
                 enum:
                 - fifo
                 - traverse
+                - priorityfifo
                 type: string
               deserved:
                 additionalProperties:

--- a/docs/design/dequeue-strategy.md
+++ b/docs/design/dequeue-strategy.md
@@ -1,0 +1,116 @@
+# Dequeue Strategy
+
+## Overview
+
+`dequeueStrategy` is a per-queue setting on `Queue.spec`. It is evaluated in the **allocate** action when a job cannot allocate resources in the current scheduling cycle.
+
+- **Job order** within a queue comes from `JobOrderFn` (e.g. `priority` plugin). Dequeue strategy does not change sorting.
+- **Scope** is one scheduling cycle. Blocked jobs are retried in the next cycle; the `failedPriority` map is not persisted across cycles.
+
+## API
+
+```yaml
+apiVersion: scheduling.volcano.sh/v1beta1
+kind: Queue
+spec:
+  dequeueStrategy: traverse   # default
+```
+
+| Value | Constant | Behavior on allocation failure |
+|-------|----------|--------------------------------|
+| `traverse` | `DequeueStrategyTraverse` | No blocking; other jobs keep trying |
+| `fifo` | `DequeueStrategyFIFO` | Skip jobs with `priority ≤` failed threshold |
+| `priorityfifo` | `DequeueStrategyPriorityFIFO` | Skip jobs with `priority <` failed threshold |
+
+Default: `traverse` when the field is empty or unset.
+
+Priority is `job.Priority` (from `PriorityClass`; higher value = higher priority).
+
+## Strategy Semantics
+
+### `traverse`
+
+No extra logic. After any job fails, the queue is re-queued and other jobs are attempted normally.
+
+### `fifo`
+
+**Goal**: strict ordering within a priority tier — if a job fails, nothing at the same or lower priority runs in this cycle.
+
+When job A fails:
+
+1. Record A's priority as the queue's **failed threshold** (keep the highest value if multiple jobs fail).
+2. Re-queue the queue and continue.
+3. For each subsequent job: if `job.Priority ≤ threshold`, skip it and set `FIFOBlocked` status.
+
+Same-priority jobs are blocked even when they have smaller resource requests that could fit.
+
+### `priorityfifo`
+
+**Goal**: respect priority tiers without letting one oversized job block same-priority peers.
+
+When job A fails:
+
+1. Same threshold tracking as `fifo`.
+2. Re-queue the queue and continue.
+3. For each subsequent job: if `job.Priority < threshold`, skip it and set `PriorityFIFOBlocked` status.
+4. Jobs with `job.Priority == threshold` may still be scheduled.
+
+**Example** (node has 2 CPU):
+
+| Job | Priority | Request | Result |
+|-----|----------|---------|--------|
+| A | 1000 | 4 CPU | Fails |
+| B | 1000 | 1 CPU | `fifo`: blocked; `priorityfifo`: scheduled |
+| C | 500 | 1 CPU | Both strategies: blocked |
+
+## Implementation
+
+Location: `pkg/scheduler/actions/allocate/allocate.go` → `allocateResources()`.
+
+```
+failedPriority := map[QueueID]*int32{}   // per-cycle, per queue
+
+pop queue → pop job
+  if fifo/priorityfifo and job matches block rule → record blocked status, re-push queue, continue
+  try allocate
+  if failed and strategy is fifo/priorityfifo:
+      threshold = max(existing, job.Priority)
+      re-push queue, continue
+  re-push queue
+```
+
+Blocking check:
+
+| Strategy | Skip when |
+|----------|-----------|
+| `fifo` | `job.Priority <= threshold` |
+| `priorityfifo` | `job.Priority < threshold` |
+
+Threshold update on failure: `threshold = max(existing, job.Priority)` so a later failure at a higher priority raises the bar.
+
+## Status Reporting
+
+Blocked jobs populate:
+
+- `JobInfo.JobFitErrors` / `JobInfo.UnschedulableReason`
+- Per-task fit errors for pending, non-gated tasks
+
+The **gang** plugin reads `UnschedulableReason` when writing the PodGroup `Unschedulable` condition:
+
+| Strategy | `reason` |
+|----------|----------|
+| `fifo` | `FIFOBlocked` |
+| `priorityfifo` | `PriorityFIFOBlocked` |
+
+Constants: `staging/src/volcano.sh/apis/pkg/apis/scheduling/types.go`.
+
+## Tests
+
+`pkg/scheduler/actions/allocate/allocate_priority_fifo_test.go` covers:
+
+- `priorityfifo`: same-priority proceeds, lower-priority blocked
+- `fifo`: same- and lower-priority blocked after failure
+
+## Related Docs
+
+User guide: [how_to_use_dequeue_strategy.md](../user-guide/how_to_use_dequeue_strategy.md)

--- a/docs/user-guide/how_to_use_dequeue_strategy.md
+++ b/docs/user-guide/how_to_use_dequeue_strategy.md
@@ -1,0 +1,57 @@
+# Dequeue Strategy
+
+When a job in a queue fails to allocate resources, `dequeueStrategy` decides whether the scheduler keeps trying other jobs in that queue **in the same scheduling cycle**.
+
+Job order within a queue (by `PriorityClass` or creation time) is controlled by scheduler plugins such as `priority`, not by this field.
+
+## Configure
+
+```yaml
+apiVersion: scheduling.volcano.sh/v1beta1
+kind: Queue
+metadata:
+  name: my-queue
+spec:
+  dequeueStrategy: traverse   # default; also: fifo, priorityfifo
+```
+
+| Value | Effect after a job fails |
+|-------|--------------------------|
+| `traverse` *(default)* | All other jobs in the queue keep trying |
+| `fifo` | Jobs with **priority ≤** the failed job are skipped for this cycle |
+| `priorityfifo` | Only jobs with **priority <** the failed job are skipped; same-priority jobs may still run |
+
+Omit `dequeueStrategy` or set an invalid value → `traverse`.
+
+## How the three strategies differ
+
+Jobs are dequeued in priority order (higher `PriorityClass` value first). Suppose job A fails because it needs more resources than the cluster can offer right now:
+
+| Strategy | Job B (same priority as A) | Job C (lower priority than A) |
+|----------|---------------------------|-------------------------------|
+| `traverse` | Tries to schedule | Tries to schedule |
+| `fifo` | Blocked | Blocked |
+| `priorityfifo` | Tries to schedule | Blocked |
+
+`priorityfifo` is useful when a large high-priority job blocks the queue but smaller jobs at the same priority could still fit.
+
+## Blocked jobs (`fifo` / `priorityfifo`)
+
+Blocked jobs receive a PodGroup `Unschedulable` condition:
+
+| Strategy | `reason` |
+|----------|----------|
+| `fifo` | `FIFOBlocked` |
+| `priorityfifo` | `PriorityFIFOBlocked` |
+
+```bash
+kubectl get podgroup <name> -n <namespace> -o jsonpath='{.status.conditions}'
+```
+
+## Choose a strategy
+
+| You need… | Use |
+|-----------|-----|
+| Highest utilization; do not hold up the queue for one failing job | `traverse` |
+| Strict blocking: nothing at or below the failed job's priority runs this cycle | `fifo` |
+| Honor priority tiers, but allow same-priority jobs to proceed past a failed peer | `priorityfifo` |

--- a/installer/helm/chart/volcano/crd/bases/scheduling.volcano.sh_queues.yaml
+++ b/installer/helm/chart/volcano/crd/bases/scheduling.volcano.sh_queues.yaml
@@ -95,6 +95,7 @@ spec:
                 enum:
                 - fifo
                 - traverse
+                - priorityfifo
                 type: string
               deserved:
                 additionalProperties:

--- a/installer/volcano-development-vap-map.yaml
+++ b/installer/volcano-development-vap-map.yaml
@@ -9745,6 +9745,7 @@ spec:
                 enum:
                 - fifo
                 - traverse
+                - priorityfifo
                 type: string
               deserved:
                 additionalProperties:

--- a/installer/volcano-development-vap.yaml
+++ b/installer/volcano-development-vap.yaml
@@ -9745,6 +9745,7 @@ spec:
                 enum:
                 - fifo
                 - traverse
+                - priorityfifo
                 type: string
               deserved:
                 additionalProperties:

--- a/installer/volcano-development.yaml
+++ b/installer/volcano-development.yaml
@@ -9745,6 +9745,7 @@ spec:
                 enum:
                 - fifo
                 - traverse
+                - priorityfifo
                 type: string
               deserved:
                 additionalProperties:

--- a/pkg/scheduler/actions/allocate/allocate.go
+++ b/pkg/scheduler/actions/allocate/allocate.go
@@ -38,6 +38,38 @@ import (
 	commonutil "volcano.sh/volcano/pkg/util"
 )
 
+func recordDequeueBlocked(job *api.JobInfo, reason, msg string) {
+	job.JobFitErrors = msg
+	job.UnschedulableReason = reason
+	for _, task := range job.TaskStatusIndex[api.Pending] {
+		if task.SchGated {
+			continue
+		}
+		fe := api.NewFitErrors()
+		fe.SetError(msg)
+		job.NodesFitErrors[task.UID] = fe
+	}
+}
+
+func recordFIFOBlocked(job *api.JobInfo, queue *api.QueueInfo, threshold int32) {
+	msg := fmt.Sprintf("FIFO: Job <%s/%s> (priority=%d) is blocked by failed priority threshold (%d) in Queue <%s>",
+		job.Namespace, job.Name, job.Priority, threshold, queue.Name)
+	recordDequeueBlocked(job, scheduling.FIFOBlockedReason, msg)
+}
+
+func recordPriorityFIFOBlocked(job *api.JobInfo, queue *api.QueueInfo, threshold int32) {
+	msg := fmt.Sprintf("PriorityFIFO: Job <%s/%s> (priority=%d) is blocked by failed priority threshold (%d) in Queue <%s>",
+		job.Namespace, job.Name, job.Priority, threshold, queue.Name)
+	recordDequeueBlocked(job, scheduling.PriorityFIFOBlockedReason, msg)
+}
+
+func getDequeueStrategy(queue *api.QueueInfo) scheduling.DequeueStrategy {
+	if queue.Queue != nil && queue.Queue.Spec.DequeueStrategy != "" {
+		return queue.Queue.Spec.DequeueStrategy
+	}
+	return scheduling.DefaultDequeueStrategy
+}
+
 type allocateContext struct {
 	queues              *util.PriorityQueue                 // queue of *api.QueueInfo
 	jobsByQueue         map[api.QueueID]*util.PriorityQueue // queue of *api.JobInfo
@@ -283,6 +315,11 @@ func (alloc *Action) organizeJobWorksheet(job *api.JobInfo) *JobWorksheet {
 func (alloc *Action) allocateResources(actx *allocateContext) {
 	ssn := alloc.session
 
+	// For FIFO/PriorityFIFO strategies: track the highest failed priority per queue.
+	// PriorityFIFO blocks jobs with priority lower than the threshold.
+	// FIFO blocks jobs with priority lower than or equal to the threshold.
+	failedPriority := map[api.QueueID]*int32{}
+
 	queues := actx.queues
 	for {
 		if queues.Empty() {
@@ -303,6 +340,34 @@ func (alloc *Action) allocateResources(actx *allocateContext) {
 		}
 
 		job := jobs.Pop().(*api.JobInfo)
+
+		strategy := getDequeueStrategy(queue)
+		klog.V(3).Infof("Try to allocate resource to Jobs in Queue <%s> with strategy <%s>", queue.Name, strategy)
+
+		// PriorityFIFO/FIFO: check if this job should be blocked by failed priority threshold.
+		if threshold, exists := failedPriority[queue.UID]; exists {
+			switch strategy {
+			case scheduling.DequeueStrategyPriorityFIFO:
+				if job.Priority < *threshold {
+					klog.V(3).Infof("PriorityFIFO: Job <%s/%s> (priority=%d) is blocked by failed priority threshold (%d) in Queue <%s>",
+						job.Namespace, job.Name, job.Priority, *threshold, queue.Name)
+					recordPriorityFIFOBlocked(job, queue, *threshold)
+					queues.Push(queue)
+					continue
+				}
+			case scheduling.DequeueStrategyFIFO:
+				if job.Priority <= *threshold {
+					klog.V(3).Infof("FIFO: Job <%s/%s> (priority=%d) is blocked by failed priority threshold (%d) in Queue <%s>",
+						job.Namespace, job.Name, job.Priority, *threshold, queue.Name)
+					recordFIFOBlocked(job, queue, *threshold)
+					queues.Push(queue)
+					continue
+				}
+			}
+		}
+
+		allocateSuc := false
+
 		// Currently, both hard-mode network topology scheduling and subjob level scheduling use allocateForJob.
 		// TODO: In the future, we may need to unify the logic of network topology-aware scheduling and normal scheduling.
 		if job.ContainsHardTopology() || job.ContainsSubJobPolicy() {
@@ -312,6 +377,7 @@ func (alloc *Action) allocateResources(actx *allocateContext) {
 				"allocatedHyperNode", job.AllocatedHyperNode, "subJobNum", jobWorksheet.subJobs.Len())
 			stmt := alloc.allocateForJob(job, jobWorksheet, ssn.HyperNodes[framework.ClusterTopHyperNode])
 			if stmt != nil && ssn.JobReady(job) { // do not commit stmt when job is pipelined
+				allocateSuc = true
 				stmt.Commit()
 				ssn.MarkJobDirty(job.UID)
 				alloc.recorder.UpdateDecisionToJob(job, ssn.HyperNodes)
@@ -328,6 +394,7 @@ func (alloc *Action) allocateResources(actx *allocateContext) {
 				klog.V(3).InfoS("Try to allocate resource", "queue", queue.Name, "job", job.UID, "taskNum", tasks.Len())
 				stmt := alloc.allocateResourcesForTasks(subJob, tasks, framework.ClusterTopHyperNode)
 				if stmt != nil && ssn.JobReady(job) { // do not commit stmt when job is pipelined
+					allocateSuc = true
 					stmt.Commit()
 
 					// There are still left tasks that need to be allocated when min available < replicas, put the job back
@@ -339,6 +406,19 @@ func (alloc *Action) allocateResources(actx *allocateContext) {
 				klog.ErrorS(nil, "Can not find default subJob or tasks for job", "job", job.UID,
 					"subJobExist", sjExist, "tasksExist", tasksExist)
 			}
+		}
+
+		// For FIFO/PriorityFIFO strategy: record the failed job's priority as blocking threshold,
+		// then re-push queue so remaining jobs can be checked against the threshold.
+		if !allocateSuc && (strategy == scheduling.DequeueStrategyFIFO || strategy == scheduling.DequeueStrategyPriorityFIFO) {
+			p := job.Priority
+			if existing, ok := failedPriority[queue.UID]; !ok || p > *existing {
+				failedPriority[queue.UID] = &p
+			}
+			klog.V(3).Infof("%s: Job <%v/%v> (priority=%d) failed to allocate in Queue <%s>, recording priority threshold",
+				strategy, job.Namespace, job.Name, job.Priority, queue.Name)
+			queues.Push(queue)
+			continue
 		}
 
 		// Put back the queue to priority queue after job's resource allocating finished,

--- a/pkg/scheduler/actions/allocate/allocate_priority_fifo_test.go
+++ b/pkg/scheduler/actions/allocate/allocate_priority_fifo_test.go
@@ -1,0 +1,234 @@
+/*
+Copyright 2024 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package allocate
+
+import (
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	schedulingv1k8s "k8s.io/api/scheduling/v1"
+
+	"volcano.sh/apis/pkg/apis/scheduling"
+	vcschedulingv1 "volcano.sh/apis/pkg/apis/scheduling/v1beta1"
+	"volcano.sh/volcano/pkg/scheduler/api"
+	"volcano.sh/volcano/pkg/scheduler/conf"
+	"volcano.sh/volcano/pkg/scheduler/framework"
+	"volcano.sh/volcano/pkg/scheduler/plugins/gang"
+	"volcano.sh/volcano/pkg/scheduler/plugins/predicates"
+	"volcano.sh/volcano/pkg/scheduler/plugins/priority"
+	"volcano.sh/volcano/pkg/scheduler/plugins/proportion"
+	"volcano.sh/volcano/pkg/scheduler/uthelper"
+	"volcano.sh/volcano/pkg/scheduler/util"
+)
+
+func TestPriorityFIFO(t *testing.T) {
+	trueValue := true
+
+	plugins := map[string]framework.PluginBuilder{
+		proportion.PluginName: proportion.New,
+		predicates.PluginName: predicates.New,
+		gang.PluginName:       gang.New,
+		priority.PluginName:   priority.New,
+	}
+
+	tiers := []conf.Tier{
+		{
+			Plugins: []conf.PluginOption{
+				{
+					Name:                gang.PluginName,
+					EnabledJobOrder:     &trueValue,
+					EnabledJobReady:     &trueValue,
+					EnabledJobPipelined: &trueValue,
+				},
+				{
+					Name:               proportion.PluginName,
+					EnabledQueueOrder:  &trueValue,
+					EnabledAllocatable: &trueValue,
+				},
+				{
+					Name:             predicates.PluginName,
+					EnabledPredicate: &trueValue,
+				},
+				{
+					Name:            priority.PluginName,
+					EnabledJobOrder: &trueValue,
+				},
+			},
+		},
+	}
+
+	highPri := int32(1000)
+	lowPri := int32(500)
+
+	tests := []uthelper.TestCommonStruct{
+		{
+			Name: "PriorityFIFO: same priority job can proceed after failure, lower priority blocked",
+			PodGroups: []*vcschedulingv1.PodGroup{
+				util.BuildPodGroupWithPrio("pg-a", "ns1", "q1", 1, nil, vcschedulingv1.PodGroupInqueue, "high"),
+				util.BuildPodGroupWithPrio("pg-b", "ns1", "q1", 1, nil, vcschedulingv1.PodGroupInqueue, "high"),
+				util.BuildPodGroupWithPrio("pg-c", "ns1", "q1", 1, nil, vcschedulingv1.PodGroupInqueue, "low"),
+			},
+			Pods: []*v1.Pod{
+				util.BuildPodWithPriority("ns1", "pod-a", "", v1.PodPending, api.BuildResourceList("4", "1G"), "pg-a", make(map[string]string), make(map[string]string), &highPri),
+				util.BuildPodWithPriority("ns1", "pod-b", "", v1.PodPending, api.BuildResourceList("1", "1G"), "pg-b", make(map[string]string), make(map[string]string), &highPri),
+				util.BuildPodWithPriority("ns1", "pod-c", "", v1.PodPending, api.BuildResourceList("1", "1G"), "pg-c", make(map[string]string), make(map[string]string), &lowPri),
+			},
+			Nodes: []*v1.Node{
+				util.BuildNode("n1", api.BuildResourceList("2", "4Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), nil),
+			},
+			Queues: []*vcschedulingv1.Queue{
+				util.BuildQueueWithDequeueStrategy("q1", 1, nil, vcschedulingv1.DequeueStrategyPriorityFIFO),
+			},
+			PriClass: []*schedulingv1k8s.PriorityClass{
+				util.BuildPriorityClass("high", 1000),
+				util.BuildPriorityClass("low", 500),
+			},
+			ExpectBindMap: map[string]string{
+				"ns1/pod-b": "n1",
+			},
+			ExpectBindsNum: 1,
+		},
+		{
+			Name: "PriorityFIFO: all same priority, all can proceed",
+			PodGroups: []*vcschedulingv1.PodGroup{
+				util.BuildPodGroupWithPrio("pg-a", "ns1", "q1", 1, nil, vcschedulingv1.PodGroupInqueue, "high"),
+				util.BuildPodGroupWithPrio("pg-b", "ns1", "q1", 1, nil, vcschedulingv1.PodGroupInqueue, "high"),
+				util.BuildPodGroupWithPrio("pg-c", "ns1", "q1", 1, nil, vcschedulingv1.PodGroupInqueue, "high"),
+			},
+			Pods: []*v1.Pod{
+				util.BuildPodWithPriority("ns1", "pod-a", "", v1.PodPending, api.BuildResourceList("4", "1G"), "pg-a", make(map[string]string), make(map[string]string), &highPri),
+				util.BuildPodWithPriority("ns1", "pod-b", "", v1.PodPending, api.BuildResourceList("1", "1G"), "pg-b", make(map[string]string), make(map[string]string), &highPri),
+				util.BuildPodWithPriority("ns1", "pod-c", "", v1.PodPending, api.BuildResourceList("1", "1G"), "pg-c", make(map[string]string), make(map[string]string), &highPri),
+			},
+			Nodes: []*v1.Node{
+				util.BuildNode("n1", api.BuildResourceList("2", "4Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), nil),
+			},
+			Queues: []*vcschedulingv1.Queue{
+				util.BuildQueueWithDequeueStrategy("q1", 1, nil, vcschedulingv1.DequeueStrategyPriorityFIFO),
+			},
+			PriClass: []*schedulingv1k8s.PriorityClass{
+				util.BuildPriorityClass("high", 1000),
+			},
+			ExpectBindMap: map[string]string{
+				"ns1/pod-b": "n1",
+				"ns1/pod-c": "n1",
+			},
+			ExpectBindsNum: 2,
+		},
+		{
+			Name: "FIFO backward compatibility: all blocked after first failure",
+			PodGroups: []*vcschedulingv1.PodGroup{
+				util.BuildPodGroupWithPrio("pg-a", "ns1", "q1", 1, nil, vcschedulingv1.PodGroupInqueue, "high"),
+				util.BuildPodGroupWithPrio("pg-b", "ns1", "q1", 1, nil, vcschedulingv1.PodGroupInqueue, "high"),
+			},
+			Pods: []*v1.Pod{
+				util.BuildPodWithPriority("ns1", "pod-a", "", v1.PodPending, api.BuildResourceList("4", "1G"), "pg-a", make(map[string]string), make(map[string]string), &highPri),
+				util.BuildPodWithPriority("ns1", "pod-b", "", v1.PodPending, api.BuildResourceList("1", "1G"), "pg-b", make(map[string]string), make(map[string]string), &highPri),
+			},
+			Nodes: []*v1.Node{
+				util.BuildNode("n1", api.BuildResourceList("2", "4Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), nil),
+			},
+			Queues: []*vcschedulingv1.Queue{
+				util.BuildQueueWithDequeueStrategy("q1", 1, nil, vcschedulingv1.DequeueStrategyFIFO),
+			},
+			PriClass: []*schedulingv1k8s.PriorityClass{
+				util.BuildPriorityClass("high", 1000),
+			},
+			ExpectBindMap:  map[string]string{},
+			ExpectBindsNum: 0,
+		},
+		{
+			Name: "FIFO: same priority and lower priority blocked after failure",
+			PodGroups: []*vcschedulingv1.PodGroup{
+				util.BuildPodGroupWithPrio("pg-a", "ns1", "q1", 1, nil, vcschedulingv1.PodGroupInqueue, "high"),
+				util.BuildPodGroupWithPrio("pg-b", "ns1", "q1", 1, nil, vcschedulingv1.PodGroupInqueue, "high"),
+				util.BuildPodGroupWithPrio("pg-c", "ns1", "q1", 1, nil, vcschedulingv1.PodGroupInqueue, "low"),
+			},
+			Pods: []*v1.Pod{
+				util.BuildPodWithPriority("ns1", "pod-a", "", v1.PodPending, api.BuildResourceList("4", "1G"), "pg-a", make(map[string]string), make(map[string]string), &highPri),
+				util.BuildPodWithPriority("ns1", "pod-b", "", v1.PodPending, api.BuildResourceList("1", "1G"), "pg-b", make(map[string]string), make(map[string]string), &highPri),
+				util.BuildPodWithPriority("ns1", "pod-c", "", v1.PodPending, api.BuildResourceList("1", "1G"), "pg-c", make(map[string]string), make(map[string]string), &lowPri),
+			},
+			Nodes: []*v1.Node{
+				util.BuildNode("n1", api.BuildResourceList("2", "4Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), nil),
+			},
+			Queues: []*vcschedulingv1.Queue{
+				util.BuildQueueWithDequeueStrategy("q1", 1, nil, vcschedulingv1.DequeueStrategyFIFO),
+			},
+			PriClass: []*schedulingv1k8s.PriorityClass{
+				util.BuildPriorityClass("high", 1000),
+				util.BuildPriorityClass("low", 500),
+			},
+			ExpectBindMap:  map[string]string{},
+			ExpectBindsNum: 0,
+		},
+	}
+
+	for i, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			test.Plugins = plugins
+			ssn := test.RegisterSession(tiers, nil)
+			defer test.Close()
+			test.Run([]framework.Action{New()})
+			if err := test.CheckAll(i); err != nil {
+				t.Fatal(err)
+			}
+			checkDequeueBlockedJobStatus(t, ssn, i, test.Name)
+		})
+	}
+}
+
+func checkDequeueBlockedJobStatus(t *testing.T, ssn *framework.Session, caseIndex int, caseName string) {
+	t.Helper()
+
+	gangPlugin := gang.New(nil)
+	gangPlugin.OnSessionClose(ssn)
+
+	checkBlocked := func(jobID api.JobID, wantReason string) {
+		t.Helper()
+		job := ssn.Jobs[jobID]
+		if job == nil {
+			t.Fatalf("case %d(%s): job <%v> not found in session", caseIndex, caseName, jobID)
+		}
+		if job.UnschedulableReason != wantReason {
+			t.Fatalf("case %d(%s): job <%v> UnschedulableReason want %q, got %q", caseIndex, caseName, jobID, wantReason, job.UnschedulableReason)
+		}
+		if job.JobFitErrors == "" {
+			t.Fatalf("case %d(%s): job <%v> JobFitErrors should not be empty", caseIndex, caseName, jobID)
+		}
+		var found bool
+		for _, cond := range job.PodGroup.Status.Conditions {
+			if cond.Type == scheduling.PodGroupUnschedulableType && cond.Reason == wantReason {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("case %d(%s): job <%v> PodGroup condition Reason want %q", caseIndex, caseName, jobID, wantReason)
+		}
+	}
+
+	switch caseIndex {
+	case 0:
+		checkBlocked(api.JobID("ns1/pg-c"), scheduling.PriorityFIFOBlockedReason)
+	case 2:
+		checkBlocked(api.JobID("ns1/pg-b"), scheduling.FIFOBlockedReason)
+	case 3:
+		checkBlocked(api.JobID("ns1/pg-b"), scheduling.FIFOBlockedReason)
+		checkBlocked(api.JobID("ns1/pg-c"), scheduling.FIFOBlockedReason)
+	}
+}

--- a/pkg/scheduler/api/job_info.go
+++ b/pkg/scheduler/api/job_info.go
@@ -378,6 +378,10 @@ type JobInfo struct {
 	JobFitErrors   string
 	NodesFitErrors map[TaskID]*FitErrors
 
+	// UnschedulableReason is the PodGroup condition Reason when the job is unschedulable.
+	// When empty, gang plugin defaults to NotEnoughResources.
+	UnschedulableReason string
+
 	AllocatedHyperNode string
 	NetworkTopology    *scheduling.NetworkTopologySpec
 	SubJobs            map[SubJobID]*SubJobInfo
@@ -729,8 +733,9 @@ func (ji *JobInfo) Clone() *JobInfo {
 
 		MinAvailable:   ji.MinAvailable,
 		WaitingTime:    ji.WaitingTime,
-		JobFitErrors:   ji.JobFitErrors,
-		NodesFitErrors: make(map[TaskID]*FitErrors),
+		JobFitErrors:        ji.JobFitErrors,
+		UnschedulableReason: ji.UnschedulableReason,
+		NodesFitErrors:      make(map[TaskID]*FitErrors),
 		Allocated:      EmptyResource(),
 		TotalRequest:   EmptyResource(),
 

--- a/pkg/scheduler/api/job_info.go
+++ b/pkg/scheduler/api/job_info.go
@@ -731,13 +731,13 @@ func (ji *JobInfo) Clone() *JobInfo {
 		Queue:     ji.Queue,
 		Priority:  ji.Priority,
 
-		MinAvailable:   ji.MinAvailable,
-		WaitingTime:    ji.WaitingTime,
+		MinAvailable:        ji.MinAvailable,
+		WaitingTime:         ji.WaitingTime,
 		JobFitErrors:        ji.JobFitErrors,
 		UnschedulableReason: ji.UnschedulableReason,
 		NodesFitErrors:      make(map[TaskID]*FitErrors),
-		Allocated:      EmptyResource(),
-		TotalRequest:   EmptyResource(),
+		Allocated:           EmptyResource(),
+		TotalRequest:        EmptyResource(),
 
 		PodGroup: ji.PodGroup.Clone(),
 

--- a/pkg/scheduler/plugins/gang/gang.go
+++ b/pkg/scheduler/plugins/gang/gang.go
@@ -259,12 +259,16 @@ func (gp *gangPlugin) OnSessionClose(ssn *framework.Session) {
 			// TODO: If the Job is gang-unschedulable due to scheduling gates
 			// we need a new message and reason to tell users
 			// More detail in design doc pod-scheduling-readiness.md
+			reason := v1beta1.NotEnoughResourcesReason
+			if job.UnschedulableReason != "" {
+				reason = job.UnschedulableReason
+			}
 			jc := &scheduling.PodGroupCondition{
 				Type:               scheduling.PodGroupUnschedulableType,
 				Status:             v1.ConditionTrue,
 				LastTransitionTime: metav1.Now(),
 				TransitionID:       string(ssn.UID),
-				Reason:             v1beta1.NotEnoughResourcesReason,
+				Reason:             reason,
 				Message:            msg,
 			}
 

--- a/pkg/scheduler/util/test_utils.go
+++ b/pkg/scheduler/util/test_utils.go
@@ -493,6 +493,13 @@ func BuildQueueWithState(qname string, weight int32, cap v1.ResourceList, state 
 	}
 }
 
+// BuildQueueWithDequeueStrategy returns a Queue with the given dequeue strategy.
+func BuildQueueWithDequeueStrategy(qname string, weight int32, cap v1.ResourceList, strategy schedulingv1beta1.DequeueStrategy) *schedulingv1beta1.Queue {
+	queue := BuildQueue(qname, weight, cap)
+	queue.Spec.DequeueStrategy = strategy
+	return queue
+}
+
 // BuildQueueWithAnnos return a Queue with annotations
 func BuildQueueWithAnnos(qname string, weight int32, cap v1.ResourceList, annos map[string]string) *schedulingv1beta1.Queue {
 	queue := BuildQueue(qname, weight, cap)

--- a/staging/src/volcano.sh/apis/pkg/apis/scheduling/types.go
+++ b/staging/src/volcano.sh/apis/pkg/apis/scheduling/types.go
@@ -111,6 +111,12 @@ const (
 
 	// NotEnoughPodsReason is probed if there're not enough tasks compared to `spec.minMember`
 	NotEnoughPodsReason string = "NotEnoughTasks"
+
+	// FIFOBlockedReason is probed if a job is blocked by the FIFO dequeue strategy
+	FIFOBlockedReason string = "FIFOBlocked"
+
+	// PriorityFIFOBlockedReason is probed if a job is blocked by the PriorityFIFO dequeue strategy
+	PriorityFIFOBlockedReason string = "PriorityFIFOBlocked"
 )
 
 // QueueEvent represent the phase of queue.
@@ -462,6 +468,9 @@ const (
 	// DequeueStrategyTraverse defines a strategy that traverses the queue. If the head of the queue cannot be scheduled,
 	// it will be skipped and the scheduler will attempt to dequeue subsequent jobs.
 	DequeueStrategyTraverse DequeueStrategy = "traverse"
+	// DequeueStrategyPriorityFIFO defines a priority-aware FIFO strategy. If a job fails to allocate,
+	// jobs with the same priority can still be scheduled, but lower-priority jobs are blocked.
+	DequeueStrategyPriorityFIFO DequeueStrategy = "priorityfifo"
 
 	// DefaultDequeueStrategy is the default dequeue strategy.
 	DefaultDequeueStrategy DequeueStrategy = DequeueStrategyTraverse

--- a/staging/src/volcano.sh/apis/pkg/apis/scheduling/v1beta1/types.go
+++ b/staging/src/volcano.sh/apis/pkg/apis/scheduling/v1beta1/types.go
@@ -117,6 +117,12 @@ const (
 
 	// NotEnoughPodsOfTaskReason is probed if there're not enough pods of task compared to `spec.minTaskMember`
 	NotEnoughPodsOfTaskReason string = "NotEnoughPodsOfTask"
+
+	// FIFOBlockedReason is probed if a job is blocked by the FIFO dequeue strategy
+	FIFOBlockedReason string = "FIFOBlocked"
+
+	// PriorityFIFOBlockedReason is probed if a job is blocked by the PriorityFIFO dequeue strategy
+	PriorityFIFOBlockedReason string = "PriorityFIFOBlocked"
 )
 
 // QueueEvent represent the phase of queue.
@@ -501,7 +507,7 @@ type QueueSpec struct {
 	// DequeueStrategy defines the dequeue strategy of queue
 	// +optional
 	// +kubebuilder:default:=traverse
-	// +kubebuilder:validation:Enum=fifo;traverse
+	// +kubebuilder:validation:Enum=fifo;traverse;priorityfifo
 	DequeueStrategy DequeueStrategy `json:"dequeueStrategy,omitempty" protobuf:"bytes,11,opt,name=dequeueStrategy"`
 }
 
@@ -514,6 +520,9 @@ const (
 	// DequeueStrategyTraverse defines a strategy that traverses the queue. If the head of the queue cannot be scheduled,
 	// it will be skipped and the scheduler will attempt to dequeue subsequent jobs.
 	DequeueStrategyTraverse DequeueStrategy = "traverse"
+	// DequeueStrategyPriorityFIFO defines a priority-aware FIFO strategy. If a job fails to allocate,
+	// jobs with the same priority can still be scheduled, but lower-priority jobs are blocked.
+	DequeueStrategyPriorityFIFO DequeueStrategy = "priorityfifo"
 
 	// DefaultDequeueStrategy is the default dequeue strategy.
 	DefaultDequeueStrategy DequeueStrategy = DequeueStrategyTraverse


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:

This PR introduces dequeue strategies for Volcano queues, allowing administrators to control how jobs are scheduled within queues when resources are limited. 

**Key Features:**
Defined DequeueStrategy type with two supported strategies:

1. **FIFO Strategy**

   * The scheduler repeatedly tries to dequeue the first task in the queue.
   * If the first task cannot be dequeued (e.g., insufficient resources), it will keep retrying without skipping to the next task.

2. **Traversal Strategy**

   * If the first task cannot be dequeued, the scheduler skips it and attempts to dequeue the next jobs in the queue sequentially.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Notice that do not add `Fixes` if the issue is associated with multiple PRs.
-->
Fixes #4572 #4690 #3950

#### Special notes for your reviewer:

1. **Backward Compatibility**: This change is fully backward compatible. Existing queues without dequeue strategy annotations will continue to use the traverse strategy (current default behavior).

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
support FIFO dequeue strategies for Volcano queues..
```

---

**Additional Context:**

This feature addresses common scheduling scenarios where different queues require different behavior patterns:

- **Production queues** often need strict ordering and can tolerate some resource underutilization
- **Development/testing queues** typically prioritize maximum resource utilization over strict ordering

The implementation uses a unified scheduling loop with conditional logic, making it maintainable and efficient while providing clear behavioral differences between the two strategies.