### PR TITLE
volcano scheduler support multi-schedulers deploy

### DIFF
--- a/installer/helm/chart/volcano/templates/scheduler.yaml
+++ b/installer/helm/chart/volcano/templates/scheduler.yaml
@@ -5,6 +5,7 @@
 {{ $scheduler_main_csc := or .Values.custom.scheduler_main_csc .Values.custom.default_csc }}
 {{ $scheduler_ns := or .Values.custom.scheduler_ns .Values.custom.default_ns }}
 {{ $scheduler_name := .Values.custom.scheduler_name }}
+{{ $multi_scheduler_enabled := .Values.custom.multi_scheduler_enabled | default false }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -139,9 +140,12 @@ roleRef:
   kind: ClusterRole
   name: {{ .Release.Name }}-scheduler
   apiGroup: rbac.authorization.k8s.io
-
 ---
+{{- if not $multi_scheduler_enabled }}
 kind: Deployment
+{{- else }}
+kind: StatefulSet
+{{- end }}
 apiVersion: apps/v1
 metadata:
   name: {{ .Release.Name }}-scheduler
@@ -232,6 +236,16 @@ spec:
             - -v={{.Values.custom.scheduler_log_level}}
             - 2>&1
           env:
+            {{- if $multi_scheduler_enabled }}
+            - name: MULTI_SCHEDULER_ENABLE
+              value: "{{ $multi_scheduler_enabled }}"
+            - name: SCHEDULER_NUM
+              value: "{{ .Values.custom.scheduler_replicas }}"
+            - name: SCHEDULER_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            {{- end }} 
             - name: DEBUG_SOCKET_DIR
               value: /tmp/klog-socks
           imagePullPolicy: {{ .Values.basic.image_pull_policy }}
@@ -266,6 +280,9 @@ metadata:
     {{- toYaml .Values.custom.common_labels | nindent 4 }}
     {{- end }}
 spec:
+  {{- if $multi_scheduler_enabled }}
+  clusterIP: None
+  {{- end }}
   {{- if .Values.service.ipFamilyPolicy }}
   ipFamilyPolicy: {{ .Values.service.ipFamilyPolicy }}
   {{- end }}

--- a/installer/helm/chart/volcano/values.yaml
+++ b/installer/helm/chart/volcano/values.yaml
@@ -212,6 +212,10 @@ custom:
   scheduler_log_level: 3
   controller_log_level: 4
 
+  # Multi-scheduler configuration
+  # Enable multi-scheduler deployment mode (deploys as StatefulSet instead of Deployment)
+  multi_scheduler_enabled: false
+
 # Specify container security context for admission
 # For example:
 #

--- a/installer/volcano-development.yaml
+++ b/installer/volcano-development.yaml
@@ -8837,7 +8837,7 @@ spec:
             - --node-worker-threads=20
             - -v=3
             - 2>&1
-          env:
+          env: 
             - name: DEBUG_SOCKET_DIR
               value: /tmp/klog-socks
           imagePullPolicy: Always


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
This PR adds support for deploying multiple Volcano schedulers using Helm chart with StatefulSet, enabling the multi-scheduler feature without using selectors.

**Key Changes:**
- Added conditional logic in scheduler.yaml to support both Deployment (single scheduler) and StatefulSet (multi-scheduler) deployment modes
- Introduced `multi_scheduler_enable` configuration option to toggle between deployment types
**Why we need this:**
The single scheduler cannot satisfy high throughput requirements in some scenarios. Deploying multiple schedulers improves overall scheduling throughput without requiring manual node labeling or workload modifications.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Notice that do not add `Fixes` if the issue is associated with multiple PRs.
-->
Fixes #hajnalmt multi-scheduler helm support issue

#### Special notes for your reviewer:
**Testing Instructions:**
1. Single scheduler mode (default): `helm install volcano installer/helm/chart/volcano/`
2. Multi-scheduler mode: `helm install volcano installer/helm/chart/volcano/ --set custom.multi_scheduler_enable=true --set custom.scheduler_replicas=3`

**Backward Compatibility:**
- Default behavior remains unchanged (single scheduler via Deployment)
- All existing configurations continue to work without modification
- Multi-scheduler mode is opt-in via explicit configuration

**Implementation Details:**
- Uses consistent hashing algorithm for automatic job/node assignment
- StatefulSet ensures stable network identities for schedulers
- Headless Service enables direct pod-to-pod communication

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
Added support for deploying multiple Volcano schedulers via Helm chart using StatefulSet. This enables high-throughput scheduling scenarios by running multiple scheduler instances with automatic load distribution. Use `--set custom.multi_scheduler_enable=true` to enable multi-scheduler mode.
 

#4645 