### PR TITLE
Add overwriteRootCapability argument to capacity plugin

### DIFF
--- a/docs/design/hierarchical-queue-on-capacity-plugin.md
+++ b/docs/design/hierarchical-queue-on-capacity-plugin.md
@@ -138,3 +138,28 @@ When job A performs reclaim or preempt actions, the system should first consider
 - The current design does not support scheduling jobs/podgroups to non-leaf queues. Only leaf queues can directly schedule and allocate resources to jobs/podgroups.
 - The current design does not consider the queue migration issues related to hierarchical queue management in order to avoid manual operation and maintenance.
 - When introducing a paused scheduling state for queues, optimize the management of the hierarchical queue structure under this state. For example, if a parent queue is paused for scheduling, it will cause its child queues to be paused as well. When resuming the parent queue, provide the capability to automatically resume the child queues in conjunction.
+
+## Cluster-autoscalers and the root queue
+By default, the root queue’s resource limits are set to the actual cluster resources, ignoring any user-configured capability values.
+This behavior can be overridden by setting the overwriteRootQueueRealCapability plugin argument to true.
+
+Example configuration:
+```
+actions: "enqueue, reclaim, allocate"
+tiers:
+- plugins:
+  - name: priority
+  - name: gang
+    enablePreemptable: false
+  - name: conformance
+- plugins:
+  - name: drf
+    enablePreemptable: false
+  - name: predicates
+  - name: capacity
+    enableHierarchy: true
+    arguments:
+      overwriteRootQueueRealCapability: true
+```
+
+When this feature is enabled, cluster-autoscalers can scale up correctly, and the root queue’s user-defined capability is propagated to child queues, overriding the default behavior.

