### PR TITLE
fix: vgpu memory allocate wrong when use volcano.sh/vgpu-memory-percentage

### DIFF
--- a/pkg/scheduler/api/devices/nvidia/vgpu/utils.go
+++ b/pkg/scheduler/api/devices/nvidia/vgpu/utils.go
@@ -387,7 +387,7 @@ func checkNodeGPUSharingPredicateAndScore(pod *v1.Pod, gssnap *GPUDevices, repli
 				continue
 			}
 			if val.MemPercentagereq != 101 && val.Memreq == 0 {
-				val.Memreq = gs.Device[i].Memory * uint(val.MemPercentagereq/100)
+				val.Memreq = gs.Device[i].Memory * uint(val.MemPercentagereq) / 100
 			}
 			if int(gs.Device[i].Memory)-int(gs.Device[i].UsedMem) < int(val.Memreq) {
 				continue


### PR DESCRIPTION

#### What type of PR is this?
/kind bug
#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Notice that do not add `Fixes` if the issue is associated with multiple PRs.
-->
Fixes #
when use volcano.sh/vgpu-memory-percentage, vgpu-memory always is 0

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```