### PR TITLE
chore: improve session logging

### DIFF
--- a/pkg/scheduler/framework/session.go
+++ b/pkg/scheduler/framework/session.go
@@ -225,6 +225,9 @@ func openSession(cache cache.Cache) *Session {
 	klog.V(3).Infof("Open Session %v with <%d> Job and <%d> Queues",
 		ssn.UID, len(ssn.Jobs), len(ssn.Queues))
 
+	klog.V(4).Infof("Session %v is opened with TotalResource: <%s>, TotalDeserved: <%s>, TotalGuaranteed: <%s>",
+		ssn.UID, ssn.TotalResource.String(), ssn.TotalDeserved.String(), ssn.TotalGuarantee.String())
+
 	return ssn
 }
 

--- a/pkg/scheduler/plugins/capacity/capacity.go
+++ b/pkg/scheduler/plugins/capacity/capacity.go
@@ -451,8 +451,8 @@ func (cp *capacityPlugin) buildQueueAttrs(ssn *framework.Session) {
 
 		attr.deserved = helpers.Max(attr.deserved, attr.guarantee)
 		cp.updateShare(attr)
-		klog.V(4).Infof("The attributes of queue <%s> in capacity: deserved <%v>, realCapability <%v>, allocate <%v>, request <%v>, elastic <%v>, share <%0.2f>",
-			attr.name, attr.deserved, attr.realCapability, attr.allocated, attr.request, attr.elastic, attr.share)
+		klog.V(4).Infof("The attributes of queue <%s> in capacity: deserved <%v>, capability <%v>, realCapability <%v>, allocate <%v>, request <%v>, elastic <%v>, share <%0.2f>",
+			attr.name, attr.deserved, attr.capability, attr.realCapability, attr.allocated, attr.request, attr.elastic, attr.share)
 	}
 
 	// Record metrics
@@ -609,8 +609,8 @@ func (cp *capacityPlugin) buildHierarchicalQueueAttrs(ssn *framework.Session) bo
 	// Update share
 	for _, attr := range cp.queueOpts {
 		cp.updateShare(attr)
-		klog.V(4).Infof("The attributes of queue <%s> in capacity: deserved <%v>, realCapability <%v>, allocate <%v>, request <%v>, elastic <%v>, share <%0.2f>",
-			attr.name, attr.deserved, attr.realCapability, attr.allocated, attr.request, attr.elastic, attr.share)
+		klog.V(4).Infof("The attributes of hierarchical queue <%s> in capacity: deserved <%v>, capability <%v>, realCapability <%v>, allocate <%v>, request <%v>, elastic <%v>, share <%0.2f>",
+			attr.name, attr.deserved, attr.capability, attr.realCapability, attr.allocated, attr.request, attr.elastic, attr.share)
 	}
 
 	// Record metrics


### PR DESCRIPTION
Adding a log line about the session's total schedulable capacities.

Recently there has been various changes in the session resource handlings, and it would be generally useful to have a log line about the cached resource, including TotalResource, TotalDeserved and TotalGuaranteed.

Enhance capacity plugin queue attribute logs to include 'capability' for both flat and hierarchical queues and distinguishing the log line in the two cases.

#### What type of PR is this?
Minor improvements on the session logging to help on debugging activites.

#### What this PR does / why we need it:
We don't have log lines about the totalResources when the session initializiation happens.
This part of the code changed a lot recently with the introduction of totalDeserved in the picture:
https://github.com/volcano-sh/volcano/pull/4354

Furthermore, currently the log message is the same for the capacity plugin when hierarchy is enabled and when it isn't,
I just see a log message in both cases that the.
"The attributes of queue..."
I am regularly testing with and without hierachy now, and I am checking various behaviors since I enable the
hierarchy configuration for the plugin runtime it would be helpful if the two log messages would be different.

Additionally the capability of the queues is not written at the output at all.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Notice that do not add `Fixes` if the issue is associated with multiple PRs.
-->
I didn't create one.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```