--- a/pkg/scheduler/plugins/capacity/capacity.go
+++ b/pkg/scheduler/plugins/capacity/capacity.go
@@ -51,8 +51,8 @@ type capacityPlugin struct {
 
 	queueOpts map[api.QueueID]*queueAttr
 	// Arguments given for the plugin
-	pluginArguments         framework.Arguments
-	overwriteRootCapability bool
+	pluginArguments                  framework.Arguments
+	overwriteRootQueueRealCapability bool
 }
 
 type queueAttr struct {
@@ -78,14 +78,14 @@ type queueAttr struct {
 // New return capacityPlugin action
 func New(arguments framework.Arguments) framework.Plugin {
 	cp := &capacityPlugin{
-		totalResource:           api.EmptyResource(),
-		totalGuarantee:          api.EmptyResource(),
-		queueOpts:               map[api.QueueID]*queueAttr{},
-		pluginArguments:         arguments,
-		overwriteRootCapability: false,
+		totalResource:                    api.EmptyResource(),
+		totalGuarantee:                   api.EmptyResource(),
+		queueOpts:                        map[api.QueueID]*queueAttr{},
+		pluginArguments:                  arguments,
+		overwriteRootQueueRealCapability: false,
 	}
 
-	arguments.GetBool(&cp.overwriteRootCapability, "overwriteRootCapability")
+	arguments.GetBool(&cp.overwriteRootQueueRealCapability, "overwriteRootQueueRealCapability")
 
 	return cp
 }
@@ -611,15 +611,16 @@ func (cp *capacityPlugin) buildHierarchicalQueueAttrs(ssn *framework.Session) bo
 	}
 
 	// https://github.com/volcano-sh/volcano/issues/3910
-	// If overwriteRootCapability is true, we need to set realCapability to the user-configured capability.
+	// If overwriteRootQueueRealCapability is true, we need to set realCapability to the user-configured capability.
 	// If the user does not edit the root queue's capability, it will be set to total resource above.
-	if cp.overwriteRootCapability {
-		rootQueueAttr.realCapability = rootQueueAttr.capability
-		klog.V(4).Infof("Using user-configured root queue capability <%v> instead of cluster resources <%v> due to overwriteRootCapability=true",
+	if cp.overwriteRootQueueRealCapability {
+		// Use user-configured capability instead of forcing cluster resources
+		rootQueueAttr.realCapability = rootQueueAttr.capability.Clone()
+		klog.V(4).Infof("Using user-configured root queue capability <%v> instead of cluster resources <%v> due to overwriteRootQueueRealCapability=true",
 			rootQueueAttr.capability, cp.totalResource)
 	} else {
-		// Use actual cluster resources
-		rootQueueAttr.realCapability = cp.totalResource
+		// Default behavior: use actual cluster resources
+		rootQueueAttr.realCapability = cp.totalResource.Clone()
 	}
 
 	// Check the hierarchical structure of queues

--- a/pkg/scheduler/plugins/capacity/capacity.go
+++ b/pkg/scheduler/plugins/capacity/capacity.go
@@ -41,6 +41,8 @@ const (
 	// Using the name of the plugin will likely help us avoid collisions with other plugins.
 	capacityStateKey = PluginName
 	rootQueueID      = "root"
+
+	overwriteRootQueueRealCapability = "overwriteRootQueueRealCapability"
 )
 
 type capacityPlugin struct {
@@ -85,7 +87,7 @@ func New(arguments framework.Arguments) framework.Plugin {
 		overwriteRootQueueRealCapability: false,
 	}
 
-	arguments.GetBool(&cp.overwriteRootQueueRealCapability, "overwriteRootQueueRealCapability")
+	arguments.GetBool(&cp.overwriteRootQueueRealCapability, overwriteRootQueueRealCapability)
 
 	return cp
 }

--- a/pkg/scheduler/plugins/capacity/capacity.go
+++ b/pkg/scheduler/plugins/capacity/capacity.go
@@ -612,16 +612,14 @@ func (cp *capacityPlugin) buildHierarchicalQueueAttrs(ssn *framework.Session) bo
 		rootQueueAttr.deserved = cp.totalResource
 	}
 
-	// https://github.com/volcano-sh/volcano/issues/3910
-	// If overwriteRootQueueRealCapability is true, we need to set realCapability to the user-configured capability.
-	// If the user does not edit the root queue's capability, it will be set to total resource above.
+	// If overwriteRootQueueRealCapability is true and the user has explicitly configured the root queue's
+	// capability, use that value. Otherwise, default to the total cluster resources as the root queue's realCapability.
+	// This allows cluster-autoscalers to work correctly by respecting user overrides.
 	if cp.overwriteRootQueueRealCapability {
-		// Use user-configured capability instead of forcing cluster resources
 		rootQueueAttr.realCapability = rootQueueAttr.capability.Clone()
-		klog.V(4).Infof("Using user-configured root queue capability <%v> instead of cluster resources <%v> due to overwriteRootQueueRealCapability=true",
-			rootQueueAttr.capability, cp.totalResource)
+		klog.V(4).Infof("Root queue realCapability: <%v> (user override); cluster resources: <%v>",
+			rootQueueAttr.realCapability, cp.totalResource)
 	} else {
-		// Default behavior: use actual cluster resources
 		rootQueueAttr.realCapability = cp.totalResource.Clone()
 	}
 


### PR DESCRIPTION
#### What type of PR is this?
Feature

#### What this PR does / why we need it:
Problem: 
Currently, the root queue's resource limits are always set to the actual cluster resources, regardless of any user-configured capability values. This prevents administrators from setting virtual resource limits that differ from the physical cluster capacity. This helps in cases where a user has cluster-autoscaled enabled and the "virtual" resources can be higher than the "real" resources. 

#### Which issue(s) this PR fixes:
Fixes #3910 

#### Special notes for your reviewer: I have not yet tested this in our production clusters, I plan to test it in the following week. 

#### Does this PR introduce a user-facing change?
None
```release-note
Add overwriteRootCapability argument to capacity plugin to allow using user-configured root queue capability instead of actual cluster resources
```