### PR TITLE
Support task level network topology constrain

### DIFF
--- a/config/crd/jobflow/bases/flow.volcano.sh_jobflows.yaml
+++ b/config/crd/jobflow/bases/flow.volcano.sh_jobflows.yaml
@@ -114,8 +114,9 @@ spec:
                             networkTopology:
                               properties:
                                 highestTierAllowed:
-                                  default: 1
                                   type: integer
+                                highestTierName:
+                                  type: string
                                 mode:
                                   default: hard
                                   enum:
@@ -199,6 +200,35 @@ spec:
                                     type: integer
                                   name:
                                     type: string
+                                  partitionPolicy:
+                                    properties:
+                                      minPartitions:
+                                        default: 0
+                                        format: int32
+                                        type: integer
+                                      networkTopology:
+                                        properties:
+                                          highestTierAllowed:
+                                            type: integer
+                                          highestTierName:
+                                            type: string
+                                          mode:
+                                            default: hard
+                                            enum:
+                                            - hard
+                                            - soft
+                                            type: string
+                                        type: object
+                                      partitionSize:
+                                        format: int32
+                                        type: integer
+                                      totalPartitions:
+                                        format: int32
+                                        type: integer
+                                    required:
+                                    - partitionSize
+                                    - totalPartitions
+                                    type: object
                                   policies:
                                     items:
                                       properties:

--- a/config/crd/jobflow/bases/flow.volcano.sh_jobtemplates.yaml
+++ b/config/crd/jobflow/bases/flow.volcano.sh_jobtemplates.yaml
@@ -42,8 +42,9 @@ spec:
               networkTopology:
                 properties:
                   highestTierAllowed:
-                    default: 1
                     type: integer
+                  highestTierName:
+                    type: string
                   mode:
                     default: hard
                     enum:
@@ -127,6 +128,35 @@ spec:
                       type: integer
                     name:
                       type: string
+                    partitionPolicy:
+                      properties:
+                        minPartitions:
+                          default: 0
+                          format: int32
+                          type: integer
+                        networkTopology:
+                          properties:
+                            highestTierAllowed:
+                              type: integer
+                            highestTierName:
+                              type: string
+                            mode:
+                              default: hard
+                              enum:
+                              - hard
+                              - soft
+                              type: string
+                          type: object
+                        partitionSize:
+                          format: int32
+                          type: integer
+                        totalPartitions:
+                          format: int32
+                          type: integer
+                      required:
+                      - partitionSize
+                      - totalPartitions
+                      type: object
                     policies:
                       items:
                         properties:

--- a/config/crd/volcano/bases/batch.volcano.sh_cronjobs.yaml
+++ b/config/crd/volcano/bases/batch.volcano.sh_cronjobs.yaml
@@ -78,8 +78,9 @@ spec:
                       networkTopology:
                         properties:
                           highestTierAllowed:
-                            default: 1
                             type: integer
+                          highestTierName:
+                            type: string
                           mode:
                             default: hard
                             enum:
@@ -163,6 +164,35 @@ spec:
                               type: integer
                             name:
                               type: string
+                            partitionPolicy:
+                              properties:
+                                minPartitions:
+                                  default: 0
+                                  format: int32
+                                  type: integer
+                                networkTopology:
+                                  properties:
+                                    highestTierAllowed:
+                                      type: integer
+                                    highestTierName:
+                                      type: string
+                                    mode:
+                                      default: hard
+                                      enum:
+                                      - hard
+                                      - soft
+                                      type: string
+                                  type: object
+                                partitionSize:
+                                  format: int32
+                                  type: integer
+                                totalPartitions:
+                                  format: int32
+                                  type: integer
+                              required:
+                              - partitionSize
+                              - totalPartitions
+                              type: object
                             policies:
                               items:
                                 properties:

--- a/config/crd/volcano/bases/batch.volcano.sh_jobs.yaml
+++ b/config/crd/volcano/bases/batch.volcano.sh_jobs.yaml
@@ -60,8 +60,9 @@ spec:
               networkTopology:
                 properties:
                   highestTierAllowed:
-                    default: 1
                     type: integer
+                  highestTierName:
+                    type: string
                   mode:
                     default: hard
                     enum:
@@ -145,6 +146,35 @@ spec:
                       type: integer
                     name:
                       type: string
+                    partitionPolicy:
+                      properties:
+                        minPartitions:
+                          default: 0
+                          format: int32
+                          type: integer
+                        networkTopology:
+                          properties:
+                            highestTierAllowed:
+                              type: integer
+                            highestTierName:
+                              type: string
+                            mode:
+                              default: hard
+                              enum:
+                              - hard
+                              - soft
+                              type: string
+                          type: object
+                        partitionSize:
+                          format: int32
+                          type: integer
+                        totalPartitions:
+                          format: int32
+                          type: integer
+                      required:
+                      - partitionSize
+                      - totalPartitions
+                      type: object
                     policies:
                       items:
                         properties:

--- a/config/crd/volcano/bases/scheduling.volcano.sh_podgroups.yaml
+++ b/config/crd/volcano/bases/scheduling.volcano.sh_podgroups.yaml
@@ -95,10 +95,14 @@ spec:
                   CRD.
                 properties:
                   highestTierAllowed:
-                    default: 1
                     description: HighestTierAllowed specifies the highest tier that
                       a job allowed to cross when scheduling.
                     type: integer
+                  highestTierName:
+                    description: |-
+                      HighestTierName specifies the highest tier name that a job allowed to cross when scheduling.
+                      HighestTierName and HighestTierAllowed cannot be set simultaneously.
+                    type: string
                   mode:
                     default: hard
                     description: Mode specifies the mode of the network topology constrain.
@@ -122,6 +126,63 @@ spec:
                   Queue defines the queue to allocate resource for PodGroup; if queue does not exist,
                   the PodGroup will not be scheduled. Defaults to `default` Queue with the lowest weight.
                 type: string
+              subGroupPolicy:
+                description: SubGroupPolicy defines policies for dividing all pods
+                  within the podGroup into multiple groups.
+                items:
+                  properties:
+                    matchPolicy:
+                      description: |-
+                        MatchPolicy defines matching strategies for different groups, where pods with the same labelKey value are grouped together.
+                        The LabelKey in the list is unique.
+                      items:
+                        properties:
+                          labelKey:
+                            description: LabelKey specifies the label key used to
+                              group pods.
+                            type: string
+                        type: object
+                      type: array
+                    minSubGroups:
+                      default: 0
+                      description: MinSubGroups defines the minimum number of sub-affinity
+                        groups required.
+                      format: int32
+                      type: integer
+                    name:
+                      description: Name specifies the name of SubGroupPolicy
+                      type: string
+                    networkTopology:
+                      description: NetworkTopology defines the NetworkTopology config,
+                        this field works in conjunction with network topology feature
+                        and hyperNode CRD.
+                      properties:
+                        highestTierAllowed:
+                          description: HighestTierAllowed specifies the highest tier
+                            that a job allowed to cross when scheduling.
+                          type: integer
+                        highestTierName:
+                          description: |-
+                            HighestTierName specifies the highest tier name that a job allowed to cross when scheduling.
+                            HighestTierName and HighestTierAllowed cannot be set simultaneously.
+                          type: string
+                        mode:
+                          default: hard
+                          description: Mode specifies the mode of the network topology
+                            constrain.
+                          enum:
+                          - hard
+                          - soft
+                          type: string
+                      type: object
+                    subGroupSize:
+                      description: |-
+                        SubGroupSize defines the number of pods in each sub-affinity group.
+                        Only when a subGroup of pods, with a size of "subGroupSize", can satisfy the network topology constraint then will the subGroup be scheduled.
+                      format: int32
+                      type: integer
+                  type: object
+                type: array
             type: object
           status:
             description: |-

