### PR TITLE
Correctly populates job.Status.Succeeded when a job gets completed

### DIFF
--- a/pkg/controllers/job/job_controller_actions.go
+++ b/pkg/controllers/job/job_controller_actions.go
@@ -163,6 +163,22 @@ func (cc *jobcontroller) killPods(jobInfo *apis.JobInfo, podRetainPhase state.Ph
 		classifyAndAddUpPodBaseOnPhase(pod, &pending, &running, &succeeded, &failed, &unknown)
 		calcPodStatus(pod, taskStatusCount)
 	}
+	// update the status for the pods which are not going to be killed
+	for _, pods := range jobInfo.Pods {
+		for _, pod := range pods {
+			_, isPodGoingToBeKilled := podsToKill[pod.Name]
+			if !isPodGoingToBeKilled {
+				if pod.DeletionTimestamp != nil {
+					klog.Infof("Pod <%s/%s> is terminating", pod.Namespace, pod.Name)
+					terminating++
+					continue
+				}
+
+				classifyAndAddUpPodBaseOnPhase(pod, &pending, &running, &succeeded, &failed, &unknown)
+				calcPodStatus(pod, taskStatusCount)
+			}
+		}
+	}
 
 	if len(errs) != 0 {
 		klog.Errorf("failed to kill pods for job %s/%s, with err %+v", job.Namespace, job.Name, errs)


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
#### What this PR does / why we need it:
Currently after a job is submitted and is completed the job.status.succeeded and job.status.failed fields do not get populated.

When the Job is in the Running Phase we are able to see the status of all the pods
<img width="541" height="571" alt="image" src="https://github.com/user-attachments/assets/445f9bf7-5a32-4542-8381-da121bd2eb09" />


However as show in #4616  when the pod is in the completed phase we were not able to see the status of any of the pods.

Now we will be able to see the status of the pods even in the Completed phase
<img width="553" height="567" alt="image" src="https://github.com/user-attachments/assets/d22df052-2319-45a3-8acc-a7019b891442" />



#### Which issue(s) this PR fixes:
Fixes #4616 