### PR TITLE
[Cherry-pick 1.13] fix: Initialize realCapability field in newQueueAttr

### DIFF
--- a/pkg/scheduler/plugins/capacity/capacity.go
+++ b/pkg/scheduler/plugins/capacity/capacity.go
@@ -702,13 +702,14 @@ func (cp *capacityPlugin) newQueueAttr(queue *api.QueueInfo) *queueAttr {
 		ancestors: make([]api.QueueID, 0),
 		children:  make(map[api.QueueID]*queueAttr),
 
-		deserved:   api.NewResource(queue.Queue.Spec.Deserved),
-		allocated:  api.EmptyResource(),
-		request:    api.EmptyResource(),
-		elastic:    api.EmptyResource(),
-		inqueue:    api.EmptyResource(),
-		guarantee:  api.EmptyResource(),
-		capability: api.EmptyResource(),
+		deserved:       api.NewResource(queue.Queue.Spec.Deserved),
+		allocated:      api.EmptyResource(),
+		request:        api.EmptyResource(),
+		elastic:        api.EmptyResource(),
+		inqueue:        api.EmptyResource(),
+		guarantee:      api.EmptyResource(),
+		capability:     api.EmptyResource(),
+		realCapability: api.EmptyResource(),
 	}
 	if len(queue.Queue.Spec.Capability) != 0 {
 		attr.capability = api.NewResource(queue.Queue.Spec.Capability)


### PR DESCRIPTION
#### What type of PR is this?
/bug

#### What this PR does / why we need it:
This PR initializes the  `realCapability` fields in the `newQueueAttr` function.  
Without this initialization, these fields could remain `nil`, leading to runtime panics (e.g., nil pointer dereference in `queueAttr.Clone()` when the `capacity` plugin handles queue resources).

#### Which issue(s) this PR fixes:
Fixes #<issue number>

#### Special notes for your reviewer:
- The bug is triggered when hierarchical queues have inconsistent resource specifications between parent and child queues.  
- The uninitialized fields caused `queueAttr.Clone()` to dereference a `nil` `Resource`.  
- This PR ensures safe initialization to avoid such panics.

#### Does this PR introduce a user-facing change?
```release-note
Fix a panic in the capacity plugin caused by uninitialized realCapability` fields in `newQueueAttr`.