--- a/config/crd/volcano/bases/topology.volcano.sh_hypernodes.yaml
+++ b/config/crd/volcano/bases/topology.volcano.sh_hypernodes.yaml
@@ -20,6 +20,9 @@ spec:
     - jsonPath: .spec.tier
       name: Tier
       type: string
+    - jsonPath: .spec.tierName
+      name: TierName
+      type: string
     - jsonPath: .status.nodeCount
       name: NodeCount
       type: integer
@@ -147,6 +150,9 @@ spec:
               tier:
                 description: Tier categorizes the performance level of the HyperNode.
                 type: integer
+              tierName:
+                description: TierName represents the level name of the HyperNode.
+                type: string
             required:
             - tier
             type: object

--- a/docs/user-guide/how_to_use_job_policy.md
+++ b/docs/user-guide/how_to_use_job_policy.md
@@ -13,25 +13,26 @@ the task policy.
 * Users can set multiple policy for a job or a task.
 * Currently, Volcano provides **6 built-in events** for users. The details are as follows.
 
-| ID  | Event           | Description                                                                                                       |
-|-----|----------------|-------------------------------------------------------------------------------------------------------------------|
-| 1   | `PodFailed`    | Check whether there is any pod' status is `Failed`.                                                               |
-| 2   | `PodEvicted`   | Check whether there is any pod is evicted.                                                                        |
-| 3   | `PodPending`   | Check whether there is any pod is pending. It is usually used with timeout. If the pod is not pending, the timeout action will be canceled.                                                                        |
-| 4   | `TaskCompleted`| Check whether there is a task whose all pods are succeed. If `minsuccess` is configured for a task, it will also be regarded as task completes. |
-| 4   | `Unknown`      | Check whether the status of a volcano job is `Unknown`. The most possible factor is task unschedulable. It is triggered when part pods can't be scheduled while some are already running in gang-scheduling case. |
-| 5   | `*`           | It means all the events, which is not so common used.                                                             |
+| ID | Event           | Description                                                                                                       |
+|----|-----------------|-------------------------------------------------------------------------------------------------------------------|
+| 1  | `PodFailed`     | Check whether there is any pod' status is `Failed`.                                                               |
+| 2  | `PodEvicted`    | Check whether there is any pod is evicted.                                                                        |
+| 3  | `PodPending`    | Check whether there is any pod is pending. It is usually used with timeout. If the pod is not pending, the timeout action will be canceled.                                                                        |
+| 4  | `TaskCompleted` | Check whether there is a task whose all pods are succeed. If `minsuccess` is configured for a task, it will also be regarded as task completes. |
+| 5  | `Unknown`       | Check whether the status of a volcano job is `Unknown`. The most possible factor is task unschedulable. It is triggered when part pods can't be scheduled while some are already running in gang-scheduling case. |
+| 6  | `*`             | It means all the events, which is not so common used.                                                             |
 
 * Currently, Volcano provides **5 built-in actions** for users. The details are as follows.
 
-| ID  | Action            | Description                                                                                                      |
-|-----|-------------------|------------------------------------------------------------------------------------------------------------------|
-| 1   | `AbortJob`        | Abort the whole job, but it can be resumed. All pods will be evicted and no pod will be recreated.               |
-| 2   | `RestartJob`      | Restart the whole job.                                                                                           |
-| 3   | `RestartTask`     | The task will be restarted. This action **cannot** work with job level events such as `Unknown`. |
-| 2   | `RestartPod`      | The pod will be restarted. This action **cannot** work with job level events such as `Unknown`. |
-| 4   | `TerminateJob`    | Terminate the whole job and it **cannot** be resumed. All pods will be evicted and no pod will be recreated.     |
-| 5   | `CompleteJob`     | Regard the job as completed. The unfinished pods will be killed.                                                 |
+| ID | Action             | Description                                                                                                  |
+|----|--------------------|--------------------------------------------------------------------------------------------------------------|
+| 1  | `AbortJob`         | Abort the whole job, but it can be resumed. All pods will be evicted and no pod will be recreated.           |
+| 2  | `RestartJob`       | Restart the whole job.                                                                                       |
+| 3  | `RestartTask`      | The task will be restarted. This action **cannot** work with job level events such as `Unknown`.             |
+| 4  | `RestartPod`       | The pod will be restarted. This action **cannot** work with job level events such as `Unknown`.              |
+| 5  | `RestartPartition` | The partition will be restarted. This action **cannot** work with job level events such as `Unknown`.        |
+| 6  | `TerminateJob`     | Terminate the whole job and it **cannot** be resumed. All pods will be evicted and no pod will be recreated. |
+| 7  | `CompleteJob`      | Regard the job as completed. The unfinished pods will be killed.                                             |
 
 ## Examples
 1. Set a pair of `event` and `action`.

