### PR TITLE
feat: enhance network topology binpack

### DIFF
--- a/docs/user-guide/how_to_use_network_topology_aware_plugin.md
+++ b/docs/user-guide/how_to_use_network_topology_aware_plugin.md
@@ -1,0 +1,171 @@
+# Volcano Network Topology-Aware Scheduling Guide
+
+## 1. Network Topology Challenges and Solutions
+
+### 1.1 Challenges in RDMA Network Architectures
+
+Modern data centers often employ RDMA networks (e.g., InfiniBand, RoCE) with **Fat Tree** or **Clos** architectures, featuring multi-layer switching hierarchies:
+
+```mermaid
+graph TD
+    Spine[Spine Layer] -->|Higher Bandwidth| Leaf1[Leaf Switch 1]
+    Spine -->|Higher Bandwidth| Leaf2[Leaf Switch 2]
+    
+    Leaf1 -->|Lower Latency| Node1[Node 1]
+    Leaf1 -->|Lower Latency| Node2[Node 2]
+    Leaf1 -->|Lower Latency| Node3[Node 3]
+    Leaf1 -->|Lower Latency| Node4[Node 4]
+    
+    Leaf2 -->|Lower Latency| Node5[Node 5]
+    Leaf2 -->|Lower Latency| Node6[Node 6]
+    Leaf2 -->|Lower Latency| Node7[Node 7]
+    Leaf2 -->|Lower Latency| Node8[Node 8]
+```
+
+This hierarchical architecture introduces the following scheduling challenges:
+- **Performance Variance**: Nodes under the same Leaf switch experience higher bandwidth and lower latency; jobs communicating across more switches may face network congestion.
+- **Resource Fragmentation**: Without BinPack considerations, fragmented hierarchical resources can degrade cluster network performance.
+- **Topology Constraints**: AI/ML training jobs require specific network topologies to meet communication requirements.
+
+### 1.2 Volcano's Solution
+
+Volcano provides **Network Topology-Aware Scheduling** capabilities:
+- **HyperNode CRD**: Describes network topology hierarchies.
+- **Topology Constraints**: Specifies network topology requirements within Jobs.
+- **Intelligent Scheduling**: Prioritizes scheduling jobs within optimal topology domains to prevent performance degradation.
+
+## 2. Network Topology Labeling and Management
+
+### 2.1 Manual HyperNode Creation
+
+Use the `HyperNode` CRD to describe network topology:
+
+```yaml
+apiVersion: topology.volcano.sh/v1alpha1
+kind: HyperNode
+metadata:
+  name: leaf-switch-1
+spec:
+  tier: "1"  # Lower tier values indicate higher performance
+  members:
+  - type: Node
+    selector:
+      labelMatch:
+        matchLabels:
+          leaf: leaf-1
+---
+apiVersion: topology.volcano.sh/v1alpha1
+kind: HyperNode
+metadata:
+  name: spine-switch-1
+spec:
+  tier: "2"  # Higher tier (lower performance)
+  members:
+  - type: HyperNode
+    selector:
+      exactMatch:
+        name: leaf-switch-1
+  - type: HyperNode
+    selector:
+      exactMatch:
+        name: leaf-switch-2
+```
+
+### 2.2 Automated Topology Discovery
+
+Volcano provides topology generation tools supporting multiple discovery methods:
+
+- **InfiniBand**: Offers the `ibnetdiscover` tool for automatic IB network topology discovery. See: https://github.com/volcano-sh/volcano/pull/4286/files
+- **RoCE**: Currently lacks a dedicated solution; may require collecting all LLDP information from each node.
+
+## 3. Job Topology Constraint Configuration
+
+### 3.1 Volcano Job Topology Constraints
+
+Specify network topology requirements in Volcano Jobs:
+
+```yaml
+apiVersion: batch.volcano.sh/v1alpha1
+kind: Job
+metadata:
+  name: distributed-training-job
+spec:
+  minAvailable: 3
+  schedulerName: volcano
+  networkTopology:
+    mode: hard  # Hard constraint: topology requirements must be met
+    highestTierAllowed: 1  # Highest allowed tier (lower numerical value indicates better performance)
+  tasks:
+  - replicas: 1
+    name: master
+    template:
+      spec:
+        containers:
+        - name: master
+          image: training-image:latest
+          resources:
+            requests:
+              cpu: 4
+              memory: 16Gi
+              nvidia.com/gpu: 1
+  - replicas: 2
+    name: worker
+    template:
+      spec:
+        containers:
+        - name: worker
+          image: training-image:latest
+          resources:
+            requests:
+              cpu: 8
+              memory: 32Gi
+              nvidia.com/gpu: 4
+```
+
+## 4. Scheduler Configuration and Optimization
+
+### 4.1 Key Scheduler Parameters
+
+Configure the following parameters to ensure proper network topology-aware scheduling:
+
+```yaml
+# volcano-scheduler deployment configuration
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: volcano-scheduler
+spec:
+  template:
+    spec:
+      containers:
+      - name: scheduler
+        image: volcano-scheduler:latest
+        command:
+        - /vc-scheduler
+        - --percentage-nodes-to-find=100  # Critical: must evaluate all nodes to guarantee optimal topology
+```
+
+### 4.2 Network Topology Plugin Configuration
+
+Enable and optimize the network topology plugin in the scheduler configuration:
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: volcano-scheduler-config
+data:
+  volcano-scheduler.conf: |
+    actions: "allocate, backfill"
+    tiers:
+    - plugins:
+      - name: network-topology-aware  # Enable network topology plugin
+        arguments:
+          weight: 20                  # Plugin weight (impacts scheduling decisions)
+          binpack.cpu: 1              # CPU resource weight
+          binpack.memory: 2           # Memory resource weight
+          binpack.resources: nvidia.com/gpu  # Custom resources
+          binpack.resources.nvidia.com/gpu: 10  # GPU weight (higher)
+```
+
+Through the above configurations and usage guidelines, users can fully leverage Volcano's network topology-aware scheduling capabilities to optimize the performance and resource utilization of distributed workloads in complex network environments.

--- a/installer/helm/chart/volcano/templates/scheduler.yaml
+++ b/installer/helm/chart/volcano/templates/scheduler.yaml
@@ -226,6 +226,9 @@ spec:
             {{- if .Values.custom.scheduler_feature_gates }}
             - --feature-gates={{ .Values.custom.scheduler_feature_gates }}
             {{- end }}
+            {{- if .Values.custom.scheduler_percentage_nodes_to_find }}
+            - --percentage-nodes-to-find={{.Values.custom.scheduler_percentage_nodes_to_find}}
+            {{- end }}
             {{- if .Values.custom.ignored_provisioners }}
             - --ignored-provisioners={{ .Values.custom.ignored_provisioners}}
             {{- end}}

--- a/pkg/scheduler/api/cluster_info.go
+++ b/pkg/scheduler/api/cluster_info.go
@@ -32,6 +32,7 @@ type ClusterInfo struct {
 	Nodes                     map[string]*NodeInfo
 	HyperNodes                HyperNodeInfoMap
 	HyperNodesSetByTier       map[int]sets.Set[string]
+	MinHyperNodeOfNodeMap     map[string]string
 	RealNodesSet              map[string]sets.Set[string]
 	HyperNodesReadyToSchedule bool
 	Queues                    map[QueueID]*QueueInfo

--- a/pkg/scheduler/api/hyper_node_info.go
+++ b/pkg/scheduler/api/hyper_node_info.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"regexp"
 	"slices"
+	"sort"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -198,6 +199,29 @@ func (hni *HyperNodesInfo) RealNodesSet() map[string]sets.Set[string] {
 	}
 
 	return copiedRealNodesSet
+}
+
+func (hni *HyperNodesInfo) MinHyperNodeOfNodeMap() map[string]string {
+	minHyperNodeOfNodeMap := make(map[string]string)
+
+	if len(hni.hyperNodesSetByTier) == 0 {
+		return minHyperNodeOfNodeMap
+	}
+
+	tiers := make([]int, 0, len(hni.hyperNodesSetByTier))
+	for tier := range hni.hyperNodesSetByTier {
+		tiers = append(tiers, tier)
+	}
+	sort.Ints(tiers)
+
+	nodeTypeHyperNodes := hni.hyperNodesSetByTier[tiers[0]]
+	for hyperNode := range nodeTypeHyperNodes {
+		nodes := hni.realNodesSet[hyperNode]
+		for node := range nodes {
+			minHyperNodeOfNodeMap[node] = hyperNode
+		}
+	}
+	return minHyperNodeOfNodeMap
 }
 
 // DeleteHyperNode deletes a HyperNode from the cache and update hyperNode tree.

--- a/pkg/scheduler/cache/cache.go
+++ b/pkg/scheduler/cache/cache.go
@@ -1400,6 +1400,7 @@ func (sc *SchedulerCache) Snapshot() *schedulingapi.ClusterInfo {
 	snapshot.HyperNodes = sc.HyperNodesInfo.HyperNodes()
 	snapshot.HyperNodesSetByTier = sc.HyperNodesInfo.HyperNodesSetByTier()
 	snapshot.RealNodesSet = sc.HyperNodesInfo.RealNodesSet()
+	snapshot.MinHyperNodeOfNodeMap = sc.HyperNodesInfo.MinHyperNodeOfNodeMap()
 	snapshot.HyperNodesReadyToSchedule = sc.HyperNodesInfo.Ready()
 	sc.HyperNodesInfo.Unlock()
 

--- a/pkg/scheduler/framework/session.go
+++ b/pkg/scheduler/framework/session.go
@@ -94,6 +94,7 @@ type Session struct {
 	HyperNodesTiers     []int
 	// RealNodesList maps hyperNode Name -> nodes under the hyperNode.
 	RealNodesList             map[string][]*api.NodeInfo
+	MinHyperNodeOfNodeMap     map[string]string
 	HyperNodesReadyToSchedule bool
 
 	plugins             map[string]Plugin
@@ -211,6 +212,7 @@ func openSession(cache cache.Cache) *Session {
 	ssn.HyperNodesSetByTier = snapshot.HyperNodesSetByTier
 	ssn.parseHyperNodesTiers()
 	ssn.RealNodesList = util.GetRealNodesListByHyperNode(snapshot.RealNodesSet, snapshot.Nodes)
+	ssn.MinHyperNodeOfNodeMap = snapshot.MinHyperNodeOfNodeMap
 	ssn.HyperNodesReadyToSchedule = snapshot.HyperNodesReadyToSchedule
 	ssn.Nodes = snapshot.Nodes
 	ssn.CSINodesStatus = snapshot.CSINodesStatus

--- a/pkg/scheduler/plugins/network-topology-aware/network_topology_aware.go
+++ b/pkg/scheduler/plugins/network-topology-aware/network_topology_aware.go
@@ -17,6 +17,13 @@ limitations under the License.
 package networktopologyaware
 
 import (
+	"fmt"
+	"math"
+	"sort"
+	"strings"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog/v2"
 
 	"volcano.sh/volcano/pkg/scheduler/api"
@@ -30,13 +37,67 @@ const (
 	BaseScore             = 100.0
 	ZeroScore             = 0.0
 	NetworkTopologyWeight = "weight"
+
+	// Default binpack configuration values
+	DefaultResourceWeight = 1
+	MinValidWeight        = 0
+
+	// Binpack scoring weights
+	// ConsolidationWeight prioritizes resource consolidation and task affinity
+	ConsolidationWeight = 0.5
+	// CapacityWeight prioritizes layers that can accommodate remaining tasks
+	CapacityWeight = 0.5
+
+	// BinpackCPU is the key for weight of cpu
+	BinpackCPU = "binpack.cpu"
+	// BinpackMemory is the key for weight of memory
+	BinpackMemory = "binpack.memory"
+
+	// BinpackResources is the key for additional resource key name
+	BinpackResources = "binpack.resources"
+	// BinpackResourcesPrefix is the key prefix for additional resource key name
+	BinpackResourcesPrefix = BinpackResources + "."
+
+	resourceFmt = "%s[%d]"
 )
 
 type networkTopologyAwarePlugin struct {
 	// Arguments given for the plugin
 	pluginArguments framework.Arguments
 	weight          int
+	binpack         binpackConfig
+
+	// HyperNode
 	*hyperNodesTier
+	hyperNodeCapacities map[string]*api.Resource
+	leafAncestors       map[string][]string
+	tierWeights         map[int]float64
+}
+
+type binpackConfig struct {
+	BinPackingCPU       int
+	BinPackingMemory    int
+	BinPackingResources map[v1.ResourceName]int
+}
+
+func (w *binpackConfig) String() string {
+	length := 3
+	if extendLength := len(w.BinPackingResources); extendLength == 0 {
+		length++
+	} else {
+		length += extendLength
+	}
+	msg := make([]string, 0, length)
+
+	if len(w.BinPackingResources) == 0 {
+		msg = append(msg, "no extend resources.")
+	} else {
+		for name, weight := range w.BinPackingResources {
+			msg = append(msg, fmt.Sprintf(resourceFmt, name, weight))
+		}
+	}
+	sort.Strings(msg)
+	return strings.Join(msg, ", ")
 }
 
 type hyperNodesTier struct {
@@ -58,6 +119,7 @@ func New(arguments framework.Arguments) framework.Plugin {
 		pluginArguments: arguments,
 		hyperNodesTier:  &hyperNodesTier{},
 		weight:          calculateWeight(arguments),
+		binpack:         calculateBinpackWeight(arguments),
 	}
 }
 
@@ -79,6 +141,68 @@ func calculateWeight(args framework.Arguments) int {
 	return weight
 }
 
+func calculateBinpackWeight(args framework.Arguments) binpackConfig {
+	/*
+		User Should give priorityWeight in this format(binpack.config, binpack.cpu, binpack.memory).
+		Support change the config about cpu, memory and additional resource by arguments:
+
+		tiers:
+		- plugins:
+			- name: network-topology-aware
+				arguments:
+				weight: 20
+				binpack.cpu: 1
+				binpack.memory: 2
+				binpack.resources: nvidia.com/gpu
+				binpack.resources.nvidia.com/gpu: 10
+
+		Also, you should set `--percentage-nodes-to-find=100` to make binpack work effectively.
+	*/
+	config := binpackConfig{
+		BinPackingCPU:       DefaultResourceWeight,
+		BinPackingMemory:    DefaultResourceWeight,
+		BinPackingResources: map[v1.ResourceName]int{},
+	}
+
+	// Checks whether binpack.cpu is provided or not, if given, modifies the value in weight struct.
+	args.GetInt(&config.BinPackingCPU, BinpackCPU)
+	if config.BinPackingCPU < 0 {
+		config.BinPackingCPU = MinValidWeight
+	}
+	// Checks whether binpack.memory is provided or not, if given, modifies the value in weight struct.
+	args.GetInt(&config.BinPackingMemory, BinpackMemory)
+	if config.BinPackingMemory < 0 {
+		config.BinPackingMemory = MinValidWeight
+	}
+
+	resourcesStr, ok := args[BinpackResources].(string)
+	if !ok {
+		resourcesStr = ""
+	}
+
+	resources := strings.SplitSeq(resourcesStr, ",")
+	for resource := range resources {
+		resource = strings.TrimSpace(resource)
+		if resource == "" {
+			continue
+		}
+
+		// binpack.resources.[ResourceName]
+		resourceKey := BinpackResourcesPrefix + resource
+		resourceWeight := 1
+		args.GetInt(&resourceWeight, resourceKey)
+		if resourceWeight < 0 {
+			resourceWeight = MinValidWeight
+		}
+		config.BinPackingResources[v1.ResourceName(resource)] = resourceWeight
+	}
+
+	config.BinPackingResources[v1.ResourceCPU] = config.BinPackingCPU
+	config.BinPackingResources[v1.ResourceMemory] = config.BinPackingMemory
+
+	return config
+}
+
 func (nta *networkTopologyAwarePlugin) OnSessionOpen(ssn *framework.Session) {
 	klog.V(5).Infof("Enter networkTopologyAwarePlugin plugin ...")
 	defer func() {
@@ -86,7 +210,23 @@ func (nta *networkTopologyAwarePlugin) OnSessionOpen(ssn *framework.Session) {
 	}()
 	nta.hyperNodesTier.init(ssn.HyperNodesTiers)
 
-	nodeFn := func(task *api.TaskInfo, nodes []*api.NodeInfo) (map[string]float64, error) {
+	// Validate tier information before expensive initialization
+	if nta.minTier == nta.maxTier && nta.minTier == 0 {
+		klog.V(4).Infof("networkTopologyAware: no valid tier information, disabling binpack")
+	} else {
+		nta.initializeHierarchyCapacity(ssn)
+		nta.tierWeights = calculateTierWeights(nta.minTier, nta.maxTier)
+		klog.V(4).Infof("networkTopologyAware: binpack initialized with %d tier levels", nta.maxTier-nta.minTier+1)
+	}
+
+	// Register scoring functions
+	ssn.AddBatchNodeOrderFn(nta.Name(), nta.batchNodeScoringFn(ssn))
+}
+
+// batchNodeScoringFn returns a function that scores nodes for task placement.
+// The scoring considers both network topology awareness and binpack optimization.
+func (nta *networkTopologyAwarePlugin) batchNodeScoringFn(ssn *framework.Session) api.BatchNodeOrderFn {
+	return func(task *api.TaskInfo, nodes []*api.NodeInfo) (map[string]float64, error) {
 		nodeScores := make(map[string]float64)
 
 		taskJob := ssn.Jobs[task.Job]
@@ -95,58 +235,76 @@ func (nta *networkTopologyAwarePlugin) OnSessionOpen(ssn *framework.Session) {
 		}
 
 		jobAllocatedHyperNode := task.JobAllocatedHyperNode
+
+		minHyperNodeOfNodeMap := ssn.MinHyperNodeOfNodeMap
+		var resourceRequest *api.Resource
+		var binpackScores map[string]float64
+
+		resourceRequest = calculateUnallocatedResources(taskJob)
+		allocatedLeafMap := collectAllocatedLeafMap(taskJob.Tasks, minHyperNodeOfNodeMap)
+		binpackScores = nta.calculateLeafBinpackScores(nodes, resourceRequest, minHyperNodeOfNodeMap, allocatedLeafMap)
+
+		// Handle subsequent allocation scenarios (combining topology and Binpack scores)
+		var maxScore, minScore float64 = -1, math.MaxFloat64
+		normalizeScore := func(scores map[string]float64) {
+			// Normalize nodeScores to the range [0, BaseScore]
+			for nodeName, score := range scores {
+				if maxScore-minScore < 1e-6 {
+					scores[nodeName] = BaseScore
+				} else {
+					scores[nodeName] = (score - minScore) / (maxScore - minScore) * BaseScore
+				}
+				scores[nodeName] *= float64(nta.weight)
+			}
+		}
+
+		// Handle initial allocation scenario
 		if jobAllocatedHyperNode == "" {
+			for _, node := range nodes {
+				leafNode := minHyperNodeOfNodeMap[node.Name]
+				nodeScores[node.Name] = binpackScores[leafNode]
+				minScore = min(minScore, nodeScores[node.Name])
+				maxScore = max(maxScore, nodeScores[node.Name])
+			}
+
+			normalizeScore(nodeScores)
+			klog.V(4).Infof("networkTopologyAware initial hyperNode selection scores: %v", nodeScores)
 			return nodeScores, nil
 		}
-		// Calculate score based on LCAHyperNode tier.
-		var maxScore float64 = -1
+
 		scoreToNodes := map[float64][]string{}
 		for _, node := range nodes {
-			hyperNode := util.FindHyperNodeForNode(node.Name, ssn.RealNodesList, ssn.HyperNodesTiers, ssn.HyperNodesSetByTier)
-			score := nta.networkTopologyAwareScore(hyperNode, jobAllocatedHyperNode, ssn.HyperNodes)
-			score *= float64(nta.weight)
+			leafNode := minHyperNodeOfNodeMap[node.Name]
+
+			// Calculate topology score
+			score := binpackScores[leafNode]
 			nodeScores[node.Name] = score
 			if score >= maxScore {
 				maxScore = score
 				scoreToNodes[maxScore] = append(scoreToNodes[maxScore], node.Name)
 			}
+			minScore = min(minScore, score)
 		}
 		// Calculate score based on the number of tasks scheduled for the job when max score of node has more than one.
 		if len(scoreToNodes[maxScore]) > 1 {
 			candidateNodes := scoreToNodes[maxScore]
+
 			for _, node := range candidateNodes {
-				hyperNode := util.FindHyperNodeForNode(node, ssn.RealNodesList, ssn.HyperNodesTiers, ssn.HyperNodesSetByTier)
+				hyperNode := minHyperNodeOfNodeMap[node]
 				taskNumScore := nta.scoreWithTaskNum(hyperNode, taskJob, ssn.RealNodesList)
-				taskNumScore *= float64(nta.weight)
 				nodeScores[node] += taskNumScore
+				maxScore = max(maxScore, nodeScores[node])
 			}
 		}
 
+		// Normalize nodeScores to the range [0, BaseScore] * weight
+		normalizeScore(nodeScores)
 		klog.V(4).Infof("networkTopologyAware node score is: %v", nodeScores)
 		return nodeScores, nil
 	}
-	ssn.AddBatchNodeOrderFn(nta.Name(), nodeFn)
 }
 
 func (bp *networkTopologyAwarePlugin) OnSessionClose(ssn *framework.Session) {
-}
-
-// networkTopologyAwareScore use the best fit polices during scheduling.
-
-// Goals:
-// - The tier of LCAHyperNode of the hyperNode and the job allocatedHyperNode should be as low as possible.
-func (nta *networkTopologyAwarePlugin) networkTopologyAwareScore(hyperNodeName, jobAllocatedHyperNode string, hyperNodeMap api.HyperNodeInfoMap) float64 {
-	if hyperNodeName == jobAllocatedHyperNode {
-		return BaseScore
-	}
-	LCAHyperNode := hyperNodeMap.GetLCAHyperNode(hyperNodeName, jobAllocatedHyperNode)
-	hyperNodeInfo, ok := hyperNodeMap[LCAHyperNode]
-	if !ok {
-		return ZeroScore
-	}
-	// Calculate score: (maxTier - LCAhyperNode.tier)/(maxTier - minTier)
-	hyperNodeTierScore := BaseScore * nta.scoreHyperNodeWithTier(hyperNodeInfo.Tier())
-	return hyperNodeTierScore
 }
 
 // Goals:
@@ -161,18 +319,245 @@ func (nta *networkTopologyAwarePlugin) scoreWithTaskNum(hyperNodeName string, jo
 	return taskNumScore
 }
 
-func (nta *networkTopologyAwarePlugin) scoreHyperNodeWithTier(tier int) float64 {
-	// Use tier to calculate scores and map the original score to the range between 0 and 1.
-	if nta.minTier == nta.maxTier {
-		return ZeroScore
-	}
-	return float64(nta.maxTier-tier) / float64(nta.maxTier-nta.minTier)
-}
-
 func scoreHyperNodeWithTaskNum(taskNum int, allTaskNum int) float64 {
 	// Calculate task distribution rate as score and map the original score to the range between 0 and 1.
 	if allTaskNum == 0 {
 		return ZeroScore
 	}
 	return float64(taskNum) / float64(allTaskNum)
+}
+
+// calculateLeafBinpackScores computes binpack scores for leaf hypernodes based on resource utilization.
+// This function implements a hierarchical scoring approach that considers:
+// 1. Resource availability at each tier level
+// 2. Existing job allocation to promote task consolidation
+// 3. Tier-based weighting to prefer lower tiers (better locality)
+//
+// The scoring mechanism combines two key metrics:
+// - Consolidation Score: Measures resource consolidation efficiency
+//   - Prioritizes hypernodes that already contain tasks from the same job (promotes task affinity)
+//   - For empty hypernodes, favors higher resource utilization to minimize resource fragmentation
+//
+// - Capacity Score: Measures the hypernode's ability to accommodate remaining tasks
+//   - Gives maximum score to hypernodes that can fit all remaining unscheduled tasks
+//   - Partially rewards hypernodes based on how much of the remaining workload they can handle
+//
+// Parameters:
+// - nodes: candidate nodes for scheduling
+// - required: total unallocated resources needed by the job
+// - leafOfNodeMap: mapping from node names to their leaf hypernode names
+// - allocatedLeafMap: set of leaf hypernodes that already contain tasks from this job
+//
+// Returns a map of hypernode names to their binpack scores.
+func (nta *networkTopologyAwarePlugin) calculateLeafBinpackScores(
+	nodes []*api.NodeInfo,
+	required *api.Resource,
+	leafOfNodeMap map[string]string,
+	allocatedLeafMap sets.Set[string],
+) map[string]float64 {
+	scores := make(map[string]float64)
+	hyperNodeIdles := make(map[string]*api.Resource)
+	leafMap := sets.New[string]()
+
+	for _, node := range nodes {
+		leaf := leafOfNodeMap[node.Name]
+		leafMap.Insert(leaf)
+		for _, hn := range nta.leafAncestors[leaf] {
+			if hyperNodeIdles[hn] == nil {
+				hyperNodeIdles[hn] = api.EmptyResource()
+			}
+			if node.Idle != nil {
+				hyperNodeIdles[hn].Add(node.Idle)
+			}
+		}
+	}
+
+	hyperNodeAllocated := sets.New[string]()
+	for leaf := range allocatedLeafMap {
+		for _, hn := range nta.leafAncestors[leaf] {
+			hyperNodeAllocated.Insert(hn)
+		}
+	}
+
+	for leaf := range leafMap {
+		totalScore := 0.0
+
+		// Traverse hierarchy from min to max tier
+		for tierOffset, hn := range nta.leafAncestors[leaf] {
+			consolidationScore, capacityScore := 0.0, 0.0
+			tier := nta.minTier + tierOffset
+			idle, okIdle := hyperNodeIdles[hn]
+			capacity, okCap := nta.hyperNodeCapacities[hn]
+
+			if !okIdle || !okCap {
+				continue
+			}
+
+			isEnough := required.LessEqual(idle, api.Zero)
+
+			if isEnough {
+				// Current layer can accommodate all remaining tasks, capacity score should be 1 (optimal fit)
+				capacityScore = 1.0
+			} else {
+				// Calculate partial capacity satisfaction based on resource gap
+				notEnough, _ := required.Diff(idle, api.Zero)
+				capacityScore = 1.0 - nta.calculateResourceDiffScore(notEnough, required, required)
+			}
+
+			// If current layer already contains tasks of the job, consolidation score should be 1 (maximum affinity)
+			if hyperNodeAllocated.Has(hn) {
+				consolidationScore = 1.0
+			} else if isEnough {
+				// For empty hypernodes with sufficient capacity, favor higher resource utilization
+				consolidationScore = 1.0 - nta.calculateResourceDiffScore(idle, capacity, required)
+			}
+
+			klog.V(5).Infof("networkTopologyAware tier %s (%d) has consolidation: %f, capacity: %f", hn, tier, consolidationScore, capacityScore)
+			totalScore += (ConsolidationWeight*consolidationScore + CapacityWeight*capacityScore) * nta.tierWeights[tier]
+		}
+
+		scores[leaf] = totalScore * BaseScore
+		klog.V(4).Infof("networkTopologyAware leaf %s has binpack score: %f", leaf, scores[leaf])
+	}
+
+	return scores
+}
+
+// initializeHierarchyCapacity builds capacity hierarchy for hypernodes.
+// This function calculates the total capacity for each hypernode by aggregating
+// the capacity of all real nodes within its subtree.
+//
+// The function performs the following steps:
+// 1. Iterate through all leaf hypernodes (lowest tier)
+// 2. Calculate total capacity for each leaf by summing real node capacities
+// 3. Propagate capacity up the hierarchy by adding leaf capacity to ancestors
+//
+// Error handling: Logs warnings for missing hypernode information but continues processing.
+func (nta *networkTopologyAwarePlugin) initializeHierarchyCapacity(ssn *framework.Session) {
+	nta.hyperNodeCapacities = make(map[string]*api.Resource)
+	nta.leafAncestors = make(map[string][]string)
+
+	hnim := ssn.HyperNodes
+	// Check if we have valid tier information
+	hyperNodesSet, exists := ssn.HyperNodesSetByTier[nta.minTier]
+	if !exists || len(hyperNodesSet) == 0 {
+		klog.V(4).Infof("networkTopologyAware: no hypernodes found at min tier %d", nta.minTier)
+		return
+	}
+
+	for leaf := range hyperNodesSet {
+		capacity := api.EmptyResource()
+
+		// Get real nodes for this leaf hypernode
+		realNodes, exists := ssn.RealNodesList[leaf]
+		if !exists || len(realNodes) == 0 {
+			klog.V(4).Infof("networkTopologyAware: no real nodes found for leaf hypernode %s", leaf)
+			continue
+		}
+
+		for _, rn := range realNodes {
+			if rn == nil {
+				klog.Warningf("networkTopologyAware: found nil real node in leaf %s", leaf)
+				continue
+			}
+			capacity.Add(rn.Capacity)
+		}
+
+		hnAncestors := hnim.GetAncestors(leaf)
+		if len(hnAncestors) == 0 {
+			klog.V(4).Infof("networkTopologyAware: no ancestors found for leaf %s", leaf)
+			continue
+		}
+
+		nta.leafAncestors[leaf] = hnAncestors
+
+		for _, hyperNode := range hnAncestors {
+			if _, ok := nta.hyperNodeCapacities[hyperNode]; !ok {
+				nta.hyperNodeCapacities[hyperNode] = api.EmptyResource()
+			}
+			nta.hyperNodeCapacities[hyperNode].Add(capacity)
+		}
+	}
+
+	klog.V(4).Infof("networkTopologyAware: initialized capacity for %d hypernodes", len(nta.hyperNodeCapacities))
+}
+
+// collectAllocatedLeafMap gathers all hypernodes in the lowest tier which contains tasks
+func collectAllocatedLeafMap(tasks map[api.TaskID]*api.TaskInfo, minHyperNodeOfNodeMap map[string]string) sets.Set[string] {
+	leafMap := sets.New[string]()
+	for _, task := range tasks {
+		if task.NodeName == "" {
+			continue
+		}
+		currentHN := minHyperNodeOfNodeMap[task.NodeName]
+		leafMap.Insert(currentHN)
+	}
+	return leafMap
+}
+
+// calculateUnallocatedResources get unallocated resource totals for a job
+func calculateUnallocatedResources(job *api.JobInfo) *api.Resource {
+	unallocated := api.EmptyResource()
+	for _, t := range job.TaskStatusIndex[api.Pending] {
+		if t.NodeName != "" {
+			continue
+		}
+		unallocated.Add(t.Resreq)
+	}
+	return unallocated
+}
+
+// calculateResourceDiffScore calculates the weighted resource utilization score based on configured weights.
+// It considers all resources specified in binpackWeight configuration.
+// Returns a normalized value between 0 (no utilization) and 1 (full utilization).
+func (nta *networkTopologyAwarePlugin) calculateResourceDiffScore(target, total, required *api.Resource) float64 {
+	score := 0.0
+	weightSum := 0
+
+	// Process all resources that have weights configured
+	for resource, weight := range nta.binpack.BinPackingResources {
+		if weight <= 0 {
+			continue
+		}
+
+		if required.IsZero(resource) {
+			continue
+		}
+
+		score += calculateResourceUtilization(target.Get(resource), total.Get(resource)) * float64(weight)
+		weightSum += weight
+	}
+
+	// Normalize the score if we processed any resources
+	if weightSum > 0 {
+		return score / float64(weightSum)
+	}
+	return 0
+}
+
+// calculateResourceUtilization calculates utilization for resources
+func calculateResourceUtilization(target, capacity float64) float64 {
+	if capacity <= 0 || target <= 0 {
+		return 0
+	}
+	return math.Min(1.0, target/capacity)
+}
+
+func calculateTierWeights(minTier, maxTier int) map[int]float64 {
+	weights := make(map[int]float64)
+	total := 0.0
+
+	// Exponential decay weights (higher priority for lower tiers)
+	for tier := minTier; tier <= maxTier; tier++ {
+		weight := math.Pow(0.5, float64(tier-minTier))
+		weights[tier] = weight
+		total += weight
+	}
+
+	// Normalize weights
+	for tier := range weights {
+		weights[tier] /= total
+	}
+
+	return weights
 }

--- a/pkg/scheduler/plugins/network-topology-aware/network_topology_aware_test.go
+++ b/pkg/scheduler/plugins/network-topology-aware/network_topology_aware_test.go
@@ -58,6 +58,55 @@ func TestArguments(t *testing.T) {
 	if weight != 2 {
 		t.Errorf("weight should be 2, but get %v", weight)
 	}
+
+	binpackConfig := calculateBinpackWeight(networkTopologyAware.pluginArguments)
+	expectedStr := "cpu[1], memory[1]"
+	if binpackConfig.String() != expectedStr {
+		t.Errorf("binpack config string should be %s, but get %s", expectedStr, binpackConfig.String())
+	}
+}
+
+func TestBinpackArguments(t *testing.T) {
+	framework.RegisterPluginBuilder(PluginName, New)
+	defer framework.CleanupPluginBuilders()
+
+	arguments := framework.Arguments{
+		"weight":                           2,
+		"binpack.cpu":                      1,
+		"binpack.memory":                   2,
+		"binpack.resources":                "nvidia.com/gpu",
+		"binpack.resources.nvidia.com/gpu": 10,
+	}
+
+	builder, ok := framework.GetPluginBuilder(PluginName)
+	if !ok {
+		t.Fatalf("should have plugin named %s", PluginName)
+	}
+
+	plugin := builder(arguments)
+	networkTopologyAware, ok := plugin.(*networkTopologyAwarePlugin)
+	if !ok {
+		t.Fatalf("plugin should be %T, but not %T", networkTopologyAware, plugin)
+	}
+	binpackConfig := calculateBinpackWeight(networkTopologyAware.pluginArguments)
+	if binpackConfig.BinPackingCPU != 1 {
+		t.Errorf("cpu should be 1, but get %v", binpackConfig.BinPackingCPU)
+	}
+	if binpackConfig.BinPackingMemory != 2 {
+		t.Errorf("memory should be 2, but get %v", binpackConfig.BinPackingMemory)
+	}
+	if len(binpackConfig.BinPackingResources) != 3 {
+		t.Errorf("extend resources length should be 3, but get %v", len(binpackConfig.BinPackingResources))
+	}
+	if binpackConfig.BinPackingResources["nvidia.com/gpu"] != 10 {
+		t.Errorf("nvidia.com/gpu should be 10, but get %v", binpackConfig.BinPackingResources["nvidia.com/gpu"])
+	}
+
+	binpackConfigStr := binpackConfig.String()
+	expectedStr := "cpu[1], memory[2], nvidia.com/gpu[10]"
+	if binpackConfigStr != expectedStr {
+		t.Errorf("binpack config string should be %s, but get %s", expectedStr, binpackConfigStr)
+	}
 }
 
 func TestNetworkTopologyAwareNodeScore_Hard(t *testing.T) {
@@ -65,882 +114,221 @@ func TestNetworkTopologyAwareNodeScore_Hard(t *testing.T) {
 		name string
 		uthelper.TestCommonStruct
 		arguments  framework.Arguments
-		scoreNodes []*api.NodeInfo
-		tasks      map[string]string
+		scoreNodes []string
 		expected   map[string]float64
 	}{
 		{
-			name: "Tasks in job first scheduler, score all nodes zero",
-			TestCommonStruct: uthelper.TestCommonStruct{
-				PodGroups: []*schedulingv1.PodGroup{
+			name: "first scheduling with no allocated hypernode scores all nodes equally",
+			TestCommonStruct: createThreeTierTestStruct(
+				[]*schedulingv1.PodGroup{
 					util.BuildPodGroupWithNetWorkTopologies("pg1", "c1", "", "q1", 1, nil, schedulingv1.PodGroupInqueue, "hard", 0),
 				},
-				Pods: []*v1.Pod{
+				[]*v1.Pod{
 					util.BuildPod("c1", "p4", "", v1.PodPending, api.BuildResourceList("2", "4G"), "pg1", map[string]string{"volcano.sh/task-spec": "worker"}, nil),
 				},
-				Nodes: []*v1.Node{
-					util.BuildNode("s3-n1", api.BuildResourceList("2", "4Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), nil),
-					util.BuildNode("s3-n2", api.BuildResourceList("2", "4Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), nil),
-					util.BuildNode("s4-n1", api.BuildResourceList("2", "4Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), nil),
-					util.BuildNode("s4-n2", api.BuildResourceList("2", "4Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), nil),
-					util.BuildNode("s5-n1", api.BuildResourceList("2", "4Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), nil),
-					util.BuildNode("s5-n2", api.BuildResourceList("2", "4Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), nil),
-					util.BuildNode("s6-n1", api.BuildResourceList("2", "4Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), nil),
-					util.BuildNode("s6-n2", api.BuildResourceList("2", "4Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), nil),
-				},
-				Plugins: map[string]framework.PluginBuilder{PluginName: New},
-				HyperNodesSetByTier: map[int]sets.Set[string]{
-					1: sets.New[string]("s3", "s4", "s5", "s6"),
-					2: sets.New[string]("s1", "s2"),
-					3: sets.New[string]("s0")},
-				HyperNodesMap: map[string]*api.HyperNodeInfo{
-					"s0": api.NewHyperNodeInfo(api.BuildHyperNode("s0", 3, []api.MemberConfig{
-						{
-							Name:     "s1",
-							Type:     topologyv1alpha1.MemberTypeHyperNode,
-							Selector: "exact",
-						},
-						{
-							Name:     "s2",
-							Type:     topologyv1alpha1.MemberTypeHyperNode,
-							Selector: "exact",
-						},
-					})),
-					"s1": api.NewHyperNodeInfo(api.BuildHyperNode("s1", 2, []api.MemberConfig{
-						{
-							Name:     "s3",
-							Type:     topologyv1alpha1.MemberTypeHyperNode,
-							Selector: "exact",
-						},
-						{
-							Name:     "s4",
-							Type:     topologyv1alpha1.MemberTypeHyperNode,
-							Selector: "exact",
-						},
-					})),
-					"s2": api.NewHyperNodeInfo(api.BuildHyperNode("s2", 2, []api.MemberConfig{
-						{
-							Name:     "s5",
-							Type:     topologyv1alpha1.MemberTypeHyperNode,
-							Selector: "exact",
-						},
-						{
-							Name:     "s6",
-							Type:     topologyv1alpha1.MemberTypeHyperNode,
-							Selector: "exact",
-						},
-					})),
-					"s3": api.NewHyperNodeInfo(api.BuildHyperNode("s3", 1, []api.MemberConfig{
-						{
-							Name:     "s3-n1",
-							Type:     topologyv1alpha1.MemberTypeNode,
-							Selector: "exact",
-						},
-						{
-							Name:     "s3-n2",
-							Type:     topologyv1alpha1.MemberTypeNode,
-							Selector: "exact",
-						},
-					})),
-					"s4": api.NewHyperNodeInfo(api.BuildHyperNode("s4", 1, []api.MemberConfig{
-						{
-							Name:     "s4-n1",
-							Type:     topologyv1alpha1.MemberTypeNode,
-							Selector: "exact",
-						},
-						{
-							Name:     "s4-n2",
-							Type:     topologyv1alpha1.MemberTypeNode,
-							Selector: "exact",
-						},
-					})),
-					"s5": api.NewHyperNodeInfo(api.BuildHyperNode("s5", 1, []api.MemberConfig{
-						{
-							Name:     "s5-n1",
-							Type:     topologyv1alpha1.MemberTypeNode,
-							Selector: "exact",
-						},
-						{
-							Name:     "s5-n2",
-							Type:     topologyv1alpha1.MemberTypeNode,
-							Selector: "exact",
-						},
-					})),
-					"s6": api.NewHyperNodeInfo(api.BuildHyperNode("s6", 1, []api.MemberConfig{
-						{
-							Name:     "s6-n1",
-							Type:     topologyv1alpha1.MemberTypeNode,
-							Selector: "exact",
-						},
-						{
-							Name:     "s6-n2",
-							Type:     topologyv1alpha1.MemberTypeNode,
-							Selector: "exact",
-						},
-					})),
-				},
-				HyperNodes: map[string]sets.Set[string]{
-					"s0": sets.New[string]("s3-n1", "s3-n2", "s4-n1", "s4-n2", "s5-n1", "s5-n2", "s6-n1", "s6-n2"),
-					"s1": sets.New[string]("s3-n1", "s3-n2", "s4-n1", "s4-n2"),
-					"s2": sets.New[string]("s5-n1", "s5-n2", "s6-n1", "s6-n2"),
-					"s3": sets.New[string]("s3-n1", "s3-n2"),
-					"s4": sets.New[string]("s4-n1", "s4-n2"),
-					"s5": sets.New[string]("s5-n1", "s5-n2"),
-					"s6": sets.New[string]("s6-n1", "s6-n2"),
-				},
-				Queues: []*schedulingv1.Queue{
-					util.BuildQueue("q1", 1, nil),
-				},
-			},
+			),
 			arguments: framework.Arguments{
 				"weight": 1,
 			},
-			scoreNodes: []*api.NodeInfo{
-				{
-					Name: "s3-n1",
-				},
-				{
-					Name: "s4-n1",
-				},
-				{
-					Name: "s5-n1",
-				},
-			},
-			expected: map[string]float64{
-				"s3-n1": 0.0,
-				"s4-n1": 0.0,
-				"s5-n1": 0.0,
-			},
-		},
-		{
-			name: "Tasks in job rescheduled, score zero when the hyperNode of node has empty LCA hyperNode with jobAllocatedHyperNode",
-			TestCommonStruct: uthelper.TestCommonStruct{
-				PodGroups: []*schedulingv1.PodGroup{
-					util.BuildPodGroupWithNetWorkTopologies("pg1", "c1", "s3", "q1", 1, nil, schedulingv1.PodGroupInqueue, "hard", 0),
-				},
-				Pods: []*v1.Pod{
-					util.BuildPod("c1", "p1", "s3-n1", v1.PodRunning, api.BuildResourceList("2", "4G"), "pg1", map[string]string{"volcano.sh/task-spec": "master"}, nil),
-					util.BuildPod("c1", "p2", "s3-n2", v1.PodRunning, api.BuildResourceList("2", "4G"), "pg1", map[string]string{"volcano.sh/task-spec": "worker"}, nil),
-					util.BuildPod("c1", "p3", "", v1.PodPending, api.BuildResourceList("2", "4G"), "pg1", map[string]string{"volcano.sh/task-spec": "worker"}, nil),
-				},
-				Nodes: []*v1.Node{
-					util.BuildNode("s3-n1", api.BuildResourceList("2", "4Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), nil),
-					util.BuildNode("s3-n2", api.BuildResourceList("2", "4Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), nil),
-					util.BuildNode("s4-n1", api.BuildResourceList("2", "4Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), nil),
-					util.BuildNode("s4-n2", api.BuildResourceList("2", "4Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), nil),
-					util.BuildNode("s5-n1", api.BuildResourceList("2", "4Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), nil),
-					util.BuildNode("s5-n2", api.BuildResourceList("2", "4Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), nil),
-					util.BuildNode("s6-n1", api.BuildResourceList("2", "4Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), nil),
-					util.BuildNode("s6-n2", api.BuildResourceList("2", "4Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), nil),
-				},
-				Plugins: map[string]framework.PluginBuilder{PluginName: New},
-				HyperNodesSetByTier: map[int]sets.Set[string]{
-					1: sets.New[string]("s3", "s4", "s5", "s6"),
-					2: sets.New[string]("s1", "s2"),
-					3: sets.New[string]("s0")},
-				HyperNodesMap: map[string]*api.HyperNodeInfo{
-					"s0": api.NewHyperNodeInfo(api.BuildHyperNode("s0", 3, []api.MemberConfig{
-						{
-							Name:     "s1",
-							Type:     topologyv1alpha1.MemberTypeHyperNode,
-							Selector: "exact",
-						},
-					})),
-					"s1": api.NewHyperNodeInfo(api.BuildHyperNode("s1", 2, []api.MemberConfig{
-						{
-							Name:     "s3",
-							Type:     topologyv1alpha1.MemberTypeHyperNode,
-							Selector: "exact",
-						},
-						{
-							Name:     "s4",
-							Type:     topologyv1alpha1.MemberTypeHyperNode,
-							Selector: "exact",
-						},
-					})),
-					"s2": api.NewHyperNodeInfo(api.BuildHyperNode("s2", 2, []api.MemberConfig{
-						{
-							Name:     "s5",
-							Type:     topologyv1alpha1.MemberTypeHyperNode,
-							Selector: "exact",
-						},
-						{
-							Name:     "s6",
-							Type:     topologyv1alpha1.MemberTypeHyperNode,
-							Selector: "exact",
-						},
-					})),
-					"s3": api.NewHyperNodeInfo(api.BuildHyperNode("s3", 1, []api.MemberConfig{
-						{
-							Name:     "s3-n1",
-							Type:     topologyv1alpha1.MemberTypeNode,
-							Selector: "exact",
-						},
-						{
-							Name:     "s3-n2",
-							Type:     topologyv1alpha1.MemberTypeNode,
-							Selector: "exact",
-						},
-					})),
-					"s4": api.NewHyperNodeInfo(api.BuildHyperNode("s4", 1, []api.MemberConfig{
-						{
-							Name:     "s4-n1",
-							Type:     topologyv1alpha1.MemberTypeNode,
-							Selector: "exact",
-						},
-						{
-							Name:     "s4-n2",
-							Type:     topologyv1alpha1.MemberTypeNode,
-							Selector: "exact",
-						},
-					})),
-					"s5": api.NewHyperNodeInfo(api.BuildHyperNode("s5", 1, []api.MemberConfig{
-						{
-							Name:     "s5-n1",
-							Type:     topologyv1alpha1.MemberTypeNode,
-							Selector: "exact",
-						},
-						{
-							Name:     "s5-n2",
-							Type:     topologyv1alpha1.MemberTypeNode,
-							Selector: "exact",
-						},
-					})),
-					"s6": api.NewHyperNodeInfo(api.BuildHyperNode("s6", 1, []api.MemberConfig{
-						{
-							Name:     "s6-n1",
-							Type:     topologyv1alpha1.MemberTypeNode,
-							Selector: "exact",
-						},
-						{
-							Name:     "s6-n2",
-							Type:     topologyv1alpha1.MemberTypeNode,
-							Selector: "exact",
-						},
-					})),
-				},
-				HyperNodes: map[string]sets.Set[string]{
-					"s0": sets.New[string]("s3-n1", "s3-n2", "s4-n1", "s4-n2", "s5-n1", "s5-n2", "s6-n1", "s6-n2"),
-					"s1": sets.New[string]("s3-n1", "s3-n2", "s4-n1", "s4-n2"),
-					"s2": sets.New[string]("s5-n1", "s5-n2", "s6-n1", "s6-n2"),
-					"s3": sets.New[string]("s3-n1", "s3-n2"),
-					"s4": sets.New[string]("s4-n1", "s4-n2"),
-					"s5": sets.New[string]("s5-n1", "s5-n2"),
-					"s6": sets.New[string]("s6-n1", "s6-n2"),
-				},
-				Queues: []*schedulingv1.Queue{
-					util.BuildQueue("q1", 1, nil),
-				},
-			},
-			arguments: framework.Arguments{
-				"weight": 1,
-			},
-			scoreNodes: []*api.NodeInfo{
-				{
-					Name: "s5-n1",
-				},
-				{
-					Name: "s6-n1",
-				},
-			},
-			expected: map[string]float64{
-				"s5-n1": 0.0,
-				"s6-n1": 0.0,
-			},
-		},
-		{
-			name: "Tasks in job rescheduled, score nodes according to node hypernode LCA hyperNode tier",
-			TestCommonStruct: uthelper.TestCommonStruct{
-				Plugins: map[string]framework.PluginBuilder{PluginName: New},
-				PodGroups: []*schedulingv1.PodGroup{
-					util.BuildPodGroupWithNetWorkTopologies("pg1", "c1", "s3", "q1", 1, nil, schedulingv1.PodGroupInqueue, "hard", 0),
-				},
-				Pods: []*v1.Pod{
-					util.BuildPod("c1", "p1", "s3-n1", v1.PodRunning, api.BuildResourceList("2", "4G"), "pg1", map[string]string{"volcano.sh/task-spec": "master"}, nil),
-					util.BuildPod("c1", "p2", "s3-n2", v1.PodRunning, api.BuildResourceList("2", "4G"), "pg1", map[string]string{"volcano.sh/task-spec": "worker"}, nil),
-					util.BuildPod("c1", "p3", "", v1.PodPending, api.BuildResourceList("2", "4G"), "pg1", map[string]string{"volcano.sh/task-spec": "worker"}, nil),
-				},
-				Nodes: []*v1.Node{
-					util.BuildNode("s3-n1", api.BuildResourceList("2", "4Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), nil),
-					util.BuildNode("s3-n2", api.BuildResourceList("2", "4Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), nil),
-					util.BuildNode("s4-n1", api.BuildResourceList("2", "4Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), nil),
-					util.BuildNode("s4-n2", api.BuildResourceList("2", "4Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), nil),
-					util.BuildNode("s5-n1", api.BuildResourceList("2", "4Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), nil),
-					util.BuildNode("s5-n2", api.BuildResourceList("2", "4Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), nil),
-					util.BuildNode("s6-n1", api.BuildResourceList("2", "4Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), nil),
-					util.BuildNode("s6-n2", api.BuildResourceList("2", "4Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), nil),
-				},
-				HyperNodesSetByTier: map[int]sets.Set[string]{
-					1: sets.New[string]("s3", "s4", "s5", "s6"),
-					2: sets.New[string]("s1", "s2"),
-					3: sets.New[string]("s0")},
-				HyperNodesMap: map[string]*api.HyperNodeInfo{
-					"s0": api.NewHyperNodeInfo(api.BuildHyperNode("s0", 3, []api.MemberConfig{
-						{
-							Name:     "s1",
-							Type:     topologyv1alpha1.MemberTypeHyperNode,
-							Selector: "exact",
-						},
-						{
-							Name:     "s2",
-							Type:     topologyv1alpha1.MemberTypeHyperNode,
-							Selector: "exact",
-						},
-					})),
-					"s1": api.NewHyperNodeInfo(api.BuildHyperNode("s1", 2, []api.MemberConfig{
-						{
-							Name:     "s3",
-							Type:     topologyv1alpha1.MemberTypeHyperNode,
-							Selector: "exact",
-						},
-						{
-							Name:     "s4",
-							Type:     topologyv1alpha1.MemberTypeHyperNode,
-							Selector: "exact",
-						},
-					})),
-					"s2": api.NewHyperNodeInfo(api.BuildHyperNode("s2", 2, []api.MemberConfig{
-						{
-							Name:     "s5",
-							Type:     topologyv1alpha1.MemberTypeHyperNode,
-							Selector: "exact",
-						},
-						{
-							Name:     "s6",
-							Type:     topologyv1alpha1.MemberTypeHyperNode,
-							Selector: "exact",
-						},
-					})),
-					"s3": api.NewHyperNodeInfo(api.BuildHyperNode("s3", 1, []api.MemberConfig{
-						{
-							Name:     "s3-n1",
-							Type:     topologyv1alpha1.MemberTypeNode,
-							Selector: "exact",
-						},
-						{
-							Name:     "s3-n2",
-							Type:     topologyv1alpha1.MemberTypeNode,
-							Selector: "exact",
-						},
-					})),
-					"s4": api.NewHyperNodeInfo(api.BuildHyperNode("s4", 1, []api.MemberConfig{
-						{
-							Name:     "s4-n1",
-							Type:     topologyv1alpha1.MemberTypeNode,
-							Selector: "exact",
-						},
-						{
-							Name:     "s4-n2",
-							Type:     topologyv1alpha1.MemberTypeNode,
-							Selector: "exact",
-						},
-					})),
-					"s5": api.NewHyperNodeInfo(api.BuildHyperNode("s5", 1, []api.MemberConfig{
-						{
-							Name:     "s5-n1",
-							Type:     topologyv1alpha1.MemberTypeNode,
-							Selector: "exact",
-						},
-						{
-							Name:     "s5-n2",
-							Type:     topologyv1alpha1.MemberTypeNode,
-							Selector: "exact",
-						},
-					})),
-					"s6": api.NewHyperNodeInfo(api.BuildHyperNode("s6", 1, []api.MemberConfig{
-						{
-							Name:     "s6-n1",
-							Type:     topologyv1alpha1.MemberTypeNode,
-							Selector: "exact",
-						},
-						{
-							Name:     "s6-n2",
-							Type:     topologyv1alpha1.MemberTypeNode,
-							Selector: "exact",
-						},
-					})),
-				},
-				HyperNodes: map[string]sets.Set[string]{
-					"s0": sets.New[string]("s3-n1", "s3-n2", "s4-n1", "s4-n2", "s5-n1", "s5-n2", "s6-n1", "s6-n2"),
-					"s1": sets.New[string]("s3-n1", "s3-n2", "s4-n1", "s4-n2"),
-					"s2": sets.New[string]("s5-n1", "s5-n2", "s6-n1", "s6-n2"),
-					"s3": sets.New[string]("s3-n1", "s3-n2"),
-					"s4": sets.New[string]("s4-n1", "s4-n2"),
-					"s5": sets.New[string]("s5-n1", "s5-n2"),
-					"s6": sets.New[string]("s6-n1", "s6-n2"),
-				},
-				Queues: []*schedulingv1.Queue{
-					util.BuildQueue("q1", 1, nil),
-				},
-			},
-			arguments: framework.Arguments{
-				"weight": 1,
-			},
-			scoreNodes: []*api.NodeInfo{
-				{
-					Name: "s3-n1",
-				},
-				{
-					Name: "s4-n1",
-				},
-				{
-					Name: "s5-n1",
-				},
+			scoreNodes: []string{
+				"s3-n1",
+				"s3-n2",
+				"s4-n1",
+				"s4-n2",
+				"s5-n1",
+				"s5-n2",
+				"s6-n1",
+				"s6-n2",
 			},
 			expected: map[string]float64{
 				"s3-n1": 100.0,
-				"s4-n1": 50.0,
-				"s5-n1": 0.0,
+				"s3-n2": 100.0,
+				"s4-n1": 100.0,
+				"s4-n2": 100.0,
+				"s5-n1": 100.0,
+				"s5-n2": 100.0,
+				"s6-n1": 100.0,
+				"s6-n2": 100.0,
 			},
 		},
 		{
-			name: "Tasks in job rescheduled, score hyperNodes according to node LCA hyperNode tier of the hyperNode and jobAllocatedHyperNode when hyperNodesInfo has two tier",
-			TestCommonStruct: uthelper.TestCommonStruct{
-				Plugins: map[string]framework.PluginBuilder{PluginName: New},
-				PodGroups: []*schedulingv1.PodGroup{
-					util.BuildPodGroupWithNetWorkTopologies("pg1", "c1", "s1", "q1", 1, nil, schedulingv1.PodGroupInqueue, "hard", 0),
-				},
-				Pods: []*v1.Pod{
-					util.BuildPod("c1", "p1", "s1-n1", v1.PodRunning, api.BuildResourceList("2", "4G"), "pg1", map[string]string{"volcano.sh/task-spec": "master"}, nil),
-					util.BuildPod("c1", "p2", "", v1.PodPending, api.BuildResourceList("2", "4G"), "pg1", map[string]string{"volcano.sh/task-spec": "worker"}, nil),
-				},
-				Nodes: []*v1.Node{
-					util.BuildNode("s1-n1", api.BuildResourceList("2", "4Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), nil),
-					util.BuildNode("s1-n2", api.BuildResourceList("2", "4Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), nil),
-					util.BuildNode("s2-n1", api.BuildResourceList("2", "4Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), nil),
-					util.BuildNode("s2-n2", api.BuildResourceList("2", "4Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), nil),
-				},
-				HyperNodesSetByTier: map[int]sets.Set[string]{
-					1: sets.New[string]("s1", "s2"),
-					2: sets.New[string]("s0")},
-				HyperNodesMap: map[string]*api.HyperNodeInfo{
-					"s0": api.NewHyperNodeInfo(api.BuildHyperNode("s0", 2, []api.MemberConfig{
-						{
-							Name:     "s1",
-							Type:     topologyv1alpha1.MemberTypeHyperNode,
-							Selector: "exact",
-						},
-						{
-							Name:     "s2",
-							Type:     topologyv1alpha1.MemberTypeHyperNode,
-							Selector: "exact",
-						},
-					})),
-					"s1": api.NewHyperNodeInfo(api.BuildHyperNode("s1", 1, []api.MemberConfig{
-						{
-							Name:     "s1-n1",
-							Type:     topologyv1alpha1.MemberTypeNode,
-							Selector: "exact",
-						},
-						{
-							Name:     "s1-n2",
-							Type:     topologyv1alpha1.MemberTypeNode,
-							Selector: "exact",
-						},
-					})),
-					"s2": api.NewHyperNodeInfo(api.BuildHyperNode("s2", 1, []api.MemberConfig{
-						{
-							Name:     "s2-n1",
-							Type:     topologyv1alpha1.MemberTypeNode,
-							Selector: "exact",
-						},
-						{
-							Name:     "s2-n2",
-							Type:     topologyv1alpha1.MemberTypeNode,
-							Selector: "exact",
-						},
-					})),
-				},
-				HyperNodes: map[string]sets.Set[string]{
-					"s0": sets.New[string]("s1-n1", "s1-n2", "s2-n1", "s2-n2"),
-					"s1": sets.New[string]("s1-n1", "s1-n2"),
-					"s2": sets.New[string]("s2-n1", "s2-n2"),
-				},
-				Queues: []*schedulingv1.Queue{
-					util.BuildQueue("q1", 1, nil),
-				},
-			},
-			arguments: framework.Arguments{
-				"weight": 1,
-			},
-			scoreNodes: []*api.NodeInfo{
-				{
-					Name: "s1-n1",
-				},
-				{
-					Name: "s2-n1",
-				},
-			},
-			expected: map[string]float64{
-				"s1-n1": 100.0,
-				"s2-n1": 0.0,
-			},
-		},
-		{
-			name: "Tasks in job rescheduled, score hyperNodes according to node LCA hyperNode tier of the hyperNode and jobAllocatedHyperNode when hyperNodesInfo has one tier",
-			TestCommonStruct: uthelper.TestCommonStruct{
-				Plugins: map[string]framework.PluginBuilder{PluginName: New},
-				PodGroups: []*schedulingv1.PodGroup{
-					util.BuildPodGroupWithNetWorkTopologies("pg1", "c1", "s1", "q1", 1, nil, schedulingv1.PodGroupInqueue, "hard", 0),
-				},
-				Pods: []*v1.Pod{
-					util.BuildPod("c1", "p1", "s1-n1", v1.PodRunning, api.BuildResourceList("2", "4G"), "pg1", map[string]string{"volcano.sh/task-spec": "master"}, nil),
-					util.BuildPod("c1", "p2", "", v1.PodPending, api.BuildResourceList("2", "4G"), "pg1", map[string]string{"volcano.sh/task-spec": "worker"}, nil),
-				},
-				Nodes: []*v1.Node{
-					util.BuildNode("s1-n1", api.BuildResourceList("2", "4Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), nil),
-					util.BuildNode("s1-n2", api.BuildResourceList("2", "4Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), nil),
-					util.BuildNode("s2-n1", api.BuildResourceList("2", "4Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), nil),
-					util.BuildNode("s2-n2", api.BuildResourceList("2", "4Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), nil),
-				},
-				HyperNodesSetByTier: map[int]sets.Set[string]{
-					1: sets.New[string]("s1", "s2"),
-				},
-				HyperNodesMap: map[string]*api.HyperNodeInfo{
-					"s1": api.NewHyperNodeInfo(api.BuildHyperNode("s1", 1, []api.MemberConfig{
-						{
-							Name:     "s1-n1",
-							Type:     topologyv1alpha1.MemberTypeNode,
-							Selector: "exact",
-						},
-						{
-							Name:     "s1-n2",
-							Type:     topologyv1alpha1.MemberTypeNode,
-							Selector: "exact",
-						},
-					})),
-					"s2": api.NewHyperNodeInfo(api.BuildHyperNode("s2", 1, []api.MemberConfig{
-						{
-							Name:     "s2-n1",
-							Type:     topologyv1alpha1.MemberTypeNode,
-							Selector: "exact",
-						},
-						{
-							Name:     "s2-n2",
-							Type:     topologyv1alpha1.MemberTypeNode,
-							Selector: "exact",
-						},
-					})),
-				},
-				HyperNodes: map[string]sets.Set[string]{
-					"s1": sets.New[string]("s1-n1", "s1-n2"),
-					"s2": sets.New[string]("s2-n1", "s2-n2"),
-				},
-				Queues: []*schedulingv1.Queue{
-					util.BuildQueue("q1", 1, nil),
-				},
-			},
-			arguments: framework.Arguments{
-				"weight": 1,
-			},
-			scoreNodes: []*api.NodeInfo{
-				{
-					Name: "s1-n1",
-				},
-				{
-					Name: "s2-n1",
-				},
-			},
-			expected: map[string]float64{
-				"s1-n1": 100.0,
-				"s2-n1": 0.0,
-			},
-		},
-		{
-			name: "Tasks in job rescheduled, score hyperNodes according to node LCA hyperNode tier of the hyperNode and jobAllocatedHyperNode with plugin weight 2",
-			TestCommonStruct: uthelper.TestCommonStruct{
-				Plugins: map[string]framework.PluginBuilder{PluginName: New},
-				PodGroups: []*schedulingv1.PodGroup{
+			name: "hard mode restricts nodes outside same hypernode tree branch",
+			TestCommonStruct: createThreeTierTestStruct(
+				[]*schedulingv1.PodGroup{
 					util.BuildPodGroupWithNetWorkTopologies("pg1", "c1", "s3", "q1", 1, nil, schedulingv1.PodGroupInqueue, "hard", 0),
 				},
-				Pods: []*v1.Pod{
+				[]*v1.Pod{
 					util.BuildPod("c1", "p1", "s3-n1", v1.PodRunning, api.BuildResourceList("2", "4G"), "pg1", map[string]string{"volcano.sh/task-spec": "master"}, nil),
 					util.BuildPod("c1", "p2", "s3-n2", v1.PodRunning, api.BuildResourceList("2", "4G"), "pg1", map[string]string{"volcano.sh/task-spec": "worker"}, nil),
 					util.BuildPod("c1", "p3", "", v1.PodPending, api.BuildResourceList("2", "4G"), "pg1", map[string]string{"volcano.sh/task-spec": "worker"}, nil),
 				},
-				Nodes: []*v1.Node{
-					util.BuildNode("s3-n1", api.BuildResourceList("2", "4Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), nil),
-					util.BuildNode("s3-n2", api.BuildResourceList("2", "4Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), nil),
-					util.BuildNode("s4-n1", api.BuildResourceList("2", "4Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), nil),
-					util.BuildNode("s4-n2", api.BuildResourceList("2", "4Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), nil),
-					util.BuildNode("s5-n1", api.BuildResourceList("2", "4Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), nil),
-					util.BuildNode("s5-n2", api.BuildResourceList("2", "4Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), nil),
-					util.BuildNode("s6-n1", api.BuildResourceList("2", "4Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), nil),
-					util.BuildNode("s6-n2", api.BuildResourceList("2", "4Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), nil),
-				},
-				HyperNodesSetByTier: map[int]sets.Set[string]{
-					1: sets.New[string]("s3", "s4", "s5", "s6"),
-					2: sets.New[string]("s1", "s2"),
-					3: sets.New[string]("s0")},
-				HyperNodesMap: map[string]*api.HyperNodeInfo{
-					"s0": api.NewHyperNodeInfo(api.BuildHyperNode("s0", 3, []api.MemberConfig{
-						{
-							Name:     "s1",
-							Type:     topologyv1alpha1.MemberTypeHyperNode,
-							Selector: "exact",
-						},
-						{
-							Name:     "s2",
-							Type:     topologyv1alpha1.MemberTypeHyperNode,
-							Selector: "exact",
-						},
-					})),
-					"s1": api.NewHyperNodeInfo(api.BuildHyperNode("s1", 2, []api.MemberConfig{
-						{
-							Name:     "s3",
-							Type:     topologyv1alpha1.MemberTypeHyperNode,
-							Selector: "exact",
-						},
-						{
-							Name:     "s4",
-							Type:     topologyv1alpha1.MemberTypeHyperNode,
-							Selector: "exact",
-						},
-					})),
-					"s2": api.NewHyperNodeInfo(api.BuildHyperNode("s2", 2, []api.MemberConfig{
-						{
-							Name:     "s5",
-							Type:     topologyv1alpha1.MemberTypeHyperNode,
-							Selector: "exact",
-						},
-						{
-							Name:     "s6",
-							Type:     topologyv1alpha1.MemberTypeHyperNode,
-							Selector: "exact",
-						},
-					})),
-					"s3": api.NewHyperNodeInfo(api.BuildHyperNode("s3", 1, []api.MemberConfig{
-						{
-							Name:     "s3-n1",
-							Type:     topologyv1alpha1.MemberTypeNode,
-							Selector: "exact",
-						},
-						{
-							Name:     "s3-n2",
-							Type:     topologyv1alpha1.MemberTypeNode,
-							Selector: "exact",
-						},
-					})),
-					"s4": api.NewHyperNodeInfo(api.BuildHyperNode("s4", 1, []api.MemberConfig{
-						{
-							Name:     "s4-n1",
-							Type:     topologyv1alpha1.MemberTypeNode,
-							Selector: "exact",
-						},
-						{
-							Name:     "s4-n2",
-							Type:     topologyv1alpha1.MemberTypeNode,
-							Selector: "exact",
-						},
-					})),
-					"s5": api.NewHyperNodeInfo(api.BuildHyperNode("s5", 1, []api.MemberConfig{
-						{
-							Name:     "s5-n1",
-							Type:     topologyv1alpha1.MemberTypeNode,
-							Selector: "exact",
-						},
-						{
-							Name:     "s5-n2",
-							Type:     topologyv1alpha1.MemberTypeNode,
-							Selector: "exact",
-						},
-					})),
-					"s6": api.NewHyperNodeInfo(api.BuildHyperNode("s6", 1, []api.MemberConfig{
-						{
-							Name:     "s6-n1",
-							Type:     topologyv1alpha1.MemberTypeNode,
-							Selector: "exact",
-						},
-						{
-							Name:     "s6-n2",
-							Type:     topologyv1alpha1.MemberTypeNode,
-							Selector: "exact",
-						},
-					})),
-				},
-				HyperNodes: map[string]sets.Set[string]{
-					"s0": sets.New[string]("s3-n1", "s3-n2", "s4-n1", "s4-n2", "s5-n1", "s5-n2", "s6-n1", "s6-n2"),
-					"s1": sets.New[string]("s3-n1", "s3-n2", "s4-n1", "s4-n2"),
-					"s2": sets.New[string]("s5-n1", "s5-n2", "s6-n1", "s6-n2"),
-					"s3": sets.New[string]("s3-n1", "s3-n2"),
-					"s4": sets.New[string]("s4-n1", "s4-n2"),
-					"s5": sets.New[string]("s5-n1", "s5-n2"),
-					"s6": sets.New[string]("s6-n1", "s6-n2"),
-				},
-				Queues: []*schedulingv1.Queue{
-					util.BuildQueue("q1", 1, nil),
-				},
+			),
+			arguments: framework.Arguments{
+				"weight": 1,
 			},
+			scoreNodes: []string{
+				"s4-n1",
+				"s4-n2",
+				"s5-n1",
+				"s5-n2",
+				"s6-n1",
+				"s6-n2",
+			},
+			expected: map[string]float64{
+				"s4-n1": 100.0,
+				"s4-n2": 100.0,
+				"s5-n1": 0.0,
+				"s5-n2": 0.0,
+				"s6-n1": 0.0,
+				"s6-n2": 0.0,
+			},
+		},
+		{
+			name: "prioritizes nodes within same hypernode as existing pods",
+			TestCommonStruct: createThreeTierTestStruct(
+				[]*schedulingv1.PodGroup{
+					util.BuildPodGroupWithNetWorkTopologies("pg1", "c1", "s3", "q1", 1, nil, schedulingv1.PodGroupInqueue, "hard", 0),
+				},
+				[]*v1.Pod{
+					util.BuildPod("c1", "p1", "s3-n1", v1.PodRunning, api.BuildResourceList("2", "4G"), "pg1", map[string]string{"volcano.sh/task-spec": "master"}, nil),
+					util.BuildPod("c1", "p2", "s3-n2", v1.PodRunning, api.BuildResourceList("2", "4G"), "pg1", map[string]string{"volcano.sh/task-spec": "worker"}, nil),
+					util.BuildPod("c1", "p3", "", v1.PodPending, api.BuildResourceList("2", "4G"), "pg1", map[string]string{"volcano.sh/task-spec": "worker"}, nil),
+				},
+			),
+			arguments: framework.Arguments{
+				"weight": 1,
+			},
+			scoreNodes: []string{
+				"s3-n1",
+				"s3-n2",
+			},
+			expected: map[string]float64{
+				"s3-n1": 100.0,
+				"s3-n2": 100.0,
+			},
+		},
+		{
+			name: "scores nodes by distance from allocated hypernode in three-tier topology",
+			TestCommonStruct: createThreeTierTestStruct(
+				[]*schedulingv1.PodGroup{
+					util.BuildPodGroupWithNetWorkTopologies("pg1", "c1", "s3", "q1", 1, nil, schedulingv1.PodGroupInqueue, "hard", 0),
+				},
+				[]*v1.Pod{
+					util.BuildPod("c1", "p1", "s3-n1", v1.PodRunning, api.BuildResourceList("2", "4G"), "pg1", map[string]string{"volcano.sh/task-spec": "master"}, nil),
+					util.BuildPod("c1", "p2", "s3-n2", v1.PodRunning, api.BuildResourceList("2", "4G"), "pg1", map[string]string{"volcano.sh/task-spec": "worker"}, nil),
+					util.BuildPod("c1", "p3", "", v1.PodPending, api.BuildResourceList("2", "4G"), "pg1", map[string]string{"volcano.sh/task-spec": "worker"}, nil),
+				},
+			),
+			arguments: framework.Arguments{
+				"weight": 1,
+			},
+			scoreNodes: []string{
+				"s3-n1",
+				"s3-n2",
+				"s4-n1",
+				"s4-n2",
+				"s5-n1",
+				"s5-n2",
+				"s6-n1",
+				"s6-n2",
+			},
+			expected: map[string]float64{
+				"s3-n1": 100.0,
+				"s3-n2": 100.0,
+				"s4-n1": 17.19941772880241,
+				"s4-n2": 17.19941772880241,
+				"s5-n1": 0.0,
+				"s5-n2": 0.0,
+				"s6-n1": 0.0,
+				"s6-n2": 0.0,
+			},
+		},
+		{
+			name: "restricts scheduling across different hypernodes in two-tier topology",
+			TestCommonStruct: createTwoTierTestStruct(
+				[]*schedulingv1.PodGroup{
+					util.BuildPodGroupWithNetWorkTopologies("pg1", "c1", "s1", "q1", 1, nil, schedulingv1.PodGroupInqueue, "hard", 0),
+				},
+				[]*v1.Pod{
+					util.BuildPod("c1", "p1", "s1-n1", v1.PodRunning, api.BuildResourceList("2", "4G"), "pg1", map[string]string{"volcano.sh/task-spec": "master"}, nil),
+					util.BuildPod("c1", "p2", "", v1.PodPending, api.BuildResourceList("2", "4G"), "pg1", map[string]string{"volcano.sh/task-spec": "worker"}, nil),
+				},
+			),
+			arguments: framework.Arguments{
+				"weight": 1,
+			},
+			scoreNodes: []string{
+				"s1-n2",
+				"s2-n1",
+				"s2-n2",
+			},
+			expected: map[string]float64{
+				"s1-n2": 100.0,
+				"s2-n1": 0.0,
+				"s2-n2": 0.0,
+			},
+		},
+		{
+			name: "restricts scheduling across different hypernodes in single-tier topology",
+			TestCommonStruct: createSingleTierTestStruct(
+				[]*schedulingv1.PodGroup{
+					util.BuildPodGroupWithNetWorkTopologies("pg1", "c1", "s1", "q1", 1, nil, schedulingv1.PodGroupInqueue, "hard", 0),
+				},
+				[]*v1.Pod{
+					util.BuildPod("c1", "p1", "s1-n1", v1.PodRunning, api.BuildResourceList("2", "4G"), "pg1", map[string]string{"volcano.sh/task-spec": "master"}, nil),
+					util.BuildPod("c1", "p2", "", v1.PodPending, api.BuildResourceList("2", "4G"), "pg1", map[string]string{"volcano.sh/task-spec": "worker"}, nil),
+				},
+			),
+			arguments: framework.Arguments{
+				"weight": 1,
+			},
+			scoreNodes: []string{
+				"s1-n1",
+				"s1-n2",
+				"s2-n1",
+				"s2-n2",
+			},
+			expected: map[string]float64{
+				"s1-n1": 100.0,
+				"s1-n2": 100.0,
+				"s2-n1": 0.0,
+				"s2-n2": 0.0,
+			},
+		},
+		{
+			name: "applies weight multiplier to node scores correctly",
+			TestCommonStruct: createThreeTierTestStruct(
+				[]*schedulingv1.PodGroup{
+					util.BuildPodGroupWithNetWorkTopologies("pg1", "c1", "s3", "q1", 1, nil, schedulingv1.PodGroupInqueue, "hard", 0),
+				},
+				[]*v1.Pod{
+					util.BuildPod("c1", "p1", "s3-n1", v1.PodRunning, api.BuildResourceList("2", "4G"), "pg1", map[string]string{"volcano.sh/task-spec": "master"}, nil),
+					util.BuildPod("c1", "p2", "s3-n2", v1.PodRunning, api.BuildResourceList("2", "4G"), "pg1", map[string]string{"volcano.sh/task-spec": "worker"}, nil),
+					util.BuildPod("c1", "p3", "", v1.PodPending, api.BuildResourceList("2", "4G"), "pg1", map[string]string{"volcano.sh/task-spec": "worker"}, nil),
+				},
+			),
 			arguments: framework.Arguments{
 				"weight": 2,
 			},
-			scoreNodes: []*api.NodeInfo{
-				{
-					Name: "s3-n1",
-				},
-				{
-					Name: "s4-n1",
-				},
-				{
-					Name: "s5-n1",
-				},
+			scoreNodes: []string{
+				"s3-n1",
+				"s3-n2",
+				"s4-n1",
+				"s4-n2",
+				"s5-n1",
+				"s5-n2",
+				"s6-n1",
+				"s6-n2",
 			},
 			expected: map[string]float64{
 				"s3-n1": 200.0,
-				"s4-n1": 100.0,
+				"s3-n2": 200.0,
+				"s4-n1": 34.39883545760482,
+				"s4-n2": 34.39883545760482,
 				"s5-n1": 0.0,
-			},
-		},
-		{
-			name: "Tasks in job rescheduled, score hyperNodes according to node LCA hyperNode tier and task num of the hyperNode when there are at least two hyperNodes have max hyperNode tier score",
-			TestCommonStruct: uthelper.TestCommonStruct{
-				Plugins: map[string]framework.PluginBuilder{PluginName: New},
-				PodGroups: []*schedulingv1.PodGroup{
-					util.BuildPodGroupWithNetWorkTopologies("pg1", "c1", "s1", "q1", 3, nil, schedulingv1.PodGroupInqueue, "hard", 0),
-				},
-				Pods: []*v1.Pod{
-					util.BuildPod("c1", "p1", "s3-n1", v1.PodRunning, api.BuildResourceList("2", "4G"), "pg1", map[string]string{"volcano.sh/task-spec": "master"}, nil),
-					util.BuildPod("c1", "p2", "s3-n2", v1.PodRunning, api.BuildResourceList("2", "4G"), "pg1", map[string]string{"volcano.sh/task-spec": "worker"}, nil),
-					util.BuildPod("c1", "p3", "s4-n1", v1.PodRunning, api.BuildResourceList("2", "4G"), "pg1", map[string]string{"volcano.sh/task-spec": "worker"}, nil),
-					util.BuildPod("c1", "p4", "", v1.PodPending, api.BuildResourceList("2", "4G"), "pg1", map[string]string{"volcano.sh/task-spec": "worker"}, nil),
-				},
-				Nodes: []*v1.Node{
-					util.BuildNode("s3-n1", api.BuildResourceList("2", "4Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), nil),
-					util.BuildNode("s3-n2", api.BuildResourceList("2", "4Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), nil),
-					util.BuildNode("s4-n1", api.BuildResourceList("2", "4Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), nil),
-					util.BuildNode("s4-n2", api.BuildResourceList("2", "4Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), nil),
-					util.BuildNode("s5-n1", api.BuildResourceList("2", "4Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), nil),
-					util.BuildNode("s5-n2", api.BuildResourceList("2", "4Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), nil),
-					util.BuildNode("s6-n1", api.BuildResourceList("2", "4Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), nil),
-					util.BuildNode("s6-n2", api.BuildResourceList("2", "4Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), nil),
-				},
-				HyperNodesSetByTier: map[int]sets.Set[string]{
-					1: sets.New[string]("s3", "s4", "s5", "s6"),
-					2: sets.New[string]("s1", "s2"),
-					3: sets.New[string]("s0")},
-				HyperNodesMap: map[string]*api.HyperNodeInfo{
-					"s0": api.NewHyperNodeInfo(api.BuildHyperNode("s0", 3, []api.MemberConfig{
-						{
-							Name:     "s1",
-							Type:     topologyv1alpha1.MemberTypeHyperNode,
-							Selector: "exact",
-						},
-						{
-							Name:     "s2",
-							Type:     topologyv1alpha1.MemberTypeHyperNode,
-							Selector: "exact",
-						},
-					})),
-					"s1": api.NewHyperNodeInfo(api.BuildHyperNode("s1", 2, []api.MemberConfig{
-						{
-							Name:     "s3",
-							Type:     topologyv1alpha1.MemberTypeHyperNode,
-							Selector: "exact",
-						},
-						{
-							Name:     "s4",
-							Type:     topologyv1alpha1.MemberTypeHyperNode,
-							Selector: "exact",
-						},
-					})),
-					"s2": api.NewHyperNodeInfo(api.BuildHyperNode("s2", 2, []api.MemberConfig{
-						{
-							Name:     "s5",
-							Type:     topologyv1alpha1.MemberTypeHyperNode,
-							Selector: "exact",
-						},
-						{
-							Name:     "s6",
-							Type:     topologyv1alpha1.MemberTypeHyperNode,
-							Selector: "exact",
-						},
-					})),
-					"s3": api.NewHyperNodeInfo(api.BuildHyperNode("s3", 1, []api.MemberConfig{
-						{
-							Name:     "s3-n1",
-							Type:     topologyv1alpha1.MemberTypeNode,
-							Selector: "exact",
-						},
-						{
-							Name:     "s3-n2",
-							Type:     topologyv1alpha1.MemberTypeNode,
-							Selector: "exact",
-						},
-					})),
-					"s4": api.NewHyperNodeInfo(api.BuildHyperNode("s4", 1, []api.MemberConfig{
-						{
-							Name:     "s4-n1",
-							Type:     topologyv1alpha1.MemberTypeNode,
-							Selector: "exact",
-						},
-						{
-							Name:     "s4-n2",
-							Type:     topologyv1alpha1.MemberTypeNode,
-							Selector: "exact",
-						},
-					})),
-					"s5": api.NewHyperNodeInfo(api.BuildHyperNode("s5", 1, []api.MemberConfig{
-						{
-							Name:     "s5-n1",
-							Type:     topologyv1alpha1.MemberTypeNode,
-							Selector: "exact",
-						},
-						{
-							Name:     "s5-n2",
-							Type:     topologyv1alpha1.MemberTypeNode,
-							Selector: "exact",
-						},
-					})),
-					"s6": api.NewHyperNodeInfo(api.BuildHyperNode("s6", 1, []api.MemberConfig{
-						{
-							Name:     "s6-n1",
-							Type:     topologyv1alpha1.MemberTypeNode,
-							Selector: "exact",
-						},
-						{
-							Name:     "s6-n2",
-							Type:     topologyv1alpha1.MemberTypeNode,
-							Selector: "exact",
-						},
-					})),
-				},
-				HyperNodes: map[string]sets.Set[string]{
-					"s0": sets.New[string]("s3-n1", "s3-n2", "s4-n1", "s4-n2", "s5-n1", "s5-n2", "s6-n1", "s6-n2"),
-					"s1": sets.New[string]("s3-n1", "s3-n2", "s4-n1", "s4-n2"),
-					"s2": sets.New[string]("s5-n1", "s5-n2", "s6-n1", "s6-n2"),
-					"s3": sets.New[string]("s3-n1", "s3-n2"),
-					"s4": sets.New[string]("s4-n1", "s4-n2"),
-					"s5": sets.New[string]("s5-n1", "s5-n2"),
-					"s6": sets.New[string]("s6-n1", "s6-n2"),
-				},
-				Queues: []*schedulingv1.Queue{
-					util.BuildQueue("q1", 1, nil),
-				},
-			},
-			arguments: framework.Arguments{
-				"weight": 1,
-			},
-			scoreNodes: []*api.NodeInfo{
-				{
-					Name: "s3-n1",
-				},
-				{
-					Name: "s4-n1",
-				},
-				{
-					Name: "s5-n1",
-				},
-			},
-			tasks: map[string]string{
-				"task1": "s3-n1",
-				"task2": "s3-n2",
-				"task3": "s4-n1",
-				"test4": "",
-			},
-			expected: map[string]float64{
-				"s3-n1": 100.0,
-				"s4-n1": 75.0,
-				"s5-n1": 0.0,
+				"s5-n2": 0.0,
+				"s6-n1": 0.0,
+				"s6-n2": 0.0,
 			},
 		},
 	}
@@ -967,7 +355,12 @@ func TestNetworkTopologyAwareNodeScore_Hard(t *testing.T) {
 		ssn := test.RegisterSession(tiers, nil)
 		defer test.Close()
 
-		nodeScores, err := ssn.BatchNodeOrderFn(parseTask(ssn.Jobs), test.scoreNodes)
+		scoreNodes := make([]*api.NodeInfo, len(test.scoreNodes))
+		for i, nodeName := range test.scoreNodes {
+			scoreNodes[i] = ssn.Nodes[nodeName]
+		}
+
+		nodeScores, err := ssn.BatchNodeOrderFn(parseTask(ssn.Jobs), scoreNodes)
 		if err != nil {
 			t.Errorf("case%d: task %s  has err %v", i, test.Name, err)
 			continue
@@ -980,894 +373,245 @@ func TestNetworkTopologyAwareNodeScore_Hard(t *testing.T) {
 	}
 }
 
-func parseJob(jobInfoMap map[api.JobID]*api.JobInfo) *api.JobInfo {
-	for _, job := range jobInfoMap {
-		return job
-	}
-	return nil
-}
-
 func TestNetworkTopologyAwareNodeScore_Soft(t *testing.T) {
 	tests := []struct {
 		name string
 		uthelper.TestCommonStruct
 		arguments  framework.Arguments
-		scoreNodes []*api.NodeInfo
+		scoreNodes []string
 		tasks      map[string]string
 		expected   map[string]float64
 	}{
 		{
-			name: "Tasks in job first scheduler, score all nodes zero",
-			TestCommonStruct: uthelper.TestCommonStruct{
-				PodGroups: []*schedulingv1.PodGroup{
+			name: "first scheduling with no allocated hypernode scores all nodes equally",
+			TestCommonStruct: createThreeTierTestStruct(
+				[]*schedulingv1.PodGroup{
 					util.BuildPodGroupWithNetWorkTopologies("pg1", "c1", "", "q1", 1, nil, schedulingv1.PodGroupInqueue, "soft", 0),
 				},
-				Pods: []*v1.Pod{
+				[]*v1.Pod{
 					util.BuildPod("c1", "p4", "", v1.PodPending, api.BuildResourceList("2", "4G"), "pg1", map[string]string{"volcano.sh/task-spec": "worker"}, nil),
 				},
-				Nodes: []*v1.Node{
-					util.BuildNode("s3-n1", api.BuildResourceList("2", "4Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), nil),
-					util.BuildNode("s3-n2", api.BuildResourceList("2", "4Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), nil),
-					util.BuildNode("s4-n1", api.BuildResourceList("2", "4Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), nil),
-					util.BuildNode("s4-n2", api.BuildResourceList("2", "4Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), nil),
-					util.BuildNode("s5-n1", api.BuildResourceList("2", "4Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), nil),
-					util.BuildNode("s5-n2", api.BuildResourceList("2", "4Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), nil),
-					util.BuildNode("s6-n1", api.BuildResourceList("2", "4Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), nil),
-					util.BuildNode("s6-n2", api.BuildResourceList("2", "4Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), nil),
-				},
-				Plugins: map[string]framework.PluginBuilder{PluginName: New},
-				HyperNodesSetByTier: map[int]sets.Set[string]{
-					1: sets.New[string]("s3", "s4", "s5", "s6"),
-					2: sets.New[string]("s1", "s2"),
-					3: sets.New[string]("s0")},
-				HyperNodesMap: map[string]*api.HyperNodeInfo{
-					"s0": api.NewHyperNodeInfo(api.BuildHyperNode("s0", 3, []api.MemberConfig{
-						{
-							Name:     "s1",
-							Type:     topologyv1alpha1.MemberTypeHyperNode,
-							Selector: "exact",
-						},
-						{
-							Name:     "s2",
-							Type:     topologyv1alpha1.MemberTypeHyperNode,
-							Selector: "exact",
-						},
-					})),
-					"s1": api.NewHyperNodeInfo(api.BuildHyperNode("s1", 2, []api.MemberConfig{
-						{
-							Name:     "s3",
-							Type:     topologyv1alpha1.MemberTypeHyperNode,
-							Selector: "exact",
-						},
-						{
-							Name:     "s4",
-							Type:     topologyv1alpha1.MemberTypeHyperNode,
-							Selector: "exact",
-						},
-					})),
-					"s2": api.NewHyperNodeInfo(api.BuildHyperNode("s2", 2, []api.MemberConfig{
-						{
-							Name:     "s5",
-							Type:     topologyv1alpha1.MemberTypeHyperNode,
-							Selector: "exact",
-						},
-						{
-							Name:     "s6",
-							Type:     topologyv1alpha1.MemberTypeHyperNode,
-							Selector: "exact",
-						},
-					})),
-					"s3": api.NewHyperNodeInfo(api.BuildHyperNode("s3", 1, []api.MemberConfig{
-						{
-							Name:     "s3-n1",
-							Type:     topologyv1alpha1.MemberTypeNode,
-							Selector: "exact",
-						},
-						{
-							Name:     "s3-n2",
-							Type:     topologyv1alpha1.MemberTypeNode,
-							Selector: "exact",
-						},
-					})),
-					"s4": api.NewHyperNodeInfo(api.BuildHyperNode("s4", 1, []api.MemberConfig{
-						{
-							Name:     "s4-n1",
-							Type:     topologyv1alpha1.MemberTypeNode,
-							Selector: "exact",
-						},
-						{
-							Name:     "s4-n2",
-							Type:     topologyv1alpha1.MemberTypeNode,
-							Selector: "exact",
-						},
-					})),
-					"s5": api.NewHyperNodeInfo(api.BuildHyperNode("s5", 1, []api.MemberConfig{
-						{
-							Name:     "s5-n1",
-							Type:     topologyv1alpha1.MemberTypeNode,
-							Selector: "exact",
-						},
-						{
-							Name:     "s5-n2",
-							Type:     topologyv1alpha1.MemberTypeNode,
-							Selector: "exact",
-						},
-					})),
-					"s6": api.NewHyperNodeInfo(api.BuildHyperNode("s6", 1, []api.MemberConfig{
-						{
-							Name:     "s6-n1",
-							Type:     topologyv1alpha1.MemberTypeNode,
-							Selector: "exact",
-						},
-						{
-							Name:     "s6-n2",
-							Type:     topologyv1alpha1.MemberTypeNode,
-							Selector: "exact",
-						},
-					})),
-				},
-				HyperNodes: map[string]sets.Set[string]{
-					"s0": sets.New[string]("s3-n1", "s3-n2", "s4-n1", "s4-n2", "s5-n1", "s5-n2", "s6-n1", "s6-n2"),
-					"s1": sets.New[string]("s3-n1", "s3-n2", "s4-n1", "s4-n2"),
-					"s2": sets.New[string]("s5-n1", "s5-n2", "s6-n1", "s6-n2"),
-					"s3": sets.New[string]("s3-n1", "s3-n2"),
-					"s4": sets.New[string]("s4-n1", "s4-n2"),
-					"s5": sets.New[string]("s5-n1", "s5-n2"),
-					"s6": sets.New[string]("s6-n1", "s6-n2"),
-				},
-				Queues: []*schedulingv1.Queue{
-					util.BuildQueue("q1", 1, nil),
-				},
-			},
+			),
 			arguments: framework.Arguments{
 				"weight": 1,
 			},
-			scoreNodes: []*api.NodeInfo{
-				{
-					Name: "s3-n1",
-				},
-				{
-					Name: "s4-n1",
-				},
-				{
-					Name: "s5-n1",
-				},
+			scoreNodes: []string{
+				"s3-n1",
+				"s3-n2",
+				"s4-n1",
+				"s4-n2",
+				"s5-n1",
+				"s5-n2",
+				"s6-n1",
+				"s6-n2",
 			},
+			expected: map[string]float64{
+				"s3-n1": 100.0,
+				"s3-n2": 100.0,
+				"s4-n1": 100.0,
+				"s4-n2": 100.0,
+				"s5-n1": 100.0,
+				"s5-n2": 100.0,
+				"s6-n1": 100.0,
+				"s6-n2": 100.0,
+			},
+		},
+		{
+			name: "hypernode which can satisfy resource requirement with less idle resources scores higher",
+			TestCommonStruct: createThreeTierTestStruct(
+				[]*schedulingv1.PodGroup{
+					util.BuildPodGroupWithNetWorkTopologies("pg1", "c1", "", "q1", 1, nil, schedulingv1.PodGroupInqueue, "soft", 0),
+				},
+				[]*v1.Pod{
+					util.BuildPod("c1", "p4", "", v1.PodPending, api.BuildResourceList("2", "4G"), "pg1", map[string]string{"volcano.sh/task-spec": "worker"}, nil),
+				},
+			),
+			arguments: framework.Arguments{
+				"weight": 1,
+			},
+			scoreNodes: []string{
+				"s3-n1",
+				"s4-n1",
+				"s5-n1",
+			},
+			// s3 and s4 belong to same hypernode s1, s5 belongs to a different hypernode s2
+			// s2 has less idle resources than s1, so s5 should get higher score
 			expected: map[string]float64{
 				"s3-n1": 0.0,
 				"s4-n1": 0.0,
-				"s5-n1": 0.0,
+				"s5-n1": 100.0,
 			},
 		},
 		{
-			name: "Tasks in job rescheduled, score zero when the hyperNode of node has empty LCA hyperNode with jobAllocatedHyperNode",
-			TestCommonStruct: uthelper.TestCommonStruct{
-				PodGroups: []*schedulingv1.PodGroup{
-					util.BuildPodGroupWithNetWorkTopologies("pg1", "c1", "s3", "q1", 1, nil, schedulingv1.PodGroupInqueue, "soft", 0),
-				},
-				Pods: []*v1.Pod{
-					util.BuildPod("c1", "p1", "s3-n1", v1.PodRunning, api.BuildResourceList("2", "4G"), "pg1", map[string]string{"volcano.sh/task-spec": "master"}, nil),
-					util.BuildPod("c1", "p2", "s3-n2", v1.PodRunning, api.BuildResourceList("2", "4G"), "pg1", map[string]string{"volcano.sh/task-spec": "worker"}, nil),
-					util.BuildPod("c1", "p3", "", v1.PodPending, api.BuildResourceList("2", "4G"), "pg1", map[string]string{"volcano.sh/task-spec": "worker"}, nil),
-				},
-				Nodes: []*v1.Node{
-					util.BuildNode("s3-n1", api.BuildResourceList("2", "4Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), nil),
-					util.BuildNode("s3-n2", api.BuildResourceList("2", "4Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), nil),
-					util.BuildNode("s4-n1", api.BuildResourceList("2", "4Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), nil),
-					util.BuildNode("s4-n2", api.BuildResourceList("2", "4Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), nil),
-					util.BuildNode("s5-n1", api.BuildResourceList("2", "4Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), nil),
-					util.BuildNode("s5-n2", api.BuildResourceList("2", "4Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), nil),
-					util.BuildNode("s6-n1", api.BuildResourceList("2", "4Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), nil),
-					util.BuildNode("s6-n2", api.BuildResourceList("2", "4Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), nil),
-				},
-				Plugins: map[string]framework.PluginBuilder{PluginName: New},
-				HyperNodesSetByTier: map[int]sets.Set[string]{
-					1: sets.New[string]("s3", "s4", "s5", "s6"),
-					2: sets.New[string]("s1", "s2"),
-					3: sets.New[string]("s0")},
-				HyperNodesMap: map[string]*api.HyperNodeInfo{
-					"s0": api.NewHyperNodeInfo(api.BuildHyperNode("s0", 3, []api.MemberConfig{
-						{
-							Name:     "s1",
-							Type:     topologyv1alpha1.MemberTypeHyperNode,
-							Selector: "exact",
-						},
-					})),
-					"s1": api.NewHyperNodeInfo(api.BuildHyperNode("s1", 2, []api.MemberConfig{
-						{
-							Name:     "s3",
-							Type:     topologyv1alpha1.MemberTypeHyperNode,
-							Selector: "exact",
-						},
-						{
-							Name:     "s4",
-							Type:     topologyv1alpha1.MemberTypeHyperNode,
-							Selector: "exact",
-						},
-					})),
-					"s2": api.NewHyperNodeInfo(api.BuildHyperNode("s2", 2, []api.MemberConfig{
-						{
-							Name:     "s5",
-							Type:     topologyv1alpha1.MemberTypeHyperNode,
-							Selector: "exact",
-						},
-						{
-							Name:     "s6",
-							Type:     topologyv1alpha1.MemberTypeHyperNode,
-							Selector: "exact",
-						},
-					})),
-					"s3": api.NewHyperNodeInfo(api.BuildHyperNode("s3", 1, []api.MemberConfig{
-						{
-							Name:     "s3-n1",
-							Type:     topologyv1alpha1.MemberTypeNode,
-							Selector: "exact",
-						},
-						{
-							Name:     "s3-n2",
-							Type:     topologyv1alpha1.MemberTypeNode,
-							Selector: "exact",
-						},
-					})),
-					"s4": api.NewHyperNodeInfo(api.BuildHyperNode("s4", 1, []api.MemberConfig{
-						{
-							Name:     "s4-n1",
-							Type:     topologyv1alpha1.MemberTypeNode,
-							Selector: "exact",
-						},
-						{
-							Name:     "s4-n2",
-							Type:     topologyv1alpha1.MemberTypeNode,
-							Selector: "exact",
-						},
-					})),
-					"s5": api.NewHyperNodeInfo(api.BuildHyperNode("s5", 1, []api.MemberConfig{
-						{
-							Name:     "s5-n1",
-							Type:     topologyv1alpha1.MemberTypeNode,
-							Selector: "exact",
-						},
-						{
-							Name:     "s5-n2",
-							Type:     topologyv1alpha1.MemberTypeNode,
-							Selector: "exact",
-						},
-					})),
-					"s6": api.NewHyperNodeInfo(api.BuildHyperNode("s6", 1, []api.MemberConfig{
-						{
-							Name:     "s6-n1",
-							Type:     topologyv1alpha1.MemberTypeNode,
-							Selector: "exact",
-						},
-						{
-							Name:     "s6-n2",
-							Type:     topologyv1alpha1.MemberTypeNode,
-							Selector: "exact",
-						},
-					})),
-				},
-				HyperNodes: map[string]sets.Set[string]{
-					"s0": sets.New[string]("s3-n1", "s3-n2", "s4-n1", "s4-n2", "s5-n1", "s5-n2", "s6-n1", "s6-n2"),
-					"s1": sets.New[string]("s3-n1", "s3-n2", "s4-n1", "s4-n2"),
-					"s2": sets.New[string]("s5-n1", "s5-n2", "s6-n1", "s6-n2"),
-					"s3": sets.New[string]("s3-n1", "s3-n2"),
-					"s4": sets.New[string]("s4-n1", "s4-n2"),
-					"s5": sets.New[string]("s5-n1", "s5-n2"),
-					"s6": sets.New[string]("s6-n1", "s6-n2"),
-				},
-				Queues: []*schedulingv1.Queue{
-					util.BuildQueue("q1", 1, nil),
-				},
-			},
-			arguments: framework.Arguments{
-				"weight": 1,
-			},
-			scoreNodes: []*api.NodeInfo{
-				{
-					Name: "s5-n1",
-				},
-				{
-					Name: "s6-n1",
-				},
-			},
-			expected: map[string]float64{
-				"s5-n1": 0.0,
-				"s6-n1": 0.0,
-			},
-		},
-		{
-			name: "Tasks in job rescheduled, score nodes according to node hypernode LCA hyperNode tier",
-			TestCommonStruct: uthelper.TestCommonStruct{
-				Plugins: map[string]framework.PluginBuilder{PluginName: New},
-				PodGroups: []*schedulingv1.PodGroup{
-					util.BuildPodGroupWithNetWorkTopologies("pg1", "c1", "s3", "q1", 1, nil, schedulingv1.PodGroupInqueue, "soft", 0),
-				},
-				Pods: []*v1.Pod{
-					util.BuildPod("c1", "p1", "s3-n1", v1.PodRunning, api.BuildResourceList("2", "4G"), "pg1", map[string]string{"volcano.sh/task-spec": "master"}, nil),
-					util.BuildPod("c1", "p2", "s3-n2", v1.PodRunning, api.BuildResourceList("2", "4G"), "pg1", map[string]string{"volcano.sh/task-spec": "worker"}, nil),
-					util.BuildPod("c1", "p3", "", v1.PodPending, api.BuildResourceList("2", "4G"), "pg1", map[string]string{"volcano.sh/task-spec": "worker"}, nil),
-				},
-				Nodes: []*v1.Node{
-					util.BuildNode("s3-n1", api.BuildResourceList("2", "4Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), nil),
-					util.BuildNode("s3-n2", api.BuildResourceList("2", "4Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), nil),
-					util.BuildNode("s4-n1", api.BuildResourceList("2", "4Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), nil),
-					util.BuildNode("s4-n2", api.BuildResourceList("2", "4Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), nil),
-					util.BuildNode("s5-n1", api.BuildResourceList("2", "4Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), nil),
-					util.BuildNode("s5-n2", api.BuildResourceList("2", "4Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), nil),
-					util.BuildNode("s6-n1", api.BuildResourceList("2", "4Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), nil),
-					util.BuildNode("s6-n2", api.BuildResourceList("2", "4Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), nil),
-				},
-				HyperNodesSetByTier: map[int]sets.Set[string]{
-					1: sets.New[string]("s3", "s4", "s5", "s6"),
-					2: sets.New[string]("s1", "s2"),
-					3: sets.New[string]("s0")},
-				HyperNodesMap: map[string]*api.HyperNodeInfo{
-					"s0": api.NewHyperNodeInfo(api.BuildHyperNode("s0", 3, []api.MemberConfig{
-						{
-							Name:     "s1",
-							Type:     topologyv1alpha1.MemberTypeHyperNode,
-							Selector: "exact",
-						},
-						{
-							Name:     "s2",
-							Type:     topologyv1alpha1.MemberTypeHyperNode,
-							Selector: "exact",
-						},
-					})),
-					"s1": api.NewHyperNodeInfo(api.BuildHyperNode("s1", 2, []api.MemberConfig{
-						{
-							Name:     "s3",
-							Type:     topologyv1alpha1.MemberTypeHyperNode,
-							Selector: "exact",
-						},
-						{
-							Name:     "s4",
-							Type:     topologyv1alpha1.MemberTypeHyperNode,
-							Selector: "exact",
-						},
-					})),
-					"s2": api.NewHyperNodeInfo(api.BuildHyperNode("s2", 2, []api.MemberConfig{
-						{
-							Name:     "s5",
-							Type:     topologyv1alpha1.MemberTypeHyperNode,
-							Selector: "exact",
-						},
-						{
-							Name:     "s6",
-							Type:     topologyv1alpha1.MemberTypeHyperNode,
-							Selector: "exact",
-						},
-					})),
-					"s3": api.NewHyperNodeInfo(api.BuildHyperNode("s3", 1, []api.MemberConfig{
-						{
-							Name:     "s3-n1",
-							Type:     topologyv1alpha1.MemberTypeNode,
-							Selector: "exact",
-						},
-						{
-							Name:     "s3-n2",
-							Type:     topologyv1alpha1.MemberTypeNode,
-							Selector: "exact",
-						},
-					})),
-					"s4": api.NewHyperNodeInfo(api.BuildHyperNode("s4", 1, []api.MemberConfig{
-						{
-							Name:     "s4-n1",
-							Type:     topologyv1alpha1.MemberTypeNode,
-							Selector: "exact",
-						},
-						{
-							Name:     "s4-n2",
-							Type:     topologyv1alpha1.MemberTypeNode,
-							Selector: "exact",
-						},
-					})),
-					"s5": api.NewHyperNodeInfo(api.BuildHyperNode("s5", 1, []api.MemberConfig{
-						{
-							Name:     "s5-n1",
-							Type:     topologyv1alpha1.MemberTypeNode,
-							Selector: "exact",
-						},
-						{
-							Name:     "s5-n2",
-							Type:     topologyv1alpha1.MemberTypeNode,
-							Selector: "exact",
-						},
-					})),
-					"s6": api.NewHyperNodeInfo(api.BuildHyperNode("s6", 1, []api.MemberConfig{
-						{
-							Name:     "s6-n1",
-							Type:     topologyv1alpha1.MemberTypeNode,
-							Selector: "exact",
-						},
-						{
-							Name:     "s6-n2",
-							Type:     topologyv1alpha1.MemberTypeNode,
-							Selector: "exact",
-						},
-					})),
-				},
-				HyperNodes: map[string]sets.Set[string]{
-					"s0": sets.New[string]("s3-n1", "s3-n2", "s4-n1", "s4-n2", "s5-n1", "s5-n2", "s6-n1", "s6-n2"),
-					"s1": sets.New[string]("s3-n1", "s3-n2", "s4-n1", "s4-n2"),
-					"s2": sets.New[string]("s5-n1", "s5-n2", "s6-n1", "s6-n2"),
-					"s3": sets.New[string]("s3-n1", "s3-n2"),
-					"s4": sets.New[string]("s4-n1", "s4-n2"),
-					"s5": sets.New[string]("s5-n1", "s5-n2"),
-					"s6": sets.New[string]("s6-n1", "s6-n2"),
-				},
-				Queues: []*schedulingv1.Queue{
-					util.BuildQueue("q1", 1, nil),
-				},
-			},
-			arguments: framework.Arguments{
-				"weight": 1,
-			},
-			scoreNodes: []*api.NodeInfo{
-				{
-					Name: "s3-n1",
-				},
-				{
-					Name: "s4-n1",
-				},
-				{
-					Name: "s5-n1",
-				},
-			},
-			expected: map[string]float64{
-				"s3-n1": 100.0,
-				"s4-n1": 50.0,
-				"s5-n1": 0.0,
-			},
-		},
-		{
-			name: "Tasks in job rescheduled, score hyperNodes according to node LCA hyperNode tier of the hyperNode and jobAllocatedHyperNode when hyperNodesInfo has two tier",
-			TestCommonStruct: uthelper.TestCommonStruct{
-				Plugins: map[string]framework.PluginBuilder{PluginName: New},
-				PodGroups: []*schedulingv1.PodGroup{
+			name: "nodes within same hypernode score equally",
+			TestCommonStruct: createTwoTierTestStruct(
+				[]*schedulingv1.PodGroup{
 					util.BuildPodGroupWithNetWorkTopologies("pg1", "c1", "s1", "q1", 1, nil, schedulingv1.PodGroupInqueue, "soft", 0),
 				},
-				Pods: []*v1.Pod{
+				[]*v1.Pod{
 					util.BuildPod("c1", "p1", "s1-n1", v1.PodRunning, api.BuildResourceList("2", "4G"), "pg1", map[string]string{"volcano.sh/task-spec": "master"}, nil),
 					util.BuildPod("c1", "p2", "", v1.PodPending, api.BuildResourceList("2", "4G"), "pg1", map[string]string{"volcano.sh/task-spec": "worker"}, nil),
 				},
-				Nodes: []*v1.Node{
-					util.BuildNode("s1-n1", api.BuildResourceList("2", "4Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), nil),
-					util.BuildNode("s1-n2", api.BuildResourceList("2", "4Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), nil),
-					util.BuildNode("s2-n1", api.BuildResourceList("2", "4Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), nil),
-					util.BuildNode("s2-n2", api.BuildResourceList("2", "4Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), nil),
-				},
-				HyperNodesSetByTier: map[int]sets.Set[string]{
-					1: sets.New[string]("s1", "s2"),
-					2: sets.New[string]("s0")},
-				HyperNodesMap: map[string]*api.HyperNodeInfo{
-					"s0": api.NewHyperNodeInfo(api.BuildHyperNode("s0", 2, []api.MemberConfig{
-						{
-							Name:     "s1",
-							Type:     topologyv1alpha1.MemberTypeHyperNode,
-							Selector: "exact",
-						},
-						{
-							Name:     "s2",
-							Type:     topologyv1alpha1.MemberTypeHyperNode,
-							Selector: "exact",
-						},
-					})),
-					"s1": api.NewHyperNodeInfo(api.BuildHyperNode("s1", 1, []api.MemberConfig{
-						{
-							Name:     "s1-n1",
-							Type:     topologyv1alpha1.MemberTypeNode,
-							Selector: "exact",
-						},
-						{
-							Name:     "s1-n2",
-							Type:     topologyv1alpha1.MemberTypeNode,
-							Selector: "exact",
-						},
-					})),
-					"s2": api.NewHyperNodeInfo(api.BuildHyperNode("s2", 1, []api.MemberConfig{
-						{
-							Name:     "s2-n1",
-							Type:     topologyv1alpha1.MemberTypeNode,
-							Selector: "exact",
-						},
-						{
-							Name:     "s2-n2",
-							Type:     topologyv1alpha1.MemberTypeNode,
-							Selector: "exact",
-						},
-					})),
-				},
-				HyperNodes: map[string]sets.Set[string]{
-					"s0": sets.New[string]("s1-n1", "s1-n2", "s2-n1", "s2-n2"),
-					"s1": sets.New[string]("s1-n1", "s1-n2"),
-					"s2": sets.New[string]("s2-n1", "s2-n2"),
-				},
-				Queues: []*schedulingv1.Queue{
-					util.BuildQueue("q1", 1, nil),
-				},
-			},
+			),
 			arguments: framework.Arguments{
 				"weight": 1,
 			},
-			scoreNodes: []*api.NodeInfo{
-				{
-					Name: "s1-n1",
-				},
-				{
-					Name: "s2-n1",
-				},
+			scoreNodes: []string{
+				"s1-n1",
+				"s1-n2",
 			},
+			// s1-n1 and s1-n2 belong to same hypernode s1, with same score
 			expected: map[string]float64{
 				"s1-n1": 100.0,
+				"s1-n2": 100.0,
+			},
+		},
+		{
+			name: "hypernode which can satisfy resource requirement with existing pods scores higher",
+			TestCommonStruct: createTwoTierTestStruct(
+				[]*schedulingv1.PodGroup{
+					util.BuildPodGroupWithNetWorkTopologies("pg1", "c1", "s1", "q1", 1, nil, schedulingv1.PodGroupInqueue, "soft", 0),
+				},
+				[]*v1.Pod{
+					util.BuildPod("c1", "p1", "s1-n1", v1.PodRunning, api.BuildResourceList("2", "4G"), "pg1", map[string]string{"volcano.sh/task-spec": "master"}, nil),
+					util.BuildPod("c1", "p2", "", v1.PodPending, api.BuildResourceList("2", "4G"), "pg1", map[string]string{"volcano.sh/task-spec": "worker"}, nil),
+				},
+			),
+			arguments: framework.Arguments{
+				"weight": 1,
+			},
+			scoreNodes: []string{
+				"s1-n2",
+				"s2-n1",
+			},
+			expected: map[string]float64{
+				"s1-n2": 100.0,
 				"s2-n1": 0.0,
 			},
 		},
 		{
-			name: "Tasks in job rescheduled, score hyperNodes according to node LCA hyperNode tier of the hyperNode and jobAllocatedHyperNode when hyperNodesInfo has one tier",
-			TestCommonStruct: uthelper.TestCommonStruct{
-				Plugins: map[string]framework.PluginBuilder{PluginName: New},
-				PodGroups: []*schedulingv1.PodGroup{
+			name: "hypernode must have enough idle resources to schedule pending pod",
+			TestCommonStruct: createTwoTierTestStruct(
+				[]*schedulingv1.PodGroup{
 					util.BuildPodGroupWithNetWorkTopologies("pg1", "c1", "s1", "q1", 1, nil, schedulingv1.PodGroupInqueue, "soft", 0),
 				},
-				Pods: []*v1.Pod{
+				[]*v1.Pod{
 					util.BuildPod("c1", "p1", "s1-n1", v1.PodRunning, api.BuildResourceList("2", "4G"), "pg1", map[string]string{"volcano.sh/task-spec": "master"}, nil),
 					util.BuildPod("c1", "p2", "", v1.PodPending, api.BuildResourceList("2", "4G"), "pg1", map[string]string{"volcano.sh/task-spec": "worker"}, nil),
 				},
-				Nodes: []*v1.Node{
-					util.BuildNode("s1-n1", api.BuildResourceList("2", "4Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), nil),
-					util.BuildNode("s1-n2", api.BuildResourceList("2", "4Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), nil),
-					util.BuildNode("s2-n1", api.BuildResourceList("2", "4Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), nil),
-					util.BuildNode("s2-n2", api.BuildResourceList("2", "4Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), nil),
-				},
-				HyperNodesSetByTier: map[int]sets.Set[string]{
-					1: sets.New[string]("s1", "s2"),
-				},
-				HyperNodesMap: map[string]*api.HyperNodeInfo{
-					"s1": api.NewHyperNodeInfo(api.BuildHyperNode("s1", 1, []api.MemberConfig{
-						{
-							Name:     "s1-n1",
-							Type:     topologyv1alpha1.MemberTypeNode,
-							Selector: "exact",
-						},
-						{
-							Name:     "s1-n2",
-							Type:     topologyv1alpha1.MemberTypeNode,
-							Selector: "exact",
-						},
-					})),
-					"s2": api.NewHyperNodeInfo(api.BuildHyperNode("s2", 1, []api.MemberConfig{
-						{
-							Name:     "s2-n1",
-							Type:     topologyv1alpha1.MemberTypeNode,
-							Selector: "exact",
-						},
-						{
-							Name:     "s2-n2",
-							Type:     topologyv1alpha1.MemberTypeNode,
-							Selector: "exact",
-						},
-					})),
-				},
-				HyperNodes: map[string]sets.Set[string]{
-					"s1": sets.New[string]("s1-n1", "s1-n2"),
-					"s2": sets.New[string]("s2-n1", "s2-n2"),
-				},
-				Queues: []*schedulingv1.Queue{
-					util.BuildQueue("q1", 1, nil),
-				},
-			},
+			),
 			arguments: framework.Arguments{
 				"weight": 1,
 			},
-			scoreNodes: []*api.NodeInfo{
-				{
-					Name: "s1-n1",
-				},
-				{
-					Name: "s2-n1",
-				},
+			scoreNodes: []string{
+				"s1-n1",
+				"s2-n1",
 			},
 			expected: map[string]float64{
-				"s1-n1": 100.0,
-				"s2-n1": 0.0,
+				"s1-n1": 0,
+				"s2-n1": 100.0,
 			},
 		},
 		{
-			name: "Tasks in job rescheduled, score hyperNodes according to node LCA hyperNode tier of the hyperNode and jobAllocatedHyperNode with plugin weight 2",
-			TestCommonStruct: uthelper.TestCommonStruct{
-				Plugins: map[string]framework.PluginBuilder{PluginName: New},
-				PodGroups: []*schedulingv1.PodGroup{
+			name: "soft mode allows sibling hypernode placement in three-tier topology",
+			TestCommonStruct: createThreeTierTestStruct(
+				[]*schedulingv1.PodGroup{
 					util.BuildPodGroupWithNetWorkTopologies("pg1", "c1", "s3", "q1", 1, nil, schedulingv1.PodGroupInqueue, "soft", 0),
 				},
-				Pods: []*v1.Pod{
+				[]*v1.Pod{
 					util.BuildPod("c1", "p1", "s3-n1", v1.PodRunning, api.BuildResourceList("2", "4G"), "pg1", map[string]string{"volcano.sh/task-spec": "master"}, nil),
 					util.BuildPod("c1", "p2", "s3-n2", v1.PodRunning, api.BuildResourceList("2", "4G"), "pg1", map[string]string{"volcano.sh/task-spec": "worker"}, nil),
 					util.BuildPod("c1", "p3", "", v1.PodPending, api.BuildResourceList("2", "4G"), "pg1", map[string]string{"volcano.sh/task-spec": "worker"}, nil),
 				},
-				Nodes: []*v1.Node{
-					util.BuildNode("s3-n1", api.BuildResourceList("2", "4Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), nil),
-					util.BuildNode("s3-n2", api.BuildResourceList("2", "4Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), nil),
-					util.BuildNode("s4-n1", api.BuildResourceList("2", "4Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), nil),
-					util.BuildNode("s4-n2", api.BuildResourceList("2", "4Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), nil),
-					util.BuildNode("s5-n1", api.BuildResourceList("2", "4Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), nil),
-					util.BuildNode("s5-n2", api.BuildResourceList("2", "4Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), nil),
-					util.BuildNode("s6-n1", api.BuildResourceList("2", "4Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), nil),
-					util.BuildNode("s6-n2", api.BuildResourceList("2", "4Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), nil),
-				},
-				HyperNodesSetByTier: map[int]sets.Set[string]{
-					1: sets.New[string]("s3", "s4", "s5", "s6"),
-					2: sets.New[string]("s1", "s2"),
-					3: sets.New[string]("s0")},
-				HyperNodesMap: map[string]*api.HyperNodeInfo{
-					"s0": api.NewHyperNodeInfo(api.BuildHyperNode("s0", 3, []api.MemberConfig{
-						{
-							Name:     "s1",
-							Type:     topologyv1alpha1.MemberTypeHyperNode,
-							Selector: "exact",
-						},
-						{
-							Name:     "s2",
-							Type:     topologyv1alpha1.MemberTypeHyperNode,
-							Selector: "exact",
-						},
-					})),
-					"s1": api.NewHyperNodeInfo(api.BuildHyperNode("s1", 2, []api.MemberConfig{
-						{
-							Name:     "s3",
-							Type:     topologyv1alpha1.MemberTypeHyperNode,
-							Selector: "exact",
-						},
-						{
-							Name:     "s4",
-							Type:     topologyv1alpha1.MemberTypeHyperNode,
-							Selector: "exact",
-						},
-					})),
-					"s2": api.NewHyperNodeInfo(api.BuildHyperNode("s2", 2, []api.MemberConfig{
-						{
-							Name:     "s5",
-							Type:     topologyv1alpha1.MemberTypeHyperNode,
-							Selector: "exact",
-						},
-						{
-							Name:     "s6",
-							Type:     topologyv1alpha1.MemberTypeHyperNode,
-							Selector: "exact",
-						},
-					})),
-					"s3": api.NewHyperNodeInfo(api.BuildHyperNode("s3", 1, []api.MemberConfig{
-						{
-							Name:     "s3-n1",
-							Type:     topologyv1alpha1.MemberTypeNode,
-							Selector: "exact",
-						},
-						{
-							Name:     "s3-n2",
-							Type:     topologyv1alpha1.MemberTypeNode,
-							Selector: "exact",
-						},
-					})),
-					"s4": api.NewHyperNodeInfo(api.BuildHyperNode("s4", 1, []api.MemberConfig{
-						{
-							Name:     "s4-n1",
-							Type:     topologyv1alpha1.MemberTypeNode,
-							Selector: "exact",
-						},
-						{
-							Name:     "s4-n2",
-							Type:     topologyv1alpha1.MemberTypeNode,
-							Selector: "exact",
-						},
-					})),
-					"s5": api.NewHyperNodeInfo(api.BuildHyperNode("s5", 1, []api.MemberConfig{
-						{
-							Name:     "s5-n1",
-							Type:     topologyv1alpha1.MemberTypeNode,
-							Selector: "exact",
-						},
-						{
-							Name:     "s5-n2",
-							Type:     topologyv1alpha1.MemberTypeNode,
-							Selector: "exact",
-						},
-					})),
-					"s6": api.NewHyperNodeInfo(api.BuildHyperNode("s6", 1, []api.MemberConfig{
-						{
-							Name:     "s6-n1",
-							Type:     topologyv1alpha1.MemberTypeNode,
-							Selector: "exact",
-						},
-						{
-							Name:     "s6-n2",
-							Type:     topologyv1alpha1.MemberTypeNode,
-							Selector: "exact",
-						},
-					})),
-				},
-				HyperNodes: map[string]sets.Set[string]{
-					"s0": sets.New[string]("s3-n1", "s3-n2", "s4-n1", "s4-n2", "s5-n1", "s5-n2", "s6-n1", "s6-n2"),
-					"s1": sets.New[string]("s3-n1", "s3-n2", "s4-n1", "s4-n2"),
-					"s2": sets.New[string]("s5-n1", "s5-n2", "s6-n1", "s6-n2"),
-					"s3": sets.New[string]("s3-n1", "s3-n2"),
-					"s4": sets.New[string]("s4-n1", "s4-n2"),
-					"s5": sets.New[string]("s5-n1", "s5-n2"),
-					"s6": sets.New[string]("s6-n1", "s6-n2"),
-				},
-				Queues: []*schedulingv1.Queue{
-					util.BuildQueue("q1", 1, nil),
-				},
-			},
+			),
 			arguments: framework.Arguments{
-				"weight": 2,
+				"weight": 1,
 			},
-			scoreNodes: []*api.NodeInfo{
-				{
-					Name: "s3-n1",
-				},
-				{
-					Name: "s4-n1",
-				},
-				{
-					Name: "s5-n1",
-				},
+			scoreNodes: []string{
+				"s4-n1",
+				"s4-n2",
+				"s5-n1",
+				"s5-n2",
+				"s6-n1",
+				"s6-n2",
 			},
 			expected: map[string]float64{
-				"s3-n1": 200.0,
 				"s4-n1": 100.0,
+				"s4-n2": 100.0,
 				"s5-n1": 0.0,
+				"s5-n2": 0.0,
+				"s6-n1": 0.0,
+				"s6-n2": 0.0,
 			},
 		},
+
 		{
-			name: "Tasks in job rescheduled, score hyperNodes according to node LCA hyperNode tier and task num of the hyperNode when there are at least two hyperNodes have max hyperNode tier score",
-			TestCommonStruct: uthelper.TestCommonStruct{
-				Plugins: map[string]framework.PluginBuilder{PluginName: New},
-				PodGroups: []*schedulingv1.PodGroup{
-					util.BuildPodGroupWithNetWorkTopologies("pg1", "c1", "s1", "q1", 3, nil, schedulingv1.PodGroupInqueue, "soft", 0),
+			name: "binpacking with existing pods in same hypernode",
+			TestCommonStruct: createThreeTierTestStruct(
+				[]*schedulingv1.PodGroup{
+					util.BuildPodGroupWithNetWorkTopologies("pg1", "c1", "", "q1", 1, nil, schedulingv1.PodGroupInqueue, "soft", 0),
+					util.BuildPodGroupWithNetWorkTopologies("pg2", "c1", "", "q1", 1, nil, schedulingv1.PodGroupInqueue, "soft", 0),
 				},
-				Pods: []*v1.Pod{
-					util.BuildPod("c1", "p1", "s3-n1", v1.PodRunning, api.BuildResourceList("2", "4G"), "pg1", map[string]string{"volcano.sh/task-spec": "master"}, nil),
-					util.BuildPod("c1", "p2", "s3-n2", v1.PodRunning, api.BuildResourceList("2", "4G"), "pg1", map[string]string{"volcano.sh/task-spec": "worker"}, nil),
-					util.BuildPod("c1", "p3", "s4-n1", v1.PodRunning, api.BuildResourceList("2", "4G"), "pg1", map[string]string{"volcano.sh/task-spec": "worker"}, nil),
+				[]*v1.Pod{
 					util.BuildPod("c1", "p4", "", v1.PodPending, api.BuildResourceList("2", "4G"), "pg1", map[string]string{"volcano.sh/task-spec": "worker"}, nil),
+					util.BuildPod("c1", "p-other", "s3-n1", v1.PodRunning, api.BuildResourceList("2", "4G"), "pg2", map[string]string{"volcano.sh/task-spec": "worker"}, nil),
 				},
-				Nodes: []*v1.Node{
-					util.BuildNode("s3-n1", api.BuildResourceList("2", "4Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), nil),
-					util.BuildNode("s3-n2", api.BuildResourceList("2", "4Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), nil),
-					util.BuildNode("s4-n1", api.BuildResourceList("2", "4Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), nil),
-					util.BuildNode("s4-n2", api.BuildResourceList("2", "4Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), nil),
-					util.BuildNode("s5-n1", api.BuildResourceList("2", "4Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), nil),
-					util.BuildNode("s5-n2", api.BuildResourceList("2", "4Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), nil),
-					util.BuildNode("s6-n1", api.BuildResourceList("2", "4Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), nil),
-					util.BuildNode("s6-n2", api.BuildResourceList("2", "4Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), nil),
-				},
-				HyperNodesSetByTier: map[int]sets.Set[string]{
-					1: sets.New[string]("s3", "s4", "s5", "s6"),
-					2: sets.New[string]("s1", "s2"),
-					3: sets.New[string]("s0")},
-				HyperNodesMap: map[string]*api.HyperNodeInfo{
-					"s0": api.NewHyperNodeInfo(api.BuildHyperNode("s0", 3, []api.MemberConfig{
-						{
-							Name:     "s1",
-							Type:     topologyv1alpha1.MemberTypeHyperNode,
-							Selector: "exact",
-						},
-						{
-							Name:     "s2",
-							Type:     topologyv1alpha1.MemberTypeHyperNode,
-							Selector: "exact",
-						},
-					})),
-					"s1": api.NewHyperNodeInfo(api.BuildHyperNode("s1", 2, []api.MemberConfig{
-						{
-							Name:     "s3",
-							Type:     topologyv1alpha1.MemberTypeHyperNode,
-							Selector: "exact",
-						},
-						{
-							Name:     "s4",
-							Type:     topologyv1alpha1.MemberTypeHyperNode,
-							Selector: "exact",
-						},
-					})),
-					"s2": api.NewHyperNodeInfo(api.BuildHyperNode("s2", 2, []api.MemberConfig{
-						{
-							Name:     "s5",
-							Type:     topologyv1alpha1.MemberTypeHyperNode,
-							Selector: "exact",
-						},
-						{
-							Name:     "s6",
-							Type:     topologyv1alpha1.MemberTypeHyperNode,
-							Selector: "exact",
-						},
-					})),
-					"s3": api.NewHyperNodeInfo(api.BuildHyperNode("s3", 1, []api.MemberConfig{
-						{
-							Name:     "s3-n1",
-							Type:     topologyv1alpha1.MemberTypeNode,
-							Selector: "exact",
-						},
-						{
-							Name:     "s3-n2",
-							Type:     topologyv1alpha1.MemberTypeNode,
-							Selector: "exact",
-						},
-					})),
-					"s4": api.NewHyperNodeInfo(api.BuildHyperNode("s4", 1, []api.MemberConfig{
-						{
-							Name:     "s4-n1",
-							Type:     topologyv1alpha1.MemberTypeNode,
-							Selector: "exact",
-						},
-						{
-							Name:     "s4-n2",
-							Type:     topologyv1alpha1.MemberTypeNode,
-							Selector: "exact",
-						},
-					})),
-					"s5": api.NewHyperNodeInfo(api.BuildHyperNode("s5", 1, []api.MemberConfig{
-						{
-							Name:     "s5-n1",
-							Type:     topologyv1alpha1.MemberTypeNode,
-							Selector: "exact",
-						},
-						{
-							Name:     "s5-n2",
-							Type:     topologyv1alpha1.MemberTypeNode,
-							Selector: "exact",
-						},
-					})),
-					"s6": api.NewHyperNodeInfo(api.BuildHyperNode("s6", 1, []api.MemberConfig{
-						{
-							Name:     "s6-n1",
-							Type:     topologyv1alpha1.MemberTypeNode,
-							Selector: "exact",
-						},
-						{
-							Name:     "s6-n2",
-							Type:     topologyv1alpha1.MemberTypeNode,
-							Selector: "exact",
-						},
-					})),
-				},
-				HyperNodes: map[string]sets.Set[string]{
-					"s0": sets.New[string]("s3-n1", "s3-n2", "s4-n1", "s4-n2", "s5-n1", "s5-n2", "s6-n1", "s6-n2"),
-					"s1": sets.New[string]("s3-n1", "s3-n2", "s4-n1", "s4-n2"),
-					"s2": sets.New[string]("s5-n1", "s5-n2", "s6-n1", "s6-n2"),
-					"s3": sets.New[string]("s3-n1", "s3-n2"),
-					"s4": sets.New[string]("s4-n1", "s4-n2"),
-					"s5": sets.New[string]("s5-n1", "s5-n2"),
-					"s6": sets.New[string]("s6-n1", "s6-n2"),
-				},
-				Queues: []*schedulingv1.Queue{
-					util.BuildQueue("q1", 1, nil),
-				},
-			},
+			),
 			arguments: framework.Arguments{
 				"weight": 1,
 			},
-			scoreNodes: []*api.NodeInfo{
-				{
-					Name: "s3-n1",
-				},
-				{
-					Name: "s4-n1",
-				},
-				{
-					Name: "s5-n1",
-				},
-			},
-			tasks: map[string]string{
-				"task1": "s3-n1",
-				"task2": "s3-n2",
-				"task3": "s4-n1",
-				"test4": "",
+			scoreNodes: []string{
+				"s3-n2",
+				"s4-n1",
+				"s4-n2",
+				"s5-n1",
+				"s5-n2",
+				"s6-n1",
+				"s6-n2",
 			},
 			expected: map[string]float64{
-				"s3-n1": 100.0,
-				"s4-n1": 75.0,
+				"s3-n2": 100.0,
+				"s4-n1": 19.999999999999986,
+				"s4-n2": 19.999999999999986,
 				"s5-n1": 0.0,
+				"s5-n2": 0.0,
+				"s6-n1": 0.0,
+				"s6-n2": 0.0,
+			},
+		},
+		{
+			name: "binpacking with existing pods with best tier",
+			TestCommonStruct: createThreeTierTestStruct(
+				[]*schedulingv1.PodGroup{
+					util.BuildPodGroupWithNetWorkTopologies("pg1", "c1", "", "q1", 1, nil, schedulingv1.PodGroupInqueue, "soft", 0),
+					util.BuildPodGroupWithNetWorkTopologies("pg2", "c1", "", "q1", 1, nil, schedulingv1.PodGroupInqueue, "soft", 0),
+				},
+				[]*v1.Pod{
+					util.BuildPod("c1", "p1", "", v1.PodPending, api.BuildResourceList("2", "4G"), "pg1", map[string]string{"volcano.sh/task-spec": "worker"}, nil),
+					util.BuildPod("c1", "p2", "", v1.PodPending, api.BuildResourceList("2", "4G"), "pg1", map[string]string{"volcano.sh/task-spec": "worker"}, nil),
+					util.BuildPod("c1", "p-other", "s3-n1", v1.PodRunning, api.BuildResourceList("2", "4G"), "pg2", map[string]string{"volcano.sh/task-spec": "worker"}, nil),
+				},
+			),
+			arguments: framework.Arguments{
+				"weight": 1,
+			},
+			scoreNodes: []string{
+				"s3-n2",
+				"s4-n1",
+				"s4-n2",
+				"s5-n1",
+				"s5-n2",
+				"s6-n1",
+				"s6-n2",
+			},
+			expected: map[string]float64{
+				"s3-n2": 0.0,
+				"s4-n1": 100.0,
+				"s4-n2": 100.0,
+				"s5-n1": 74.04293950677567,
+				"s5-n2": 74.04293950677567,
+				"s6-n1": 74.04293950677567,
+				"s6-n2": 74.04293950677567,
 			},
 		},
 	}
@@ -1894,14 +638,19 @@ func TestNetworkTopologyAwareNodeScore_Soft(t *testing.T) {
 		ssn := test.RegisterSession(tiers, nil)
 		defer test.Close()
 
-		nodeScores, err := ssn.BatchNodeOrderFn(parseTask(ssn.Jobs), test.scoreNodes)
+		scoreNodes := make([]*api.NodeInfo, len(test.scoreNodes))
+		for i, nodeName := range test.scoreNodes {
+			scoreNodes[i] = ssn.Nodes[nodeName]
+		}
+
+		nodeScores, err := ssn.BatchNodeOrderFn(parseTask(ssn.Jobs), scoreNodes)
 		if err != nil {
-			t.Errorf("case%d: task %s  has err %v", i, test.Name, err)
+			t.Errorf("case%d: %s has err %v", i, test.name, err)
 			continue
 		}
 		for node, expected := range test.expected {
 			if math.Abs(nodeScores[node]-expected) > eps {
-				t.Errorf("case%d: task %s on node %s expect have score %v, but get %v", i+1, test.name, node, expected, nodeScores[node])
+				t.Errorf("case%d: %s on node %s expect have score %v, but get %v", i+1, test.name, node, expected, nodeScores[node])
 			}
 		}
 	}
@@ -1923,4 +672,318 @@ func parseTask(jobInfoMap map[api.JobID]*api.JobInfo) *api.TaskInfo {
 		}
 	}
 	return nil
+}
+
+// buildThreeTierTopology creates a 3-tier network topology with 8 nodes
+//
+//		        s0
+//		      /    \
+//		    s1      s2
+//		   /  \    /  \
+//		  s3  s4  s5   s6
+//		/ \   / \ / \  / \
+//	  n1 n2 n1 n2 n1 n2 n1 n2
+//
+// each node has 2 CPU, 4Gi memory and 10 pods allocatable
+func buildThreeTierTopology() (
+	nodes []*v1.Node,
+	hyperNodesSetByTier map[int]sets.Set[string],
+	hyperNodesMap map[string]*api.HyperNodeInfo,
+	hyperNodes map[string]sets.Set[string],
+) {
+	nodes = []*v1.Node{
+		util.BuildNode("s3-n1", api.BuildResourceList("2", "4Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), nil),
+		util.BuildNode("s3-n2", api.BuildResourceList("2", "4Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), nil),
+		util.BuildNode("s4-n1", api.BuildResourceList("2", "4Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), nil),
+		util.BuildNode("s4-n2", api.BuildResourceList("2", "4Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), nil),
+		util.BuildNode("s5-n1", api.BuildResourceList("2", "4Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), nil),
+		util.BuildNode("s5-n2", api.BuildResourceList("2", "4Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), nil),
+		util.BuildNode("s6-n1", api.BuildResourceList("2", "4Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), nil),
+		util.BuildNode("s6-n2", api.BuildResourceList("2", "4Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), nil),
+	}
+
+	hyperNodesSetByTier = map[int]sets.Set[string]{
+		1: sets.New("s3", "s4", "s5", "s6"),
+		2: sets.New("s1", "s2"),
+		3: sets.New("s0"),
+	}
+
+	hyperNodesMap = map[string]*api.HyperNodeInfo{
+		"s0": api.NewHyperNodeInfo(api.BuildHyperNode("s0", 3, []api.MemberConfig{
+			{
+				Name:     "s1",
+				Type:     topologyv1alpha1.MemberTypeHyperNode,
+				Selector: "exact",
+			},
+			{
+				Name:     "s2",
+				Type:     topologyv1alpha1.MemberTypeHyperNode,
+				Selector: "exact",
+			},
+		})),
+		"s1": api.NewHyperNodeInfo(api.BuildHyperNode("s1", 2, []api.MemberConfig{
+			{
+				Name:     "s3",
+				Type:     topologyv1alpha1.MemberTypeHyperNode,
+				Selector: "exact",
+			},
+			{
+				Name:     "s4",
+				Type:     topologyv1alpha1.MemberTypeHyperNode,
+				Selector: "exact",
+			},
+		})),
+		"s2": api.NewHyperNodeInfo(api.BuildHyperNode("s2", 2, []api.MemberConfig{
+			{
+				Name:     "s5",
+				Type:     topologyv1alpha1.MemberTypeHyperNode,
+				Selector: "exact",
+			},
+			{
+				Name:     "s6",
+				Type:     topologyv1alpha1.MemberTypeHyperNode,
+				Selector: "exact",
+			},
+		})),
+		"s3": api.NewHyperNodeInfo(api.BuildHyperNode("s3", 1, []api.MemberConfig{
+			{
+				Name:     "s3-n1",
+				Type:     topologyv1alpha1.MemberTypeNode,
+				Selector: "exact",
+			},
+			{
+				Name:     "s3-n2",
+				Type:     topologyv1alpha1.MemberTypeNode,
+				Selector: "exact",
+			},
+		})),
+		"s4": api.NewHyperNodeInfo(api.BuildHyperNode("s4", 1, []api.MemberConfig{
+			{
+				Name:     "s4-n1",
+				Type:     topologyv1alpha1.MemberTypeNode,
+				Selector: "exact",
+			},
+			{
+				Name:     "s4-n2",
+				Type:     topologyv1alpha1.MemberTypeNode,
+				Selector: "exact",
+			},
+		})),
+		"s5": api.NewHyperNodeInfo(api.BuildHyperNode("s5", 1, []api.MemberConfig{
+			{
+				Name:     "s5-n1",
+				Type:     topologyv1alpha1.MemberTypeNode,
+				Selector: "exact",
+			},
+			{
+				Name:     "s5-n2",
+				Type:     topologyv1alpha1.MemberTypeNode,
+				Selector: "exact",
+			},
+		})),
+		"s6": api.NewHyperNodeInfo(api.BuildHyperNode("s6", 1, []api.MemberConfig{
+			{
+				Name:     "s6-n1",
+				Type:     topologyv1alpha1.MemberTypeNode,
+				Selector: "exact",
+			},
+			{
+				Name:     "s6-n2",
+				Type:     topologyv1alpha1.MemberTypeNode,
+				Selector: "exact",
+			},
+		})),
+	}
+
+	hyperNodes = map[string]sets.Set[string]{
+		"s0": sets.New("s3-n1", "s3-n2", "s4-n1", "s4-n2", "s5-n1", "s5-n2", "s6-n1", "s6-n2"),
+		"s1": sets.New("s3-n1", "s3-n2", "s4-n1", "s4-n2"),
+		"s2": sets.New("s5-n1", "s5-n2", "s6-n1", "s6-n2"),
+		"s3": sets.New("s3-n1", "s3-n2"),
+		"s4": sets.New("s4-n1", "s4-n2"),
+		"s5": sets.New("s5-n1", "s5-n2"),
+		"s6": sets.New("s6-n1", "s6-n2"),
+	}
+
+	return nodes, hyperNodesSetByTier, hyperNodesMap, hyperNodes
+}
+
+// buildTwoTierTopology creates a 2-tier network topology with 4 nodes
+//
+//		    s0
+//		   /  \
+//		  s1    s2
+//		/ \    / \
+//	  n1  n2 n1  n2
+//
+// each node has 2 CPU, 4Gi memory and 10 pods allocatable
+func buildTwoTierTopology() (
+	nodes []*v1.Node,
+	hyperNodesSetByTier map[int]sets.Set[string],
+	hyperNodesMap map[string]*api.HyperNodeInfo,
+	hyperNodes map[string]sets.Set[string],
+) {
+	nodes = []*v1.Node{
+		util.BuildNode("s1-n1", api.BuildResourceList("2", "4Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), nil),
+		util.BuildNode("s1-n2", api.BuildResourceList("2", "4Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), nil),
+		util.BuildNode("s2-n1", api.BuildResourceList("2", "4Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), nil),
+		util.BuildNode("s2-n2", api.BuildResourceList("2", "4Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), nil),
+	}
+
+	hyperNodesSetByTier = map[int]sets.Set[string]{
+		1: sets.New("s1", "s2"),
+		2: sets.New("s0"),
+	}
+
+	hyperNodesMap = map[string]*api.HyperNodeInfo{
+		"s0": api.NewHyperNodeInfo(api.BuildHyperNode("s0", 2, []api.MemberConfig{
+			{
+				Name:     "s1",
+				Type:     topologyv1alpha1.MemberTypeHyperNode,
+				Selector: "exact",
+			},
+			{
+				Name:     "s2",
+				Type:     topologyv1alpha1.MemberTypeHyperNode,
+				Selector: "exact",
+			},
+		})),
+		"s1": api.NewHyperNodeInfo(api.BuildHyperNode("s1", 1, []api.MemberConfig{
+			{
+				Name:     "s1-n1",
+				Type:     topologyv1alpha1.MemberTypeNode,
+				Selector: "exact",
+			},
+			{
+				Name:     "s1-n2",
+				Type:     topologyv1alpha1.MemberTypeNode,
+				Selector: "exact",
+			},
+		})),
+		"s2": api.NewHyperNodeInfo(api.BuildHyperNode("s2", 1, []api.MemberConfig{
+			{
+				Name:     "s2-n1",
+				Type:     topologyv1alpha1.MemberTypeNode,
+				Selector: "exact",
+			},
+			{
+				Name:     "s2-n2",
+				Type:     topologyv1alpha1.MemberTypeNode,
+				Selector: "exact",
+			},
+		})),
+	}
+
+	hyperNodes = map[string]sets.Set[string]{
+		"s0": sets.New("s1-n1", "s1-n2", "s2-n1", "s2-n2"),
+		"s1": sets.New("s1-n1", "s1-n2"),
+		"s2": sets.New("s2-n1", "s2-n2"),
+	}
+
+	return nodes, hyperNodesSetByTier, hyperNodesMap, hyperNodes
+}
+
+// buildSingleTierTopology creates a 1-tier network topology with 4 nodes
+//
+//		  s1    s2
+//		/ \    / \
+//	  n1  n2 n1  n2
+//
+// each node has 2 CPU, 4Gi memory and 10 pods allocatable
+func buildSingleTierTopology() (
+	nodes []*v1.Node,
+	hyperNodesSetByTier map[int]sets.Set[string],
+	hyperNodesMap map[string]*api.HyperNodeInfo,
+	hyperNodes map[string]sets.Set[string],
+) {
+	nodes = []*v1.Node{
+		util.BuildNode("s1-n1", api.BuildResourceList("2", "4Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), nil),
+		util.BuildNode("s1-n2", api.BuildResourceList("2", "4Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), nil),
+		util.BuildNode("s2-n1", api.BuildResourceList("2", "4Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), nil),
+		util.BuildNode("s2-n2", api.BuildResourceList("2", "4Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), nil),
+	}
+
+	hyperNodesSetByTier = map[int]sets.Set[string]{
+		1: sets.New("s1", "s2"),
+	}
+
+	hyperNodesMap = map[string]*api.HyperNodeInfo{
+		"s1": api.NewHyperNodeInfo(api.BuildHyperNode("s1", 1, []api.MemberConfig{
+			{
+				Name:     "s1-n1",
+				Type:     topologyv1alpha1.MemberTypeNode,
+				Selector: "exact",
+			},
+			{
+				Name:     "s1-n2",
+				Type:     topologyv1alpha1.MemberTypeNode,
+				Selector: "exact",
+			},
+		})),
+		"s2": api.NewHyperNodeInfo(api.BuildHyperNode("s2", 1, []api.MemberConfig{
+			{
+				Name:     "s2-n1",
+				Type:     topologyv1alpha1.MemberTypeNode,
+				Selector: "exact",
+			},
+			{
+				Name:     "s2-n2",
+				Type:     topologyv1alpha1.MemberTypeNode,
+				Selector: "exact",
+			},
+		})),
+	}
+
+	hyperNodes = map[string]sets.Set[string]{
+		"s1": sets.New("s1-n1", "s1-n2"),
+		"s2": sets.New("s2-n1", "s2-n2"),
+	}
+
+	return nodes, hyperNodesSetByTier, hyperNodesMap, hyperNodes
+}
+
+// buildTestCommonStruct creates a TestCommonStruct with the specified topology
+func buildTestCommonStruct(
+	nodes []*v1.Node,
+	hyperNodesSetByTier map[int]sets.Set[string],
+	hyperNodesMap map[string]*api.HyperNodeInfo,
+	hyperNodes map[string]sets.Set[string],
+) uthelper.TestCommonStruct {
+	return uthelper.TestCommonStruct{
+		Plugins:             map[string]framework.PluginBuilder{PluginName: New},
+		Nodes:               nodes,
+		HyperNodesSetByTier: hyperNodesSetByTier,
+		HyperNodesMap:       hyperNodesMap,
+		HyperNodes:          hyperNodes,
+		Queues: []*schedulingv1.Queue{
+			util.BuildQueue("q1", 1, nil),
+		},
+	}
+}
+
+// createThreeTierTestStruct creates a TestCommonStruct with 3-tier topology and custom pods/podgroups
+func createThreeTierTestStruct(podGroups []*schedulingv1.PodGroup, pods []*v1.Pod) uthelper.TestCommonStruct {
+	nodes, hyperNodesSetByTier, hyperNodesMap, hyperNodes := buildThreeTierTopology()
+	testStruct := buildTestCommonStruct(nodes, hyperNodesSetByTier, hyperNodesMap, hyperNodes)
+	testStruct.PodGroups = podGroups
+	testStruct.Pods = pods
+	return testStruct
+}
+
+// createTwoTierTestStruct creates a TestCommonStruct with 2-tier topology and custom pods/podgroups
+func createTwoTierTestStruct(podGroups []*schedulingv1.PodGroup, pods []*v1.Pod) uthelper.TestCommonStruct {
+	nodes, hyperNodesSetByTier, hyperNodesMap, hyperNodes := buildTwoTierTopology()
+	testStruct := buildTestCommonStruct(nodes, hyperNodesSetByTier, hyperNodesMap, hyperNodes)
+	testStruct.PodGroups = podGroups
+	testStruct.Pods = pods
+	return testStruct
+}
+
+// createSingleTierTestStruct creates a TestCommonStruct with 1-tier topology and custom pods/podgroups
+func createSingleTierTestStruct(podGroups []*schedulingv1.PodGroup, pods []*v1.Pod) uthelper.TestCommonStruct {
+	nodes, hyperNodesSetByTier, hyperNodesMap, hyperNodes := buildSingleTierTopology()
+	testStruct := buildTestCommonStruct(nodes, hyperNodesSetByTier, hyperNodesMap, hyperNodes)
+	testStruct.PodGroups = podGroups
+	testStruct.Pods = pods
+	return testStruct
 }


### PR DESCRIPTION
#### What type of PR is this?

Network Topology Aware Plugin Enhancement.

#### What this PR does / why we need it:

The current Network Topology Aware plugin optimizes RDMA network topology (e.g., Fat Tree) for distributed jobs by scheduling pods to topologically close nodes. While Volcano already supports intra-job HyperNode binpacking (packing tasks of a single job into compact HyperNodes), it lacks HyperNode-Level Resource Usage Aware Binpacking across hierarchical units (e.g., Leaf, and Spine switches).

This causes suboptimal scheduling: Small jobs scattered across HyperNodes prevent placement of future large jobs.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Notice that do not add `Fixes` if the issue is associated with multiple PRs.
-->
Fixes #4368

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
Configure the following parameters to ensure proper network topology-aware scheduling:

# volcano-scheduler deployment configuration
apiVersion: apps/v1
kind: Deployment
metadata:
  name: volcano-scheduler
spec:
  template:
    spec:
      containers:
      - name: scheduler
        image: volcano-scheduler:latest
        command:
        - /vc-scheduler
        - --percentage-nodes-to-find=100  # Critical: must evaluate all nodes to guarantee optimal topology

Enable and optimize the network topology plugin in the scheduler configuration:

apiVersion: v1
kind: ConfigMap
metadata:
  name: volcano-scheduler-config
data:
  volcano-scheduler.conf: |
    actions: "allocate, backfill"
    tiers:
    - plugins:
      - name: network-topology-aware  # Enable network topology plugin
        arguments:
          weight: 20                  # Plugin weight (impacts scheduling decisions)
          binpack.cpu: 1              # CPU resource weight
          binpack.memory: 2           # Memory resource weight
          binpack.resources: nvidia.com/gpu  # Custom resources
          binpack.resources.nvidia.com/gpu: 10  # GPU weight (higher)

Through the above configurations and usage guidelines, users can fully leverage Volcano's network topology-aware scheduling capabilities to optimize the performance and resource utilization of distributed workloads in complex network environments.
```