### PR TITLE
Feature: (opt-in) Gang Aware Preemption

### DIFF
--- a/pkg/scheduler/api/resource_info.go
+++ b/pkg/scheduler/api/resource_info.go
@@ -823,6 +823,31 @@ func (r *Resource) setDefaultValue(leftResource, rightResource *Resource, defaul
 	}
 }
 
+// SubFloorZero returns max(r - idle, 0) but only for resource dimensions requested by r.
+// This avoids negative remaining (e.g. pods) and naturally handles any scalar resources.
+func (r *Resource) SubFloorZero(idle *Resource) *Resource {
+	if r == nil {
+		return EmptyResource()
+	}
+	out := r.Clone()
+	if idle != nil {
+		out.SubWithoutAssert(idle)
+	}
+
+	if out.MilliCPU < 0 {
+		out.MilliCPU = 0
+	}
+	if out.Memory < 0 {
+		out.Memory = 0
+	}
+	for k, v := range out.ScalarResources {
+		if v < 0 {
+			out.ScalarResources[k] = 0
+		}
+	}
+	return out
+}
+
 // ParseResourceList parses the given configuration map into an API
 // ResourceList or returns an error.
 func ParseResourceList(m map[string]string) (v1.ResourceList, error) {

--- a/pkg/scheduler/util/scheduler_helper.go
+++ b/pkg/scheduler/util/scheduler_helper.go
@@ -330,3 +330,30 @@ func FindJobTaskNumOfHyperNode(hyperNodeName string, tasks api.TasksMap, hyperNo
 	}
 	return taskCount
 }
+
+// This helper can evolve to support skipping specific tasks or nodes.
+// For now, we only need to exclude a single job ID, so we keep the API simple.
+func GroupTasksByNodeJob(
+	tasks []*api.TaskInfo,
+	skipJobID api.JobID,
+) map[string]map[api.JobID][]*api.TaskInfo {
+	nodeJobTasks := make(map[string]map[api.JobID][]*api.TaskInfo)
+
+	for _, t := range tasks {
+		jobID := t.Job
+		if jobID == skipJobID {
+			continue
+		}
+
+		node := t.NodeName
+		jobMap, ok := nodeJobTasks[node]
+		if !ok {
+			jobMap = make(map[api.JobID][]*api.TaskInfo)
+			nodeJobTasks[node] = jobMap
+		}
+
+		jobMap[jobID] = append(jobMap[jobID], t)
+	}
+
+	return nodeJobTasks
+}


### PR DESCRIPTION
#### What type of PR is this?
Feature: Gang-aware preemption modes for AI/ML training and other gang-scheduled workloads (PodGroup/VCJob).

#### What this PR does / why we need it:
Today, preemption picks nodes first and only then decides which tasks to evict, without considering gang (PodGroup/VCJob) boundaries. As a result, victims can span multiple jobs, and the Gang plugin ends up acting as a guard-rail (via minMember) rather than guiding which gang should be preempted. This can yield partial/fragmented evictions that are sub-optimal for AI/ML jobs.

This PR introduces an opt-in gang-aware preemption strategy that selects victims at the gang level. It reduces cross-job churn, preserves job atomicity when desired, and better aligns with workloads that need “all-or-nothing” capacity.

Modes (policy):
- `disabled` (default): Existing behavior. Preemption remains node-first and task-level; no gang semantics applied.
- `minimal`: Preemption will group preemptable tasks on each node into gangs then
  - On each candidate node, group preemptable tasks by gang.
  - Prefer a single gang whose eviction satisfies the preemptor task’s request (most cases).
  - If no single gang suffices, fall back to a greedy gang selection (still within gang units) until the preemptor fits (rare).
- `atomic`:  Same selection as minimal, but if a victim gang is chosen, evict all of its tasks across all nodes (cluster-wide gang eviction). This matches AI/ML expectations where partial eviction often dooms the job anyway.


- Fewer cross-job evictions: Victims come from a coherent gang, not scattered tasks across jobs.
- Predictability for gang jobs: Respects “start/stop together” intent; atomic ensures clean state.
- Backwards compatible: Fully opt-in; disabled preserves current behavior.

#### Which issue(s) this PR fixes:
Partially fixes #4607.
In addition to the changes discussed in the above issue, this PR also adds:
- Handles node fragmentation.
- It also adds `atomic` mode.

Happy to create a new issue if needed.

#### Special notes for your reviewer:
- Objective:
Minimize the number of gangs disrupted on a node without hurting scheduler throughput.
- Why not try all k (1..J) combinations:
Per node combos = sum_{t=1..J} C(J, t) = 2^J − 1 (exponential)
Exponential time is unacceptable in a high-throughput scheduler like Volcano.
- Two-phase heuristic (fast, practical):
  - Phase 1 – Single-gang fit (minimal overage):
If any single gang can satisfy the preemptor’s need on a node, choose the best one (least overage).
Rationale: in most cases, preempting one gang frees enough capacity for the incoming task.
  - Phase 2 – Greedy multi-gang (minimize count, then overage):
If Phase 1 fails (e.g., preemptor is large), sort candidate gangs by size (largest first) and accumulate until the need is met.
Complexity: O(J log J) per node (sort) + O(J) accumulate — suitable for high QPS.
- Trade-off example (1D, non-negative):
Preemptor need: 80
Node gangs: [50, 50, 50, 50, 20, 20, 20, 20]
Greedy (fast): 50 + 50 = 100 → meets need with +20 overage
Optimal overage (exhaustive search): 20 + 20 + 20 + 20 = 80 → 0 overage
- Conclusion:
We accept small overage to preserve throughput and avoid exponential search.
Avoids the 2^J blow-up while keeping decisions near-optimal in practice.

#### Does this PR introduce a user-facing change?
Yes
```release-note
The following block needs to be added to `volcano-scheduler-configmap`
data:
  volcano-scheduler.conf: |
    actions: "...preempt..."
    configurations:
    - name: preempt
      arguments:
        gangPreemptionMode: off  # Accepted values: off (default) | minimal | atomic
```