--- a/go.mod
+++ b/go.mod
@@ -52,7 +52,7 @@ require (
 	sigs.k8s.io/controller-runtime v0.13.0
 	sigs.k8s.io/yaml v1.6.0
 	stathat.com/c/consistent v1.0.0
-	volcano.sh/apis v1.13.1-0.20251020121257-f562f82b42fd
+	volcano.sh/apis v1.13.1-0.20251114021538-d1e61c510040
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -496,5 +496,5 @@ sigs.k8s.io/yaml v1.6.0 h1:G8fkbMSAFqgEFgh4b1wmtzDnioxFCUgTZhlbj5P9QYs=
 sigs.k8s.io/yaml v1.6.0/go.mod h1:796bPqUfzR/0jLAl6XjHl3Ck7MiyVv8dbTdyT3/pMf4=
 stathat.com/c/consistent v1.0.0 h1:ezyc51EGcRPJUxfHGSgJjWzJdj3NiMU9pNfLNGiXV0c=
 stathat.com/c/consistent v1.0.0/go.mod h1:QkzMWzcbB+yQBL2AttO6sgsQS/JSTapcDISJalmCDS0=
-volcano.sh/apis v1.13.1-0.20251020121257-f562f82b42fd h1:LdemLOIsCwABz4wS4wTHB6WA7dXz4gdq5TuUj/RZRKA=
-volcano.sh/apis v1.13.1-0.20251020121257-f562f82b42fd/go.mod h1:CKQbxVt0o4lTKisC0MonoXWruGFC0S8KU+UuzaZ5E7k=
+volcano.sh/apis v1.13.1-0.20251114021538-d1e61c510040 h1:FP8O0jjsPbKiNAY0UOwAkW4mEX5JuCOqdnEfzZteE8k=
+volcano.sh/apis v1.13.1-0.20251114021538-d1e61c510040/go.mod h1:CKQbxVt0o4lTKisC0MonoXWruGFC0S8KU+UuzaZ5E7k=

--- a/installer/helm/chart/volcano/charts/jobflow/crd/bases/flow.volcano.sh_jobflows.yaml
+++ b/installer/helm/chart/volcano/charts/jobflow/crd/bases/flow.volcano.sh_jobflows.yaml
@@ -113,8 +113,9 @@ spec:
                             networkTopology:
                               properties:
                                 highestTierAllowed:
-                                  default: 1
                                   type: integer
+                                highestTierName:
+                                  type: string
                                 mode:
                                   default: hard
                                   enum:
@@ -198,6 +199,35 @@ spec:
                                     type: integer
                                   name:
                                     type: string
+                                  partitionPolicy:
+                                    properties:
+                                      minPartitions:
+                                        default: 0
+                                        format: int32
+                                        type: integer
+                                      networkTopology:
+                                        properties:
+                                          highestTierAllowed:
+                                            type: integer
+                                          highestTierName:
+                                            type: string
+                                          mode:
+                                            default: hard
+                                            enum:
+                                            - hard
+                                            - soft
+                                            type: string
+                                        type: object
+                                      partitionSize:
+                                        format: int32
+                                        type: integer
+                                      totalPartitions:
+                                        format: int32
+                                        type: integer
+                                    required:
+                                    - partitionSize
+                                    - totalPartitions
+                                    type: object
                                   policies:
                                     items:
                                       properties:

--- a/installer/helm/chart/volcano/charts/jobflow/crd/bases/flow.volcano.sh_jobtemplates.yaml
+++ b/installer/helm/chart/volcano/charts/jobflow/crd/bases/flow.volcano.sh_jobtemplates.yaml
@@ -41,8 +41,9 @@ spec:
               networkTopology:
                 properties:
                   highestTierAllowed:
-                    default: 1
                     type: integer
+                  highestTierName:
+                    type: string
                   mode:
                     default: hard
                     enum:
@@ -126,6 +127,35 @@ spec:
                       type: integer
                     name:
                       type: string
+                    partitionPolicy:
+                      properties:
+                        minPartitions:
+                          default: 0
+                          format: int32
+                          type: integer
+                        networkTopology:
+                          properties:
+                            highestTierAllowed:
+                              type: integer
+                            highestTierName:
+                              type: string
+                            mode:
+                              default: hard
+                              enum:
+                              - hard
+                              - soft
+                              type: string
+                          type: object
+                        partitionSize:
+                          format: int32
+                          type: integer
+                        totalPartitions:
+                          format: int32
+                          type: integer
+                      required:
+                      - partitionSize
+                      - totalPartitions
+                      type: object
                     policies:
                       items:
                         properties:

--- a/installer/helm/chart/volcano/crd/bases/batch.volcano.sh_cronjobs.yaml
+++ b/installer/helm/chart/volcano/crd/bases/batch.volcano.sh_cronjobs.yaml
@@ -77,8 +77,9 @@ spec:
                       networkTopology:
                         properties:
                           highestTierAllowed:
-                            default: 1
                             type: integer
+                          highestTierName:
+                            type: string
                           mode:
                             default: hard
                             enum:
@@ -162,6 +163,35 @@ spec:
                               type: integer
                             name:
                               type: string
+                            partitionPolicy:
+                              properties:
+                                minPartitions:
+                                  default: 0
+                                  format: int32
+                                  type: integer
+                                networkTopology:
+                                  properties:
+                                    highestTierAllowed:
+                                      type: integer
+                                    highestTierName:
+                                      type: string
+                                    mode:
+                                      default: hard
+                                      enum:
+                                      - hard
+                                      - soft
+                                      type: string
+                                  type: object
+                                partitionSize:
+                                  format: int32
+                                  type: integer
+                                totalPartitions:
+                                  format: int32
+                                  type: integer
+                              required:
+                              - partitionSize
+                              - totalPartitions
+                              type: object
                             policies:
                               items:
                                 properties:

--- a/installer/helm/chart/volcano/crd/bases/batch.volcano.sh_jobs.yaml
+++ b/installer/helm/chart/volcano/crd/bases/batch.volcano.sh_jobs.yaml
@@ -59,8 +59,9 @@ spec:
               networkTopology:
                 properties:
                   highestTierAllowed:
-                    default: 1
                     type: integer
+                  highestTierName:
+                    type: string
                   mode:
                     default: hard
                     enum:
@@ -144,6 +145,35 @@ spec:
                       type: integer
                     name:
                       type: string
+                    partitionPolicy:
+                      properties:
+                        minPartitions:
+                          default: 0
+                          format: int32
+                          type: integer
+                        networkTopology:
+                          properties:
+                            highestTierAllowed:
+                              type: integer
+                            highestTierName:
+                              type: string
+                            mode:
+                              default: hard
+                              enum:
+                              - hard
+                              - soft
+                              type: string
+                          type: object
+                        partitionSize:
+                          format: int32
+                          type: integer
+                        totalPartitions:
+                          format: int32
+                          type: integer
+                      required:
+                      - partitionSize
+                      - totalPartitions
+                      type: object
                     policies:
                       items:
                         properties:

--- a/installer/helm/chart/volcano/crd/bases/scheduling.volcano.sh_podgroups.yaml
+++ b/installer/helm/chart/volcano/crd/bases/scheduling.volcano.sh_podgroups.yaml
@@ -94,10 +94,14 @@ spec:
                   CRD.
                 properties:
                   highestTierAllowed:
-                    default: 1
                     description: HighestTierAllowed specifies the highest tier that
                       a job allowed to cross when scheduling.
                     type: integer
+                  highestTierName:
+                    description: |-
+                      HighestTierName specifies the highest tier name that a job allowed to cross when scheduling.
+                      HighestTierName and HighestTierAllowed cannot be set simultaneously.
+                    type: string
                   mode:
                     default: hard
                     description: Mode specifies the mode of the network topology constrain.
@@ -121,6 +125,63 @@ spec:
                   Queue defines the queue to allocate resource for PodGroup; if queue does not exist,
                   the PodGroup will not be scheduled. Defaults to `default` Queue with the lowest weight.
                 type: string
+              subGroupPolicy:
+                description: SubGroupPolicy defines policies for dividing all pods
+                  within the podGroup into multiple groups.
+                items:
+                  properties:
+                    matchPolicy:
+                      description: |-
+                        MatchPolicy defines matching strategies for different groups, where pods with the same labelKey value are grouped together.
+                        The LabelKey in the list is unique.
+                      items:
+                        properties:
+                          labelKey:
+                            description: LabelKey specifies the label key used to
+                              group pods.
+                            type: string
+                        type: object
+                      type: array
+                    minSubGroups:
+                      default: 0
+                      description: MinSubGroups defines the minimum number of sub-affinity
+                        groups required.
+                      format: int32
+                      type: integer
+                    name:
+                      description: Name specifies the name of SubGroupPolicy
+                      type: string
+                    networkTopology:
+                      description: NetworkTopology defines the NetworkTopology config,
+                        this field works in conjunction with network topology feature
+                        and hyperNode CRD.
+                      properties:
+                        highestTierAllowed:
+                          description: HighestTierAllowed specifies the highest tier
+                            that a job allowed to cross when scheduling.
+                          type: integer
+                        highestTierName:
+                          description: |-
+                            HighestTierName specifies the highest tier name that a job allowed to cross when scheduling.
+                            HighestTierName and HighestTierAllowed cannot be set simultaneously.
+                          type: string
+                        mode:
+                          default: hard
+                          description: Mode specifies the mode of the network topology
+                            constrain.
+                          enum:
+                          - hard
+                          - soft
+                          type: string
+                      type: object
+                    subGroupSize:
+                      description: |-
+                        SubGroupSize defines the number of pods in each sub-affinity group.
+                        Only when a subGroup of pods, with a size of "subGroupSize", can satisfy the network topology constraint then will the subGroup be scheduled.
+                      format: int32
+                      type: integer
+                  type: object
+                type: array
             type: object
           status:
             description: |-

--- a/installer/helm/chart/volcano/crd/bases/topology.volcano.sh_hypernodes.yaml
+++ b/installer/helm/chart/volcano/crd/bases/topology.volcano.sh_hypernodes.yaml
@@ -19,6 +19,9 @@ spec:
     - jsonPath: .spec.tier
       name: Tier
       type: string
+    - jsonPath: .spec.tierName
+      name: TierName
+      type: string
     - jsonPath: .status.nodeCount
       name: NodeCount
       type: integer
@@ -146,6 +149,9 @@ spec:
               tier:
                 description: Tier categorizes the performance level of the HyperNode.
                 type: integer
+              tierName:
+                description: TierName represents the level name of the HyperNode.
+                type: string
             required:
             - tier
             type: object

--- a/installer/volcano-development.yaml
+++ b/installer/volcano-development.yaml
@@ -328,8 +328,9 @@ spec:
               networkTopology:
                 properties:
                   highestTierAllowed:
-                    default: 1
                     type: integer
+                  highestTierName:
+                    type: string
                   mode:
                     default: hard
                     enum:
@@ -413,6 +414,35 @@ spec:
                       type: integer
                     name:
                       type: string
+                    partitionPolicy:
+                      properties:
+                        minPartitions:
+                          default: 0
+                          format: int32
+                          type: integer
+                        networkTopology:
+                          properties:
+                            highestTierAllowed:
+                              type: integer
+                            highestTierName:
+                              type: string
+                            mode:
+                              default: hard
+                              enum:
+                              - hard
+                              - soft
+                              type: string
+                          type: object
+                        partitionSize:
+                          format: int32
+                          type: integer
+                        totalPartitions:
+                          format: int32
+                          type: integer
+                      required:
+                      - partitionSize
+                      - totalPartitions
+                      type: object
                     policies:
                       items:
                         properties:
@@ -4535,8 +4565,9 @@ spec:
                       networkTopology:
                         properties:
                           highestTierAllowed:
-                            default: 1
                             type: integer
+                          highestTierName:
+                            type: string
                           mode:
                             default: hard
                             enum:
@@ -4620,6 +4651,35 @@ spec:
                               type: integer
                             name:
                               type: string
+                            partitionPolicy:
+                              properties:
+                                minPartitions:
+                                  default: 0
+                                  format: int32
+                                  type: integer
+                                networkTopology:
+                                  properties:
+                                    highestTierAllowed:
+                                      type: integer
+                                    highestTierName:
+                                      type: string
+                                    mode:
+                                      default: hard
+                                      enum:
+                                      - hard
+                                      - soft
+                                      type: string
+                                  type: object
+                                partitionSize:
+                                  format: int32
+                                  type: integer
+                                totalPartitions:
+                                  format: int32
+                                  type: integer
+                              required:
+                              - partitionSize
+                              - totalPartitions
+                              type: object
                             policies:
                               items:
                                 properties:
@@ -9241,10 +9301,14 @@ spec:
                   CRD.
                 properties:
                   highestTierAllowed:
-                    default: 1
                     description: HighestTierAllowed specifies the highest tier that
                       a job allowed to cross when scheduling.
                     type: integer
+                  highestTierName:
+                    description: |-
+                      HighestTierName specifies the highest tier name that a job allowed to cross when scheduling.
+                      HighestTierName and HighestTierAllowed cannot be set simultaneously.
+                    type: string
                   mode:
                     default: hard
                     description: Mode specifies the mode of the network topology constrain.
@@ -9268,6 +9332,63 @@ spec:
                   Queue defines the queue to allocate resource for PodGroup; if queue does not exist,
                   the PodGroup will not be scheduled. Defaults to `default` Queue with the lowest weight.
                 type: string
+              subGroupPolicy:
+                description: SubGroupPolicy defines policies for dividing all pods
+                  within the podGroup into multiple groups.
+                items:
+                  properties:
+                    matchPolicy:
+                      description: |-
+                        MatchPolicy defines matching strategies for different groups, where pods with the same labelKey value are grouped together.
+                        The LabelKey in the list is unique.
+                      items:
+                        properties:
+                          labelKey:
+                            description: LabelKey specifies the label key used to
+                              group pods.
+                            type: string
+                        type: object
+                      type: array
+                    minSubGroups:
+                      default: 0
+                      description: MinSubGroups defines the minimum number of sub-affinity
+                        groups required.
+                      format: int32
+                      type: integer
+                    name:
+                      description: Name specifies the name of SubGroupPolicy
+                      type: string
+                    networkTopology:
+                      description: NetworkTopology defines the NetworkTopology config,
+                        this field works in conjunction with network topology feature
+                        and hyperNode CRD.
+                      properties:
+                        highestTierAllowed:
+                          description: HighestTierAllowed specifies the highest tier
+                            that a job allowed to cross when scheduling.
+                          type: integer
+                        highestTierName:
+                          description: |-
+                            HighestTierName specifies the highest tier name that a job allowed to cross when scheduling.
+                            HighestTierName and HighestTierAllowed cannot be set simultaneously.
+                          type: string
+                        mode:
+                          default: hard
+                          description: Mode specifies the mode of the network topology
+                            constrain.
+                          enum:
+                          - hard
+                          - soft
+                          type: string
+                      type: object
+                    subGroupSize:
+                      description: |-
+                        SubGroupSize defines the number of pods in each sub-affinity group.
+                        Only when a subGroup of pods, with a size of "subGroupSize", can satisfy the network topology constraint then will the subGroup be scheduled.
+                      format: int32
+                      type: integer
+                  type: object
+                type: array
             type: object
           status:
             description: |-
@@ -9662,6 +9783,9 @@ spec:
     - jsonPath: .spec.tier
       name: Tier
       type: string
+    - jsonPath: .spec.tierName
+      name: TierName
+      type: string
     - jsonPath: .status.nodeCount
       name: NodeCount
       type: integer
@@ -9789,6 +9913,9 @@ spec:
               tier:
                 description: Tier categorizes the performance level of the HyperNode.
                 type: integer
+              tierName:
+                description: TierName represents the level name of the HyperNode.
+                type: string
             required:
             - tier
             type: object
@@ -10174,8 +10301,9 @@ spec:
               networkTopology:
                 properties:
                   highestTierAllowed:
-                    default: 1
                     type: integer
+                  highestTierName:
+                    type: string
                   mode:
                     default: hard
                     enum:
@@ -10259,6 +10387,35 @@ spec:
                       type: integer
                     name:
                       type: string
+                    partitionPolicy:
+                      properties:
+                        minPartitions:
+                          default: 0
+                          format: int32
+                          type: integer
+                        networkTopology:
+                          properties:
+                            highestTierAllowed:
+                              type: integer
+                            highestTierName:
+                              type: string
+                            mode:
+                              default: hard
+                              enum:
+                              - hard
+                              - soft
+                              type: string
+                          type: object
+                        partitionSize:
+                          format: int32
+                          type: integer
+                        totalPartitions:
+                          format: int32
+                          type: integer
+                      required:
+                      - partitionSize
+                      - totalPartitions
+                      type: object
                     policies:
                       items:
                         properties:
@@ -14354,8 +14511,9 @@ spec:
                             networkTopology:
                               properties:
                                 highestTierAllowed:
-                                  default: 1
                                   type: integer
+                                highestTierName:
+                                  type: string
                                 mode:
                                   default: hard
                                   enum:
@@ -14439,6 +14597,35 @@ spec:
                                     type: integer
                                   name:
                                     type: string
+                                  partitionPolicy:
+                                    properties:
+                                      minPartitions:
+                                        default: 0
+                                        format: int32
+                                        type: integer
+                                      networkTopology:
+                                        properties:
+                                          highestTierAllowed:
+                                            type: integer
+                                          highestTierName:
+                                            type: string
+                                          mode:
+                                            default: hard
+                                            enum:
+                                            - hard
+                                            - soft
+                                            type: string
+                                        type: object
+                                      partitionSize:
+                                        format: int32
+                                        type: integer
+                                      totalPartitions:
+                                        format: int32
+                                        type: integer
+                                    required:
+                                    - partitionSize
+                                    - totalPartitions
+                                    type: object
                                   policies:
                                     items:
                                       properties:

--- a/pkg/controllers/apis/job_info.go
+++ b/pkg/controllers/apis/job_info.go
@@ -22,6 +22,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 
 	batch "volcano.sh/apis/pkg/apis/batch/v1alpha1"
+	scheduling "volcano.sh/apis/pkg/apis/scheduling/v1beta1"
 )
 
 // JobInfo struct.
