### PR TITLE
Sync kube-scheduler: Improve CSILimits plugin accuracy by using VolumeAttachments

### DIFF
--- a/installer/helm/chart/volcano/templates/scheduler.yaml
+++ b/installer/helm/chart/volcano/templates/scheduler.yaml
@@ -78,7 +78,7 @@ rules:
     resources: ["nodes"]
     verbs: ["get","list", "watch","update","patch"]
   - apiGroups: [ "storage.k8s.io" ]
-    resources: ["storageclasses", "csinodes", "csidrivers", "csistoragecapacities"]
+    resources: ["storageclasses", "csinodes", "csidrivers", "csistoragecapacities", "volumeattachments"]
     verbs: [ "list", "watch" ]
   - apiGroups: ["policy"]
     resources: ["poddisruptionbudgets"]

--- a/installer/volcano-development.yaml
+++ b/installer/volcano-development.yaml
@@ -4663,7 +4663,7 @@ rules:
     resources: ["nodes"]
     verbs: ["get","list", "watch","update","patch"]
   - apiGroups: [ "storage.k8s.io" ]
-    resources: ["storageclasses", "csinodes", "csidrivers", "csistoragecapacities"]
+    resources: ["storageclasses", "csinodes", "csidrivers", "csistoragecapacities", "volumeattachments"]
     verbs: [ "list", "watch" ]
   - apiGroups: ["policy"]
     resources: ["poddisruptionbudgets"]

--- a/pkg/scheduler/cache/cache.go
+++ b/pkg/scheduler/cache/cache.go
@@ -66,6 +66,7 @@ import (
 	cpuinformerv1 "volcano.sh/apis/pkg/client/informers/externalversions/nodeinfo/v1alpha1"
 	vcinformerv1 "volcano.sh/apis/pkg/client/informers/externalversions/scheduling/v1beta1"
 	topologyinformerv1alpha1 "volcano.sh/apis/pkg/client/informers/externalversions/topology/v1alpha1"
+
 	"volcano.sh/volcano/cmd/scheduler/app/options"
 	"volcano.sh/volcano/pkg/features"
 	schedulingapi "volcano.sh/volcano/pkg/scheduler/api"
@@ -119,6 +120,7 @@ type SchedulerCache struct {
 	pvInformer                 infov1.PersistentVolumeInformer
 	pvcInformer                infov1.PersistentVolumeClaimInformer
 	scInformer                 storagev1.StorageClassInformer
+	vaInformer                 storagev1.VolumeAttachmentInformer
 	pcInformer                 schedv1.PriorityClassInformer
 	quotaInformer              infov1.ResourceQuotaInformer
 	csiNodeInformer            storagev1.CSINodeInformer
@@ -638,6 +640,8 @@ func (sc *SchedulerCache) addEventHandler() {
 	sc.pvInformer.Informer()
 	sc.scInformer = informerFactory.Storage().V1().StorageClasses()
 	sc.scInformer.Informer()
+	sc.vaInformer = informerFactory.Storage().V1().VolumeAttachments()
+	sc.vaInformer.Informer()
 	sc.csiNodeInformer = informerFactory.Storage().V1().CSINodes()
 	sc.csiNodeInformer.Informer().AddEventHandler(
 		cache.ResourceEventHandlerFuncs{


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
Starting from version 1.32, kube-scheduler supports retrieving volumeattachment to accurately calculate CSILimits. Volcano also needs to be updated accordingly. For details, see the Kubernetes pr：https://github.com/kubernetes/kubernetes/pull/127757 
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Notice that do not add `Fixes` if the issue is associated with multiple PRs.
-->
Fixes #    See the Kubernetes issue：https://github.com/kubernetes/kubernetes/issues/126502

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```