### PR TITLE
🐛  fix mpi job plugin panic when mpi job only has master task

### DIFF
--- a/pkg/controllers/job/plugins/distributed-framework/mpi/mpi.go
+++ b/pkg/controllers/job/plugins/distributed-framework/mpi/mpi.go
@@ -83,9 +83,10 @@ func (mp *Plugin) OnPodCreate(pod *v1.Pod, job *batch.Job) error {
 	env := v1.EnvVar{}
 	if helpers.GetTaskKey(pod) == mp.masterName {
 		taskIndex := helpers.GetTaskIndexUnderJob(mp.workerName, job)
-		if taskIndex >= 0 {
-			workerHosts = mp.generateTaskHosts(job.Spec.Tasks[taskIndex], job.Name)
+		if taskIndex == -1 {
+			return nil
 		}
+		workerHosts = mp.generateTaskHosts(job.Spec.Tasks[taskIndex], job.Name)
 		env = v1.EnvVar{
 			Name:  MPIHost,
 			Value: workerHosts,

--- a/pkg/controllers/job/plugins/distributed-framework/mpi/mpi.go
+++ b/pkg/controllers/job/plugins/distributed-framework/mpi/mpi.go
@@ -82,7 +82,10 @@ func (mp *Plugin) OnPodCreate(pod *v1.Pod, job *batch.Job) error {
 	workerHosts := ""
 	env := v1.EnvVar{}
 	if helpers.GetTaskKey(pod) == mp.masterName {
-		workerHosts = mp.generateTaskHosts(job.Spec.Tasks[helpers.GetTaskIndexUnderJob(mp.workerName, job)], job.Name)
+		taskIndex := helpers.GetTaskIndexUnderJob(mp.workerName, job)
+		if taskIndex >= 0 {
+			workerHosts = mp.generateTaskHosts(job.Spec.Tasks[taskIndex], job.Name)
+		}
 		env = v1.EnvVar{
 			Name:  MPIHost,
 			Value: workerHosts,

--- a/pkg/controllers/job/plugins/distributed-framework/mpi/mpi_test.go
+++ b/pkg/controllers/job/plugins/distributed-framework/mpi/mpi_test.go
@@ -118,3 +118,222 @@ func TestMpi(t *testing.T) {
 		})
 	}
 }
+
+func TestMpiWithEmptyWorker(t *testing.T) {
+	testcases := []struct {
+		Name           string
+		Job            *v1alpha1.Job
+		Pod            *v1.Pod
+		ExpectedEnvVar v1.EnvVar
+		IsMaster       bool
+	}{
+		{
+			Name: "master pod with no worker task - should not panic",
+			Job: &v1alpha1.Job{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-mpi-no-worker"},
+				Spec: v1alpha1.JobSpec{
+					Tasks: []v1alpha1.TaskSpec{
+						{
+							Name:     "master",
+							Replicas: 1,
+							Template: v1.PodTemplateSpec{},
+						},
+						// No worker task defined
+					},
+				},
+			},
+			Pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-mpi-no-worker-master-0",
+					Annotations: map[string]string{
+						"volcano.sh/task-spec": "master",
+					},
+				},
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Name: "master",
+						},
+					},
+				},
+			},
+			ExpectedEnvVar: v1.EnvVar{
+				Name:  MPIHost,
+				Value: "", // Should be empty when no worker task exists
+			},
+			IsMaster: true,
+		},
+		{
+			Name: "master pod with worker task having 0 replicas",
+			Job: &v1alpha1.Job{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-mpi-zero-worker"},
+				Spec: v1alpha1.JobSpec{
+					Tasks: []v1alpha1.TaskSpec{
+						{
+							Name:     "master",
+							Replicas: 1,
+							Template: v1.PodTemplateSpec{},
+						},
+						{
+							Name:     "worker",
+							Replicas: 0, // Zero replicas
+							Template: v1.PodTemplateSpec{},
+						},
+					},
+				},
+			},
+			Pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-mpi-zero-worker-master-0",
+					Annotations: map[string]string{
+						"volcano.sh/task-spec": "master",
+					},
+				},
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Name: "master",
+						},
+					},
+				},
+			},
+			ExpectedEnvVar: v1.EnvVar{
+				Name:  MPIHost,
+				Value: "", // Should be empty when worker replicas is 0
+			},
+			IsMaster: true,
+		},
+		{
+			Name: "master pod with valid worker task",
+			Job: &v1alpha1.Job{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-mpi-valid-worker"},
+				Spec: v1alpha1.JobSpec{
+					Tasks: []v1alpha1.TaskSpec{
+						{
+							Name:     "master",
+							Replicas: 1,
+							Template: v1.PodTemplateSpec{},
+						},
+						{
+							Name:     "worker",
+							Replicas: 2,
+							Template: v1.PodTemplateSpec{},
+						},
+					},
+				},
+			},
+			Pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-mpi-valid-worker-master-0",
+					Annotations: map[string]string{
+						"volcano.sh/task-spec": "master",
+					},
+				},
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Name: "master",
+						},
+					},
+				},
+			},
+			ExpectedEnvVar: v1.EnvVar{
+				Name:  MPIHost,
+				Value: "test-mpi-valid-worker-worker-0.test-mpi-valid-worker,test-mpi-valid-worker-worker-1.test-mpi-valid-worker",
+			},
+			IsMaster: true,
+		},
+		{
+			Name: "worker pod should not have MPI_HOST env var",
+			Job: &v1alpha1.Job{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-mpi-worker-pod"},
+				Spec: v1alpha1.JobSpec{
+					Tasks: []v1alpha1.TaskSpec{
+						{
+							Name:     "master",
+							Replicas: 1,
+							Template: v1.PodTemplateSpec{},
+						},
+						{
+							Name:     "worker",
+							Replicas: 1,
+							Template: v1.PodTemplateSpec{},
+						},
+					},
+				},
+			},
+			Pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-mpi-worker-pod-worker-0",
+					Annotations: map[string]string{
+						"volcano.sh/task-spec": "worker",
+					},
+				},
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Name: "worker",
+						},
+					},
+				},
+			},
+			ExpectedEnvVar: v1.EnvVar{}, // Should be empty for worker pods
+			IsMaster:       false,
+		},
+	}
+
+	for index, testcase := range testcases {
+		t.Run(testcase.Name, func(t *testing.T) {
+			mp := New(pluginsinterface.PluginClientset{}, []string{})
+
+			// Test that OnPodCreate doesn't panic
+			if err := mp.OnPodCreate(testcase.Pod, testcase.Job); err != nil {
+				t.Errorf("Case %d (%s): expect no error, but got error %v", index, testcase.Name, err)
+			}
+
+			// Check if master pod has the correct MPI_HOST environment variable
+			if testcase.IsMaster {
+				// Check init containers
+				checkMPIHostEnvVar(t, index, testcase.Name, "InitContainer", testcase.Pod.Spec.InitContainers, testcase.ExpectedEnvVar)
+
+				// Check regular containers
+				checkMPIHostEnvVar(t, index, testcase.Name, "Container", testcase.Pod.Spec.Containers, testcase.ExpectedEnvVar)
+			} else {
+				// For worker pods, ensure no MPI_HOST environment variable is set
+				checkNoMPIHostEnvVar(t, index, testcase.Name, testcase.Pod.Spec.Containers)
+			}
+		})
+	}
+}
+
+// checkMPIHostEnvVar checks if containers have the expected MPI_HOST environment variable
+func checkMPIHostEnvVar(t *testing.T, index int, testName, containerType string, containers []v1.Container, expectedEnvVar v1.EnvVar) {
+	for _, c := range containers {
+		found := false
+		for _, env := range c.Env {
+			if env.Name == MPIHost {
+				found = true
+				if env.Value != expectedEnvVar.Value {
+					t.Errorf("Case %d (%s): %s MPI_HOST value mismatch, expected '%s', got '%s'",
+						index, testName, containerType, expectedEnvVar.Value, env.Value)
+				}
+				break
+			}
+		}
+		if !found && expectedEnvVar.Name != "" {
+			t.Errorf("Case %d (%s): %s missing MPI_HOST environment variable", index, testName, containerType)
+		}
+	}
+}
+
+// checkNoMPIHostEnvVar ensures that containers do not have MPI_HOST environment variable
+func checkNoMPIHostEnvVar(t *testing.T, index int, testName string, containers []v1.Container) {
+	for _, c := range containers {
+		for _, env := range c.Env {
+			if env.Name == MPIHost {
+				t.Errorf("Case %d (%s): Worker pod should not have MPI_HOST environment variable, but found: %s",
+					index, testName, env.Value)
+			}
+		}
+	}
+}