@@ -31,6 +32,15 @@ type JobInfo struct {
 
 	Job  *batch.Job
 	Pods map[string]map[string]*v1.Pod
+	// Partitions taskName:PartitionInfo
+	Partitions map[string]*PartitionInfo
+}
+
+type PartitionInfo struct {
+	// Partition partitionID:{podName:pod}
+	Partition       map[string]map[string]*v1.Pod
+	MatchPolicy     []*scheduling.MatchPolicySpec
+	NetworkTopology *batch.NetworkTopologySpec
 }
 
 // Clone function clones the k8s pod values to the JobInfo struct.
@@ -40,7 +50,8 @@ func (ji *JobInfo) Clone() *JobInfo {
 		Name:      ji.Name,
 		Job:       ji.Job,
 
-		Pods: make(map[string]map[string]*v1.Pod, len(ji.Pods)),
+		Pods:       make(map[string]map[string]*v1.Pod, len(ji.Pods)),
+		Partitions: make(map[string]*PartitionInfo, len(ji.Partitions)),
 	}
 
 	for key, pods := range ji.Pods {
@@ -48,6 +59,27 @@ func (ji *JobInfo) Clone() *JobInfo {
 		for pn, pod := range pods {
 			job.Pods[key][pn] = pod
 		}
+	}
+
+	for taskName, partitionInfo := range ji.Partitions {
+		job.Partitions[taskName] = &PartitionInfo{}
+		partition := make(map[string]map[string]*v1.Pod, len(partitionInfo.Partition))
+		for partitionID, pods := range partitionInfo.Partition {
+			group := make(map[string]*v1.Pod, len(pods))
+			for podName, pod := range pods {
+				group[podName] = pod
+			}
+			partition[partitionID] = group
+		}
+		job.Partitions[taskName].Partition = partition
+		if partitionInfo.NetworkTopology != nil {
+			job.Partitions[taskName].NetworkTopology = partitionInfo.NetworkTopology.DeepCopy()
+		}
+		matchPolicy := make([]*scheduling.MatchPolicySpec, 0, len(partitionInfo.MatchPolicy))
+		for _, value := range partitionInfo.MatchPolicy {
+			matchPolicy = append(matchPolicy, value.DeepCopy())
+		}
+		job.Partitions[taskName].MatchPolicy = matchPolicy
 	}
 
 	return job
@@ -58,6 +90,41 @@ func (ji *JobInfo) SetJob(job *batch.Job) {
 	ji.Name = job.Name
 	ji.Namespace = job.Namespace
 	ji.Job = job
+	ji.Partitions = make(map[string]*PartitionInfo)
+	for _, taskSpec := range job.Spec.Tasks {
+		if taskSpec.PartitionPolicy == nil {
+			continue
+		}
+		ji.Partitions[taskSpec.Name] = &PartitionInfo{}
+		ji.Partitions[taskSpec.Name].Partition = make(map[string]map[string]*v1.Pod)
+		if taskSpec.PartitionPolicy.NetworkTopology != nil {
+			nt := &batch.NetworkTopologySpec{
+				Mode:               taskSpec.PartitionPolicy.NetworkTopology.Mode,
+				HighestTierAllowed: taskSpec.PartitionPolicy.NetworkTopology.HighestTierAllowed,
+			}
+			ji.Partitions[taskSpec.Name].NetworkTopology = nt
+		}
+		ji.Partitions[taskSpec.Name].MatchPolicy = make([]*scheduling.MatchPolicySpec, 0)
+		labelKey := fmt.Sprintf("volcano.sh/%s-subgroup-id", taskSpec.Name)
+		matchPolicySpec := &scheduling.MatchPolicySpec{
+			LabelKey: labelKey,
+		}
+		ji.Partitions[taskSpec.Name].MatchPolicy = append(ji.Partitions[taskSpec.Name].MatchPolicy, matchPolicySpec)
+	}
+	for taskName, podMap := range ji.Pods {
+		for _, pod := range podMap {
+			if partitionInfo, found := ji.Partitions[taskName]; found {
+				partitionID := getPartitionID(pod)
+				if partitionID == "" {
+					continue
+				}
+				if _, found := partitionInfo.Partition[partitionID]; !found {
+					partitionInfo.Partition[partitionID] = make(map[string]*v1.Pod)
+				}
+				partitionInfo.Partition[partitionID][pod.Name] = pod
+			}
+		}
+	}
 }
 
 // AddPod adds the k8s pod object values to the Pods field
@@ -82,6 +149,19 @@ func (ji *JobInfo) AddPod(pod *v1.Pod) error {
 		return fmt.Errorf("duplicated pod")
 	}
 	ji.Pods[taskName][pod.Name] = pod
+
+	if ji.Partitions != nil {
+		if partitionInfo, found := ji.Partitions[taskName]; found {
+			partitionID := getPartitionID(pod)
+			if partitionID == "" {
+				return nil
+			}
+			if _, found := partitionInfo.Partition[partitionID]; !found {
+				partitionInfo.Partition[partitionID] = make(map[string]*v1.Pod)
+			}
+			partitionInfo.Partition[partitionID][pod.Name] = pod
+		}
+	}
 
 	return nil
 }
