### PR TITLE
chore: refactor ray plugin e2e test

### DIFF
--- a/test/e2e/jobseq/common.go
+++ b/test/e2e/jobseq/common.go
@@ -7,6 +7,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
+	e2eutil "volcano.sh/volcano/test/e2e/util"
 )
 
 func PruneUnusedImagesOnAllNodes(clientset *kubernetes.Clientset) error {
@@ -18,18 +19,24 @@ func PruneUnusedImagesOnAllNodes(clientset *kubernetes.Clientset) error {
 	for _, node := range nodes.Items {
 		fmt.Printf("[Prune] Node: %s\n", node.Name)
 
-		ctrCheckCmd := fmt.Sprintf("kubectl debug node/%s --image=busybox -- chroot /host sh -c 'test -S /run/containerd/containerd.sock'", node.Name)
+		ctrCheckCmd := fmt.Sprintf("kubectl debug node/%s --image=%s -- chroot /host sh -c 'test -S /run/containerd/containerd.sock'", node.Name, e2eutil.DefaultBusyBoxImage)
 		if err := exec.Command("bash", "-c", ctrCheckCmd).Run(); err == nil {
-			cmd := fmt.Sprintf("kubectl debug node/%s --image=busybox -- chroot /host sh -c 'ctr -n k8s.io images prune -all || true'", node.Name)
-			out, _ := exec.Command("bash", "-c", cmd).CombinedOutput()
+			cmd := fmt.Sprintf("kubectl debug node/%s --image=%s -- chroot /host sh -c 'ctr -n k8s.io images prune -all || true'", node.Name, e2eutil.DefaultBusyBoxImage)
+			out, err := exec.Command("bash", "-c", cmd).CombinedOutput()
+			if err != nil {
+				fmt.Printf("[Warning] Failed to run containerd image prune on node %s: %v. Output: %s\n", node.Name, err, string(out))
+			}
 			fmt.Printf("[CTR Prune Output]\n%s\n", string(out))
 			continue
 		}
 
-		dockerCheckCmd := fmt.Sprintf("kubectl debug node/%s --image=busybox -- chroot /host sh -c 'docker version >/dev/null 2>&1'", node.Name)
+		dockerCheckCmd := fmt.Sprintf("kubectl debug node/%s --image=%s -- chroot /host sh -c 'docker version >/dev/null 2>&1'", node.Name, e2eutil.DefaultBusyBoxImage)
 		if err := exec.Command("bash", "-c", dockerCheckCmd).Run(); err == nil {
-			cmd := fmt.Sprintf("kubectl debug node/%s --image=busybox -- chroot /host sh -c 'docker image prune -af || true'", node.Name)
-			out, _ := exec.Command("bash", "-c", cmd).CombinedOutput()
+			cmd := fmt.Sprintf("kubectl debug node/%s --image=%s -- chroot /host sh -c 'docker image prune -af || true'", node.Name, e2eutil.DefaultBusyBoxImage)
+			out, err := exec.Command("bash", "-c", cmd).CombinedOutput()
+			if err != nil {
+				fmt.Printf("[Warning] Failed to run docker image prune on node %s: %v. Output: %s\n", node.Name, err, string(out))
+			}
 			fmt.Printf("[Docker Prune Output]\n%s\n", string(out))
 			continue
 		}

--- a/test/e2e/jobseq/ray_plugin.go
+++ b/test/e2e/jobseq/ray_plugin.go
@@ -30,17 +30,11 @@ import (
 var _ = Describe("Ray Plugin E2E Test", func() {
 	BeforeEach(func() {
 		By("Prune images before test")
-
-		ctx := e2eutil.InitTestContext(e2eutil.Options{})
-		client := ctx.Kubeclient
-		PruneUnusedImagesOnAllNodes(client)
+		PruneUnusedImagesOnAllNodes(e2eutil.KubeClient)
 	})
 	AfterEach(func() {
 		By("Prune images after test")
-
-		ctx := e2eutil.InitTestContext(e2eutil.Options{})
-		client := ctx.Kubeclient
-		PruneUnusedImagesOnAllNodes(client)
+		PruneUnusedImagesOnAllNodes(e2eutil.KubeClient)
 	})
 
 	It("Will Start in pending state and  get running phase", func() {


### PR DESCRIPTION
#### What type of PR is this?
This PR is a chore commit to refactor `test/e2e/jobseq/ray_plugin.go`.

#### What this PR does / why we need it:
This PR is originated from #4681.
- Remove unnecessary test context initialization in both `BeforeEach` and `AfterEach`  of `test/e2e/jobseq/ray_plugin.go`
- Replace hardcoded busy-box image names by a `e2eutil.DefaultBusyBoxImage` and Add if-statement to handle error when pruning docker images. 


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Notice that do not add `Fixes` if the issue is associated with multiple PRs.
-->
Fixes #4669 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```