### PR TITLE
Automated cherry pick of #4670: fix: ci err caused bt ray e2e default image

### DIFF
--- a/test/e2e/jobseq/common.go
+++ b/test/e2e/jobseq/common.go
@@ -1,0 +1,48 @@
+package jobseq
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	e2eutil "volcano.sh/volcano/test/e2e/util"
+)
+
+func PruneUnusedImagesOnAllNodes(clientset *kubernetes.Clientset) error {
+	nodes, err := clientset.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to list nodes: %v", err)
+	}
+
+	for _, node := range nodes.Items {
+		fmt.Printf("[Prune] Node: %s\n", node.Name)
+
+		ctrCheckCmd := fmt.Sprintf("kubectl debug node/%s --image=%s -- chroot /host sh -c 'test -S /run/containerd/containerd.sock'", node.Name, e2eutil.DefaultBusyBoxImage)
+		if err := exec.Command("bash", "-c", ctrCheckCmd).Run(); err == nil {
+			cmd := fmt.Sprintf("kubectl debug node/%s --image=%s -- chroot /host sh -c 'ctr -n k8s.io images prune -all || true'", node.Name, e2eutil.DefaultBusyBoxImage)
+			out, err := exec.Command("bash", "-c", cmd).CombinedOutput()
+			if err != nil {
+				fmt.Printf("[Warning] Failed to run containerd image prune on node %s: %v. Output: %s\n", node.Name, err, string(out))
+			}
+			fmt.Printf("[CTR Prune Output]\n%s\n", string(out))
+			continue
+		}
+
+		dockerCheckCmd := fmt.Sprintf("kubectl debug node/%s --image=%s -- chroot /host sh -c 'docker version >/dev/null 2>&1'", node.Name, e2eutil.DefaultBusyBoxImage)
+		if err := exec.Command("bash", "-c", dockerCheckCmd).Run(); err == nil {
+			cmd := fmt.Sprintf("kubectl debug node/%s --image=%s -- chroot /host sh -c 'docker image prune -af || true'", node.Name, e2eutil.DefaultBusyBoxImage)
+			out, err := exec.Command("bash", "-c", cmd).CombinedOutput()
+			if err != nil {
+				fmt.Printf("[Warning] Failed to run docker image prune on node %s: %v. Output: %s\n", node.Name, err, string(out))
+			}
+			fmt.Printf("[Docker Prune Output]\n%s\n", string(out))
+			continue
+		}
+
+		fmt.Printf("[Warning] Node %s: No known container runtime detected, skipping prune\n", node.Name)
+	}
+
+	return nil
+}

--- a/test/e2e/jobseq/ray_plugin.go
+++ b/test/e2e/jobseq/ray_plugin.go
@@ -28,6 +28,15 @@ import (
 )
 
 var _ = Describe("Ray Plugin E2E Test", func() {
+	BeforeEach(func() {
+		By("Prune images before test")
+		PruneUnusedImagesOnAllNodes(e2eutil.KubeClient)
+	})
+	AfterEach(func() {
+		By("Prune images after test")
+		PruneUnusedImagesOnAllNodes(e2eutil.KubeClient)
+	})
+
 	It("Will Start in pending state and  get running phase", func() {
 		ctx := e2eutil.InitTestContext(e2eutil.Options{})
 		defer e2eutil.CleanupTestContext(ctx)

--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -83,7 +83,7 @@ const (
 	DefaultTFImage      = "volcanosh/dist-mnist-tf-example:0.0.1"
 	// "volcanosh/pytorch-mnist-v1beta1-9ee8fda-example:0.0.1" is from "docker.io/kubeflowkatib/pytorch-mnist:v1beta1-9ee8fda"
 	DefaultPytorchImage = "volcanosh/pytorch-mnist-v1beta1-9ee8fda-example:0.0.1"
-	DefaultRayImage     = "bitnami/ray:2.49.0"
+	DefaultRayImage     = "rayproject/ray:2.49.0"
 	LogTimeFormat       = "[ 2006/01/02 15:04:05.000 ]"
 )
 


### PR DESCRIPTION
Cherry pick of #4670 on release-1.13.

#4670: fix: ci err caused bt ray e2e default image
For details on the cherry pick process, see the [cherry picks](https://github.com/volcano-sh/volcano/tree/master/docs/development/cherry-picks.md) page.
```release-note

```