@@ -108,6 +188,19 @@ func (ji *JobInfo) UpdatePod(pod *v1.Pod) error {
 	}
 	ji.Pods[taskName][pod.Name] = pod
 
+	if ji.Partitions != nil {
+		if partitionInfo, found := ji.Partitions[taskName]; found {
+			partitionID := getPartitionID(pod)
+			if partitionID == "" {
+				return nil
+			}
+			if _, found := partitionInfo.Partition[partitionID]; found {
+				if _, found := partitionInfo.Partition[partitionID][pod.Name]; found {
+					partitionInfo.Partition[partitionID][pod.Name] = pod
+				}
+			}
+		}
+	}
 	return nil
 }
 
@@ -131,5 +224,28 @@ func (ji *JobInfo) DeletePod(pod *v1.Pod) error {
 		}
 	}
 
+	if ji.Partitions != nil {
+		if partitionInfo, found := ji.Partitions[taskName]; found {
+			partitionID := getPartitionID(pod)
+			if partitionID == "" {
+				return nil
+			}
+			if _, found := partitionInfo.Partition[partitionID]; found {
+				delete(partitionInfo.Partition[partitionID], pod.Name)
+				if len(partitionInfo.Partition[partitionID]) == 0 {
+					delete(partitionInfo.Partition, partitionID)
+				}
+			}
+		}
+	}
+
 	return nil
