### PR TITLE
Automated cherry pick of #4599: fix: report all scalar metrics for each queue

### DIFF
--- a/pkg/scheduler/metrics/queue_scalar_test.go
+++ b/pkg/scheduler/metrics/queue_scalar_test.go
@@ -8,6 +8,12 @@ import (
 )
 
 func TestUpdateScalarResourceMetrics_ZeroAndCleanup(t *testing.T) {
+	// Reset global state for this test to ensure isolation.
+	queueAllocatedScalarResource.Reset()
+	knownScalarResourcesLock.Lock()
+	knownScalarResources = make(map[string]map[string]struct{})
+	knownScalarResourcesLock.Unlock()
+
 	queueName := "testqueue"
 	resourceA := v1.ResourceName("nvidia.com/gpu")
 	resourceB := v1.ResourceName("amd.com/gpu")


### PR DESCRIPTION
Cherry pick of #4599 on release-1.12.

#4599: fix: report all scalar metrics for each queue
For details on the cherry pick process, see the [cherry picks](https://github.com/volcano-sh/volcano/tree/master/docs/development/cherry-picks.md) page.
```release-note
Queue scalar metrics are now reported on each resource. This change prevents stale scalar metrics reported by the scheduler.
```