### PR TITLE
fix: ci err caused bt ray e2e default image

### DIFF
--- a/test/e2e/jobseq/common.go
+++ b/test/e2e/jobseq/common.go
@@ -1,0 +1,41 @@
+package jobseq
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+func PruneUnusedImagesOnAllNodes(clientset *kubernetes.Clientset) error {
+	nodes, err := clientset.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to list nodes: %v", err)
+	}
+
+	for _, node := range nodes.Items {
+		fmt.Printf("[Prune] Node: %s\n", node.Name)
+
+		ctrCheckCmd := fmt.Sprintf("kubectl debug node/%s --image=busybox -- chroot /host sh -c 'test -S /run/containerd/containerd.sock'", node.Name)
+		if err := exec.Command("bash", "-c", ctrCheckCmd).Run(); err == nil {
+			cmd := fmt.Sprintf("kubectl debug node/%s --image=busybox -- chroot /host sh -c 'ctr -n k8s.io images prune -all || true'", node.Name)
+			out, _ := exec.Command("bash", "-c", cmd).CombinedOutput()
+			fmt.Printf("[CTR Prune Output]\n%s\n", string(out))
+			continue
+		}
+
+		dockerCheckCmd := fmt.Sprintf("kubectl debug node/%s --image=busybox -- chroot /host sh -c 'docker version >/dev/null 2>&1'", node.Name)
+		if err := exec.Command("bash", "-c", dockerCheckCmd).Run(); err == nil {
+			cmd := fmt.Sprintf("kubectl debug node/%s --image=busybox -- chroot /host sh -c 'docker image prune -af || true'", node.Name)
+			out, _ := exec.Command("bash", "-c", cmd).CombinedOutput()
+			fmt.Printf("[Docker Prune Output]\n%s\n", string(out))
+			continue
+		}
+
+		fmt.Printf("[Warning] Node %s: No known container runtime detected, skipping prune\n", node.Name)
+	}
+
+	return nil
+}

--- a/test/e2e/jobseq/ray_plugin.go
+++ b/test/e2e/jobseq/ray_plugin.go
@@ -28,6 +28,21 @@ import (
 )
 
 var _ = Describe("Ray Plugin E2E Test", func() {
+	BeforeEach(func() {
+		By("Prune images before test")
+
+		ctx := e2eutil.InitTestContext(e2eutil.Options{})
+		client := ctx.Kubeclient
+		PruneUnusedImagesOnAllNodes(client)
+	})
+	AfterEach(func() {
+		By("Prune images after test")
+
+		ctx := e2eutil.InitTestContext(e2eutil.Options{})
+		client := ctx.Kubeclient
+		PruneUnusedImagesOnAllNodes(client)
+	})
+
 	It("Will Start in pending state and  get running phase", func() {
 		ctx := e2eutil.InitTestContext(e2eutil.Options{})
 		defer e2eutil.CleanupTestContext(ctx)

--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -83,7 +83,7 @@ const (
 	DefaultTFImage      = "volcanosh/dist-mnist-tf-example:0.0.1"
 	// "volcanosh/pytorch-mnist-v1beta1-9ee8fda-example:0.0.1" is from "docker.io/kubeflowkatib/pytorch-mnist:v1beta1-9ee8fda"
 	DefaultPytorchImage = "volcanosh/pytorch-mnist-v1beta1-9ee8fda-example:0.0.1"
-	DefaultRayImage     = "bitnami/ray:2.49.0"
+	DefaultRayImage     = "rayproject/ray:2.49.0"
 	LogTimeFormat       = "[ 2006/01/02 15:04:05.000 ]"
 )
 


### PR DESCRIPTION
#### What type of PR is this?
Fix ci error caused by ray default image.

#### What this PR does / why we need it:
When ray e2e sequence test is executed, the pod could not pull the e2e default image(bitnami/ray:2.49.0, not found)

```
Oct 02 06:57:23 integration-worker2 kubelet[273]: E1002 06:57:23.173290     273 pod_workers.go:1301] "Error syncing pod, skipping" err="failed to \"StartContainer\" for \"ray\" with ImagePullBackOff: \"Back-off pulling image \\\"bitnami/ray:2.49.0\\\": ErrImagePull: rpc error: code = NotFound desc = failed to pull and unpack image \\\"docker.io/bitnami/ray:2.49.0\\\": failed to resolve reference \\\"docker.io/bitnami/ray:2.49.0\\\": docker.io/bitnami/ray:2.49.0: not found\"" pod="erli6hgc/ray-cluster-job-head-0" podUID="433a6958-3d9e-43cc-9d14-965b43db6541"
```

Because bitnami no longer provide the image. [bitnami/ray:2.49.0](https://hub.docker.com/r/bitnami/ray)
<img width="1021" height="714" alt="image" src="https://github.com/user-attachments/assets/86707caa-2158-44bb-bb73-742661f59cdd" />

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Notice that do not add `Fixes` if the issue is associated with multiple PRs.
-->
Fixes #4669 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```