+}
+
+func getPartitionID(pod *v1.Pod) string {
+	value, ok := pod.Labels[batch.Partitionkey]
+	if ok {
+		return value
+	}
+	return ""
 }

--- a/pkg/controllers/apis/request.go
+++ b/pkg/controllers/apis/request.go
@@ -27,14 +27,14 @@ import (
 
 // Request struct.
 type Request struct {
-	Namespace string
-	JobName   string
-	JobUid    types.UID
-	TaskName  string
-	QueueName string
-	PodName   string
-	PodUID    types.UID
-
+	Namespace  string
+	JobName    string
+	JobUid     types.UID
+	TaskName   string
+	QueueName  string
+	PodName    string
+	PodUID     types.UID
+	Partition  string
 	Event      v1alpha1.Event
 	ExitCode   int32
 	Action     v1alpha1.Action

--- a/pkg/controllers/cache/cache.go
+++ b/pkg/controllers/cache/cache.go
@@ -141,6 +141,7 @@ func (jc *jobCache) Add(job *v1alpha1.Job) error {
 		Job:  job,
 		Pods: make(map[string]map[string]*v1.Pod),
 	}
+	jc.jobs[key].SetJob(job)
 
 	return nil
 }
@@ -169,7 +170,7 @@ func (jc *jobCache) Update(obj *v1alpha1.Job) error {
 			return fmt.Errorf("job <%v> has too old resource version: %d (%d)", key, newResourceVersion, oldResourceVersion)
 		}
 	}
-	job.Job = obj
+	job.SetJob(obj)
 	return nil
 }
 

--- a/pkg/controllers/job/fuzz_test.go
+++ b/pkg/controllers/job/fuzz_test.go
@@ -48,6 +48,6 @@ func FuzzCreateJobPod(f *testing.F) {
 		// Create a random PTS
 		template := &v1.PodTemplateSpec{}
 		fdp.GenerateStruct(template)
-		_ = createJobPod(job, template, batch.NumaPolicy(numaPolicy), ix, jobForwarding)
+		_ = createJobPod(job, template, ix, jobForwarding, nil, nil)
 	})
 }

