### PR TITLE
Add permissions for managing namespaces in admission rules

### DIFF
--- a/installer/helm/chart/volcano/templates/admission.yaml
+++ b/installer/helm/chart/volcano/templates/admission.yaml
@@ -63,6 +63,11 @@ rules:
   - apiGroups: ["scheduling.incubator.k8s.io", "scheduling.volcano.sh"]
     resources: ["podgroups"]
     verbs: ["get", "list", "watch"]
+  {{- if .Values.custom.enabled_admissions | regexMatch "/podgroups/mutate" }}
+  - apiGroups: [""]
+    resources: ["namespaces"]
+    verbs: ["get", "list", "watch"]
+  {{- end }}
 
 ---
 kind: ClusterRoleBinding


### PR DESCRIPTION
#### What type of PR is this?
Bugfix

#### What this PR does / why we need it:
This PR adds permissions for managing namespaces (`get`, `list`, `watch`) in the admission webhook's ClusterRole. This is required for the mutating webhook to read namespace annotations and mutate PodGroup resources accordingly. Without these permissions, the webhook cannot access namespace annotations and will fail to update the PodGroup's `queue` field based on the namespace's settings.

#### Which issue(s) this PR fixes:
Fixes #4589

#### Special notes for your reviewer:
- Verified that after adding the permissions, PodGroup mutation works as expected when namespace annotations are present.
- Please review the permission scope for security and correctness.

#### Does this PR introduce a user-facing change?
NONE

```release-note
The Volcano admission webhook can now mutate PodGroup resources based on namespace annotations, as the required permissions to read namespaces are granted.
```