### PR TITLE
Upload ci logs when ci is unsuccessful, include cancel

### DIFF
--- a/.github/workflows/e2e_cronjob.yaml
+++ b/.github/workflows/e2e_cronjob.yaml
@@ -46,7 +46,7 @@ jobs:
           make e2e-test-cronjob CC=/usr/local/musl/bin/musl-gcc
 
       - name: Upload e2e cronjob logs
-        if: failure()
+        if: '!success()'
         uses: actions/upload-artifact@v4
         with:
           name: volcano_e2e_cronjob_logs

--- a/.github/workflows/e2e_dra.yml
+++ b/.github/workflows/e2e_dra.yml
@@ -42,7 +42,7 @@ jobs:
           make e2e-test-dra CC=/usr/local/musl/bin/musl-gcc
 
       - name: Upload e2e dra logs
-        if: failure()
+        if: '!success()'
         uses: actions/upload-artifact@v4
         with:
           name: volcano_e2e_dra_logs

--- a/.github/workflows/e2e_hypernode.yaml
+++ b/.github/workflows/e2e_hypernode.yaml
@@ -44,7 +44,7 @@ jobs:
           make e2e-test-hypernode CC=/usr/local/musl/bin/musl-gcc
 
       - name: Upload e2e hypernode logs
-        if: failure()
+        if: '!success()'
         uses: actions/upload-artifact@v4
         with:
           name: volcano_e2e_hypernode_logs

--- a/.github/workflows/e2e_parallel_jobs.yaml
+++ b/.github/workflows/e2e_parallel_jobs.yaml
@@ -46,7 +46,7 @@ jobs:
           make e2e-test-jobp CC=/usr/local/musl/bin/musl-gcc
 
       - name: Upload e2e parallel jobs logs
-        if: failure()
+        if: '!success()'
         uses: actions/upload-artifact@v4
         with:
           name: volcano_e2e_parallel_jobs_logs

--- a/.github/workflows/e2e_scheduling_actions.yaml
+++ b/.github/workflows/e2e_scheduling_actions.yaml
@@ -42,7 +42,7 @@ jobs:
           make e2e-test-schedulingaction CC=/usr/local/musl/bin/musl-gcc
 
       - name: Upload e2e scheduling actions logs
-        if: failure()
+        if: '!success()'
         uses: actions/upload-artifact@v4
         with:
           name: volcano_e2e_scheduling_actions_logs

--- a/.github/workflows/e2e_scheduling_basic.yaml
+++ b/.github/workflows/e2e_scheduling_basic.yaml
@@ -42,7 +42,7 @@ jobs:
           make e2e-test-schedulingbase CC=/usr/local/musl/bin/musl-gcc
 
       - name: Upload e2e scheduling basic logs
-        if: failure()
+        if: '!success()'
         uses: actions/upload-artifact@v4
         with:
           name: volcano_e2e_scheduling_basic_logs

--- a/.github/workflows/e2e_sequence.yaml
+++ b/.github/workflows/e2e_sequence.yaml
@@ -42,7 +42,7 @@ jobs:
           make e2e-test-jobseq CC=/usr/local/musl/bin/musl-gcc
 
       - name: Upload e2e sequence logs
-        if: failure()
+        if: '!success()'
         uses: actions/upload-artifact@v4
         with:
           name: volcano_e2e_sequence_logs

--- a/.github/workflows/e2e_spark.yaml
+++ b/.github/workflows/e2e_spark.yaml
@@ -105,7 +105,7 @@ jobs:
         build/sbt -Pvolcano -Pkubernetes -Pkubernetes-integration-tests -Dspark.kubernetes.test.driverRequestCores=0.5 -Dspark.kubernetes.test.executorRequestCores=0.2 -Dspark.kubernetes.test.volcanoMaxConcurrencyJobNum=1 -Dtest.include.tags=volcano "kubernetes-integration-tests/test"
       working-directory: ${{ github.workspace }}/spark
     - name: Collect Volcano logs
-      if: failure()
+      if: '!success()'
       run: |
         kubectl logs $(kubectl get po -nvolcano-system | grep volcano-scheduler |cut -d" " -f1) -nvolcano-system > volcano-scheduler.log
         kubectl logs $(kubectl get po -nvolcano-system | grep volcano-admission |cut -d" " -f1 | grep -v init) -nvolcano-system > volcano-admission.log
@@ -113,7 +113,7 @@ jobs:
         kubectl get pod -A
         kubectl describe node
     - name: Upload Spark on K8S integration tests log files
-      if: failure()
+      if: '!success()'
       uses: actions/upload-artifact@v4
       with:
         name: spark-on-kubernetes-it-log

--- a/.github/workflows/e2e_vcctl.yaml
+++ b/.github/workflows/e2e_vcctl.yaml
@@ -42,7 +42,7 @@ jobs:
           make e2e-test-vcctl CC=/usr/local/musl/bin/musl-gcc
 
       - name: Upload e2e vcctl logs
-        if: failure()
+        if: '!success()'
         uses: actions/upload-artifact@v4
         with:
           name: volcano_e2e_vcctl_logs


### PR DESCRIPTION
#### What type of PR is this?
/kind failing-test

#### What this PR does / why we need it:
Sometimes, the CI will be canceled if timeout, but we can't download the component's log from the CI, therefore it's hard for us to debug, currently we only update logs when the CI failed. But sometimes if the component met some errors, it also will block the CIs to execute, therefore we need to also upload logs when CI canceled:
<img width="1343" height="807" alt="image" src="https://github.com/user-attachments/assets/d5270b8a-de26-41e8-8e4b-9dc7680ff76d" />


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Notice that do not add `Fixes` if the issue is associated with multiple PRs.
-->
NONE

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```