--- a/pkg/controllers/job/job_controller.go
+++ b/pkg/controllers/job/job_controller.go
@@ -75,6 +75,8 @@ type delayAction struct {
 	// The UID of the pod
 	podUID types.UID
 
+	partition string
+
 	// The event caused the action
 	event busv1alpha1.Event
 
@@ -552,6 +554,10 @@ func (cc *jobcontroller) cleanupDelayActions(currentDelayAction *delayAction) {
 				}
 				// For Pod level actions, only cancel delayed actions for the same pod
 				if actionType == PodAction && delayAct.podName != currentDelayAction.podName {
+					continue
+				}
+				// For partition group level actions, only cancel delayed actions for the same group
+				if actionType == PartitionAction && delayAct.partition != currentDelayAction.partition {
 					continue
 				}
 

--- a/pkg/controllers/job/job_controller_actions.go
+++ b/pkg/controllers/job/job_controller_actions.go
@@ -33,7 +33,6 @@ import (
 	batch "volcano.sh/apis/pkg/apis/batch/v1alpha1"
 	"volcano.sh/apis/pkg/apis/helpers"
 	scheduling "volcano.sh/apis/pkg/apis/scheduling/v1beta1"
-
 	"volcano.sh/volcano/pkg/controllers/apis"
 	jobhelpers "volcano.sh/volcano/pkg/controllers/job/helpers"
 	"volcano.sh/volcano/pkg/controllers/job/state"
@@ -65,12 +64,17 @@ func (cc *jobcontroller) generateRelatedPodGroupName(job *batch.Job) string {
 }
 
 func (cc *jobcontroller) killTarget(jobInfo *apis.JobInfo, target state.Target, updateStatus state.UpdateStatusFn) error {
-	if target.Type == state.TargetTypeTask {
+	switch target.Type {
+	case state.TargetTypeTask:
 		klog.V(3).Infof("Killing task <%s> of Job <%s/%s>, current version %d", target.TaskName, jobInfo.Namespace, jobInfo.Name, jobInfo.Job.Status.Version)
 		defer klog.V(3).Infof("Finished task <%s> of Job <%s/%s> killing, current version %d", target.TaskName, jobInfo.Namespace, jobInfo.Name, jobInfo.Job.Status.Version)
-	} else if target.Type == state.TargetTypePod {
+	case state.TargetTypePod:
 		klog.V(3).Infof("Killing pod <%s> of Job <%s/%s>, current version %d", target.PodName, jobInfo.Namespace, jobInfo.Name, jobInfo.Job.Status.Version)
 		defer klog.V(3).Infof("Finished pod <%s> of Job <%s/%s> killing, current version %d", target.PodName, jobInfo.Namespace, jobInfo.Name, jobInfo.Job.Status.Version)
+	case state.TargetTypePartition:
+		klog.V(3).Infof("Killing partition <%s> partition of Job <%s/%s>, current version %d", target.PartitionName, jobInfo.Namespace, jobInfo.Name, jobInfo.Job.Status.Version)
+		defer klog.V(3).Infof("Finished partition <%s> of Job <%s/%s> killing, current version %d", target.PartitionName, jobInfo.Namespace, jobInfo.Name, jobInfo.Job.Status.Version)
+	default:
 	}
 	return cc.killPods(jobInfo, nil, &target, updateStatus)
 }
@@ -99,16 +103,43 @@ func (cc *jobcontroller) killPods(jobInfo *apis.JobInfo, podRetainPhase state.Ph
 	podsToKill := make(map[string]*v1.Pod)
 
 	if target != nil {
-		if target.Type == state.TargetTypeTask {
+		switch target.Type {
+		case state.TargetTypeTask:
 			if targetPods, found := jobInfo.Pods[target.TaskName]; found {
 				podsToKill = targetPods
 			}
-		} else if target.Type == state.TargetTypePod {
+		case state.TargetTypePod:
 			if targetPods, found := jobInfo.Pods[target.TaskName]; found {
 				if pod, found := targetPods[target.PodName]; found {
 					podsToKill[target.PodName] = pod
 				}
 			}
+		case state.TargetTypePartition:
+			partitionInfo, found := jobInfo.Partitions[target.TaskName]
+			if !found || partitionInfo == nil || partitionInfo.Partition == nil {
+				klog.Infof("Job <%s/%s> has not partition group in task %s, skip management process.",
+					job.Namespace, job.Name, target.TaskName)
+				return nil
+			}
+			podsInPartition, found := partitionInfo.Partition[target.PartitionName]
+			if !found || podsInPartition == nil {
+				klog.Infof("Job <%s/%s> has not partition group %s in task %s, skip management process.",
+					job.Namespace, job.Name, target.PartitionName, target.TaskName)
+				return nil
+			}
+			if targetPods, found := jobInfo.Pods[target.TaskName]; found {
+				for _, pod := range podsInPartition {
+					if pod, found := targetPods[pod.Name]; found {
+						podsToKill[pod.Name] = pod
+					}
+				}
+			}
+			if len(podsToKill) == 0 {
+				klog.Infof("Job <%s/%s> has not partition group in task %s, skip management process.",
+					job.Namespace, job.Name, target.TaskName)
+				return nil
+			}
+		default:
 		}
 		total += len(podsToKill)
 	} else {
@@ -421,7 +452,7 @@ func (cc *jobcontroller) syncJob(jobInfo *apis.JobInfo, updateStatus state.Updat
 		for i := 0; i < int(ts.Replicas); i++ {
 			podName := fmt.Sprintf(jobhelpers.PodNameFmt, job.Name, name, i)
 			if pod, found := pods[podName]; !found {
-				newPod := createJobPod(job, tc, ts.TopologyPolicy, i, jobForwarding)
+				newPod := createJobPod(job, tc, i, jobForwarding, pg, &ts)
 				if err := cc.pluginOnPodCreate(job, newPod); err != nil {
 					return err
 				}
@@ -773,6 +804,8 @@ func (cc *jobcontroller) createOrUpdatePodGroup(job *batch.Job) error {
 			}
 			pg.Spec.NetworkTopology = nt
 		}
+		// Adding PgSubGroupPolicy Information for PodGroup
+		setPgSubGroupPolicy(pg, job.Spec.Tasks)
 
 		if _, err = cc.vcClient.SchedulingV1beta1().PodGroups(job.Namespace).Create(context.TODO(), pg, metav1.CreateOptions{}); err != nil {
 			if !apierrors.IsAlreadyExists(err) {
@@ -787,6 +820,7 @@ func (cc *jobcontroller) createOrUpdatePodGroup(job *batch.Job) error {
 	podGroupToUpdate := pg.DeepCopy()
 
 	pgShouldUpdate := cc.shouldUpdateExistingPodGroup(podGroupToUpdate, job)
+
 	if !pgShouldUpdate {
 		return nil
 	}
@@ -835,6 +869,9 @@ func (cc *jobcontroller) shouldUpdateExistingPodGroup(pg *scheduling.PodGroup, j
 			pgShouldUpdate = true
 			pg.Spec.MinTaskMember[task.Name] = cnt
 		}
+	}
+	if updatePgSubGroupPolicy(pg, job.Spec.Tasks) {
+		pgShouldUpdate = true
 	}
 
 	return pgShouldUpdate
@@ -992,4 +1029,71 @@ func newCondition(status batch.JobPhase, lastTransitionTime *metav1.Time) batch.
 		Status:             status,
 		LastTransitionTime: lastTransitionTime,
 	}
+}
+
+func setPgSubGroupPolicy(pg *scheduling.PodGroup, tasks []batch.TaskSpec) {
+	pg.Spec.SubGroupPolicy = make([]scheduling.SubGroupPolicySpec, 0)
+	for _, taskSpec := range tasks {
+		if taskSpec.PartitionPolicy == nil {
+			continue
+		}
+		subGroupPolicy := getSubGroupPolicy(taskSpec)
+		pg.Spec.SubGroupPolicy = append(pg.Spec.SubGroupPolicy, subGroupPolicy)
+	}
+}
+
+func updatePgSubGroupPolicy(pg *scheduling.PodGroup, tasks []batch.TaskSpec) bool {
+	subGroupPolicyShouldUpdate := false
+
+	// Record the old SubGroupPolicy.
+	oldSubGroupPolicyMap := make(map[string]scheduling.SubGroupPolicySpec)
+	for _, subGroupPolicy := range pg.Spec.SubGroupPolicy {
+		oldSubGroupPolicyMap[subGroupPolicy.Name] = subGroupPolicy
+	}
+	newSubGroupPolicyList := make([]scheduling.SubGroupPolicySpec, 0)
+	for _, taskSpec := range tasks {
+		if taskSpec.PartitionPolicy == nil {
+			if _, ok := oldSubGroupPolicyMap[taskSpec.Name]; ok {
+				subGroupPolicyShouldUpdate = true
+			}
+			continue
+		}
+
+		newSubGroupPolicy := getSubGroupPolicy(taskSpec)
+		newSubGroupPolicyList = append(newSubGroupPolicyList, newSubGroupPolicy)
+		// compare the new subGroupPolicy and old subGroupPolicy
+		if !equality.Semantic.DeepEqual(newSubGroupPolicy, oldSubGroupPolicyMap[taskSpec.Name]) {
+			subGroupPolicyShouldUpdate = true
+		}
+	}
+
+	// update subGroupPolicy
+	if subGroupPolicyShouldUpdate {
+		pg.Spec.SubGroupPolicy = newSubGroupPolicyList
+	}
+	return subGroupPolicyShouldUpdate
+}
+
+func getSubGroupPolicy(taskSpec batch.TaskSpec) scheduling.SubGroupPolicySpec {
+	subGroupPolicy := scheduling.SubGroupPolicySpec{
+		Name:         taskSpec.Name,
+		MatchPolicy:  make([]scheduling.MatchPolicySpec, 0),
+		SubGroupSize: &taskSpec.PartitionPolicy.PartitionSize,
+	}
+	// set MatchPolicy
+	labelKey := fmt.Sprintf("volcano.sh/%s-subgroup-id", subGroupPolicy.Name)
+	matchPolicySpec := scheduling.MatchPolicySpec{
+		LabelKey: labelKey,
+	}
+	subGroupPolicy.MatchPolicy = append(subGroupPolicy.MatchPolicy, matchPolicySpec)
+
+	// set NetworkTopology
+	if taskSpec.PartitionPolicy.NetworkTopology != nil {
+		nt := &scheduling.NetworkTopologySpec{
+			Mode:               scheduling.NetworkTopologyMode(taskSpec.PartitionPolicy.NetworkTopology.Mode),
+			HighestTierAllowed: taskSpec.PartitionPolicy.NetworkTopology.HighestTierAllowed,
+		}
+		subGroupPolicy.NetworkTopology = nt
+	}
+	return subGroupPolicy
 }

--- a/pkg/controllers/job/job_controller_handler.go
+++ b/pkg/controllers/job/job_controller_handler.go
@@ -175,18 +175,26 @@ func (cc *jobcontroller) addPod(obj interface{}) {
 		return
 	}
 
+	taskName, found := pod.Annotations[batch.TaskSpecKey]
+	if !found {
+		klog.Infof("Failed to find taskName of Pod <%s/%s>, skipping",
+			pod.Namespace, pod.Name)
+		return
+	}
+
 	if pod.DeletionTimestamp != nil {
 		cc.deletePod(pod)
 		return
 	}
 
 	req := apis.Request{
-		Namespace: pod.Namespace,
-		JobName:   jobName,
-		JobUid:    jobUid,
-		PodName:   pod.Name,
-		PodUID:    pod.UID,
-
+		Namespace:  pod.Namespace,
+		JobName:    jobName,
+		JobUid:     jobUid,
+		PodName:    pod.Name,
+		PodUID:     pod.UID,
+		TaskName:   taskName,
+		Partition:  getPodPartition(pod),
 		Event:      bus.PodPendingEvent,
 		JobVersion: int32(dVersion),
 	}
@@ -298,13 +306,13 @@ func (cc *jobcontroller) updatePod(oldObj, newObj interface{}) {
 	}
 
 	req := apis.Request{
-		Namespace: newPod.Namespace,
-		JobName:   jobName,
-		JobUid:    jobUid,
-		TaskName:  taskName,
-		PodName:   newPod.Name,
-		PodUID:    newPod.UID,
-
+		Namespace:  newPod.Namespace,
+		JobName:    jobName,
+		JobUid:     jobUid,
+		TaskName:   taskName,
+		PodName:    newPod.Name,
+		PodUID:     newPod.UID,
+		Partition:  getPodPartition(newPod),
 		Event:      event,
 		ExitCode:   exitCode,
 		JobVersion: int32(dVersion),
@@ -368,13 +376,13 @@ func (cc *jobcontroller) deletePod(obj interface{}) {
 	}
 
 	req := apis.Request{
-		Namespace: pod.Namespace,
-		JobName:   jobName,
-		JobUid:    jobUid,
-		TaskName:  taskName,
-		PodName:   pod.Name,
-		PodUID:    pod.UID,
-
+		Namespace:  pod.Namespace,
+		JobName:    jobName,
+		JobUid:     jobUid,
+		TaskName:   taskName,
+		PodName:    pod.Name,
+		PodUID:     pod.UID,
+		Partition:  getPodPartition(pod),
 		Event:      bus.PodEvictedEvent,
 		JobVersion: int32(dVersion),
 	}

--- a/pkg/controllers/job/job_controller_handler_test.go
+++ b/pkg/controllers/job/job_controller_handler_test.go
@@ -31,6 +31,7 @@ import (
 	batch "volcano.sh/apis/pkg/apis/batch/v1alpha1"
 	bus "volcano.sh/apis/pkg/apis/bus/v1alpha1"
 	"volcano.sh/apis/pkg/apis/helpers"
+
 	scheduling "volcano.sh/apis/pkg/apis/scheduling/v1beta1"
 	vcclientset "volcano.sh/apis/pkg/client/clientset/versioned"
 	informerfactory "volcano.sh/apis/pkg/client/informers/externalversions"

--- a/pkg/controllers/job/state/factory.go
+++ b/pkg/controllers/job/state/factory.go
@@ -60,14 +60,16 @@ var (
 type TargetType string
 
 const (
-	TargetTypeTask TargetType = "task"
-	TargetTypePod  TargetType = "pod"
+	TargetTypeTask      TargetType = "task"
+	TargetTypePod       TargetType = "pod"
+	TargetTypePartition TargetType = "partition"
 )
 
 type Target struct {
-	TaskName string
-	PodName  string
-	Type     TargetType
+	TaskName      string
+	PodName       string
+	PartitionName string
+	Type          TargetType
 }
 
 type Action struct {

--- a/pkg/controllers/job/state/pending.go
+++ b/pkg/controllers/job/state/pending.go
@@ -34,7 +34,7 @@ func (ps *pendingState) Execute(action Action) error {
 			status.State.Phase = vcbatch.Restarting
 			return true
 		})
-	case v1alpha1.RestartTaskAction, v1alpha1.RestartPodAction:
+	case v1alpha1.RestartTaskAction, v1alpha1.RestartPodAction, v1alpha1.RestartPartitionAction:
 		return KillTarget(ps.job, action.Target, func(status *vcbatch.JobStatus) bool {
 			status.RetryCount++
 			status.State.Phase = vcbatch.Restarting

--- a/pkg/controllers/job/state/restarting.go
+++ b/pkg/controllers/job/state/restarting.go
@@ -55,7 +55,7 @@ func (ps *restartingState) Execute(action Action) error {
 	switch action.Action {
 	case v1alpha1.SyncJobAction:
 		return SyncJob(ps.job, ps.restartingUpdateStatus)
-	case v1alpha1.RestartTaskAction, v1alpha1.RestartPodAction:
+	case v1alpha1.RestartTaskAction, v1alpha1.RestartPodAction, v1alpha1.RestartPartitionAction:
 		return KillTarget(ps.job, action.Target, ps.restartingUpdateStatus)
 	default:
 		return KillJob(ps.job, PodRetainPhaseNone, ps.restartingUpdateStatus)

--- a/pkg/controllers/job/state/running.go
+++ b/pkg/controllers/job/state/running.go
@@ -38,7 +38,7 @@ func (ps *runningState) Execute(action Action) error {
 			status.RetryCount++
 			return true
 		})
-	case v1alpha1.RestartTaskAction, v1alpha1.RestartPodAction:
+	case v1alpha1.RestartTaskAction, v1alpha1.RestartPodAction, v1alpha1.RestartPartitionAction:
 		return KillTarget(ps.job, action.Target, func(status *vcbatch.JobStatus) bool {
 			status.State.Phase = vcbatch.Restarting
 			status.RetryCount++

--- a/pkg/webhooks/admission/jobs/validate/util.go
+++ b/pkg/webhooks/admission/jobs/validate/util.go
@@ -44,18 +44,19 @@ var policyEventMap = map[busv1alpha1.Event]bool{
 
 // policyActionMap defines all policy actions and whether to allow external use.
 var policyActionMap = map[busv1alpha1.Action]bool{
-	busv1alpha1.AbortJobAction:     true,
-	busv1alpha1.RestartJobAction:   true,
-	busv1alpha1.RestartTaskAction:  true,
-	busv1alpha1.RestartPodAction:   true,
-	busv1alpha1.TerminateJobAction: true,
-	busv1alpha1.CompleteJobAction:  true,
-	busv1alpha1.ResumeJobAction:    true,
-	busv1alpha1.SyncJobAction:      false,
-	busv1alpha1.EnqueueAction:      false,
-	busv1alpha1.SyncQueueAction:    false,
-	busv1alpha1.OpenQueueAction:    false,
-	busv1alpha1.CloseQueueAction:   false,
+	busv1alpha1.AbortJobAction:         true,
+	busv1alpha1.RestartJobAction:       true,
+	busv1alpha1.RestartTaskAction:      true,
+	busv1alpha1.RestartPodAction:       true,
+	busv1alpha1.RestartPartitionAction: true,
+	busv1alpha1.TerminateJobAction:     true,
+	busv1alpha1.CompleteJobAction:      true,
+	busv1alpha1.ResumeJobAction:        true,
+	busv1alpha1.SyncJobAction:          false,
+	busv1alpha1.EnqueueAction:          false,
+	busv1alpha1.SyncQueueAction:        false,
+	busv1alpha1.OpenQueueAction:        false,
+	busv1alpha1.CloseQueueAction:       false,
 }
 
 func validatePolicies(policies []batchv1alpha1.LifecyclePolicy, fldPath *field.Path) error {


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
Add support for task-level network topology constraints, including deployment file updates and webhooks and controller sections.

#### Which issue(s) this PR fixes:
Fixes #4188

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
Example YAML for vcJob after modification
```yaml
apiVersion: batch.volcano.sh/v1alpha1
kind: Job
metadata:
  name: network-topology-job
spec:
  minAvailable: 6
  schedulerName: volcano
  networkTopology:
    mode: hard
    highestTierAllowed: 2
  tasks:
    - replicas: 6
      name: "task"
      partitionPolicy:
        totalPartitions: 2
        partitionSize: 3
        networkTopology:
            mode: hard
            highestTierAllowed: 1
      template:
        metadata:
          name: task
        spec:
          containers:
            - image: ubuntu
              imagePullPolicy: IfNotPresent
              name: task
              resources:
                requests:
                  cpu: "2"
                  memory: 2Gi
          restartPolicy: OnFailure
```
Example YAML for podGroup after modification
```yaml
apiVersion: scheduling.volcano.sh/v1beta1
kind: PodGroup
metadata:
  name: network-topology-podgroup
spec:
  minMember: 6
  networkTopology:
    mode: hard 
    highestTierAllowed: 2
  subGroupPolicy: 
    - subGroupSize: 3
      name: task
      matchPolicy:
        - labelKey: volcano.sh/task-bunch-id
      networkTopology:
        mode: hard 
        highestTierAllowed: 1
```