--- a/pkg/controllers/job/plugins/distributed-framework/mpi/mpi_test.go
+++ b/pkg/controllers/job/plugins/distributed-framework/mpi/mpi_test.go
@@ -157,11 +157,8 @@ func TestMpiWithEmptyWorker(t *testing.T) {
 					},
 				},
 			},
-			ExpectedEnvVar: v1.EnvVar{
-				Name:  MPIHost,
-				Value: "", // Should be empty when no worker task exists
-			},
-			IsMaster: true,
+			ExpectedEnvVar: v1.EnvVar{},
+			IsMaster:       true,
 		},
 		{
 			Name: "master pod with worker task having 0 replicas",
@@ -197,11 +194,8 @@ func TestMpiWithEmptyWorker(t *testing.T) {
 					},
 				},
 			},
-			ExpectedEnvVar: v1.EnvVar{
-				Name:  MPIHost,
-				Value: "", // Should be empty when worker replicas is 0
-			},
-			IsMaster: true,
+			ExpectedEnvVar: v1.EnvVar{},
+			IsMaster:       true,
 		},
 		{
 			Name: "master pod with valid worker task",


### PR DESCRIPTION
#### What type of PR is this?

fix mpi job plugin panic when mpi job only has master task
#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Notice that do not add `Fixes` if the issue is associated with multiple PRs.
-->
Fixes #
https://github.com/volcano-sh/volcano/issues/4609
#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
fix mpi job plugin panic when mpi job only has master task
```