### PR TITLE
[Cherry-pick v1.10] fix mpi job plugin panic when mpi job only has master task

### DIFF
--- a/pkg/controllers/job/plugins/distributed-framework/mpi/mpi.go
+++ b/pkg/controllers/job/plugins/distributed-framework/mpi/mpi.go
@@ -82,7 +82,11 @@ func (mp *Plugin) OnPodCreate(pod *v1.Pod, job *batch.Job) error {
 	workerHosts := ""
 	env := v1.EnvVar{}
 	if helpers.GetTaskKey(pod) == mp.masterName {
-		workerHosts = mp.generateTaskHosts(job.Spec.Tasks[helpers.GetTaskIndexUnderJob(mp.workerName, job)], job.Name)
+		taskIndex := helpers.GetTaskIndexUnderJob(mp.workerName, job)
+		if taskIndex == -1 {
+			return nil
+		}
+		workerHosts = mp.generateTaskHosts(job.Spec.Tasks[taskIndex], job.Name)
 		env = v1.EnvVar{
 			Name:  MPIHost,
 			Value: workerHosts,

--- a/pkg/controllers/job/plugins/distributed-framework/mpi/mpi_test.go
+++ b/pkg/controllers/job/plugins/distributed-framework/mpi/mpi_test.go
@@ -118,3 +118,14 @@ func TestMpi(t *testing.T) {
 		})
 	}
 }
+
+func TestMpiWithEmptyWorker(t *testing.T) {
+}
+
+// checkMPIHostEnvVar checks if containers have the expected MPI_HOST environment variable
+func checkMPIHostEnvVar(t *testing.T, index int, testName, containerType string, containers []v1.Container, expectedEnvVar v1.EnvVar) {
+}
+
+// checkNoMPIHostEnvVar ensures that containers do not have MPI_HOST environment variable
+func checkNoMPIHostEnvVar(t *testing.T, index int, testName string, containers []v1.Container) {
+}


### PR DESCRIPTION
#### What type of PR is this?

fix mpi job plugin panic when mpi job only has master task
#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Notice that do not add `Fixes` if the issue is associated with multiple PRs.
-->
Fixes #
https://github.com/volcano-sh/volcano/issues/4609
#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
fix mpi job plugin panic when mpi job only has master task
```