### PR TITLE
Fix: Add a mount of the node memory metrics for Volcano Agent

### DIFF
--- a/installer/helm/chart/volcano/templates/agent.yaml
+++ b/installer/helm/chart/volcano/templates/agent.yaml
@@ -85,6 +85,10 @@ spec:
           hostPath:
             path: /proc/stat
             type: File
+        - name: proc-meminfo
+          hostPath:
+            path: /proc/meminfo
+            type: File
       initContainers:
         - name: volcano-agent-init
           image: {{ .Values.basic.image_registry }}/{{.Values.basic.agent_image_name}}:{{.Values.basic.image_tag_version}}
@@ -183,6 +187,13 @@ spec:
             - name: proc-stat
               readOnly: true
               mountPath: /host/proc/stat
+            - name: proc-meminfo
+              readOnly: true
+              mountPath: /host/proc/meminfo
+          ports:
+            - name: metrics
+              containerPort: 3300
+              protocol: TCP
           livenessProbe:
             httpGet:
               path: /healthz

--- a/installer/volcano-agent-development.yaml
+++ b/installer/volcano-agent-development.yaml
@@ -126,6 +126,10 @@ spec:
           hostPath:
             path: /proc/stat
             type: File
+        - name: proc-meminfo
+          hostPath:
+            path: /proc/meminfo
+            type: File
       initContainers:
         - name: volcano-agent-init
           image: docker.io/volcanosh/vc-agent:latest
@@ -221,6 +225,13 @@ spec:
             - name: proc-stat
               readOnly: true
               mountPath: /host/proc/stat
+            - name: proc-meminfo
+              readOnly: true
+              mountPath: /host/proc/meminfo
+          ports:
+            - name: metrics
+              containerPort: 3300
+              protocol: TCP
           livenessProbe:
             httpGet:
               path: /healthz


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:

The Volcano Agent code includes a default path, intended for reading the node's memory metrics.

> https://github.com/volcano-sh/volcano/blob/v1.13.0/pkg/metriccollect/local/memory.go#L42

```go
const (
	defaultMemInfoPath = "/host/proc/meminfo"
	memInfoPathEnv     = "MEM_INFO_PATH_ENV"
)
```

However, the deployment manifests (both the Helm chart and the development YAML) were missing the configuration to mount the host's `/proc/meminfo` file into the agent's container.

This PR fixes this issue by adding the required `hostPath` volume and `volumeMount` to the Volcano Agent's pod specification. This ensures that the agent can access the node's memory information at the expected path and collect metrics correctly.

#### Special notes for your reviewer:
None

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```