### PR TITLE
Expose more helm config for agent

### DIFF
--- a/installer/build/volcano-agent/install.sh
+++ b/installer/build/volcano-agent/install.sh
@@ -32,7 +32,7 @@ function log()
 function set_sched_prio_load_balance_enabled() {
     log "Start to enable cpu load balance"
     if [[ ! -f ${LOAD_BALANCE_ENABLED_PATH} ]]; then
-        log "Enable cpu load balance failed, file(${LOAD_BALANCE_ENABLED_PATH}) does not existed"
+        log "Skip enabling CPU load balance: file(${LOAD_BALANCE_ENABLED_PATH}) not found. OverSubscription, Node Pressure Eviction colocation features remain available"
         return 0
     fi
     cat ${LOAD_BALANCE_ENABLED_PATH}
@@ -43,7 +43,7 @@ function set_sched_prio_load_balance_enabled() {
 function set_memory_qos_enabled(){
     log "Start to enable memory qos enable"
     if [[ ! -f ${MEMORY_QOS_ENABLED_PATH} ]]; then
-        log "Enable memory cgroup qos failed, file(${MEMORY_QOS_ENABLED_PATH}) does not existed"
+        log "Skip enabling memory cgroup qos: file(${MEMORY_QOS_ENABLED_PATH}) not found. OverSubscription, Node Pressure Eviction colocation features remain available"
         return 0
     fi
     cat ${MEMORY_QOS_ENABLED_PATH}

--- a/installer/helm/chart/volcano/templates/agent.yaml
+++ b/installer/helm/chart/volcano/templates/agent.yaml
@@ -122,9 +122,20 @@ spec:
             {{- toYaml $agent_main_csc | nindent 12 }}
           {{- end }}
           command:
-            - /bin/sh
-            - '-c'
-            - /vc-agent --v=2 1>>/var/log/volcano/agent/volcano-agent.log 2>&1
+          - /bin/sh
+          - -c
+          - |
+           /vc-agent \
+           {{- with .Values.custom.agent_supported_features }}
+           --supported-features={{ . }} \
+           {{- end }}
+           {{- with .Values.custom.agent_extend_resource_cpu_name }}
+           --extend-resource-cpu-name={{ . }} \
+           {{- end }}
+           {{- with .Values.custom.agent_extend_resource_memory_name }}
+           --extend-resource-memory-name={{ . }} \
+           {{- end }}
+           --v=2 1>> /var/log/volcano/agent/volcano-agent.log 2>&1
           env:
             - name: SYS_FS_PATH
               value: /host/sys/fs

--- a/installer/helm/chart/volcano/values.yaml
+++ b/installer/helm/chart/volcano/values.yaml
@@ -37,6 +37,14 @@ custom:
   enabled_admissions: "/jobs/mutate,/jobs/validate,/podgroups/validate,/queues/mutate,/queues/validate,/hypernodes/validate"
   colocation_enable: false
   ignored_provisioners: ~
+# Override the configuration for agent.
+# For example:
+# agent_supported_features: "OverSubscription\,Eviction\,Resources"
+# agent_extend_resource_cpu_name: "example.com/cpu"
+# agent_extend_resource_memory_name: "example.com/memory"
+  agent_supported_features: ~
+  agent_extend_resource_cpu_name: ~
+  agent_extend_resource_memory_name: ~
 
 # Override the configuration for admission, scheduler or scheduler.
 # For example:

--- a/installer/volcano-agent-development.yaml
+++ b/installer/volcano-agent-development.yaml
@@ -173,9 +173,11 @@ spec:
             runAsNonRoot: true
             runAsUser: 1000
           command:
-            - /bin/sh
-            - '-c'
-            - /vc-agent --v=2 1>>/var/log/volcano/agent/volcano-agent.log 2>&1
+          - /bin/sh
+          - -c
+          - |
+           /vc-agent \
+           --v=2 1>> /var/log/volcano/agent/volcano-agent.log 2>&1
           env:
             - name: SYS_FS_PATH
               value: /host/sys/fs


### PR DESCRIPTION
#### What type of PR is this?
/kind feature
/area colocation
#### What this PR does / why we need it:
Add more helm config `agent_supported_features`, `agent_extend_resource_cpu_name`, `agent_extend_resource_memory_name`, and more importantly, user can use volcano user mode colocation and do not depend on specific OS.
Based on https://github.com/volcano-sh/volcano/pull/4409 and https://github.com/volcano-sh/volcano/pull/4413

For example, user can use volcano agent colocation features without depending on specific OS with the following installation command：
`helm install volcano . --create-namespace -n volcano-system --set custom.colocation_enable=true --set "custom.agent_supported_features=OverSubscription\,Eviction\,Resources" --set custom.agent_extend_resource_cpu_name=test.com/cpu --set custom.agent_extend_resource_memory_name=test.com/gpu`
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Notice that do not add `Fixes` if the issue is associated with multiple PRs.
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
User now can use volcano's user mode colocation and are no longer dependent on a specific OS.
```