### PR TITLE
Fix: Prevent queue parent self-reference causing scheduler crash

### DIFF
--- a/pkg/webhooks/admission/queues/validate/validate_queue.go
+++ b/pkg/webhooks/admission/queues/validate/validate_queue.go
@@ -273,6 +273,12 @@ func validateHierarchicalQueue(queue *schedulingv1beta1.Queue) error {
 	if queue.Spec.Parent == "" || queue.Spec.Parent == "root" {
 		return nil
 	}
+
+	// Prevent a queue from using its own name as the parent
+	if queue.Spec.Parent == queue.Name {
+		return fmt.Errorf("queue %s cannot use itself as parent", queue.Name)
+	}
+
 	parentQueue, err := config.QueueLister.Get(queue.Spec.Parent)
 	if err != nil {
 		return fmt.Errorf("failed to get parent queue of queue %s: %v", queue.Name, err)


### PR DESCRIPTION
# Fix: Prevent queue parent self-reference causing scheduler crash

Fix infinite recursion when a queue uses itself as parent, which causes stack overflow and scheduler crash during startup.

## Changes:
- Add webhook validation to reject self-referencing queue configurations
- Add cycle detection in capacity plugin's updateAncestors() function
- Add test case for self-referencing queue validation

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Fixes scheduler crash when `queue.spec.parent` references the queue's own name. Adds validation at admission time and cycle detection in scheduler as backup protection.

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

Two-layer defense: webhook validation (primary) + scheduler cycle detection (backup).
Pattern follows existing implementation in nodegroup plugin.

#### Does this PR introduce a user-facing change?

```release-note
Fix scheduler crash caused by queue self-referencing parent configuration.
