### PR TITLE
introduce new plugin `capacity-card` to provide fine-grained GPU, NPU and other accelerator card resource management and scheduling capabilities in heterogeneous computing clusters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -162,6 +162,9 @@ e2e-test-admission-webhook: images
 e2e-test-admission-policy: images
 	E2E_TYPE=ADMISSION_POLICY ./hack/run-e2e-kind.sh
 
+e2e-test-capacitycard: images
+	E2E_TYPE=CAPACITYCARD ./hack/run-e2e-kind.sh
+
 generate-yaml: init manifests
 	./hack/generate-yaml.sh CRD_VERSION=${CRD_VERSION}
 

--- a/docs/design/capacity-card.md
+++ b/docs/design/capacity-card.md
@@ -1,0 +1,865 @@
+# Capacity Card Scheduling Plugin
+
+## Introduction
+
+The Capacity Card plugin is a Volcano scheduler plugin designed to provide fine-grained management and scheduling capabilities for GPU/NPU/DCU and other accelerator card resources in heterogeneous computing clusters. It extends Volcano's capacity scheduling capabilities to support various types of accelerator cards, including whole cards, MPS (Multi-Process Service) shared cards, MIG (Multi-Instance GPU) cards, and other shared card technologies.
+
+As AI and HPC workloads increasingly rely on diverse GPU hardware (A100, H100, H200, V100, etc.), users need precise control over card resource allocation at the queue level, while supporting flexible multi-card selection strategies for jobs.
+
+## Motivation
+
+Current schedulers face several limitations when handling heterogeneous GPU clusters:
+
+1. **Lack of fine-grained card type quota management**: Standard GPU resource requests cannot differentiate between different card types. For example, card models like `NVIDIA-H200` and `NVIDIA-A800` all use the resource name `nvidia.com/gpu`. Current queue quotas only support card resource names and cannot implement card type configuration.
+
+2. **Lack of support for single-instance multi-card requirements**: Due to scarce GPU resources, to maximize utilization of existing GPU resources, online and offline instances (Pods) need to support single-instance multi-card model deployment. For example, when deploying a single instance, it needs to support simultaneous use of GPU models like `NVIDIA GPU 4090, 4090D, 5090`, deploying whichever GPU type has available resources.
+
+3. **CPU/memory coupled with GPU resources**: For GPU servers, GPU is the bottleneck, so there's no need to limit CPU/memory. CPU/memory quotas should only apply to non-GPU servers.
+
+## User Stories
+
+### Story 1: Heterogeneous GPU Cluster Management
+
+As a cluster administrator, I want to manage a cluster with multiple GPU types (A100, H100, V100) and allocate specific card quotas to different teams through queues.
+
+For example:
+- Team A (queue-a): 10 A100 cards, 5 H100 cards
+- Team B (queue-b): 20 V100 cards, 3 A100 cards
+
+### Story 2: Job Flexibility with Multi-Card Selection
+
+As a data scientist, I want to submit a training job that can run on either H100 or A100 GPUs, with preference for H100.
+
+### Story 3: CPU/Memory Decoupled from GPU Resources
+
+As a resource administrator, I want to ensure GPU tasks only consume GPU quotas, not CPU/memory quotas, thereby reducing configuration complexity.
+
+## Core Goals
+
+1. Implement fine-grained card type quota management
+
+2. Support single-instance multi-card requirements
+
+3. Decouple CPU/memory from GPU resource quotas
+
+## Design Details
+
+### Architecture Overview
+
+How the Capacity Card plugin works:
+1. Discover card resources from node labels and status
+2. Parse card quotas from queue annotations
+3. Validate job card requests against queue card quotas
+4. Track card resource allocation across jobs and tasks
+5. Enforce allocation limits during scheduling
+
+### Key Concepts
+
+#### Card Resources vs. K8S Resources
+
+- **K8S Resource Name**: The actual resource name in node status and Pod requests (e.g., `nvidia.com/gpu`, `nvidia.com/gpu.shared`, `nvidia.com/mig-1g.18gb`)
+- **Card Type Name**: User-friendly, canonical name for card types (e.g., `NVIDIA-A100`, `NVIDIA-H800/mps-80*1/2`, `NVIDIA-H200/mig-1g.18gb-mixed`)
+
+|K8S Resource Name|Card Type Name|Note|
+|---|---|---|
+|`nvidia.com/gpu`|`NVIDIA-A100`|Whole card|
+|`nvidia.com/gpu.shared`|`NVIDIA-H800/mps-80*1/2`|MPS sub-card|
+|`nvidia.com/mig-1g.18gb`|`NVIDIA-H200/mig-1g.18gb-mixed`|MIG sub-card|
+
+The plugin maintains mappings between card names and K8s resource names for scheduling decisions.
+
+#### Multi-Card Requests
+
+Tasks can specify multiple acceptable card types, separated by `|`, with priority decreasing from left to right:
+```
+NVIDIA-A100|NVIDIA-H100
+```
+
+### API Design
+
+#### Queue Annotations for Card Quotas
+
+Queues use the annotation `volcano.sh/card.quota` to specify card resource quotas:
+
+```yaml
+apiVersion: scheduling.volcano.sh/v1beta1
+kind: Queue
+metadata:
+  name: queue-a
+  annotations:
+    volcano.sh/card.quota: |
+      {
+        "NVIDIA-A100": 10,
+        "NVIDIA-H100": 5,
+        "NVIDIA-A100/mps-80g*1/8": 16
+      }
+spec:
+  capability:
+    cpu: "100"
+    memory: "200Gi"
+```
+
+**Card Type Quotas**: Set quotas for each card type via JSON object in the `volcano.sh/card.quota` annotation. Card types without quotas default to 0, and must have a quota to use that card type.
+
+Using annotations rather than configuring in `capability`, `deserved`, or `guarantee` avoids compatibility issues and only takes effect for the Capacity Card plugin.
+
+Additionally, there's no need to set K8S resource names like `nvidia.com/gpu` in `capability`, `deserved`, or `guarantee`. The Capacity Card plugin automatically maps card type names to K8S resource names, simplifying management complexity.
+
+**CPU/Memory Quotas**: CPU/memory quotas are set in `capability`. If not set, the default quota is also 0. No need to configure `guarantee` as lower-level queues don't reserve resources; upper-level business systems control `capability` during allocation to implement resource reservation. `deserved` also doesn't need configuration as resource reclamation is not currently supported.
+
+**Other Resources**: Resources other than CPU/memory/card types are not limited and don't need configuration.
+
+#### Job Annotations for Card Requests
+
+`volcano.sh/card.name`: Located in `Pod` annotations, specifies the card model name used by specific instances in the task. The scheduler uses the card model from this annotation combined with queue quotas for quota management.
+
+```yaml
+metadata:
+  annotations:
+    volcano.sh/card.name: "NVIDIA-A100"
+```
+
+`volcano.sh/card.request` (optional): Located in `PodGroup` annotations, specifies the total requested card model resource quantity for the current task. Used for resource checking to prevent tasks from entering `Inqueue` state, avoiding the scheduler creating too many `Pending` `Pods`.
+
+If `Pods` have already been created, `volcano.sh/card.request` will not take effect, deferring to the actual resources requested by `Pods`, such as `Deployment` type workloads, which directly generate `Pods` after creation without queuing.
+
+```yaml
+metadata:
+  annotations:
+    volcano.sh/card.request: |
+      {
+        "NVIDIA-A100": 8
+      }
+```
+
+##### Job Resource Card Requests
+
+K8S resource types must still be configured in `resources`. The Capacity Card plugin cannot inject K8S resource type requests into `Pods`. K8S resource types need to correspond to the card model requested by the task.
+
+```yaml
+resources:
+  limits:
+    nvidia.com/gpu: 1
+  requests:
+    nvidia.com/gpu: 1
+```
+
+##### Node Selection
+
+Node selection is implemented through affinity. The Capacity Card plugin does not perform node filtering.
+
+```yaml
+spec:
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoreDuringExecution:
+        nodeSelectorTerms:
+        - matchExpressions:
+          - key: nvidia.com/gpu.product
+            operation: In
+            values:
+            - NVIDIA-A100
+```
+
+##### Volcano Job Example
+
+`volcano.sh/card.request` and `volcano.sh/card.name` are new annotations, other fields remain unchanged.
+
+```yaml
+apiVersion: batch.volcano.sh/v1alpha1
+kind: Job
+metadata:
+  name: training-job
+  annotations:
+    volcano.sh/card.request: |
+      {
+        "NVIDIA-A100": 8
+      }
+spec:
+  schedulerName: volcano
+  queue: queue-a
+  minAvailable: 1
+  tasks:
+    - replicas: 8
+      name: worker
+      template:
+        metadata:
+          annotations:
+            volcano.sh/card.name: "NVIDIA-A100"
+        spec:
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoreDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: nvidia.com/gpu.product
+                    operation: In
+                    values:
+                    - NVIDIA-A100
+          containers:
+            - name: trainer
+              image: training:latest
+              resources:
+                limits:
+                  nvidia.com/gpu: 1
+                requests:
+                  nvidia.com/gpu: 1
+```
+
+##### Deployment Example
+
+`volcano.sh/card.name` is a new annotation, other fields remain unchanged.
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: inference-deployment
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: inference
+  template:
+    metadata:
+      labels:
+        app: inference
+      annotations:
+        volcano.sh/card.name: "NVIDIA-A100"
+        scheduling.volcano.sh/queue-name: "cr-queue1"
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoreDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: nvidia.com/gpu.product
+                operation: In
+                values:
+                - NVIDIA-A100
+      containers:
+        - name: inference
+          image: inference:latest
+          resources:
+            limits:
+              nvidia.com/gpu: 1
+            requests:
+              nvidia.com/gpu: 1
+      schedulerName: volcano
+```
+
+##### Single-Instance Multi-Card Request Example
+
+To use single-instance multi-card deployment, simply set the `volcano.sh/card.request` and `volcano.sh/card.name` annotations to multi-card configuration, such as `NVIDIA-A100|NVIDIA-H100`, to use either `NVIDIA-A100` or `NVIDIA-H100`.
+
+Note that multiple card types must correspond to the same K8S resource type, and must match the K8S resource type configured in the task's `resources`. Combining card resources with different K8S resource types is not supported. If K8S resource types differ, the K8S resource type in `resources` must match the finally selected card type, but `resources` are determined when the task is created and cannot be dynamically modified during scheduling. For example:
+
+- Whole GPU and Shared card combination: `NVIDIA-A100|NVIDIA-H800/mps-80*1/2`, with K8S resources `nvidia.com/gpu` and `nvidia.com/gpu.shared` respectively
+- Different GPU Shared card combination: `NVIDIA-H200/mig-1g.18gb-mixed|NVIDIA-H200/mig-2g.36gb-mixed`, with K8S resources `nvidia.com/mig-1g.18gb` and `nvidia.com/mig-2g.36gb` respectively
+- Different card type combination: `NVIDIA-A100|Ascend-910B`, with K8S resources `nvidia.com/gpu` and `huawei.com/ascend-910` respectively
+
+Volcano Job Example
+
+```yaml
+apiVersion: batch.volcano.sh/v1alpha1
+kind: Job
+metadata:
+  name: training-job
+  annotations:
+    volcano.sh/card.request: |
+      {
+        "NVIDIA-A100|NVIDIA-H100": 8
+      }
+spec:
+  schedulerName: volcano
+  queue: queue-a
+  minAvailable: 1
+  tasks:
+    - replicas: 8
+      name: worker
+      template:
+        metadata:
+          annotations:
+            volcano.sh/card.name: "NVIDIA-A100|NVIDIA-H100"
+        spec:
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoreDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: nvidia.com/gpu.product
+                    operation: In
+                    values:
+                    - NVIDIA-A100
+                    - NVIDIA-H100
+          containers:
+            - name: trainer
+              image: training:latest
+              resources:
+                limits:
+                  nvidia.com/gpu: 1
+                requests:
+                  nvidia.com/gpu: 1
+```
+
+Deployment Example
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: inference-deployment
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: inference
+  template:
+    metadata:
+      labels:
+        app: inference
+      annotations:
+        volcano.sh/card.name: "NVIDIA-A100|NVIDIA-H100"
+        scheduling.volcano.sh/queue-name: "cr-queue1"
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoreDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: nvidia.com/gpu.product
+                operation: In
+                values:
+                - NVIDIA-A100
+                - NVIDIA-H100
+      containers:
+        - name: inference
+          image: inference:latest
+          resources:
+            limits:
+              nvidia.com/gpu: 1
+            requests:
+              nvidia.com/gpu: 1
+      schedulerName: volcano
+```
+
+### Plugin Configuration
+
+The plugin supports configuration through scheduler configuration:
+
+```yaml
+actions: "enqueue, allocate, backfill"
+tiers:
+  - plugins:
+      - name: capacity-card
+        arguments:
+          cardUnlimitedCpuMemory: true  # Optional: if true, card resources don't need CPU/memory quotas
+          nodeOrderWeight: 1.0 # Optional, node ordering weight coefficient
+```
+
+**Configuration Options**:
+- `cardUnlimitedCpuMemory` (bool, default: false): If set to true, tasks requesting card resources won't be checked against the queue's CPU/memory quota limits. Useful when card resources are the primary constraint.
+- `nodeOrderWeight` (float64, default: 1.0): Node ordering weight coefficient, used to adjust the importance of card type priority in scheduling decisions. Must be positive. Larger values increase the impact of card type priority.
+
+### Node Card Discovery
+
+The plugin automatically discovers card resources from node labels and status. The system identifies card types by matching node labels with regex patterns in the format: `<prefix>/<type>.product` (e.g., `nvidia.com/gpu.product`).
+
+#### Node Label and Resource Examples
+
+```yaml
+apiVersion: v1
+kind: Node
+metadata:
+  labels:
+    # Basic card information (required)
+    nvidia.com/gpu.product: "NVIDIA-A100"     # Card product name
+    nvidia.com/gpu.count: "8"                 # Physical card count
+    nvidia.com/gpu.memory: "81920"            # Memory per card (MB)
+    
+    # MPS-specific labels (optional)
+    nvidia.com/gpu.replicas: "8"              # MPS shared replica count
+    
+    # MIG-specific labels (optional)
+    nvidia.com/mig-1g.5gb.count: "7"          # MIG profile instance count
+status:
+  allocatable:
+    nvidia.com/gpu: "8"                       # Whole card resource count
+    nvidia.com/gpu.shared: "64"               # MPS shared resource count (replicas * count)
+    nvidia.com/mig-1g.5gb: "7"                # MIG partition resource count
+```
+
+#### Card Type Name and Quantity Generation Rules
+
+The plugin automatically generates card type names based on node labels and allocatable resources, used for internal scheduler resource management and quota checking.
+
+##### 1. MPS Shared Cards (Multi-Process Service)
+
+**Card Name Generation**:
+- **Format**: `<card-product>/mps-<memory>g*1/<replicas>`
+- **Components**:
+  - `<card-product>`: Retrieved from `<prefix>/<type>.product` label (e.g., `NVIDIA-A100`)
+  - `<memory>`: Retrieved from `<prefix>/<type>.memory` label, converted from MB to GB (rounded)
+  - `<replicas>`: Retrieved from `<prefix>/<type>.replicas` label
+
+**Card Quantity Retrieval**:
+- Read MPS resource count from `status.allocatable`
+- **Resource name**: Fixed as `nvidia.com/gpu.shared` (plugin internal constant `MPSResourceName`)
+
+**Complete Example**:
+```yaml
+metadata:
+  labels:
+    nvidia.com/gpu.product: "NVIDIA-A100"
+    nvidia.com/gpu.count: "8"
+    nvidia.com/gpu.memory: "81920"        # 81920 MB ≈ 80 GB
+    nvidia.com/gpu.replicas: "8"
+status:
+  allocatable:
+    nvidia.com/gpu.shared: "64"           # 8 cards × 8 replicas = 64
+```
+- **Generated card type name**: `NVIDIA-A100/mps-80g*1/8`
+- **Card quantity**: `64` (represents a total of 64 MPS instances)
+
+##### 2. MIG Partition Cards (Multi-Instance GPU)
+
+**Card Name Generation**:
+- **Format**: `<card-product>/mig-<profile>-mixed`
+- **Components**:
+  - `<card-product>`: Retrieved from `<prefix>/<type>.product` label (e.g., `NVIDIA-A100`)
+  - `<profile>`: Extracted from resource name, the part after removing `nvidia.com/mig-` prefix
+
+**Card Quantity Retrieval**:
+- Read corresponding MIG resource count from `status.allocatable`
+- **Matching rule**: All resources with names starting with `nvidia.com/mig-`
+
+**Complete Example**:
+```yaml
+metadata:
+  labels:
+    nvidia.com/gpu.product: "NVIDIA-A100"
+    nvidia.com/gpu.count: "8"
+    nvidia.com/gpu.memory: "81920"
+    nvidia.com/mig-1g.5gb.count: "7"
+    nvidia.com/mig-2g.10gb.count: "4"
+status:
+  allocatable:
+    nvidia.com/mig-1g.5gb: "7"
+    nvidia.com/mig-2g.10gb: "4"
+```
+- **Generated card type names**:
+  - `NVIDIA-A100/mig-1g.5gb-mixed` (quantity: 7)
+  - `NVIDIA-A100/mig-2g.10gb-mixed` (quantity: 4)
+
+##### 3. Whole Cards (Whole GPU)
+
+**Card Name Generation**:
+- Directly uses the value of `<prefix>/<type>.product` label as the card name
+- **Matching rule**: Finds labels matching `^((.+?)/(\w+))\.product$`
+  - Example: `nvidia.com/gpu.product: "NVIDIA-A100"` → Card name is `NVIDIA-A100`
+
+**Card Quantity Retrieval**:
+- Read corresponding resource count from `status.allocatable`
+- **Matching rule**: Resources with names starting with the extracted resource prefix (`<prefix>`)
+  - Example: `nvidia.com/gpu: "8"` → Card quantity is 8
+
+**Complete Example**:
+```yaml
+metadata:
+  labels:
+    nvidia.com/gpu.product: "NVIDIA-A100"
+    nvidia.com/gpu.count: "8"
+    nvidia.com/gpu.memory: "81920"
+status:
+  allocatable:
+    nvidia.com/gpu: "8"
+```
+- **Generated card type name**: `NVIDIA-A100`
+- **Card quantity**: `8`
+
+#### Card Type Discovery Flow
+
+1. **Label Parsing**: Iterate through node labels, find labels matching the `<prefix>/<type>.product` pattern
+2. **Extract Basic Information**: Extract `product`, `count`, `memory`, etc. from labels
+3. **Resource Scanning**: Iterate through all resources in `status.allocatable`
+4. **Type Determination and Mapping**:
+   - If resource name is `nvidia.com/gpu.shared`, generate MPS card type
+   - If resource name starts with `nvidia.com/mig-`, generate corresponding MIG card type
+   - If resource name starts with the extracted prefix, generate whole card type
+5. **Establish Mapping**: Maintain `Card Type Name → Kubernetes Resource Name` mapping for scheduling decisions
+
+### Main Workflows
+
+#### Plugin Initialization (OnSessionOpen)
+
+1. **Build Total Resources**:
+   - List all nodes from informer
+   - Extract card information from node labels
+   - Parse card resources from node status
+   - Build mapping: card name → K8s resource name
+   - Calculate cluster total resources (CPU, memory, cards)
+
+2. **Build Queue Attributes**:
+   - Parse card quotas from queue annotations (`volcano.sh/card.quota`)
+   - Calculate queue capability, guarantee, and deserved resources
+   - Track allocated, inqueue, and elastic resources for each queue
+
+3. **Register Scheduling Functions**:
+   - `JobEnqueueableFn`: Pre-check job card requests against queue quotas
+   - `AllocatableFn`: Validate task card allocation against queue quotas
+   - `NodeOrderFn`: Score and sort nodes based on card type priority
+   - `AllocateFunc` / `DeallocateFunc`: Update queue resource tracking
+
+#### Job Enqueueable Check
+
+When submitting a job:
+
+1. Parse job's card requests from annotations (`volcano.sh/card.request`)
+2. Calculate total resources to be used: `allocated + inqueue + job.minResources - elastic`
+3. Check CPU/memory quotas (unless `cardUnlimitedCpuMemory` is enabled and task uses card resources)
+4. Check card resource quotas:
+   - For each requested card type
+   - If multi-card request (contains `|`), check each alternative
+   - Verify: `totalToBeUsed[cardType] <= queueCapability[cardType]`
+5. If all checks pass, mark job as Inqueue and reserve resources
+
+#### Task Allocatable Check
+
+When scheduling a task:
+
+1. Parse task's card request from annotations (`volcano.sh/card.name`)
+2. Extract card resources from Pod's resource requests
+3. Calculate total resources to be allocated: `allocated + task.request`
+4. Check CPU/memory quotas (unless `cardUnlimitedCpuMemory` is enabled and task uses card resources)
+5. Check card resource quotas:
+   - Support multi-card selection (e.g., `A100|H100`)
+   - For multi-card, check each option, succeed if any passes
+   - Verify: `totalToBeAllocated[cardType] <= queueCapability[cardType]`
+6. If check fails, emit Kubernetes event to Pod with reason
+
+#### Node Ordering
+
+When a task specifies multi-card type selection (e.g., `A100|H100|V100`), the plugin scores nodes to implement card type priority scheduling:
+
+1. Parse card name from task annotation (`volcano.sh/card.name`)
+2. Check if it contains `|` separator, if not return score 0 (no priority preference)
+3. Split card type list by `|` separator, left side has highest priority
+4. Iterate through card type list, check if node has that card type resource
+5. Calculate node score:
+   - Use exponential decay formula: `baseScore = 100 × (0.5 ^ index)`
+     - 0th card type (highest priority): 100 points
+     - 1st card type: 50 points
+     - 2nd card type: 25 points
+     - 3rd card type: 12.5 points
+   - Apply weight coefficient: `finalScore = baseScore × nodeOrderWeight`
+   - Return score immediately after finding first matching card type
+6. Final score combines with scores from other plugins to determine node selection
+
+**Scoring Characteristics**:
+- Only multi-card selection tasks participate in node ordering
+- Each card type has a unique non-zero score
+- Adjust overall influence of card type priority through `nodeOrderWeight` parameter
+
+#### Resource Tracking
+
+The plugin maintains real-time resource tracking:
+
+- **On allocation**: Add task resources to `queue.allocated`
+- **On deallocation**: Subtract task resources from `queue.allocated`
+- **Queue share calculation**: `share = max(allocated[resource] / deserved[resource])`
+
+### Implementation Details
+
+#### Card Resource Quantification
+
+Card resources are stored as scalar resources in milli-units (multiplied by 1000), consistent with Volcano's internal resource representation: 2 cards → 2000 in scalar resources
+
+#### Multi-Card Request Processing
+
+The plugin supports two modes for multi-card request checking:
+
+##### Task Mode (Task-level Check)
+
+For task allocation, the plugin checks if **any single card type** can satisfy the request, since each task must use only one card type:
+
+For a multi-card request like `A100|H100|V100`:
+
+1. Split by `|` separator
+2. For each card type in the list:
+   - Clone `toBeUsedResource`
+   - Add requested quantity to each individual card name
+   - Check `toBeUsedResource[cardType] <= queueCapability[cardType]`
+   - If any card type passes, return success
+3. If all fail, return error with multi-card name
+
+##### Job Mode (Job-level Check)
+
+For job enqueue, the plugin checks if **the sum of all card type quotas** can satisfy the request, since different tasks in the same job can use different card types:
+
+For a multi-card request like `A100|H100`:
+
+1. Split by `|` separator
+2. Calculate sum of available quotas for all card types:
+   - `totalAvailableQuota = queueCapability[A100] + queueCapability[H100]`
+3. Calculate sum of resources to be used for all card types:
+   - `totalToBeUsed = toBeUsedResource[A100] + toBeUsedResource[H100] + requestedQuantity`
+4. Check `totalToBeUsed <= totalAvailableQuota`
+5. If yes, return success; otherwise, return error
+
+**Example:**
+- Queue has: A100=5, H100=3 (total=8)
+- Allocated: A100=2, H100=1 (total=3)
+- New job requests: `A100|H100` 4 cards
+- Job mode check: (2+1+4) = 7 <= 8 ✓ Success
+- This allows different tasks in the job to potentially use 3 additional A100s and 1 additional H100
+
+This enhancement allows flexible job submission where different tasks can use different card types, maximizing resource utilization.
+
+#### Event Recording
+
+The plugin emits Kubernetes events for the following situations:
+- `GetTaskRequestResourceFailed`: Failed to parse task resource request
+- `EmptyQueueCapability`: Queue has no configured capability
+- `InsufficientCPUQuota`: Insufficient CPU quota in queue
+- `InsufficientMemoryQuota`: Insufficient memory quota in queue
+- `InsufficientScalarQuota`: Insufficient card/scalar quota in queue
+
+### Metrics and Observability
+
+The plugin exports Prometheus metrics to track queue resources:
+- `volcano_queue_card_deserved`: Deserved card resources per queue
+- `volcano_queue_card_allocated`: Currently allocated card resources per queue
+- `volcano_queue_card_request`: Requested card resources per queue
+- `volcano_queue_card_capacity`: Card capacity per queue
+
+## Example Scenarios
+
+### Example 1: Basic Card Quota
+
+**Cluster Setup**:
+- 2 nodes, each with 4 A100 cards (total: 8 A100s)
+
+**Queue Configuration**:
+```yaml
+apiVersion: scheduling.volcano.sh/v1beta1
+kind: Queue
+metadata:
+  name: team-a
+  annotations:
+    volcano.sh/card.quota: '{"NVIDIA-A100": 5}'
+spec:
+  capability:
+    cpu: "100"
+    memory: "500Gi"
+```
+
+**Job Submission**:
+```yaml
+apiVersion: batch.volcano.sh/v1alpha1
+kind: Job
+metadata:
+  name: training
+  annotations:
+    volcano.sh/card.request: '{"NVIDIA-A100": 4}'
+spec:
+  queue: team-a
+  minAvailable: 4
+  tasks:
+    - replicas: 4
+      template:
+        metadata:
+          annotations:
+            volcano.sh/card.name: "NVIDIA-A100"
+        spec:
+          containers:
+            - name: worker
+              resources:
+                limits:
+                  nvidia.com/gpu: 1
+                requests:
+                  nvidia.com/gpu: 1
+```
+
+**Result**: Job successfully enqueues (4 ≤ 5) and schedules tasks.
+
+### Example 2: Multi-Card Selection
+
+**Job Submission**:
+```yaml
+apiVersion: batch.volcano.sh/v1alpha1
+kind: Job
+metadata:
+  name: flexible-training
+  annotations:
+    volcano.sh/card.request: '{"NVIDIA-A100|NVIDIA-H100": 4}'
+spec:
+  queue: team-a
+  minAvailable: 1
+  tasks:
+    - replicas: 4
+      template:
+        metadata:
+          annotations:
+            volcano.sh/card.name: "NVIDIA-A100|NVIDIA-H100"
+        spec:
+          containers:
+            - name: worker
+              resources:
+                limits:
+                  nvidia.com/gpu: 1
+                requests:
+                  nvidia.com/gpu: 1
+```
+
+**Result**: Scheduler will try to allocate A100 first; if quota is exhausted, will try H100.
+
+### Example 3: MPS Shared GPU
+
+**Node Labels**:
+```yaml
+nvidia.com/gpu.product: "NVIDIA-A100"
+nvidia.com/gpu.count: "4"
+nvidia.com/gpu.memory: "81920"
+nvidia.com/gpu.replicas: "8"
+```
+
+**Node Status**:
+```yaml
+status:
+  allocatable:
+    nvidia.com/gpu.shared: "32"  # 4 cards × 8 replicas
+```
+
+**Queue Configuration**:
+```yaml
+metadata:
+  annotations:
+    volcano.sh/card.quota: '{"NVIDIA-A100/mps-80g*1/8": 32}'
+```
+
+**Job Submission**:
+```yaml
+metadata:
+  annotations:
+    volcano.sh/card.request: '{"NVIDIA-A100/mps-80g*1/8": 16}'
+spec:
+  tasks:
+    - replicas: 16
+      template:
+        metadata:
+          annotations:
+            volcano.sh/card.name: "NVIDIA-A100/mps-80g*1/8"
+        spec:
+          containers:
+            - resources:
+                limits:
+                  nvidia.com/gpu.shared: 1
+```
+
+**Result**: 16 inference Pods share 4 A100 GPUs via MPS.
+
+### Example 4: Node Ordering Configuration
+
+**Scheduler Configuration** (adjust weight to increase card type priority importance):
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: volcano-scheduler-configmap
+  namespace: volcano-system
+data:
+  volcano-scheduler.conf: |
+    actions: "enqueue, allocate, backfill"
+    tiers:
+    - plugins:
+      - name: capacity-card
+        arguments:
+          cardUnlimitedCpuMemory: false
+          nodeOrderWeight: 2.0    # Increase card type priority influence
+```
+
+**Job Submission** (multi-card selection with priority):
+```yaml
+apiVersion: batch.volcano.sh/v1alpha1
+kind: Job
+metadata:
+  name: multi-card-training
+  annotations:
+    volcano.sh/card.request: '{"NVIDIA-A100|NVIDIA-H100|NVIDIA-T4": 4}'
+spec:
+  queue: team-a
+  minAvailable: 1
+  tasks:
+    - replicas: 4
+      template:
+        metadata:
+          annotations:
+            volcano.sh/card.name: "NVIDIA-A100|NVIDIA-H100|NVIDIA-T4"
+        spec:
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoreDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: nvidia.com/gpu.product
+                    operation: In
+                    values:
+                    - NVIDIA-A100
+                    - NVIDIA-H100
+                    - NVIDIA-T4
+          containers:
+            - name: trainer
+              image: training:latest
+              resources:
+                limits:
+                  nvidia.com/gpu: 1
+                requests:
+                  nvidia.com/gpu: 1
+```
+
+**Node Scoring** (assuming weight of 2.0):
+- Nodes with NVIDIA-A100: `100 × 0.5^0 × 2.0 = 200` (highest priority)
+- Nodes with NVIDIA-H100: `100 × 0.5^1 × 2.0 = 100` (medium priority)
+- Nodes with NVIDIA-T4: `100 × 0.5^2 × 2.0 = 50` (lower priority)
+
+**Result**: Scheduler prefers A100 nodes when resources are available, then H100, finally T4.
+
+## Considerations
+
+1. **Plugin Compatibility**: The Capacity Card plugin is designed to work with other Volcano plugins (gang, priority, etc.). It should not be enabled simultaneously with the standard `capacity` or `proportion` plugins to avoid conflicts.
+
+2. **Card Discovery Requirements**: Node labels must be properly configured (typically by GPU operators like NVIDIA GPU Operator) for card discovery to work correctly.
+
+3. **Annotation-Based Design**: Choosing annotations over native Kubernetes ResourceList allows:
+   - Compatibility with scheduler logic
+   - More flexible naming conventions
+   - Support for multi-card selection syntax
+   - Easier evolution without API changes
+
+4. **Multi-Card Scheduling**: The plugin supports flexible multi-card scheduling:
+   - **Job Mode** (enqueue phase): Checks sum of multi-card quotas, allowing different tasks in the same job to use different card types
+     - Example: Job requests `"A100|H100": 6`, queue has `A100: 4, H100: 4`, enqueue check passes (6 ≤ 4+4)
+     - Allows 3 tasks to use A100, 3 tasks to use H100, maximizing resource utilization
+   - **Task Mode** (allocation phase): Ensures each individual task uses only one card type
+   - This provides optimal resource utilization while maintaining task-level constraints
+
+5. **Node Ordering Weight**: The `nodeOrderWeight` parameter affects the overall scale of node scoring:
+   - `> 2.0`: Card type priority dominates scheduling decisions
+   - `1.0-2.0`: Card type priority important but balanced (default 1.0)
+   - `0.5-1.0`: Other factors (like utilization) more important
+   - `< 0.5`: Card type priority has minimal impact
+
+6. **Performance Considerations**: The plugin caches node card information to minimize overhead during scheduling cycles.
+
+## Future Work
+
+- Support preemption and reclamation for card resources
+- Support hierarchical queue card quota management
+
+## References
+
+- [Volcano Capacity Scheduling Design](./capacity-scheduling.md)
+- [NVIDIA MPS Documentation](https://docs.nvidia.com/deploy/mps/index.html)
+- [NVIDIA MIG User Guide](https://docs.nvidia.com/datacenter/tesla/mig-user-guide/)
+- [Volcano Scheduler Framework](https://volcano.sh/en/docs/)
+

--- a/hack/fake-gpu-operator-values.yaml
+++ b/hack/fake-gpu-operator-values.yaml
@@ -1,0 +1,102 @@
+environment:
+  openshift: false
+  resourceReservationNamespace: runai-reservation
+
+devicePlugin:
+  image:
+    pullPolicy: IfNotPresent
+    repository: ghcr.io/run-ai/fake-gpu-operator/device-plugin
+    tag: "0.0.63"
+  resources: 
+    requests:
+      cpu: "100m"
+      memory: "100Mi"
+    limits:
+      cpu: "200m"
+      memory: "200Mi"
+
+statusUpdater:
+  image:
+    pullPolicy: IfNotPresent
+    repository: ghcr.io/run-ai/fake-gpu-operator/status-updater
+    tag: "0.0.63"
+  resources: 
+    requests:
+      cpu: "200m"
+      memory: "200Mi"
+    limits:
+      cpu: "400m"
+      memory: "400Mi"
+
+topologyServer:
+  image:
+    pullPolicy: IfNotPresent
+    repository: ghcr.io/run-ai/fake-gpu-operator/topology-server
+    tag: "0.0.63"
+  resources: 
+    requests:
+      cpu: "100m"
+      memory: "100Mi"
+    limits:
+      cpu: "200m"
+      memory: "200Mi"
+
+statusExporter:
+  image:
+    pullPolicy: IfNotPresent
+    repository: ghcr.io/run-ai/fake-gpu-operator/status-exporter
+    tag: "0.0.63"
+  resources: 
+    requests:
+      cpu: "100m"
+      memory: "100Mi"
+    limits:
+      cpu: "200m"
+      memory: "200Mi"
+  topologyMaxExportInterval: 10s
+
+kwokGpuDevicePlugin:
+  image:
+    pullPolicy: IfNotPresent
+    repository: ghcr.io/run-ai/fake-gpu-operator/kwok-gpu-device-plugin
+    tag: "0.0.63"
+  resources: 
+    requests:
+      cpu: "100m"
+      memory: "200Mi"
+    limits:
+      cpu: "200m"
+      memory: "400Mi"
+
+migFaker:
+  image:
+    pullPolicy: IfNotPresent
+    repository: ghcr.io/run-ai/fake-gpu-operator/mig-faker
+    tag: "0.0.63"
+
+ubuntu:
+  image:
+    repository: "ubuntu"
+    tag: "24.04"
+
+topology:
+  # nodePools is a map of node pool name to node pool configuration.
+  # Nodes are assigned to node pools based on the node pool label's value (key is configurable via nodePoolLabelKey).
+  # 
+  # For example, nodes that have the label "run.ai/simulated-gpu-node-pool: default"
+  # will be assigned to the "default" node pool.
+  nodePools:
+    card1:
+      gpuProduct: "Tesla-K80"
+      gpuCount: 8
+      gpuMemory: 11441
+    card2:
+      gpuProduct: "NVIDIA-GeForce-RTX-4090"
+      gpuCount: 8
+      gpuMemory: 22882
+    card3:
+      gpuProduct: "NVIDIA-H800"
+      gpuCount: 8
+      gpuMemory: 81559
+  nodePoolLabelKey: run.ai/simulated-gpu-node-pool
+  migStrategy: mixed

--- a/installer/helm/chart/volcano/config/volcano-scheduler-capacity-card-ci.conf
+++ b/installer/helm/chart/volcano/config/volcano-scheduler-capacity-card-ci.conf
@@ -1,0 +1,21 @@
+actions: "enqueue, allocate, backfill, reclaim, preempt"
+tiers:
+- plugins:
+  - name: priority
+  - name: gang
+    enablePreemptable: false
+  - name: conformance
+  - name: sla
+- plugins:
+  - name: overcommit
+  - name: drf
+    enablePreemptable: false
+  - name: predicates
+    arguments:
+      predicate.DynamicResourceAllocationEnable: true
+  - name: capacity-card
+    arguments:
+      cardUnlimitedCpuMemory: true
+  - name: nodeorder
+  - name: binpack
+  - name: network-topology-aware

--- a/pkg/scheduler/plugins/capacity-card/capacity_card.go
+++ b/pkg/scheduler/plugins/capacity-card/capacity_card.go
@@ -1,0 +1,376 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+Copyright 2018-2025 The Volcano Authors.
+
+Modifications made by Volcano authors:
+- Enhanced gang scheduling validation with task-level validity checks
+- Improved preemption logic to respect gang scheduling constraints
+- Added support for job starving detection and enhanced pipeline state management
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package capacitycard implements a capacity-based scheduler plugin for managing GPU/NPU/TPU
+// and other accelerator card resources in Volcano scheduler.
+//
+// The capacity-card plugin provides fine-grained resource management and scheduling capabilities
+// for heterogeneous computing resources, with a focus on AI accelerator cards. It extends the
+// basic capacity plugin functionality with specialized support for:
+//
+//   - Queue-level card resource quota management with per-card-type allocations
+//   - Multi-card type support (e.g., NVIDIA A100, H100, V100 mixed scheduling)
+//   - GPU sharing modes including MPS (Multi-Process Service) and MIG (Multi-Instance GPU)
+//   - Flexible card selection with priority-based multi-card-type requests
+//   - Decoupled CPU/memory quotas from card resource quotas
+//
+// # Core Features
+//
+// Queue Resource Management:
+// The plugin manages resources at the queue level, tracking allocated, requested, guaranteed,
+// and elastic resources for each queue. It calculates queue shares and enforces queue capacity
+// limits based on configured quotas.
+//
+// Card Resource Annotations:
+//   - volcano.sh/card.quota: Queue-level card quota configuration (JSON format)
+//   - volcano.sh/card.request: Job-level card request specification (JSON format)
+//   - volcano.sh/card.name: Task-level card type selection (pipe-separated list)
+//
+// Multi-Card Type Support:
+// Tasks can specify multiple acceptable card types in priority order using the card.name annotation.
+// The scheduler will select nodes based on card type availability and configured priority, allowing
+// flexible resource utilization across heterogeneous GPU clusters.
+//
+// Special Card Modes:
+//   - MPS Mode: Supports GPU time-slicing with configurable replica counts
+//   - MIG Mode: Supports NVIDIA Multi-Instance GPU with various profile configurations
+//
+// CPU/Memory Independence:
+// When cardUnlimitedCpuMemory is enabled, card resources are scheduled independently from CPU
+// and memory constraints, allowing specialized quota management for card resources.
+//
+// # Plugin Functions
+//
+// The plugin implements the following scheduler extension points:
+//
+//   - JobEnqueueableFn: Validates if a job can be enqueued based on queue card quotas
+//   - AllocatableFn: Checks if a task can be allocated to a node considering card availability
+//   - NodeOrderFn: Scores nodes based on card type preferences and availability
+//   - OnAllocate/OnDeallocate: Updates queue resource accounting on task allocation changes
+//
+// # Configuration
+//
+// Plugin configuration in scheduler configuration:
+//
+// 	actions: "enqueue, allocate, backfill"
+// 	tiers:
+// 	- plugins:
+// 	  - name: capacity-card
+// 	    arguments:
+// 	      cardUnlimitedCpuMemory: true    # Optional: decouple card from CPU/memory
+// 	      nodeOrderWeight: 1.5            # Optional: adjust node scoring weight
+//
+// # Resource Name Patterns
+//
+// The plugin recognizes the following card resource naming patterns:
+//
+//   - Standard GPU: nvidia.com/gpu, amd.com/gpu
+//   - MPS Cards: nvidia.com/mps-<N>g*1/<M> (N=card count, M=replica count)
+//   - MIG Cards: nvidia.com/mig-<profile>-mixed (e.g., mig-1g.12gb-mixed)
+//   - Custom Cards: Configured via node labels with <vendor>/<card-type> pattern
+//
+// # Example Usage
+//
+// Queue with card quota:
+//
+// 	apiVersion: scheduling.volcano.sh/v1beta1
+// 	kind: Queue
+// 	metadata:
+// 	  name: ai-queue
+// 	  annotations:
+// 	    volcano.sh/card.quota: |
+// 	      {
+// 	        "NVIDIA-A100": 8,
+// 	        "NVIDIA-V100": 16
+// 	      }
+//
+// Job with card request:
+//
+// 	apiVersion: batch.volcano.sh/v1alpha1
+// 	kind: Job
+// 	metadata:
+// 	  annotations:
+// 	    volcano.sh/card.request: |
+// 	      {
+// 	        "NVIDIA-A100": 2
+// 	      }
+//
+// Task with multi-card-type request:
+//
+// 	spec:
+// 	  tasks:
+// 	  - replicas: 1
+// 	    template:
+// 	      metadata:
+// 	        annotations:
+// 	          volcano.sh/card.name: "NVIDIA-A100|NVIDIA-H100|NVIDIA-V100"
+//
+// For detailed implementation and algorithm documentation, see capacity-card-plugin-doc.md.
+
+package capacitycard
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/client-go/listers/core/v1"
+	"k8s.io/klog/v2"
+
+	"volcano.sh/volcano/pkg/scheduler/api"
+	"volcano.sh/volcano/pkg/scheduler/framework"
+	"volcano.sh/volcano/pkg/scheduler/plugins/util"
+)
+
+const (
+	// PluginName indicates name of volcano scheduler plugin.
+	PluginName = "capacity-card"
+
+	// MPSResourceName is the fixed resource name for GPU mps card. e.g. nvidia.com/gpu.shared
+	MPSResourceName = "nvidia.com/gpu.shared"
+
+	// MpsReplicaLabel is the fixed label for GPU mps replica number. e.g. nvidia.com/gpu.replicas=2
+	MpsReplicaLabel = "nvidia.com/gpu.replicas"
+
+	// MpsSharedCardNamePattern is the fixed naming pattern for mps card name. e.g. nvidia.com/mps-2g*1/2
+	MpsSharedCardNamePattern = "%s/mps-%dg*1/%d"
+
+	// MigSharedCardNamePattern is the fixed naming pattern for mig card name. e.g. nvidia.com/mig-1g.12gb-mixed
+	MigSharedCardNamePattern = "%s/mig-%s-mixed"
+
+	// MigLabelAndResourceNamePrefix is the fixed prefix for GPU mig label and resource name.
+	MigLabelAndResourceNamePrefix = "nvidia.com/mig-"
+
+	// QueueAnnotationKeyCardQuota is the annotation keys of queue and job for card resources.
+	// This annotation is added to queue's capability and guarantee during queue creation.
+	QueueAnnotationKeyCardQuota = "volcano.sh/card.quota"
+
+	// JobAnnotationKeyCardRequest is the annotation keys of queue and job for card resources.
+	// This annotation is for job-level card request pre-check purpose.
+	JobAnnotationKeyCardRequest = "volcano.sh/card.request"
+
+	// TaskAnnotationKeyCardName is the annotation key of task for card name request.
+	TaskAnnotationKeyCardName = "volcano.sh/card.name"
+
+	// MultiCardSeparator is the separator for multi-card request in task annotation.
+	MultiCardSeparator = "|"
+
+	// cardCountQuantityMultiplier is used to convert card count to resource quantity in milli.
+	// As all volcano scalar resource quantity is in milli, we use 1000 as multiplier.
+	// For example, if a task requests 2 cards, it will be converted to 2000 in scalar resource quantity.
+	cardCountQuantityMultiplier = 1000
+
+	// cardUnlimitedCpuMemory is the plugin config name of card-unlimited cpu memory.
+	cardUnlimitedCpuMemory = "cardUnlimitedCpuMemory"
+
+	// nodeOrderWeight is the plugin config name for node order weight when multi-card types are present.
+	// This weight is multiplied with the final node score.
+	// Default value is 1.0 (no scaling). Can be any positive number.
+	// Higher values increase the importance of card type priority in overall scheduling decisions.
+	nodeOrderWeight = "nodeOrderWeight"
+
+	// defaultNodeOrderWeight is the default weight for node order scoring.
+	defaultNodeOrderWeight = 1.0
+
+	// nodeOrderDecayRate is the fixed decay rate for calculating base scores.
+	// Each subsequent card type gets this factor applied: score = maxScore * (decayRate ^ index)
+	// Using 0.5 means: 1st card=100, 2nd card=50, 3rd card=25, etc.
+	nodeOrderDecayRate = 0.5
+)
+
+// Plugin implements the capacity plugin.
+type Plugin struct {
+	queueOpts                map[api.QueueID]*queueAttr
+	totalResource            *api.Resource
+	totalGuarantee           *api.Resource
+	nodeLister               v1.NodeLister
+	nodeCardInfos            map[string]NodeCardResourceInfo
+	cardNameToResourceName   map[corev1.ResourceName]corev1.ResourceName
+	isCardUnlimitedCpuMemory bool
+	nodeOrderWeight          float64
+}
+
+// New return capacity plugin.
+func New(_ framework.Arguments) framework.Plugin {
+	return &Plugin{
+		queueOpts:              map[api.QueueID]*queueAttr{},
+		totalResource:          api.EmptyResource(),
+		totalGuarantee:         api.EmptyResource(),
+		nodeCardInfos:          map[string]NodeCardResourceInfo{},
+		cardNameToResourceName: map[corev1.ResourceName]corev1.ResourceName{},
+	}
+}
+
+// Name returns name of the plugin.
+func (p *Plugin) Name() string {
+	return PluginName
+}
+
+// OnSessionOpen initializes the plugin state.
+func (p *Plugin) OnSessionOpen(ssn *framework.Session) {
+	p.buildEventRecorder(ssn)
+	readyToSchedule := p.buildTotalResource(ssn)
+	if readyToSchedule {
+		readyToSchedule = p.buildQueueAttrs(ssn)
+	}
+	if readyToSchedule {
+		p.buildQueueMetrics(ssn)
+	}
+
+	klog.V(4).Infof("Total resource is: %v", p.totalResource)
+	klog.V(4).Infof("Total guarantee is: %v", p.totalGuarantee)
+
+	p.isCardUnlimitedCpuMemory = p.IsCardUnlimitedCpuMemory(ssn)
+	klog.V(4).Infof("IsCardUnlimitedCpuMemory: %v", p.isCardUnlimitedCpuMemory)
+
+	p.nodeOrderWeight = p.GetNodeOrderWeight(ssn)
+	klog.V(4).Infof("NodeOrderWeight: %v", p.nodeOrderWeight)
+
+	// Job enqueueable check.
+	ssn.AddJobEnqueueableFn(p.Name(), func(obj any) int {
+		jobInfo := obj.(*api.JobInfo)
+		if !readyToSchedule {
+			klog.V(2).Infof(
+				"Plugin <%s> is not ready to schedule, reject job <%s/%s>.",
+				p.Name(), jobInfo.Namespace, jobInfo.Name,
+			)
+			return util.Reject
+		}
+		return p.JobEnqueueableFn(ssn, jobInfo)
+	})
+
+	// Task allocatable check.
+	ssn.AddAllocatableFn(p.Name(), func(queue *api.QueueInfo, candidate *api.TaskInfo) bool {
+		if !readyToSchedule {
+			klog.V(2).Infof(
+				"Plugin <%s> is not ready to schedule, reject task <%s/%s>.",
+				p.Name(), candidate.Namespace, candidate.Name,
+			)
+			return false
+		}
+		return p.AllocatableFn(queue, candidate)
+	})
+
+	// It updates the queue's allocated resource and share
+	// when a task is allocated or deallocated duration plugin executing.
+	ssn.AddEventHandler(&framework.EventHandler{
+		AllocateFunc: func(event *framework.Event) {
+			p.OnAllocate(ssn, event)
+		},
+		DeallocateFunc: func(event *framework.Event) {
+			p.OnDeallocate(ssn, event)
+		},
+	})
+
+	// add AddNodeOrderFn for job using multi-card resources. To support card selection by order.
+	ssn.AddNodeOrderFn(p.Name(), func(task *api.TaskInfo, node *api.NodeInfo) (float64, error) {
+		return p.NodeOrderFn(task, node)
+	})
+}
+
+// OnSessionClose cleans up the plugin state.
+func (p *Plugin) OnSessionClose(_ *framework.Session) {
+	p.queueOpts = nil
+	p.totalResource = nil
+	p.totalGuarantee = nil
+	p.nodeCardInfos = nil
+	p.cardNameToResourceName = nil
+}
+
+// IsCardUnlimitedCpuMemory checks if the card resource is unlimited cpu memory.
+func (p *Plugin) IsCardUnlimitedCpuMemory(ssn *framework.Session) bool {
+	for _, tier := range ssn.Tiers {
+		for _, plugin := range tier.Plugins {
+			if plugin.Name != PluginName {
+				continue
+			}
+			cardUnlimitedCpuMemoryVal, ok := plugin.Arguments[cardUnlimitedCpuMemory]
+			if !ok {
+				return false
+			}
+			cardUnlimitedCpuMemoryBool, ok := cardUnlimitedCpuMemoryVal.(bool)
+			if !ok {
+				return false
+			}
+			return cardUnlimitedCpuMemoryBool
+		}
+	}
+	return false
+}
+
+// GetNodeOrderWeight gets the node order weight from plugin arguments.
+// The weight is multiplied with the final score. Must be positive.
+// Returns defaultNodeOrderWeight if not configured or invalid.
+func (p *Plugin) GetNodeOrderWeight(ssn *framework.Session) float64 {
+	for _, tier := range ssn.Tiers {
+		for _, plugin := range tier.Plugins {
+			if plugin.Name != PluginName {
+				continue
+			}
+			weightVal, ok := plugin.Arguments[nodeOrderWeight]
+			if !ok {
+				return defaultNodeOrderWeight
+			}
+
+			// Try float64 first
+			if weightFloat, ok := weightVal.(float64); ok {
+				if weightFloat > 0 {
+					return weightFloat
+				}
+				klog.Warningf("Invalid nodeOrderWeight value: %v, must be positive, using default: %v", weightFloat, defaultNodeOrderWeight)
+				return defaultNodeOrderWeight
+			}
+
+			// Try int as fallback (in case config uses integer)
+			if weightInt, ok := weightVal.(int); ok {
+				weightFloat := float64(weightInt)
+				if weightFloat > 0 {
+					return weightFloat
+				}
+				klog.Warningf("Invalid nodeOrderWeight value: %v, must be positive, using default: %v", weightFloat, defaultNodeOrderWeight)
+				return defaultNodeOrderWeight
+			}
+
+			klog.Warningf("Invalid nodeOrderWeight type: %T, using default: %v", weightVal, defaultNodeOrderWeight)
+			return defaultNodeOrderWeight
+		}
+	}
+	return defaultNodeOrderWeight
+}
+
+// HasCardResource checks whether the job has card resource.
+// If job has card resource, return true.
+// If job has scalar resource, check whether it has card resource name.
+func (p *Plugin) HasCardResource(cardResource, scalarResource *api.Resource) bool {
+	if cardResource != nil && len(cardResource.ScalarResources) > 0 {
+		return true
+	}
+
+	if scalarResource == nil || len(scalarResource.ScalarResources) == 0 {
+		return false
+	}
+
+	for _, resourceName := range p.cardNameToResourceName {
+		if _, ok := scalarResource.ScalarResources[resourceName]; ok {
+			return true
+		}
+	}
+
+	return false
+}

--- a/pkg/scheduler/plugins/capacity-card/capacity_card_event.go
+++ b/pkg/scheduler/plugins/capacity-card/capacity_card_event.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+Copyright 2018-2025 The Volcano Authors.
+
+Modifications made by Volcano authors:
+- Enhanced gang scheduling validation with task-level validity checks
+- Improved preemption logic to respect gang scheduling constraints
+- Added support for job starving detection and enhanced pipeline state management
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package capacitycard
+
+import (
+	"fmt"
+	"sync"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	typecorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/tools/record"
+
+	"volcano.sh/volcano/pkg/scheduler/framework"
+)
+
+var (
+	eventRecorder     record.EventRecorder
+	eventRecorderOnce sync.Once
+)
+
+// buildEventRecorder builds the event recorder for plugin.
+func (p *Plugin) buildEventRecorder(ssn *framework.Session) {
+	eventRecorderOnce.Do(func() {
+		eventBroadcaster := record.NewBroadcaster()
+		eventBroadcaster.StartStructuredLogging(0)
+		eventBroadcaster.StartRecordingToSink(&typecorev1.EventSinkImpl{
+			Interface: ssn.KubeClient().CoreV1().Events(""),
+		})
+		eventRecorder = eventBroadcaster.NewRecorder(scheme.Scheme, corev1.EventSource{
+			Component: fmt.Sprintf(`volcano.%s`, p.Name()),
+		})
+	})
+}

--- a/pkg/scheduler/plugins/capacity-card/capacity_card_event_handler.go
+++ b/pkg/scheduler/plugins/capacity-card/capacity_card_event_handler.go
@@ -1,0 +1,88 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+Copyright 2018-2025 The Volcano Authors.
+
+Modifications made by Volcano authors:
+- Enhanced gang scheduling validation with task-level validity checks
+- Improved preemption logic to respect gang scheduling constraints
+- Added support for job starving detection and enhanced pipeline state management
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package capacitycard
+
+import (
+	"k8s.io/klog/v2"
+
+	"volcano.sh/volcano/pkg/scheduler/framework"
+	"volcano.sh/volcano/pkg/scheduler/metrics"
+)
+
+// OnAllocate is invoked when a task is allocated.
+// This callback handler is very critical for capacity plugin to maintain the queue allocated resource,
+// especially card resource is being allocated during current scheduling session.
+func (p *Plugin) OnAllocate(ssn *framework.Session, event *framework.Event) {
+	var (
+		task    = event.Task
+		taskJob = ssn.Jobs[task.Job]
+		qAttr   = p.queueOpts[taskJob.Queue]
+	)
+
+	taskReqResource, err := p.GetTaskRequestResources(task)
+	if err != nil {
+		klog.V(5).Infof(
+			"Get request resource for Task <%s/%s> failed, error: <%s>",
+			task.Namespace, task.Name, err.Error(),
+		)
+		return
+	}
+	qAttr.allocated.Add(taskReqResource)
+
+	metrics.UpdateQueueAllocated(
+		qAttr.name, qAttr.allocated.MilliCPU, qAttr.allocated.Memory, qAttr.allocated.ScalarResources,
+	)
+	p.updateShare(qAttr)
+	klog.V(4).Infof(
+		"Capacity AllocateFunc: task <%v/%v>, resreq <%v>, share <%v>",
+		task.Namespace, task.Name, taskReqResource, qAttr.share,
+	)
+}
+
+// OnDeallocate is invoked when a task is deallocated.
+func (p *Plugin) OnDeallocate(ssn *framework.Session, event *framework.Event) {
+	var (
+		task    = event.Task
+		taskJob = ssn.Jobs[task.Job]
+		qAttr   = p.queueOpts[taskJob.Queue]
+	)
+
+	taskReqResource, err := p.GetTaskRequestResources(task)
+	if err != nil {
+		klog.V(5).Infof(
+			"Get request resource for Task <%s/%s> failed, error: <%s>",
+			task.Namespace, task.Name, err.Error(),
+		)
+		return
+	}
+	qAttr.allocated.Sub(taskReqResource)
+
+	metrics.UpdateQueueAllocated(
+		qAttr.name, qAttr.allocated.MilliCPU, qAttr.allocated.Memory, qAttr.allocated.ScalarResources,
+	)
+	p.updateShare(qAttr)
+	klog.V(4).Infof(
+		"Capacity EvictFunc: task <%v/%v>, resreq <%v>, share <%v>",
+		task.Namespace, task.Name, taskReqResource, qAttr.share,
+	)
+}

--- a/pkg/scheduler/plugins/capacity-card/capacity_card_event_handler_test.go
+++ b/pkg/scheduler/plugins/capacity-card/capacity_card_event_handler_test.go
@@ -1,0 +1,922 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+Copyright 2018-2025 The Volcano Authors.
+
+Modifications made by Volcano authors:
+- Enhanced gang scheduling validation with task-level validity checks
+- Improved preemption logic to respect gang scheduling constraints
+- Added support for job starving detection and enhanced pipeline state management
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package capacitycard
+
+import (
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"volcano.sh/apis/pkg/apis/scheduling"
+	"volcano.sh/volcano/pkg/scheduler/api"
+	"volcano.sh/volcano/pkg/scheduler/cache"
+	"volcano.sh/volcano/pkg/scheduler/framework"
+)
+
+// TestOnAllocate tests the OnAllocate event handler
+func TestOnAllocate(t *testing.T) {
+	tests := []struct {
+		name                 string
+		setupPlugin          func() *Plugin
+		setupSession         func() *framework.Session
+		taskToAllocate       *api.TaskInfo
+		expectedAllocatedCPU float64
+		expectedAllocatedMem float64
+		expectedAllocatedGPU float64
+		expectedShareGreater float64
+		shouldSucceed        bool
+	}{
+		{
+			name: "allocate task with CPU and memory only",
+			setupPlugin: func() *Plugin {
+				p := &Plugin{
+					queueOpts:              map[api.QueueID]*queueAttr{},
+					totalResource:          api.EmptyResource(),
+					totalGuarantee:         api.EmptyResource(),
+					cardNameToResourceName: map[v1.ResourceName]v1.ResourceName{},
+				}
+				// Pre-create queue attributes
+				p.queueOpts["queue-1"] = &queueAttr{
+					queueID:   "queue-1",
+					name:      "test-queue-1",
+					allocated: api.EmptyResource(),
+					deserved: &api.Resource{
+						MilliCPU: 10000,
+						Memory:   20 * 1024 * 1024 * 1024, // 10Gi
+					},
+				}
+				return p
+			},
+			setupSession: func() *framework.Session {
+				mockCache := cache.NewDefaultMockSchedulerCache("test-scheduler")
+				session := framework.OpenSession(mockCache, nil, nil)
+
+				queue := &scheduling.Queue{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-queue-1",
+					},
+					Spec: scheduling.QueueSpec{
+						Deserved: v1.ResourceList{
+							v1.ResourceCPU:    resource.MustParse("10"),
+							v1.ResourceMemory: resource.MustParse("20Gi"),
+						},
+					},
+				}
+
+				job := &api.JobInfo{
+					UID:       "job-1",
+					Name:      "test-job-1",
+					Namespace: "default",
+					Queue:     "queue-1",
+					PodGroup: &api.PodGroup{
+						PodGroup: scheduling.PodGroup{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "test-job-1",
+								Namespace: "default",
+							},
+							Spec: scheduling.PodGroupSpec{
+								MinMember: 1,
+							},
+						},
+					},
+				}
+
+				session.Queues = map[api.QueueID]*api.QueueInfo{
+					"queue-1": {
+						UID:   "queue-1",
+						Name:  "test-queue-1",
+						Queue: queue,
+					},
+				}
+				session.Jobs = map[api.JobID]*api.JobInfo{
+					"job-1": job,
+				}
+
+				return session
+			},
+			taskToAllocate: &api.TaskInfo{
+				UID:       "task-1",
+				Name:      "test-task-1",
+				Namespace: "default",
+				Job:       "job-1",
+				Resreq: &api.Resource{
+					MilliCPU: 2000,
+					Memory:   2 * 1024 * 1024 * 1024,
+				},
+				Pod: &v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-task-1",
+						Namespace: "default",
+					},
+				},
+			},
+			expectedAllocatedCPU: 2000,
+			expectedAllocatedMem: 2 * 1024 * 1024 * 1024,
+			expectedShareGreater: 0.2, // 2000/10000 = 0.2
+			shouldSucceed:        true,
+		},
+		{
+			name: "allocate task with GPU card resources and card unlimited cpu memory disabled",
+			setupPlugin: func() *Plugin {
+				p := &Plugin{
+					queueOpts:      map[api.QueueID]*queueAttr{},
+					totalResource:  api.EmptyResource(),
+					totalGuarantee: api.EmptyResource(),
+					cardNameToResourceName: map[v1.ResourceName]v1.ResourceName{
+						"NVIDIA-H200": "nvidia.com/gpu",
+					},
+					isCardUnlimitedCpuMemory: false,
+				}
+				p.queueOpts["queue-gpu"] = &queueAttr{
+					queueID:   "queue-gpu",
+					name:      "gpu-queue",
+					allocated: api.EmptyResource(),
+					deserved: &api.Resource{
+						MilliCPU: 4000,
+						Memory:   8 * 1024 * 1024 * 1024,
+						ScalarResources: map[v1.ResourceName]float64{
+							"NVIDIA-H200": 4000, // 4 GPUs
+						},
+					},
+				}
+				return p
+			},
+			setupSession: func() *framework.Session {
+				mockCache := cache.NewDefaultMockSchedulerCache("test-scheduler")
+				session := framework.OpenSession(mockCache, nil, nil)
+
+				queue := &scheduling.Queue{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "gpu-queue",
+						Annotations: map[string]string{
+							"volcano.sh/card.quota": `{"NVIDIA-H200": 4}`,
+						},
+					},
+					Spec: scheduling.QueueSpec{
+						Deserved: v1.ResourceList{
+							v1.ResourceCPU:    resource.MustParse("4"),
+							v1.ResourceMemory: resource.MustParse("8Gi"),
+						},
+					},
+				}
+
+				job := &api.JobInfo{
+					UID:       "job-gpu",
+					Name:      "gpu-job",
+					Namespace: "default",
+					Queue:     "queue-gpu",
+					PodGroup: &api.PodGroup{
+						PodGroup: scheduling.PodGroup{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "gpu-job",
+								Namespace: "default",
+							},
+						},
+					},
+				}
+
+				session.Queues = map[api.QueueID]*api.QueueInfo{
+					"queue-gpu": {
+						UID:   "queue-gpu",
+						Name:  "gpu-queue",
+						Queue: queue,
+					},
+				}
+				session.Jobs = map[api.JobID]*api.JobInfo{
+					"job-gpu": job,
+				}
+
+				return session
+			},
+			taskToAllocate: &api.TaskInfo{
+				UID:       "task-gpu",
+				Name:      "gpu-task",
+				Namespace: "default",
+				Job:       "job-gpu",
+				Resreq: &api.Resource{
+					MilliCPU: 4000,
+					Memory:   8 * 1024 * 1024 * 1024,
+				},
+				Pod: &v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "gpu-task",
+						Namespace: "default",
+						Annotations: map[string]string{
+							"volcano.sh/card.name": "NVIDIA-H200",
+						},
+					},
+					Spec: v1.PodSpec{
+						Containers: []v1.Container{
+							{
+								Resources: v1.ResourceRequirements{
+									Limits: v1.ResourceList{
+										"nvidia.com/gpu": resource.MustParse("2"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedAllocatedCPU: 4000,
+			expectedAllocatedMem: 8 * 1024 * 1024 * 1024,
+			expectedAllocatedGPU: 2000, // 2 GPUs * 1000
+			expectedShareGreater: 1,    // max(4000/4000, 8Gi/8Gi) = 1
+			shouldSucceed:        true,
+		},
+		{
+			name: "allocate task with GPU card resources and card unlimited cpu memory",
+			setupPlugin: func() *Plugin {
+				p := &Plugin{
+					queueOpts:      map[api.QueueID]*queueAttr{},
+					totalResource:  api.EmptyResource(),
+					totalGuarantee: api.EmptyResource(),
+					cardNameToResourceName: map[v1.ResourceName]v1.ResourceName{
+						"NVIDIA-H200": "nvidia.com/gpu",
+					},
+					isCardUnlimitedCpuMemory: true,
+				}
+				p.queueOpts["queue-gpu"] = &queueAttr{
+					queueID:   "queue-gpu",
+					name:      "gpu-queue",
+					allocated: api.EmptyResource(),
+					deserved: &api.Resource{
+						MilliCPU: 4000,
+						Memory:   8 * 1024 * 1024 * 1024,
+						ScalarResources: map[v1.ResourceName]float64{
+							"NVIDIA-H200": 4000, // 4 GPUs
+						},
+					},
+				}
+				return p
+			},
+			setupSession: func() *framework.Session {
+				mockCache := cache.NewDefaultMockSchedulerCache("test-scheduler")
+				session := framework.OpenSession(mockCache, nil, nil)
+
+				queue := &scheduling.Queue{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "gpu-queue",
+						Annotations: map[string]string{
+							"volcano.sh/card.quota": `{"NVIDIA-H200": 4}`,
+						},
+					},
+					Spec: scheduling.QueueSpec{
+						Deserved: v1.ResourceList{
+							v1.ResourceCPU:    resource.MustParse("4"),
+							v1.ResourceMemory: resource.MustParse("8Gi"),
+						},
+					},
+				}
+
+				job := &api.JobInfo{
+					UID:       "job-gpu",
+					Name:      "gpu-job",
+					Namespace: "default",
+					Queue:     "queue-gpu",
+					PodGroup: &api.PodGroup{
+						PodGroup: scheduling.PodGroup{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "gpu-job",
+								Namespace: "default",
+							},
+						},
+					},
+				}
+
+				session.Queues = map[api.QueueID]*api.QueueInfo{
+					"queue-gpu": {
+						UID:   "queue-gpu",
+						Name:  "gpu-queue",
+						Queue: queue,
+					},
+				}
+				session.Jobs = map[api.JobID]*api.JobInfo{
+					"job-gpu": job,
+				}
+
+				return session
+			},
+			taskToAllocate: &api.TaskInfo{
+				UID:       "task-gpu",
+				Name:      "gpu-task",
+				Namespace: "default",
+				Job:       "job-gpu",
+				Resreq: &api.Resource{
+					MilliCPU: 4000,
+					Memory:   8 * 1024 * 1024 * 1024,
+				},
+				Pod: &v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "gpu-task",
+						Namespace: "default",
+						Annotations: map[string]string{
+							"volcano.sh/card.name": "NVIDIA-H200",
+						},
+					},
+					Spec: v1.PodSpec{
+						Containers: []v1.Container{
+							{
+								Resources: v1.ResourceRequirements{
+									Limits: v1.ResourceList{
+										"nvidia.com/gpu": resource.MustParse("2"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedAllocatedCPU: 0,
+			expectedAllocatedMem: 0,
+			expectedAllocatedGPU: 2000, // 2 GPUs * 1000
+			expectedShareGreater: 0.5,  // max(2000/4000) = 0.5
+			shouldSucceed:        true,
+		},
+		{
+			name: "allocate task without pod but with Resreq",
+			setupPlugin: func() *Plugin {
+				p := &Plugin{
+					queueOpts:              map[api.QueueID]*queueAttr{},
+					totalResource:          api.EmptyResource(),
+					totalGuarantee:         api.EmptyResource(),
+					cardNameToResourceName: map[v1.ResourceName]v1.ResourceName{},
+				}
+				p.queueOpts["queue-1"] = &queueAttr{
+					queueID:   "queue-1",
+					name:      "test-queue-1",
+					allocated: api.EmptyResource(),
+					deserved: &api.Resource{
+						MilliCPU: 10000,
+						Memory:   20 * 1024 * 1024 * 1024,
+					},
+				}
+				return p
+			},
+			setupSession: func() *framework.Session {
+				mockCache := cache.NewDefaultMockSchedulerCache("test-scheduler")
+				session := framework.OpenSession(mockCache, nil, nil)
+
+				queue := &scheduling.Queue{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-queue-1",
+					},
+				}
+
+				job := &api.JobInfo{
+					UID:       "job-1",
+					Name:      "test-job-1",
+					Namespace: "default",
+					Queue:     "queue-1",
+					PodGroup: &api.PodGroup{
+						PodGroup: scheduling.PodGroup{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "test-job-1",
+								Namespace: "default",
+							},
+						},
+					},
+				}
+
+				session.Queues = map[api.QueueID]*api.QueueInfo{
+					"queue-1": {
+						UID:   "queue-1",
+						Name:  "test-queue-1",
+						Queue: queue,
+					},
+				}
+				session.Jobs = map[api.JobID]*api.JobInfo{
+					"job-1": job,
+				}
+
+				return session
+			},
+			taskToAllocate: &api.TaskInfo{
+				UID:       "task-no-pod",
+				Name:      "task-no-pod",
+				Namespace: "default",
+				Job:       "job-1",
+				Resreq: &api.Resource{
+					MilliCPU: 1000,
+					Memory:   1 * 1024 * 1024 * 1024,
+				},
+				Pod: nil, // No pod, but Resreq is still allocated
+			},
+			expectedAllocatedCPU: 1000, // Still allocated even without pod
+			expectedAllocatedMem: 1 * 1024 * 1024 * 1024,
+			expectedShareGreater: 0.1, // 1000/10000 = 0.1
+			shouldSucceed:        true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			plugin := tt.setupPlugin()
+			session := tt.setupSession()
+
+			event := &framework.Event{
+				Task: tt.taskToAllocate,
+			}
+
+			// Call OnAllocate
+			plugin.OnAllocate(session, event)
+
+			// Verify the allocated resources
+			job := session.Jobs[tt.taskToAllocate.Job]
+			if job == nil {
+				t.Fatalf("Job not found for task %s", tt.taskToAllocate.Name)
+			}
+
+			qAttr := plugin.queueOpts[job.Queue]
+			if qAttr == nil {
+				t.Fatalf("Queue attributes not found for queue %s", job.Queue)
+			}
+
+			if tt.shouldSucceed {
+				if qAttr.allocated.MilliCPU != tt.expectedAllocatedCPU {
+					t.Errorf("Expected allocated CPU %v, got %v", tt.expectedAllocatedCPU, qAttr.allocated.MilliCPU)
+				}
+
+				if qAttr.allocated.Memory != tt.expectedAllocatedMem {
+					t.Errorf("Expected allocated memory %v, got %v", tt.expectedAllocatedMem, qAttr.allocated.Memory)
+				}
+
+				if tt.expectedAllocatedGPU > 0 {
+					if qAttr.allocated.ScalarResources == nil {
+						t.Errorf("Expected scalar resources to be allocated, got nil")
+					} else {
+						allocatedGPU := qAttr.allocated.ScalarResources["NVIDIA-H200"]
+						if allocatedGPU != tt.expectedAllocatedGPU {
+							t.Errorf("Expected allocated GPU %v, got %v", tt.expectedAllocatedGPU, allocatedGPU)
+						}
+					}
+				}
+
+				if tt.expectedShareGreater >= 0 && qAttr.share != tt.expectedShareGreater {
+					t.Errorf("Expected share %v, got %v", tt.expectedShareGreater, qAttr.share)
+				}
+			}
+		})
+	}
+}
+
+// TestOnDeallocate tests the OnDeallocate event handler
+func TestOnDeallocate(t *testing.T) {
+	tests := []struct {
+		name                 string
+		setupPlugin          func() *Plugin
+		setupSession         func() *framework.Session
+		taskToDeallocate     *api.TaskInfo
+		initialAllocatedCPU  float64
+		initialAllocatedMem  float64
+		initialAllocatedGPU  float64
+		expectedAllocatedCPU float64
+		expectedAllocatedMem float64
+		expectedAllocatedGPU float64
+		shouldSucceed        bool
+	}{
+		{
+			name: "deallocate task with CPU and memory",
+			setupPlugin: func() *Plugin {
+				p := &Plugin{
+					queueOpts:              map[api.QueueID]*queueAttr{},
+					totalResource:          api.EmptyResource(),
+					totalGuarantee:         api.EmptyResource(),
+					cardNameToResourceName: map[v1.ResourceName]v1.ResourceName{},
+				}
+				p.queueOpts["queue-1"] = &queueAttr{
+					queueID: "queue-1",
+					name:    "test-queue-1",
+					allocated: &api.Resource{
+						MilliCPU: 5000, // Already allocated
+						Memory:   5 * 1024 * 1024 * 1024,
+					},
+					deserved: &api.Resource{
+						MilliCPU: 10000,
+						Memory:   10 * 1024 * 1024 * 1024,
+					},
+				}
+				return p
+			},
+			setupSession: func() *framework.Session {
+				mockCache := cache.NewDefaultMockSchedulerCache("test-scheduler")
+				session := framework.OpenSession(mockCache, nil, nil)
+
+				queue := &scheduling.Queue{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-queue-1",
+					},
+				}
+
+				job := &api.JobInfo{
+					UID:       "job-1",
+					Name:      "test-job-1",
+					Namespace: "default",
+					Queue:     "queue-1",
+					PodGroup: &api.PodGroup{
+						PodGroup: scheduling.PodGroup{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "test-job-1",
+								Namespace: "default",
+							},
+						},
+					},
+				}
+
+				session.Queues = map[api.QueueID]*api.QueueInfo{
+					"queue-1": {
+						UID:   "queue-1",
+						Name:  "test-queue-1",
+						Queue: queue,
+					},
+				}
+				session.Jobs = map[api.JobID]*api.JobInfo{
+					"job-1": job,
+				}
+
+				return session
+			},
+			taskToDeallocate: &api.TaskInfo{
+				UID:       "task-1",
+				Name:      "test-task-1",
+				Namespace: "default",
+				Job:       "job-1",
+				Resreq: &api.Resource{
+					MilliCPU: 2000,
+					Memory:   2 * 1024 * 1024 * 1024,
+				},
+				Pod: &v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-task-1",
+						Namespace: "default",
+					},
+				},
+			},
+			initialAllocatedCPU:  5000,
+			initialAllocatedMem:  5 * 1024 * 1024 * 1024,
+			expectedAllocatedCPU: 3000, // 5000 - 2000
+			expectedAllocatedMem: 3 * 1024 * 1024 * 1024,
+			shouldSucceed:        true,
+		},
+		{
+			name: "deallocate task with GPU resources and card unlimited cpu memory enabled",
+			setupPlugin: func() *Plugin {
+				p := &Plugin{
+					queueOpts:      map[api.QueueID]*queueAttr{},
+					totalResource:  api.EmptyResource(),
+					totalGuarantee: api.EmptyResource(),
+					cardNameToResourceName: map[v1.ResourceName]v1.ResourceName{
+						"NVIDIA-H200": "nvidia.com/gpu",
+					},
+					isCardUnlimitedCpuMemory: true,
+				}
+				p.queueOpts["queue-gpu"] = &queueAttr{
+					queueID: "queue-gpu",
+					name:    "gpu-queue",
+					allocated: &api.Resource{
+						MilliCPU: 8000,
+						Memory:   16 * 1024 * 1024 * 1024,
+						ScalarResources: map[v1.ResourceName]float64{
+							"NVIDIA-H200": 4000, // 4 GPUs allocated
+						},
+					},
+					deserved: &api.Resource{
+						MilliCPU: 16000,
+						Memory:   32 * 1024 * 1024 * 1024,
+						ScalarResources: map[v1.ResourceName]float64{
+							"NVIDIA-H200": 8000,
+						},
+					},
+				}
+				return p
+			},
+			setupSession: func() *framework.Session {
+				mockCache := cache.NewDefaultMockSchedulerCache("test-scheduler")
+				session := framework.OpenSession(mockCache, nil, nil)
+
+				queue := &scheduling.Queue{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "gpu-queue",
+					},
+				}
+
+				job := &api.JobInfo{
+					UID:       "job-gpu",
+					Name:      "gpu-job",
+					Namespace: "default",
+					Queue:     "queue-gpu",
+					PodGroup: &api.PodGroup{
+						PodGroup: scheduling.PodGroup{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "gpu-job",
+								Namespace: "default",
+							},
+						},
+					},
+				}
+
+				session.Queues = map[api.QueueID]*api.QueueInfo{
+					"queue-gpu": {
+						UID:   "queue-gpu",
+						Name:  "gpu-queue",
+						Queue: queue,
+					},
+				}
+				session.Jobs = map[api.JobID]*api.JobInfo{
+					"job-gpu": job,
+				}
+
+				return session
+			},
+			taskToDeallocate: &api.TaskInfo{
+				UID:       "task-gpu",
+				Name:      "gpu-task",
+				Namespace: "default",
+				Job:       "job-gpu",
+				Resreq: &api.Resource{
+					MilliCPU: 4000,
+					Memory:   8 * 1024 * 1024 * 1024,
+				},
+				Pod: &v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "gpu-task",
+						Namespace: "default",
+						Annotations: map[string]string{
+							"volcano.sh/card.name": "NVIDIA-H200",
+						},
+					},
+					Spec: v1.PodSpec{
+						Containers: []v1.Container{
+							{
+								Resources: v1.ResourceRequirements{
+									Limits: v1.ResourceList{
+										"nvidia.com/gpu": resource.MustParse("2"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			initialAllocatedCPU:  8000,
+			initialAllocatedMem:  16 * 1024 * 1024 * 1024,
+			initialAllocatedGPU:  4000,
+			expectedAllocatedCPU: 8000,
+			expectedAllocatedMem: 16 * 1024 * 1024 * 1024,
+			expectedAllocatedGPU: 2000, // 4000 - 2000
+			shouldSucceed:        true,
+		},
+		{
+			name: "deallocate task with GPU resources and card unlimited cpu memory disabled",
+			setupPlugin: func() *Plugin {
+				p := &Plugin{
+					queueOpts:      map[api.QueueID]*queueAttr{},
+					totalResource:  api.EmptyResource(),
+					totalGuarantee: api.EmptyResource(),
+					cardNameToResourceName: map[v1.ResourceName]v1.ResourceName{
+						"NVIDIA-H200": "nvidia.com/gpu",
+					},
+					isCardUnlimitedCpuMemory: false,
+				}
+				p.queueOpts["queue-gpu"] = &queueAttr{
+					queueID: "queue-gpu",
+					name:    "gpu-queue",
+					allocated: &api.Resource{
+						MilliCPU: 8000,
+						Memory:   16 * 1024 * 1024 * 1024,
+						ScalarResources: map[v1.ResourceName]float64{
+							"NVIDIA-H200": 4000, // 4 GPUs allocated
+						},
+					},
+					deserved: &api.Resource{
+						MilliCPU: 16000,
+						Memory:   32 * 1024 * 1024 * 1024,
+						ScalarResources: map[v1.ResourceName]float64{
+							"NVIDIA-H200": 8000,
+						},
+					},
+				}
+				return p
+			},
+			setupSession: func() *framework.Session {
+				mockCache := cache.NewDefaultMockSchedulerCache("test-scheduler")
+				session := framework.OpenSession(mockCache, nil, nil)
+
+				queue := &scheduling.Queue{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "gpu-queue",
+					},
+				}
+
+				job := &api.JobInfo{
+					UID:       "job-gpu",
+					Name:      "gpu-job",
+					Namespace: "default",
+					Queue:     "queue-gpu",
+					PodGroup: &api.PodGroup{
+						PodGroup: scheduling.PodGroup{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "gpu-job",
+								Namespace: "default",
+							},
+						},
+					},
+				}
+
+				session.Queues = map[api.QueueID]*api.QueueInfo{
+					"queue-gpu": {
+						UID:   "queue-gpu",
+						Name:  "gpu-queue",
+						Queue: queue,
+					},
+				}
+				session.Jobs = map[api.JobID]*api.JobInfo{
+					"job-gpu": job,
+				}
+
+				return session
+			},
+			taskToDeallocate: &api.TaskInfo{
+				UID:       "task-gpu",
+				Name:      "gpu-task",
+				Namespace: "default",
+				Job:       "job-gpu",
+				Resreq: &api.Resource{
+					MilliCPU: 4000,
+					Memory:   8 * 1024 * 1024 * 1024,
+				},
+				Pod: &v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "gpu-task",
+						Namespace: "default",
+						Annotations: map[string]string{
+							"volcano.sh/card.name": "NVIDIA-H200",
+						},
+					},
+					Spec: v1.PodSpec{
+						Containers: []v1.Container{
+							{
+								Resources: v1.ResourceRequirements{
+									Limits: v1.ResourceList{
+										"nvidia.com/gpu": resource.MustParse("2"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			initialAllocatedCPU:  8000,
+			initialAllocatedMem:  16 * 1024 * 1024 * 1024,
+			initialAllocatedGPU:  4000,
+			expectedAllocatedCPU: 4000,
+			expectedAllocatedMem: 8 * 1024 * 1024 * 1024,
+			expectedAllocatedGPU: 2000, // 4000 - 2000
+			shouldSucceed:        true,
+		},
+		{
+			name: "deallocate task without pod but with Resreq",
+			setupPlugin: func() *Plugin {
+				p := &Plugin{
+					queueOpts:              map[api.QueueID]*queueAttr{},
+					totalResource:          api.EmptyResource(),
+					totalGuarantee:         api.EmptyResource(),
+					cardNameToResourceName: map[v1.ResourceName]v1.ResourceName{},
+				}
+				p.queueOpts["queue-1"] = &queueAttr{
+					queueID: "queue-1",
+					name:    "test-queue-1",
+					allocated: &api.Resource{
+						MilliCPU: 5000,
+						Memory:   5 * 1024 * 1024 * 1024,
+					},
+					deserved: &api.Resource{
+						MilliCPU: 10000,
+						Memory:   10 * 1024 * 1024 * 1024,
+					},
+				}
+				return p
+			},
+			setupSession: func() *framework.Session {
+				mockCache := cache.NewDefaultMockSchedulerCache("test-scheduler")
+				session := framework.OpenSession(mockCache, nil, nil)
+
+				queue := &scheduling.Queue{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-queue-1",
+					},
+				}
+
+				job := &api.JobInfo{
+					UID:       "job-1",
+					Name:      "test-job-1",
+					Namespace: "default",
+					Queue:     "queue-1",
+					PodGroup: &api.PodGroup{
+						PodGroup: scheduling.PodGroup{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "test-job-1",
+								Namespace: "default",
+							},
+						},
+					},
+				}
+
+				session.Queues = map[api.QueueID]*api.QueueInfo{
+					"queue-1": {
+						UID:   "queue-1",
+						Name:  "test-queue-1",
+						Queue: queue,
+					},
+				}
+				session.Jobs = map[api.JobID]*api.JobInfo{
+					"job-1": job,
+				}
+
+				return session
+			},
+			taskToDeallocate: &api.TaskInfo{
+				UID:       "task-no-pod",
+				Name:      "task-no-pod",
+				Namespace: "default",
+				Job:       "job-1",
+				Resreq: &api.Resource{
+					MilliCPU: 1000,
+					Memory:   1 * 1024 * 1024 * 1024,
+				},
+				Pod: nil, // No pod, but Resreq is still deallocated
+			},
+			initialAllocatedCPU:  5000,
+			initialAllocatedMem:  5 * 1024 * 1024 * 1024,
+			expectedAllocatedCPU: 4000, // 5000 - 1000, still deallocated even without pod
+			expectedAllocatedMem: 4 * 1024 * 1024 * 1024,
+			shouldSucceed:        true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			plugin := tt.setupPlugin()
+			session := tt.setupSession()
+
+			event := &framework.Event{
+				Task: tt.taskToDeallocate,
+			}
+
+			// Call OnDeallocate
+			plugin.OnDeallocate(session, event)
+
+			// Verify the deallocated resources
+			job := session.Jobs[tt.taskToDeallocate.Job]
+			if job == nil {
+				t.Fatalf("Job not found for task %s", tt.taskToDeallocate.Name)
+			}
+
+			qAttr := plugin.queueOpts[job.Queue]
+			if qAttr == nil {
+				t.Fatalf("Queue attributes not found for queue %s", job.Queue)
+			}
+
+			if qAttr.allocated.MilliCPU != tt.expectedAllocatedCPU {
+				t.Errorf("Expected allocated CPU %v, got %v", tt.expectedAllocatedCPU, qAttr.allocated.MilliCPU)
+			}
+
+			if qAttr.allocated.Memory != tt.expectedAllocatedMem {
+				t.Errorf("Expected allocated memory %v, got %v", tt.expectedAllocatedMem, qAttr.allocated.Memory)
+			}
+
+			if tt.expectedAllocatedGPU > 0 {
+				if qAttr.allocated.ScalarResources == nil {
+					t.Errorf("Expected scalar resources, got nil")
+				} else {
+					allocatedGPU := qAttr.allocated.ScalarResources["NVIDIA-H200"]
+					if allocatedGPU != tt.expectedAllocatedGPU {
+						t.Errorf("Expected allocated GPU %v, got %v", tt.expectedAllocatedGPU, allocatedGPU)
+					}
+				}
+			}
+		})
+	}
+}

--- a/pkg/scheduler/plugins/capacity-card/capacity_card_fn_allocatable.go
+++ b/pkg/scheduler/plugins/capacity-card/capacity_card_fn_allocatable.go
@@ -1,0 +1,171 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+Copyright 2018-2025 The Volcano Authors.
+
+Modifications made by Volcano authors:
+- Enhanced gang scheduling validation with task-level validity checks
+- Improved preemption logic to respect gang scheduling constraints
+- Added support for job starving detection and enhanced pipeline state management
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package capacitycard
+
+import (
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/klog/v2"
+
+	"volcano.sh/apis/pkg/apis/scheduling"
+	"volcano.sh/volcano/pkg/scheduler/api"
+)
+
+// AllocatableFn checks whether the task can be allocated, which does the queue-level capacity check.
+// If it returns true, which will do the following aspects to resources:
+// 1. Pod phase will be changed from Pending to Running.
+func (p *Plugin) AllocatableFn(queue *api.QueueInfo, candidate *api.TaskInfo) bool {
+	if queue.Queue.Status.State != scheduling.QueueStateOpen {
+		klog.V(3).Infof(
+			"Queue <%s> current state: %s, cannot allocate task <%s/%s>.",
+			queue.Name, queue.Queue.Status.State, candidate.Namespace, candidate.Name,
+		)
+		return false
+	}
+	return p.isTaskAllocatable(p.queueOpts[queue.UID], candidate)
+}
+
+// isTaskAllocatable checks whether the task can be allocated in the queue according to the queue's real capability.
+func (p *Plugin) isTaskAllocatable(qAttr *queueAttr, ti *api.TaskInfo) bool {
+	taskReqResource, err := p.GetTaskRequestResources(ti)
+	if err != nil {
+		klog.V(5).Infof(
+			"Get request resource for Task <%s/%s> failed, Queue <%s>, error: <%s>",
+			ti.Namespace, ti.Name, qAttr.name, err.Error(),
+		)
+		if ti.Pod != nil {
+			eventRecorder.Eventf(
+				ti.Pod, v1.EventTypeWarning, EventTypeGetTaskRequestResourceFailed,
+				"Get request resource failed, Queue <%s>, error: <%s>",
+				qAttr.name, err.Error(),
+			)
+		}
+		return false
+	}
+
+	var (
+		queueCapability    = qAttr.capability
+		totalToBeAllocated = qAttr.allocated.Clone().Add(taskReqResource)
+	)
+	if totalToBeAllocated == nil {
+		klog.V(5).Infof(
+			"Task <%s/%s>, Queue <%s> totalToBeAllocated is nil, allow it to allocate",
+			ti.Namespace, ti.Name, qAttr.name,
+		)
+		return true
+	}
+	if taskReqResource == nil {
+		if ok := totalToBeAllocated.LessEqual(queueCapability, api.Zero); !ok {
+			klog.Warningf(
+				"Task <%s/%s>, Queue <%s> capability <%s> is empty, deny it to allocate",
+				ti.Namespace, ti.Name, qAttr.name, queueCapability.String(),
+			)
+			if ti.Pod != nil {
+				eventRecorder.Eventf(
+					ti.Pod, v1.EventTypeWarning, EventTypeEmptyQueueCapability,
+					"Queue <%s> capability <%s> is empty, deny it to allocate",
+					qAttr.name, queueCapability.String(),
+				)
+			}
+			return false
+		}
+		klog.V(5).Infof(
+			"Task <%s/%s>, Queue <%s> request is nil, allow it to allocate",
+			ti.Namespace, ti.Name, qAttr.name,
+		)
+		return true
+	}
+
+	// check cpu and memory
+	if taskReqResource.MilliCPU > 0 && totalToBeAllocated.MilliCPU > queueCapability.MilliCPU {
+		klog.Warningf(
+			"Task <%s/%s>, Queue <%s> has no enough CPU, request <%v>, total would be <%v>, capability <%v>",
+			ti.Namespace, ti.Name, qAttr.name,
+			taskReqResource.MilliCPU, totalToBeAllocated.MilliCPU, queueCapability.MilliCPU,
+		)
+		if ti.Pod != nil {
+			eventRecorder.Eventf(
+				ti.Pod, v1.EventTypeWarning, EventTypeInsufficientCPUQuota,
+				"Queue <%s> has insufficient CPU quota: requested <%v>, total would be <%v>, but capability is <%v>",
+				qAttr.name, taskReqResource.MilliCPU, totalToBeAllocated.MilliCPU, queueCapability.MilliCPU,
+			)
+		}
+		return false
+	}
+	if taskReqResource.Memory > 0 && totalToBeAllocated.Memory > queueCapability.Memory {
+		var (
+			taskReqResourceMi    = taskReqResource.Memory / 1024 / 1024
+			totalToBeAllocatedMi = totalToBeAllocated.Memory / 1024 / 1024
+			queueCapabilityMi    = queueCapability.Memory / 1024 / 1024
+		)
+		klog.Warningf(
+			"Task <%s/%s>, Queue <%s> has no enough Memory, request <%v Mi>, total would be <%v Mi>, capability <%v Mi>",
+			ti.Namespace, ti.Name, qAttr.name, taskReqResourceMi, totalToBeAllocatedMi, queueCapabilityMi,
+		)
+		if ti.Pod != nil {
+			eventRecorder.Eventf(
+				ti.Pod, v1.EventTypeWarning, EventTypeInsufficientMemoryQuota,
+				"Queue <%s> has insufficient memory quota: requested <%v Mi>, total would be <%v Mi>, but capability is <%v Mi>",
+				qAttr.name, taskReqResourceMi, totalToBeAllocatedMi, queueCapabilityMi,
+			)
+		}
+		return false
+	}
+
+	// if r.scalar is nil, whatever rr.scalar is, r is less or equal to rr
+	if totalToBeAllocated.ScalarResources == nil {
+		return true
+	}
+
+	for scalarName, scalarQuant := range taskReqResource.ScalarResources {
+		if api.IsIgnoredScalarResource(scalarName) {
+			continue
+		}
+		checkResult := CheckSingleScalarResource(
+			scalarName, scalarQuant, totalToBeAllocated, queueCapability, CheckModeTask,
+		)
+		if checkResult.Ok {
+			continue
+		}
+		klog.Warningf(
+			"Task <%s/%s>, Queue <%s> has no enough %s, request <%v>, total would be <%v>, capability <%v>",
+			ti.Namespace, ti.Name, qAttr.name,
+			checkResult.NoEnoughScalarName,
+			checkResult.NoEnoughScalarCount,
+			checkResult.ToBeUsedScalarQuant,
+			checkResult.QueueCapabilityQuant,
+		)
+		if ti.Pod != nil {
+			eventRecorder.Eventf(
+				ti.Pod, v1.EventTypeWarning, EventTypeInsufficientScalarQuota,
+				"Queue <%s> has insufficient <%s> quota: requested <%v>, total would be <%v>, but capability is <%v>",
+				qAttr.name,
+				checkResult.NoEnoughScalarName,
+				checkResult.NoEnoughScalarCount,
+				checkResult.ToBeUsedScalarQuant,
+				checkResult.QueueCapabilityQuant,
+			)
+		}
+		return false
+	}
+	return true
+}

--- a/pkg/scheduler/plugins/capacity-card/capacity_card_fn_allocatable_test.go
+++ b/pkg/scheduler/plugins/capacity-card/capacity_card_fn_allocatable_test.go
@@ -1,0 +1,779 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+Copyright 2018-2025 The Volcano Authors.
+
+Modifications made by Volcano authors:
+- Enhanced gang scheduling validation with task-level validity checks
+- Improved preemption logic to respect gang scheduling constraints
+- Added support for job starving detection and enhanced pipeline state management
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package capacitycard
+
+import (
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/record"
+
+	"volcano.sh/apis/pkg/apis/scheduling"
+	"volcano.sh/volcano/pkg/scheduler/api"
+)
+
+// TestAllocatableFn tests the AllocatableFn function
+func TestAllocatableFn(t *testing.T) {
+	tests := []struct {
+		name        string
+		plugin      *Plugin
+		queue       *api.QueueInfo
+		task        *api.TaskInfo
+		queueState  scheduling.QueueState
+		expected    bool
+		description string
+	}{
+		{
+			name: "queue is open and task is allocatable",
+			plugin: &Plugin{
+				queueOpts: map[api.QueueID]*queueAttr{
+					"queue-1": {
+						queueID: "queue-1",
+						name:    "test-queue",
+						allocated: &api.Resource{
+							MilliCPU: 1000,
+							Memory:   1 * 1024 * 1024 * 1024,
+						},
+						capability: &api.Resource{
+							MilliCPU: 10000,
+							Memory:   10 * 1024 * 1024 * 1024,
+						},
+					},
+				},
+				cardNameToResourceName:   map[v1.ResourceName]v1.ResourceName{},
+				isCardUnlimitedCpuMemory: false,
+			},
+			queue: &api.QueueInfo{
+				UID:  "queue-1",
+				Name: "test-queue",
+				Queue: &scheduling.Queue{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-queue",
+					},
+					Status: scheduling.QueueStatus{
+						State: scheduling.QueueStateOpen,
+					},
+				},
+			},
+			task: &api.TaskInfo{
+				UID:       "task-1",
+				Name:      "test-task",
+				Namespace: "default",
+				Resreq: &api.Resource{
+					MilliCPU: 2000,
+					Memory:   2 * 1024 * 1024 * 1024,
+				},
+				Pod: &v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-task",
+						Namespace: "default",
+					},
+				},
+			},
+			queueState:  scheduling.QueueStateOpen,
+			expected:    true,
+			description: "Queue is open and has enough resources",
+		},
+		{
+			name: "queue is closed",
+			plugin: &Plugin{
+				queueOpts: map[api.QueueID]*queueAttr{
+					"queue-2": {
+						queueID: "queue-2",
+						name:    "closed-queue",
+						allocated: &api.Resource{
+							MilliCPU: 0,
+							Memory:   0,
+						},
+						capability: &api.Resource{
+							MilliCPU: 10000,
+							Memory:   10 * 1024 * 1024 * 1024,
+						},
+					},
+				},
+				cardNameToResourceName:   map[v1.ResourceName]v1.ResourceName{},
+				isCardUnlimitedCpuMemory: false,
+			},
+			queue: &api.QueueInfo{
+				UID:  "queue-2",
+				Name: "closed-queue",
+				Queue: &scheduling.Queue{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "closed-queue",
+					},
+					Status: scheduling.QueueStatus{
+						State: scheduling.QueueStateClosed,
+					},
+				},
+			},
+			task: &api.TaskInfo{
+				UID:       "task-2",
+				Name:      "test-task-2",
+				Namespace: "default",
+				Resreq: &api.Resource{
+					MilliCPU: 1000,
+					Memory:   1 * 1024 * 1024 * 1024,
+				},
+			},
+			queueState:  scheduling.QueueStateClosed,
+			expected:    false,
+			description: "Queue is closed, should reject task",
+		},
+		{
+			name: "queue is unknown state",
+			plugin: &Plugin{
+				queueOpts: map[api.QueueID]*queueAttr{
+					"queue-3": {
+						queueID:   "queue-3",
+						name:      "unknown-queue",
+						allocated: api.EmptyResource(),
+						capability: &api.Resource{
+							MilliCPU: 5000,
+							Memory:   5 * 1024 * 1024 * 1024,
+						},
+					},
+				},
+				cardNameToResourceName:   map[v1.ResourceName]v1.ResourceName{},
+				isCardUnlimitedCpuMemory: false,
+			},
+			queue: &api.QueueInfo{
+				UID:  "queue-3",
+				Name: "unknown-queue",
+				Queue: &scheduling.Queue{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "unknown-queue",
+					},
+					Status: scheduling.QueueStatus{
+						State: scheduling.QueueStateUnknown,
+					},
+				},
+			},
+			task: &api.TaskInfo{
+				UID:       "task-3",
+				Name:      "test-task-3",
+				Namespace: "default",
+				Resreq: &api.Resource{
+					MilliCPU: 1000,
+					Memory:   1 * 1024 * 1024 * 1024,
+				},
+			},
+			queueState:  scheduling.QueueStateUnknown,
+			expected:    false,
+			description: "Queue state is unknown, should reject task",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.plugin.AllocatableFn(tt.queue, tt.task)
+			if result != tt.expected {
+				t.Errorf("%s: expected %v, got %v", tt.description, tt.expected, result)
+			}
+		})
+	}
+}
+
+// TestIsTaskAllocatable tests the isTaskAllocatable function
+func TestIsTaskAllocatable(t *testing.T) {
+	// Initialize the global eventRecorder for testing
+	eventRecorder = record.NewFakeRecorder(100)
+
+	tests := []struct {
+		name        string
+		plugin      *Plugin
+		qAttr       *queueAttr
+		task        *api.TaskInfo
+		expected    bool
+		description string
+	}{
+		{
+			name: "task with card resource but no card name - should use CPU/Memory only",
+			plugin: &Plugin{
+				cardNameToResourceName: map[v1.ResourceName]v1.ResourceName{
+					"NVIDIA-H200": "nvidia.com/gpu",
+				},
+				isCardUnlimitedCpuMemory: false,
+			},
+			qAttr: &queueAttr{
+				queueID: "queue-1",
+				name:    "test-queue",
+				allocated: &api.Resource{
+					MilliCPU: 1000,
+					Memory:   1 * 1024 * 1024 * 1024,
+				},
+				capability: &api.Resource{
+					MilliCPU: 10000,
+					Memory:   10 * 1024 * 1024 * 1024,
+				},
+			},
+			task: &api.TaskInfo{
+				UID:       "task-1",
+				Name:      "no-card-name-task",
+				Namespace: "default",
+				Resreq: &api.Resource{
+					MilliCPU: 2000,
+					Memory:   2 * 1024 * 1024 * 1024,
+				},
+				Pod: &v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "no-card-name-task",
+						Namespace: "default",
+						// No card annotation
+					},
+					Spec: v1.PodSpec{
+						Containers: []v1.Container{
+							{
+								Resources: v1.ResourceRequirements{
+									Limits: v1.ResourceList{
+										"nvidia.com/gpu": resource.MustParse("1"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected:    true,
+			description: "Task without card name annotation should be allocatable based on CPU/Memory",
+		},
+		{
+			name: "empty allocated resource should work",
+			plugin: &Plugin{
+				cardNameToResourceName:   map[v1.ResourceName]v1.ResourceName{},
+				isCardUnlimitedCpuMemory: false,
+			},
+			qAttr: &queueAttr{
+				queueID:   "queue-2",
+				name:      "empty-allocated-queue",
+				allocated: api.EmptyResource(),
+				capability: &api.Resource{
+					MilliCPU: 10000,
+					Memory:   10 * 1024 * 1024 * 1024,
+				},
+			},
+			task: &api.TaskInfo{
+				UID:       "task-2",
+				Name:      "test-task",
+				Namespace: "default",
+				Resreq: &api.Resource{
+					MilliCPU: 1000,
+					Memory:   1 * 1024 * 1024 * 1024,
+				},
+			},
+			expected:    true,
+			description: "Empty allocated resource should allow allocation",
+		},
+		{
+			name: "insufficient CPU quota",
+			plugin: &Plugin{
+				cardNameToResourceName:   map[v1.ResourceName]v1.ResourceName{},
+				isCardUnlimitedCpuMemory: false,
+			},
+			qAttr: &queueAttr{
+				queueID: "queue-3",
+				name:    "cpu-limited-queue",
+				allocated: &api.Resource{
+					MilliCPU: 8000,
+					Memory:   5 * 1024 * 1024 * 1024,
+				},
+				capability: &api.Resource{
+					MilliCPU: 10000,
+					Memory:   20 * 1024 * 1024 * 1024,
+				},
+			},
+			task: &api.TaskInfo{
+				UID:       "task-3",
+				Name:      "cpu-heavy-task",
+				Namespace: "default",
+				Resreq: &api.Resource{
+					MilliCPU: 3000, // 8000 + 3000 > 10000
+					Memory:   2 * 1024 * 1024 * 1024,
+				},
+				Pod: nil, // No pod to avoid eventRecorder issue in unit test
+			},
+			expected:    false,
+			description: "Should reject task when CPU quota is insufficient",
+		},
+		{
+			name: "insufficient Memory quota",
+			plugin: &Plugin{
+				cardNameToResourceName:   map[v1.ResourceName]v1.ResourceName{},
+				isCardUnlimitedCpuMemory: false,
+			},
+			qAttr: &queueAttr{
+				queueID: "queue-4",
+				name:    "memory-limited-queue",
+				allocated: &api.Resource{
+					MilliCPU: 2000,
+					Memory:   8 * 1024 * 1024 * 1024,
+				},
+				capability: &api.Resource{
+					MilliCPU: 20000,
+					Memory:   10 * 1024 * 1024 * 1024,
+				},
+			},
+			task: &api.TaskInfo{
+				UID:       "task-4",
+				Name:      "memory-heavy-task",
+				Namespace: "default",
+				Resreq: &api.Resource{
+					MilliCPU: 1000,
+					Memory:   3 * 1024 * 1024 * 1024, // 8 + 3 > 10
+				},
+				Pod: nil, // No pod to avoid eventRecorder issue in unit test
+			},
+			expected:    false,
+			description: "Should reject task when memory quota is insufficient",
+		},
+		{
+			name: "task without GPU request should pass even with GPU quota nearly full",
+			plugin: &Plugin{
+				cardNameToResourceName: map[v1.ResourceName]v1.ResourceName{
+					"NVIDIA-H200": "nvidia.com/gpu",
+				},
+				isCardUnlimitedCpuMemory: false,
+			},
+			qAttr: &queueAttr{
+				queueID: "queue-5",
+				name:    "gpu-limited-queue",
+				allocated: &api.Resource{
+					MilliCPU: 4000,
+					Memory:   8 * 1024 * 1024 * 1024,
+					ScalarResources: map[v1.ResourceName]float64{
+						"NVIDIA-H200": 3500, // 3.5 GPUs already allocated
+					},
+				},
+				capability: &api.Resource{
+					MilliCPU: 16000,
+					Memory:   32 * 1024 * 1024 * 1024,
+					ScalarResources: map[v1.ResourceName]float64{
+						"NVIDIA-H200": 4000, // Only 4 GPUs available
+					},
+				},
+			},
+			task: &api.TaskInfo{
+				UID:       "task-5",
+				Name:      "cpu-only-task",
+				Namespace: "default",
+				Resreq: &api.Resource{
+					MilliCPU: 2000,
+					Memory:   4 * 1024 * 1024 * 1024,
+				},
+				Pod: nil, // No pod, no GPU request
+			},
+			expected:    true,
+			description: "Task without GPU request should pass even if GPU quota is nearly full",
+		},
+		{
+			name: "successful allocation with CPU and memory",
+			plugin: &Plugin{
+				cardNameToResourceName:   map[v1.ResourceName]v1.ResourceName{},
+				isCardUnlimitedCpuMemory: false,
+			},
+			qAttr: &queueAttr{
+				queueID: "queue-6",
+				name:    "normal-queue",
+				allocated: &api.Resource{
+					MilliCPU: 2000,
+					Memory:   2 * 1024 * 1024 * 1024,
+				},
+				capability: &api.Resource{
+					MilliCPU: 10000,
+					Memory:   10 * 1024 * 1024 * 1024,
+				},
+			},
+			task: &api.TaskInfo{
+				UID:       "task-6",
+				Name:      "normal-task",
+				Namespace: "default",
+				Resreq: &api.Resource{
+					MilliCPU: 3000,
+					Memory:   3 * 1024 * 1024 * 1024,
+				},
+				Pod: &v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "normal-task",
+						Namespace: "default",
+					},
+				},
+			},
+			expected:    true,
+			description: "Should allow allocation when resources are sufficient",
+		},
+		{
+			name: "successful allocation with GPU",
+			plugin: &Plugin{
+				cardNameToResourceName: map[v1.ResourceName]v1.ResourceName{
+					"NVIDIA-A100": "nvidia.com/gpu",
+				},
+				isCardUnlimitedCpuMemory: false,
+			},
+			qAttr: &queueAttr{
+				queueID: "queue-7",
+				name:    "gpu-queue",
+				allocated: &api.Resource{
+					MilliCPU: 4000,
+					Memory:   8 * 1024 * 1024 * 1024,
+					ScalarResources: map[v1.ResourceName]float64{
+						"NVIDIA-A100": 2000, // 2 GPUs allocated
+					},
+				},
+				capability: &api.Resource{
+					MilliCPU: 16000,
+					Memory:   32 * 1024 * 1024 * 1024,
+					ScalarResources: map[v1.ResourceName]float64{
+						"NVIDIA-A100": 8000, // 8 GPUs available
+					},
+				},
+			},
+			task: &api.TaskInfo{
+				UID:       "task-7",
+				Name:      "gpu-task-ok",
+				Namespace: "default",
+				Resreq: &api.Resource{
+					MilliCPU: 4000,
+					Memory:   8 * 1024 * 1024 * 1024,
+				},
+				Pod: &v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "gpu-task-ok",
+						Namespace: "default",
+						Annotations: map[string]string{
+							TaskAnnotationKeyCardName: "NVIDIA-A100",
+						},
+					},
+					Spec: v1.PodSpec{
+						Containers: []v1.Container{
+							{
+								Resources: v1.ResourceRequirements{
+									Limits: v1.ResourceList{
+										"nvidia.com/gpu": resource.MustParse("4"), // 2 + 4 <= 8, OK
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected:    true,
+			description: "Should allow allocation when GPU quota is sufficient",
+		},
+		{
+			name: "successful allocation with GPU and card unlimited cpu memory enabled",
+			plugin: &Plugin{
+				cardNameToResourceName: map[v1.ResourceName]v1.ResourceName{
+					"NVIDIA-A100": "nvidia.com/gpu",
+				},
+				isCardUnlimitedCpuMemory: true,
+			},
+			qAttr: &queueAttr{
+				queueID: "queue-7",
+				name:    "gpu-queue",
+				allocated: &api.Resource{
+					MilliCPU: 16000,
+					Memory:   32 * 1024 * 1024 * 1024,
+					ScalarResources: map[v1.ResourceName]float64{
+						"NVIDIA-A100": 2000, // 2 GPUs allocated
+					},
+				},
+				capability: &api.Resource{
+					MilliCPU: 16000,
+					Memory:   32 * 1024 * 1024 * 1024,
+					ScalarResources: map[v1.ResourceName]float64{
+						"NVIDIA-A100": 8000, // 8 GPUs available
+					},
+				},
+			},
+			task: &api.TaskInfo{
+				UID:       "task-7",
+				Name:      "gpu-task-ok",
+				Namespace: "default",
+				Resreq: &api.Resource{
+					MilliCPU: 4000,
+					Memory:   8 * 1024 * 1024 * 1024,
+				},
+				Pod: &v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "gpu-task-ok",
+						Namespace: "default",
+						Annotations: map[string]string{
+							TaskAnnotationKeyCardName: "NVIDIA-A100",
+						},
+					},
+					Spec: v1.PodSpec{
+						Containers: []v1.Container{
+							{
+								Resources: v1.ResourceRequirements{
+									Limits: v1.ResourceList{
+										"nvidia.com/gpu": resource.MustParse("4"), // 2 + 4 <= 8, OK
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected:    true,
+			description: "Should allow allocation when GPU quota is sufficient and card unlimited cpu memory is enabled",
+		},
+		{
+			name: "successful allocation with GPU and card unlimited cpu memory disabled",
+			plugin: &Plugin{
+				cardNameToResourceName: map[v1.ResourceName]v1.ResourceName{
+					"NVIDIA-A100": "nvidia.com/gpu",
+				},
+				isCardUnlimitedCpuMemory: false,
+			},
+			qAttr: &queueAttr{
+				queueID: "queue-7",
+				name:    "gpu-queue",
+				allocated: &api.Resource{
+					MilliCPU: 16000,
+					Memory:   32 * 1024 * 1024 * 1024,
+					ScalarResources: map[v1.ResourceName]float64{
+						"NVIDIA-A100": 2000, // 2 GPUs allocated
+					},
+				},
+				capability: &api.Resource{
+					MilliCPU: 16000,
+					Memory:   32 * 1024 * 1024 * 1024,
+					ScalarResources: map[v1.ResourceName]float64{
+						"NVIDIA-A100": 8000, // 8 GPUs available
+					},
+				},
+			},
+			task: &api.TaskInfo{
+				UID:       "task-7",
+				Name:      "gpu-task-ok",
+				Namespace: "default",
+				Resreq: &api.Resource{
+					MilliCPU: 4000,
+					Memory:   8 * 1024 * 1024 * 1024,
+				},
+				Pod: &v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "gpu-task-ok",
+						Namespace: "default",
+						Annotations: map[string]string{
+							TaskAnnotationKeyCardName: "NVIDIA-A100",
+						},
+					},
+					Spec: v1.PodSpec{
+						Containers: []v1.Container{
+							{
+								Resources: v1.ResourceRequirements{
+									Limits: v1.ResourceList{
+										"nvidia.com/gpu": resource.MustParse("4"), // 2 + 4 <= 8, OK
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected:    false,
+			description: "Should not allow allocation when GPU quota is sufficient and card unlimited cpu memory is disabled",
+		},
+		{
+			name: "task with nil request resource should pass if queue has capacity",
+			plugin: &Plugin{
+				cardNameToResourceName:   map[v1.ResourceName]v1.ResourceName{},
+				isCardUnlimitedCpuMemory: false,
+			},
+			qAttr: &queueAttr{
+				queueID: "queue-8",
+				name:    "test-queue",
+				allocated: &api.Resource{
+					MilliCPU: 1000,
+					Memory:   1 * 1024 * 1024 * 1024,
+				},
+				capability: &api.Resource{
+					MilliCPU: 10000,
+					Memory:   10 * 1024 * 1024 * 1024,
+				},
+			},
+			task: &api.TaskInfo{
+				UID:       "task-8",
+				Name:      "nil-request-task",
+				Namespace: "default",
+				Resreq:    nil,
+				Pod:       nil,
+			},
+			expected:    true,
+			description: "Task with nil request should be allowed if allocated is within capability",
+		},
+		{
+			name: "totalToBeAllocated ScalarResources is nil - should allow",
+			plugin: &Plugin{
+				cardNameToResourceName:   map[v1.ResourceName]v1.ResourceName{},
+				isCardUnlimitedCpuMemory: false,
+			},
+			qAttr: &queueAttr{
+				queueID: "queue-9",
+				name:    "no-scalar-queue",
+				allocated: &api.Resource{
+					MilliCPU:        2000,
+					Memory:          2 * 1024 * 1024 * 1024,
+					ScalarResources: nil, // No scalar resources
+				},
+				capability: &api.Resource{
+					MilliCPU: 10000,
+					Memory:   10 * 1024 * 1024 * 1024,
+				},
+			},
+			task: &api.TaskInfo{
+				UID:       "task-9",
+				Name:      "no-scalar-task",
+				Namespace: "default",
+				Resreq: &api.Resource{
+					MilliCPU: 1000,
+					Memory:   1 * 1024 * 1024 * 1024,
+				},
+			},
+			expected:    true,
+			description: "Should allow when totalToBeAllocated has no scalar resources",
+		},
+		{
+			name: "zero CPU request should not trigger CPU check",
+			plugin: &Plugin{
+				cardNameToResourceName:   map[v1.ResourceName]v1.ResourceName{},
+				isCardUnlimitedCpuMemory: false,
+			},
+			qAttr: &queueAttr{
+				queueID: "queue-10",
+				name:    "zero-cpu-queue",
+				allocated: &api.Resource{
+					MilliCPU: 9500, // Almost full
+					Memory:   2 * 1024 * 1024 * 1024,
+				},
+				capability: &api.Resource{
+					MilliCPU: 10000,
+					Memory:   10 * 1024 * 1024 * 1024,
+				},
+			},
+			task: &api.TaskInfo{
+				UID:       "task-10",
+				Name:      "zero-cpu-task",
+				Namespace: "default",
+				Resreq: &api.Resource{
+					MilliCPU: 0, // Zero CPU, should skip CPU check
+					Memory:   1 * 1024 * 1024 * 1024,
+				},
+			},
+			expected:    true,
+			description: "Zero CPU request should skip CPU quota check",
+		},
+		{
+			name: "zero memory request should not trigger memory check",
+			plugin: &Plugin{
+				cardNameToResourceName:   map[v1.ResourceName]v1.ResourceName{},
+				isCardUnlimitedCpuMemory: false,
+			},
+			qAttr: &queueAttr{
+				queueID: "queue-11",
+				name:    "zero-memory-queue",
+				allocated: &api.Resource{
+					MilliCPU: 2000,
+					Memory:   9 * 1024 * 1024 * 1024, // Almost full
+				},
+				capability: &api.Resource{
+					MilliCPU: 10000,
+					Memory:   10 * 1024 * 1024 * 1024,
+				},
+			},
+			task: &api.TaskInfo{
+				UID:       "task-11",
+				Name:      "zero-memory-task",
+				Namespace: "default",
+				Resreq: &api.Resource{
+					MilliCPU: 1000,
+					Memory:   0, // Zero memory, should skip memory check
+				},
+			},
+			expected:    true,
+			description: "Zero memory request should skip memory quota check",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.plugin.isTaskAllocatable(tt.qAttr, tt.task)
+			if result != tt.expected {
+				t.Errorf("%s: expected %v, got %v", tt.description, tt.expected, result)
+			}
+		})
+	}
+}
+
+// TestIsTaskAllocatableWithIgnoredScalarResource tests ignored scalar resources
+func TestIsTaskAllocatableWithIgnoredScalarResource(t *testing.T) {
+	// Initialize the global eventRecorder for testing
+	eventRecorder = record.NewFakeRecorder(100)
+
+	// This test verifies that ignored scalar resources (like ephemeral-storage)
+	// are not checked against quota
+	plugin := &Plugin{
+		cardNameToResourceName:   map[v1.ResourceName]v1.ResourceName{},
+		isCardUnlimitedCpuMemory: false,
+	}
+
+	qAttr := &queueAttr{
+		queueID: "queue-ignore",
+		name:    "ignore-scalar-queue",
+		allocated: &api.Resource{
+			MilliCPU: 2000,
+			Memory:   2 * 1024 * 1024 * 1024,
+			ScalarResources: map[v1.ResourceName]float64{
+				v1.ResourceEphemeralStorage: 100 * 1024 * 1024 * 1024, // High ephemeral storage
+			},
+		},
+		capability: &api.Resource{
+			MilliCPU: 10000,
+			Memory:   10 * 1024 * 1024 * 1024,
+			ScalarResources: map[v1.ResourceName]float64{
+				v1.ResourceEphemeralStorage: 50 * 1024 * 1024 * 1024, // Lower than allocated
+			},
+		},
+	}
+
+	task := &api.TaskInfo{
+		UID:       "task-ignore",
+		Name:      "ignore-scalar-task",
+		Namespace: "default",
+		Resreq: &api.Resource{
+			MilliCPU: 1000,
+			Memory:   1 * 1024 * 1024 * 1024,
+			ScalarResources: map[v1.ResourceName]float64{
+				v1.ResourceEphemeralStorage: 10 * 1024 * 1024 * 1024,
+			},
+		},
+	}
+
+	// Should pass because ephemeral-storage is ignored
+	result := plugin.isTaskAllocatable(qAttr, task)
+	if !result {
+		t.Errorf("Expected task to be allocatable when only ignored scalar resources exceed quota, got false")
+	}
+}

--- a/pkg/scheduler/plugins/capacity-card/capacity_card_fn_job_enqueueable.go
+++ b/pkg/scheduler/plugins/capacity-card/capacity_card_fn_job_enqueueable.go
@@ -1,0 +1,202 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+Copyright 2018-2025 The Volcano Authors.
+
+Modifications made by Volcano authors:
+- Enhanced gang scheduling validation with task-level validity checks
+- Improved preemption logic to respect gang scheduling constraints
+- Added support for job starving detection and enhanced pipeline state management
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package capacitycard
+
+import (
+	"fmt"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/klog/v2"
+
+	"volcano.sh/apis/pkg/apis/scheduling"
+	"volcano.sh/volcano/pkg/scheduler/api"
+	"volcano.sh/volcano/pkg/scheduler/framework"
+	"volcano.sh/volcano/pkg/scheduler/plugins/util"
+)
+
+// JobEnqueueableFn checks whether the job can be enqueued, which does the queue-level capacity pre-check.
+// It handles pending PodGroups, and checks whether the queue has enough resource to proceed.
+// If it returns util.Permit, which will do the following aspects to resources:
+// 1. PogGroup phase will be changed from Pending to InQueue.
+// 2. Pod will be created and in phase of Pending.
+func (p *Plugin) JobEnqueueableFn(ssn *framework.Session, jobInfo *api.JobInfo) int {
+	job, err := p.NewJobInfo(jobInfo)
+	if err != nil {
+		klog.Errorf(
+			"Failed to create jobInfo for job <%s/%s>: %+v",
+			jobInfo.Namespace, jobInfo.Name, err,
+		)
+		return util.Reject
+	}
+
+	var (
+		queueID = job.Queue
+		queue   = ssn.Queues[queueID]
+		qAttr   = p.queueOpts[queueID]
+	)
+	// If the queue is not open, do not enqueue
+	if queue.Queue.Status.State != scheduling.QueueStateOpen {
+		klog.V(3).Infof(
+			"Queue <%s> current state: %s, is not open state, reject job <%s/%s>.",
+			queue.Name, queue.Queue.Status.State, job.Namespace, job.Name,
+		)
+		return util.Reject
+	}
+
+	// it checks whether the queue has enough resource to run the job.
+	if !p.isJobEnqueueable(ssn, qAttr, job) {
+		klog.V(2).Infof(
+			"Queue <%s> has no enough resource for job <%s/%s>",
+			queue.Name, job.Namespace, job.Name,
+		)
+		return util.Reject
+	}
+
+	// job enqueued
+	deductedResources := job.DeductSchGatedResources(p.GetMinResources(job))
+	qAttr.inqueue.Add(deductedResources)
+	klog.V(5).Infof("Job <%s/%s> enqueued", job.Namespace, job.Name)
+	return util.Permit
+}
+
+// isJobEnqueueable checks whether the job can be enqueued in the queue according to the queue's real capability.
+func (p *Plugin) isJobEnqueueable(ssn *framework.Session, qAttr *queueAttr, job *JobInfo) bool {
+	var (
+		jobReqResource  = p.GetMinResources(job)
+		queueCapability = qAttr.capability
+		totalToBeUsed   = jobReqResource.Clone().
+				Add(qAttr.allocated).
+				Add(qAttr.inqueue).
+				Sub(qAttr.elastic)
+	)
+	klog.V(5).Infof(
+		"Job <%s/%s> min resource <%s>, queue %s capability <%s> allocated <%s> inqueue <%s> elastic <%s>",
+		job.Namespace, job.Name, jobReqResource.String(), qAttr.name,
+		queueCapability.String(),
+		qAttr.allocated.String(),
+		qAttr.inqueue.String(),
+		qAttr.elastic.String(),
+	)
+
+	if jobReqResource == nil {
+		if ok := totalToBeUsed.LessEqual(queueCapability, api.Zero); !ok {
+			klog.Warningf(
+				"Job <%s/%s>, Queue <%s> capability <%s> is empty, deny it to enqueue",
+				job.Namespace, job.Name, qAttr.name, queueCapability.String(),
+			)
+			ssn.RecordPodGroupEvent(
+				job.PodGroup, v1.EventTypeWarning, EventTypeEmptyQueueCapability,
+				fmt.Sprintf(
+					"Queue <%s> capability <%s> is empty, deny it to enqueue",
+					qAttr.name, queueCapability.String(),
+				),
+			)
+			return false
+		}
+		klog.V(5).Infof(
+			"Job <%s/%s>, Queue <%s> request is nil, allow it to enqueue",
+			job.Namespace, job.Name, qAttr.name,
+		)
+		return true
+	}
+
+	if totalToBeUsed == nil {
+		klog.V(5).Infof(
+			"Job <%s/%s>, Queue <%s> totalToBeUsed is nil, allow it to enqueue",
+			job.Namespace, job.Name, qAttr.name,
+		)
+		return true
+	}
+
+	// check cpu and memory
+	if jobReqResource.MilliCPU > 0 && totalToBeUsed.MilliCPU > queueCapability.MilliCPU {
+		klog.Warningf(
+			"Job <%s/%s>, Queue <%s> has no enough CPU, request <%v>, total would be <%v>, capability <%v>",
+			job.Namespace, job.Name, qAttr.name,
+			jobReqResource.MilliCPU, totalToBeUsed.MilliCPU, queueCapability.MilliCPU,
+		)
+		ssn.RecordPodGroupEvent(
+			job.PodGroup, v1.EventTypeWarning, EventTypeInsufficientCPUQuota,
+			fmt.Sprintf(
+				"Queue <%s> has insufficient CPU quota: requested <%v>, total would be <%v>, but capability is <%v>",
+				qAttr.name, jobReqResource.MilliCPU, totalToBeUsed.MilliCPU, queueCapability.MilliCPU,
+			),
+		)
+		return false
+	}
+	if jobReqResource.Memory > 0 && totalToBeUsed.Memory > queueCapability.Memory {
+		var (
+			jobReqResourceMi  = jobReqResource.Memory / 1024 / 1024
+			totalToBeUsedMi   = totalToBeUsed.Memory / 1024 / 1024
+			queueCapabilityMi = queueCapability.Memory / 1024 / 1024
+		)
+		klog.Warningf(
+			"Job <%s/%s>, Queue <%s> has no enough Memory, request <%v Mi>, total would be <%v Mi>, capability <%v Mi>",
+			job.Namespace, job.Name, qAttr.name,
+			jobReqResourceMi, totalToBeUsedMi, queueCapabilityMi,
+		)
+		ssn.RecordPodGroupEvent(
+			job.PodGroup, v1.EventTypeWarning, EventTypeInsufficientMemoryQuota,
+			fmt.Sprintf(
+				"Queue %s has insufficient memory quota: requested <%v Mi>, total would be <%v Mi>, but capability is <%v Mi>",
+				qAttr.name, jobReqResourceMi, totalToBeUsedMi, queueCapabilityMi,
+			),
+		)
+		return false
+	}
+
+	// if r.scalar is nil, whatever rr.scalar is, r is less or equal to rr
+	if totalToBeUsed.ScalarResources == nil {
+		return true
+	}
+
+	for scalarName, scalarQuant := range jobReqResource.ScalarResources {
+		if api.IsIgnoredScalarResource(scalarName) {
+			continue
+		}
+		checkResult := CheckSingleScalarResource(
+			scalarName, scalarQuant, totalToBeUsed, queueCapability, CheckModeJob,
+		)
+		if checkResult.Ok {
+			continue
+		}
+		klog.Warningf(
+			"Job <%s/%s>, Queue <%s> has no enough %s, request <%v>, total would be <%v>, capability <%v>",
+			job.Namespace, job.Name, qAttr.name,
+			checkResult.NoEnoughScalarName,
+			checkResult.NoEnoughScalarCount,
+			checkResult.ToBeUsedScalarQuant,
+			checkResult.QueueCapabilityQuant,
+		)
+		ssn.RecordPodGroupEvent(
+			job.PodGroup, v1.EventTypeWarning, EventTypeInsufficientScalarQuota,
+			fmt.Sprintf(
+				"Queue <%s> has insufficient <%s> quota: requested <%v>, total would be <%v>, but capability is <%v>",
+				qAttr.name, checkResult.NoEnoughScalarName, checkResult.NoEnoughScalarCount,
+				checkResult.ToBeUsedScalarQuant, checkResult.QueueCapabilityQuant,
+			),
+		)
+		return false
+	}
+	return true
+}

--- a/pkg/scheduler/plugins/capacity-card/capacity_card_fn_job_enqueueable_test.go
+++ b/pkg/scheduler/plugins/capacity-card/capacity_card_fn_job_enqueueable_test.go
@@ -1,0 +1,1225 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+Copyright 2018-2025 The Volcano Authors.
+
+Modifications made by Volcano authors:
+- Enhanced gang scheduling validation with task-level validity checks
+- Improved preemption logic to respect gang scheduling constraints
+- Added support for job starving detection and enhanced pipeline state management
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package capacitycard
+
+import (
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"volcano.sh/apis/pkg/apis/scheduling"
+	"volcano.sh/volcano/pkg/scheduler/api"
+	"volcano.sh/volcano/pkg/scheduler/cache"
+	"volcano.sh/volcano/pkg/scheduler/framework"
+	"volcano.sh/volcano/pkg/scheduler/plugins/util"
+)
+
+// TestJobEnqueueableFn tests the JobEnqueueableFn function
+func TestJobEnqueueableFn(t *testing.T) {
+	tests := []struct {
+		name        string
+		plugin      *Plugin
+		jobInfo     *api.JobInfo
+		queueState  scheduling.QueueState
+		expected    int
+		description string
+	}{
+		{
+			name: "queue is open and job is enqueueable",
+			plugin: &Plugin{
+				queueOpts: map[api.QueueID]*queueAttr{
+					"queue-1": {
+						queueID: "queue-1",
+						name:    "test-queue",
+						allocated: &api.Resource{
+							MilliCPU: 2000,
+							Memory:   2 * 1024 * 1024 * 1024,
+						},
+						inqueue: api.EmptyResource(),
+						elastic: api.EmptyResource(),
+						capability: &api.Resource{
+							MilliCPU: 10000,
+							Memory:   10 * 1024 * 1024 * 1024,
+						},
+					},
+				},
+				cardNameToResourceName:   map[v1.ResourceName]v1.ResourceName{},
+				isCardUnlimitedCpuMemory: false,
+			},
+			jobInfo: &api.JobInfo{
+				UID:          "job-1",
+				Name:         "test-job",
+				Namespace:    "default",
+				Queue:        "queue-1",
+				MinAvailable: 1,
+				PodGroup: &api.PodGroup{
+					PodGroup: scheduling.PodGroup{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "test-job",
+							Namespace: "default",
+						},
+						Spec: scheduling.PodGroupSpec{
+							MinResources: &v1.ResourceList{
+								v1.ResourceCPU:    resource.MustParse("1"),
+								v1.ResourceMemory: resource.MustParse("1Gi"),
+							},
+						},
+					},
+					Version: api.PodGroupVersionV1Beta1,
+				},
+				Tasks: map[api.TaskID]*api.TaskInfo{
+					"task-1": {
+						UID:       "task-1",
+						Name:      "test-task",
+						Namespace: "default",
+						Resreq: &api.Resource{
+							MilliCPU: 1000,
+							Memory:   1 * 1024 * 1024 * 1024,
+						},
+					},
+				},
+			},
+			queueState:  scheduling.QueueStateOpen,
+			expected:    util.Permit,
+			description: "Queue is open and has enough resources, should permit",
+		},
+		{
+			name: "queue is closed",
+			plugin: &Plugin{
+				queueOpts: map[api.QueueID]*queueAttr{
+					"queue-2": {
+						queueID: "queue-2",
+						name:    "closed-queue",
+						allocated: &api.Resource{
+							MilliCPU: 0,
+							Memory:   0,
+						},
+						inqueue: api.EmptyResource(),
+						elastic: api.EmptyResource(),
+						capability: &api.Resource{
+							MilliCPU: 10000,
+							Memory:   10 * 1024 * 1024 * 1024,
+						},
+					},
+				},
+				cardNameToResourceName:   map[v1.ResourceName]v1.ResourceName{},
+				isCardUnlimitedCpuMemory: false,
+			},
+			jobInfo: &api.JobInfo{
+				UID:          "job-2",
+				Name:         "test-job-2",
+				Namespace:    "default",
+				Queue:        "queue-2",
+				MinAvailable: 1,
+				PodGroup: &api.PodGroup{
+					PodGroup: scheduling.PodGroup{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "test-job-2",
+							Namespace: "default",
+						},
+						Spec: scheduling.PodGroupSpec{
+							MinResources: &v1.ResourceList{
+								v1.ResourceCPU:    resource.MustParse("1"),
+								v1.ResourceMemory: resource.MustParse("1Gi"),
+							},
+						},
+					},
+					Version: api.PodGroupVersionV1Beta1,
+				},
+			},
+			queueState:  scheduling.QueueStateClosed,
+			expected:    util.Reject,
+			description: "Queue is closed, should reject job",
+		},
+		{
+			name: "queue has insufficient CPU quota",
+			plugin: &Plugin{
+				queueOpts: map[api.QueueID]*queueAttr{
+					"queue-3": {
+						queueID: "queue-3",
+						name:    "cpu-limited-queue",
+						allocated: &api.Resource{
+							MilliCPU: 8000,
+							Memory:   2 * 1024 * 1024 * 1024,
+						},
+						inqueue: api.EmptyResource(),
+						elastic: api.EmptyResource(),
+						capability: &api.Resource{
+							MilliCPU: 10000,
+							Memory:   10 * 1024 * 1024 * 1024,
+						},
+					},
+				},
+				cardNameToResourceName:   map[v1.ResourceName]v1.ResourceName{},
+				isCardUnlimitedCpuMemory: false,
+			},
+			jobInfo: &api.JobInfo{
+				UID:          "job-3",
+				Name:         "cpu-heavy-job",
+				Namespace:    "default",
+				Queue:        "queue-3",
+				MinAvailable: 1,
+				PodGroup: &api.PodGroup{
+					PodGroup: scheduling.PodGroup{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "cpu-heavy-job",
+							Namespace: "default",
+						},
+						Spec: scheduling.PodGroupSpec{
+							MinResources: &v1.ResourceList{
+								v1.ResourceCPU:    resource.MustParse("3"),
+								v1.ResourceMemory: resource.MustParse("1Gi"),
+							},
+						},
+					},
+					Version: api.PodGroupVersionV1Beta1,
+				},
+			},
+			queueState:  scheduling.QueueStateOpen,
+			expected:    util.Reject,
+			description: "Queue has insufficient CPU quota, should reject job",
+		},
+		{
+			name: "queue has insufficient Memory quota",
+			plugin: &Plugin{
+				queueOpts: map[api.QueueID]*queueAttr{
+					"queue-4": {
+						queueID: "queue-4",
+						name:    "memory-limited-queue",
+						allocated: &api.Resource{
+							MilliCPU: 2000,
+							Memory:   8 * 1024 * 1024 * 1024,
+						},
+						inqueue: api.EmptyResource(),
+						elastic: api.EmptyResource(),
+						capability: &api.Resource{
+							MilliCPU: 10000,
+							Memory:   10 * 1024 * 1024 * 1024,
+						},
+					},
+				},
+				cardNameToResourceName:   map[v1.ResourceName]v1.ResourceName{},
+				isCardUnlimitedCpuMemory: false,
+			},
+			jobInfo: &api.JobInfo{
+				UID:          "job-4",
+				Name:         "memory-heavy-job",
+				Namespace:    "default",
+				Queue:        "queue-4",
+				MinAvailable: 1,
+				PodGroup: &api.PodGroup{
+					PodGroup: scheduling.PodGroup{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "memory-heavy-job",
+							Namespace: "default",
+						},
+						Spec: scheduling.PodGroupSpec{
+							MinResources: &v1.ResourceList{
+								v1.ResourceCPU:    resource.MustParse("1"),
+								v1.ResourceMemory: resource.MustParse("3Gi"),
+							},
+						},
+					},
+					Version: api.PodGroupVersionV1Beta1,
+				},
+			},
+			queueState:  scheduling.QueueStateOpen,
+			expected:    util.Reject,
+			description: "Queue has insufficient memory quota, should reject job",
+		},
+		{
+			name: "queue has insufficient scalar quota (GPU)",
+			plugin: &Plugin{
+				queueOpts: map[api.QueueID]*queueAttr{
+					"queue-5": {
+						queueID: "queue-5",
+						name:    "gpu-limited-queue",
+						allocated: &api.Resource{
+							MilliCPU: 2000,
+							Memory:   2 * 1024 * 1024 * 1024,
+							ScalarResources: map[v1.ResourceName]float64{
+								"NVIDIA-A100": 3500, // 3.5 GPUs allocated
+							},
+						},
+						inqueue: api.EmptyResource(),
+						elastic: api.EmptyResource(),
+						capability: &api.Resource{
+							MilliCPU: 10000,
+							Memory:   10 * 1024 * 1024 * 1024,
+							ScalarResources: map[v1.ResourceName]float64{
+								"NVIDIA-A100": 4000, // Only 4 GPUs available
+							},
+						},
+					},
+				},
+				cardNameToResourceName:   map[v1.ResourceName]v1.ResourceName{},
+				isCardUnlimitedCpuMemory: false,
+			},
+			jobInfo: &api.JobInfo{
+				UID:          "job-5",
+				Name:         "gpu-job",
+				Namespace:    "default",
+				Queue:        "queue-5",
+				MinAvailable: 1,
+				PodGroup: &api.PodGroup{
+					PodGroup: scheduling.PodGroup{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "gpu-job",
+							Namespace: "default",
+							Annotations: map[string]string{
+								JobAnnotationKeyCardRequest: `{"NVIDIA-A100": 1}`,
+							},
+						},
+						Spec: scheduling.PodGroupSpec{
+							MinResources: &v1.ResourceList{
+								v1.ResourceCPU:    resource.MustParse("1"),
+								v1.ResourceMemory: resource.MustParse("1Gi"),
+							},
+						},
+					},
+					Version: api.PodGroupVersionV1Beta1,
+				},
+			},
+			queueState:  scheduling.QueueStateOpen,
+			expected:    util.Reject,
+			description: "Queue has insufficient GPU quota, should reject job",
+		},
+		{
+			name: "job with card annotation and sufficient resources",
+			plugin: &Plugin{
+				queueOpts: map[api.QueueID]*queueAttr{
+					"queue-6": {
+						queueID: "queue-6",
+						name:    "gpu-queue",
+						allocated: &api.Resource{
+							MilliCPU: 2000,
+							Memory:   2 * 1024 * 1024 * 1024,
+							ScalarResources: map[v1.ResourceName]float64{
+								"NVIDIA-A100": 2000, // 2 GPUs allocated
+							},
+						},
+						inqueue: api.EmptyResource(),
+						elastic: api.EmptyResource(),
+						capability: &api.Resource{
+							MilliCPU: 10000,
+							Memory:   10 * 1024 * 1024 * 1024,
+							ScalarResources: map[v1.ResourceName]float64{
+								"NVIDIA-A100": 8000, // 8 GPUs available
+							},
+						},
+					},
+				},
+				cardNameToResourceName:   map[v1.ResourceName]v1.ResourceName{},
+				isCardUnlimitedCpuMemory: false,
+			},
+			jobInfo: &api.JobInfo{
+				UID:          "job-6",
+				Name:         "gpu-job-ok",
+				Namespace:    "default",
+				Queue:        "queue-6",
+				MinAvailable: 1,
+				PodGroup: &api.PodGroup{
+					PodGroup: scheduling.PodGroup{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "gpu-job-ok",
+							Namespace: "default",
+							Annotations: map[string]string{
+								JobAnnotationKeyCardRequest: `{"NVIDIA-A100": 2}`,
+							},
+						},
+						Spec: scheduling.PodGroupSpec{
+							MinResources: &v1.ResourceList{
+								v1.ResourceCPU:    resource.MustParse("2"),
+								v1.ResourceMemory: resource.MustParse("2Gi"),
+							},
+						},
+					},
+					Version: api.PodGroupVersionV1Beta1,
+				},
+			},
+			queueState:  scheduling.QueueStateOpen,
+			expected:    util.Permit,
+			description: "Job with card annotation and sufficient resources should be permitted",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create session using mock cache
+			mockCache := cache.NewDefaultMockSchedulerCache("test-scheduler")
+
+			// Create queue info
+			queueInfo := &api.QueueInfo{
+				UID:  api.QueueID(tt.jobInfo.Queue),
+				Name: tt.plugin.queueOpts[api.QueueID(tt.jobInfo.Queue)].name,
+				Queue: &scheduling.Queue{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: tt.plugin.queueOpts[api.QueueID(tt.jobInfo.Queue)].name,
+					},
+					Status: scheduling.QueueStatus{
+						State: tt.queueState,
+					},
+				},
+			}
+
+			ssn := framework.OpenSession(mockCache, nil, nil)
+			defer framework.CloseSession(ssn)
+
+			// Add queue to session
+			ssn.Queues[queueInfo.UID] = queueInfo
+
+			result := tt.plugin.JobEnqueueableFn(ssn, tt.jobInfo)
+			if result != tt.expected {
+				t.Errorf("%s: expected %v, got %v", tt.description, tt.expected, result)
+			}
+		})
+	}
+}
+
+// TestIsJobEnqueueable tests the isJobEnqueueable function
+func TestIsJobEnqueueable(t *testing.T) {
+	// Create a mock session for event recording
+	mockCache := cache.NewDefaultMockSchedulerCache("test-scheduler")
+	ssn := framework.OpenSession(mockCache, nil, nil)
+	defer framework.CloseSession(ssn)
+
+	tests := []struct {
+		name        string
+		plugin      *Plugin
+		qAttr       *queueAttr
+		job         *JobInfo
+		expected    bool
+		description string
+	}{
+		{
+			name: "cpu and memory job with sufficient resources and isCardUnlimitedCpuMemory is false",
+			plugin: &Plugin{
+				cardNameToResourceName:   map[v1.ResourceName]v1.ResourceName{},
+				isCardUnlimitedCpuMemory: false,
+			},
+			qAttr: &queueAttr{
+				queueID: "queue-1",
+				name:    "test-queue",
+				allocated: &api.Resource{
+					MilliCPU: 2000,
+					Memory:   2 * 1024 * 1024 * 1024,
+				},
+				inqueue: api.EmptyResource(),
+				elastic: api.EmptyResource(),
+				capability: &api.Resource{
+					MilliCPU: 10000,
+					Memory:   10 * 1024 * 1024 * 1024,
+				},
+			},
+			job: &JobInfo{
+				JobInfo: &api.JobInfo{
+					UID:       "job-1",
+					Name:      "test-job",
+					Namespace: "default",
+					PodGroup: &api.PodGroup{
+						PodGroup: scheduling.PodGroup{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "test-job",
+								Namespace: "default",
+							},
+							Spec: scheduling.PodGroupSpec{
+								MinResources: &v1.ResourceList{
+									v1.ResourceCPU:    resource.MustParse("8"),
+									v1.ResourceMemory: resource.MustParse("8Gi"),
+								},
+							},
+						},
+						Version: api.PodGroupVersionV1Beta1,
+					},
+				},
+				preCheckCardResource: &api.Resource{},
+			},
+			expected:    true,
+			description: "Job with sufficient resources and isCardUnlimitedCpuMemory is false should be enqueueable",
+		},
+		{
+			name: "cpu and memory job with insufficient cpu and isCardUnlimitedCpuMemory is false",
+			plugin: &Plugin{
+				cardNameToResourceName:   map[v1.ResourceName]v1.ResourceName{},
+				isCardUnlimitedCpuMemory: false,
+			},
+			qAttr: &queueAttr{
+				queueID: "queue-1",
+				name:    "test-queue",
+				allocated: &api.Resource{
+					MilliCPU: 2000,
+					Memory:   2 * 1024 * 1024 * 1024,
+				},
+				inqueue: api.EmptyResource(),
+				elastic: api.EmptyResource(),
+				capability: &api.Resource{
+					MilliCPU: 10000,
+					Memory:   10 * 1024 * 1024 * 1024,
+				},
+			},
+			job: &JobInfo{
+				JobInfo: &api.JobInfo{
+					UID:       "job-1",
+					Name:      "test-job",
+					Namespace: "default",
+					PodGroup: &api.PodGroup{
+						PodGroup: scheduling.PodGroup{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "test-job",
+								Namespace: "default",
+							},
+							Spec: scheduling.PodGroupSpec{
+								MinResources: &v1.ResourceList{
+									v1.ResourceCPU:    resource.MustParse("9"),
+									v1.ResourceMemory: resource.MustParse("8Gi"),
+								},
+							},
+						},
+						Version: api.PodGroupVersionV1Beta1,
+					},
+				},
+				preCheckCardResource: &api.Resource{},
+			},
+			expected:    false,
+			description: "Job with insufficient cpu and isCardUnlimitedCpuMemory is false should be enqueueable",
+		},
+		{
+			name: "cpu and memory job with insufficient memory and isCardUnlimitedCpuMemory is false",
+			plugin: &Plugin{
+				cardNameToResourceName:   map[v1.ResourceName]v1.ResourceName{},
+				isCardUnlimitedCpuMemory: false,
+			},
+			qAttr: &queueAttr{
+				queueID: "queue-1",
+				name:    "test-queue",
+				allocated: &api.Resource{
+					MilliCPU: 2000,
+					Memory:   2 * 1024 * 1024 * 1024,
+				},
+				inqueue: api.EmptyResource(),
+				elastic: api.EmptyResource(),
+				capability: &api.Resource{
+					MilliCPU: 10000,
+					Memory:   10 * 1024 * 1024 * 1024,
+				},
+			},
+			job: &JobInfo{
+				JobInfo: &api.JobInfo{
+					UID:       "job-1",
+					Name:      "test-job",
+					Namespace: "default",
+					PodGroup: &api.PodGroup{
+						PodGroup: scheduling.PodGroup{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "test-job",
+								Namespace: "default",
+							},
+							Spec: scheduling.PodGroupSpec{
+								MinResources: &v1.ResourceList{
+									v1.ResourceCPU:    resource.MustParse("8"),
+									v1.ResourceMemory: resource.MustParse("9Gi"),
+								},
+							},
+						},
+						Version: api.PodGroupVersionV1Beta1,
+					},
+				},
+				preCheckCardResource: &api.Resource{},
+			},
+			expected:    false,
+			description: "Job with insufficient memory and isCardUnlimitedCpuMemory is false should be enqueueable",
+		},
+		{
+			name: "cpu and memory job with sufficient resources and isCardUnlimitedCpuMemory is true",
+			plugin: &Plugin{
+				cardNameToResourceName:   map[v1.ResourceName]v1.ResourceName{},
+				isCardUnlimitedCpuMemory: true,
+			},
+			qAttr: &queueAttr{
+				queueID: "queue-1",
+				name:    "test-queue",
+				allocated: &api.Resource{
+					MilliCPU: 2000,
+					Memory:   2 * 1024 * 1024 * 1024,
+				},
+				inqueue: api.EmptyResource(),
+				elastic: api.EmptyResource(),
+				capability: &api.Resource{
+					MilliCPU: 10000,
+					Memory:   10 * 1024 * 1024 * 1024,
+				},
+			},
+			job: &JobInfo{
+				JobInfo: &api.JobInfo{
+					UID:       "job-1",
+					Name:      "test-job",
+					Namespace: "default",
+					PodGroup: &api.PodGroup{
+						PodGroup: scheduling.PodGroup{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "test-job",
+								Namespace: "default",
+							},
+							Spec: scheduling.PodGroupSpec{
+								MinResources: &v1.ResourceList{
+									v1.ResourceCPU:    resource.MustParse("8"),
+									v1.ResourceMemory: resource.MustParse("8Gi"),
+								},
+							},
+						},
+						Version: api.PodGroupVersionV1Beta1,
+					},
+				},
+				preCheckCardResource: &api.Resource{},
+			},
+			expected:    true,
+			description: "Job with sufficient resources and isCardUnlimitedCpuMemory is false should be enqueueable",
+		},
+		{
+			name: "cpu and memory job with insufficient cpu and isCardUnlimitedCpuMemory is true",
+			plugin: &Plugin{
+				cardNameToResourceName:   map[v1.ResourceName]v1.ResourceName{},
+				isCardUnlimitedCpuMemory: true,
+			},
+			qAttr: &queueAttr{
+				queueID: "queue-1",
+				name:    "test-queue",
+				allocated: &api.Resource{
+					MilliCPU: 2000,
+					Memory:   2 * 1024 * 1024 * 1024,
+				},
+				inqueue: api.EmptyResource(),
+				elastic: api.EmptyResource(),
+				capability: &api.Resource{
+					MilliCPU: 10000,
+					Memory:   10 * 1024 * 1024 * 1024,
+				},
+			},
+			job: &JobInfo{
+				JobInfo: &api.JobInfo{
+					UID:       "job-1",
+					Name:      "test-job",
+					Namespace: "default",
+					PodGroup: &api.PodGroup{
+						PodGroup: scheduling.PodGroup{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "test-job",
+								Namespace: "default",
+							},
+							Spec: scheduling.PodGroupSpec{
+								MinResources: &v1.ResourceList{
+									v1.ResourceCPU:    resource.MustParse("9"),
+									v1.ResourceMemory: resource.MustParse("8Gi"),
+								},
+							},
+						},
+						Version: api.PodGroupVersionV1Beta1,
+					},
+				},
+				preCheckCardResource: &api.Resource{},
+			},
+			expected:    false,
+			description: "Job with insufficient cpu and isCardUnlimitedCpuMemory is false should be enqueueable",
+		},
+		{
+			name: "cpu and memory job with insufficient memory and isCardUnlimitedCpuMemory is true",
+			plugin: &Plugin{
+				cardNameToResourceName:   map[v1.ResourceName]v1.ResourceName{},
+				isCardUnlimitedCpuMemory: true,
+			},
+			qAttr: &queueAttr{
+				queueID: "queue-1",
+				name:    "test-queue",
+				allocated: &api.Resource{
+					MilliCPU: 2000,
+					Memory:   2 * 1024 * 1024 * 1024,
+				},
+				inqueue: api.EmptyResource(),
+				elastic: api.EmptyResource(),
+				capability: &api.Resource{
+					MilliCPU: 10000,
+					Memory:   10 * 1024 * 1024 * 1024,
+				},
+			},
+			job: &JobInfo{
+				JobInfo: &api.JobInfo{
+					UID:       "job-1",
+					Name:      "test-job",
+					Namespace: "default",
+					PodGroup: &api.PodGroup{
+						PodGroup: scheduling.PodGroup{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "test-job",
+								Namespace: "default",
+							},
+							Spec: scheduling.PodGroupSpec{
+								MinResources: &v1.ResourceList{
+									v1.ResourceCPU:    resource.MustParse("8"),
+									v1.ResourceMemory: resource.MustParse("9Gi"),
+								},
+							},
+						},
+						Version: api.PodGroupVersionV1Beta1,
+					},
+				},
+				preCheckCardResource: &api.Resource{},
+			},
+			expected:    false,
+			description: "Job with insufficient memory and isCardUnlimitedCpuMemory is false should be enqueueable",
+		},
+		{
+			name: "cpu and memory job with sufficient elastic resources",
+			plugin: &Plugin{
+				cardNameToResourceName:   map[v1.ResourceName]v1.ResourceName{},
+				isCardUnlimitedCpuMemory: false,
+			},
+			qAttr: &queueAttr{
+				queueID: "queue-1",
+				name:    "test-queue",
+				allocated: &api.Resource{
+					MilliCPU: 2000,
+					Memory:   2 * 1024 * 1024 * 1024,
+				},
+				inqueue: api.EmptyResource(),
+				elastic: &api.Resource{
+					MilliCPU: 1000,
+				},
+				capability: &api.Resource{
+					MilliCPU: 10000,
+					Memory:   10 * 1024 * 1024 * 1024,
+				},
+			},
+			job: &JobInfo{
+				JobInfo: &api.JobInfo{
+					UID:       "job-1",
+					Name:      "test-job",
+					Namespace: "default",
+					PodGroup: &api.PodGroup{
+						PodGroup: scheduling.PodGroup{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "test-job",
+								Namespace: "default",
+							},
+							Spec: scheduling.PodGroupSpec{
+								MinResources: &v1.ResourceList{
+									v1.ResourceCPU:    resource.MustParse("9"),
+									v1.ResourceMemory: resource.MustParse("8Gi"),
+								},
+							},
+						},
+						Version: api.PodGroupVersionV1Beta1,
+					},
+				},
+				preCheckCardResource: &api.Resource{},
+			},
+			expected:    true,
+			description: "Job with sufficient elastic resources should be enqueueable",
+		},
+		{
+			name: "cpu and memory job with sufficient elastic resources",
+			plugin: &Plugin{
+				cardNameToResourceName:   map[v1.ResourceName]v1.ResourceName{},
+				isCardUnlimitedCpuMemory: false,
+			},
+			qAttr: &queueAttr{
+				queueID: "queue-1",
+				name:    "test-queue",
+				allocated: &api.Resource{
+					MilliCPU: 2000,
+					Memory:   2 * 1024 * 1024 * 1024,
+				},
+				inqueue: api.EmptyResource(),
+				elastic: &api.Resource{
+					Memory: 1 * 1024 * 1024 * 1024,
+				},
+				capability: &api.Resource{
+					MilliCPU: 10000,
+					Memory:   10 * 1024 * 1024 * 1024,
+				},
+			},
+			job: &JobInfo{
+				JobInfo: &api.JobInfo{
+					UID:       "job-1",
+					Name:      "test-job",
+					Namespace: "default",
+					PodGroup: &api.PodGroup{
+						PodGroup: scheduling.PodGroup{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "test-job",
+								Namespace: "default",
+							},
+							Spec: scheduling.PodGroupSpec{
+								MinResources: &v1.ResourceList{
+									v1.ResourceCPU:    resource.MustParse("8"),
+									v1.ResourceMemory: resource.MustParse("9Gi"),
+								},
+							},
+						},
+						Version: api.PodGroupVersionV1Beta1,
+					},
+				},
+				preCheckCardResource: &api.Resource{},
+			},
+			expected:    true,
+			description: "Job with sufficient elastic resources should be enqueueable",
+		},
+		{
+			name: "cpu and memory job with insufficient inqueue cpu",
+			plugin: &Plugin{
+				cardNameToResourceName:   map[v1.ResourceName]v1.ResourceName{},
+				isCardUnlimitedCpuMemory: false,
+			},
+			qAttr: &queueAttr{
+				queueID: "queue-1",
+				name:    "test-queue",
+				allocated: &api.Resource{
+					MilliCPU: 2000,
+					Memory:   2 * 1024 * 1024 * 1024,
+				},
+				inqueue: &api.Resource{
+					MilliCPU: 1000,
+				},
+				elastic: api.EmptyResource(),
+				capability: &api.Resource{
+					MilliCPU: 10000,
+					Memory:   10 * 1024 * 1024 * 1024,
+				},
+			},
+			job: &JobInfo{
+				JobInfo: &api.JobInfo{
+					UID:       "job-1",
+					Name:      "test-job",
+					Namespace: "default",
+					PodGroup: &api.PodGroup{
+						PodGroup: scheduling.PodGroup{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "test-job",
+								Namespace: "default",
+							},
+							Spec: scheduling.PodGroupSpec{
+								MinResources: &v1.ResourceList{
+									v1.ResourceCPU:    resource.MustParse("8"),
+									v1.ResourceMemory: resource.MustParse("8Gi"),
+								},
+							},
+						},
+						Version: api.PodGroupVersionV1Beta1,
+					},
+				},
+				preCheckCardResource: &api.Resource{},
+			},
+			expected:    false,
+			description: "Job with insufficient inqueue cpu should be rejected",
+		},
+		{
+			name: "cpu and memory job with insufficient inqueue memory",
+			plugin: &Plugin{
+				cardNameToResourceName:   map[v1.ResourceName]v1.ResourceName{},
+				isCardUnlimitedCpuMemory: false,
+			},
+			qAttr: &queueAttr{
+				queueID: "queue-1",
+				name:    "test-queue",
+				allocated: &api.Resource{
+					MilliCPU: 2000,
+					Memory:   2 * 1024 * 1024 * 1024,
+				},
+				inqueue: &api.Resource{
+					Memory: 1 * 1024 * 1024 * 1024,
+				},
+				elastic: api.EmptyResource(),
+				capability: &api.Resource{
+					MilliCPU: 10000,
+					Memory:   10 * 1024 * 1024 * 1024,
+				},
+			},
+			job: &JobInfo{
+				JobInfo: &api.JobInfo{
+					UID:       "job-1",
+					Name:      "test-job",
+					Namespace: "default",
+					PodGroup: &api.PodGroup{
+						PodGroup: scheduling.PodGroup{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "test-job",
+								Namespace: "default",
+							},
+							Spec: scheduling.PodGroupSpec{
+								MinResources: &v1.ResourceList{
+									v1.ResourceCPU:    resource.MustParse("8"),
+									v1.ResourceMemory: resource.MustParse("8Gi"),
+								},
+							},
+						},
+						Version: api.PodGroupVersionV1Beta1,
+					},
+				},
+				preCheckCardResource: &api.Resource{},
+			},
+			expected:    false,
+			description: "Job with insufficient inqueue cpu should be rejected",
+		},
+		{
+			name: "job with nil resource request",
+			plugin: &Plugin{
+				cardNameToResourceName:   map[v1.ResourceName]v1.ResourceName{},
+				isCardUnlimitedCpuMemory: false,
+			},
+			qAttr: &queueAttr{
+				queueID: "queue-2",
+				name:    "test-queue-2",
+				allocated: &api.Resource{
+					MilliCPU: 2000,
+					Memory:   2 * 1024 * 1024 * 1024,
+				},
+				inqueue: api.EmptyResource(),
+				elastic: api.EmptyResource(),
+				capability: &api.Resource{
+					MilliCPU: 10000,
+					Memory:   10 * 1024 * 1024 * 1024,
+				},
+			},
+			job: &JobInfo{
+				JobInfo: &api.JobInfo{
+					UID:       "job-2",
+					Name:      "nil-request-job",
+					Namespace: "default",
+					PodGroup: &api.PodGroup{
+						PodGroup: scheduling.PodGroup{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "nil-request-job",
+								Namespace: "default",
+							},
+						},
+						Version: api.PodGroupVersionV1Beta1,
+					},
+				},
+				preCheckCardResource: nil,
+			},
+			expected:    true,
+			description: "Job with nil request should be allowed if allocated is within capability",
+		},
+		{
+			name: "job with no resource quota used - should allow",
+			plugin: &Plugin{
+				cardNameToResourceName:   map[v1.ResourceName]v1.ResourceName{},
+				isCardUnlimitedCpuMemory: false,
+			},
+			qAttr: &queueAttr{
+				queueID:   "queue-5",
+				name:      "empty-queue",
+				allocated: api.EmptyResource(),
+				inqueue:   api.EmptyResource(),
+				elastic:   api.EmptyResource(),
+				capability: &api.Resource{
+					MilliCPU: 10000,
+					Memory:   10 * 1024 * 1024 * 1024,
+				},
+			},
+			job: &JobInfo{
+				JobInfo: &api.JobInfo{
+					UID:       "job-5",
+					Name:      "test-job-5",
+					Namespace: "default",
+					PodGroup: &api.PodGroup{
+						PodGroup: scheduling.PodGroup{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "test-job-5",
+								Namespace: "default",
+							},
+						},
+						Version: api.PodGroupVersionV1Beta1,
+					},
+				},
+				preCheckCardResource: &api.Resource{},
+			},
+			expected:    true,
+			description: "Should allow when queue has no allocated resources",
+		},
+		{
+			name: "zero CPU request should not trigger CPU check",
+			plugin: &Plugin{
+				cardNameToResourceName:   map[v1.ResourceName]v1.ResourceName{},
+				isCardUnlimitedCpuMemory: false,
+			},
+			qAttr: &queueAttr{
+				queueID: "queue-6",
+				name:    "zero-cpu-queue",
+				allocated: &api.Resource{
+					MilliCPU: 10000,
+					Memory:   10 * 1024 * 1024 * 1024,
+				},
+				inqueue: api.EmptyResource(),
+				elastic: api.EmptyResource(),
+				capability: &api.Resource{
+					MilliCPU: 10000,
+					Memory:   10 * 1024 * 1024 * 1024,
+				},
+			},
+			job: &JobInfo{
+				JobInfo: &api.JobInfo{
+					UID:       "job-6",
+					Name:      "zero-cpu-job",
+					Namespace: "default",
+					PodGroup: &api.PodGroup{
+						PodGroup: scheduling.PodGroup{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "zero-cpu-job",
+								Namespace: "default",
+							},
+						},
+						Version: api.PodGroupVersionV1Beta1,
+					},
+				},
+				preCheckCardResource: &api.Resource{},
+			},
+			expected:    true,
+			description: "Zero CPU request should skip CPU quota check",
+		},
+		{
+			name: "sufficient scalar quota",
+			plugin: &Plugin{
+				cardNameToResourceName:   map[v1.ResourceName]v1.ResourceName{},
+				isCardUnlimitedCpuMemory: true,
+			},
+			qAttr: &queueAttr{
+				queueID: "queue-8",
+				name:    "gpu-limited-queue",
+				allocated: &api.Resource{
+					MilliCPU: 2000,
+					Memory:   2 * 1024 * 1024 * 1024,
+					ScalarResources: map[v1.ResourceName]float64{
+						"NVIDIA-A100": 3000,
+					},
+				},
+				inqueue: api.EmptyResource(),
+				elastic: api.EmptyResource(),
+				capability: &api.Resource{
+					MilliCPU: 10000,
+					Memory:   10 * 1024 * 1024 * 1024,
+					ScalarResources: map[v1.ResourceName]float64{
+						"NVIDIA-A100": 4000,
+					},
+				},
+			},
+			job: &JobInfo{
+				JobInfo: &api.JobInfo{
+					UID:       "job-8",
+					Name:      "gpu-job",
+					Namespace: "default",
+					PodGroup: &api.PodGroup{
+						PodGroup: scheduling.PodGroup{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "gpu-job",
+								Namespace: "default",
+							},
+							Spec: scheduling.PodGroupSpec{
+								MinResources: &v1.ResourceList{
+									v1.ResourceCPU:    resource.MustParse("10"),
+									v1.ResourceMemory: resource.MustParse("10Gi"),
+								},
+							},
+						},
+						Version: api.PodGroupVersionV1Beta1,
+					},
+				},
+				preCheckCardResource: &api.Resource{
+					ScalarResources: map[v1.ResourceName]float64{
+						"NVIDIA-A100": 1000,
+					},
+				},
+			},
+			expected:    true,
+			description: "Should allow job when scalar quota is sufficient",
+		},
+		{
+			name: "insufficient scalar quota",
+			plugin: &Plugin{
+				cardNameToResourceName:   map[v1.ResourceName]v1.ResourceName{},
+				isCardUnlimitedCpuMemory: true,
+			},
+			qAttr: &queueAttr{
+				queueID: "queue-8",
+				name:    "gpu-limited-queue",
+				allocated: &api.Resource{
+					MilliCPU: 2000,
+					Memory:   2 * 1024 * 1024 * 1024,
+					ScalarResources: map[v1.ResourceName]float64{
+						"NVIDIA-A100": 3000,
+					},
+				},
+				inqueue: api.EmptyResource(),
+				elastic: api.EmptyResource(),
+				capability: &api.Resource{
+					MilliCPU: 10000,
+					Memory:   10 * 1024 * 1024 * 1024,
+					ScalarResources: map[v1.ResourceName]float64{
+						"NVIDIA-A100": 4000,
+					},
+				},
+			},
+			job: &JobInfo{
+				JobInfo: &api.JobInfo{
+					UID:       "job-8",
+					Name:      "gpu-job",
+					Namespace: "default",
+					PodGroup: &api.PodGroup{
+						PodGroup: scheduling.PodGroup{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "gpu-job",
+								Namespace: "default",
+							},
+							Spec: scheduling.PodGroupSpec{
+								MinResources: &v1.ResourceList{
+									v1.ResourceCPU:    resource.MustParse("10"),
+									v1.ResourceMemory: resource.MustParse("10Gi"),
+								},
+							},
+						},
+						Version: api.PodGroupVersionV1Beta1,
+					},
+				},
+				preCheckCardResource: &api.Resource{
+					ScalarResources: map[v1.ResourceName]float64{
+						"NVIDIA-A100": 2000,
+					},
+				},
+			},
+			expected:    false,
+			description: "Should reject job when scalar quota is insufficient",
+		},
+		{
+			name: "insufficient memory and cpu quota and isCardUnlimitedCpuMemory is false",
+			plugin: &Plugin{
+				cardNameToResourceName:   map[v1.ResourceName]v1.ResourceName{},
+				isCardUnlimitedCpuMemory: false,
+			},
+			qAttr: &queueAttr{
+				queueID: "queue-8",
+				name:    "gpu-limited-queue",
+				allocated: &api.Resource{
+					MilliCPU: 2000,
+					Memory:   2 * 1024 * 1024 * 1024,
+					ScalarResources: map[v1.ResourceName]float64{
+						"NVIDIA-A100": 3000,
+					},
+				},
+				inqueue: api.EmptyResource(),
+				elastic: api.EmptyResource(),
+				capability: &api.Resource{
+					MilliCPU: 10000,
+					Memory:   10 * 1024 * 1024 * 1024,
+					ScalarResources: map[v1.ResourceName]float64{
+						"NVIDIA-A100": 4000,
+					},
+				},
+			},
+			job: &JobInfo{
+				JobInfo: &api.JobInfo{
+					UID:       "job-8",
+					Name:      "gpu-job",
+					Namespace: "default",
+					PodGroup: &api.PodGroup{
+						PodGroup: scheduling.PodGroup{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "gpu-job",
+								Namespace: "default",
+							},
+							Spec: scheduling.PodGroupSpec{
+								MinResources: &v1.ResourceList{
+									v1.ResourceCPU:    resource.MustParse("10"),
+									v1.ResourceMemory: resource.MustParse("10Gi"),
+								},
+							},
+						},
+						Version: api.PodGroupVersionV1Beta1,
+					},
+				},
+				preCheckCardResource: &api.Resource{
+					ScalarResources: map[v1.ResourceName]float64{
+						"NVIDIA-A100": 1000,
+					},
+				},
+			},
+			expected:    false,
+			description: "Should reject job when memory quota is insufficient",
+		},
+		{
+			name: "ignored scalar resource (pods) should not be checked",
+			plugin: &Plugin{
+				cardNameToResourceName:   map[v1.ResourceName]v1.ResourceName{},
+				isCardUnlimitedCpuMemory: false,
+			},
+			qAttr: &queueAttr{
+				queueID:   "queue-11",
+				name:      "ignore-scalar-queue",
+				allocated: api.EmptyResource(),
+				inqueue:   api.EmptyResource(),
+				elastic:   api.EmptyResource(),
+				capability: &api.Resource{
+					MilliCPU: 10000,
+					Memory:   10 * 1024 * 1024 * 1024,
+					ScalarResources: map[v1.ResourceName]float64{
+						v1.ResourcePods: 0, // Pods is set to 0 to simulate exceeding quota
+					},
+				},
+			},
+			job: &JobInfo{
+				JobInfo: &api.JobInfo{
+					UID:       "job-11",
+					Name:      "ignore-scalar-job",
+					Namespace: "default",
+					PodGroup: &api.PodGroup{
+						PodGroup: scheduling.PodGroup{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "ignore-scalar-job",
+								Namespace: "default",
+							},
+							Spec: scheduling.PodGroupSpec{
+								MinResources: &v1.ResourceList{
+									v1.ResourceCPU:    resource.MustParse("1"),
+									v1.ResourceMemory: resource.MustParse("1Gi"),
+								},
+							},
+						},
+						Version: api.PodGroupVersionV1Beta1,
+					},
+				},
+				preCheckCardResource: &api.Resource{},
+			},
+			expected:    true,
+			description: "Pods resource should be ignored and not block enqueue even when quota is exceeded",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.plugin.isJobEnqueueable(ssn, tt.qAttr, tt.job)
+			if result != tt.expected {
+				t.Errorf("%s: expected %v, got %v", tt.description, tt.expected, result)
+			}
+		})
+	}
+}

--- a/pkg/scheduler/plugins/capacity-card/capacity_card_fn_nodeorder.go
+++ b/pkg/scheduler/plugins/capacity-card/capacity_card_fn_nodeorder.go
@@ -1,0 +1,100 @@
+package capacitycard
+
+import (
+	"math"
+	"strings"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/klog/v2"
+
+	"volcano.sh/volcano/pkg/scheduler/api"
+)
+
+// NodeOrderFn scores nodes for tasks with multi-card type options.
+// For tasks with multiple card type options (separated by "|"), nodes that can provide
+// card types on the left (higher priority) get higher scores.
+// Example: "NVIDIA-A100|NVIDIA-H100" means A100 has higher priority than H100.
+//
+// The scoring algorithm:
+//
+//	baseScore = maxScore * (decayRate ^ index)
+//	finalScore = baseScore * nodeOrderWeight
+//
+// where:
+//   - maxScore is 100
+//   - decayRate is fixed at 0.5 (each subsequent card type gets 50% less base score)
+//   - index is the position of the card type (0-based, 0 is highest priority)
+//   - nodeOrderWeight is configurable (default: 1.0, must be positive)
+//
+// This ensures every card type has a unique, non-zero score, even with many options.
+// The nodeOrderWeight allows adjusting the overall importance of card type priority.
+func (p *Plugin) NodeOrderFn(task *api.TaskInfo, node *api.NodeInfo) (float64, error) {
+	// Get card name from task annotation
+	if task.Pod == nil {
+		return 0, nil
+	}
+
+	cardName := p.getCardNameFromTask(task)
+	if cardName == "" {
+		// No card requested, no ordering preference
+		return 0, nil
+	}
+
+	// Check if this is a multi-card type task (contains separator "|")
+	if !strings.Contains(cardName, MultiCardSeparator) {
+		// Single card type, no ordering preference
+		return 0, nil
+	}
+
+	// Split multi-card types, left has higher priority
+	multiCardNames := strings.Split(cardName, MultiCardSeparator)
+	if len(multiCardNames) <= 1 {
+		return 0, nil
+	}
+
+	// Get node card information
+	if node.Node == nil {
+		return 0, nil
+	}
+
+	nodeCardInfo := p.getCardResourceFromNode(node.Node)
+	if len(nodeCardInfo.CardResource) == 0 {
+		return 0, nil
+	}
+
+	// Iterate through card types from left to right (high to low priority)
+	// Assign score based on position using exponential decay
+	// Note: NodeOrderFn is called after filtering, so the node already satisfies resource requirements
+	score := float64(0)
+	for idx, singleCardName := range multiCardNames {
+		// Check if node has this card type
+		_, ok := nodeCardInfo.CardNameToResourceName[v1.ResourceName(singleCardName)]
+		if !ok {
+			// Node doesn't have this card type, continue to next
+			continue
+		}
+
+		// Node has this card type, calculate score based on priority
+		// Use exponential decay with fixed rate, then multiply by weight
+		// baseScore = 100 * (0.5 ^ index), finalScore = baseScore * weight
+		// This ensures all card types have unique, non-zero scores
+		const maxScoreValue = 100.0
+		baseScore := maxScoreValue * math.Pow(nodeOrderDecayRate, float64(idx))
+		score = baseScore * p.nodeOrderWeight
+
+		klog.V(5).Infof(
+			"NodeOrderFn: task <%s/%s> matched card type <%s> (priority index %d) on node <%s>, baseScore: %.2f, weight: %.2f, finalScore: %.2f",
+			task.Namespace, task.Name, singleCardName, idx, node.Name, baseScore, p.nodeOrderWeight, score,
+		)
+
+		// Found the highest priority card type available on this node
+		break
+	}
+
+	klog.V(4).Infof(
+		"NodeOrderFn: task <%s/%s> with multi-card types <%s> on node <%s>, final score: %.2f",
+		task.Namespace, task.Name, cardName, node.Name, score,
+	)
+
+	return score, nil
+}

--- a/pkg/scheduler/plugins/capacity-card/capacity_card_fn_nodeorder_test.go
+++ b/pkg/scheduler/plugins/capacity-card/capacity_card_fn_nodeorder_test.go
@@ -1,0 +1,626 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+Copyright 2018-2025 The Volcano Authors.
+
+Modifications made by Volcano authors:
+- Enhanced gang scheduling validation with task-level validity checks
+- Improved preemption logic to respect gang scheduling constraints
+- Added support for job starving detection and enhanced pipeline state management
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package capacitycard
+
+import (
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"volcano.sh/volcano/pkg/scheduler/api"
+)
+
+// TestNodeOrderFn tests the NodeOrderFn function
+func TestNodeOrderFn(t *testing.T) {
+	tests := []struct {
+		name          string
+		plugin        *Plugin
+		task          *api.TaskInfo
+		node          *api.NodeInfo
+		expectedScore float64
+		description   string
+		expectError   bool
+	}{
+		{
+			name: "task without card request",
+			plugin: &Plugin{
+				cardNameToResourceName: map[v1.ResourceName]v1.ResourceName{},
+				nodeCardInfos:          map[string]NodeCardResourceInfo{},
+			},
+			task: &api.TaskInfo{
+				UID:       "task-1",
+				Name:      "cpu-task",
+				Namespace: "default",
+				Pod: &v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "cpu-task",
+						Namespace: "default",
+					},
+					Spec: v1.PodSpec{
+						Containers: []v1.Container{
+							{
+								Name: "container",
+								Resources: v1.ResourceRequirements{
+									Requests: v1.ResourceList{
+										v1.ResourceCPU:    resource.MustParse("1"),
+										v1.ResourceMemory: resource.MustParse("1Gi"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			node: &api.NodeInfo{
+				Name: "node-1",
+				Node: &v1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node-1",
+					},
+					Status: v1.NodeStatus{
+						Allocatable: v1.ResourceList{
+							v1.ResourceCPU:    resource.MustParse("8"),
+							v1.ResourceMemory: resource.MustParse("16Gi"),
+						},
+					},
+				},
+			},
+			expectedScore: 0,
+			description:   "Task without card request should return score 0",
+			expectError:   false,
+		},
+		{
+			name: "single card type request",
+			plugin: &Plugin{
+				cardNameToResourceName: map[v1.ResourceName]v1.ResourceName{
+					"NVIDIA-A100": "nvidia.com/gpu",
+				},
+				nodeCardInfos: map[string]NodeCardResourceInfo{
+					"node-1": {
+						CardInfo: CardInfo{
+							Name:           "NVIDIA-A100",
+							Count:          4,
+							Memory:         40 * 1024 * 1024 * 1024,
+							ResourcePrefix: "nvidia.com",
+						},
+						CardResource: v1.ResourceList{
+							"NVIDIA-A100": resource.MustParse("4"),
+						},
+						CardNameToResourceName: map[v1.ResourceName]v1.ResourceName{
+							"NVIDIA-A100": "nvidia.com/gpu",
+						},
+					},
+				},
+			},
+			task: &api.TaskInfo{
+				UID:       "task-2",
+				Name:      "single-type-gpu-task",
+				Namespace: "default",
+				Pod: &v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "single-type-gpu-task",
+						Namespace: "default",
+						Annotations: map[string]string{
+							TaskAnnotationKeyCardName: "NVIDIA-A100",
+						},
+					},
+					Spec: v1.PodSpec{
+						Containers: []v1.Container{
+							{
+								Name: "container",
+								Resources: v1.ResourceRequirements{
+									Requests: v1.ResourceList{
+										v1.ResourceCPU:    resource.MustParse("4"),
+										v1.ResourceMemory: resource.MustParse("8Gi"),
+										"nvidia.com/gpu":  resource.MustParse("1"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			node: &api.NodeInfo{
+				Name: "node-1",
+				Node: &v1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node-1",
+					},
+					Status: v1.NodeStatus{
+						Allocatable: v1.ResourceList{
+							v1.ResourceCPU:    resource.MustParse("32"),
+							v1.ResourceMemory: resource.MustParse("128Gi"),
+							"nvidia.com/gpu":  resource.MustParse("4"),
+						},
+					},
+				},
+				Allocatable: &api.Resource{
+					MilliCPU: 32000,
+					Memory:   128 * 1024 * 1024 * 1024,
+					ScalarResources: map[v1.ResourceName]float64{
+						"nvidia.com/gpu": 4000,
+					},
+				},
+				Idle: &api.Resource{
+					MilliCPU: 32000,
+					Memory:   128 * 1024 * 1024 * 1024,
+					ScalarResources: map[v1.ResourceName]float64{
+						"nvidia.com/gpu": 4000,
+					},
+				},
+			},
+			expectedScore: 0,
+			description:   "Single card type request should return score 0 (no ordering needed)",
+			expectError:   false,
+		},
+		{
+			name: "multi-card types - node has first priority card (A100)",
+			plugin: &Plugin{
+				cardNameToResourceName: map[v1.ResourceName]v1.ResourceName{
+					"NVIDIA-A100": "nvidia.com/gpu",
+					"NVIDIA-H100": "nvidia.com/gpu",
+				},
+				nodeCardInfos: map[string]NodeCardResourceInfo{
+					"node-1": {
+						CardInfo: CardInfo{
+							Name:           "NVIDIA-A100",
+							Count:          4,
+							Memory:         40 * 1024 * 1024 * 1024,
+							ResourcePrefix: "nvidia.com",
+						},
+						CardResource: v1.ResourceList{
+							"NVIDIA-A100": resource.MustParse("4"),
+						},
+						CardNameToResourceName: map[v1.ResourceName]v1.ResourceName{
+							"NVIDIA-A100": "nvidia.com/gpu",
+						},
+					},
+				},
+				nodeOrderWeight: 1.0, // Default weight
+			},
+			task: &api.TaskInfo{
+				UID:       "task-3",
+				Name:      "multi-type-gpu-task",
+				Namespace: "default",
+				Pod: &v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "multi-type-gpu-task",
+						Namespace: "default",
+						Annotations: map[string]string{
+							TaskAnnotationKeyCardName: "NVIDIA-A100|NVIDIA-H100",
+						},
+					},
+					Spec: v1.PodSpec{
+						Containers: []v1.Container{
+							{
+								Name: "container",
+								Resources: v1.ResourceRequirements{
+									Requests: v1.ResourceList{
+										v1.ResourceCPU:    resource.MustParse("8"),
+										v1.ResourceMemory: resource.MustParse("32Gi"),
+										"nvidia.com/gpu":  resource.MustParse("2"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			node: &api.NodeInfo{
+				Name: "node-1",
+				Node: &v1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node-1",
+					},
+					Status: v1.NodeStatus{
+						Allocatable: v1.ResourceList{
+							v1.ResourceCPU:    resource.MustParse("32"),
+							v1.ResourceMemory: resource.MustParse("128Gi"),
+							"nvidia.com/gpu":  resource.MustParse("4"),
+						},
+					},
+				},
+				Allocatable: &api.Resource{
+					MilliCPU: 32000,
+					Memory:   128 * 1024 * 1024 * 1024,
+					ScalarResources: map[v1.ResourceName]float64{
+						"nvidia.com/gpu": 4000,
+					},
+				},
+				Idle: &api.Resource{
+					MilliCPU: 32000,
+					Memory:   128 * 1024 * 1024 * 1024,
+					ScalarResources: map[v1.ResourceName]float64{
+						"nvidia.com/gpu": 4000,
+					},
+				},
+			},
+			expectedScore: 100,
+			description:   "Node with first priority card type (A100) should get score 100",
+			expectError:   false,
+		},
+		{
+			name: "multi-card types - node has second priority card (H100)",
+			plugin: &Plugin{
+				cardNameToResourceName: map[v1.ResourceName]v1.ResourceName{
+					"NVIDIA-A100": "nvidia.com/gpu-a100",
+					"NVIDIA-H100": "nvidia.com/gpu-h100",
+				},
+				nodeCardInfos: map[string]NodeCardResourceInfo{
+					"node-2": {
+						CardInfo: CardInfo{
+							Name:           "NVIDIA-H100",
+							Count:          4,
+							Memory:         80 * 1024 * 1024 * 1024,
+							ResourcePrefix: "nvidia.com",
+						},
+						CardResource: v1.ResourceList{
+							"NVIDIA-H100": resource.MustParse("4"),
+						},
+						CardNameToResourceName: map[v1.ResourceName]v1.ResourceName{
+							"NVIDIA-H100": "nvidia.com/gpu-h100",
+						},
+					},
+				},
+				nodeOrderWeight: 1.0, // Default weight
+			},
+			task: &api.TaskInfo{
+				UID:       "task-4",
+				Name:      "multi-type-gpu-task-2",
+				Namespace: "default",
+				Pod: &v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "multi-type-gpu-task-2",
+						Namespace: "default",
+						Annotations: map[string]string{
+							TaskAnnotationKeyCardName: "NVIDIA-A100|NVIDIA-H100",
+						},
+					},
+					Spec: v1.PodSpec{
+						Containers: []v1.Container{
+							{
+								Name: "container",
+								Resources: v1.ResourceRequirements{
+									Requests: v1.ResourceList{
+										v1.ResourceCPU:        resource.MustParse("8"),
+										v1.ResourceMemory:     resource.MustParse("32Gi"),
+										"nvidia.com/gpu-h100": resource.MustParse("2"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			node: &api.NodeInfo{
+				Name: "node-2",
+				Node: &v1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node-2",
+					},
+					Status: v1.NodeStatus{
+						Allocatable: v1.ResourceList{
+							v1.ResourceCPU:        resource.MustParse("32"),
+							v1.ResourceMemory:     resource.MustParse("128Gi"),
+							"nvidia.com/gpu-h100": resource.MustParse("4"),
+						},
+					},
+				},
+				Allocatable: &api.Resource{
+					MilliCPU: 32000,
+					Memory:   128 * 1024 * 1024 * 1024,
+					ScalarResources: map[v1.ResourceName]float64{
+						"nvidia.com/gpu-h100": 4000,
+					},
+				},
+				Idle: &api.Resource{
+					MilliCPU: 32000,
+					Memory:   128 * 1024 * 1024 * 1024,
+					ScalarResources: map[v1.ResourceName]float64{
+						"nvidia.com/gpu-h100": 4000,
+					},
+				},
+			},
+			expectedScore: 50, // baseScore: 100 * 0.5^1 = 50, finalScore: 50 * 1.0 = 50
+			description:   "Node with second priority card type (H100) should get score 50 (with default weight 1.0)",
+			expectError:   false,
+		},
+		{
+			name: "multi-card types - node has third priority card (T4)",
+			plugin: &Plugin{
+				cardNameToResourceName: map[v1.ResourceName]v1.ResourceName{
+					"NVIDIA-A100": "nvidia.com/gpu-a100",
+					"NVIDIA-H100": "nvidia.com/gpu-h100",
+					"NVIDIA-T4":   "nvidia.com/gpu-t4",
+				},
+				nodeCardInfos: map[string]NodeCardResourceInfo{
+					"node-3": {
+						CardInfo: CardInfo{
+							Name:           "NVIDIA-T4",
+							Count:          4,
+							Memory:         16 * 1024 * 1024 * 1024,
+							ResourcePrefix: "nvidia.com",
+						},
+						CardResource: v1.ResourceList{
+							"NVIDIA-T4": resource.MustParse("4"),
+						},
+						CardNameToResourceName: map[v1.ResourceName]v1.ResourceName{
+							"NVIDIA-T4": "nvidia.com/gpu-t4",
+						},
+					},
+				},
+				nodeOrderWeight: 1.0, // Default weight
+			},
+			task: &api.TaskInfo{
+				UID:       "task-5",
+				Name:      "multi-type-gpu-task-3",
+				Namespace: "default",
+				Pod: &v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "multi-type-gpu-task-3",
+						Namespace: "default",
+						Annotations: map[string]string{
+							TaskAnnotationKeyCardName: "NVIDIA-A100|NVIDIA-H100|NVIDIA-T4",
+						},
+					},
+					Spec: v1.PodSpec{
+						Containers: []v1.Container{
+							{
+								Name: "container",
+								Resources: v1.ResourceRequirements{
+									Requests: v1.ResourceList{
+										v1.ResourceCPU:      resource.MustParse("4"),
+										v1.ResourceMemory:   resource.MustParse("16Gi"),
+										"nvidia.com/gpu-t4": resource.MustParse("1"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			node: &api.NodeInfo{
+				Name: "node-3",
+				Node: &v1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node-3",
+					},
+					Status: v1.NodeStatus{
+						Allocatable: v1.ResourceList{
+							v1.ResourceCPU:      resource.MustParse("16"),
+							v1.ResourceMemory:   resource.MustParse("64Gi"),
+							"nvidia.com/gpu-t4": resource.MustParse("4"),
+						},
+					},
+				},
+				Allocatable: &api.Resource{
+					MilliCPU: 16000,
+					Memory:   64 * 1024 * 1024 * 1024,
+					ScalarResources: map[v1.ResourceName]float64{
+						"nvidia.com/gpu-t4": 4000,
+					},
+				},
+				Idle: &api.Resource{
+					MilliCPU: 16000,
+					Memory:   64 * 1024 * 1024 * 1024,
+					ScalarResources: map[v1.ResourceName]float64{
+						"nvidia.com/gpu-t4": 4000,
+					},
+				},
+			},
+			expectedScore: 25, // baseScore: 100 * 0.5^2 = 25, finalScore: 25 * 1.0 = 25
+			description:   "Node with third priority card type (T4) should get score 25 (with default weight 1.0)",
+			expectError:   false,
+		},
+		{
+			name: "multi-card types with custom weight 2.0 - second priority card",
+			plugin: &Plugin{
+				cardNameToResourceName: map[v1.ResourceName]v1.ResourceName{
+					"NVIDIA-A100": "nvidia.com/gpu-a100",
+					"NVIDIA-H100": "nvidia.com/gpu-h100",
+				},
+				nodeCardInfos: map[string]NodeCardResourceInfo{
+					"node-5": {
+						CardInfo: CardInfo{
+							Name:           "NVIDIA-H100",
+							Count:          4,
+							Memory:         80 * 1024 * 1024 * 1024,
+							ResourcePrefix: "nvidia.com",
+						},
+						CardResource: v1.ResourceList{
+							"NVIDIA-H100": resource.MustParse("4"),
+						},
+						CardNameToResourceName: map[v1.ResourceName]v1.ResourceName{
+							"NVIDIA-H100": "nvidia.com/gpu-h100",
+						},
+					},
+				},
+				nodeOrderWeight: 2.0, // Custom weight to scale up scores
+			},
+			task: &api.TaskInfo{
+				UID:       "task-6",
+				Name:      "multi-type-gpu-task-custom-weight",
+				Namespace: "default",
+				Pod: &v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "multi-type-gpu-task-custom-weight",
+						Namespace: "default",
+						Annotations: map[string]string{
+							TaskAnnotationKeyCardName: "NVIDIA-A100|NVIDIA-H100",
+						},
+					},
+					Spec: v1.PodSpec{
+						Containers: []v1.Container{
+							{
+								Name: "container",
+								Resources: v1.ResourceRequirements{
+									Requests: v1.ResourceList{
+										v1.ResourceCPU:        resource.MustParse("8"),
+										v1.ResourceMemory:     resource.MustParse("32Gi"),
+										"nvidia.com/gpu-h100": resource.MustParse("2"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			node: &api.NodeInfo{
+				Name: "node-5",
+				Node: &v1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node-5",
+					},
+					Status: v1.NodeStatus{
+						Allocatable: v1.ResourceList{
+							v1.ResourceCPU:        resource.MustParse("32"),
+							v1.ResourceMemory:     resource.MustParse("128Gi"),
+							"nvidia.com/gpu-h100": resource.MustParse("4"),
+						},
+					},
+				},
+				Allocatable: &api.Resource{
+					MilliCPU: 32000,
+					Memory:   128 * 1024 * 1024 * 1024,
+					ScalarResources: map[v1.ResourceName]float64{
+						"nvidia.com/gpu-h100": 4000,
+					},
+				},
+				Idle: &api.Resource{
+					MilliCPU: 32000,
+					Memory:   128 * 1024 * 1024 * 1024,
+					ScalarResources: map[v1.ResourceName]float64{
+						"nvidia.com/gpu-h100": 4000,
+					},
+				},
+			},
+			expectedScore: 100, // baseScore: 100 * 0.5^1 = 50, finalScore: 50 * 2.0 = 100
+			description:   "Node with second priority card and custom weight 2.0 should get score 100",
+			expectError:   false,
+		},
+		{
+			name: "multi-card types - node has no matching card type",
+			plugin: &Plugin{
+				cardNameToResourceName: map[v1.ResourceName]v1.ResourceName{
+					"NVIDIA-A100": "nvidia.com/gpu-a100",
+					"NVIDIA-H100": "nvidia.com/gpu-h100",
+					"NVIDIA-V100": "nvidia.com/gpu-v100",
+				},
+				nodeCardInfos: map[string]NodeCardResourceInfo{
+					"node-4": {
+						CardInfo: CardInfo{
+							Name:           "NVIDIA-V100",
+							Count:          4,
+							Memory:         32 * 1024 * 1024 * 1024,
+							ResourcePrefix: "nvidia.com",
+						},
+						CardResource: v1.ResourceList{
+							"NVIDIA-V100": resource.MustParse("4"),
+						},
+						CardNameToResourceName: map[v1.ResourceName]v1.ResourceName{
+							"NVIDIA-V100": "nvidia.com/gpu-v100",
+						},
+					},
+				},
+				nodeOrderWeight: 1.0, // Default weight
+			},
+			task: &api.TaskInfo{
+				UID:       "task-7",
+				Name:      "multi-type-gpu-task-4",
+				Namespace: "default",
+				Pod: &v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "multi-type-gpu-task-4",
+						Namespace: "default",
+						Annotations: map[string]string{
+							TaskAnnotationKeyCardName: "NVIDIA-A100|NVIDIA-H100",
+						},
+					},
+					Spec: v1.PodSpec{
+						Containers: []v1.Container{
+							{
+								Name: "container",
+								Resources: v1.ResourceRequirements{
+									Requests: v1.ResourceList{
+										v1.ResourceCPU:        resource.MustParse("8"),
+										v1.ResourceMemory:     resource.MustParse("32Gi"),
+										"nvidia.com/gpu-v100": resource.MustParse("2"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			node: &api.NodeInfo{
+				Name: "node-4",
+				Node: &v1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node-4",
+					},
+					Status: v1.NodeStatus{
+						Allocatable: v1.ResourceList{
+							v1.ResourceCPU:        resource.MustParse("32"),
+							v1.ResourceMemory:     resource.MustParse("128Gi"),
+							"nvidia.com/gpu-v100": resource.MustParse("4"),
+						},
+					},
+				},
+				Allocatable: &api.Resource{
+					MilliCPU: 32000,
+					Memory:   128 * 1024 * 1024 * 1024,
+					ScalarResources: map[v1.ResourceName]float64{
+						"nvidia.com/gpu-v100": 4000,
+					},
+				},
+				Idle: &api.Resource{
+					MilliCPU: 32000,
+					Memory:   128 * 1024 * 1024 * 1024,
+					ScalarResources: map[v1.ResourceName]float64{
+						"nvidia.com/gpu-v100": 4000,
+					},
+				},
+			},
+			expectedScore: 0,
+			description:   "Node without any matching card type should get score 0",
+			expectError:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			score, err := tt.plugin.NodeOrderFn(tt.task, tt.node)
+			if tt.expectError && err == nil {
+				t.Errorf("%s: expected error but got none", tt.description)
+			}
+			if !tt.expectError && err != nil {
+				t.Errorf("%s: unexpected error: %v", tt.description, err)
+			}
+			if score != tt.expectedScore {
+				t.Errorf("%s: expected score %.2f, got %.2f", tt.description, tt.expectedScore, score)
+			}
+		})
+	}
+}

--- a/pkg/scheduler/plugins/capacity-card/capacity_card_job.go
+++ b/pkg/scheduler/plugins/capacity-card/capacity_card_job.go
@@ -1,0 +1,246 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+Copyright 2018-2025 The Volcano Authors.
+
+Modifications made by Volcano authors:
+- Enhanced gang scheduling validation with task-level validity checks
+- Improved preemption logic to respect gang scheduling constraints
+- Added support for job starving detection and enhanced pipeline state management
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package capacitycard
+
+import (
+	"fmt"
+	"strings"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/klog/v2"
+	resourcehelper "k8s.io/kubectl/pkg/util/resource"
+
+	"volcano.sh/volcano/pkg/scheduler/api"
+)
+
+// JobInfo describes the job used in capacity plugin.
+type JobInfo struct {
+	*api.JobInfo
+
+	// allocated is the allocated cpu, memory and card resource to job. Ignore none card scalar resource.
+	allocated *api.Resource
+
+	// preCheckCardResource is the card resource retrieved from job annotation for pre-check purpose.
+	// Pre-check will prevent pending pod created(working in JobEnqueueableFn) when queue has no enough card resource.
+	// It is suggested to set this annotation for jobs which need card resource, although it is optional.
+	preCheckCardResource *api.Resource
+}
+
+// NewJobInfo creates a JobInfo instance.
+func (p *Plugin) NewJobInfo(job *api.JobInfo) (*JobInfo, error) {
+	// read card request from Job(PodGroup).
+	preCheckCardResource := GetCardResourceFromAnnotations(
+		"job"+"/"+job.Namespace+"/"+job.Name,
+		job.PodGroup.Annotations,
+		JobAnnotationKeyCardRequest,
+	)
+
+	// job allocated cpu, memory and card resource to job. Ignore none card scalar resource.
+	allocated := api.EmptyResource()
+	// job request cpu, memory and card resource to job. Ignore none card scalar resource.
+	request := api.EmptyResource()
+	for _, ti := range job.Tasks {
+		if ti.Pod != nil {
+			resReq, err := p.GetTaskRequestResources(ti)
+			if err != nil {
+				klog.Warningf(
+					"Failed to get request resource for task <%s/%s> in job <%s/%s>: %+v",
+					ti.Namespace, ti.Name, job.Namespace, job.Name, err,
+				)
+				continue
+			}
+
+			request.Add(resReq)
+			if api.AllocatedStatus(ti.Status) {
+				allocated.Add(resReq)
+			}
+		}
+	}
+
+	// update preCheckCardResource with job request resource
+	if len(request.ScalarResources) > 0 {
+		preCheckCardResource.ScalarResources = request.ScalarResources
+	}
+
+	return &JobInfo{
+		JobInfo:              job,
+		allocated:            allocated,
+		preCheckCardResource: preCheckCardResource,
+	}, nil
+}
+
+// GetMinResources return the min resources of PodGroup.
+func (p *Plugin) GetMinResources(ji *JobInfo) *api.Resource {
+	jobResource := api.EmptyResource()
+	if ji.preCheckCardResource != nil {
+		jobResource.Add(ji.preCheckCardResource)
+	}
+
+	jobMinReq := ji.JobInfo.GetMinResources()
+
+	// add scalar resources if cardUnlimitedCpuMemory not set or has no card resources
+	if (!p.isCardUnlimitedCpuMemory || !p.HasCardResource(jobResource, jobMinReq)) && jobMinReq != nil {
+		jobResource.MilliCPU = jobMinReq.MilliCPU
+		jobResource.Memory = jobMinReq.Memory
+	}
+
+	return jobResource
+}
+
+// GetElasticResources returns those partly resources in allocated which are more than its minResource
+func (p *Plugin) GetElasticResources(ji *JobInfo) *api.Resource {
+	if ji.allocated == nil {
+		return api.EmptyResource()
+	}
+	var (
+		minResource = p.GetMinResources(ji)
+		elastic     = api.ExceededPart(ji.allocated, minResource)
+	)
+	return elastic
+}
+
+// getCardNameFromTask retrieves the card name from task's pod annotations.
+func (p *Plugin) getCardNameFromTask(ti *api.TaskInfo) string {
+	if ti.Pod == nil {
+		return ""
+	}
+	return ti.Pod.Annotations[TaskAnnotationKeyCardName]
+}
+
+// getCardResourceFromTask retrieves the card resource from task's pod annotations and requests/limits.
+func (p *Plugin) getCardResourceFromTask(ti *api.TaskInfo) (*api.Resource, error) {
+	if ti.Pod == nil {
+		return api.EmptyResource(), nil
+	}
+
+	cardName := p.getCardNameFromTask(ti)
+	if cardName == "" {
+		// no card requested, might be CPU type task.
+		return api.EmptyResource(), nil
+	}
+
+	// if multi-cards are requested, retrieve the confirmed card name from bound node.
+	if strings.Contains(cardName, MultiCardSeparator) {
+		multiCardNames := strings.Split(cardName, MultiCardSeparator)
+		if ti.Pod.Spec.NodeName == "" {
+			podCardResource, err := p.getCardResourceFromTaskPod(multiCardNames[0], ti.Pod)
+			if err != nil {
+				return api.EmptyResource(), err
+			}
+			for _, scalarCount := range podCardResource.ScalarResources {
+				// change to multi-card resource.
+				return &api.Resource{
+					ScalarResources: map[v1.ResourceName]float64{
+						v1.ResourceName(cardName): scalarCount,
+					},
+				}, nil
+			}
+		}
+		return p.getCardResourceFromNodeNameForMultiCardTask(ti, cardName)
+	}
+	return p.getCardResourceFromTaskPod(cardName, ti.Pod)
+}
+
+// getCardResourceFromNodeNameForMultiCardTask retrieves the real card resource from node label if pod is
+// already bound to certain node.
+func (p *Plugin) getCardResourceFromNodeNameForMultiCardTask(
+	ti *api.TaskInfo, multiCardName string,
+) (*api.Resource, error) {
+	// already bound to certain node, retrieve the real card name from node label.
+	node, err := p.nodeLister.Get(ti.Pod.Spec.NodeName)
+	if err != nil {
+		return api.EmptyResource(), fmt.Errorf(
+			"failed to get node <%s> for task <%s/%s>: %+v",
+			ti.Pod.Spec.NodeName, ti.Namespace, ti.Name, err,
+		)
+	}
+	var (
+		nodeCardInfo   = p.getCardResourceFromNode(node)
+		multiCardNames = strings.Split(multiCardName, MultiCardSeparator)
+	)
+	for _, singleCardName := range multiCardNames {
+		if _, ok := nodeCardInfo.CardNameToResourceName[v1.ResourceName(singleCardName)]; ok {
+			podCardResource, err := p.getCardResourceFromTaskPod(singleCardName, ti.Pod)
+			if err == nil {
+				return podCardResource, nil
+			}
+		}
+	}
+	return api.EmptyResource(), fmt.Errorf(
+		"no valid card found on node <%s> for task <%s/%s> with multi-card name <%s>",
+		node.Name, ti.Namespace, ti.Name, multiCardName,
+	)
+}
+
+// getCardResourceFromTaskPod retrieves the card resource from task's pod requests/limits.
+func (p *Plugin) getCardResourceFromTaskPod(cardName string, pod *v1.Pod) (*api.Resource, error) {
+	if pod == nil {
+		return api.EmptyResource(), fmt.Errorf("invalid parameter: pod is nil")
+	}
+
+	// retrieve card resource name from requests/limits.
+	// eg: cardName is "NVIDIA-H200", the resource name in requests/limits is "nvidia.com/gpu".
+	cardResourceName, ok := p.cardNameToResourceName[v1.ResourceName(cardName)]
+	if !ok {
+		return api.EmptyResource(), fmt.Errorf("no resource name found for card <%s>", cardName)
+	}
+	// retrieve card count from requests/limits by card resource name.
+	// eg: card name is "NVIDIA-H200", resource name is "nvidia.com/gpu",
+	// the "nvidia.com/gpu" count is 2 in pod requests/limits,
+	// then the "NVIDIA-H200" card count is 2.
+	podRequests, podLimits := resourcehelper.PodRequestsAndLimits(pod)
+	if quantity, found := podLimits[cardResourceName]; found {
+		return &api.Resource{
+			ScalarResources: map[v1.ResourceName]float64{
+				v1.ResourceName(cardName): float64(quantity.Value() * cardCountQuantityMultiplier),
+			},
+		}, nil
+	}
+	if quantity, found := podRequests[cardResourceName]; found {
+		return &api.Resource{
+			ScalarResources: map[v1.ResourceName]float64{
+				v1.ResourceName(cardName): float64(quantity.Value() * cardCountQuantityMultiplier),
+			},
+		}, nil
+	}
+	return api.EmptyResource(), fmt.Errorf(
+		"no resource <%s> defined in requests/limits for card <%s>",
+		cardResourceName, cardName,
+	)
+}
+
+// GetTaskRequestResources get the task request cpu, memory and card resource to job. Ignore none card scalar resource.
+func (p *Plugin) GetTaskRequestResources(task *api.TaskInfo) (*api.Resource, error) {
+	totalRequest, err := p.getCardResourceFromTask(task)
+	if err != nil {
+		return nil, err
+	}
+
+	// add cpu and memory if cardUnlimitedCpuMemory not set or has no card resources
+	if (!p.isCardUnlimitedCpuMemory || !p.HasCardResource(totalRequest, task.Resreq)) && task.Resreq != nil {
+		totalRequest.MilliCPU = task.Resreq.MilliCPU
+		totalRequest.Memory = task.Resreq.Memory
+	}
+
+	return totalRequest, nil
+}

--- a/pkg/scheduler/plugins/capacity-card/capacity_card_job_test.go
+++ b/pkg/scheduler/plugins/capacity-card/capacity_card_job_test.go
@@ -1,0 +1,1385 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+Copyright 2018-2025 The Volcano Authors.
+
+Modifications made by Volcano authors:
+- Enhanced gang scheduling validation with task-level validity checks
+- Improved preemption logic to respect gang scheduling constraints
+- Added support for job starving detection and enhanced pipeline state management
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package capacitycard
+
+import (
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+	v1lister "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
+
+	"volcano.sh/apis/pkg/apis/scheduling"
+	"volcano.sh/volcano/pkg/scheduler/api"
+)
+
+func TestNewJobInfo(t *testing.T) {
+	tests := []struct {
+		name                     string
+		plugin                   *Plugin
+		job                      *api.JobInfo
+		expectedError            bool
+		expectedAllocatedCPU     float64
+		expectedAllocatedMemory  float64
+		expectedPreCheckCardName v1.ResourceName
+		expectedPreCheckCardQty  float64
+		description              string
+	}{
+		{
+			name: "job with card request annotation and card unlimited cpu memory disabled",
+			plugin: &Plugin{
+				cardNameToResourceName:   map[v1.ResourceName]v1.ResourceName{"NVIDIA-A100": "nvidia.com/gpu"},
+				isCardUnlimitedCpuMemory: false,
+			},
+			job: &api.JobInfo{
+				UID:       "job-1",
+				Name:      "test-job",
+				Namespace: "default",
+				PodGroup: &api.PodGroup{
+					PodGroup: scheduling.PodGroup{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "test-job",
+							Namespace: "default",
+							Annotations: map[string]string{
+								JobAnnotationKeyCardRequest: `{"NVIDIA-A100": 2}`,
+							},
+						},
+					},
+				},
+				Tasks: map[api.TaskID]*api.TaskInfo{
+					"task-1": {
+						UID:       "task-1",
+						Name:      "task-1",
+						Namespace: "default",
+						TransactionContext: api.TransactionContext{
+							Status: api.Running,
+						},
+						Resreq: &api.Resource{
+							MilliCPU: 1000,
+							Memory:   1024 * 1024 * 1024,
+						},
+						Pod: &v1.Pod{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "task-1",
+								Namespace: "default",
+								Annotations: map[string]string{
+									TaskAnnotationKeyCardName: "NVIDIA-A100",
+								},
+							},
+							Spec: v1.PodSpec{
+								Containers: []v1.Container{
+									{
+										Resources: v1.ResourceRequirements{
+											Requests: v1.ResourceList{
+												"nvidia.com/gpu": resource.MustParse("1"),
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedError:            false,
+			expectedAllocatedCPU:     1000,
+			expectedAllocatedMemory:  1024 * 1024 * 1024,
+			expectedPreCheckCardName: "NVIDIA-A100",
+			expectedPreCheckCardQty:  1000,
+			description:              "Should create JobInfo with card request annotation and allocated resources when card unlimited cpu memory is enabled",
+		},
+		{
+			name: "job with card request annotation and card unlimited cpu memory enabled",
+			plugin: &Plugin{
+				cardNameToResourceName:   map[v1.ResourceName]v1.ResourceName{"NVIDIA-A100": "nvidia.com/gpu"},
+				isCardUnlimitedCpuMemory: true,
+			},
+			job: &api.JobInfo{
+				UID:       "job-1",
+				Name:      "test-job",
+				Namespace: "default",
+				PodGroup: &api.PodGroup{
+					PodGroup: scheduling.PodGroup{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "test-job",
+							Namespace: "default",
+							Annotations: map[string]string{
+								JobAnnotationKeyCardRequest: `{"NVIDIA-A100": 2}`,
+							},
+						},
+					},
+				},
+				Tasks: map[api.TaskID]*api.TaskInfo{
+					"task-1": {
+						UID:       "task-1",
+						Name:      "task-1",
+						Namespace: "default",
+						TransactionContext: api.TransactionContext{
+							Status: api.Running,
+						},
+						Resreq: &api.Resource{
+							MilliCPU: 1000,
+							Memory:   1024 * 1024 * 1024,
+						},
+						Pod: &v1.Pod{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "task-1",
+								Namespace: "default",
+								Annotations: map[string]string{
+									TaskAnnotationKeyCardName: "NVIDIA-A100",
+								},
+							},
+							Spec: v1.PodSpec{
+								Containers: []v1.Container{
+									{
+										Resources: v1.ResourceRequirements{
+											Requests: v1.ResourceList{
+												"nvidia.com/gpu": resource.MustParse("1"),
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedError:            false,
+			expectedAllocatedCPU:     0,
+			expectedAllocatedMemory:  0,
+			expectedPreCheckCardName: "NVIDIA-A100",
+			expectedPreCheckCardQty:  1000,
+			description:              "Should create JobInfo with card request annotation and allocated resources when card unlimited cpu memory is disabled",
+		},
+		{
+			name: "job without card request annotation",
+			plugin: &Plugin{
+				cardNameToResourceName:   map[v1.ResourceName]v1.ResourceName{},
+				isCardUnlimitedCpuMemory: false,
+			},
+			job: &api.JobInfo{
+				UID:       "job-2",
+				Name:      "test-job-2",
+				Namespace: "default",
+				PodGroup: &api.PodGroup{
+					PodGroup: scheduling.PodGroup{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "test-job-2",
+							Namespace: "default",
+						},
+					},
+				},
+				Tasks: map[api.TaskID]*api.TaskInfo{
+					"task-1": {
+						UID:       "task-1",
+						Name:      "task-1",
+						Namespace: "default",
+						TransactionContext: api.TransactionContext{
+							Status: api.Running,
+						},
+						Resreq: &api.Resource{
+							MilliCPU: 2000,
+							Memory:   2 * 1024 * 1024 * 1024,
+						},
+						Pod: &v1.Pod{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "task-1",
+								Namespace: "default",
+							},
+							Spec: v1.PodSpec{
+								Containers: []v1.Container{
+									{
+										Resources: v1.ResourceRequirements{
+											Requests: v1.ResourceList{
+												v1.ResourceCPU:    resource.MustParse("2"),
+												v1.ResourceMemory: resource.MustParse("2Gi"),
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedError:           false,
+			expectedAllocatedCPU:    2000,
+			expectedAllocatedMemory: 2 * 1024 * 1024 * 1024,
+			description:             "Should create JobInfo without card request annotation",
+		},
+		{
+			name: "job with pending task",
+			plugin: &Plugin{
+				cardNameToResourceName:   map[v1.ResourceName]v1.ResourceName{"NVIDIA-A100": "nvidia.com/gpu"},
+				isCardUnlimitedCpuMemory: false,
+			},
+			job: &api.JobInfo{
+				UID:       "job-3",
+				Name:      "test-job-3",
+				Namespace: "default",
+				PodGroup: &api.PodGroup{
+					PodGroup: scheduling.PodGroup{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "test-job-3",
+							Namespace: "default",
+						},
+					},
+				},
+				Tasks: map[api.TaskID]*api.TaskInfo{
+					"task-1": {
+						UID:       "task-1",
+						Name:      "task-1",
+						Namespace: "default",
+						TransactionContext: api.TransactionContext{
+							Status: api.Pending,
+						},
+						Resreq: &api.Resource{
+							MilliCPU: 1000,
+							Memory:   1024 * 1024 * 1024,
+						},
+						Pod: &v1.Pod{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "task-1",
+								Namespace: "default",
+								Annotations: map[string]string{
+									TaskAnnotationKeyCardName: "NVIDIA-A100",
+								},
+							},
+							Spec: v1.PodSpec{
+								Containers: []v1.Container{
+									{
+										Resources: v1.ResourceRequirements{
+											Requests: v1.ResourceList{
+												"nvidia.com/gpu": resource.MustParse("1"),
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedError:            false,
+			expectedAllocatedCPU:     0,
+			expectedAllocatedMemory:  0,
+			expectedPreCheckCardName: "NVIDIA-A100",
+			expectedPreCheckCardQty:  1000,
+			description:              "Should not count pending task in allocated resources",
+		},
+		{
+			name: "job with task that has invalid card",
+			plugin: &Plugin{
+				cardNameToResourceName:   map[v1.ResourceName]v1.ResourceName{},
+				isCardUnlimitedCpuMemory: false,
+			},
+			job: &api.JobInfo{
+				UID:       "job-4",
+				Name:      "test-job-4",
+				Namespace: "default",
+				PodGroup: &api.PodGroup{
+					PodGroup: scheduling.PodGroup{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "test-job-4",
+							Namespace: "default",
+						},
+					},
+				},
+				Tasks: map[api.TaskID]*api.TaskInfo{
+					"task-1": {
+						UID:       "task-1",
+						Name:      "task-1",
+						Namespace: "default",
+						TransactionContext: api.TransactionContext{
+							Status: api.Running,
+						},
+						Resreq: &api.Resource{
+							MilliCPU: 1000,
+							Memory:   1024 * 1024 * 1024,
+						},
+						Pod: &v1.Pod{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "task-1",
+								Namespace: "default",
+								Annotations: map[string]string{
+									TaskAnnotationKeyCardName: "INVALID-CARD",
+								},
+							},
+							Spec: v1.PodSpec{
+								Containers: []v1.Container{
+									{
+										Resources: v1.ResourceRequirements{
+											Requests: v1.ResourceList{
+												v1.ResourceCPU: resource.MustParse("1"),
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedError: false,
+			description:   "Should not return error when task has invalid card name",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			jobInfo, err := tt.plugin.NewJobInfo(tt.job)
+
+			if tt.expectedError {
+				if err == nil {
+					t.Errorf("Expected error but got none")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("Unexpected error: %v", err)
+				return
+			}
+
+			if jobInfo == nil {
+				t.Errorf("Expected JobInfo but got nil")
+				return
+			}
+
+			if jobInfo.allocated.MilliCPU != tt.expectedAllocatedCPU {
+				t.Errorf("Expected allocated CPU %v, got %v", tt.expectedAllocatedCPU, jobInfo.allocated.MilliCPU)
+			}
+
+			if jobInfo.allocated.Memory != tt.expectedAllocatedMemory {
+				t.Errorf("Expected allocated Memory %v, got %v", tt.expectedAllocatedMemory, jobInfo.allocated.Memory)
+			}
+
+			if tt.expectedPreCheckCardName != "" {
+				if qty, ok := jobInfo.preCheckCardResource.ScalarResources[tt.expectedPreCheckCardName]; !ok {
+					t.Errorf("Expected preCheckCardResource to have %v", tt.expectedPreCheckCardName)
+				} else if qty != tt.expectedPreCheckCardQty {
+					t.Errorf("Expected preCheckCardResource quantity %v, got %v", tt.expectedPreCheckCardQty, qty)
+				}
+			}
+		})
+	}
+}
+
+func TestGetMinResources(t *testing.T) {
+	tests := []struct {
+		name                 string
+		plugin               *Plugin
+		jobInfo              *JobInfo
+		expectedCPU          float64
+		expectedMemory       float64
+		expectedCardName     v1.ResourceName
+		expectedCardQuantity float64
+		description          string
+	}{
+		{
+			name: "job with card resource and cardUnlimitedCpuMemory enabled",
+			plugin: &Plugin{
+				isCardUnlimitedCpuMemory: true,
+			},
+			jobInfo: &JobInfo{
+				JobInfo: &api.JobInfo{
+					PodGroup: &api.PodGroup{
+						PodGroup: scheduling.PodGroup{
+							Spec: scheduling.PodGroupSpec{
+								MinResources: &v1.ResourceList{
+									v1.ResourceCPU:    resource.MustParse("4"),
+									v1.ResourceMemory: resource.MustParse("4Gi"),
+									"nvidia.com/gpu":  resource.MustParse("2"),
+								},
+							},
+						},
+					},
+				},
+				preCheckCardResource: &api.Resource{
+					ScalarResources: map[v1.ResourceName]float64{
+						"NVIDIA-A100": 2000,
+					},
+				},
+			},
+			expectedCardName:     "NVIDIA-A100",
+			expectedCardQuantity: 2000,
+			description:          "Should not include MinResources CPU/Memory when card resource exists and cardUnlimitedCpuMemory is enabled",
+		},
+		{
+			name: "job with card resource and cardUnlimitedCpuMemory disabled",
+			plugin: &Plugin{
+				isCardUnlimitedCpuMemory: false,
+			},
+			jobInfo: &JobInfo{
+				JobInfo: &api.JobInfo{
+					PodGroup: &api.PodGroup{
+						PodGroup: scheduling.PodGroup{
+							Spec: scheduling.PodGroupSpec{
+								MinResources: &v1.ResourceList{
+									v1.ResourceCPU:    resource.MustParse("4"),
+									v1.ResourceMemory: resource.MustParse("4Gi"),
+									"nvidia.com/gpu":  resource.MustParse("2"),
+								},
+							},
+						},
+					},
+				},
+				preCheckCardResource: &api.Resource{
+					ScalarResources: map[v1.ResourceName]float64{
+						"NVIDIA-A100": 2000,
+					},
+				},
+			},
+			expectedCPU:          4000,                   // MinResources CPU replaces preCheckCardResource CPU
+			expectedMemory:       4 * 1024 * 1024 * 1024, // MinResources Memory replaces preCheckCardResource Memory
+			expectedCardName:     "NVIDIA-A100",
+			expectedCardQuantity: 2000,
+			description:          "Should replace with MinResources CPU/Memory when cardUnlimitedCpuMemory is disabled",
+		},
+		{
+			name: "job without card resource",
+			plugin: &Plugin{
+				isCardUnlimitedCpuMemory: true,
+			},
+			jobInfo: &JobInfo{
+				JobInfo: &api.JobInfo{
+					PodGroup: &api.PodGroup{
+						PodGroup: scheduling.PodGroup{
+							Spec: scheduling.PodGroupSpec{
+								MinResources: &v1.ResourceList{
+									v1.ResourceCPU:    resource.MustParse("2"),
+									v1.ResourceMemory: resource.MustParse("2Gi"),
+									"nvidia.com/gpu":  resource.MustParse("2"),
+								},
+							},
+						},
+					},
+				},
+				preCheckCardResource: &api.Resource{
+					ScalarResources: map[v1.ResourceName]float64{},
+				},
+			},
+			expectedCPU:    2000,
+			expectedMemory: 2 * 1024 * 1024 * 1024,
+			description:    "Should include CPU/Memory when no card resource exists",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			minRes := tt.plugin.GetMinResources(tt.jobInfo)
+
+			if minRes.MilliCPU != tt.expectedCPU {
+				t.Errorf("Expected CPU %v, got %v", tt.expectedCPU, minRes.MilliCPU)
+			}
+
+			if minRes.Memory != tt.expectedMemory {
+				t.Errorf("Expected Memory %v, got %v", tt.expectedMemory, minRes.Memory)
+			}
+
+			if tt.expectedCardName != "" {
+				if qty, ok := minRes.ScalarResources[tt.expectedCardName]; !ok {
+					t.Errorf("Expected card resource %v", tt.expectedCardName)
+				} else if qty != tt.expectedCardQuantity {
+					t.Errorf("Expected card quantity %v, got %v", tt.expectedCardQuantity, qty)
+				}
+			}
+		})
+	}
+}
+
+func TestGetElasticResources(t *testing.T) {
+	tests := []struct {
+		name                 string
+		plugin               *Plugin
+		jobInfo              *JobInfo
+		expectedCPU          float64
+		expectedMemory       float64
+		expectedCardName     v1.ResourceName
+		expectedCardQuantity float64
+		description          string
+	}{
+		{
+			name: "job with elastic resources and card unlimited cpu memory disabled",
+			plugin: &Plugin{
+				isCardUnlimitedCpuMemory: false,
+			},
+			jobInfo: &JobInfo{
+				JobInfo: &api.JobInfo{
+					PodGroup: &api.PodGroup{
+						PodGroup: scheduling.PodGroup{
+							Spec: scheduling.PodGroupSpec{
+								MinResources: &v1.ResourceList{
+									v1.ResourceCPU:    resource.MustParse("2"),
+									v1.ResourceMemory: resource.MustParse("2Gi"),
+									"nvidia.com/gpu":  resource.MustParse("2"),
+								},
+							},
+						},
+					},
+				},
+				allocated: &api.Resource{
+					MilliCPU: 4000,
+					Memory:   4 * 1024 * 1024 * 1024,
+					ScalarResources: map[v1.ResourceName]float64{
+						"Tesla-V100": 6000,
+					},
+				},
+				preCheckCardResource: &api.Resource{
+					ScalarResources: map[v1.ResourceName]float64{
+						"Tesla-V100": 4000,
+					},
+				},
+			},
+			expectedCPU:          2000,
+			expectedMemory:       2 * 1024 * 1024 * 1024,
+			expectedCardName:     "Tesla-V100",
+			expectedCardQuantity: 2000,
+			description:          "Should return elastic resources (allocated - min)",
+		},
+
+		{
+			name: "job with elastic resources and card unlimited cpu memory enabled",
+			plugin: &Plugin{
+				isCardUnlimitedCpuMemory: true,
+			},
+			jobInfo: &JobInfo{
+				JobInfo: &api.JobInfo{
+					PodGroup: &api.PodGroup{
+						PodGroup: scheduling.PodGroup{
+							Spec: scheduling.PodGroupSpec{
+								MinResources: &v1.ResourceList{
+									v1.ResourceCPU:    resource.MustParse("2"),
+									v1.ResourceMemory: resource.MustParse("2Gi"),
+									"nvidia.com/gpu":  resource.MustParse("2"),
+								},
+							},
+						},
+					},
+				},
+				allocated: &api.Resource{
+					MilliCPU: 4000,
+					Memory:   4 * 1024 * 1024 * 1024,
+					ScalarResources: map[v1.ResourceName]float64{
+						"Tesla-V100": 6000,
+					},
+				},
+				preCheckCardResource: &api.Resource{
+					ScalarResources: map[v1.ResourceName]float64{
+						"Tesla-V100": 4000,
+					},
+				},
+			},
+			expectedCPU:          4000,
+			expectedMemory:       4 * 1024 * 1024 * 1024,
+			expectedCardName:     "Tesla-V100",
+			expectedCardQuantity: 2000,
+			description:          "Should return elastic resources (allocated - min)",
+		},
+		{
+			name: "job without allocated resources",
+			plugin: &Plugin{
+				isCardUnlimitedCpuMemory: false,
+			},
+			jobInfo: &JobInfo{
+				JobInfo: &api.JobInfo{
+					PodGroup: &api.PodGroup{
+						PodGroup: scheduling.PodGroup{
+							Spec: scheduling.PodGroupSpec{
+								MinResources: &v1.ResourceList{
+									v1.ResourceCPU:    resource.MustParse("2"),
+									v1.ResourceMemory: resource.MustParse("2Gi"),
+								},
+							},
+						},
+					},
+				},
+				allocated:            nil,
+				preCheckCardResource: &api.Resource{},
+			},
+			expectedCPU:          0,
+			expectedMemory:       0,
+			expectedCardName:     "",
+			expectedCardQuantity: 0,
+			description:          "Should return empty resource when allocated is nil",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			elastic := tt.plugin.GetElasticResources(tt.jobInfo)
+
+			if elastic.MilliCPU != tt.expectedCPU {
+				t.Errorf("Expected elastic CPU %v, got %v", tt.expectedCPU, elastic.MilliCPU)
+			}
+
+			if elastic.Memory != tt.expectedMemory {
+				t.Errorf("Expected elastic Memory %v, got %v", tt.expectedMemory, elastic.Memory)
+			}
+
+			if tt.expectedCardName != "" {
+				if qty, ok := elastic.ScalarResources[tt.expectedCardName]; !ok {
+					t.Errorf("Expected card resource %v", tt.expectedCardName)
+				} else if qty != tt.expectedCardQuantity {
+					t.Errorf("Expected card quantity %v, got %v", tt.expectedCardQuantity, qty)
+				}
+			}
+		})
+	}
+}
+
+func TestGetCardNameFromTask(t *testing.T) {
+	tests := []struct {
+		name         string
+		plugin       *Plugin
+		task         *api.TaskInfo
+		expectedName string
+		description  string
+	}{
+		{
+			name:   "task with card name annotation",
+			plugin: &Plugin{},
+			task: &api.TaskInfo{
+				Pod: &v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							TaskAnnotationKeyCardName: "NVIDIA-A100",
+						},
+					},
+				},
+			},
+			expectedName: "NVIDIA-A100",
+			description:  "Should return card name from annotation",
+		},
+		{
+			name:   "task without card name annotation",
+			plugin: &Plugin{},
+			task: &api.TaskInfo{
+				Pod: &v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{},
+					},
+				},
+			},
+			expectedName: "",
+			description:  "Should return empty string when no card name annotation",
+		},
+		{
+			name:   "task without pod",
+			plugin: &Plugin{},
+			task: &api.TaskInfo{
+				Pod: nil,
+			},
+			expectedName: "",
+			description:  "Should return empty string when pod is nil",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cardName := tt.plugin.getCardNameFromTask(tt.task)
+
+			if cardName != tt.expectedName {
+				t.Errorf("Expected card name %v, got %v", tt.expectedName, cardName)
+			}
+		})
+	}
+}
+
+func TestGetCardResourceFromTaskPod(t *testing.T) {
+	tests := []struct {
+		name          string
+		plugin        *Plugin
+		cardName      string
+		pod           *v1.Pod
+		expectedCard  v1.ResourceName
+		expectedQty   float64
+		expectedError bool
+		description   string
+	}{
+		{
+			name: "pod with card in limits",
+			plugin: &Plugin{
+				cardNameToResourceName: map[v1.ResourceName]v1.ResourceName{
+					"NVIDIA-A100": "nvidia.com/gpu",
+				},
+			},
+			cardName: "NVIDIA-A100",
+			pod: &v1.Pod{
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Resources: v1.ResourceRequirements{
+								Limits: v1.ResourceList{
+									"nvidia.com/gpu": resource.MustParse("2"),
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedCard:  "NVIDIA-A100",
+			expectedQty:   2000,
+			expectedError: false,
+			description:   "Should get card resource from limits",
+		},
+		{
+			name: "pod with card in requests",
+			plugin: &Plugin{
+				cardNameToResourceName: map[v1.ResourceName]v1.ResourceName{
+					"NVIDIA-A100": "nvidia.com/gpu",
+				},
+			},
+			cardName: "NVIDIA-A100",
+			pod: &v1.Pod{
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Resources: v1.ResourceRequirements{
+								Requests: v1.ResourceList{
+									"nvidia.com/gpu": resource.MustParse("1"),
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedCard:  "NVIDIA-A100",
+			expectedQty:   1000,
+			expectedError: false,
+			description:   "Should get card resource from requests",
+		},
+		{
+			name: "pod without card resource",
+			plugin: &Plugin{
+				cardNameToResourceName: map[v1.ResourceName]v1.ResourceName{
+					"NVIDIA-A100": "nvidia.com/gpu",
+				},
+			},
+			cardName: "NVIDIA-A100",
+			pod: &v1.Pod{
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Resources: v1.ResourceRequirements{
+								Requests: v1.ResourceList{
+									v1.ResourceCPU: resource.MustParse("1"),
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedError: true,
+			description:   "Should return error when card resource not found",
+		},
+		{
+			name: "unknown card name",
+			plugin: &Plugin{
+				cardNameToResourceName: map[v1.ResourceName]v1.ResourceName{},
+			},
+			cardName: "UNKNOWN-CARD",
+			pod: &v1.Pod{
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{},
+				},
+			},
+			expectedError: true,
+			description:   "Should return error for unknown card name",
+		},
+		{
+			name: "nil pod",
+			plugin: &Plugin{
+				cardNameToResourceName: map[v1.ResourceName]v1.ResourceName{
+					"NVIDIA-A100": "nvidia.com/gpu",
+				},
+			},
+			cardName:      "NVIDIA-A100",
+			pod:           nil,
+			expectedError: true,
+			description:   "Should return error when pod is nil",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res, err := tt.plugin.getCardResourceFromTaskPod(tt.cardName, tt.pod)
+
+			if tt.expectedError {
+				if err == nil {
+					t.Errorf("Expected error but got none")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("Unexpected error: %v", err)
+				return
+			}
+
+			if qty, ok := res.ScalarResources[tt.expectedCard]; !ok {
+				t.Errorf("Expected card resource %v", tt.expectedCard)
+			} else if qty != tt.expectedQty {
+				t.Errorf("Expected card quantity %v, got %v", tt.expectedQty, qty)
+			}
+		})
+	}
+}
+
+func TestGetCardResourceFromTask(t *testing.T) {
+	tests := []struct {
+		name          string
+		plugin        *Plugin
+		task          *api.TaskInfo
+		expectedCard  v1.ResourceName
+		expectedQty   float64
+		expectedError bool
+		description   string
+	}{
+		{
+			name: "task with single card",
+			plugin: &Plugin{
+				cardNameToResourceName: map[v1.ResourceName]v1.ResourceName{
+					"NVIDIA-A100": "nvidia.com/gpu",
+				},
+			},
+			task: &api.TaskInfo{
+				Pod: &v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							TaskAnnotationKeyCardName: "NVIDIA-A100",
+						},
+					},
+					Spec: v1.PodSpec{
+						Containers: []v1.Container{
+							{
+								Resources: v1.ResourceRequirements{
+									Requests: v1.ResourceList{
+										"nvidia.com/gpu": resource.MustParse("2"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedCard:  "NVIDIA-A100",
+			expectedQty:   2000,
+			expectedError: false,
+			description:   "Should get card resource from single card task",
+		},
+		{
+			name: "task without card",
+			plugin: &Plugin{
+				cardNameToResourceName: map[v1.ResourceName]v1.ResourceName{},
+			},
+			task: &api.TaskInfo{
+				Pod: &v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{},
+					},
+					Spec: v1.PodSpec{
+						Containers: []v1.Container{
+							{
+								Resources: v1.ResourceRequirements{
+									Requests: v1.ResourceList{
+										v1.ResourceCPU: resource.MustParse("1"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedError: false,
+			description:   "Should return empty resource for CPU-only task",
+		},
+		{
+			name:   "task without pod",
+			plugin: &Plugin{},
+			task: &api.TaskInfo{
+				Pod: nil,
+			},
+			expectedError: false,
+			description:   "Should return empty resource when pod is nil",
+		},
+		{
+			name: "multi-card task without bound node",
+			plugin: &Plugin{
+				cardNameToResourceName: map[v1.ResourceName]v1.ResourceName{
+					"NVIDIA-A100": "nvidia.com/gpu",
+					"NVIDIA-H100": "nvidia.com/gpu",
+				},
+			},
+			task: &api.TaskInfo{
+				Pod: &v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							TaskAnnotationKeyCardName: "NVIDIA-A100|NVIDIA-H100",
+						},
+					},
+					Spec: v1.PodSpec{
+						NodeName: "", // Not bound to any node
+						Containers: []v1.Container{
+							{
+								Resources: v1.ResourceRequirements{
+									Requests: v1.ResourceList{
+										"nvidia.com/gpu": resource.MustParse("1"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedCard:  "NVIDIA-A100|NVIDIA-H100",
+			expectedQty:   1000,
+			expectedError: false,
+			description:   "Should get multi-card resource from unbound pod using first card name",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res, err := tt.plugin.getCardResourceFromTask(tt.task)
+
+			if tt.expectedError {
+				if err == nil {
+					t.Errorf("Expected error but got none")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("Unexpected error: %v", err)
+				return
+			}
+
+			if tt.expectedCard != "" {
+				if qty, ok := res.ScalarResources[tt.expectedCard]; !ok {
+					t.Errorf("Expected card resource %v", tt.expectedCard)
+				} else if qty != tt.expectedQty {
+					t.Errorf("Expected card quantity %v, got %v", tt.expectedQty, qty)
+				}
+			}
+		})
+	}
+}
+
+func TestGetTaskRequestResources(t *testing.T) {
+	tests := []struct {
+		name           string
+		plugin         *Plugin
+		task           *api.TaskInfo
+		expectedCPU    float64
+		expectedMemory float64
+		expectedCard   v1.ResourceName
+		expectedQty    float64
+		expectedError  bool
+		description    string
+	}{
+		{
+			name: "task with card and cardUnlimitedCpuMemory enabled",
+			plugin: &Plugin{
+				cardNameToResourceName: map[v1.ResourceName]v1.ResourceName{
+					"NVIDIA-A100": "nvidia.com/gpu",
+				},
+				isCardUnlimitedCpuMemory: true,
+			},
+			task: &api.TaskInfo{
+				Resreq: &api.Resource{
+					MilliCPU: 2000,
+					Memory:   2 * 1024 * 1024 * 1024,
+				},
+				Pod: &v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							TaskAnnotationKeyCardName: "NVIDIA-A100",
+						},
+					},
+					Spec: v1.PodSpec{
+						Containers: []v1.Container{
+							{
+								Resources: v1.ResourceRequirements{
+									Requests: v1.ResourceList{
+										"nvidia.com/gpu": resource.MustParse("1"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedCPU:    0,
+			expectedMemory: 0,
+			expectedCard:   "NVIDIA-A100",
+			expectedQty:    1000,
+			expectedError:  false,
+			description:    "Should not include CPU/Memory when card exists and cardUnlimitedCpuMemory is enabled",
+		},
+		{
+			name: "task with card and cardUnlimitedCpuMemory disabled",
+			plugin: &Plugin{
+				cardNameToResourceName: map[v1.ResourceName]v1.ResourceName{
+					"NVIDIA-A100": "nvidia.com/gpu",
+				},
+				isCardUnlimitedCpuMemory: false,
+			},
+			task: &api.TaskInfo{
+				Resreq: &api.Resource{
+					MilliCPU: 2000,
+					Memory:   2 * 1024 * 1024 * 1024,
+				},
+				Pod: &v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							TaskAnnotationKeyCardName: "NVIDIA-A100",
+						},
+					},
+					Spec: v1.PodSpec{
+						Containers: []v1.Container{
+							{
+								Resources: v1.ResourceRequirements{
+									Requests: v1.ResourceList{
+										"nvidia.com/gpu": resource.MustParse("1"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedCPU:    2000,
+			expectedMemory: 2 * 1024 * 1024 * 1024,
+			expectedCard:   "NVIDIA-A100",
+			expectedQty:    1000,
+			expectedError:  false,
+			description:    "Should include CPU/Memory when cardUnlimitedCpuMemory is disabled",
+		},
+		{
+			name: "CPU-only task",
+			plugin: &Plugin{
+				cardNameToResourceName:   map[v1.ResourceName]v1.ResourceName{},
+				isCardUnlimitedCpuMemory: true,
+			},
+			task: &api.TaskInfo{
+				Resreq: &api.Resource{
+					MilliCPU: 1000,
+					Memory:   1024 * 1024 * 1024,
+				},
+				Pod: &v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{},
+					},
+					Spec: v1.PodSpec{
+						Containers: []v1.Container{
+							{
+								Resources: v1.ResourceRequirements{
+									Requests: v1.ResourceList{
+										v1.ResourceCPU:    resource.MustParse("1"),
+										v1.ResourceMemory: resource.MustParse("1Gi"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedCPU:    1000,
+			expectedMemory: 1024 * 1024 * 1024,
+			expectedError:  false,
+			description:    "Should include CPU/Memory for CPU-only task",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res, err := tt.plugin.GetTaskRequestResources(tt.task)
+
+			if tt.expectedError {
+				if err == nil {
+					t.Errorf("Expected error but got none")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("Unexpected error: %v", err)
+				return
+			}
+
+			if res.MilliCPU != tt.expectedCPU {
+				t.Errorf("Expected CPU %v, got %v", tt.expectedCPU, res.MilliCPU)
+			}
+
+			if res.Memory != tt.expectedMemory {
+				t.Errorf("Expected Memory %v, got %v", tt.expectedMemory, res.Memory)
+			}
+
+			if tt.expectedCard != "" {
+				if qty, ok := res.ScalarResources[tt.expectedCard]; !ok {
+					t.Errorf("Expected card resource %v", tt.expectedCard)
+				} else if qty != tt.expectedQty {
+					t.Errorf("Expected card quantity %v, got %v", tt.expectedQty, qty)
+				}
+			}
+		})
+	}
+}
+
+func TestGetCardResourceFromNodeNameForMultiCardTask(t *testing.T) {
+	tests := []struct {
+		name          string
+		plugin        *Plugin
+		task          *api.TaskInfo
+		multiCardName string
+		expectedCard  v1.ResourceName
+		expectedQty   float64
+		expectedError bool
+		description   string
+	}{
+		{
+			name: "multi-card task with bound node",
+			plugin: &Plugin{
+				cardNameToResourceName: map[v1.ResourceName]v1.ResourceName{
+					"NVIDIA-A100": "nvidia.com/gpu",
+					"NVIDIA-H100": "nvidia.com/gpu",
+				},
+			},
+			task: &api.TaskInfo{
+				Pod: &v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							TaskAnnotationKeyCardName: "NVIDIA-A100|NVIDIA-H100",
+						},
+					},
+					Spec: v1.PodSpec{
+						NodeName: "test-node",
+						Containers: []v1.Container{
+							{
+								Resources: v1.ResourceRequirements{
+									Requests: v1.ResourceList{
+										"nvidia.com/gpu": resource.MustParse("1"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			multiCardName: "NVIDIA-A100|NVIDIA-H100",
+			expectedError: true, // Will fail without proper node lister setup
+			description:   "Should attempt to retrieve card from bound node",
+		},
+		{
+			name: "task with empty node name",
+			plugin: &Plugin{
+				cardNameToResourceName: map[v1.ResourceName]v1.ResourceName{
+					"NVIDIA-A100": "nvidia.com/gpu",
+				},
+			},
+			task: &api.TaskInfo{
+				Pod: &v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							TaskAnnotationKeyCardName: "NVIDIA-A100",
+						},
+					},
+					Spec: v1.PodSpec{
+						NodeName: "", // Empty node name
+						Containers: []v1.Container{
+							{
+								Resources: v1.ResourceRequirements{
+									Requests: v1.ResourceList{
+										"nvidia.com/gpu": resource.MustParse("1"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			multiCardName: "NVIDIA-A100",
+			expectedError: true,
+			description:   "Should fail when node name is empty",
+		},
+		{
+			name: "task with non-existent node",
+			plugin: &Plugin{
+				cardNameToResourceName: map[v1.ResourceName]v1.ResourceName{
+					"NVIDIA-T4": "nvidia.com/gpu",
+				},
+			},
+			task: &api.TaskInfo{
+				Pod: &v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							TaskAnnotationKeyCardName: "NVIDIA-T4",
+						},
+					},
+					Spec: v1.PodSpec{
+						NodeName: "non-existent-node",
+						Containers: []v1.Container{
+							{
+								Resources: v1.ResourceRequirements{
+									Requests: v1.ResourceList{
+										"nvidia.com/gpu": resource.MustParse("2"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			multiCardName: "NVIDIA-T4",
+			expectedError: true,
+			description:   "Should fail when node does not exist in lister",
+		},
+		{
+			name: "multi-card task with empty multi-card name",
+			plugin: &Plugin{
+				cardNameToResourceName: map[v1.ResourceName]v1.ResourceName{
+					"NVIDIA-A100": "nvidia.com/gpu",
+				},
+			},
+			task: &api.TaskInfo{
+				Pod: &v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{},
+					},
+					Spec: v1.PodSpec{
+						NodeName: "test-node",
+						Containers: []v1.Container{
+							{
+								Resources: v1.ResourceRequirements{
+									Requests: v1.ResourceList{
+										"nvidia.com/gpu": resource.MustParse("1"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			multiCardName: "", // Empty multi-card name
+			expectedError: true,
+			description:   "Should fail when multi-card name is empty",
+		},
+		{
+			name: "multi-card task successfully retrieves card from bound node",
+			plugin: &Plugin{
+				cardNameToResourceName: map[v1.ResourceName]v1.ResourceName{
+					"NVIDIA-A100": "nvidia.com/gpu",
+					"NVIDIA-H100": "nvidia.com/gpu",
+				},
+				nodeCardInfos: make(map[string]NodeCardResourceInfo),
+			},
+			task: &api.TaskInfo{
+				Pod: &v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							TaskAnnotationKeyCardName: "NVIDIA-A100|NVIDIA-H100",
+						},
+					},
+					Spec: v1.PodSpec{
+						NodeName: "success-node",
+						Containers: []v1.Container{
+							{
+								Resources: v1.ResourceRequirements{
+									Requests: v1.ResourceList{
+										"nvidia.com/gpu": resource.MustParse("2"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			multiCardName: "NVIDIA-A100|NVIDIA-H100",
+			expectedCard:  "NVIDIA-A100",
+			expectedQty:   2000, // 2 * 1000
+			expectedError: false,
+			description:   "Should successfully retrieve card resource from bound node",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create fake Kubernetes clientset and node lister
+			_ = fake.NewSimpleClientset()
+			informer := cache.NewSharedIndexInformer(
+				nil,
+				&v1.Node{},
+				0,
+				cache.Indexers{},
+			)
+			tt.plugin.nodeLister = v1lister.NewNodeLister(informer.GetIndexer())
+
+			// For success case, add node to indexer
+			if !tt.expectedError {
+				node := &v1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: tt.task.Pod.Spec.NodeName,
+						Labels: map[string]string{
+							"nvidia.com/gpu.product": "NVIDIA-A100",
+							"nvidia.com/gpu.count":   "8",
+							"nvidia.com/gpu.memory":  "81920",
+						},
+					},
+					Status: v1.NodeStatus{
+						Allocatable: v1.ResourceList{
+							"nvidia.com/gpu": resource.MustParse("8"),
+						},
+					},
+				}
+				_ = informer.GetIndexer().Add(node)
+			}
+
+			res, err := tt.plugin.getCardResourceFromNodeNameForMultiCardTask(tt.task, tt.multiCardName)
+
+			if tt.expectedError {
+				if err == nil {
+					t.Errorf("Expected error but got none")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("Unexpected error: %v", err)
+				return
+			}
+
+			// Verify successful result
+			if tt.expectedCard != "" {
+				if qty, ok := res.ScalarResources[tt.expectedCard]; !ok {
+					t.Errorf("Expected card resource %v not found", tt.expectedCard)
+				} else if qty != tt.expectedQty {
+					t.Errorf("Expected card quantity %v, got %v", tt.expectedQty, qty)
+				}
+			}
+		})
+	}
+}

--- a/pkg/scheduler/plugins/capacity-card/capacity_card_node.go
+++ b/pkg/scheduler/plugins/capacity-card/capacity_card_node.go
@@ -1,0 +1,241 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+Copyright 2018-2025 The Volcano Authors.
+
+Modifications made by Volcano authors:
+- Enhanced gang scheduling validation with task-level validity checks
+- Improved preemption logic to respect gang scheduling constraints
+- Added support for job starving detection and enhanced pipeline state management
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package capacitycard
+
+import (
+	"fmt"
+	"math"
+	"regexp"
+	"strconv"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/klog/v2"
+
+	"volcano.sh/volcano/pkg/scheduler/api"
+	"volcano.sh/volcano/pkg/scheduler/framework"
+)
+
+// CardInfo defines the basic information of a card.
+// One node only has one type of card.
+type CardInfo struct {
+	Name           string // card name
+	Count          int64  // card count in board slots(PCIE/SXM,etc.)
+	Memory         int64  // card memory in bytes
+	ResourcePrefix string // resource prefix, e.g. nvidia.com
+}
+
+// NodeCardResourceInfo defines the card resource information of a node.
+type NodeCardResourceInfo struct {
+	// card basic info in node labels, created by gpu operator or manually.
+	CardInfo CardInfo
+	// actual card resources in node status.capacity, created by device plugin.
+	CardResource corev1.ResourceList
+	// mapping from card name to resource name, for quick indexing in scheduler logic.
+	CardNameToResourceName map[corev1.ResourceName]corev1.ResourceName
+}
+
+var (
+	// nodeCardProductLabelRegex is used to extract card product information from node labels.
+	// car product label is necessary to get card name, count and memory.
+	nodeCardProductLabelRegex = regexp.MustCompile(`^((.+?)/(\w+))\.product$`)
+)
+
+// buildTotalResource builds the total resource of the cluster by listing all nodes from informer.
+// Note that, DO NOT use ssn.Nodes where, because ssn.Nodes are synced in node event handlers asynchronously,
+// which might lost some nodes in scheduling starting to work.
+func (p *Plugin) buildTotalResource(ssn *framework.Session) bool {
+	p.nodeLister = ssn.InformerFactory().Core().V1().Nodes().Lister()
+	nodes, err := p.nodeLister.List(labels.Everything())
+	if err != nil {
+		klog.Errorf("Failed to list nodes: %+v", err)
+		return false
+	}
+	p.buildTotalResourceFromNodes(nodes)
+	return true
+}
+
+// buildTotalResourceFromNodes builds the total resource of the cluster from the given nodes.
+func (p *Plugin) buildTotalResourceFromNodes(nodes []*corev1.Node) {
+	var (
+		totalNormalResource = make(corev1.ResourceList) // CPU, Memory, EphemeralStorage, etc.
+		totalCardResource   = make(corev1.ResourceList) // GPU/NPU/PPU cards, etc.
+	)
+	for _, node := range nodes {
+		// calculate cpu and memory resource
+		cpuMemoryResource := make(corev1.ResourceList)
+		if cpu, ok := node.Status.Allocatable[corev1.ResourceCPU]; ok {
+			cpuMemoryResource[corev1.ResourceCPU] = cpu
+		}
+		if memory, ok := node.Status.Allocatable[corev1.ResourceMemory]; ok {
+			cpuMemoryResource[corev1.ResourceMemory] = memory
+		}
+		addResourceList(
+			totalNormalResource, cpuMemoryResource,
+		)
+
+		// calculate card resource
+		nodeCardInfo := p.getCardResourceFromNode(node)
+		addResourceList(totalCardResource, nodeCardInfo.CardResource)
+		for cardName, resourceName := range nodeCardInfo.CardNameToResourceName {
+			p.cardNameToResourceName[cardName] = resourceName
+		}
+	}
+	p.totalResource = api.NewResource(totalNormalResource)
+	for resName, quantity := range totalCardResource {
+		p.totalResource.AddScalar(resName, float64(quantity.Value()*cardCountQuantityMultiplier))
+	}
+}
+
+// getCardResourceFromNode gets the card resource from the node.
+func (p *Plugin) getCardResourceFromNode(node *corev1.Node) NodeCardResourceInfo {
+	if nodeCardInfo, ok := p.nodeCardInfos[node.Name]; ok {
+		return nodeCardInfo
+	}
+	nodeCardInfo := NodeCardResourceInfo{
+		CardInfo:               p.getCardInfoFromNode(node),
+		CardResource:           map[corev1.ResourceName]resource.Quantity{},
+		CardNameToResourceName: map[corev1.ResourceName]corev1.ResourceName{},
+	}
+	for resName, cardCapacity := range node.Status.Allocatable {
+		if cardCapacity.Value() <= 0 {
+			continue
+		}
+		// special MPS resource.
+		if isMpsResourceName(resName) {
+			mpsReplicas, err := strconv.Atoi(node.Labels[MpsReplicaLabel])
+			if err != nil {
+				klog.Errorf(
+					"Failed to parse MPS replica label %s: %+v",
+					node.Labels[MpsReplicaLabel], err,
+				)
+			}
+			if mpsReplicas > 0 {
+				cardName := fmt.Sprintf(
+					MpsSharedCardNamePattern,
+					nodeCardInfo.CardInfo.Name,
+					int(math.Round(float64(nodeCardInfo.CardInfo.Memory)/1024)),
+					mpsReplicas,
+				)
+				cardResourceName := corev1.ResourceName(cardName)
+				nodeCardInfo.CardResource[cardResourceName] = cardCapacity.DeepCopy()
+				nodeCardInfo.CardNameToResourceName[cardResourceName] = resName
+			}
+			continue
+		}
+
+		// special MIG resource.
+		if isMigResourceName(resName) {
+			var (
+				migSpec          = strings.TrimPrefix(string(resName), MigLabelAndResourceNamePrefix)
+				cardName         = fmt.Sprintf(MigSharedCardNamePattern, nodeCardInfo.CardInfo.Name, migSpec)
+				cardResourceName = corev1.ResourceName(cardName)
+			)
+			nodeCardInfo.CardResource[cardResourceName] = cardCapacity.DeepCopy()
+			nodeCardInfo.CardNameToResourceName[cardResourceName] = resName
+			continue
+		}
+
+		// 1. whole card resource
+		// 2. parts are shared card resource, parts are whole card resource
+		if nodeCardInfo.CardInfo.ResourcePrefix != "" {
+			if strings.HasPrefix(string(resName), nodeCardInfo.CardInfo.ResourcePrefix) && cardCapacity.Value() > 0 {
+				cardResourceName := corev1.ResourceName(nodeCardInfo.CardInfo.Name)
+				nodeCardInfo.CardResource[cardResourceName] = cardCapacity.DeepCopy()
+				nodeCardInfo.CardNameToResourceName[cardResourceName] = resName
+				continue
+			}
+		}
+	}
+
+	if nodeCardInfo.CardInfo.Name != "" && len(nodeCardInfo.CardResource) == 0 {
+		klog.Warningf("Node <%s> has card <%s> but no card resource found.",
+			node.Name,
+			nodeCardInfo.CardInfo.Name,
+		)
+	}
+
+	p.nodeCardInfos[node.Name] = nodeCardInfo
+	return nodeCardInfo
+}
+
+// getCardInfoFromNode gets the card basic information from the node labels.
+func (p *Plugin) getCardInfoFromNode(node *corev1.Node) CardInfo {
+	for k, v := range node.Labels {
+		if strings.Contains(k, MigLabelAndResourceNamePrefix) {
+			continue
+		}
+		match := nodeCardProductLabelRegex.FindStringSubmatch(k)
+		if len(match) == 4 {
+			var (
+				labelPrefix    = match[1]                              // eg: nvidia.com/gpu
+				resourcePrefix = match[2]                              // eg: nvidia.com
+				countLabel     = fmt.Sprintf("%s.count", labelPrefix)  // eg: nvidia.com/gpu.count
+				memoryLabel    = fmt.Sprintf("%s.memory", labelPrefix) // eg: nvidia.com/gpu.memory
+				cardCount      = node.Labels[countLabel]               // eg: 8
+				cardMemory     = node.Labels[memoryLabel]              // eg: 81920 (in MB)
+			)
+			if cardCount != "" && cardMemory != "" {
+				cardCountInt64, err := strconv.ParseInt(cardCount, 10, 64)
+				if err != nil {
+					klog.Errorf("Failed to parse label %s: %+v", countLabel, err)
+				}
+				cardMemoryInt64, err := strconv.ParseInt(cardMemory, 10, 64)
+				if err != nil {
+					klog.Errorf("Failed to parse label %s: %+v", cardMemory, err)
+				}
+				return CardInfo{
+					Name:           v,
+					Count:          cardCountInt64,
+					Memory:         cardMemoryInt64,
+					ResourcePrefix: resourcePrefix,
+				}
+			}
+		}
+	}
+	return CardInfo{}
+}
+
+// isMpsResourceName checks if the resource name is MPS resource name.
+func isMpsResourceName(resourceName corev1.ResourceName) bool {
+	return resourceName == MPSResourceName
+}
+
+// isMigResourceName checks if the resource name is MIG resource name.
+func isMigResourceName(resourceName corev1.ResourceName) bool {
+	return strings.HasPrefix(string(resourceName), MigLabelAndResourceNamePrefix)
+}
+
+// addResourceList adds the resources in 'add' to 'total'.
+func addResourceList(total corev1.ResourceList, add corev1.ResourceList) {
+	for resourceName, quantity := range add {
+		if val, ok := total[resourceName]; ok {
+			val.Add(quantity)
+			total[resourceName] = val
+		} else {
+			total[resourceName] = quantity.DeepCopy()
+		}
+	}
+}

--- a/pkg/scheduler/plugins/capacity-card/capacity_card_node_test.go
+++ b/pkg/scheduler/plugins/capacity-card/capacity_card_node_test.go
@@ -1,0 +1,448 @@
+package capacitycard
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"volcano.sh/volcano/pkg/scheduler/api"
+)
+
+// TestBuildTotalResourceFromNodes tests the buildTotalResourceFromNodes function
+func TestBuildTotalResourceFromNodes(t *testing.T) {
+	tests := []struct {
+		name           string
+		nodes          []*corev1.Node
+		expectedCPU    string
+		expectedMemory string
+		expectedCards  map[corev1.ResourceName]string
+	}{
+		{
+			name: "single node with CPU and memory",
+			nodes: []*corev1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "node-1"},
+					Status: corev1.NodeStatus{
+						Allocatable: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("4"),
+							corev1.ResourceMemory: resource.MustParse("8Gi"),
+						},
+					},
+				},
+			},
+			expectedCPU:    "4",
+			expectedMemory: "8Gi",
+			expectedCards:  map[corev1.ResourceName]string{},
+		},
+		{
+			name: "multiple nodes with CPU and memory",
+			nodes: []*corev1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "node-1"},
+					Status: corev1.NodeStatus{
+						Allocatable: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("4"),
+							corev1.ResourceMemory: resource.MustParse("8Gi"),
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "node-2"},
+					Status: corev1.NodeStatus{
+						Allocatable: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("8"),
+							corev1.ResourceMemory: resource.MustParse("16Gi"),
+						},
+					},
+				},
+			},
+			expectedCPU:    "12",
+			expectedMemory: "24Gi",
+			expectedCards:  map[corev1.ResourceName]string{},
+		},
+		{
+			name: "node with GPU card resources",
+			nodes: []*corev1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node-1",
+						Labels: map[string]string{
+							"nvidia.com/gpu.product": "Tesla-V100",
+							"nvidia.com/gpu.count":   "2",
+							"nvidia.com/gpu.memory":  "32768",
+						},
+					},
+					Status: corev1.NodeStatus{
+						Allocatable: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("4"),
+							corev1.ResourceMemory: resource.MustParse("8Gi"),
+							"nvidia.com/gpu":      resource.MustParse("2"),
+						},
+					},
+				},
+			},
+			expectedCPU:    "4",
+			expectedMemory: "8Gi",
+			expectedCards: map[corev1.ResourceName]string{
+				"Tesla-V100": "2",
+			},
+		},
+		{
+			name: "node with MPS resources",
+			nodes: []*corev1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node-1",
+						Labels: map[string]string{
+							"nvidia.com/gpu.product":  "Tesla-V100",
+							"nvidia.com/gpu.count":    "4",
+							"nvidia.com/gpu.memory":   "32768",
+							"nvidia.com/gpu.replicas": "4",
+						},
+					},
+					Status: corev1.NodeStatus{
+						Allocatable: corev1.ResourceList{
+							corev1.ResourceCPU:      resource.MustParse("4"),
+							corev1.ResourceMemory:   resource.MustParse("8Gi"),
+							"nvidia.com/gpu":        resource.MustParse("2"),
+							"nvidia.com/gpu.shared": resource.MustParse("8"),
+						},
+					},
+				},
+			},
+			expectedCPU:    "4",
+			expectedMemory: "8Gi",
+			expectedCards: map[corev1.ResourceName]string{
+				"Tesla-V100":             "2",
+				"Tesla-V100/mps-32g*1/4": "8",
+			},
+		},
+		{
+			name: "node with MIG resources",
+			nodes: []*corev1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node-1",
+						Labels: map[string]string{
+							"nvidia.com/mig-1g.10gb.count":     "4",
+							"nvidia.com/mig-2g.20gb.count":     "2",
+							"nvidia.com/mig-1g.10gb.memory":    "10240",
+							"nvidia.com/mig-2g.20gb.memory":    "20480",
+							"nvidia.com/mig-1g.10gb.slices.ci": "1",
+							"nvidia.com/mig-2g.20gb.slices.ci": "2",
+							"nvidia.com/mig-1g.10gb.slices.gi": "1",
+							"nvidia.com/mig-2g.20gb.slices.gi": "2",
+							"nvidia.com/gpu.product":           "Tesla-A100",
+							"nvidia.com/gpu.count":             "1",
+							"nvidia.com/gpu.memory":            "40960",
+						},
+					},
+					Status: corev1.NodeStatus{
+						Allocatable: corev1.ResourceList{
+							corev1.ResourceCPU:       resource.MustParse("4"),
+							corev1.ResourceMemory:    resource.MustParse("8Gi"),
+							"nvidia.com/mig-1g.10gb": resource.MustParse("4"),
+							"nvidia.com/mig-2g.20gb": resource.MustParse("2"),
+						},
+					},
+				},
+			},
+			expectedCPU:    "4",
+			expectedMemory: "8Gi",
+			expectedCards: map[corev1.ResourceName]string{
+				"Tesla-A100/mig-1g.10gb-mixed": "4",
+				"Tesla-A100/mig-2g.20gb-mixed": "2",
+			},
+		},
+		{
+			name:           "empty node list",
+			nodes:          []*corev1.Node{},
+			expectedCPU:    "0",
+			expectedMemory: "0",
+			expectedCards:  map[corev1.ResourceName]string{},
+		},
+		{
+			name: "node with invalid GPU count",
+			nodes: []*corev1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node-1",
+						Labels: map[string]string{
+							"nvidia.com/gpu.product": "Tesla-V100",
+							"nvidia.com/gpu.count":   "a",
+							"nvidia.com/gpu.memory":  "32768",
+						},
+					},
+					Status: corev1.NodeStatus{
+						Allocatable: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("4"),
+							corev1.ResourceMemory: resource.MustParse("8Gi"),
+							"nvidia.com/gpu":      resource.MustParse("2"),
+						},
+					},
+				},
+			},
+			expectedCPU:    "4",
+			expectedMemory: "8Gi",
+			expectedCards: map[corev1.ResourceName]string{
+				"Tesla-V100": "2",
+			},
+		},
+		{
+			name: "node with invalid GPU memory",
+			nodes: []*corev1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node-1",
+						Labels: map[string]string{
+							"nvidia.com/gpu.product": "Tesla-V100",
+							"nvidia.com/gpu.count":   "2",
+							"nvidia.com/gpu.memory":  "a",
+						},
+					},
+					Status: corev1.NodeStatus{
+						Allocatable: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("4"),
+							corev1.ResourceMemory: resource.MustParse("8Gi"),
+							"nvidia.com/gpu":      resource.MustParse("2"),
+						},
+					},
+				},
+			},
+			expectedCPU:    "4",
+			expectedMemory: "8Gi",
+			expectedCards: map[corev1.ResourceName]string{
+				"Tesla-V100": "2",
+			},
+		},
+		{
+			name: "duplicate node name",
+			nodes: []*corev1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node-1",
+						Labels: map[string]string{
+							"nvidia.com/gpu.product": "Tesla-V100",
+							"nvidia.com/gpu.count":   "2",
+							"nvidia.com/gpu.memory":  "32768",
+						},
+					},
+					Status: corev1.NodeStatus{
+						Allocatable: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("4"),
+							corev1.ResourceMemory: resource.MustParse("8Gi"),
+							"nvidia.com/gpu":      resource.MustParse("2"),
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node-1",
+						Labels: map[string]string{
+							"nvidia.com/gpu.product": "Tesla-V100",
+							"nvidia.com/gpu.count":   "2",
+							"nvidia.com/gpu.memory":  "32768",
+						},
+					},
+					Status: corev1.NodeStatus{
+						Allocatable: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("4"),
+							corev1.ResourceMemory: resource.MustParse("8Gi"),
+							"nvidia.com/gpu":      resource.MustParse("2"),
+						},
+					},
+				},
+			},
+			expectedCPU:    "8",
+			expectedMemory: "16Gi",
+			expectedCards: map[corev1.ResourceName]string{
+				"Tesla-V100": "4",
+			},
+		},
+		{
+			name: "node with invalid MPS label",
+			nodes: []*corev1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node-1",
+						Labels: map[string]string{
+							"nvidia.com/gpu.product":  "Tesla-V100",
+							"nvidia.com/gpu.count":    "4",
+							"nvidia.com/gpu.memory":   "32768",
+							"nvidia.com/gpu.replicas": "a",
+						},
+					},
+					Status: corev1.NodeStatus{
+						Allocatable: corev1.ResourceList{
+							corev1.ResourceCPU:      resource.MustParse("4"),
+							corev1.ResourceMemory:   resource.MustParse("8Gi"),
+							"nvidia.com/gpu":        resource.MustParse("2"),
+							"nvidia.com/gpu.shared": resource.MustParse("8"),
+						},
+					},
+				},
+			},
+			expectedCPU:    "4",
+			expectedMemory: "8Gi",
+			expectedCards: map[corev1.ResourceName]string{
+				"Tesla-V100": "2",
+			},
+		},
+		{
+			name: "node with invalid GPU card name",
+			nodes: []*corev1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node-1",
+						Labels: map[string]string{
+							"nvidia-invalid.com/gpu.product": "Tesla-V100",
+							"nvidia-invalid.com/gpu.count":   "2",
+							"nvidia-invalid.com/gpu.memory":  "32768",
+						},
+					},
+					Status: corev1.NodeStatus{
+						Allocatable: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("4"),
+							corev1.ResourceMemory: resource.MustParse("8Gi"),
+							"nvidia.com/gpu":      resource.MustParse("2"),
+						},
+					},
+				},
+			},
+			expectedCPU:    "4",
+			expectedMemory: "8Gi",
+			expectedCards:  map[corev1.ResourceName]string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			plugin := &Plugin{
+				nodeCardInfos:          make(map[string]NodeCardResourceInfo),
+				cardNameToResourceName: make(map[corev1.ResourceName]corev1.ResourceName),
+				totalResource:          api.EmptyResource(),
+			}
+
+			plugin.buildTotalResourceFromNodes(tt.nodes)
+
+			// Check CPU resource
+			if tt.expectedCPU != "0" {
+				expectedCPU := resource.MustParse(tt.expectedCPU)
+				actualCPU := plugin.totalResource.Get(corev1.ResourceCPU)
+				if actualCPU != float64(expectedCPU.MilliValue()) {
+					t.Errorf("expected CPU %v, got %v", expectedCPU.MilliValue(), actualCPU)
+				}
+			} else {
+				actualCPU := plugin.totalResource.Get(corev1.ResourceCPU)
+				if actualCPU != 0 {
+					t.Errorf("expected CPU 0, got %v", actualCPU)
+				}
+			}
+
+			// Check Memory resource
+			if tt.expectedMemory != "0" {
+				expectedMemory := resource.MustParse(tt.expectedMemory)
+				actualMemory := plugin.totalResource.Get(corev1.ResourceMemory)
+				if actualMemory != float64(expectedMemory.Value()) {
+					t.Errorf("expected Memory %v, got %v", expectedMemory.Value(), actualMemory)
+				}
+			} else {
+				actualMemory := plugin.totalResource.Get(corev1.ResourceMemory)
+				if actualMemory != 0 {
+					t.Errorf("expected Memory 0, got %v", actualMemory)
+				}
+			}
+
+			// Check card resources
+			for cardName, expectedValue := range tt.expectedCards {
+				expectedQuantity := resource.MustParse(expectedValue)
+				actualValue := plugin.totalResource.Get(cardName)
+				if actualValue != float64(expectedQuantity.MilliValue()) {
+					t.Errorf("expected card %s value %v, got %v", cardName, expectedQuantity.MilliValue(), actualValue)
+				}
+			}
+
+			// Check that no unexpected card resources exist
+			if len(tt.expectedCards) == 0 {
+				if len(plugin.totalResource.ScalarResources) > 0 {
+					t.Errorf("expected no card resources, but found %v", plugin.totalResource.ScalarResources)
+				}
+			}
+		})
+	}
+}
+
+// TestBuildTotalResourceFromNodesEdgeCases tests edge cases for buildTotalResourceFromNodes
+func TestBuildTotalResourceFromNodesEdgeCases(t *testing.T) {
+	tests := []struct {
+		name          string
+		nodes         []*corev1.Node
+		expectedError bool
+	}{
+		{
+			name: "node with zero allocatable resources",
+			nodes: []*corev1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "node-1"},
+					Status: corev1.NodeStatus{
+						Allocatable: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("0"),
+							corev1.ResourceMemory: resource.MustParse("0"),
+						},
+					},
+				},
+			},
+			expectedError: false,
+		},
+		{
+			name: "node with missing allocatable section",
+			nodes: []*corev1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "node-1"},
+					Status:     corev1.NodeStatus{},
+				},
+			},
+			expectedError: false,
+		},
+		{
+			name: "node with invalid card labels but no card resources",
+			nodes: []*corev1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node-1",
+						Labels: map[string]string{
+							"nvidia.com/gpu.product": "Tesla-V100",
+							// Missing count and memory labels
+						},
+					},
+					Status: corev1.NodeStatus{
+						Allocatable: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("4"),
+							corev1.ResourceMemory: resource.MustParse("8Gi"),
+						},
+					},
+				},
+			},
+			expectedError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			plugin := &Plugin{
+				nodeCardInfos:          make(map[string]NodeCardResourceInfo),
+				cardNameToResourceName: make(map[corev1.ResourceName]corev1.ResourceName),
+				totalResource:          api.EmptyResource(),
+			}
+
+			// This should not panic
+			plugin.buildTotalResourceFromNodes(tt.nodes)
+
+			// Basic sanity check - plugin should still be in a valid state
+			if plugin.totalResource == nil {
+				t.Error("totalResource should not be nil after buildTotalResourceFromNodes")
+			}
+		})
+	}
+}

--- a/pkg/scheduler/plugins/capacity-card/capacity_card_queue.go
+++ b/pkg/scheduler/plugins/capacity-card/capacity_card_queue.go
@@ -1,0 +1,303 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+Copyright 2018-2025 The Volcano Authors.
+
+Modifications made by Volcano authors:
+- Enhanced gang scheduling validation with task-level validity checks
+- Improved preemption logic to respect gang scheduling constraints
+- Added support for job starving detection and enhanced pipeline state management
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package capacitycard
+
+import (
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/klog/v2"
+
+	"volcano.sh/apis/pkg/apis/scheduling"
+	"volcano.sh/volcano/pkg/scheduler/api"
+	"volcano.sh/volcano/pkg/scheduler/api/helpers"
+	"volcano.sh/volcano/pkg/scheduler/framework"
+	"volcano.sh/volcano/pkg/scheduler/metrics"
+	"volcano.sh/volcano/pkg/scheduler/plugins/util"
+)
+
+// queueAttr is used to store the attributes of a queue.
+type queueAttr struct {
+	queueID        api.QueueID   // queue UID
+	name           string        // queue name
+	share          float64       // share = max(allocated/deserved) of all resources
+	deserved       *api.Resource // deserved = min(realCapability, max(guarantee, queue.deserved))
+	allocated      *api.Resource // allocated = sum(job.allocated) of all active jobs
+	request        *api.Resource // request = sum(job.request) of all active jobs
+	elastic        *api.Resource // elastic = job.allocated - job.minAvailable
+	inqueue        *api.Resource // inqueue = sum(job.minAvailable) of all inqueue jobs
+	capability     *api.Resource // the capability of a queue
+	realCapability *api.Resource // the real capability of a queue = min(capability, guarantee + exceeded part of cluster)
+	guarantee      *api.Resource // the guaranteed resource of a queue
+}
+
+// buildQueueAttrs builds the attributes for all queues in the session.
+func (p *Plugin) buildQueueAttrs(ssn *framework.Session) bool {
+	// initialize totalGuarantee from all queues.
+	for _, queue := range ssn.Queues {
+		guarantee := p.newQueueResourceSupportingCard(queue.Queue, queue.Queue.Spec.Guarantee.Resource)
+		p.totalGuarantee.Add(guarantee)
+	}
+
+	// build attributes for Queues.
+	for _, apiJob := range ssn.Jobs {
+		if !p.buildQueueAttrByJob(ssn, apiJob) {
+			return false
+		}
+	}
+
+	// update queue deserved and print queue info.
+	for _, qAttr := range p.queueOpts {
+		if qAttr.realCapability != nil {
+			qAttr.deserved.MinDimensionResource(qAttr.realCapability, api.Infinity)
+		}
+		qAttr.deserved = helpers.Max(qAttr.deserved, qAttr.guarantee)
+		p.updateShare(qAttr)
+		klog.V(4).Infof(
+			"The attributes of queue <%s>: capacity: <%v>, realCapability <%v>, allocate <%v>, request <%v>",
+			qAttr.name, qAttr.capability, qAttr.realCapability, qAttr.allocated, qAttr.request,
+		)
+	}
+
+	// add the queue comparison function according to the queue's priority and share.
+	ssn.AddQueueOrderFn(p.Name(), func(l, r interface{}) int {
+		lv := l.(*api.QueueInfo)
+		rv := r.(*api.QueueInfo)
+		if lv.Queue.Spec.Priority != rv.Queue.Spec.Priority {
+			// return negative means high priority
+			return int(rv.Queue.Spec.Priority) - int(lv.Queue.Spec.Priority)
+		}
+		if p.queueOpts[lv.UID].share == p.queueOpts[rv.UID].share {
+			return 0
+		}
+		if p.queueOpts[lv.UID].share < p.queueOpts[rv.UID].share {
+			return -1
+		}
+		return 1
+	})
+
+	return true
+}
+
+// buildQueueAttrByJob builds/updates the attributes of a queue by a job.
+func (p *Plugin) buildQueueAttrByJob(ssn *framework.Session, apiJob *api.JobInfo) bool {
+	job, err := p.NewJobInfo(apiJob)
+	if err != nil {
+		klog.Errorf(
+			"Failed to create jobInfo for job <%s/%s>: %+v",
+			apiJob.Namespace, apiJob.Name, err,
+		)
+		return false
+	}
+	klog.V(5).Infof("Considering Job <%s/%s>.", job.Namespace, job.Name)
+	if _, found := p.queueOpts[job.Queue]; !found {
+		queue := ssn.Queues[job.Queue]
+		qAttr := p.newQueueAttr(queue)
+		p.queueOpts[job.Queue] = qAttr
+		klog.V(5).Infof("Created Queue attr for queue <%s>.", queue.Name)
+	}
+
+	// calculate allocated and request resource for running and pending tasks in a job to queue.
+	qAttr := p.queueOpts[job.Queue]
+	for status, tasks := range job.TaskStatusIndex {
+		for _, t := range tasks {
+			resReq, err := p.GetTaskRequestResources(t)
+			if err != nil {
+				klog.Warningf(
+					"Failed to get request resource for task <%s/%s> in job <%s/%s>: %+v",
+					t.Namespace, t.Name, apiJob.Namespace, apiJob.Name, err,
+				)
+				continue
+			}
+			if api.AllocatedStatus(status) {
+				qAttr.allocated.Add(resReq)
+				qAttr.request.Add(resReq)
+			} else if status == api.Pending {
+				qAttr.request.Add(resReq)
+			}
+		}
+	}
+
+	// calculate inqueue resource for pending jobs to queue.
+	if job.PodGroup.Status.Phase == scheduling.PodGroupInqueue {
+		// deduct the resources of scheduling gated tasks in a job when calculating inqueued resources
+		// so that it will not block other jobs from being inqueued.
+		qAttr.inqueue.Add(job.DeductSchGatedResources(p.GetMinResources(job)))
+	}
+
+	// calculate inqueue resource for running jobs
+	// the judgement 'job.PodGroup.Status.Running >= job.PodGroup.Spec.MinMember'
+	// will work on cases such as the following condition:
+	// Considering a Spark job is completed(driver pod is completed) while the PodGroup keeps running,
+	// the allocated resource will be reserved again if without the judgement.
+	if job.PodGroup.Status.Phase == scheduling.PodGroupRunning &&
+		job.PodGroup.Spec.MinResources != nil &&
+		int32(util.CalculateAllocatedTaskNum(job.JobInfo)) >= job.PodGroup.Spec.MinMember {
+		inqueued := p.GetInqueueResource(job, job.allocated)
+		qAttr.inqueue.Add(job.DeductSchGatedResources(inqueued))
+	}
+	qAttr.elastic.Add(p.GetElasticResources(job))
+	klog.V(5).Infof(
+		"Built queue <%s> with job <%s/%s>: allocated <%s>, request <%s>, inqueue <%s>",
+		qAttr.name, job.Namespace, job.Name,
+		qAttr.allocated.String(),
+		qAttr.request.String(),
+		qAttr.inqueue.String(),
+	)
+
+	return true
+}
+
+// newQueueAttr creates a new queueAttr from a QueueInfo object.
+func (p *Plugin) newQueueAttr(queue *api.QueueInfo) *queueAttr {
+	var (
+		deserved   = p.newQueueResourceSupportingCard(queue.Queue, queue.Queue.Spec.Deserved)
+		capability = p.newQueueResourceSupportingCard(queue.Queue, queue.Queue.Spec.Capability)
+		guarantee  = p.newQueueResourceSupportingCard(queue.Queue, queue.Queue.Spec.Guarantee.Resource)
+	)
+	qAttr := &queueAttr{
+		queueID:    queue.UID,
+		name:       queue.Name,
+		deserved:   deserved,
+		capability: capability,
+		guarantee:  guarantee,
+		allocated:  api.EmptyResource(),
+		request:    api.EmptyResource(),
+		elastic:    api.EmptyResource(),
+		inqueue:    api.EmptyResource(),
+	}
+	realCapability := api.ExceededPart(p.totalResource, p.totalGuarantee).Add(qAttr.guarantee)
+	qAttr.realCapability = realCapability
+	return qAttr
+}
+
+// newQueueResourceSupportingCard creates a new resource object from resource list
+func (p *Plugin) newQueueResourceSupportingCard(q *scheduling.Queue, rl v1.ResourceList) *api.Resource {
+	var (
+		queueResource     = api.NewResource(rl)
+		queueCardResource = GetCardResourceFromAnnotations("queue"+"/"+q.Name, q.Annotations, QueueAnnotationKeyCardQuota)
+	)
+	queueResource.ScalarResources = make(map[v1.ResourceName]float64)
+	for cardName, cardCountMilli := range queueCardResource.ScalarResources {
+		queueResource.ScalarResources[cardName] = cardCountMilli
+	}
+	return queueResource
+}
+
+// buildQueueMetrics builds the metrics for all queues in the session.
+func (p *Plugin) buildQueueMetrics(ssn *framework.Session) {
+	for queueID, queueInfo := range ssn.Queues {
+		queue := ssn.Queues[queueID]
+		if attr, ok := p.queueOpts[queueID]; ok {
+			metrics.UpdateQueueDeserved(
+				attr.name, attr.deserved.MilliCPU, attr.deserved.Memory, attr.deserved.ScalarResources,
+			)
+			metrics.UpdateQueueAllocated(
+				attr.name, attr.allocated.MilliCPU, attr.allocated.Memory, attr.allocated.ScalarResources,
+			)
+			metrics.UpdateQueueRequest(
+				attr.name, attr.request.MilliCPU, attr.request.Memory, attr.request.ScalarResources,
+			)
+			if attr.capability != nil {
+				metrics.UpdateQueueCapacity(
+					attr.name, attr.capability.MilliCPU, attr.capability.Memory, attr.capability.ScalarResources,
+				)
+			}
+			metrics.UpdateQueueRealCapacity(
+				attr.name,
+				attr.realCapability.MilliCPU, attr.realCapability.Memory,
+				attr.realCapability.ScalarResources,
+			)
+			continue
+		}
+		deservedCPU, deservedMem, scalarResources := 0.0, 0.0, map[v1.ResourceName]float64{}
+		if queue.Queue.Spec.Deserved != nil {
+			attr := p.newQueueResourceSupportingCard(queue.Queue, queue.Queue.Spec.Deserved)
+			deservedCPU = attr.MilliCPU
+			deservedMem = attr.Memory
+			scalarResources = attr.ScalarResources
+		}
+		metrics.UpdateQueueDeserved(queueInfo.Name, deservedCPU, deservedMem, scalarResources)
+		metrics.UpdateQueueAllocated(queueInfo.Name, 0, 0, map[v1.ResourceName]float64{})
+		metrics.UpdateQueueRequest(queueInfo.Name, 0, 0, map[v1.ResourceName]float64{})
+		guarantee := api.EmptyResource()
+		if len(queue.Queue.Spec.Guarantee.Resource) != 0 {
+			guarantee = p.newQueueResourceSupportingCard(queue.Queue, queue.Queue.Spec.Guarantee.Resource)
+		}
+		realCapacity := api.ExceededPart(p.totalResource, p.totalGuarantee).Add(guarantee)
+		if len(queue.Queue.Spec.Capability) > 0 {
+			capacity := p.newQueueResourceSupportingCard(queue.Queue, queue.Queue.Spec.Capability)
+			realCapacity.MinDimensionResource(capacity, api.Infinity)
+			metrics.UpdateQueueCapacity(
+				queueInfo.Name, capacity.MilliCPU, capacity.Memory, capacity.ScalarResources,
+			)
+		}
+		metrics.UpdateQueueRealCapacity(
+			queueInfo.Name, realCapacity.MilliCPU, realCapacity.Memory, realCapacity.ScalarResources,
+		)
+	}
+}
+
+// updateShare updates the share of the queueAttr and records the metric.
+func (p *Plugin) updateShare(attr *queueAttr) {
+	updateQueueAttrShare(attr)
+	metrics.UpdateQueueShare(attr.name, attr.share)
+}
+
+// updateQueueAttrShare updates the share of the queueAttr.
+func updateQueueAttrShare(attr *queueAttr) {
+	res := float64(0)
+	for _, rn := range attr.deserved.ResourceNames() {
+		res = max(res, helpers.Share(attr.allocated.Get(rn), attr.deserved.Get(rn)))
+	}
+	attr.share = res
+}
+
+// GetInqueueResource returns reserved resource for running job whose part of pods have not been allocated resource.
+func (p *Plugin) GetInqueueResource(job *JobInfo, allocated *api.Resource) *api.Resource {
+	inqueue := &api.Resource{}
+	minResources := p.GetMinResources(job)
+
+	reservedCPU := float64(minResources.MilliCPU) - allocated.MilliCPU
+	if reservedCPU > 0 {
+		inqueue.MilliCPU = reservedCPU
+	}
+
+	reservedMemory := float64(minResources.Memory) - allocated.Memory
+	if reservedMemory > 0 {
+		inqueue.Memory = reservedMemory
+	}
+
+	for name, quantity := range minResources.ScalarResources {
+		if inqueue.ScalarResources == nil {
+			inqueue.ScalarResources = make(map[v1.ResourceName]float64)
+		}
+		if allocatedMount, ok := allocated.ScalarResources[name]; !ok {
+			inqueue.ScalarResources[name] = quantity
+		} else {
+			reservedScalarRes := quantity - allocatedMount
+			if reservedScalarRes > 0 {
+				inqueue.ScalarResources[name] = reservedScalarRes
+			}
+		}
+	}
+	return inqueue
+}

--- a/pkg/scheduler/plugins/capacity-card/capacity_card_queue_test.go
+++ b/pkg/scheduler/plugins/capacity-card/capacity_card_queue_test.go
@@ -1,0 +1,2261 @@
+package capacitycard
+
+import (
+	"fmt"
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"volcano.sh/apis/pkg/apis/scheduling"
+	"volcano.sh/volcano/pkg/scheduler/api"
+	"volcano.sh/volcano/pkg/scheduler/cache"
+	"volcano.sh/volcano/pkg/scheduler/framework"
+)
+
+// createTestSessionWithQueuesAndJobs creates a test session with queues and jobs
+func createTestSessionWithQueuesAndJobs() *framework.Session {
+	// Create a mock cache
+	mockCache := cache.NewDefaultMockSchedulerCache("test-scheduler")
+
+	// Create session
+	session := framework.OpenSession(mockCache, nil, nil)
+
+	// Create queues
+	queue1 := &scheduling.Queue{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-queue-1",
+		},
+		Spec: scheduling.QueueSpec{
+			Deserved: v1.ResourceList{
+				v1.ResourceCPU: resource.MustParse("10"),
+			},
+			Capability: v1.ResourceList{
+				v1.ResourceCPU: resource.MustParse("20"),
+			},
+			Guarantee: scheduling.Guarantee{
+				Resource: v1.ResourceList{
+					v1.ResourceCPU: resource.MustParse("5"),
+				},
+			},
+		},
+	}
+
+	queue2 := &scheduling.Queue{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-queue-2",
+		},
+		Spec: scheduling.QueueSpec{
+			Deserved: v1.ResourceList{
+				v1.ResourceCPU: resource.MustParse("15"),
+			},
+		},
+	}
+
+	// Create a simple job
+	job1 := &api.JobInfo{
+		UID:       "job-1",
+		Name:      "test-job-1",
+		Namespace: "default",
+		Queue:     "queue-1",
+		PodGroup: &api.PodGroup{
+			PodGroup: scheduling.PodGroup{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-job-1",
+					Namespace: "default",
+				},
+				Spec: scheduling.PodGroupSpec{
+					MinMember: 1,
+				},
+				Status: scheduling.PodGroupStatus{
+					Phase: scheduling.PodGroupRunning,
+				},
+			},
+			Version: api.PodGroupVersionV1Beta1,
+		},
+		Tasks: map[api.TaskID]*api.TaskInfo{
+			"task-1": {
+				UID:       "task-1",
+				Name:      "task-1",
+				Namespace: "default",
+				Job:       "job-1",
+				Resreq: &api.Resource{
+					MilliCPU: 1000,
+				},
+				TransactionContext: api.TransactionContext{
+					Status: api.Running,
+				},
+			},
+		},
+	}
+
+	// Manually set the queues and jobs
+	session.Queues = map[api.QueueID]*api.QueueInfo{
+		"queue-1": {
+			UID:   "queue-1",
+			Name:  "test-queue-1",
+			Queue: queue1,
+		},
+		"queue-2": {
+			UID:   "queue-2",
+			Name:  "test-queue-2",
+			Queue: queue2,
+		},
+	}
+
+	session.Jobs = map[api.JobID]*api.JobInfo{
+		"job-1": job1,
+	}
+
+	return session
+}
+
+// createTestSessionWithNoQueues creates a test session with no queues
+func createTestSessionWithNoQueues() *framework.Session {
+	// Create a mock cache
+	mockCache := cache.NewDefaultMockSchedulerCache("test-scheduler")
+
+	// Create session
+	session := framework.OpenSession(mockCache, nil, nil)
+
+	// Ensure queues map is empty
+	session.Queues = map[api.QueueID]*api.QueueInfo{}
+
+	return session
+}
+
+// createTestSessionWithElasticAndInqueueResources creates a test session with jobs that have elastic and inqueue resources
+func createTestSessionWithElasticAndInqueueResources() *framework.Session {
+	// Create a mock cache
+	mockCache := cache.NewDefaultMockSchedulerCache("test-scheduler")
+
+	// Create session using OpenSession to properly initialize internal fields
+	session := framework.OpenSession(mockCache, nil, nil)
+
+	// Create queue with card annotations
+	queue := &scheduling.Queue{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "elastic-inqueue-test-queue",
+			Annotations: map[string]string{
+				"volcano.sh/card.quota": `{"nvidia.com/gpu": 8}`,
+			},
+		},
+		Spec: scheduling.QueueSpec{
+			Deserved: v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("50"),
+				v1.ResourceMemory: resource.MustParse("100Gi"),
+			},
+			Capability: v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("100"),
+				v1.ResourceMemory: resource.MustParse("200Gi"),
+			},
+			Guarantee: scheduling.Guarantee{
+				Resource: v1.ResourceList{
+					v1.ResourceCPU:    resource.MustParse("20"),
+					v1.ResourceMemory: resource.MustParse("40Gi"),
+				},
+			},
+		},
+	}
+
+	// Job 1: Running job with elastic resources (allocated > minResources for CPU/Memory)
+	// MinMember = 2, MinResources = 4 CPU + 8Gi (CPU/Memory from MinResources spec)
+	// preCheckCardResource = 4 GPU (from card.request annotation, will be replaced by task GPU sum = 3*1 = 3 GPU)
+	// Allocated = 3 running tasks with 3 CPU + 6Gi + 1 GPU each = 9 CPU + 18Gi + 3 GPU
+	// Final preCheckCardResource = 3 GPU (from task GPU sum, replaces card.request)
+	// minResources = 4 CPU + 8Gi + 3 GPU
+	// Elastic = Allocated - MinResources = 5 CPU + 10Gi + 0 GPU (GPU is 0 because all tasks are running)
+	task1_1 := &api.TaskInfo{
+		UID:       "task-1-1",
+		Name:      "elastic-task-1-1",
+		Namespace: "default",
+		Job:       "elastic-job-1",
+		Resreq: &api.Resource{
+			MilliCPU: 3000,
+			Memory:   6 * 1024 * 1024 * 1024, // 6Gi
+		},
+		Pod: &v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "elastic-task-1-1",
+				Namespace: "default",
+				UID:       "task-1-1",
+				Annotations: map[string]string{
+					"volcano.sh/card.name": "NVIDIA-H200",
+				},
+			},
+			Spec: v1.PodSpec{
+				Containers: []v1.Container{
+					{
+						Resources: v1.ResourceRequirements{
+							Requests: v1.ResourceList{
+								"nvidia.com/gpu": resource.MustParse("1"),
+							},
+						},
+					},
+				},
+			},
+		},
+		TransactionContext: api.TransactionContext{
+			Status: api.Running,
+		},
+	}
+
+	task1_2 := &api.TaskInfo{
+		UID:       "task-1-2",
+		Name:      "elastic-task-1-2",
+		Namespace: "default",
+		Job:       "elastic-job-1",
+		Resreq: &api.Resource{
+			MilliCPU: 3000,
+			Memory:   6 * 1024 * 1024 * 1024, // 6Gi
+		},
+		Pod: &v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "elastic-task-1-2",
+				Namespace: "default",
+				UID:       "task-1-2",
+				Annotations: map[string]string{
+					"volcano.sh/card.name": "NVIDIA-H200",
+				},
+			},
+			Spec: v1.PodSpec{
+				Containers: []v1.Container{
+					{
+						Resources: v1.ResourceRequirements{
+							Requests: v1.ResourceList{
+								"nvidia.com/gpu": resource.MustParse("1"),
+							},
+						},
+					},
+				},
+			},
+		},
+		TransactionContext: api.TransactionContext{
+			Status: api.Running,
+		},
+	}
+
+	task1_3 := &api.TaskInfo{
+		UID:       "task-1-3",
+		Name:      "elastic-task-1-3",
+		Namespace: "default",
+		Job:       "elastic-job-1",
+		Resreq: &api.Resource{
+			MilliCPU: 3000,
+			Memory:   6 * 1024 * 1024 * 1024, // 6Gi
+		},
+		Pod: &v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "elastic-task-1-3",
+				Namespace: "default",
+				UID:       "task-1-3",
+				Annotations: map[string]string{
+					"volcano.sh/card.name": "NVIDIA-H200",
+				},
+			},
+			Spec: v1.PodSpec{
+				Containers: []v1.Container{
+					{
+						Resources: v1.ResourceRequirements{
+							Requests: v1.ResourceList{
+								"nvidia.com/gpu": resource.MustParse("1"),
+							},
+						},
+					},
+				},
+			},
+		},
+		TransactionContext: api.TransactionContext{
+			Status: api.Running,
+		},
+	}
+
+	job1 := api.NewJobInfo("elastic-job-1", task1_1, task1_2, task1_3)
+	job1.Name = "elastic-job-1"
+	job1.Namespace = "default"
+	job1.Queue = "elastic-inqueue-test-queue"
+	job1.PodGroup = &api.PodGroup{
+		PodGroup: scheduling.PodGroup{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "elastic-job-1",
+				Namespace: "default",
+				Annotations: map[string]string{
+					"volcano.sh/card.request": `{"NVIDIA-H200": 4}`,
+				},
+			},
+			Spec: scheduling.PodGroupSpec{
+				MinMember: 2,
+				Queue:     "elastic-inqueue-test-queue",
+				MinResources: &v1.ResourceList{
+					v1.ResourceCPU:    resource.MustParse("4"),
+					v1.ResourceMemory: resource.MustParse("8Gi"),
+				},
+			},
+			Status: scheduling.PodGroupStatus{
+				Phase:   scheduling.PodGroupRunning,
+				Running: 3,
+			},
+		},
+		Version: api.PodGroupVersionV1Beta1,
+	}
+
+	// Job 2: Inqueue job with MinResources set
+	// MinMember = 2, MinResources = 6 CPU + 12Gi + 2 GPU (from preCheckCardResource)
+	// Inqueue = MinResources = 6 CPU + 12Gi + 2 GPU
+	task2_1 := &api.TaskInfo{
+		UID:       "task-2-1",
+		Name:      "inqueue-task-2-1",
+		Namespace: "default",
+		Job:       "inqueue-job-2",
+		Resreq: &api.Resource{
+			MilliCPU: 3000,
+			Memory:   6 * 1024 * 1024 * 1024, // 6Gi
+		},
+		Pod: &v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "inqueue-task-2-1",
+				Namespace: "default",
+				UID:       "task-2-1",
+				Annotations: map[string]string{
+					"volcano.sh/card.name": "NVIDIA-H200",
+				},
+			},
+			Spec: v1.PodSpec{
+				Containers: []v1.Container{
+					{
+						Resources: v1.ResourceRequirements{
+							Requests: v1.ResourceList{
+								"nvidia.com/gpu": resource.MustParse("1"),
+							},
+						},
+					},
+				},
+			},
+		},
+		TransactionContext: api.TransactionContext{
+			Status: api.Pending,
+		},
+	}
+
+	task2_2 := &api.TaskInfo{
+		UID:       "task-2-2",
+		Name:      "inqueue-task-2-2",
+		Namespace: "default",
+		Job:       "inqueue-job-2",
+		Resreq: &api.Resource{
+			MilliCPU: 3000,
+			Memory:   6 * 1024 * 1024 * 1024, // 6Gi
+		},
+		Pod: &v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "inqueue-task-2-2",
+				Namespace: "default",
+				UID:       "task-2-2",
+				Annotations: map[string]string{
+					"volcano.sh/card.name": "NVIDIA-H200",
+				},
+			},
+			Spec: v1.PodSpec{
+				Containers: []v1.Container{
+					{
+						Resources: v1.ResourceRequirements{
+							Requests: v1.ResourceList{
+								"nvidia.com/gpu": resource.MustParse("1"),
+							},
+						},
+					},
+				},
+			},
+		},
+		TransactionContext: api.TransactionContext{
+			Status: api.Pending,
+		},
+	}
+
+	job2 := api.NewJobInfo("inqueue-job-2", task2_1, task2_2)
+	job2.Name = "inqueue-job-2"
+	job2.Namespace = "default"
+	job2.Queue = "elastic-inqueue-test-queue"
+	job2.PodGroup = &api.PodGroup{
+		PodGroup: scheduling.PodGroup{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "inqueue-job-2",
+				Namespace: "default",
+				Annotations: map[string]string{
+					"volcano.sh/card.request": `{"NVIDIA-H200": 2}`,
+				},
+			},
+			Spec: scheduling.PodGroupSpec{
+				MinMember: 2,
+				Queue:     "elastic-inqueue-test-queue",
+				MinResources: &v1.ResourceList{
+					v1.ResourceCPU:    resource.MustParse("6"),
+					v1.ResourceMemory: resource.MustParse("12Gi"),
+				},
+			},
+			Status: scheduling.PodGroupStatus{
+				Phase: scheduling.PodGroupInqueue,
+			},
+		},
+		Version: api.PodGroupVersionV1Beta1,
+	}
+
+	// Set queues and jobs in session
+	session.Queues = map[api.QueueID]*api.QueueInfo{
+		"elastic-inqueue-test-queue": {
+			UID:   "elastic-inqueue-test-queue",
+			Name:  "elastic-inqueue-test-queue",
+			Queue: queue,
+		},
+	}
+
+	session.Jobs = map[api.JobID]*api.JobInfo{
+		"elastic-job-1": job1,
+		"inqueue-job-2": job2,
+	}
+
+	return session
+}
+
+// createTestSessionWithMultipleJobsAndScalarResources creates a test session with multiple jobs that have scalar resources
+func createTestSessionWithMultipleJobsAndScalarResources() *framework.Session {
+	// Create a mock cache
+	mockCache := cache.NewDefaultMockSchedulerCache("test-scheduler")
+
+	// Create session using OpenSession to properly initialize internal fields
+	session := framework.OpenSession(mockCache, nil, nil)
+
+	// Create queue and jobs
+	queue4 := &scheduling.Queue{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "multi-job-queue",
+			Annotations: map[string]string{
+				"volcano.sh/card.quota": `{"nvidia.com/gpu": 4, "amd.com/gpu": 2}`,
+			},
+		},
+		Spec: scheduling.QueueSpec{
+			Deserved: v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("20"),
+				v1.ResourceMemory: resource.MustParse("40Gi"),
+			},
+			Capability: v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("40"),
+				v1.ResourceMemory: resource.MustParse("80Gi"),
+			},
+			Guarantee: scheduling.Guarantee{
+				Resource: v1.ResourceList{
+					v1.ResourceCPU:    resource.MustParse("10"),
+					v1.ResourceMemory: resource.MustParse("20Gi"),
+				},
+			},
+		},
+	}
+
+	task1 := &api.TaskInfo{
+		UID:       "task-1",
+		Name:      "gpu-task-1",
+		Namespace: "default",
+		Job:       "job-1",
+		Resreq: &api.Resource{
+			MilliCPU: 3000,
+			Memory:   1073741824, // 1Gi
+			ScalarResources: map[v1.ResourceName]float64{
+				"nvidia.com/gpu": 1000, // 1 GPU
+				"amd.com/gpu":    500,  // 0.5 GPU
+			},
+		},
+		Pod: &v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "gpu-task-1",
+				Namespace: "default",
+				UID:       "task-1",
+			},
+		},
+		TransactionContext: api.TransactionContext{
+			Status: api.Running,
+		},
+	}
+
+	// Use api.NewJobInfo to properly initialize TaskStatusIndex and other fields
+	job1 := api.NewJobInfo("job-1", task1)
+	job1.Name = "gpu-job-1"
+	job1.Namespace = "default"
+	job1.Queue = "queue-4"
+	job1.PodGroup = &api.PodGroup{
+		PodGroup: scheduling.PodGroup{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "gpu-job-1",
+				Namespace: "default",
+			},
+			Spec: scheduling.PodGroupSpec{
+				MinMember: 1,
+				Queue:     "queue-4",
+			},
+			Status: scheduling.PodGroupStatus{
+				Phase: scheduling.PodGroupRunning,
+			},
+		},
+		Version: api.PodGroupVersionV1Beta1,
+	}
+
+	task2 := &api.TaskInfo{
+		UID:       "task-2",
+		Name:      "gpu-task-2",
+		Namespace: "default",
+		Job:       "job-2",
+		Resreq: &api.Resource{
+			MilliCPU: 6000,
+			Memory:   1073741824, // 1Gi
+			ScalarResources: map[v1.ResourceName]float64{
+				"nvidia.com/gpu": 2000, // 2 GPUs
+				"amd.com/gpu":    1000, // 1 GPU
+			},
+		},
+		Pod: &v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "gpu-task-2",
+				Namespace: "default",
+				UID:       "task-2",
+			},
+		},
+		TransactionContext: api.TransactionContext{
+			Status: api.Running,
+		},
+	}
+
+	// Use api.NewJobInfo to properly initialize TaskStatusIndex and other fields
+	job2 := api.NewJobInfo("job-2", task2)
+	job2.Name = "gpu-job-2"
+	job2.Namespace = "default"
+	job2.Queue = "queue-4"
+	job2.PodGroup = &api.PodGroup{
+		PodGroup: scheduling.PodGroup{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "gpu-job-2",
+				Namespace: "default",
+			},
+			Spec: scheduling.PodGroupSpec{
+				MinMember: 1,
+				Queue:     "queue-4",
+			},
+			Status: scheduling.PodGroupStatus{
+				Phase: scheduling.PodGroupRunning,
+			},
+		},
+		Version: api.PodGroupVersionV1Beta1,
+	}
+
+	// Set queues and jobs in session
+	session.Queues = map[api.QueueID]*api.QueueInfo{
+		"queue-4": {
+			UID:   "queue-4",
+			Name:  "multi-job-queue",
+			Queue: queue4,
+		},
+	}
+
+	session.Jobs = map[api.JobID]*api.JobInfo{
+		"job-1": job1,
+		"job-2": job2,
+	}
+
+	return session
+}
+
+// TestNewQueueAttr tests the newQueueAttr function
+func TestNewQueueAttr(t *testing.T) {
+	tests := []struct {
+		name                   string
+		queue                  *api.QueueInfo
+		expectedName           string
+		expectedUID            api.QueueID
+		expectedFields         []string
+		expectedDeserved       *api.Resource
+		expectedCapability     *api.Resource
+		expectedGuarantee      *api.Resource
+		expectedAllocated      *api.Resource
+		expectedRequest        *api.Resource
+		expectedElastic        *api.Resource
+		expectedInqueue        *api.Resource
+		expectedRealCapability *api.Resource
+	}{
+		{
+			name: "queue without card resources in annotations",
+			queue: &api.QueueInfo{
+				UID:  "queue-1",
+				Name: "test-queue",
+				Queue: &scheduling.Queue{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-queue",
+					},
+					Spec: scheduling.QueueSpec{
+						Deserved: v1.ResourceList{
+							v1.ResourceCPU:    resource.MustParse("10"),
+							v1.ResourceMemory: resource.MustParse("20Gi"),
+						},
+						Capability: v1.ResourceList{
+							v1.ResourceCPU:    resource.MustParse("20"),
+							v1.ResourceMemory: resource.MustParse("40Gi"),
+						},
+						Guarantee: scheduling.Guarantee{
+							Resource: v1.ResourceList{
+								v1.ResourceCPU:    resource.MustParse("5"),
+								v1.ResourceMemory: resource.MustParse("10Gi"),
+							},
+						},
+					},
+				},
+			},
+			expectedName:   "test-queue",
+			expectedUID:    "queue-1",
+			expectedFields: []string{"deserved", "capability", "guarantee", "allocated", "request", "elastic", "inqueue"},
+			expectedDeserved: api.NewResource(v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("10"),
+				v1.ResourceMemory: resource.MustParse("20Gi"),
+			}),
+			expectedCapability: api.NewResource(v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("20"),
+				v1.ResourceMemory: resource.MustParse("40Gi"),
+			}),
+			expectedGuarantee: api.NewResource(v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("5"),
+				v1.ResourceMemory: resource.MustParse("10Gi"),
+			}),
+			expectedAllocated: api.EmptyResource(),
+			expectedRequest:   api.EmptyResource(),
+			expectedElastic:   api.EmptyResource(),
+			expectedInqueue:   api.EmptyResource(),
+			expectedRealCapability: &api.Resource{
+				MilliCPU: 105 * 1000,
+				Memory:   210 * 1024 * 1024 * 1024,
+			},
+		},
+		{
+			name: "queue with card resources in annotations",
+			queue: &api.QueueInfo{
+				UID:  "queue-3",
+				Name: "scalar-queue",
+				Queue: &scheduling.Queue{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "scalar-queue",
+						Annotations: map[string]string{
+							"volcano.sh/card.quota": `{"Tesla-V100": 2, "AMD-RX-7900-XT": 1, "NVIDIA-H200": 3}`,
+						},
+					},
+					Spec: scheduling.QueueSpec{
+						Deserved: v1.ResourceList{
+							v1.ResourceCPU:    resource.MustParse("10"),
+							v1.ResourceMemory: resource.MustParse("20Gi"),
+						},
+						Capability: v1.ResourceList{
+							v1.ResourceCPU:    resource.MustParse("20"),
+							v1.ResourceMemory: resource.MustParse("40Gi"),
+						},
+						Guarantee: scheduling.Guarantee{
+							Resource: v1.ResourceList{
+								v1.ResourceCPU:    resource.MustParse("5"),
+								v1.ResourceMemory: resource.MustParse("10Gi"),
+							},
+						},
+					},
+				},
+			},
+			expectedName:   "scalar-queue",
+			expectedUID:    "queue-3",
+			expectedFields: []string{"deserved", "capability", "guarantee", "allocated", "request", "elastic", "inqueue"},
+			expectedDeserved: &api.Resource{
+				MilliCPU: 10000,
+				Memory:   21474836480,
+				ScalarResources: map[v1.ResourceName]float64{
+					"Tesla-V100":     2000,
+					"AMD-RX-7900-XT": 1000,
+					"NVIDIA-H200":    3000,
+				},
+			},
+			expectedCapability: &api.Resource{
+				MilliCPU: 20000,
+				Memory:   42949672960,
+				ScalarResources: map[v1.ResourceName]float64{
+					"Tesla-V100":     2000,
+					"AMD-RX-7900-XT": 1000,
+					"NVIDIA-H200":    3000,
+				},
+			},
+			expectedGuarantee: &api.Resource{
+				MilliCPU: 5000,
+				Memory:   10737418240,
+				ScalarResources: map[v1.ResourceName]float64{
+					"Tesla-V100":     2000,
+					"AMD-RX-7900-XT": 1000,
+					"NVIDIA-H200":    3000,
+				},
+			},
+			expectedAllocated: api.EmptyResource(),
+			expectedRequest:   api.EmptyResource(),
+			expectedElastic:   api.EmptyResource(),
+			expectedInqueue:   api.EmptyResource(),
+			expectedRealCapability: &api.Resource{
+				MilliCPU: 105 * 1000,
+				Memory:   210 * 1024 * 1024 * 1024,
+				ScalarResources: map[v1.ResourceName]float64{
+					"Tesla-V100":     2000,
+					"AMD-RX-7900-XT": 1000,
+					"NVIDIA-H200":    3000,
+				},
+			},
+		},
+		{
+			name: "queue without card resources in annotations and empty resource",
+			queue: &api.QueueInfo{
+				UID:  "queue-1",
+				Name: "test-queue",
+				Queue: &scheduling.Queue{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-queue",
+					},
+					Spec: scheduling.QueueSpec{
+						Deserved: v1.ResourceList{
+							v1.ResourceCPU:    resource.MustParse("0"),
+							v1.ResourceMemory: resource.MustParse("0"),
+						},
+						Capability: v1.ResourceList{
+							v1.ResourceCPU:    resource.MustParse("0"),
+							v1.ResourceMemory: resource.MustParse("0"),
+						},
+						Guarantee: scheduling.Guarantee{
+							Resource: v1.ResourceList{
+								v1.ResourceCPU:    resource.MustParse("0"),
+								v1.ResourceMemory: resource.MustParse("0"),
+							},
+						},
+					},
+				},
+			},
+			expectedName:   "test-queue",
+			expectedUID:    "queue-1",
+			expectedFields: []string{"deserved", "capability", "guarantee", "allocated", "request", "elastic", "inqueue"},
+			expectedDeserved: api.NewResource(v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("0"),
+				v1.ResourceMemory: resource.MustParse("0"),
+			}),
+			expectedCapability: api.NewResource(v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("0"),
+				v1.ResourceMemory: resource.MustParse("0"),
+			}),
+			expectedGuarantee: api.NewResource(v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("0"),
+				v1.ResourceMemory: resource.MustParse("0"),
+			}),
+			expectedAllocated: api.EmptyResource(),
+			expectedRequest:   api.EmptyResource(),
+			expectedElastic:   api.EmptyResource(),
+			expectedInqueue:   api.EmptyResource(),
+			expectedRealCapability: &api.Resource{
+				MilliCPU: 100 * 1000,
+				Memory:   200 * 1024 * 1024 * 1024,
+			},
+		},
+		{
+			name: "queue with card resources in annotations and empty resource",
+			queue: &api.QueueInfo{
+				UID:  "queue-3",
+				Name: "scalar-queue",
+				Queue: &scheduling.Queue{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "scalar-queue",
+						Annotations: map[string]string{
+							"volcano.sh/card.quota": `{"Tesla-V100": 2, "AMD-RX-7900-XT": 1, "NVIDIA-H200": 3}`,
+						},
+					},
+					Spec: scheduling.QueueSpec{
+						Deserved: v1.ResourceList{
+							v1.ResourceCPU:    resource.MustParse("0"),
+							v1.ResourceMemory: resource.MustParse("0"),
+						},
+						Capability: v1.ResourceList{
+							v1.ResourceCPU:    resource.MustParse("0"),
+							v1.ResourceMemory: resource.MustParse("0"),
+						},
+						Guarantee: scheduling.Guarantee{
+							Resource: v1.ResourceList{
+								v1.ResourceCPU:    resource.MustParse("0"),
+								v1.ResourceMemory: resource.MustParse("0"),
+							},
+						},
+					},
+				},
+			},
+			expectedName:   "scalar-queue",
+			expectedUID:    "queue-3",
+			expectedFields: []string{"deserved", "capability", "guarantee", "allocated", "request", "elastic", "inqueue"},
+			expectedDeserved: &api.Resource{
+				MilliCPU: 0,
+				Memory:   0,
+				ScalarResources: map[v1.ResourceName]float64{
+					"Tesla-V100":     2000,
+					"AMD-RX-7900-XT": 1000,
+					"NVIDIA-H200":    3000,
+				},
+			},
+			expectedCapability: &api.Resource{
+				MilliCPU: 0,
+				Memory:   0,
+				ScalarResources: map[v1.ResourceName]float64{
+					"Tesla-V100":     2000,
+					"AMD-RX-7900-XT": 1000,
+					"NVIDIA-H200":    3000,
+				},
+			},
+			expectedGuarantee: &api.Resource{
+				MilliCPU: 0,
+				Memory:   0,
+				ScalarResources: map[v1.ResourceName]float64{
+					"Tesla-V100":     2000,
+					"AMD-RX-7900-XT": 1000,
+					"NVIDIA-H200":    3000,
+				},
+			},
+			expectedAllocated: api.EmptyResource(),
+			expectedRequest:   api.EmptyResource(),
+			expectedElastic:   api.EmptyResource(),
+			expectedInqueue:   api.EmptyResource(),
+			expectedRealCapability: &api.Resource{
+				MilliCPU: 100 * 1000,
+				Memory:   200 * 1024 * 1024 * 1024,
+				ScalarResources: map[v1.ResourceName]float64{
+					"Tesla-V100":     2000,
+					"AMD-RX-7900-XT": 1000,
+					"NVIDIA-H200":    3000,
+				},
+			},
+		},
+		{
+			name: "queue without card resources in annotations and nil resource",
+			queue: &api.QueueInfo{
+				UID:  "queue-1",
+				Name: "test-queue",
+				Queue: &scheduling.Queue{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-queue",
+					},
+					Spec: scheduling.QueueSpec{},
+				},
+			},
+			expectedName:   "test-queue",
+			expectedUID:    "queue-1",
+			expectedFields: []string{"deserved", "capability", "guarantee", "allocated", "request", "elastic", "inqueue"},
+			expectedDeserved: api.NewResource(v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("0"),
+				v1.ResourceMemory: resource.MustParse("0"),
+			}),
+			expectedCapability: api.NewResource(v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("0"),
+				v1.ResourceMemory: resource.MustParse("0"),
+			}),
+			expectedGuarantee: api.NewResource(v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("0"),
+				v1.ResourceMemory: resource.MustParse("0"),
+			}),
+			expectedAllocated: api.EmptyResource(),
+			expectedRequest:   api.EmptyResource(),
+			expectedElastic:   api.EmptyResource(),
+			expectedInqueue:   api.EmptyResource(),
+			expectedRealCapability: &api.Resource{
+				MilliCPU: 100 * 1000,
+				Memory:   200 * 1024 * 1024 * 1024,
+			},
+		},
+		{
+			name: "queue with card resources in annotations and nil resource",
+			queue: &api.QueueInfo{
+				UID:  "queue-3",
+				Name: "scalar-queue",
+				Queue: &scheduling.Queue{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "scalar-queue",
+						Annotations: map[string]string{
+							"volcano.sh/card.quota": `{"Tesla-V100": 2, "AMD-RX-7900-XT": 1, "NVIDIA-H200": 3}`,
+						},
+					},
+					Spec: scheduling.QueueSpec{},
+				},
+			},
+			expectedName:   "scalar-queue",
+			expectedUID:    "queue-3",
+			expectedFields: []string{"deserved", "capability", "guarantee", "allocated", "request", "elastic", "inqueue"},
+			expectedDeserved: &api.Resource{
+				MilliCPU: 0,
+				Memory:   0,
+				ScalarResources: map[v1.ResourceName]float64{
+					"Tesla-V100":     2000,
+					"AMD-RX-7900-XT": 1000,
+					"NVIDIA-H200":    3000,
+				},
+			},
+			expectedCapability: &api.Resource{
+				MilliCPU: 0,
+				Memory:   0,
+				ScalarResources: map[v1.ResourceName]float64{
+					"Tesla-V100":     2000,
+					"AMD-RX-7900-XT": 1000,
+					"NVIDIA-H200":    3000,
+				},
+			},
+			expectedGuarantee: &api.Resource{
+				MilliCPU: 0,
+				Memory:   0,
+				ScalarResources: map[v1.ResourceName]float64{
+					"Tesla-V100":     2000,
+					"AMD-RX-7900-XT": 1000,
+					"NVIDIA-H200":    3000,
+				},
+			},
+			expectedAllocated: api.EmptyResource(),
+			expectedRequest:   api.EmptyResource(),
+			expectedElastic:   api.EmptyResource(),
+			expectedInqueue:   api.EmptyResource(),
+			expectedRealCapability: &api.Resource{
+				MilliCPU: 100 * 1000,
+				Memory:   200 * 1024 * 1024 * 1024,
+				ScalarResources: map[v1.ResourceName]float64{
+					"Tesla-V100":     2000,
+					"AMD-RX-7900-XT": 1000,
+					"NVIDIA-H200":    3000,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			plugin := &Plugin{
+				totalResource: api.NewResource(v1.ResourceList{
+					v1.ResourceCPU:    resource.MustParse("100"),
+					v1.ResourceMemory: resource.MustParse("200Gi"),
+				}),
+				totalGuarantee: api.EmptyResource(),
+			}
+
+			qAttr := plugin.newQueueAttr(tt.queue)
+
+			if qAttr.name != tt.expectedName {
+				t.Errorf("expected name %s, got %s", tt.expectedName, qAttr.name)
+			}
+
+			if qAttr.queueID != tt.expectedUID {
+				t.Errorf("expected UID %s, got %s", tt.expectedUID, qAttr.queueID)
+			}
+
+			// Check that all expected fields are initialized and have expected values
+			for _, field := range tt.expectedFields {
+				switch field {
+				case "deserved":
+					if qAttr.deserved == nil {
+						t.Error("deserved should not be nil")
+					} else if tt.expectedDeserved != nil {
+						// Check deserved resource values using expected values from test case
+						if qAttr.deserved.MilliCPU != tt.expectedDeserved.MilliCPU {
+							t.Errorf("expected deserved CPU %f, got %f", tt.expectedDeserved.MilliCPU, qAttr.deserved.MilliCPU)
+						}
+						if qAttr.deserved.Memory != tt.expectedDeserved.Memory {
+							t.Errorf("expected deserved Memory %f, got %f", tt.expectedDeserved.Memory, qAttr.deserved.Memory)
+						}
+						// Check scalar resources if present
+						for resName, expectedValue := range tt.expectedDeserved.ScalarResources {
+							actualValue, exists := qAttr.deserved.ScalarResources[resName]
+							if !exists {
+								t.Errorf("expected deserved scalar resource %s not found", resName)
+							} else if actualValue != expectedValue {
+								t.Errorf("expected deserved scalar resource %s value %f, got %f", resName, expectedValue, actualValue)
+							}
+						}
+					}
+				case "capability":
+					if qAttr.capability == nil {
+						t.Error("capability should not be nil")
+					} else if tt.expectedCapability != nil {
+						// Check capability resource values using expected values from test case
+						if qAttr.capability.MilliCPU != tt.expectedCapability.MilliCPU {
+							t.Errorf("expected capability CPU %f, got %f", tt.expectedCapability.MilliCPU, qAttr.capability.MilliCPU)
+						}
+						if qAttr.capability.Memory != tt.expectedCapability.Memory {
+							t.Errorf("expected capability Memory %f, got %f", tt.expectedCapability.Memory, qAttr.capability.Memory)
+						}
+						// Check scalar resources if present
+						for resName, expectedValue := range tt.expectedCapability.ScalarResources {
+							actualValue, exists := qAttr.capability.ScalarResources[resName]
+							if !exists {
+								t.Errorf("expected capability scalar resource %s not found", resName)
+							} else if actualValue != expectedValue {
+								t.Errorf("expected capability scalar resource %s value %f, got %f", resName, expectedValue, actualValue)
+							}
+						}
+					}
+				case "guarantee":
+					if qAttr.guarantee == nil {
+						t.Error("guarantee should not be nil")
+					} else if tt.expectedGuarantee != nil {
+						// Check guarantee resource values using expected values from test case
+						if qAttr.guarantee.MilliCPU != tt.expectedGuarantee.MilliCPU {
+							t.Errorf("expected guarantee CPU %f, got %f", tt.expectedGuarantee.MilliCPU, qAttr.guarantee.MilliCPU)
+						}
+						if qAttr.guarantee.Memory != tt.expectedGuarantee.Memory {
+							t.Errorf("expected guarantee Memory %f, got %f", tt.expectedGuarantee.Memory, qAttr.guarantee.Memory)
+						}
+						// Check scalar resources if present
+						for resName, expectedValue := range tt.expectedGuarantee.ScalarResources {
+							actualValue, exists := qAttr.guarantee.ScalarResources[resName]
+							if !exists {
+								t.Errorf("expected guarantee scalar resource %s not found", resName)
+							} else if actualValue != expectedValue {
+								t.Errorf("expected guarantee scalar resource %s value %f, got %f", resName, expectedValue, actualValue)
+							}
+						}
+					}
+				case "allocated":
+					if qAttr.allocated == nil {
+						t.Error("allocated should not be nil")
+					} else if tt.expectedAllocated != nil {
+						// Check allocated resource values using expected values from test case
+						if qAttr.allocated.MilliCPU != tt.expectedAllocated.MilliCPU {
+							t.Errorf("expected allocated CPU %f, got %f", tt.expectedAllocated.MilliCPU, qAttr.allocated.MilliCPU)
+						}
+						if qAttr.allocated.Memory != tt.expectedAllocated.Memory {
+							t.Errorf("expected allocated Memory %f, got %f", tt.expectedAllocated.Memory, qAttr.allocated.Memory)
+						}
+						// Check scalar resources if present
+						for resName, expectedValue := range tt.expectedAllocated.ScalarResources {
+							actualValue, exists := qAttr.allocated.ScalarResources[resName]
+							if !exists {
+								t.Errorf("expected allocated scalar resource %s not found", resName)
+							} else if actualValue != expectedValue {
+								t.Errorf("expected allocated scalar resource %s value %f, got %f", resName, expectedValue, actualValue)
+							}
+						}
+					}
+				case "request":
+					if qAttr.request == nil {
+						t.Error("request should not be nil")
+					} else if tt.expectedRequest != nil {
+						// Check request resource values using expected values from test case
+						if qAttr.request.MilliCPU != tt.expectedRequest.MilliCPU {
+							t.Errorf("expected request CPU %f, got %f", tt.expectedRequest.MilliCPU, qAttr.request.MilliCPU)
+						}
+						if qAttr.request.Memory != tt.expectedRequest.Memory {
+							t.Errorf("expected request Memory %f, got %f", tt.expectedRequest.Memory, qAttr.request.Memory)
+						}
+						// Check scalar resources if present
+						for resName, expectedValue := range tt.expectedRequest.ScalarResources {
+							actualValue, exists := qAttr.request.ScalarResources[resName]
+							if !exists {
+								t.Errorf("expected request scalar resource %s not found", resName)
+							} else if actualValue != expectedValue {
+								t.Errorf("expected request scalar resource %s value %f, got %f", resName, expectedValue, actualValue)
+							}
+						}
+					}
+				case "elastic":
+					if qAttr.elastic == nil {
+						t.Error("elastic should not be nil")
+					} else if tt.expectedElastic != nil {
+						// Check elastic resource values using expected values from test case
+						if qAttr.elastic.MilliCPU != tt.expectedElastic.MilliCPU {
+							t.Errorf("expected elastic CPU %f, got %f", tt.expectedElastic.MilliCPU, qAttr.elastic.MilliCPU)
+						}
+						if qAttr.elastic.Memory != tt.expectedElastic.Memory {
+							t.Errorf("expected elastic Memory %f, got %f", tt.expectedElastic.Memory, qAttr.elastic.Memory)
+						}
+						// Check scalar resources if present
+						for resName, expectedValue := range tt.expectedElastic.ScalarResources {
+							actualValue, exists := qAttr.elastic.ScalarResources[resName]
+							if !exists {
+								t.Errorf("expected elastic scalar resource %s not found", resName)
+							} else if actualValue != expectedValue {
+								t.Errorf("expected elastic scalar resource %s value %f, got %f", resName, expectedValue, actualValue)
+							}
+						}
+					}
+				case "inqueue":
+					if qAttr.inqueue == nil {
+						t.Error("inqueue should not be nil")
+					} else if tt.expectedInqueue != nil {
+						// Check inqueue resource values using expected values from test case
+						if qAttr.inqueue.MilliCPU != tt.expectedInqueue.MilliCPU {
+							t.Errorf("expected inqueue CPU %f, got %f", tt.expectedInqueue.MilliCPU, qAttr.inqueue.MilliCPU)
+						}
+						if qAttr.inqueue.Memory != tt.expectedInqueue.Memory {
+							t.Errorf("expected inqueue Memory %f, got %f", tt.expectedInqueue.Memory, qAttr.inqueue.Memory)
+						}
+						// Check scalar resources if present
+						for resName, expectedValue := range tt.expectedInqueue.ScalarResources {
+							actualValue, exists := qAttr.inqueue.ScalarResources[resName]
+							if !exists {
+								t.Errorf("expected inqueue scalar resource %s not found", resName)
+							} else if actualValue != expectedValue {
+								t.Errorf("expected inqueue scalar resource %s value %f, got %f", resName, expectedValue, actualValue)
+							}
+						}
+					}
+				}
+			}
+
+			// Check realCapability calculation
+			if qAttr.realCapability == nil {
+				t.Error("realCapability should not be nil")
+			} else if tt.expectedRealCapability != nil {
+				// Check realCapability resource values using expected values from test case
+				if qAttr.realCapability.MilliCPU != tt.expectedRealCapability.MilliCPU {
+					t.Errorf("expected realCapability CPU %f, got %f", tt.expectedRealCapability.MilliCPU, qAttr.realCapability.MilliCPU)
+				}
+				if qAttr.realCapability.Memory != tt.expectedRealCapability.Memory {
+					t.Errorf("expected realCapability Memory %f, got %f", tt.expectedRealCapability.Memory, qAttr.realCapability.Memory)
+				}
+				// Check scalar resources if present
+				for resName, expectedValue := range tt.expectedRealCapability.ScalarResources {
+					actualValue, exists := qAttr.realCapability.ScalarResources[resName]
+					if !exists {
+						t.Errorf("expected realCapability scalar resource %s not found", resName)
+					} else if actualValue != expectedValue {
+						t.Errorf("expected realCapability scalar resource %s value %f, got %f", resName, expectedValue, actualValue)
+					}
+				}
+			}
+
+		})
+	}
+}
+
+// TestBuildQueueAttrs tests the buildQueueAttrs function
+func TestBuildQueueAttrs(t *testing.T) {
+	tests := []struct {
+		name                    string
+		session                 *framework.Session
+		totalResource           *api.Resource
+		totalGuarantee          *api.Resource
+		expectedQueueCount      int
+		expectedError           bool
+		queueID                 api.QueueID                 // Optional: specific queue to check
+		expectedAllocatedCPU    *float64                    // Optional: expected allocated CPU
+		expectedAllocatedMemory *float64                    // Optional: expected allocated Memory
+		expectedAllocatedCards  map[v1.ResourceName]float64 // Optional: expected allocated scalar resources
+		expectedRequestCPU      *float64                    // Optional: expected request CPU
+		expectedRequestMemory   *float64                    // Optional: expected request Memory
+		expectedRequestCards    map[v1.ResourceName]float64 // Optional: expected request scalar resources
+		expectedElasticCPU      *float64                    // Optional: expected elastic CPU
+		expectedElasticMemory   *float64                    // Optional: expected elastic Memory
+		expectedElasticCards    map[v1.ResourceName]float64 // Optional: expected elastic scalar resources
+		expectedInqueueCPU      *float64                    // Optional: expected inqueue CPU
+		expectedInqueueMemory   *float64                    // Optional: expected inqueue Memory
+		expectedInqueueCards    map[v1.ResourceName]float64 // Optional: expected inqueue scalar resources
+	}{
+		{
+			name:    "session with multiple queues and jobs",
+			session: createTestSessionWithQueuesAndJobs(),
+			totalResource: api.NewResource(v1.ResourceList{
+				v1.ResourceCPU: resource.MustParse("100"),
+			}),
+			totalGuarantee:     api.EmptyResource(),
+			expectedQueueCount: 1,
+			expectedError:      false,
+		},
+		{
+			name:               "session with no queues",
+			session:            createTestSessionWithNoQueues(),
+			totalResource:      api.EmptyResource(),
+			totalGuarantee:     api.EmptyResource(),
+			expectedQueueCount: 0,
+			expectedError:      false,
+		},
+		{
+			name:    "session with multiple jobs and scalar resources",
+			session: createTestSessionWithMultipleJobsAndScalarResources(),
+			totalResource: api.NewResource(v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("100"),
+				v1.ResourceMemory: resource.MustParse("200Gi"),
+			}),
+			totalGuarantee:          api.EmptyResource(),
+			expectedQueueCount:      1,
+			expectedError:           false,
+			queueID:                 "queue-4",
+			expectedAllocatedCPU:    floatPtr(9000.0),       // 3 + 6 = 9 CPUs
+			expectedAllocatedMemory: floatPtr(2147483648.0), // 1Gi + 1Gi = 2Gi
+			expectedRequestCPU:      floatPtr(9000.0),       // Same as allocated since all tasks are running
+			expectedRequestMemory:   floatPtr(2147483648.0), // Same as allocated since all tasks are running
+		},
+		{
+			name:    "session with elastic and inqueue resources",
+			session: createTestSessionWithElasticAndInqueueResources(),
+			totalResource: api.NewResource(v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("200"),
+				v1.ResourceMemory: resource.MustParse("400Gi"),
+			}),
+			totalGuarantee:     api.EmptyResource(),
+			expectedQueueCount: 1,
+			expectedError:      false,
+			queueID:            "elastic-inqueue-test-queue",
+			// Job 1: 3 running tasks * (3 CPU + 6Gi + 1 GPU) = 9 CPU + 18Gi + 3 GPU allocated
+			// Job 2: 0 allocated (all pending)
+			expectedAllocatedCPU:    floatPtr(9000.0),        // 9 CPUs
+			expectedAllocatedMemory: floatPtr(19327352832.0), // 18Gi
+			// Job 1: 3 running tasks request = 9 CPU + 18Gi + 3 GPU
+			// Job 2: 2 pending tasks request = 6 CPU + 12Gi + 2 GPU
+			expectedRequestCPU:    floatPtr(15000.0),       // 9 + 6 = 15 CPUs
+			expectedRequestMemory: floatPtr(32212254720.0), // 18 + 12 = 30 Gi
+			// Job 1 elastic: allocated (9 CPU + 18Gi + 3 GPU) - minResources (4 CPU + 8Gi + 3 GPU) = 5 CPU + 10Gi + 0 GPU
+			// Note: elastic GPU is 0 because all tasks are running, so allocated GPU = preCheckCardResource GPU
+			expectedElasticCPU:    floatPtr(5000.0),              // 5 CPUs
+			expectedElasticMemory: floatPtr(10737418240.0),       // 10Gi
+			expectedElasticCards:  map[v1.ResourceName]float64{}, // 0 GPU (3 allocated - 3 from tasks = 0)
+			// Job 2 inqueue: minResources (6 CPU + 12Gi + 2 GPU) - allocated (0) = 6 CPU + 12Gi + 2 GPU
+			expectedInqueueCPU:    floatPtr(6000.0),        // 6 CPUs
+			expectedInqueueMemory: floatPtr(12884901888.0), // 12Gi
+			expectedInqueueCards: map[v1.ResourceName]float64{
+				"NVIDIA-H200": 2000, // 2 GPUs
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			plugin := &Plugin{
+				totalResource:  tt.totalResource,
+				totalGuarantee: tt.totalGuarantee,
+				queueOpts:      make(map[api.QueueID]*queueAttr),
+				cardNameToResourceName: map[v1.ResourceName]v1.ResourceName{
+					"NVIDIA-H200": "nvidia.com/gpu",
+				},
+			}
+
+			result := plugin.buildQueueAttrs(tt.session)
+
+			if tt.expectedError {
+				if result {
+					t.Error("expected error but got success")
+				}
+			} else {
+				if !result {
+					t.Error("expected success but got error")
+				}
+
+				if len(plugin.queueOpts) != tt.expectedQueueCount {
+					t.Errorf("expected %d queue options, got %d", tt.expectedQueueCount, len(plugin.queueOpts))
+				}
+
+				// Check that queue order function was added
+				if tt.expectedQueueCount > 0 {
+					// This is a bit tricky to test directly, but we can verify the function was set
+					// by checking that the plugin state was properly updated
+					for _, qAttr := range plugin.queueOpts {
+						if qAttr.deserved == nil {
+							t.Error("queue deserved should not be nil")
+						}
+					}
+				}
+
+				// Optional: Check specific queue attributes
+				if tt.queueID != "" {
+					qAttr, exists := plugin.queueOpts[tt.queueID]
+					if !exists {
+						t.Errorf("expected queue %s to exist in queueOpts", tt.queueID)
+						return
+					}
+
+					// Check allocated resources
+					if tt.expectedAllocatedCPU != nil || tt.expectedAllocatedMemory != nil || len(tt.expectedAllocatedCards) > 0 {
+						if qAttr.allocated == nil {
+							t.Error("allocated should not be nil")
+						} else {
+							if tt.expectedAllocatedCPU != nil && qAttr.allocated.MilliCPU != *tt.expectedAllocatedCPU {
+								t.Errorf("expected allocated CPU %f, got %f", *tt.expectedAllocatedCPU, qAttr.allocated.MilliCPU)
+							}
+							if tt.expectedAllocatedMemory != nil && qAttr.allocated.Memory != *tt.expectedAllocatedMemory {
+								t.Errorf("expected allocated Memory %f, got %f", *tt.expectedAllocatedMemory, qAttr.allocated.Memory)
+							}
+							// Check scalar resources
+							for resName, expectedValue := range tt.expectedAllocatedCards {
+								actualValue, exists := qAttr.allocated.ScalarResources[resName]
+								if !exists {
+									t.Errorf("expected allocated scalar resource %s not found", resName)
+								} else if actualValue != expectedValue {
+									t.Errorf("expected allocated scalar resource %s value %f, got %f", resName, expectedValue, actualValue)
+								}
+							}
+						}
+					}
+
+					// Check request resources
+					if tt.expectedRequestCPU != nil || tt.expectedRequestMemory != nil || len(tt.expectedRequestCards) > 0 {
+						if qAttr.request == nil {
+							t.Error("request should not be nil")
+						} else {
+							if tt.expectedRequestCPU != nil && qAttr.request.MilliCPU != *tt.expectedRequestCPU {
+								t.Errorf("expected request CPU %f, got %f", *tt.expectedRequestCPU, qAttr.request.MilliCPU)
+							}
+							if tt.expectedRequestMemory != nil && qAttr.request.Memory != *tt.expectedRequestMemory {
+								t.Errorf("expected request Memory %f, got %f", *tt.expectedRequestMemory, qAttr.request.Memory)
+							}
+							// Check scalar resources
+							for resName, expectedValue := range tt.expectedRequestCards {
+								actualValue, exists := qAttr.request.ScalarResources[resName]
+								if !exists {
+									t.Errorf("expected request scalar resource %s not found", resName)
+								} else if actualValue != expectedValue {
+									t.Errorf("expected request scalar resource %s value %f, got %f", resName, expectedValue, actualValue)
+								}
+							}
+						}
+					}
+
+					// Check elastic resources
+					if tt.expectedElasticCPU != nil || tt.expectedElasticMemory != nil || len(tt.expectedElasticCards) > 0 {
+						if qAttr.elastic == nil {
+							t.Error("elastic should not be nil")
+						} else {
+							if tt.expectedElasticCPU != nil && qAttr.elastic.MilliCPU != *tt.expectedElasticCPU {
+								t.Errorf("expected elastic CPU %f, got %f", *tt.expectedElasticCPU, qAttr.elastic.MilliCPU)
+							}
+							if tt.expectedElasticMemory != nil && qAttr.elastic.Memory != *tt.expectedElasticMemory {
+								t.Errorf("expected elastic Memory %f, got %f", *tt.expectedElasticMemory, qAttr.elastic.Memory)
+							}
+							// Check scalar resources if present
+							for resName, expectedValue := range tt.expectedElasticCards {
+								actualValue, exists := qAttr.elastic.ScalarResources[resName]
+								if !exists {
+									t.Errorf("expected elastic scalar resource %s not found", resName)
+								} else if actualValue != expectedValue {
+									t.Errorf("expected elastic scalar resource %s value %f, got %f", resName, expectedValue, actualValue)
+								}
+							}
+						}
+					}
+
+					// Check inqueue resources
+					if tt.expectedInqueueCPU != nil || tt.expectedInqueueMemory != nil || len(tt.expectedInqueueCards) > 0 {
+						if qAttr.inqueue == nil {
+							t.Error("inqueue should not be nil")
+						} else {
+							if tt.expectedInqueueCPU != nil && qAttr.inqueue.MilliCPU != *tt.expectedInqueueCPU {
+								t.Errorf("expected inqueue CPU %f, got %f", *tt.expectedInqueueCPU, qAttr.inqueue.MilliCPU)
+							}
+							if tt.expectedInqueueMemory != nil && qAttr.inqueue.Memory != *tt.expectedInqueueMemory {
+								t.Errorf("expected inqueue Memory %f, got %f", *tt.expectedInqueueMemory, qAttr.inqueue.Memory)
+							}
+							// Check scalar resources if present
+							for resName, expectedValue := range tt.expectedInqueueCards {
+								actualValue, exists := qAttr.inqueue.ScalarResources[resName]
+								if !exists {
+									t.Errorf("expected inqueue scalar resource %s not found", resName)
+								} else if actualValue != expectedValue {
+									t.Errorf("expected inqueue scalar resource %s value %f, got %f", resName, expectedValue, actualValue)
+								}
+							}
+						}
+					}
+
+					// Log queue attributes for debugging
+					if tt.queueID != "" {
+						t.Logf("Queue %s allocated: %v", qAttr.name, qAttr.allocated)
+						t.Logf("Queue %s request: %v", qAttr.name, qAttr.request)
+						t.Logf("Queue %s elastic: %v", qAttr.name, qAttr.elastic)
+						t.Logf("Queue %s inqueue: %v", qAttr.name, qAttr.inqueue)
+						t.Logf("Queue %s deserved: %v", qAttr.name, qAttr.deserved)
+						t.Logf("Queue %s capability: %v", qAttr.name, qAttr.capability)
+						t.Logf("Queue %s guarantee: %v", qAttr.name, qAttr.guarantee)
+						t.Logf("Queue %s realCapability: %v", qAttr.name, qAttr.realCapability)
+					}
+				}
+			}
+		})
+	}
+}
+
+// floatPtr is a helper function to create a pointer to a float64 value
+func floatPtr(f float64) *float64 {
+	return &f
+}
+
+// TestBuildQueueMetrics tests the buildQueueMetrics function
+func TestBuildQueueMetrics(t *testing.T) {
+	tests := []struct {
+		name      string
+		session   *framework.Session
+		queueOpts map[api.QueueID]*queueAttr
+	}{
+		{
+			name: "session with queue options",
+			session: &framework.Session{
+				Queues: map[api.QueueID]*api.QueueInfo{
+					"queue-1": {
+						UID:  "queue-1",
+						Name: "test-queue",
+						Queue: &scheduling.Queue{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "test-queue",
+							},
+						},
+					},
+				},
+			},
+			queueOpts: map[api.QueueID]*queueAttr{
+				"queue-1": {
+					queueID:        "queue-1",
+					name:           "test-queue",
+					deserved:       &api.Resource{MilliCPU: 10000, Memory: 16 * 1024 * 1024 * 1024},
+					allocated:      &api.Resource{MilliCPU: 5000, Memory: 8 * 1024 * 1024 * 1024},
+					request:        &api.Resource{MilliCPU: 6000, Memory: 10 * 1024 * 1024 * 1024},
+					capability:     &api.Resource{MilliCPU: 20000, Memory: 32 * 1024 * 1024 * 1024},
+					realCapability: &api.Resource{MilliCPU: 15000, Memory: 24 * 1024 * 1024 * 1024},
+				},
+			},
+		},
+		{
+			name: "session with queue but no queue options",
+			session: &framework.Session{
+				Queues: map[api.QueueID]*api.QueueInfo{
+					"queue-1": {
+						UID:  "queue-1",
+						Name: "test-queue",
+						Queue: &scheduling.Queue{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "test-queue",
+							},
+							Spec: scheduling.QueueSpec{
+								Deserved: v1.ResourceList{
+									v1.ResourceCPU: resource.MustParse("10"),
+								},
+								Capability: v1.ResourceList{
+									v1.ResourceCPU: resource.MustParse("20"),
+								},
+								Guarantee: scheduling.Guarantee{
+									Resource: v1.ResourceList{
+										v1.ResourceCPU: resource.MustParse("5"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			queueOpts: map[api.QueueID]*queueAttr{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			plugin := &Plugin{
+				totalResource:  api.NewResource(v1.ResourceList{v1.ResourceCPU: resource.MustParse("100")}),
+				totalGuarantee: api.EmptyResource(),
+				queueOpts:      tt.queueOpts,
+			}
+
+			// This should not panic and should execute without errors
+			plugin.buildQueueMetrics(tt.session)
+
+			// Since metrics.UpdateQueue* functions are external, we can't easily verify
+			// their calls. But we can verify that the function executes without panicking
+			// and that the plugin state remains consistent.
+			if len(tt.queueOpts) > 0 {
+				// Verify that queue options are still intact
+				for queueID, qAttr := range tt.queueOpts {
+					if qAttr.name == "" {
+						t.Errorf("queue attribute for %s should have a name", queueID)
+					}
+				}
+			}
+		})
+	}
+}
+
+// TestUpdateShare tests the updateShare function
+func TestUpdateShare(t *testing.T) {
+	tests := []struct {
+		name          string
+		attr          *queueAttr
+		expectedShare float64
+	}{
+		{
+			name: "queue with normal share calculation",
+			attr: &queueAttr{
+				name: "test-queue",
+				deserved: &api.Resource{
+					MilliCPU: 10000,
+					Memory:   16 * 1024 * 1024 * 1024,
+				},
+				allocated: &api.Resource{
+					MilliCPU: 1000,
+					Memory:   8 * 1024 * 1024 * 1024,
+				},
+			},
+			expectedShare: 0.5,
+		},
+		{
+			name: "queue with card share calculation",
+			attr: &queueAttr{
+				name: "test-queue",
+				deserved: &api.Resource{
+					MilliCPU: 10000,
+					Memory:   16 * 1024 * 1024 * 1024,
+					ScalarResources: map[v1.ResourceName]float64{
+						"Tesla-V100": 4,
+					},
+				},
+				allocated: &api.Resource{
+					MilliCPU: 1000,
+					Memory:   8 * 1024 * 1024 * 1024,
+					ScalarResources: map[v1.ResourceName]float64{
+						"Tesla-V100": 3,
+					},
+				},
+			},
+			expectedShare: 0.75,
+		},
+		{
+			name: "queue with zero allocated resources",
+			attr: &queueAttr{
+				name: "test-queue",
+				deserved: &api.Resource{
+					MilliCPU: 10000,
+					Memory:   16 * 1024 * 1024 * 1024,
+				},
+				allocated: &api.Resource{
+					MilliCPU: 0,
+					Memory:   0,
+				},
+			},
+			expectedShare: 0.0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			plugin := &Plugin{}
+
+			plugin.updateShare(tt.attr)
+
+			if tt.attr.share != tt.expectedShare {
+				t.Errorf("expected share %f, got %f", tt.expectedShare, tt.attr.share)
+			}
+		})
+	}
+}
+
+// TestNewQueueResourceSupportingCard tests the newQueueResourceSupportingCard function
+func TestNewQueueResourceSupportingCard(t *testing.T) {
+	tests := []struct {
+		name           string
+		queue          *scheduling.Queue
+		resourceList   v1.ResourceList
+		expectedCPU    float64
+		expectedMemory float64
+		expectedCards  map[v1.ResourceName]float64
+	}{
+		{
+			name: "basic resource list without cards",
+			queue: &scheduling.Queue{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-queue",
+				},
+			},
+			resourceList: v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("4"),
+				v1.ResourceMemory: resource.MustParse("8Gi"),
+			},
+			expectedCPU:    4000,                   // 4 * 1000
+			expectedMemory: 8 * 1024 * 1024 * 1024, // 8Gi in bytes
+			expectedCards:  map[v1.ResourceName]float64{},
+		},
+		{
+			name: "resource list with card annotations",
+			queue: &scheduling.Queue{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "gpu-queue",
+					Annotations: map[string]string{
+						"volcano.sh/card.quota": `{"Tesla-V100": 2, "AMD-RX-7900-XT": 1}`,
+					},
+				},
+			},
+			resourceList: v1.ResourceList{
+				v1.ResourceCPU: resource.MustParse("8"),
+			},
+			expectedCPU:    8000,
+			expectedMemory: 0,
+			expectedCards: map[v1.ResourceName]float64{
+				"Tesla-V100":     2000, // 2 * 1000
+				"AMD-RX-7900-XT": 1000, // 1 * 1000
+			},
+		},
+		{
+			name: "empty resource list",
+			queue: &scheduling.Queue{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "empty-queue",
+				},
+			},
+			resourceList:   v1.ResourceList{},
+			expectedCPU:    0,
+			expectedMemory: 0,
+			expectedCards:  map[v1.ResourceName]float64{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			plugin := &Plugin{}
+
+			result := plugin.newQueueResourceSupportingCard(tt.queue, tt.resourceList)
+
+			if result.MilliCPU != tt.expectedCPU {
+				t.Errorf("expected CPU %f, got %f", tt.expectedCPU, result.MilliCPU)
+			}
+
+			if result.Memory != tt.expectedMemory {
+				t.Errorf("expected Memory %f, got %f", tt.expectedMemory, result.Memory)
+			}
+
+			// Check card resources
+			for cardName, expectedValue := range tt.expectedCards {
+				actualValue, exists := result.ScalarResources[cardName]
+				if !exists {
+					t.Errorf("expected card resource %s not found", cardName)
+					continue
+				}
+				if actualValue != expectedValue {
+					t.Errorf("expected card %s value %f, got %f", cardName, expectedValue, actualValue)
+				}
+			}
+
+			// Check that no unexpected card resources exist
+			if len(tt.expectedCards) == 0 && len(result.ScalarResources) > 0 {
+				t.Errorf("expected no card resources, but found %v", result.ScalarResources)
+			}
+		})
+	}
+}
+
+// TestUpdateQueueAttrShare tests the updateQueueAttrShare function
+func TestUpdateQueueAttrShare(t *testing.T) {
+	tests := []struct {
+		name          string
+		attr          *queueAttr
+		expectedShare float64
+	}{
+		{
+			name: "queue with allocated less than deserved",
+			attr: &queueAttr{
+				deserved: &api.Resource{
+					MilliCPU: 10000,                   // 10 CPUs
+					Memory:   16 * 1024 * 1024 * 1024, // 16Gi
+				},
+				allocated: &api.Resource{
+					MilliCPU: 1000,                   // 5 CPUs
+					Memory:   8 * 1024 * 1024 * 1024, // 8Gi
+				},
+			},
+			expectedShare: 0.5, // max(5/10, 8/16) = 0.5
+		},
+		{
+			name: "queue with allocated equal to deserved",
+			attr: &queueAttr{
+				deserved: &api.Resource{
+					MilliCPU: 10000,
+					Memory:   16 * 1024 * 1024 * 1024,
+				},
+				allocated: &api.Resource{
+					MilliCPU: 1000,
+					Memory:   16 * 1024 * 1024 * 1024,
+				},
+			},
+			expectedShare: 1.0, // max(10/10, 16/16) = 1.0
+		},
+		{
+			name: "queue with allocated more than deserved",
+			attr: &queueAttr{
+				deserved: &api.Resource{
+					MilliCPU: 10000,
+					Memory:   16 * 1024 * 1024 * 1024,
+				},
+				allocated: &api.Resource{
+					MilliCPU: 1000,
+					Memory:   24 * 1024 * 1024 * 1024,
+				},
+			},
+			expectedShare: 1.5, // max(15/10, 24/16) = 1.5
+		},
+		{
+			name: "queue with zero deserved resources",
+			attr: &queueAttr{
+				deserved: &api.Resource{
+					MilliCPU: 0,
+					Memory:   0,
+				},
+				allocated: &api.Resource{
+					MilliCPU: 5000,
+					Memory:   8 * 1024 * 1024 * 1024,
+				},
+			},
+			expectedShare: 0, // division by zero should be handled gracefully
+		},
+		{
+			name: "queue with zero allocated resources",
+			attr: &queueAttr{
+				deserved: &api.Resource{
+					MilliCPU: 5000,
+					Memory:   8 * 1024 * 1024 * 1024,
+				},
+				allocated: &api.Resource{
+					MilliCPU: 0,
+					Memory:   0,
+				},
+			},
+			expectedShare: 0, // division by zero should be handled gracefully
+		},
+		{
+			name: "queue with card resources",
+			attr: &queueAttr{
+				deserved: &api.Resource{
+					MilliCPU: 10000,
+					Memory:   10 * 1024 * 1024 * 1024,
+					ScalarResources: map[v1.ResourceName]float64{
+						"Tesla-V100": 2000, // 2 GPUs
+					},
+				},
+				allocated: &api.Resource{
+					MilliCPU: 1000,
+					Memory:   1 * 1024 * 1024 * 1024,
+					ScalarResources: map[v1.ResourceName]float64{
+						"Tesla-V100": 1000, // 1 GPU
+					},
+				},
+			},
+			expectedShare: 0.5, // max(5/10, 8/16, 1/2) = 0.5
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			updateQueueAttrShare(tt.attr)
+
+			if tt.attr.share != tt.expectedShare {
+				t.Errorf("expected share %f, got %f", tt.expectedShare, tt.attr.share)
+			}
+		})
+	}
+}
+
+// TestGetInqueueResource tests the GetInqueueResource function
+func TestGetInqueueResource(t *testing.T) {
+	tests := []struct {
+		name                     string
+		minCPU                   string // MinResources CPU (e.g., "5" for 5 cores)
+		minMemory                string // MinResources Memory (e.g., "10Gi")
+		minCards                 map[string]int
+		allocatedCPU             float64                     // Allocated CPU in milli-cores
+		allocatedMemory          float64                     // Allocated Memory in bytes
+		allocatedCards           map[v1.ResourceName]float64 // Allocated card resources
+		isCardUnlimitedCpuMemory bool
+		expectedCPU              float64
+		expectedMemory           float64
+		expectedCards            map[v1.ResourceName]float64
+	}{
+		{
+			name:                     "job with allocated less than min resources - cardUnlimited=false",
+			minCPU:                   "5",
+			minMemory:                "10Gi",
+			allocatedCPU:             2000,                   // 2 CPUs allocated
+			allocatedMemory:          4 * 1024 * 1024 * 1024, // 4Gi allocated
+			isCardUnlimitedCpuMemory: false,
+			expectedCPU:              3000,                   // 5 - 2 = 3 CPUs needed
+			expectedMemory:           6 * 1024 * 1024 * 1024, // 10 - 4 = 6Gi needed
+			expectedCards:            map[v1.ResourceName]float64{},
+		},
+		{
+			name:                     "job with allocated equal to min resources - cardUnlimited=false",
+			minCPU:                   "5",
+			minMemory:                "10Gi",
+			allocatedCPU:             5000,                    // 5 CPUs allocated
+			allocatedMemory:          10 * 1024 * 1024 * 1024, // 10Gi allocated
+			isCardUnlimitedCpuMemory: false,
+			expectedCPU:              0,
+			expectedMemory:           0,
+			expectedCards:            map[v1.ResourceName]float64{},
+		},
+		{
+			name:                     "job with allocated greater than min resources - cardUnlimited=false",
+			minCPU:                   "5",
+			minMemory:                "10Gi",
+			allocatedCPU:             6000,                    // 6 CPUs allocated
+			allocatedMemory:          12 * 1024 * 1024 * 1024, // 12Gi allocated
+			isCardUnlimitedCpuMemory: false,
+			expectedCPU:              0, // no inqueue needed since allocated >= min
+			expectedMemory:           0,
+			expectedCards:            map[v1.ResourceName]float64{},
+		},
+		{
+			name:      "job with card resources - cardUnlimited=false",
+			minCPU:    "5",
+			minMemory: "10Gi",
+			minCards: map[string]int{
+				"Tesla-V100": 2,
+			},
+			allocatedCPU:    2000,
+			allocatedMemory: 4 * 1024 * 1024 * 1024,
+			allocatedCards: map[v1.ResourceName]float64{
+				"Tesla-V100": 1000, // 1 GPU allocated
+			},
+			isCardUnlimitedCpuMemory: false,
+			expectedCPU:              3000,
+			expectedMemory:           6 * 1024 * 1024 * 1024,
+			expectedCards: map[v1.ResourceName]float64{
+				"Tesla-V100": 1000, // 2 - 1 = 1 GPU needed
+			},
+		},
+		{
+			name:      "job with card resources equal to min - cardUnlimited=false",
+			minCPU:    "5",
+			minMemory: "10Gi",
+			minCards: map[string]int{
+				"Tesla-V100": 2,
+			},
+			allocatedCPU:    2000,
+			allocatedMemory: 4 * 1024 * 1024 * 1024,
+			allocatedCards: map[v1.ResourceName]float64{
+				"Tesla-V100": 2000, // 2 GPU allocated
+			},
+			isCardUnlimitedCpuMemory: false,
+			expectedCPU:              3000,
+			expectedMemory:           6 * 1024 * 1024 * 1024,
+			expectedCards:            map[v1.ResourceName]float64{},
+		},
+		{
+			name: "job with card resources - cardUnlimited=true",
+			minCards: map[string]int{
+				"Tesla-V100": 2,
+			},
+			allocatedCPU:    2000,
+			allocatedMemory: 4 * 1024 * 1024 * 1024,
+			allocatedCards: map[v1.ResourceName]float64{
+				"Tesla-V100": 1000, // 1 GPU allocated
+			},
+			isCardUnlimitedCpuMemory: true,
+			expectedCPU:              0, // CPU/Memory should not be counted when cardUnlimited=true
+			expectedMemory:           0,
+			expectedCards: map[v1.ResourceName]float64{
+				"Tesla-V100": 1000, // 2 - 1 = 1 GPU needed
+			},
+		},
+		{
+			name: "job with card resources equal to min - cardUnlimited=true",
+			minCards: map[string]int{
+				"Tesla-V100": 2,
+			},
+			allocatedCPU:    2000,
+			allocatedMemory: 4 * 1024 * 1024 * 1024,
+			allocatedCards: map[v1.ResourceName]float64{
+				"Tesla-V100": 2000, // 2 GPU allocated
+			},
+			isCardUnlimitedCpuMemory: true,
+			expectedCPU:              0, // CPU/Memory should not be counted when cardUnlimited=true
+			expectedMemory:           0,
+			expectedCards:            map[v1.ResourceName]float64{},
+		},
+		{
+			name:                     "job without card resources - cardUnlimited=true",
+			minCPU:                   "5",
+			minMemory:                "10Gi",
+			allocatedCPU:             2000,
+			allocatedMemory:          4 * 1024 * 1024 * 1024,
+			isCardUnlimitedCpuMemory: true,
+			expectedCPU:              3000,                   // CPU/Memory should be counted when no card resources
+			expectedMemory:           6 * 1024 * 1024 * 1024, // 10 - 4 = 6Gi needed
+			expectedCards:            map[v1.ResourceName]float64{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a plugin instance with the test's isCardUnlimitedCpuMemory setting
+			plugin := &Plugin{
+				isCardUnlimitedCpuMemory: tt.isCardUnlimitedCpuMemory,
+			}
+
+			// Build MinResources for PodGroup
+			minResourcesList := v1.ResourceList{}
+			if tt.minCPU != "" {
+				minResourcesList[v1.ResourceCPU] = resource.MustParse(tt.minCPU)
+			}
+			if tt.minMemory != "" {
+				minResourcesList[v1.ResourceMemory] = resource.MustParse(tt.minMemory)
+			}
+
+			// Build card request annotation
+			cardRequestAnnotation := ""
+			if len(tt.minCards) > 0 {
+				cardRequestJSON := fmt.Sprintf(`{"%s": %d}`, "Tesla-V100", tt.minCards["Tesla-V100"])
+				if len(tt.minCards) == 1 {
+					cardRequestAnnotation = cardRequestJSON
+				}
+			}
+
+			// Create JobInfo with proper structure
+			apiJob := &api.JobInfo{
+				Name:      "test-job",
+				Namespace: "default",
+				PodGroup: &api.PodGroup{
+					PodGroup: scheduling.PodGroup{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:        "test-job",
+							Namespace:   "default",
+							Annotations: map[string]string{},
+						},
+						Spec: scheduling.PodGroupSpec{
+							MinResources: &minResourcesList,
+						},
+					},
+				},
+			}
+
+			if cardRequestAnnotation != "" {
+				apiJob.PodGroup.Annotations["volcano.sh/card.request"] = cardRequestAnnotation
+			}
+
+			// Create JobInfo instance
+			job := &JobInfo{
+				JobInfo: apiJob,
+				preCheckCardResource: &api.Resource{
+					ScalarResources: map[v1.ResourceName]float64{},
+				},
+			}
+
+			// Set preCheckCardResource based on minCards
+			for cardName, qty := range tt.minCards {
+				job.preCheckCardResource.ScalarResources[v1.ResourceName(cardName)] = float64(qty * 1000)
+			}
+
+			// Create allocated resource
+			allocated := &api.Resource{
+				MilliCPU: tt.allocatedCPU,
+				Memory:   tt.allocatedMemory,
+			}
+			if len(tt.allocatedCards) > 0 {
+				allocated.ScalarResources = make(map[v1.ResourceName]float64)
+				for cardName, qty := range tt.allocatedCards {
+					allocated.ScalarResources[cardName] = qty
+				}
+			}
+
+			// Call GetInqueueResource
+			inqueue := plugin.GetInqueueResource(job, allocated)
+
+			// Compare with expected results
+			if inqueue.MilliCPU != tt.expectedCPU {
+				t.Errorf("expected CPU %f, got %f", tt.expectedCPU, inqueue.MilliCPU)
+			}
+
+			if inqueue.Memory != tt.expectedMemory {
+				t.Errorf("expected Memory %f, got %f", tt.expectedMemory, inqueue.Memory)
+			}
+
+			// Check card resources
+			for cardName, expectedValue := range tt.expectedCards {
+				actualValue, exists := inqueue.ScalarResources[cardName]
+				if expectedValue == 0 {
+					// If expected is 0, it should not exist in the map or be 0
+					if exists && actualValue != 0 {
+						t.Errorf("expected card %s to be absent or 0, got %f", cardName, actualValue)
+					}
+				} else {
+					if !exists {
+						t.Errorf("expected card resource %s not found", cardName)
+						continue
+					}
+					if actualValue != expectedValue {
+						t.Errorf("expected card %s value %f, got %f", cardName, expectedValue, actualValue)
+					}
+				}
+			}
+		})
+	}
+}
+
+// TestBuildQueueAttrByJob tests the buildQueueAttrByJob function
+func TestBuildQueueAttrByJob(t *testing.T) {
+	tests := []struct {
+		name                     string
+		session                  *framework.Session
+		job                      *api.JobInfo
+		queueOpts                map[api.QueueID]*queueAttr
+		isCardUnlimitedCpuMemory bool
+		expectedAllocatedCPU     float64
+		expectedAllocatedMemory  float64
+		expectedCardName         v1.ResourceName
+		expectedCardQty          float64
+		expectedError            bool
+	}{
+		{
+			name: "job with running tasks isCardUnlimitedCpuMemory=false",
+			session: &framework.Session{
+				Queues: map[api.QueueID]*api.QueueInfo{
+					"queue-1": {
+						UID:  "queue-1",
+						Name: "test-queue",
+						Queue: &scheduling.Queue{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "test-queue",
+							},
+						},
+					},
+				},
+			},
+			job: api.NewJobInfo("job-1", &api.TaskInfo{
+				UID:       "task-1",
+				Name:      "task-1",
+				Namespace: "default",
+				Job:       "job-1",
+				Resreq: &api.Resource{
+					MilliCPU: 1000,
+					Memory:   2 * 1024 * 1024 * 1024,
+				},
+				TransactionContext: api.TransactionContext{
+					Status: api.Running,
+				},
+			}),
+			queueOpts: map[api.QueueID]*queueAttr{
+				"queue-1": {
+					queueID:   "queue-1",
+					name:      "test-queue",
+					allocated: api.EmptyResource(),
+					request:   api.EmptyResource(),
+					elastic:   api.EmptyResource(),
+					inqueue:   api.EmptyResource(),
+				},
+			},
+			isCardUnlimitedCpuMemory: false,
+			expectedAllocatedCPU:     1000,
+			expectedAllocatedMemory:  2 * 1024 * 1024 * 1024,
+			expectedCardName:         "",
+			expectedCardQty:          0,
+			expectedError:            false,
+		},
+		{
+			name: "job with running tasks and card resources isCardUnlimitedCpuMemory=false",
+			session: &framework.Session{
+				Queues: map[api.QueueID]*api.QueueInfo{
+					"queue-1": {
+						UID:  "queue-1",
+						Name: "test-queue",
+						Queue: &scheduling.Queue{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "test-queue",
+							},
+						},
+					},
+				},
+			},
+			job: api.NewJobInfo("job-1", &api.TaskInfo{
+				UID:       "task-1",
+				Name:      "task-1",
+				Namespace: "default",
+				Job:       "job-1",
+				Resreq: &api.Resource{
+					MilliCPU: 1000,
+					Memory:   2 * 1024 * 1024 * 1024,
+				},
+				TransactionContext: api.TransactionContext{
+					Status: api.Running,
+				},
+				Pod: &v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							"volcano.sh/card.name": "Tesla-V100",
+						},
+					},
+					Spec: v1.PodSpec{
+						Containers: []v1.Container{
+							{
+								Resources: v1.ResourceRequirements{
+									Requests: v1.ResourceList{
+										"nvidia.com/gpu": resource.MustParse("2"),
+									},
+								},
+							},
+						},
+					},
+				},
+			}),
+			queueOpts: map[api.QueueID]*queueAttr{
+				"queue-1": {
+					queueID:   "queue-1",
+					name:      "test-queue",
+					allocated: api.EmptyResource(),
+					request:   api.EmptyResource(),
+					elastic:   api.EmptyResource(),
+					inqueue:   api.EmptyResource(),
+				},
+			},
+			isCardUnlimitedCpuMemory: false,
+			expectedAllocatedCPU:     1000,
+			expectedAllocatedMemory:  2 * 1024 * 1024 * 1024,
+			expectedCardName:         "Tesla-V100",
+			expectedCardQty:          2000,
+			expectedError:            false,
+		},
+		{
+			name: "job with running tasks isCardUnlimitedCpuMemory=true",
+			session: &framework.Session{
+				Queues: map[api.QueueID]*api.QueueInfo{
+					"queue-1": {
+						UID:  "queue-1",
+						Name: "test-queue",
+						Queue: &scheduling.Queue{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "test-queue",
+							},
+						},
+					},
+				},
+			},
+			job: api.NewJobInfo("job-1", &api.TaskInfo{
+				UID:       "task-1",
+				Name:      "task-1",
+				Namespace: "default",
+				Job:       "job-1",
+				Resreq: &api.Resource{
+					MilliCPU: 1000,
+					Memory:   2 * 1024 * 1024 * 1024,
+				},
+				TransactionContext: api.TransactionContext{
+					Status: api.Running,
+				},
+			}),
+			queueOpts: map[api.QueueID]*queueAttr{
+				"queue-1": {
+					queueID:   "queue-1",
+					name:      "test-queue",
+					allocated: api.EmptyResource(),
+					request:   api.EmptyResource(),
+					elastic:   api.EmptyResource(),
+					inqueue:   api.EmptyResource(),
+				},
+			},
+			isCardUnlimitedCpuMemory: true,
+			expectedAllocatedCPU:     1000,
+			expectedAllocatedMemory:  2 * 1024 * 1024 * 1024,
+			expectedCardName:         "",
+			expectedCardQty:          0,
+			expectedError:            false,
+		},
+		{
+			name: "job with running tasks and card resources isCardUnlimitedCpuMemory=true",
+			session: &framework.Session{
+				Queues: map[api.QueueID]*api.QueueInfo{
+					"queue-1": {
+						UID:  "queue-1",
+						Name: "test-queue",
+						Queue: &scheduling.Queue{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "test-queue",
+							},
+						},
+					},
+				},
+			},
+			job: api.NewJobInfo("job-1", &api.TaskInfo{
+				UID:       "task-1",
+				Name:      "task-1",
+				Namespace: "default",
+				Job:       "job-1",
+				Resreq: &api.Resource{
+					MilliCPU: 1000,
+					Memory:   2 * 1024 * 1024 * 1024,
+				},
+				TransactionContext: api.TransactionContext{
+					Status: api.Running,
+				},
+				Pod: &v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							"volcano.sh/card.name": "Tesla-V100",
+						},
+					},
+					Spec: v1.PodSpec{
+						Containers: []v1.Container{
+							{
+								Resources: v1.ResourceRequirements{
+									Requests: v1.ResourceList{
+										"nvidia.com/gpu": resource.MustParse("2"),
+									},
+								},
+							},
+						},
+					},
+				},
+			}),
+			queueOpts: map[api.QueueID]*queueAttr{
+				"queue-1": {
+					queueID:   "queue-1",
+					name:      "test-queue",
+					allocated: api.EmptyResource(),
+					request:   api.EmptyResource(),
+					elastic:   api.EmptyResource(),
+					inqueue:   api.EmptyResource(),
+				},
+			},
+			isCardUnlimitedCpuMemory: true,
+			expectedAllocatedCPU:     0,
+			expectedAllocatedMemory:  0,
+			expectedCardName:         "Tesla-V100",
+			expectedCardQty:          2000,
+			expectedError:            false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			plugin := &Plugin{
+				queueOpts: tt.queueOpts,
+				cardNameToResourceName: map[v1.ResourceName]v1.ResourceName{
+					"Tesla-V100": "nvidia.com/gpu",
+				},
+				isCardUnlimitedCpuMemory: tt.isCardUnlimitedCpuMemory,
+			}
+
+			tt.job.SetPodGroup(&api.PodGroup{
+				PodGroup: scheduling.PodGroup{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-job",
+						Namespace: "default",
+					},
+					Spec: scheduling.PodGroupSpec{
+						Queue: "queue-1",
+					},
+				},
+			})
+
+			result := plugin.buildQueueAttrByJob(tt.session, tt.job)
+
+			if tt.expectedError {
+				if result {
+					t.Error("expected error but got success")
+				}
+			} else {
+				if !result {
+					t.Error("expected success but got error")
+				}
+
+				qAttr := plugin.queueOpts[tt.job.Queue]
+				if qAttr.allocated.MilliCPU != tt.expectedAllocatedCPU {
+					t.Errorf("expected allocated CPU %f, got %f", tt.expectedAllocatedCPU, qAttr.allocated.MilliCPU)
+				}
+
+				if qAttr.allocated.Memory != tt.expectedAllocatedMemory {
+					t.Errorf("expected allocated Memory %f, got %f", tt.expectedAllocatedMemory, qAttr.allocated.Memory)
+				}
+
+				if qAttr.request.ScalarResources[tt.expectedCardName] != tt.expectedCardQty {
+					t.Errorf("expected card quantity %f, got %f", tt.expectedCardQty, qAttr.request.ScalarResources[tt.expectedCardName])
+				}
+			}
+		})
+	}
+}

--- a/pkg/scheduler/plugins/capacity-card/capacity_card_test.go
+++ b/pkg/scheduler/plugins/capacity-card/capacity_card_test.go
@@ -1,0 +1,220 @@
+/*
+Copyright 2024 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package capacitycard
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"volcano.sh/volcano/pkg/scheduler/api"
+	"volcano.sh/volcano/pkg/scheduler/conf"
+	"volcano.sh/volcano/pkg/scheduler/framework"
+)
+
+func TestHasCardResource(t *testing.T) {
+	p := &Plugin{
+		cardNameToResourceName: map[corev1.ResourceName]corev1.ResourceName{
+			"Tesla-V100": "nvidia.com/gpu",
+		},
+	}
+
+	tests := []struct {
+		name           string
+		cardResource   *api.Resource
+		scalarResource *api.Resource
+		expected       bool
+	}{
+		{
+			name:           "both resources nil",
+			cardResource:   nil,
+			scalarResource: nil,
+			expected:       false,
+		},
+		{
+			name: "card resource has scalar resources",
+			cardResource: &api.Resource{
+				ScalarResources: map[corev1.ResourceName]float64{
+					"Tesla-V100": 1.0,
+				},
+			},
+			scalarResource: nil,
+			expected:       true,
+		},
+		{
+			name:         "scalar resource has card resource",
+			cardResource: nil,
+			scalarResource: &api.Resource{
+				ScalarResources: map[corev1.ResourceName]float64{
+					"nvidia.com/gpu": 1.0,
+				},
+			},
+			expected: true,
+		},
+		{
+			name:         "scalar resource has non-card resource",
+			cardResource: nil,
+			scalarResource: &api.Resource{
+				ScalarResources: map[corev1.ResourceName]float64{
+					"cpu": 1.0,
+				},
+			},
+			expected: false,
+		},
+		{
+			name:         "scalar resource empty",
+			cardResource: nil,
+			scalarResource: &api.Resource{
+				ScalarResources: map[corev1.ResourceName]float64{},
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := p.HasCardResource(tt.cardResource, tt.scalarResource)
+			if result != tt.expected {
+				t.Errorf("HasCardResource() = %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestIsCardUnlimitedCpuMemory(t *testing.T) {
+	p := &Plugin{}
+
+	tests := []struct {
+		name     string
+		tiers    []conf.Tier
+		expected bool
+	}{
+		{
+			name:     "no tiers",
+			tiers:    []conf.Tier{},
+			expected: false,
+		},
+		{
+			name: "tiers without capacity-card plugin",
+			tiers: []conf.Tier{
+				{
+					Plugins: []conf.PluginOption{
+						{
+							Name: "other-plugin",
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "tiers with capacity-card plugin but no cardUnlimitedCpuMemory argument",
+			tiers: []conf.Tier{
+				{
+					Plugins: []conf.PluginOption{
+						{
+							Name: PluginName,
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "tiers with capacity-card plugin and cardUnlimitedCpuMemory false",
+			tiers: []conf.Tier{
+				{
+					Plugins: []conf.PluginOption{
+						{
+							Name: PluginName,
+							Arguments: map[string]interface{}{
+								cardUnlimitedCpuMemory: false,
+							},
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "tiers with capacity-card plugin and cardUnlimitedCpuMemory true",
+			tiers: []conf.Tier{
+				{
+					Plugins: []conf.PluginOption{
+						{
+							Name: PluginName,
+							Arguments: map[string]interface{}{
+								cardUnlimitedCpuMemory: true,
+							},
+						},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "multiple tiers with capacity-card plugin in second tier",
+			tiers: []conf.Tier{
+				{
+					Plugins: []conf.PluginOption{
+						{
+							Name: "other-plugin",
+						},
+					},
+				},
+				{
+					Plugins: []conf.PluginOption{
+						{
+							Name: PluginName,
+							Arguments: map[string]interface{}{
+								cardUnlimitedCpuMemory: true,
+							},
+						},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "cardUnlimitedCpuMemory argument is not bool",
+			tiers: []conf.Tier{
+				{
+					Plugins: []conf.PluginOption{
+						{
+							Name: PluginName,
+							Arguments: map[string]interface{}{
+								cardUnlimitedCpuMemory: "true",
+							},
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ssn := &framework.Session{
+				Tiers: tt.tiers,
+			}
+			result := p.IsCardUnlimitedCpuMemory(ssn)
+			if result != tt.expected {
+				t.Errorf("IsCardUnlimitedCpuMemory() = %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}

--- a/pkg/scheduler/plugins/capacity-card/capacity_card_utils.go
+++ b/pkg/scheduler/plugins/capacity-card/capacity_card_utils.go
@@ -1,0 +1,183 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+Copyright 2018-2025 The Volcano Authors.
+
+Modifications made by Volcano authors:
+- Enhanced gang scheduling validation with task-level validity checks
+- Improved preemption logic to respect gang scheduling constraints
+- Added support for job starving detection and enhanced pipeline state management
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package capacitycard
+
+import (
+	"encoding/json"
+	"strings"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/klog/v2"
+
+	"volcano.sh/volcano/pkg/scheduler/api"
+)
+
+const (
+	// EventTypeGetTaskRequestResourceFailed is get task request resource failed event type
+	EventTypeGetTaskRequestResourceFailed = "GetTaskRequestResourceFailed"
+
+	// EventTypeInsufficientCPUMemoryQuota is empty queue capability event type
+	EventTypeEmptyQueueCapability = "EmptyQueueCapability"
+
+	// EventTypeInsufficientCPUQuota is insufficient CPU quota event type
+	EventTypeInsufficientCPUQuota = "InsufficientCPUQuota"
+
+	// EventTypeInsufficientMemoryQuota is insufficient memory quota event type
+	EventTypeInsufficientMemoryQuota = "InsufficientMemoryQuota"
+
+	// EventTypeInsufficientScalarQuota is insufficient scalar quota event type
+	EventTypeInsufficientScalarQuota = "InsufficientScalarQuota"
+)
+
+// CheckMode defines the mode for checking scalar resources
+type CheckMode int
+
+const (
+	// CheckModeJob is for job enqueue phase, allows sum of multi-card quotas
+	CheckModeJob CheckMode = iota
+	// CheckModeTask is for task allocate phase, requires single card type to satisfy
+	CheckModeTask
+)
+
+// GetCardResourceFromAnnotations extracts card resource from annotations.
+// name is the name of the object name (e.g. job, task, queue, etc.) in string format which is used for logging the error message when unmarshal card json failed.
+// annotations is the annotations of the object
+// key is the key of the annotations
+// return the card resource
+func GetCardResourceFromAnnotations(name string, annotations map[string]string, key string) *api.Resource {
+	cardResource := api.EmptyResource()
+	if cardJson, ok := annotations[key]; ok && cardJson != "" {
+		cardMap := make(map[string]int)
+		if err := json.Unmarshal([]byte(cardJson), &cardMap); err != nil {
+			klog.Warningf(
+				`failed to unmarshal card json: %s, key: %s, name: %s, %+v`,
+				cardJson, key, name, err,
+			)
+			return cardResource
+		}
+		if cardResource.ScalarResources == nil {
+			cardResource.ScalarResources = make(map[v1.ResourceName]float64)
+		}
+		for cardName, cardCount := range cardMap {
+			cardResource.ScalarResources[v1.ResourceName(cardName)] = float64(
+				cardCount * cardCountQuantityMultiplier,
+			)
+		}
+	}
+	return cardResource
+}
+
+// CheckSingleScalarResourceResult is the result of CheckSingleScalarResource.
+type CheckSingleScalarResourceResult struct {
+	Ok                   bool
+	NoEnoughScalarName   v1.ResourceName
+	NoEnoughScalarCount  float64
+	ToBeUsedScalarQuant  float64
+	QueueCapabilityQuant float64
+}
+
+// CheckSingleScalarResource checks whether the scalar resource is enough.
+// mode: CheckModeJob for job enqueue phase (allows sum of multi-card quotas),
+//
+//	CheckModeTask for task allocate phase (requires single card type to satisfy)
+func CheckSingleScalarResource(
+	scalarName v1.ResourceName,
+	scalarQuant float64,
+	toBeUsedResource, queueCapability *api.Resource,
+	mode CheckMode,
+) CheckSingleScalarResourceResult {
+	result := CheckSingleScalarResourceResult{
+		Ok: true,
+	}
+	// The multi-cards name is given like: NVIDIA-GTX-GeForce-4090D|NVIDIA-H200 .
+	// The card name is confirmed after the task is assigned to certain node,
+	// in which the card name is extracted from node's label.
+	//
+	// For Task mode: any one of the card can satisfy the request is ok (single task uses single card type).
+	// For Job mode: sum of all card quotas can satisfy the request (different tasks in same job can use different card types).
+	if strings.Contains(scalarName.String(), MultiCardSeparator) {
+		multiCardNames := strings.Split(scalarName.String(), MultiCardSeparator)
+
+		if mode == CheckModeJob {
+			// Job mode: check if sum of all card quotas can satisfy the request
+			// This allows different tasks in the same job to use different card types
+			totalAvailableQuota := float64(0)
+			totalToBeUsed := float64(0)
+
+			for _, cardName := range multiCardNames {
+				cardResourceName := v1.ResourceName(cardName)
+				totalAvailableQuota += queueCapability.ScalarResources[cardResourceName]
+				totalToBeUsed += toBeUsedResource.ScalarResources[cardResourceName]
+			}
+
+			// Add the current request to the total to be used
+			totalToBeUsed += scalarQuant
+
+			if scalarQuant > 0 && totalToBeUsed > totalAvailableQuota {
+				result.Ok = false
+				result.NoEnoughScalarName = scalarName
+				result.NoEnoughScalarCount = scalarQuant
+				result.ToBeUsedScalarQuant = totalToBeUsed
+				result.QueueCapabilityQuant = totalAvailableQuota
+				return result
+			}
+
+			result.Ok = true
+			result.ToBeUsedScalarQuant = totalToBeUsed
+			result.QueueCapabilityQuant = totalAvailableQuota
+			return result
+		}
+
+		// Task mode: check if any single card type can satisfy the request
+		// If the scalar name is multi-cards name, the scalar quant should be added to each card.
+		// The multi-cards name is given like: NVIDIA-GTX-GeForce-4090D|NVIDIA-H200 .
+		// Now has allocated 5 NVIDIA-GTX-GeForce-4090D and 8 NVIDIA-H200, requests another 2 NVIDIA-GTX-GeForce-4090D|NVIDIA-H200
+		// The `toBeUsedResource` scalar quant is {"NVIDIA-GTX-GeForce-4090D|NVIDIA-H200": 2, "NVIDIA-GTX-GeForce-4090D": 5, "NVIDIA-H200": 8}
+		// NVIDIA-GTX-GeForce-4090D and NVIDIA-H200 in `toBeUsedResource` do not contain the requested 2 card, so it should be added to each card name.
+		// `multiCardToBeUsedResource` scalar quant is {"NVIDIA-GTX-GeForce-4090D|NVIDIA-H200": 2, "NVIDIA-GTX-GeForce-4090D": 7, "NVIDIA-H200": 10}
+		multiCardToBeUsedResource := toBeUsedResource.Clone()
+		for _, cardName := range multiCardNames {
+			multiCardToBeUsedResource.ScalarResources[v1.ResourceName(cardName)] += scalarQuant
+			if result = CheckSingleScalarResource(
+				v1.ResourceName(cardName), scalarQuant, multiCardToBeUsedResource, queueCapability, mode,
+			); result.Ok {
+				return result
+			}
+		}
+		result.Ok = false
+		result.NoEnoughScalarName = scalarName
+		result.NoEnoughScalarCount = scalarQuant
+		return result
+	}
+
+	result.ToBeUsedScalarQuant = toBeUsedResource.ScalarResources[scalarName]
+	result.QueueCapabilityQuant = queueCapability.ScalarResources[scalarName]
+	if scalarQuant > 0 && result.ToBeUsedScalarQuant > result.QueueCapabilityQuant {
+		result.Ok = false
+		result.NoEnoughScalarName = scalarName
+		result.NoEnoughScalarCount = scalarQuant
+		return result
+	}
+	result.Ok = true
+	return result
+}

--- a/pkg/scheduler/plugins/capacity-card/capacity_card_utils_test.go
+++ b/pkg/scheduler/plugins/capacity-card/capacity_card_utils_test.go
@@ -1,0 +1,581 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+Copyright 2018-2025 The Volcano Authors.
+
+Modifications made by Volcano authors:
+- Enhanced gang scheduling validation with task-level validity checks
+- Improved preemption logic to respect gang scheduling constraints
+- Added support for job starving detection and enhanced pipeline state management
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package capacitycard
+
+import (
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	"volcano.sh/volcano/pkg/scheduler/api"
+)
+
+// TestGetCardResourceFromAnnotations tests the GetCardResourceFromAnnotations function
+func TestGetCardResourceFromAnnotations(t *testing.T) {
+	tests := []struct {
+		name        string
+		annotations map[string]string
+		key         string
+		expected    *api.Resource
+	}{
+		{
+			name: "valid card resource with single card type",
+			annotations: map[string]string{
+				"volcano.sh/card-request": `{"NVIDIA-GTX-4090": 2}`,
+			},
+			key: "volcano.sh/card-request",
+			expected: &api.Resource{
+				ScalarResources: map[v1.ResourceName]float64{
+					"NVIDIA-GTX-4090": 2000, // 2 * cardCountQuantityMultiplier (1000)
+				},
+			},
+		},
+		{
+			name: "valid card resource with multiple card types",
+			annotations: map[string]string{
+				"volcano.sh/card-request": `{"NVIDIA-GTX-4090": 2, "NVIDIA-H200": 4}`,
+			},
+			key: "volcano.sh/card-request",
+			expected: &api.Resource{
+				ScalarResources: map[v1.ResourceName]float64{
+					"NVIDIA-GTX-4090": 2000,
+					"NVIDIA-H200":     4000,
+				},
+			},
+		},
+		{
+			name: "key not found in annotations",
+			annotations: map[string]string{
+				"other-key": `{"NVIDIA-GTX-4090": 2}`,
+			},
+			key: "volcano.sh/card-request",
+			expected: &api.Resource{
+				MilliCPU:        0,
+				Memory:          0,
+				ScalarResources: map[v1.ResourceName]float64{},
+			},
+		},
+		{
+			name:        "empty annotations",
+			annotations: map[string]string{},
+			key:         "volcano.sh/card-request",
+			expected: &api.Resource{
+				MilliCPU:        0,
+				Memory:          0,
+				ScalarResources: map[v1.ResourceName]float64{},
+			},
+		},
+		{
+			name:        "nil annotations",
+			annotations: nil,
+			key:         "volcano.sh/card-request",
+			expected: &api.Resource{
+				MilliCPU:        0,
+				Memory:          0,
+				ScalarResources: map[v1.ResourceName]float64{},
+			},
+		},
+		{
+			name: "invalid json format",
+			annotations: map[string]string{
+				"volcano.sh/card-request": `{"NVIDIA-GTX-4090": 2`,
+			},
+			key: "volcano.sh/card-request",
+			expected: &api.Resource{
+				MilliCPU:        0,
+				Memory:          0,
+				ScalarResources: map[v1.ResourceName]float64{},
+			},
+		},
+		{
+			name: "invalid json content - not a map",
+			annotations: map[string]string{
+				"volcano.sh/card-request": `["NVIDIA-GTX-4090"]`,
+			},
+			key: "volcano.sh/card-request",
+			expected: &api.Resource{
+				MilliCPU:        0,
+				Memory:          0,
+				ScalarResources: map[v1.ResourceName]float64{},
+			},
+		},
+		{
+			name: "zero card count",
+			annotations: map[string]string{
+				"volcano.sh/card-request": `{"NVIDIA-GTX-4090": 0}`,
+			},
+			key: "volcano.sh/card-request",
+			expected: &api.Resource{
+				ScalarResources: map[v1.ResourceName]float64{
+					"NVIDIA-GTX-4090": 0,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := GetCardResourceFromAnnotations("", tt.annotations, tt.key)
+
+			if result == nil {
+				t.Fatalf("expected non-nil result")
+			}
+
+			if result.ScalarResources == nil {
+				result.ScalarResources = map[v1.ResourceName]float64{}
+			}
+
+			if len(result.ScalarResources) != len(tt.expected.ScalarResources) {
+				t.Errorf("expected %d scalar resources, got %d",
+					len(tt.expected.ScalarResources), len(result.ScalarResources))
+			}
+
+			for name, expectedVal := range tt.expected.ScalarResources {
+				if actualVal, ok := result.ScalarResources[name]; !ok {
+					t.Errorf("expected scalar resource %s not found", name)
+				} else if actualVal != expectedVal {
+					t.Errorf("for scalar resource %s: expected %f, got %f",
+						name, expectedVal, actualVal)
+				}
+			}
+		})
+	}
+}
+
+// TestCheckSingleScalarResource tests the CheckSingleScalarResource function
+func TestCheckSingleScalarResource(t *testing.T) {
+	tests := []struct {
+		name             string
+		scalarName       v1.ResourceName
+		scalarQuant      float64
+		toBeUsedResource *api.Resource
+		queueCapability  *api.Resource
+		mode             CheckMode
+		expectedResult   CheckSingleScalarResourceResult
+	}{
+		{
+			name:        "task mode: sufficient single card resource",
+			scalarName:  "NVIDIA-GTX-4090",
+			scalarQuant: 2000,
+			toBeUsedResource: &api.Resource{
+				ScalarResources: map[v1.ResourceName]float64{
+					"NVIDIA-GTX-4090": 3000,
+				},
+			},
+			queueCapability: &api.Resource{
+				ScalarResources: map[v1.ResourceName]float64{
+					"NVIDIA-GTX-4090": 5000,
+				},
+			},
+			mode: CheckModeTask,
+			expectedResult: CheckSingleScalarResourceResult{
+				Ok:                   true,
+				ToBeUsedScalarQuant:  3000,
+				QueueCapabilityQuant: 5000,
+			},
+		},
+		{
+			name:        "task mode: insufficient single card resource",
+			scalarName:  "NVIDIA-GTX-4090",
+			scalarQuant: 2000,
+			toBeUsedResource: &api.Resource{
+				ScalarResources: map[v1.ResourceName]float64{
+					"NVIDIA-GTX-4090": 6000,
+				},
+			},
+			queueCapability: &api.Resource{
+				ScalarResources: map[v1.ResourceName]float64{
+					"NVIDIA-GTX-4090": 5000,
+				},
+			},
+			mode: CheckModeTask,
+			expectedResult: CheckSingleScalarResourceResult{
+				Ok:                   false,
+				NoEnoughScalarName:   "NVIDIA-GTX-4090",
+				NoEnoughScalarCount:  2000,
+				ToBeUsedScalarQuant:  6000,
+				QueueCapabilityQuant: 5000,
+			},
+		},
+		{
+			name:        "task mode: multi-card request with first card sufficient",
+			scalarName:  "NVIDIA-GTX-4090|NVIDIA-H200",
+			scalarQuant: 2000,
+			toBeUsedResource: &api.Resource{
+				ScalarResources: map[v1.ResourceName]float64{
+					"NVIDIA-GTX-4090|NVIDIA-H200": 2000,
+					"NVIDIA-GTX-4090":             3000,
+					"NVIDIA-H200":                 5000,
+				},
+			},
+			queueCapability: &api.Resource{
+				ScalarResources: map[v1.ResourceName]float64{
+					"NVIDIA-GTX-4090": 10000,
+					"NVIDIA-H200":     8000,
+				},
+			},
+			mode: CheckModeTask,
+			expectedResult: CheckSingleScalarResourceResult{
+				Ok:                   true,
+				ToBeUsedScalarQuant:  5000, // 3000 + 2000
+				QueueCapabilityQuant: 10000,
+			},
+		},
+		{
+			name:        "task mode: multi-card request with second card sufficient",
+			scalarName:  "NVIDIA-GTX-4090|NVIDIA-H200",
+			scalarQuant: 2000,
+			toBeUsedResource: &api.Resource{
+				ScalarResources: map[v1.ResourceName]float64{
+					"NVIDIA-GTX-4090|NVIDIA-H200": 2000,
+					"NVIDIA-GTX-4090":             9000,
+					"NVIDIA-H200":                 3000,
+				},
+			},
+			queueCapability: &api.Resource{
+				ScalarResources: map[v1.ResourceName]float64{
+					"NVIDIA-GTX-4090": 10000,
+					"NVIDIA-H200":     8000,
+				},
+			},
+			mode: CheckModeTask,
+			expectedResult: CheckSingleScalarResourceResult{
+				Ok:                   true,
+				ToBeUsedScalarQuant:  5000, // 3000 + 2000
+				QueueCapabilityQuant: 8000,
+			},
+		},
+		{
+			name:        "task mode: multi-card request with all cards insufficient",
+			scalarName:  "NVIDIA-GTX-4090|NVIDIA-H200",
+			scalarQuant: 2000,
+			toBeUsedResource: &api.Resource{
+				ScalarResources: map[v1.ResourceName]float64{
+					"NVIDIA-GTX-4090|NVIDIA-H200": 2000,
+					"NVIDIA-GTX-4090":             9000,
+					"NVIDIA-H200":                 7000,
+				},
+			},
+			queueCapability: &api.Resource{
+				ScalarResources: map[v1.ResourceName]float64{
+					"NVIDIA-GTX-4090": 10000,
+					"NVIDIA-H200":     8000,
+				},
+			},
+			mode: CheckModeTask,
+			expectedResult: CheckSingleScalarResourceResult{
+				Ok:                  false,
+				NoEnoughScalarName:  "NVIDIA-GTX-4090|NVIDIA-H200",
+				NoEnoughScalarCount: 2000,
+			},
+		},
+		{
+			name:        "task mode: zero scalar quantity request",
+			scalarName:  "NVIDIA-GTX-4090",
+			scalarQuant: 0,
+			toBeUsedResource: &api.Resource{
+				ScalarResources: map[v1.ResourceName]float64{
+					"NVIDIA-GTX-4090": 6000,
+				},
+			},
+			queueCapability: &api.Resource{
+				ScalarResources: map[v1.ResourceName]float64{
+					"NVIDIA-GTX-4090": 5000,
+				},
+			},
+			mode: CheckModeTask,
+			expectedResult: CheckSingleScalarResourceResult{
+				Ok:                   true,
+				ToBeUsedScalarQuant:  6000,
+				QueueCapabilityQuant: 5000,
+			},
+		},
+		{
+			name:        "task mode: resource not in toBeUsedResource",
+			scalarName:  "NVIDIA-H200",
+			scalarQuant: 2000,
+			toBeUsedResource: &api.Resource{
+				ScalarResources: map[v1.ResourceName]float64{},
+			},
+			queueCapability: &api.Resource{
+				ScalarResources: map[v1.ResourceName]float64{
+					"NVIDIA-H200": 5000,
+				},
+			},
+			mode: CheckModeTask,
+			expectedResult: CheckSingleScalarResourceResult{
+				Ok:                   true,
+				ToBeUsedScalarQuant:  0,
+				QueueCapabilityQuant: 5000,
+			},
+		},
+		{
+			name:        "task mode: resource not in queueCapability",
+			scalarName:  "NVIDIA-H200",
+			scalarQuant: 2000,
+			toBeUsedResource: &api.Resource{
+				ScalarResources: map[v1.ResourceName]float64{
+					"NVIDIA-H200": 3000,
+				},
+			},
+			queueCapability: &api.Resource{
+				ScalarResources: map[v1.ResourceName]float64{},
+			},
+			mode: CheckModeTask,
+			expectedResult: CheckSingleScalarResourceResult{
+				Ok:                   false,
+				NoEnoughScalarName:   "NVIDIA-H200",
+				NoEnoughScalarCount:  2000,
+				ToBeUsedScalarQuant:  3000,
+				QueueCapabilityQuant: 0,
+			},
+		},
+		{
+			name:        "task mode: boundary case - exactly at capacity",
+			scalarName:  "NVIDIA-GTX-4090",
+			scalarQuant: 2000,
+			toBeUsedResource: &api.Resource{
+				ScalarResources: map[v1.ResourceName]float64{
+					"NVIDIA-GTX-4090": 5000,
+				},
+			},
+			queueCapability: &api.Resource{
+				ScalarResources: map[v1.ResourceName]float64{
+					"NVIDIA-GTX-4090": 5000,
+				},
+			},
+			mode: CheckModeTask,
+			expectedResult: CheckSingleScalarResourceResult{
+				Ok:                   true,
+				ToBeUsedScalarQuant:  5000,
+				QueueCapabilityQuant: 5000,
+			},
+		},
+		{
+			name:        "task mode: boundary case - one unit over capacity",
+			scalarName:  "NVIDIA-GTX-4090",
+			scalarQuant: 1,
+			toBeUsedResource: &api.Resource{
+				ScalarResources: map[v1.ResourceName]float64{
+					"NVIDIA-GTX-4090": 5001,
+				},
+			},
+			queueCapability: &api.Resource{
+				ScalarResources: map[v1.ResourceName]float64{
+					"NVIDIA-GTX-4090": 5000,
+				},
+			},
+			mode: CheckModeTask,
+			expectedResult: CheckSingleScalarResourceResult{
+				Ok:                   false,
+				NoEnoughScalarName:   "NVIDIA-GTX-4090",
+				NoEnoughScalarCount:  1,
+				ToBeUsedScalarQuant:  5001,
+				QueueCapabilityQuant: 5000,
+			},
+		},
+		// Job mode tests - checking sum of multi-card quotas
+		{
+			name:        "job mode: multi-card request with sum of quotas sufficient",
+			scalarName:  "NVIDIA-GTX-4090|NVIDIA-H200",
+			scalarQuant: 2000,
+			toBeUsedResource: &api.Resource{
+				ScalarResources: map[v1.ResourceName]float64{
+					"NVIDIA-GTX-4090|NVIDIA-H200": 2000,
+					"NVIDIA-GTX-4090":             4000,
+					"NVIDIA-H200":                 3000,
+				},
+			},
+			queueCapability: &api.Resource{
+				ScalarResources: map[v1.ResourceName]float64{
+					"NVIDIA-GTX-4090": 5000,
+					"NVIDIA-H200":     4000,
+				},
+			},
+			mode: CheckModeJob,
+			expectedResult: CheckSingleScalarResourceResult{
+				Ok:                   true,
+				ToBeUsedScalarQuant:  9000, // 4000 + 3000 + 2000
+				QueueCapabilityQuant: 9000, // 5000 + 4000
+			},
+		},
+		{
+			name:        "job mode: multi-card request with sum of quotas insufficient",
+			scalarName:  "NVIDIA-GTX-4090|NVIDIA-H200",
+			scalarQuant: 3000,
+			toBeUsedResource: &api.Resource{
+				ScalarResources: map[v1.ResourceName]float64{
+					"NVIDIA-GTX-4090|NVIDIA-H200": 3000,
+					"NVIDIA-GTX-4090":             4000,
+					"NVIDIA-H200":                 3000,
+				},
+			},
+			queueCapability: &api.Resource{
+				ScalarResources: map[v1.ResourceName]float64{
+					"NVIDIA-GTX-4090": 5000,
+					"NVIDIA-H200":     4000,
+				},
+			},
+			mode: CheckModeJob,
+			expectedResult: CheckSingleScalarResourceResult{
+				Ok:                   false,
+				NoEnoughScalarName:   "NVIDIA-GTX-4090|NVIDIA-H200",
+				NoEnoughScalarCount:  3000,
+				ToBeUsedScalarQuant:  10000, // 4000 + 3000 + 3000
+				QueueCapabilityQuant: 9000,  // 5000 + 4000
+			},
+		},
+		{
+			name:        "job mode: multi-card request with one card at 0, sum sufficient",
+			scalarName:  "NVIDIA-GTX-4090|NVIDIA-H200",
+			scalarQuant: 2000,
+			toBeUsedResource: &api.Resource{
+				ScalarResources: map[v1.ResourceName]float64{
+					"NVIDIA-GTX-4090|NVIDIA-H200": 2000,
+					"NVIDIA-GTX-4090":             0,
+					"NVIDIA-H200":                 3000,
+				},
+			},
+			queueCapability: &api.Resource{
+				ScalarResources: map[v1.ResourceName]float64{
+					"NVIDIA-GTX-4090": 5000,
+					"NVIDIA-H200":     4000,
+				},
+			},
+			mode: CheckModeJob,
+			expectedResult: CheckSingleScalarResourceResult{
+				Ok:                   true,
+				ToBeUsedScalarQuant:  5000, // 0 + 3000 + 2000
+				QueueCapabilityQuant: 9000, // 5000 + 4000
+			},
+		},
+		{
+			name:        "job mode: multi-card request with three cards, sum sufficient",
+			scalarName:  "NVIDIA-A100|NVIDIA-H100|NVIDIA-H200",
+			scalarQuant: 2000,
+			toBeUsedResource: &api.Resource{
+				ScalarResources: map[v1.ResourceName]float64{
+					"NVIDIA-A100|NVIDIA-H100|NVIDIA-H200": 2000,
+					"NVIDIA-A100":                         3000,
+					"NVIDIA-H100":                         2000,
+					"NVIDIA-H200":                         1000,
+				},
+			},
+			queueCapability: &api.Resource{
+				ScalarResources: map[v1.ResourceName]float64{
+					"NVIDIA-A100": 4000,
+					"NVIDIA-H100": 3000,
+					"NVIDIA-H200": 2000,
+				},
+			},
+			mode: CheckModeJob,
+			expectedResult: CheckSingleScalarResourceResult{
+				Ok:                   true,
+				ToBeUsedScalarQuant:  8000, // 3000 + 2000 + 1000 + 2000
+				QueueCapabilityQuant: 9000, // 4000 + 3000 + 2000
+			},
+		},
+		{
+			name:        "job mode: multi-card request exactly at sum capacity",
+			scalarName:  "NVIDIA-GTX-4090|NVIDIA-H200",
+			scalarQuant: 2000,
+			toBeUsedResource: &api.Resource{
+				ScalarResources: map[v1.ResourceName]float64{
+					"NVIDIA-GTX-4090|NVIDIA-H200": 2000,
+					"NVIDIA-GTX-4090":             4000,
+					"NVIDIA-H200":                 3000,
+				},
+			},
+			queueCapability: &api.Resource{
+				ScalarResources: map[v1.ResourceName]float64{
+					"NVIDIA-GTX-4090": 5000,
+					"NVIDIA-H200":     4000,
+				},
+			},
+			mode: CheckModeJob,
+			expectedResult: CheckSingleScalarResourceResult{
+				Ok:                   true,
+				ToBeUsedScalarQuant:  9000, // 4000 + 3000 + 2000
+				QueueCapabilityQuant: 9000, // 5000 + 4000
+			},
+		},
+		{
+			name:        "job mode: single card (not multi-card)",
+			scalarName:  "NVIDIA-GTX-4090",
+			scalarQuant: 2000,
+			toBeUsedResource: &api.Resource{
+				ScalarResources: map[v1.ResourceName]float64{
+					"NVIDIA-GTX-4090": 3000,
+				},
+			},
+			queueCapability: &api.Resource{
+				ScalarResources: map[v1.ResourceName]float64{
+					"NVIDIA-GTX-4090": 5000,
+				},
+			},
+			mode: CheckModeJob,
+			expectedResult: CheckSingleScalarResourceResult{
+				Ok:                   true,
+				ToBeUsedScalarQuant:  3000,
+				QueueCapabilityQuant: 5000,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := CheckSingleScalarResource(
+				tt.scalarName,
+				tt.scalarQuant,
+				tt.toBeUsedResource,
+				tt.queueCapability,
+				tt.mode,
+			)
+
+			if result.Ok != tt.expectedResult.Ok {
+				t.Errorf("expected Ok=%v, got Ok=%v", tt.expectedResult.Ok, result.Ok)
+			}
+
+			if result.NoEnoughScalarName != tt.expectedResult.NoEnoughScalarName {
+				t.Errorf("expected NoEnoughScalarName=%s, got NoEnoughScalarName=%s",
+					tt.expectedResult.NoEnoughScalarName, result.NoEnoughScalarName)
+			}
+
+			if result.NoEnoughScalarCount != tt.expectedResult.NoEnoughScalarCount {
+				t.Errorf("expected NoEnoughScalarCount=%f, got NoEnoughScalarCount=%f",
+					tt.expectedResult.NoEnoughScalarCount, result.NoEnoughScalarCount)
+			}
+
+			if tt.expectedResult.ToBeUsedScalarQuant > 0 || tt.expectedResult.QueueCapabilityQuant > 0 {
+				if result.ToBeUsedScalarQuant != tt.expectedResult.ToBeUsedScalarQuant {
+					t.Errorf("expected ToBeUsedScalarQuant=%f, got ToBeUsedScalarQuant=%f",
+						tt.expectedResult.ToBeUsedScalarQuant, result.ToBeUsedScalarQuant)
+				}
+
+				if result.QueueCapabilityQuant != tt.expectedResult.QueueCapabilityQuant {
+					t.Errorf("expected QueueCapabilityQuant=%f, got QueueCapabilityQuant=%f",
+						tt.expectedResult.QueueCapabilityQuant, result.QueueCapabilityQuant)
+				}
+			}
+		})
+	}
+}

--- a/pkg/scheduler/plugins/factory.go
+++ b/pkg/scheduler/plugins/factory.go
@@ -24,6 +24,7 @@ import (
 	"volcano.sh/volcano/pkg/scheduler/framework"
 	"volcano.sh/volcano/pkg/scheduler/plugins/binpack"
 	"volcano.sh/volcano/pkg/scheduler/plugins/capacity"
+	capacitycard "volcano.sh/volcano/pkg/scheduler/plugins/capacity-card"
 	"volcano.sh/volcano/pkg/scheduler/plugins/cdp"
 	"volcano.sh/volcano/pkg/scheduler/plugins/conformance"
 	"volcano.sh/volcano/pkg/scheduler/plugins/deviceshare"
@@ -74,6 +75,7 @@ func init() {
 	// Plugins for Queues
 	framework.RegisterPluginBuilder(proportion.PluginName, proportion.New)
 	framework.RegisterPluginBuilder(capacity.PluginName, capacity.New)
+	framework.RegisterPluginBuilder(capacitycard.PluginName, capacitycard.New)
 
 	// Plugins for Extender
 	framework.RegisterPluginBuilder(extender.PluginName, extender.New)

--- a/test/e2e/capacitycard/README.md
+++ b/test/e2e/capacitycard/README.md
@@ -1,0 +1,97 @@
+# Capacity-Card Plugin Integration Tests
+
+This document describes the integration tests used to verify the functionality of the Volcano scheduler plugin `capacity-card`.
+
+## Test Structure
+
+The integration tests are located in the `/mnt/d/code/volcano/test/e2e/capacitycard/` directory and include the following files:
+
+- `main_test.go`: Test main function that initializes the test environment
+- `e2e_test.go`: Test suite registration function
+- `capacity_card_test.go`: Main test case implementation
+- `README.md`: Test documentation
+
+## Test Features
+
+The test cases cover the following core functionality:
+
+1. **Basic Queue Capacity Management Tests**
+   - Verify queue creation and status management with GPU card quota annotations
+
+2. **Job Enqueue Check - Success Cases**
+   - Test whether jobs with card resource requests can be enqueued normally
+   - Verify the relationship between queue card quotas and job card requests
+
+3. **Task Card Resource Allocation Tests**
+   - Verify task-level card name request functionality
+   - Test task scheduling with card name annotations
+
+4. **Card Resource Exceeding Quota Tests**
+   - Test scenarios where new job requests exceed remaining quota after the queue has already used partial card quota
+   - Verify the queue card resource quota limitation mechanism
+
+## How to Run Tests
+
+### Prerequisites
+
+- Kubernetes cluster is deployed
+- Volcano is installed
+- Scheduler configuration has enabled the capacity-card plugin
+- fake-gpu-operator Helm Chart is installed to simulate GPU card resources
+
+### Installing fake-gpu-operator
+
+Label nodes to specify which GPU card resource pool they belong to using the following command:
+
+<node-name> is the node name used to specify which node to label.
+<config> is the node labeling configuration used to specify which GPU card resource pool the node belongs to. Refer to the nodePools configuration in fake-gpu-operator/values.yaml.
+
+```bash
+kubectl label node <node-name> run.ai/simulated-gpu-node-pool=<config>
+```
+
+Before running tests, you need to install the fake-gpu-operator Helm Chart to simulate GPU card resources. You can install it using the following command:
+where `--version <VERSION>` is optional
+
+```bash
+helm upgrade -i gpu-operator oci://ghcr.io/run-ai/fake-gpu-operator/fake-gpu-operator --namespace gpu-operator --create-namespace --version <VERSION> -f ../hack/fake-gpu-operator-values.yaml
+```
+
+### Run Commands
+
+According to the project's Makefile structure, the correct run command is as follows:
+
+```bash
+cd /mnt/d/code/volcano
+E2E_TYPE=CAPACITYCARD ./hack/run-e2e-kind.sh
+```
+
+Or you can build the image first and then run:
+
+```bash
+cd /mnt/d/code/volcano
+make images
+E2E_TYPE=CAPACITYCARD ./hack/run-e2e-kind.sh
+```
+
+## Test Description
+
+The tests use the Ginkgo and Gomega testing frameworks, following the standard structure of Volcano E2E tests:
+
+1. Each test case creates an independent test namespace
+2. Tests create queues with card quota annotations
+3. Create jobs containing card resource requests
+4. Verify that jobs are created and managed correctly
+5. Clean up all created resources after test completion
+
+## Test Annotation Description
+
+- `volcano.sh/card.quota`: Queue-level card resource quota, represented in JSON format
+- `volcano.sh/card.request`: Job-level card resource request, represented in JSON format
+- `volcano.sh/card.name`: Task-level card name request
+
+## Notes
+
+- The test environment needs to support GPU resources, especially the `nvidia.com/gpu` resource type
+- Ensure the capacity-card plugin is enabled in the scheduler configuration
+- Tests will create and delete resources during execution, please run in a test environment

--- a/test/e2e/capacitycard/README_ZH.md
+++ b/test/e2e/capacitycard/README_ZH.md
@@ -1,0 +1,96 @@
+# Capacity-Card 插件集成测试
+
+本文档介绍了用于验证 Volcano 调度插件 `capacity-card` 功能的集成测试。
+
+## 测试结构
+
+集成测试位于 `/mnt/d/code/volcano/test/e2e/capacitycard/` 目录下，包含以下文件：
+
+- `main_test.go`: 测试主函数，初始化测试环境
+- `e2e_test.go`: 测试套件注册函数
+- `capacity_card_test.go`: 主要测试用例实现
+- `README.md`: 测试文档说明
+
+## 测试功能
+
+测试用例涵盖以下核心功能：
+
+1. **基本队列容量管理测试**
+   - 验证带有 GPU 卡片配额注解的队列创建和状态管理
+
+2. **作业入队性检查 - 成功案例**
+   - 测试带有卡片资源请求的作业能否正常入队
+   - 验证队列卡片配额与作业卡片请求的关系
+
+3. **任务卡片资源分配测试**
+   - 验证任务级别的卡片名称请求功能
+   - 测试带有卡片名称注解的任务调度
+
+4. **卡片资源超出配额测试**
+   - 测试当队列内已使用部分卡片配额后，新作业请求超出剩余配额的场景
+   - 验证队列卡片资源配额的限制机制
+
+## 如何运行测试
+
+### 前置条件
+
+- Kubernetes 集群已部署
+- Volcano 已安装
+- 调度器配置已启用 capacity-card 插件
+- 已安装 fake-gpu-operator Helm Chart 来模拟 GPU 卡片资源
+
+### 安装 fake-gpu-operator
+
+通过以下命令为节点打标，指定节点所属的 GPU 卡片资源池：
+
+<node-name> 为节点名称，用于指定要打标的节点。
+<config> 为节点打标配置，用于指定节点所属的 GPU 卡片资源池，参考 fake-gpu-operator/values.yaml 中的 nodePools 配置。
+
+```bash
+kubectl label node <node-name> run.ai/simulated-gpu-node-pool=<config>
+```
+
+在运行测试之前，需要先安装 fake-gpu-operator Helm Chart 来模拟 GPU 卡片资源。可以使用以下命令安装：
+其中 `--version <VERSION>` 为可选项
+
+```bash
+helm upgrade -i gpu-operator oci://ghcr.io/run-ai/fake-gpu-operator/fake-gpu-operator --namespace gpu-operator --create-namespace --version <VERSION> -f ../hack/fake-gpu-operator-values.yaml
+```
+
+### 运行命令
+
+根据项目的Makefile结构，正确的运行命令如下：
+
+```bash
+cd /mnt/d/code/volcano
+E2E_TYPE=CAPACITYCARD ./hack/run-e2e-kind.sh
+```
+
+或者可以构建镜像后运行：
+
+```bash
+cd /mnt/d/code/volcano
+make images
+E2E_TYPE=CAPACITYCARD ./hack/run-e2e-kind.sh
+```
+## 测试说明
+
+测试使用 Ginkgo 和 Gomega 测试框架，遵循 Volcano E2E 测试的标准结构：
+
+1. 每个测试用例都会创建独立的测试命名空间
+2. 测试会创建带有卡片配额注解的队列
+3. 创建包含卡片资源请求的作业
+4. 验证作业是否正确创建和管理
+5. 测试结束后会清理所有创建的资源
+
+## 测试注解说明
+
+- `volcano.sh/card.quota`: 队列级别的卡片资源配额，以 JSON 格式表示
+- `volcano.sh/card.request`: 作业级别的卡片资源请求，以 JSON 格式表示
+- `volcano.sh/card.name`: 任务级别的卡片名称请求
+
+## 注意事项
+
+- 测试环境需要支持 GPU 资源，特别是 `nvidia.com/gpu` 资源类型
+- 确保调度器配置中启用了 capacity-card 插件
+- 测试运行过程中会创建和删除资源，请在测试环境中执行

--- a/test/e2e/capacitycard/capacity_card_test.go
+++ b/test/e2e/capacitycard/capacity_card_test.go
@@ -1,0 +1,2236 @@
+/*
+Copyright 2025 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package capacitycard
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"math/rand"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	batchv1alpha1 "volcano.sh/apis/pkg/apis/batch/v1alpha1"
+	schedulingv1beta1 "volcano.sh/apis/pkg/apis/scheduling/v1beta1"
+	e2eutil "volcano.sh/volcano/test/e2e/util"
+)
+
+// Generate a random suffix to ensure resource name uniqueness
+func generateRandomSuffix() string {
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	return fmt.Sprintf("%d", r.Intn(10000))
+}
+
+// Global constant definitions
+const (
+	// Actual card types in the cluster
+	CardTypeTeslaK80 = "Tesla-K80"
+	CardTypeRTX4090  = "NVIDIA-GeForce-RTX-4090"
+	CardTypeH800     = "NVIDIA-H800"
+	// Polling configuration
+	PollInterval       = 500 * time.Millisecond
+	QueueReadyTimeout  = 30 * time.Second
+	JobProcessTimeout  = 60 * time.Second
+	CleanupGracePeriod = 10 * time.Second
+)
+
+// Initialize random number generator
+var _ = BeforeSuite(func() {
+	rand.Seed(time.Now().UnixNano())
+})
+
+var _ = Describe("Capacity Card E2E Test", func() {
+	Context("Capacity Card - Basic", func() {
+		// Test 1: Basic queue capacity management test
+		It("Queue Capacity Management", func() {
+			randomSuffix := generateRandomSuffix()
+			fmt.Printf("Test 1: Generated random suffix %s\n", randomSuffix)
+			ctx := e2eutil.InitTestContext(e2eutil.Options{
+				Namespace: fmt.Sprintf("capacity-card-test-1-%s", randomSuffix),
+			})
+			fmt.Printf("Test 1: Test context initialized, namespace %s\n", ctx.Namespace)
+			defer e2eutil.CleanupTestContext(ctx)
+
+			// Create queue with card quota
+			queueSpec := &e2eutil.QueueSpec{
+				Name:   fmt.Sprintf("capacity-test-queue-%s", randomSuffix),
+				Weight: 10,
+				Capacity: v1.ResourceList{
+					v1.ResourceCPU:    resource.MustParse("2"),
+					v1.ResourceMemory: resource.MustParse("2Gi"),
+				},
+				Annotations: map[string]string{
+					"volcano.sh/card.quota": fmt.Sprintf(`{"%s": 4}`, CardTypeTeslaK80),
+				},
+			}
+
+			// Create queue using e2eutil function
+			fmt.Printf("Test 1: Starting to create queue %s\n", queueSpec.Name)
+			e2eutil.CreateQueueWithQueueSpec(ctx, queueSpec)
+			fmt.Printf("Test 1: Queue %s created successfully, %s card quota is 4\n", queueSpec.Name, CardTypeTeslaK80)
+
+			// Clean up queue using e2eutil
+			defer func() {
+				e2eutil.DeleteQueue(ctx, queueSpec.Name)
+				fmt.Printf("Test 1: Queue %s cleaned up\n", queueSpec.Name)
+			}()
+
+			// Wait for queue status to become open
+			fmt.Printf("Test 1: Waiting for queue %s status to become open\n", queueSpec.Name)
+			queueOpenErr := e2eutil.WaitQueueStatus(func() (bool, error) {
+				queue, err := ctx.Vcclient.SchedulingV1beta1().Queues().Get(context.TODO(), queueSpec.Name, metav1.GetOptions{})
+				if err != nil {
+					return false, err
+				}
+				return queue.Status.State == schedulingv1beta1.QueueStateOpen, nil
+			})
+			Expect(queueOpenErr).NotTo(HaveOccurred(), "Queue failed to become open within timeout")
+			fmt.Printf("Test 1: Queue %s status is now open\n", queueSpec.Name)
+		})
+	})
+
+	Context("Capacity Card - VCJob", func() {
+		// Test 2: Job enqueueable check - success case
+		It("Job Enqueueable Check - Success", func() {
+			randomSuffix := generateRandomSuffix()
+			fmt.Printf("Test 2: Generated random suffix %s\n", randomSuffix)
+			ctx := e2eutil.InitTestContext(e2eutil.Options{
+				Namespace: fmt.Sprintf("capacity-card-test-2-%s", randomSuffix),
+			})
+			fmt.Printf("Test 2: Test context initialized, namespace %s\n", ctx.Namespace)
+			defer e2eutil.CleanupTestContext(ctx)
+
+			// Create queue with card quota
+			queueSpec := &e2eutil.QueueSpec{
+				Name:   fmt.Sprintf("enqueue-test-queue-%s", randomSuffix),
+				Weight: 10,
+				Capacity: v1.ResourceList{
+					v1.ResourceCPU:    resource.MustParse("8"),
+					v1.ResourceMemory: resource.MustParse("8Gi"),
+				},
+				Annotations: map[string]string{
+					"volcano.sh/card.quota": fmt.Sprintf(`{"%s": 4}`, CardTypeTeslaK80),
+				},
+			}
+
+			// Create queue using e2eutil function
+			fmt.Printf("Test 2: Starting to create queue %s\n", queueSpec.Name)
+			e2eutil.CreateQueueWithQueueSpec(ctx, queueSpec)
+			fmt.Printf("Test 2: Queue %s created successfully\n", queueSpec.Name)
+
+			// Clean up queue using e2eutil
+			defer func() {
+				e2eutil.DeleteQueue(ctx, queueSpec.Name)
+				fmt.Printf("Test 2: Queue %s cleaned up\n", queueSpec.Name)
+			}()
+
+			// Wait for queue status to become open
+			fmt.Printf("Test 2: Waiting for queue %s status to become open\n", queueSpec.Name)
+			queueOpenErr := e2eutil.WaitQueueStatus(func() (bool, error) {
+				queue, err := ctx.Vcclient.SchedulingV1beta1().Queues().Get(context.TODO(), queueSpec.Name, metav1.GetOptions{})
+				if err != nil {
+					return false, err
+				}
+				return queue.Status.State == schedulingv1beta1.QueueStateOpen, nil
+			})
+			Expect(queueOpenErr).NotTo(HaveOccurred(), "Queue failed to become open within timeout")
+			fmt.Printf("Test 2: Queue %s status is now open\n", queueSpec.Name)
+
+			// Create a job with card request
+			jobSpec := &e2eutil.JobSpec{
+				Name:  fmt.Sprintf("enqueue-success-job-%s", randomSuffix),
+				Queue: queueSpec.Name,
+				Tasks: []e2eutil.TaskSpec{
+					{
+						Name: "task",
+						Min:  1,
+						Rep:  2,
+						Img:  e2eutil.DefaultNginxImage,
+						Req: v1.ResourceList{
+							v1.ResourceCPU:                    resource.MustParse("1"),
+							v1.ResourceMemory:                 resource.MustParse("1Gi"),
+							v1.ResourceName("nvidia.com/gpu"): resource.MustParse("2"),
+						},
+						Limit: v1.ResourceList{
+							v1.ResourceCPU:                    resource.MustParse("1"),
+							v1.ResourceMemory:                 resource.MustParse("1Gi"),
+							v1.ResourceName("nvidia.com/gpu"): resource.MustParse("2"),
+						},
+					},
+				},
+			}
+
+			// Add job card request annotation to JobSpec
+			jobSpec.Annotations = map[string]string{
+				"volcano.sh/card.request": fmt.Sprintf(`{"%s": 2}`, CardTypeTeslaK80),
+			}
+
+			// Create job directly
+			fmt.Printf("Test 2: Starting to create job %s\n", jobSpec.Name)
+			job := e2eutil.CreateJob(ctx, jobSpec)
+			fmt.Printf("Test 2: Job %s created successfully\n", job.Name)
+
+			// Clean up resources
+			defer func() {
+				// Delete job
+				e2eutil.DeleteJob(ctx, job)
+				fmt.Printf("Test 2: Job %s cleaned up\n", job.Name)
+			}()
+
+			// Wait for job to be ready
+			fmt.Printf("Test 2: Waiting for job to be ready\n")
+			err := e2eutil.WaitJobReady(ctx, job)
+			Expect(err).NotTo(HaveOccurred(), "Job failed to become ready within timeout")
+			fmt.Printf("Test 2: Job %s is now ready\n", job.Name)
+		})
+
+		// Test 3: Task card resource allocation test
+		It("Task Card Resource Allocation", func() {
+			randomSuffix := generateRandomSuffix()
+			fmt.Printf("Test 3: Generated random suffix %s\n", randomSuffix)
+			ctx := e2eutil.InitTestContext(e2eutil.Options{
+				Namespace: fmt.Sprintf("capacity-card-test-3-%s", randomSuffix),
+			})
+			fmt.Printf("Test 3: Test context initialized, namespace %s created successfully\n", ctx.Namespace)
+			defer e2eutil.CleanupTestContext(ctx)
+
+			// Create queue with card quota
+			queueSpec := &e2eutil.QueueSpec{
+				Name:   fmt.Sprintf("allocation-test-queue-%s", randomSuffix),
+				Weight: 10,
+				Capacity: v1.ResourceList{
+					v1.ResourceCPU:    resource.MustParse("2"),
+					v1.ResourceMemory: resource.MustParse("2Gi"),
+				},
+				Annotations: map[string]string{
+					"volcano.sh/card.quota": fmt.Sprintf(`{"%s": 4}`, CardTypeTeslaK80),
+				},
+			}
+
+			// Create queue using e2eutil function
+			fmt.Printf("Test 3: Starting to create queue %s\n", queueSpec.Name)
+			e2eutil.CreateQueueWithQueueSpec(ctx, queueSpec)
+			fmt.Printf("Test 3: Queue %s created successfully\n", queueSpec.Name)
+
+			defer func() {
+				// Clean up queue using e2eutil
+				e2eutil.DeleteQueue(ctx, queueSpec.Name)
+				fmt.Printf("Test 3: Queue %s cleaned up\n", queueSpec.Name)
+			}()
+
+			// Wait for queue status to become open
+			fmt.Printf("Test 3: Waiting for queue %s status to become open\n", queueSpec.Name)
+			queueOpenErr := e2eutil.WaitQueueStatus(func() (bool, error) {
+				queue, err := ctx.Vcclient.SchedulingV1beta1().Queues().Get(context.TODO(), queueSpec.Name, metav1.GetOptions{})
+				if err != nil {
+					return false, err
+				}
+				return queue.Status.State == schedulingv1beta1.QueueStateOpen, nil
+			})
+			Expect(queueOpenErr).NotTo(HaveOccurred(), "Queue failed to become open within timeout")
+			fmt.Printf("Test 3: Queue %s status is now open\n", queueSpec.Name)
+
+			// Create a job with task-level card name request, set card name annotation to TaskSpec
+			taskSpecs := []e2eutil.TaskSpec{
+				{
+					Name: "card-task",
+					Min:  1,
+					Rep:  1,
+					Img:  e2eutil.DefaultNginxImage,
+					Req: v1.ResourceList{
+						v1.ResourceCPU:                    resource.MustParse("1"),
+						v1.ResourceMemory:                 resource.MustParse("1Gi"),
+						v1.ResourceName("nvidia.com/gpu"): resource.MustParse("1"),
+					},
+					Limit: v1.ResourceList{
+						v1.ResourceCPU:                    resource.MustParse("1"),
+						v1.ResourceMemory:                 resource.MustParse("1Gi"),
+						v1.ResourceName("nvidia.com/gpu"): resource.MustParse("1"),
+					},
+					Labels: map[string]string{"card-test": "true"},
+					Annotations: map[string]string{
+						"volcano.sh/card.name": CardTypeTeslaK80,
+					},
+				},
+			}
+
+			jobSpec := &e2eutil.JobSpec{
+				Name:  fmt.Sprintf("task-card-test-job-%s", randomSuffix),
+				Queue: queueSpec.Name,
+				Tasks: taskSpecs,
+			}
+
+			// Create job directly
+			fmt.Printf("Test 3: Starting to create job %s\n", jobSpec.Name)
+			job := e2eutil.CreateJob(ctx, jobSpec)
+			fmt.Printf("Test 3: Job %s created successfully\n", job.Name)
+
+			// Clean up resources
+			defer func() {
+				// Delete job
+				e2eutil.DeleteJob(ctx, job)
+				fmt.Printf("Test 3: Job %s cleaned up\n", job.Name)
+			}()
+
+			// Wait for job to be ready
+			fmt.Printf("Test 3: Waiting for job to be ready\n")
+			err := e2eutil.WaitJobReady(ctx, job)
+			Expect(err).NotTo(HaveOccurred(), "Job failed to become ready within timeout")
+			fmt.Printf("Test 3: Job %s is now ready\n", job.Name)
+		})
+
+		// Test 4: Card resource quota exceeded test
+		It("Card Resource Quota Exceeded", func() {
+			randomSuffix := generateRandomSuffix()
+			fmt.Printf("Test 4: Generated random suffix %s\n", randomSuffix)
+			ctx := e2eutil.InitTestContext(e2eutil.Options{
+				Namespace: fmt.Sprintf("capacity-card-test-4-%s", randomSuffix),
+			})
+			fmt.Printf("Test 4: Test context initialized, namespace %s created successfully\n", ctx.Namespace)
+			defer e2eutil.CleanupTestContext(ctx)
+
+			// Create queue with limited card quota
+			queueSpec := &e2eutil.QueueSpec{
+				Name:   fmt.Sprintf("quota-limit-queue-%s", randomSuffix),
+				Weight: 10,
+				Capacity: v1.ResourceList{
+					v1.ResourceCPU:    resource.MustParse("4"),
+					v1.ResourceMemory: resource.MustParse("4Gi"),
+				},
+				Annotations: map[string]string{
+					"volcano.sh/card.quota": fmt.Sprintf(`{"%s": 2}`, CardTypeTeslaK80),
+				},
+			}
+
+			// Create queue using e2eutil function
+			fmt.Printf("Test 4: Starting to create queue %s\n", queueSpec.Name)
+			e2eutil.CreateQueueWithQueueSpec(ctx, queueSpec)
+			fmt.Printf("Test 4: Queue %s created successfully, %s card quota is 2\n", queueSpec.Name, CardTypeTeslaK80)
+
+			defer func() {
+				// Clean up queue using e2eutil
+				e2eutil.DeleteQueue(ctx, queueSpec.Name)
+				fmt.Printf("Test 4: Queue %s cleaned up\n", queueSpec.Name)
+			}()
+
+			// Wait for queue status to become open
+			fmt.Printf("Test 4: Waiting for queue %s status to become open\n", queueSpec.Name)
+			queueOpenErr := e2eutil.WaitQueueStatus(func() (bool, error) {
+				queue, err := ctx.Vcclient.SchedulingV1beta1().Queues().Get(context.TODO(), queueSpec.Name, metav1.GetOptions{})
+				if err != nil {
+					return false, err
+				}
+				return queue.Status.State == schedulingv1beta1.QueueStateOpen, nil
+			})
+			Expect(queueOpenErr).NotTo(HaveOccurred(), "Queue failed to become open within timeout")
+			fmt.Printf("Test 4: Queue %s status is now open\n", queueSpec.Name)
+
+			// Create first job, using part of card quota
+			job1Spec := &e2eutil.JobSpec{
+				Name:  fmt.Sprintf("first-quota-job-%s", randomSuffix),
+				Queue: queueSpec.Name,
+				Tasks: []e2eutil.TaskSpec{
+					{
+						Name: "task",
+						Min:  1,
+						Rep:  1,
+						Img:  e2eutil.DefaultNginxImage,
+						Req: v1.ResourceList{
+							v1.ResourceCPU:                    resource.MustParse("1"),
+							v1.ResourceMemory:                 resource.MustParse("1Gi"),
+							v1.ResourceName("nvidia.com/gpu"): resource.MustParse("1"),
+						},
+						Limit: v1.ResourceList{
+							v1.ResourceCPU:                    resource.MustParse("1"),
+							v1.ResourceMemory:                 resource.MustParse("1Gi"),
+							v1.ResourceName("nvidia.com/gpu"): resource.MustParse("1"),
+						},
+						Annotations: map[string]string{
+							"volcano.sh/card.name": CardTypeTeslaK80,
+						},
+					},
+				},
+				Annotations: map[string]string{
+					"volcano.sh/card.request": fmt.Sprintf(`{"%s": 1}`, CardTypeTeslaK80),
+				},
+			}
+
+			fmt.Printf("Test 4: Starting to create first job %s\n", job1Spec.Name)
+			job1 := e2eutil.CreateJob(ctx, job1Spec)
+			fmt.Printf("Test 4: Job 1 %s created successfully, requesting %s card resource as 1\n", job1.Name, CardTypeTeslaK80)
+			fmt.Printf("Test 4: Job 1 %s validated successfully\n", job1.Name)
+
+			defer func() {
+				// Delete job
+				e2eutil.DeleteJob(ctx, job1)
+				fmt.Printf("Test 4: Job 1 %s cleaned up\n", job1.Name)
+			}()
+
+			// Create second job, using remaining card quota
+			job2Spec := &e2eutil.JobSpec{
+				Name:  fmt.Sprintf("second-quota-job-%s", randomSuffix),
+				Queue: queueSpec.Name,
+				Tasks: []e2eutil.TaskSpec{
+					{
+						Name: "task",
+						Min:  1,
+						Rep:  1,
+						Img:  e2eutil.DefaultNginxImage,
+						Req: v1.ResourceList{
+							v1.ResourceCPU:                    resource.MustParse("1"),
+							v1.ResourceMemory:                 resource.MustParse("1Gi"),
+							v1.ResourceName("nvidia.com/gpu"): resource.MustParse("1"),
+						},
+						Limit: v1.ResourceList{
+							v1.ResourceCPU:                    resource.MustParse("1"),
+							v1.ResourceMemory:                 resource.MustParse("1Gi"),
+							v1.ResourceName("nvidia.com/gpu"): resource.MustParse("1"),
+						},
+						Annotations: map[string]string{
+							"volcano.sh/card.name": CardTypeTeslaK80,
+						},
+					},
+				},
+				Annotations: map[string]string{
+					"volcano.sh/card.request": fmt.Sprintf(`{"%s": 1}`, CardTypeTeslaK80),
+				},
+			}
+
+			fmt.Printf("Test 4: Starting to create second job %s\n", job2Spec.Name)
+			job2 := e2eutil.CreateJob(ctx, job2Spec)
+			fmt.Printf("Test 4: Job 2 %s created successfully, requesting %s card resource as 1\n", job2.Name, CardTypeTeslaK80)
+			fmt.Printf("Test 4: Job 2 %s validated successfully\n", job2.Name)
+
+			defer func() {
+				// Delete job
+				e2eutil.DeleteJob(ctx, job2)
+				fmt.Printf("Test 4: Job 2 %s cleaned up\n", job2.Name)
+			}()
+
+			// Create third job, attempting to use card resource exceeding remaining quota
+			job3Spec := &e2eutil.JobSpec{
+				Name:  fmt.Sprintf("third-quota-job-%s", randomSuffix),
+				Queue: queueSpec.Name,
+				Tasks: []e2eutil.TaskSpec{
+					{
+						Name: "task",
+						Min:  1,
+						Rep:  2,
+						Img:  e2eutil.DefaultNginxImage,
+						Req: v1.ResourceList{
+							v1.ResourceCPU:                    resource.MustParse("1"),
+							v1.ResourceMemory:                 resource.MustParse("1Gi"),
+							v1.ResourceName("nvidia.com/gpu"): resource.MustParse("1"),
+						},
+						Limit: v1.ResourceList{
+							v1.ResourceCPU:                    resource.MustParse("1"),
+							v1.ResourceMemory:                 resource.MustParse("1Gi"),
+							v1.ResourceName("nvidia.com/gpu"): resource.MustParse("1"),
+						},
+						Annotations: map[string]string{
+							"volcano.sh/card.name": CardTypeTeslaK80,
+						},
+					},
+				},
+				Annotations: map[string]string{
+					"volcano.sh/card.request": fmt.Sprintf(`{"%s": 1}`, CardTypeTeslaK80), // Exceeds remaining queue quota
+				},
+			}
+
+			fmt.Printf("Test 4: Starting to create third job %s\n", job3Spec.Name)
+			job3 := e2eutil.CreateJob(ctx, job3Spec)
+			fmt.Printf("Test 4: Job 3 %s created successfully, requesting %s card resource as 3 (exceeding remaining quota)\n", job3.Name, CardTypeTeslaK80)
+			fmt.Printf("Test 4: Job 3 %s validated successfully\n", job3.Name)
+
+			defer func() {
+				// Delete job
+				e2eutil.DeleteJob(ctx, job3)
+				fmt.Printf("Test 4: Job 3 %s cleaned up\n", job3.Name)
+			}()
+
+			// Wait for job 1 to be ready (job 1 should run successfully as it doesn't exceed quota)
+			fmt.Printf("Test 4: Waiting for job 1 to be ready\n")
+			err := e2eutil.WaitJobReady(ctx, job1)
+			Expect(err).NotTo(HaveOccurred(), "Job 1 failed to become ready within timeout")
+			fmt.Printf("Test 4: Job 1 %s is now ready\n", job1.Name)
+
+			// Wait for job 2 to be ready (job 2 should run successfully as it doesn't exceed quota)
+			fmt.Printf("Test 4: Waiting for job 2 to be ready\n")
+			err = e2eutil.WaitJobReady(ctx, job2)
+			Expect(err).NotTo(HaveOccurred(), "Job 2 failed to become ready within timeout")
+			fmt.Printf("Test 4: Job 2 %s is now ready\n", job2.Name)
+
+			// For job 3 (exceeding quota), wait for some time then check status
+			fmt.Printf("Test 4: Waiting for some time to check job 3 status (expected to not be fully ready due to insufficient quota)\n")
+			time.Sleep(JobProcessTimeout / 2)
+			e2eutil.CheckJobSchedulingFailed(ctx, job3)
+		})
+
+		// Test 5: RTX4090 card queue capacity management test
+		It("RTX4090 Card Queue Capacity Management", func() {
+			randomSuffix := generateRandomSuffix()
+			fmt.Printf("Test 5: Generated random suffix %s\n", randomSuffix)
+			ctx := e2eutil.InitTestContext(e2eutil.Options{
+				Namespace: fmt.Sprintf("rtx4090-card-test-%s", randomSuffix),
+			})
+			fmt.Printf("Test 5: Test context initialized, namespace %s\n", ctx.Namespace)
+			defer e2eutil.CleanupTestContext(ctx)
+
+			// Create queue with RTX4090 card quota
+			queueSpec := &e2eutil.QueueSpec{
+				Name:   fmt.Sprintf("rtx4090-test-queue-%s", randomSuffix),
+				Weight: 10,
+				Capacity: v1.ResourceList{
+					v1.ResourceCPU:    resource.MustParse("2"),
+					v1.ResourceMemory: resource.MustParse("2Gi"),
+				},
+				Annotations: map[string]string{
+					"volcano.sh/card.quota": fmt.Sprintf(`{"%s": 4}`, CardTypeRTX4090),
+				},
+			}
+
+			// Create queue using e2eutil function
+			fmt.Printf("Test 5: Starting to create queue %s\n", queueSpec.Name)
+			e2eutil.CreateQueueWithQueueSpec(ctx, queueSpec)
+			fmt.Printf("Test 5: Queue %s created successfully, %s card quota is 4\n", queueSpec.Name, CardTypeRTX4090)
+
+			defer func() {
+				// Delete queue using e2eutil
+				fmt.Printf("Test 5: Cleaning up queue %s\n", queueSpec.Name)
+				e2eutil.DeleteQueue(ctx, queueSpec.Name)
+			}()
+
+			// Wait for queue status to become open
+			fmt.Printf("Test 5: Waiting for queue %s status to become open\n", queueSpec.Name)
+			queueOpenErr := e2eutil.WaitQueueStatus(func() (bool, error) {
+				queue, err := ctx.Vcclient.SchedulingV1beta1().Queues().Get(context.TODO(), queueSpec.Name, metav1.GetOptions{})
+				if err != nil {
+					return false, err
+				}
+				return queue.Status.State == schedulingv1beta1.QueueStateOpen, nil
+			})
+			Expect(queueOpenErr).NotTo(HaveOccurred(), "Queue failed to become open within timeout")
+			fmt.Printf("Test 5: Queue %s status is now open\n", queueSpec.Name)
+		})
+
+		// Test 6: H800 card queue capacity management test
+		It("H800 Card Queue Capacity Management", func() {
+			randomSuffix := generateRandomSuffix()
+			fmt.Printf("Test 6: Generated random suffix %s\n", randomSuffix)
+			ctx := e2eutil.InitTestContext(e2eutil.Options{
+				Namespace: fmt.Sprintf("h800-card-test-%s", randomSuffix),
+			})
+			fmt.Printf("Test 6: Test context initialized, namespace %s\n", ctx.Namespace)
+			defer e2eutil.CleanupTestContext(ctx)
+
+			// Create queue with H800 card quota
+			queueSpec := &e2eutil.QueueSpec{
+				Name:   fmt.Sprintf("h800-test-queue-%s", randomSuffix),
+				Weight: 10,
+				Capacity: v1.ResourceList{
+					v1.ResourceCPU:    resource.MustParse("2"),
+					v1.ResourceMemory: resource.MustParse("2Gi"),
+				},
+				Annotations: map[string]string{
+					"volcano.sh/card.quota": fmt.Sprintf(`{"%s": 4}`, CardTypeH800),
+				},
+			}
+
+			// Create queue using e2eutil function
+			fmt.Printf("Test 6: Starting to create queue %s\n", queueSpec.Name)
+			e2eutil.CreateQueueWithQueueSpec(ctx, queueSpec)
+			fmt.Printf("Test 6: Queue %s created successfully, %s card quota is 4\n", queueSpec.Name, CardTypeH800)
+
+			defer func() {
+				// Delete queue using e2eutil
+				fmt.Printf("Test 6: Cleaning up queue %s\n", queueSpec.Name)
+				e2eutil.DeleteQueue(ctx, queueSpec.Name)
+			}()
+
+			// Wait for queue status to become open
+			fmt.Printf("Test 6: Waiting for queue %s status to become open\n", queueSpec.Name)
+			queueOpenErr := e2eutil.WaitQueueStatus(func() (bool, error) {
+				queue, err := ctx.Vcclient.SchedulingV1beta1().Queues().Get(context.TODO(), queueSpec.Name, metav1.GetOptions{})
+				if err != nil {
+					return false, err
+				}
+				return queue.Status.State == schedulingv1beta1.QueueStateOpen, nil
+			})
+			Expect(queueOpenErr).NotTo(HaveOccurred(), "Queue failed to become open within timeout")
+			fmt.Printf("Test 6: Queue %s status is now open\n", queueSpec.Name)
+		})
+
+		// Test 7: Multiple card types mixed quota test
+		It("Multiple Card Types Mixed Quota Test", func() {
+			randomSuffix := generateRandomSuffix()
+			fmt.Printf("Test 7: Generated random suffix %s\n", randomSuffix)
+			ctx := e2eutil.InitTestContext(e2eutil.Options{
+				Namespace: fmt.Sprintf("multi-card-test-%s", randomSuffix),
+			})
+			fmt.Printf("Test 7: Test context initialized, namespace %s\n", ctx.Namespace)
+			defer e2eutil.CleanupTestContext(ctx)
+
+			// Create queue with multiple card quotas
+			queueSpec := &e2eutil.QueueSpec{
+				Name:   fmt.Sprintf("multi-card-queue-%s", randomSuffix),
+				Weight: 10,
+				Capacity: v1.ResourceList{
+					v1.ResourceCPU:    resource.MustParse("4"),
+					v1.ResourceMemory: resource.MustParse("4Gi"),
+				},
+				Annotations: map[string]string{
+					"volcano.sh/card.quota": fmt.Sprintf(`{"%s": 2, "%s": 2, "%s": 2}`,
+						CardTypeTeslaK80, CardTypeRTX4090, CardTypeH800),
+				},
+			}
+
+			// Create queue using e2eutil function
+			fmt.Printf("Test 7: Starting to create queue %s\n", queueSpec.Name)
+			e2eutil.CreateQueueWithQueueSpec(ctx, queueSpec)
+			fmt.Printf("Test 7: Queue %s created successfully, mixed card quota configured: %s:2, %s:2, %s:2\n",
+				queueSpec.Name, CardTypeTeslaK80, CardTypeRTX4090, CardTypeH800)
+
+			defer func() {
+				// Delete queue using e2eutil
+				fmt.Printf("Test 7: Cleaning up queue %s\n", queueSpec.Name)
+				e2eutil.DeleteQueue(ctx, queueSpec.Name)
+			}()
+
+			// Wait for queue status to become open
+			fmt.Printf("Test 7: Waiting for queue %s status to become open\n", queueSpec.Name)
+			queueOpenErr := e2eutil.WaitQueueStatus(func() (bool, error) {
+				queue, err := ctx.Vcclient.SchedulingV1beta1().Queues().Get(context.TODO(), queueSpec.Name, metav1.GetOptions{})
+				if err != nil {
+					return false, err
+				}
+				return queue.Status.State == schedulingv1beta1.QueueStateOpen, nil
+			})
+			Expect(queueOpenErr).NotTo(HaveOccurred(), "Queue failed to become open within timeout")
+			fmt.Printf("Test 7: Queue %s status is now open\n", queueSpec.Name)
+		})
+
+		// Test 8: Multiple card types job request test
+		It("Multiple Card Types Job Request Test", func() {
+			randomSuffix := generateRandomSuffix()
+			fmt.Printf("Test 8: Generated random suffix %s\n", randomSuffix)
+			ctx := e2eutil.InitTestContext(e2eutil.Options{
+				Namespace: fmt.Sprintf("multi-card-job-test-%s", randomSuffix),
+			})
+			fmt.Printf("Test 8: Test context initialized, namespace %s\n", ctx.Namespace)
+			defer e2eutil.CleanupTestContext(ctx)
+
+			// Create queue with multiple card quotas
+			queueSpec := &e2eutil.QueueSpec{
+				Name:   fmt.Sprintf("multi-card-job-queue-%s", randomSuffix),
+				Weight: 10,
+				Capacity: v1.ResourceList{
+					v1.ResourceCPU:    resource.MustParse("4"),
+					v1.ResourceMemory: resource.MustParse("4Gi"),
+				},
+				Annotations: map[string]string{
+					"volcano.sh/card.quota": fmt.Sprintf(`{"%s": 8, "%s": 8, "%s": 8}`,
+						CardTypeTeslaK80, CardTypeRTX4090, CardTypeH800),
+				},
+			}
+
+			// Create queue using e2eutil function
+			fmt.Printf("Test 8: Starting to create queue %s\n", queueSpec.Name)
+			e2eutil.CreateQueueWithQueueSpec(ctx, queueSpec)
+			fmt.Printf("Test 8: Queue %s created successfully, mixed card quota configured: %s:8, %s:8, %s:8\n",
+				queueSpec.Name, CardTypeTeslaK80, CardTypeRTX4090, CardTypeH800)
+
+			defer func() {
+				// Delete queue using e2eutil
+				fmt.Printf("Test 8: Cleaning up queue %s\n", queueSpec.Name)
+				e2eutil.DeleteQueue(ctx, queueSpec.Name)
+			}()
+
+			// Wait for queue status to become open
+			fmt.Printf("Test 8: Waiting for queue %s status to become open\n", queueSpec.Name)
+			queueOpenErr := e2eutil.WaitQueueStatus(func() (bool, error) {
+				queue, err := ctx.Vcclient.SchedulingV1beta1().Queues().Get(context.TODO(), queueSpec.Name, metav1.GetOptions{})
+				if err != nil {
+					return false, err
+				}
+				return queue.Status.State == schedulingv1beta1.QueueStateOpen, nil
+			})
+			Expect(queueOpenErr).NotTo(HaveOccurred(), "Queue failed to become open within timeout")
+			fmt.Printf("Test 8: Queue %s status is now open\n", queueSpec.Name)
+
+			// Create a job requesting multiple card types
+			job1Spec := &e2eutil.JobSpec{
+				Name:  fmt.Sprintf("multi-card-job-1-%s", randomSuffix),
+				Queue: queueSpec.Name,
+				Tasks: []e2eutil.TaskSpec{
+					{
+						Name: "task-1",
+						Min:  1,
+						Rep:  1,
+						Img:  e2eutil.DefaultNginxImage,
+						Req: v1.ResourceList{
+							v1.ResourceCPU:                    resource.MustParse("1"),
+							v1.ResourceMemory:                 resource.MustParse("1Gi"),
+							v1.ResourceName("nvidia.com/gpu"): resource.MustParse("8"),
+						},
+						Limit: v1.ResourceList{
+							v1.ResourceCPU:                    resource.MustParse("1"),
+							v1.ResourceMemory:                 resource.MustParse("1Gi"),
+							v1.ResourceName("nvidia.com/gpu"): resource.MustParse("8"),
+						},
+						Annotations: map[string]string{
+							"volcano.sh/card.name": CardTypeTeslaK80,
+						},
+					},
+					{
+						Name: "task-2",
+						Min:  1,
+						Rep:  1,
+						Img:  e2eutil.DefaultNginxImage,
+						Req: v1.ResourceList{
+							v1.ResourceCPU:                    resource.MustParse("1"),
+							v1.ResourceMemory:                 resource.MustParse("1Gi"),
+							v1.ResourceName("nvidia.com/gpu"): resource.MustParse("8"),
+						},
+						Limit: v1.ResourceList{
+							v1.ResourceCPU:                    resource.MustParse("1"),
+							v1.ResourceMemory:                 resource.MustParse("1Gi"),
+							v1.ResourceName("nvidia.com/gpu"): resource.MustParse("8"),
+						},
+						Annotations: map[string]string{
+							"volcano.sh/card.name": CardTypeRTX4090,
+						},
+					},
+				},
+				Annotations: map[string]string{
+					"volcano.sh/card.request": fmt.Sprintf(`{"%s": 8, "%s": 8}`,
+						CardTypeTeslaK80, CardTypeRTX4090),
+				},
+			}
+
+			// Create job directly (without using PodGroup)
+			fmt.Printf("Test 8: Starting to create multiple card type job %s\n", job1Spec.Name)
+			job1 := e2eutil.CreateJob(ctx, job1Spec)
+			fmt.Printf("Test 8: Multiple card type job %s created successfully, requesting: %s:8, %s:8, %s:0\n",
+				job1.Name, CardTypeTeslaK80, CardTypeRTX4090, CardTypeH800)
+
+			defer func() {
+				// Delete job
+				e2eutil.DeleteJob(ctx, job1)
+				fmt.Printf("Test 8: Job %s cleaned up\n", job1.Name)
+			}()
+
+			// Wait for job to be ready
+			fmt.Printf("Test 8: Waiting for job to be ready\n")
+			err := e2eutil.WaitJobReady(ctx, job1)
+			Expect(err).NotTo(HaveOccurred(), "Job failed to become ready within timeout")
+			fmt.Printf("Test 8: Job %s is now ready\n", job1.Name)
+
+			// Create third job, attempting to use card resource exceeding remaining quota
+			job2Spec := &e2eutil.JobSpec{
+				Name:  fmt.Sprintf("multi-card-job-2-%s", randomSuffix),
+				Queue: queueSpec.Name,
+				Tasks: []e2eutil.TaskSpec{
+					{
+						Name: "task-1",
+						Min:  1,
+						Rep:  2,
+						Img:  e2eutil.DefaultNginxImage,
+						Req: v1.ResourceList{
+							v1.ResourceCPU:                    resource.MustParse("1"),
+							v1.ResourceMemory:                 resource.MustParse("1Gi"),
+							v1.ResourceName("nvidia.com/gpu"): resource.MustParse("1"),
+						},
+						Limit: v1.ResourceList{
+							v1.ResourceCPU:                    resource.MustParse("1"),
+							v1.ResourceMemory:                 resource.MustParse("1Gi"),
+							v1.ResourceName("nvidia.com/gpu"): resource.MustParse("1"),
+						},
+						Annotations: map[string]string{
+							"volcano.sh/card.name": CardTypeTeslaK80,
+						},
+					},
+				},
+				Annotations: map[string]string{
+					"volcano.sh/card.request": fmt.Sprintf(`{"%s": 1}`, CardTypeTeslaK80), // Exceeds remaining queue quota
+				},
+			}
+
+			fmt.Printf("Test 8: Starting to create third job %s\n", job2Spec.Name)
+			job2 := e2eutil.CreateJob(ctx, job2Spec)
+			fmt.Printf("Test 8: Job 2 %s created successfully, requesting %s card resource as 1 (exceeding remaining quota)\n", job2.Name, CardTypeTeslaK80)
+			fmt.Printf("Test 8: Job 2 %s validated successfully\n", job2.Name)
+
+			defer func() {
+				// Delete job
+				e2eutil.DeleteJob(ctx, job2)
+				fmt.Printf("Test 8: Job %s cleaned up\n", job2.Name)
+			}()
+
+			// For job 2 (exceeding quota), wait for some time then check status
+			fmt.Printf("Test 8: Waiting for some time to check job 2 status (expected to not be fully ready due to insufficient quota)\n")
+			time.Sleep(JobProcessTimeout / 2)
+			e2eutil.CheckJobSchedulingFailed(ctx, job2)
+		})
+
+		// Test 9: Card type based priority scheduling test
+		It("Card Type Based Priority Scheduling Test", func() {
+			randomSuffix := generateRandomSuffix()
+			fmt.Printf("Test 9: Generated random suffix %s\n", randomSuffix)
+			ctx := e2eutil.InitTestContext(e2eutil.Options{
+				Namespace: fmt.Sprintf("priority-card-test-%s", randomSuffix),
+			})
+			fmt.Printf("Test 9: Test context initialized, namespace %s\n", ctx.Namespace)
+			defer e2eutil.CleanupTestContext(ctx)
+
+			// Create high priority queue - for H800 cards
+			priorityQueueSpec := &e2eutil.QueueSpec{
+				Name:   fmt.Sprintf("high-priority-queue-%s", randomSuffix),
+				Weight: 100, // High weight
+				Capacity: v1.ResourceList{
+					v1.ResourceCPU:    resource.MustParse("2"),
+					v1.ResourceMemory: resource.MustParse("2Gi"),
+				},
+				Annotations: map[string]string{
+					"volcano.sh/card.quota": fmt.Sprintf(`{"%s": 4}`, CardTypeH800),
+				},
+			}
+
+			// Create high priority queue using e2eutil function
+			fmt.Printf("Test 9: Starting to create high priority queue %s\n", priorityQueueSpec.Name)
+			e2eutil.CreateQueueWithQueueSpec(ctx, priorityQueueSpec)
+			fmt.Printf("Test 9: High priority queue %s created successfully, %s card quota is 4\n", priorityQueueSpec.Name, CardTypeH800)
+
+			defer func() {
+				// Delete queue using e2eutil
+				fmt.Printf("Test 9: Cleaning up high priority queue %s\n", priorityQueueSpec.Name)
+				e2eutil.DeleteQueue(ctx, priorityQueueSpec.Name)
+			}()
+
+			// Create normal priority queue - for RTX4090 cards
+			normalQueueSpec := &e2eutil.QueueSpec{
+				Name:   fmt.Sprintf("normal-priority-queue-%s", randomSuffix),
+				Weight: 10, // Low weight
+				Capacity: v1.ResourceList{
+					v1.ResourceCPU:    resource.MustParse("2"),
+					v1.ResourceMemory: resource.MustParse("2Gi"),
+				},
+				Annotations: map[string]string{
+					"volcano.sh/card.quota": fmt.Sprintf(`{"%s": 4}`, CardTypeRTX4090),
+				},
+			}
+
+			// Create normal priority queue using e2eutil function
+			fmt.Printf("Test 9: Starting to create normal priority queue %s\n", normalQueueSpec.Name)
+			e2eutil.CreateQueueWithQueueSpec(ctx, normalQueueSpec)
+			fmt.Printf("Test 9: Normal priority queue %s created successfully, %s card quota is 4\n", normalQueueSpec.Name, CardTypeRTX4090)
+
+			defer func() {
+				// Delete queue using e2eutil
+				fmt.Printf("Test 9: Cleaning up normal priority queue %s\n", normalQueueSpec.Name)
+				e2eutil.DeleteQueue(ctx, normalQueueSpec.Name)
+			}()
+
+			// Wait for high priority queue status to become open
+			fmt.Printf("Test 9: Waiting for high priority queue %s status to become open\n", priorityQueueSpec.Name)
+			queueOpenErr := e2eutil.WaitQueueStatus(func() (bool, error) {
+				queue, err := ctx.Vcclient.SchedulingV1beta1().Queues().Get(context.TODO(), priorityQueueSpec.Name, metav1.GetOptions{})
+				if err != nil {
+					return false, err
+				}
+				return queue.Status.State == schedulingv1beta1.QueueStateOpen, nil
+			})
+			Expect(queueOpenErr).NotTo(HaveOccurred(), "High priority queue failed to become open within timeout")
+
+			// Wait for normal priority queue status to become open
+			fmt.Printf("Test 9: Waiting for normal priority queue %s status to become open\n", normalQueueSpec.Name)
+			queueOpenErr = e2eutil.WaitQueueStatus(func() (bool, error) {
+				queue, err := ctx.Vcclient.SchedulingV1beta1().Queues().Get(context.TODO(), normalQueueSpec.Name, metav1.GetOptions{})
+				if err != nil {
+					return false, err
+				}
+				return queue.Status.State == schedulingv1beta1.QueueStateOpen, nil
+			})
+			Expect(queueOpenErr).NotTo(HaveOccurred(), "Normal priority queue failed to become open within timeout")
+
+			fmt.Printf("Test 9: Both queues status are now open\n")
+
+			// Create high priority job (H800 card)
+			highPriorityJobSpec := &e2eutil.JobSpec{
+				Name:  fmt.Sprintf("high-priority-job-%s", randomSuffix),
+				Queue: priorityQueueSpec.Name,
+				Tasks: []e2eutil.TaskSpec{
+					{
+						Name: "task",
+						Min:  1,
+						Rep:  1,
+						Img:  e2eutil.DefaultNginxImage,
+						Req: v1.ResourceList{
+							v1.ResourceCPU:                    resource.MustParse("1"),
+							v1.ResourceMemory:                 resource.MustParse("1Gi"),
+							v1.ResourceName("nvidia.com/gpu"): resource.MustParse("1"),
+						},
+						Limit: v1.ResourceList{
+							v1.ResourceCPU:                    resource.MustParse("1"),
+							v1.ResourceMemory:                 resource.MustParse("1Gi"),
+							v1.ResourceName("nvidia.com/gpu"): resource.MustParse("1"),
+						},
+						Annotations: map[string]string{
+							"volcano.sh/card.name": CardTypeH800,
+						},
+					},
+				},
+				Annotations: map[string]string{
+					"volcano.sh/card.request": fmt.Sprintf(`{"%s": 1}`, CardTypeH800),
+					"volcano.sh/job.priority": "high",
+				},
+			}
+
+			// Create high priority job directly (without using PodGroup)
+			fmt.Printf("Test 9: Starting to create high priority job %s\n", highPriorityJobSpec.Name)
+			highPriorityJob := e2eutil.CreateJob(ctx, highPriorityJobSpec)
+			fmt.Printf("Test 9: High priority job %s created successfully, requesting %s card resource\n", highPriorityJob.Name, CardTypeH800)
+
+			defer func() {
+				// Delete job
+				e2eutil.DeleteJob(ctx, highPriorityJob)
+				fmt.Printf("Test 9: High priority job %s cleaned up\n", highPriorityJob.Name)
+			}()
+
+			// Create normal priority job (RTX4090 card)
+			normalPriorityJobSpec := &e2eutil.JobSpec{
+				Name:  fmt.Sprintf("normal-priority-job-%s", randomSuffix),
+				Queue: normalQueueSpec.Name,
+				Tasks: []e2eutil.TaskSpec{
+					{
+						Name: "task",
+						Min:  1,
+						Rep:  1,
+						Img:  e2eutil.DefaultNginxImage,
+						Req: v1.ResourceList{
+							v1.ResourceCPU:                    resource.MustParse("1"),
+							v1.ResourceMemory:                 resource.MustParse("1Gi"),
+							v1.ResourceName("nvidia.com/gpu"): resource.MustParse("1"),
+						},
+						Limit: v1.ResourceList{
+							v1.ResourceCPU:                    resource.MustParse("1"),
+							v1.ResourceMemory:                 resource.MustParse("1Gi"),
+							v1.ResourceName("nvidia.com/gpu"): resource.MustParse("1"),
+						},
+						Annotations: map[string]string{
+							"volcano.sh/card.name": CardTypeRTX4090,
+						},
+					},
+				},
+				Annotations: map[string]string{
+					"volcano.sh/card.request": fmt.Sprintf(`{"%s": 1}`, CardTypeRTX4090),
+					"volcano.sh/job.priority": "normal",
+				},
+			}
+
+			// Create normal priority job directly (without using PodGroup)
+			fmt.Printf("Test 9: Starting to create normal priority job %s\n", normalPriorityJobSpec.Name)
+			normalPriorityJob := e2eutil.CreateJob(ctx, normalPriorityJobSpec)
+			fmt.Printf("Test 9: Normal priority job %s created successfully, requesting %s card resource\n", normalPriorityJob.Name, CardTypeRTX4090)
+
+			defer func() {
+				// Delete job
+				e2eutil.DeleteJob(ctx, normalPriorityJob)
+				fmt.Printf("Test 9: Normal priority job %s cleaned up\n", normalPriorityJob.Name)
+			}()
+
+			// Wait for high priority job to be ready
+			fmt.Printf("Test 9: Waiting for high priority job to be ready\n")
+			err := e2eutil.WaitJobReady(ctx, highPriorityJob)
+			Expect(err).NotTo(HaveOccurred(), "High priority job failed to become ready within timeout")
+			fmt.Printf("Test 9: High priority job %s is now ready\n", highPriorityJob.Name)
+
+			// Wait for normal priority job to be ready
+			fmt.Printf("Test 9: Waiting for normal priority job to be ready\n")
+			err = e2eutil.WaitJobReady(ctx, normalPriorityJob)
+			Expect(err).NotTo(HaveOccurred(), "Normal priority job failed to become ready within timeout")
+			fmt.Printf("Test 9: Normal priority job %s is now ready\n", normalPriorityJob.Name)
+		})
+
+		// Test 10: Mixed jobs test with unlimited CPU memory
+		It("Mixed Jobs with CardUnlimitedCpuMemory", func() {
+			randomSuffix := generateRandomSuffix()
+			fmt.Printf("Test 10: Generated random suffix %s\n", randomSuffix)
+			ctx := e2eutil.InitTestContext(e2eutil.Options{
+				Namespace: fmt.Sprintf("mixed-jobs-test-%s", randomSuffix),
+			})
+			fmt.Printf("Test 10: Test context initialized, namespace %s\n", ctx.Namespace)
+			defer e2eutil.CleanupTestContext(ctx)
+
+			// Create queue with card quota and cardUnlimitedCpuMemory=true
+			queueSpec := &e2eutil.QueueSpec{
+				Name:   fmt.Sprintf("mixed-jobs-queue-%s", randomSuffix),
+				Weight: 10,
+				Capacity: v1.ResourceList{
+					v1.ResourceCPU:    resource.MustParse("2"),
+					v1.ResourceMemory: resource.MustParse("2Gi"),
+				},
+				Annotations: map[string]string{
+					"volcano.sh/card.quota": fmt.Sprintf(`{"%s": 4}`, CardTypeTeslaK80),
+				},
+			}
+
+			// Create queue using e2eutil function
+			fmt.Printf("Test 10: Starting to create queue %s\n", queueSpec.Name)
+			e2eutil.CreateQueueWithQueueSpec(ctx, queueSpec)
+			fmt.Printf("Test 10: Queue %s created successfully, configured Tesla-K80 card quota 4, unlimited CPU/memory\n", queueSpec.Name)
+
+			defer func() {
+				// Delete queue using e2eutil
+				fmt.Printf("Test 10: Cleaning up queue %s\n", queueSpec.Name)
+				e2eutil.DeleteQueue(ctx, queueSpec.Name)
+			}()
+
+			// Wait for queue status to become open
+			fmt.Printf("Test 10: Waiting for queue %s status to become open\n", queueSpec.Name)
+			queueOpenErr := e2eutil.WaitQueueStatus(func() (bool, error) {
+				queue, err := ctx.Vcclient.SchedulingV1beta1().Queues().Get(context.TODO(), queueSpec.Name, metav1.GetOptions{})
+				if err != nil {
+					return false, err
+				}
+				return queue.Status.State == schedulingv1beta1.QueueStateOpen, nil
+			})
+			Expect(queueOpenErr).NotTo(HaveOccurred(), "Queue failed to become open within timeout")
+			fmt.Printf("Test 10: Queue %s status is now open\n", queueSpec.Name)
+
+			// 1. Create a CPU-only job
+			cpuJobSpec := &e2eutil.JobSpec{
+				Name:  fmt.Sprintf("cpu-only-job-%s", randomSuffix),
+				Queue: queueSpec.Name,
+				Tasks: []e2eutil.TaskSpec{
+					{
+						Name: "cpu-task",
+						Min:  1,
+						Rep:  2,
+						Img:  e2eutil.DefaultNginxImage,
+						Req: v1.ResourceList{
+							v1.ResourceCPU:    resource.MustParse("2"),
+							v1.ResourceMemory: resource.MustParse("2Gi"),
+						},
+					},
+				},
+			}
+
+			// Create CPU-only job
+			fmt.Printf("Test 10: Starting to create CPU-only job %s\n", cpuJobSpec.Name)
+			cpuJob := e2eutil.CreateJob(ctx, cpuJobSpec)
+			fmt.Printf("Test 10: CPU-only job %s created successfully\n", cpuJob.Name)
+
+			defer func() {
+				// Delete job
+				e2eutil.DeleteJob(ctx, cpuJob)
+				fmt.Printf("Test 10: CPU-only job %s cleaned up\n", cpuJob.Name)
+			}()
+
+			// Wait for CPU-only job to be ready
+			fmt.Printf("Test 10: Waiting for CPU-only job to be ready\n")
+			err := e2eutil.WaitJobReady(ctx, cpuJob)
+			Expect(err).NotTo(HaveOccurred(), "CPU-only job failed to become ready within timeout")
+			fmt.Printf("Test 10: CPU-only job %s is now ready\n", cpuJob.Name)
+
+			// 2. Create a job with card request
+			cardJobSpec := &e2eutil.JobSpec{
+				Name:  fmt.Sprintf("card-job-%s", randomSuffix),
+				Queue: queueSpec.Name,
+				Tasks: []e2eutil.TaskSpec{
+					{
+						Name: "card-task",
+						Min:  1,
+						Rep:  1,
+						Img:  e2eutil.DefaultNginxImage,
+						Req: v1.ResourceList{
+							v1.ResourceCPU:                    resource.MustParse("1"),
+							v1.ResourceMemory:                 resource.MustParse("1Gi"),
+							v1.ResourceName("nvidia.com/gpu"): resource.MustParse("2"),
+						},
+						Limit: v1.ResourceList{
+							v1.ResourceCPU:                    resource.MustParse("1"),
+							v1.ResourceMemory:                 resource.MustParse("1Gi"),
+							v1.ResourceName("nvidia.com/gpu"): resource.MustParse("2"),
+						},
+						Annotations: map[string]string{
+							"volcano.sh/card.name": CardTypeTeslaK80,
+						},
+					},
+				},
+				Annotations: map[string]string{
+					"volcano.sh/card.request": fmt.Sprintf(`{"%s": 2}`, CardTypeTeslaK80),
+				},
+			}
+
+			// Create job with card request
+			fmt.Printf("Test 10: Starting to create job with card request %s\n", cardJobSpec.Name)
+			cardJob := e2eutil.CreateJob(ctx, cardJobSpec)
+			fmt.Printf("Test 10: Job with card request %s created successfully, requesting 2 Tesla-K80 cards\n", cardJob.Name)
+
+			defer func() {
+				// Delete job
+				e2eutil.DeleteJob(ctx, cardJob)
+				fmt.Printf("Test 10: Job with card request %s cleaned up\n", cardJob.Name)
+			}()
+
+			// Wait for job with card request to be ready
+			fmt.Printf("Test 10: Waiting for job with card request to be ready\n")
+			err = e2eutil.WaitJobReady(ctx, cardJob)
+			Expect(err).NotTo(HaveOccurred(), "Job with card request failed to become ready within timeout")
+			fmt.Printf("Test 10: Job with card request %s is now ready\n", cardJob.Name)
+
+			// 3. Create an excess CPU-only job
+			overCpuJobSpec := &e2eutil.JobSpec{
+				Name:  fmt.Sprintf("over-cpu-job-%s", randomSuffix),
+				Queue: queueSpec.Name,
+				Tasks: []e2eutil.TaskSpec{
+					{
+						Name: "over-cpu-task",
+						Min:  1,
+						Rep:  2,
+						Img:  e2eutil.DefaultNginxImage,
+						Req: v1.ResourceList{
+							v1.ResourceCPU:    resource.MustParse("2"),
+							v1.ResourceMemory: resource.MustParse("2Gi"),
+						},
+					},
+				},
+			}
+
+			// Create excess CPU-only job
+			fmt.Printf("Test 10: Starting to create excess CPU-only job %s\n", overCpuJobSpec.Name)
+			overCpuJob := e2eutil.CreateJob(ctx, overCpuJobSpec)
+			fmt.Printf("Test 10: Excess CPU-only job %s created successfully\n", overCpuJob.Name)
+
+			defer func() {
+				// Delete job
+				e2eutil.DeleteJob(ctx, overCpuJob)
+				fmt.Printf("Test 10: Excess CPU-only job %s cleaned up\n", overCpuJob.Name)
+			}()
+
+			// Wait for excess CPU-only job to fail scheduling
+			fmt.Printf("Test 10: Waiting for excess CPU-only job to fail scheduling\n")
+			time.Sleep(JobProcessTimeout / 2)
+			e2eutil.CheckJobSchedulingFailed(ctx, overCpuJob)
+		})
+
+		// Test 11: No resource quota queue scheduling restriction test
+		It("No Resource Quota Queue Scheduling Restriction", func() {
+			randomSuffix := generateRandomSuffix()
+			fmt.Printf("Test 11: Generated random suffix %s\n", randomSuffix)
+			ctx := e2eutil.InitTestContext(e2eutil.Options{
+				Namespace: fmt.Sprintf("no-quota-test-%s", randomSuffix),
+			})
+			fmt.Printf("Test 11: Test context initialized, namespace %s\n", ctx.Namespace)
+			defer e2eutil.CleanupTestContext(ctx)
+
+			// Create queue without any resource quota (no card quota, CPU and memory guarantee)
+			queueSpec := &e2eutil.QueueSpec{
+				Name:        fmt.Sprintf("no-quota-queue-%s", randomSuffix),
+				Weight:      10,
+				Annotations: map[string]string{},
+			}
+
+			// Create queue using e2eutil function
+			fmt.Printf("Test 11: Starting to create queue without resource quota %s\n", queueSpec.Name)
+			e2eutil.CreateQueueWithQueueSpec(ctx, queueSpec)
+			fmt.Printf("Test 11: Queue without resource quota %s created successfully\n", queueSpec.Name)
+
+			// Clean up resources
+			defer func() {
+				// Delete queue using e2eutil
+				fmt.Printf("Test 11: Cleaning up queue %s\n", queueSpec.Name)
+				e2eutil.DeleteQueue(ctx, queueSpec.Name)
+			}()
+
+			// Wait for queue status to become open
+			fmt.Printf("Test 11: Waiting for queue %s status to become open\n", queueSpec.Name)
+			queueOpenErr := e2eutil.WaitQueueStatus(func() (bool, error) {
+				queue, err := ctx.Vcclient.SchedulingV1beta1().Queues().Get(context.TODO(), queueSpec.Name, metav1.GetOptions{})
+				if err != nil {
+					return false, err
+				}
+				return queue.Status.State == schedulingv1beta1.QueueStateOpen, nil
+			})
+			Expect(queueOpenErr).NotTo(HaveOccurred(), "Queue failed to become open within timeout")
+			fmt.Printf("Test 11: Queue %s status is now open\n", queueSpec.Name)
+
+			// Create a job, attempting to schedule to queue without resource quota
+			jobSpec := &e2eutil.JobSpec{
+				Name:  fmt.Sprintf("test-job-%s", randomSuffix),
+				Queue: queueSpec.Name,
+				Tasks: []e2eutil.TaskSpec{
+					{
+						Name: "task",
+						Min:  1,
+						Rep:  1,
+						Img:  e2eutil.DefaultNginxImage,
+						Req: v1.ResourceList{
+							v1.ResourceCPU:    resource.MustParse("1"),
+							v1.ResourceMemory: resource.MustParse("1Gi"),
+						},
+					},
+				},
+			}
+
+			// Create job directly (without using PodGroup), and set card request annotations
+			fmt.Printf("Test 11: Starting to create test job %s\n", jobSpec.Name)
+			job := e2eutil.CreateJob(ctx, jobSpec)
+			fmt.Printf("Test 11: Test job %s created successfully, attempting to schedule to queue without resource quota\n", job.Name)
+
+			defer func() {
+				// Delete job
+				e2eutil.DeleteJob(ctx, job)
+				fmt.Printf("Test 11: Job %s cleaned up\n", job.Name)
+			}()
+
+			// Create a card job, attempting to schedule to queue without resource quota
+			cardJobSpec := &e2eutil.JobSpec{
+				Name:  fmt.Sprintf("test-card-job-%s", randomSuffix),
+				Queue: queueSpec.Name,
+				Tasks: []e2eutil.TaskSpec{
+					{
+						Name: "card-task",
+						Min:  1,
+						Rep:  1,
+						Img:  e2eutil.DefaultNginxImage,
+						Req: v1.ResourceList{
+							v1.ResourceCPU:                    resource.MustParse("1"),
+							v1.ResourceMemory:                 resource.MustParse("1Gi"),
+							v1.ResourceName("nvidia.com/gpu"): resource.MustParse("1"),
+						},
+						Limit: v1.ResourceList{
+							v1.ResourceCPU:                    resource.MustParse("1"),
+							v1.ResourceMemory:                 resource.MustParse("1Gi"),
+							v1.ResourceName("nvidia.com/gpu"): resource.MustParse("1"),
+						},
+						Annotations: map[string]string{
+							"volcano.sh/card.name": CardTypeRTX4090,
+						},
+					},
+				},
+				Annotations: map[string]string{
+					"volcano.sh/card.request": fmt.Sprintf(`{"%s": 1}`, CardTypeRTX4090),
+				},
+			}
+
+			// Create job directly (without using PodGroup), and set card request annotations
+			fmt.Printf("Test 11: Starting to create test job %s\n", cardJobSpec.Name)
+			cardJob := e2eutil.CreateJob(ctx, cardJobSpec)
+			fmt.Printf("Test 11: Test job %s created successfully, attempting to schedule to queue without resource quota\n", cardJob.Name)
+
+			defer func() {
+				// Delete job
+				e2eutil.DeleteJob(ctx, cardJob)
+				fmt.Printf("Test 11: Job %s cleaned up\n", cardJob.Name)
+			}()
+
+			// Wait for some time to let scheduler attempt scheduling
+			fmt.Printf("Test 11: Waiting for scheduler to process jobs, timeout is %v\n", JobProcessTimeout/2)
+			time.Sleep(JobProcessTimeout / 2)
+			e2eutil.CheckJobSchedulingFailed(ctx, job)
+			e2eutil.CheckJobSchedulingFailed(ctx, cardJob)
+		})
+	})
+
+	Context("Capacity Card - Deployment", func() {
+		// Test 12: Deployment GPU card resource allocation test
+		It("Deployment GPU Card Resource Allocation", func() {
+			randomSuffix := generateRandomSuffix()
+			fmt.Printf("Test 12: Generated random suffix %s\n", randomSuffix)
+			ctx := e2eutil.InitTestContext(e2eutil.Options{
+				Namespace: fmt.Sprintf("deployment-card-test-%s", randomSuffix),
+			})
+			fmt.Printf("Test 12: Test context initialized, namespace %s\n", ctx.Namespace)
+			defer e2eutil.CleanupTestContext(ctx)
+
+			// Create queue with card quota
+			queueSpec := &e2eutil.QueueSpec{
+				Name:   fmt.Sprintf("deployment-queue-%s", randomSuffix),
+				Weight: 10,
+				Capacity: v1.ResourceList{
+					v1.ResourceCPU:    resource.MustParse("2"),
+					v1.ResourceMemory: resource.MustParse("2Gi"),
+				},
+				Annotations: map[string]string{
+					"volcano.sh/card.quota": fmt.Sprintf(`{"%s": 2}`, CardTypeRTX4090),
+				},
+			}
+
+			// Create queue using e2eutil
+			fmt.Printf("Test 12: Starting to create queue %s\n", queueSpec.Name)
+			e2eutil.CreateQueueWithQueueSpec(ctx, queueSpec)
+			fmt.Printf("Test 12: Queue %s created successfully, RTX4090 card quota is 2\n", queueSpec.Name)
+
+			defer func() {
+				// Delete queue using e2eutil
+				fmt.Printf("Test 12: Cleaning up queue %s\n", queueSpec.Name)
+				e2eutil.DeleteQueue(ctx, queueSpec.Name)
+			}()
+
+			// Wait for queue status to become open
+			fmt.Printf("Test 12: Waiting for queue %s status to become open\n", queueSpec.Name)
+			queueOpenErr := e2eutil.WaitQueueStatus(func() (bool, error) {
+				queue, err := ctx.Vcclient.SchedulingV1beta1().Queues().Get(context.TODO(), queueSpec.Name, metav1.GetOptions{})
+				if err != nil {
+					return false, err
+				}
+				return queue.Status.State == schedulingv1beta1.QueueStateOpen, nil
+			})
+			Expect(queueOpenErr).NotTo(HaveOccurred(), "Queue failed to become open within timeout")
+			fmt.Printf("Test 12: Queue %s status is now open\n", queueSpec.Name)
+
+			// Create Deployment and add GPU card request annotation
+			deploymentName := fmt.Sprintf("gpu-card-deployment-%s", randomSuffix)
+			deployment := &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      deploymentName,
+					Namespace: ctx.Namespace,
+				},
+				Spec: appsv1.DeploymentSpec{
+					Replicas: int32Ptr(1),
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"app": deploymentName,
+						},
+					},
+					Template: v1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Labels: map[string]string{
+								"app": deploymentName,
+							},
+							Annotations: map[string]string{
+								"volcano.sh/card.name":             CardTypeRTX4090,
+								"scheduling.volcano.sh/queue-name": queueSpec.Name,
+							},
+						},
+						Spec: v1.PodSpec{
+							Containers: []v1.Container{
+								{
+									Name:            "nginx",
+									Image:           e2eutil.DefaultNginxImage,
+									ImagePullPolicy: v1.PullIfNotPresent,
+									Resources: v1.ResourceRequirements{
+										Requests: v1.ResourceList{
+											v1.ResourceCPU:                    resource.MustParse("1"),
+											v1.ResourceMemory:                 resource.MustParse("1Gi"),
+											v1.ResourceName("nvidia.com/gpu"): resource.MustParse("1"),
+										},
+										Limits: v1.ResourceList{
+											v1.ResourceCPU:                    resource.MustParse("1"),
+											v1.ResourceMemory:                 resource.MustParse("1Gi"),
+											v1.ResourceName("nvidia.com/gpu"): resource.MustParse("1"),
+										},
+									},
+								},
+							},
+							SchedulerName: "volcano",
+						},
+					},
+				},
+			}
+
+			// Create Deployment
+			fmt.Printf("Test 12: Starting to create Deployment %s\n", deploymentName)
+			_, err := ctx.Kubeclient.AppsV1().Deployments(ctx.Namespace).Create(context.TODO(), deployment, metav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			fmt.Printf("Test 12: Deployment %s created successfully, requesting RTX4090 card resource\n", deploymentName)
+
+			// Clean up resources
+			defer func() {
+				fmt.Printf("Test 12: Starting to clean up resources\n")
+				// Delete Deployment
+				fmt.Printf("Test 12: Deleting Deployment %s\n", deploymentName)
+				if err := ctx.Kubeclient.AppsV1().Deployments(ctx.Namespace).Delete(context.TODO(), deploymentName, metav1.DeleteOptions{}); err != nil {
+					fmt.Printf("Test 12-Warning: Failed to delete Deployment %s: %v\n", deploymentName, err)
+				} else {
+					fmt.Printf("Test 12: Deployment %s deleted successfully\n", deploymentName)
+				}
+			}()
+
+			// Wait for Deployment to be ready
+			fmt.Printf("Test 12: Waiting for Deployment to be ready\n")
+			err = e2eutil.WaitDeploymentReady(ctx, deploymentName)
+			Expect(err).NotTo(HaveOccurred(), "Deployment failed to become ready within timeout")
+			fmt.Printf("Test 12: Deployment %s is now ready\n", deploymentName)
+		})
+	})
+
+	Context("Capacity Card - Node Ordering", func() {
+		// Test 13: Multi-card type node ordering test
+		It("Multi-Card Type Node Ordering with Priority", func() {
+			randomSuffix := generateRandomSuffix()
+			fmt.Printf("Test 13: Generated random suffix %s\n", randomSuffix)
+			ctx := e2eutil.InitTestContext(e2eutil.Options{
+				Namespace: fmt.Sprintf("multi-card-ordering-test-%s", randomSuffix),
+			})
+			fmt.Printf("Test 13: Test context initialized, namespace %s\n", ctx.Namespace)
+			defer e2eutil.CleanupTestContext(ctx)
+
+			// Create queue with multiple card type quotas
+			queueSpec := &e2eutil.QueueSpec{
+				Name:   fmt.Sprintf("ordering-queue-%s", randomSuffix),
+				Weight: 10,
+				Capacity: v1.ResourceList{
+					v1.ResourceCPU:    resource.MustParse("16"),
+					v1.ResourceMemory: resource.MustParse("32Gi"),
+				},
+				Annotations: map[string]string{
+					"volcano.sh/card.quota": fmt.Sprintf(`{"%s": 8, "%s": 8, "%s": 8}`,
+						CardTypeH800, CardTypeRTX4090, CardTypeTeslaK80),
+				},
+			}
+
+			// Create queue
+			fmt.Printf("Test 13: Starting to create queue %s\n", queueSpec.Name)
+			e2eutil.CreateQueueWithQueueSpec(ctx, queueSpec)
+			fmt.Printf("Test 13: Queue %s created with quotas - %s:8, %s:8, %s:8\n",
+				queueSpec.Name, CardTypeH800, CardTypeRTX4090, CardTypeTeslaK80)
+
+			defer func() {
+				e2eutil.DeleteQueue(ctx, queueSpec.Name)
+				fmt.Printf("Test 13: Queue %s cleaned up\n", queueSpec.Name)
+			}()
+
+			// Wait for queue to become open
+			fmt.Printf("Test 13: Waiting for queue %s to become open\n", queueSpec.Name)
+			queueOpenErr := e2eutil.WaitQueueStatus(func() (bool, error) {
+				queue, err := ctx.Vcclient.SchedulingV1beta1().Queues().Get(context.TODO(), queueSpec.Name, metav1.GetOptions{})
+				if err != nil {
+					return false, err
+				}
+				return queue.Status.State == schedulingv1beta1.QueueStateOpen, nil
+			})
+			Expect(queueOpenErr).NotTo(HaveOccurred(), "Queue failed to become open")
+			fmt.Printf("Test 13: Queue %s is now open\n", queueSpec.Name)
+
+			// Create a job with multi-card type option: H800 | RTX4090 | TeslaK80
+			// Priority: H800 (highest) > RTX4090 (medium) > TeslaK80 (lowest)
+			multiCardJobSpec := &e2eutil.JobSpec{
+				Name:  fmt.Sprintf("multi-card-type-job-%s", randomSuffix),
+				Queue: queueSpec.Name,
+				Tasks: []e2eutil.TaskSpec{
+					{
+						Name: "gpu-task",
+						Min:  1,
+						Rep:  1,
+						Img:  e2eutil.DefaultNginxImage,
+						Req: v1.ResourceList{
+							v1.ResourceCPU:                    resource.MustParse("1"),
+							v1.ResourceMemory:                 resource.MustParse("1Gi"),
+							v1.ResourceName("nvidia.com/gpu"): resource.MustParse("2"),
+						},
+						Limit: v1.ResourceList{
+							v1.ResourceCPU:                    resource.MustParse("1"),
+							v1.ResourceMemory:                 resource.MustParse("1Gi"),
+							v1.ResourceName("nvidia.com/gpu"): resource.MustParse("2"),
+						},
+						Annotations: map[string]string{
+							// Multiple card types with priority order
+							"volcano.sh/card.name": fmt.Sprintf("%s|%s|%s",
+								CardTypeH800, CardTypeRTX4090, CardTypeTeslaK80),
+						},
+					},
+				},
+				Annotations: map[string]string{
+					"volcano.sh/card.request": fmt.Sprintf(`{"%s|%s|%s": 2}`,
+						CardTypeH800, CardTypeRTX4090, CardTypeTeslaK80),
+				},
+			}
+
+			fmt.Printf("Test 13: Creating job with multi-card type priority: %s > %s > %s\n",
+				CardTypeH800, CardTypeRTX4090, CardTypeTeslaK80)
+			multiCardJob := e2eutil.CreateJob(ctx, multiCardJobSpec)
+			fmt.Printf("Test 13: Multi-card type job %s created\n", multiCardJob.Name)
+
+			defer func() {
+				e2eutil.DeleteJob(ctx, multiCardJob)
+				fmt.Printf("Test 13: Job %s cleaned up\n", multiCardJob.Name)
+			}()
+
+			// Wait for job to be ready
+			fmt.Printf("Test 13: Waiting for multi-card type job to be scheduled\n")
+			err := e2eutil.WaitJobReady(ctx, multiCardJob)
+			Expect(err).NotTo(HaveOccurred(), "Multi-card type job failed to become ready")
+			fmt.Printf("Test 13: Multi-card type job %s is ready\n", multiCardJob.Name)
+
+			// Verify job was scheduled to the highest priority card type
+			fmt.Printf("Test 13: Verifying job was scheduled to a node with highest priority card type\n")
+			cardPriority := []string{CardTypeH800, CardTypeRTX4090, CardTypeTeslaK80}
+			verifyPodScheduledToHighestPriorityCardType(ctx, multiCardJob.Name, cardPriority, 2, "Test 13")
+			fmt.Printf("Test 13: Multi-card type scheduling verified successfully\n")
+		})
+
+		// Test 14: Node ordering with different card type priorities
+		It("Node Ordering Prefers Higher Priority Card Types", func() {
+			randomSuffix := generateRandomSuffix()
+			fmt.Printf("Test 14: Generated random suffix %s\n", randomSuffix)
+			ctx := e2eutil.InitTestContext(e2eutil.Options{
+				Namespace: fmt.Sprintf("card-priority-test-%s", randomSuffix),
+			})
+			fmt.Printf("Test 14: Test context initialized, namespace %s\n", ctx.Namespace)
+			defer e2eutil.CleanupTestContext(ctx)
+
+			// Create queue with quota for all card types
+			queueSpec := &e2eutil.QueueSpec{
+				Name:   fmt.Sprintf("priority-test-queue-%s", randomSuffix),
+				Weight: 10,
+				Capacity: v1.ResourceList{
+					v1.ResourceCPU:    resource.MustParse("32"),
+					v1.ResourceMemory: resource.MustParse("64Gi"),
+				},
+				Annotations: map[string]string{
+					"volcano.sh/card.quota": fmt.Sprintf(`{"%s": 8, "%s": 8}`,
+						CardTypeH800, CardTypeTeslaK80),
+				},
+			}
+
+			fmt.Printf("Test 14: Creating queue %s\n", queueSpec.Name)
+			e2eutil.CreateQueueWithQueueSpec(ctx, queueSpec)
+			fmt.Printf("Test 14: Queue %s created with %s:8, %s:8\n",
+				queueSpec.Name, CardTypeH800, CardTypeTeslaK80)
+
+			defer func() {
+				e2eutil.DeleteQueue(ctx, queueSpec.Name)
+				fmt.Printf("Test 14: Queue %s cleaned up\n", queueSpec.Name)
+			}()
+
+			// Wait for queue to become open
+			queueOpenErr := e2eutil.WaitQueueStatus(func() (bool, error) {
+				queue, err := ctx.Vcclient.SchedulingV1beta1().Queues().Get(context.TODO(), queueSpec.Name, metav1.GetOptions{})
+				if err != nil {
+					return false, err
+				}
+				return queue.Status.State == schedulingv1beta1.QueueStateOpen, nil
+			})
+			Expect(queueOpenErr).NotTo(HaveOccurred())
+			fmt.Printf("Test 14: Queue %s is open\n", queueSpec.Name)
+
+			// Create multiple jobs with card type priority: H800 | TeslaK80
+			// Scheduler should prefer H800 nodes over TeslaK80 nodes
+			var jobs []*batchv1alpha1.Job
+
+			for i := 0; i < 3; i++ {
+				jobSpec := &e2eutil.JobSpec{
+					Name:  fmt.Sprintf("priority-job-%d-%s", i, randomSuffix),
+					Queue: queueSpec.Name,
+					Tasks: []e2eutil.TaskSpec{
+						{
+							Name: "task",
+							Min:  1,
+							Rep:  1,
+							Img:  e2eutil.DefaultNginxImage,
+							Req: v1.ResourceList{
+								v1.ResourceCPU:                    resource.MustParse("1"),
+								v1.ResourceMemory:                 resource.MustParse("1Gi"),
+								v1.ResourceName("nvidia.com/gpu"): resource.MustParse("1"),
+							},
+							Limit: v1.ResourceList{
+								v1.ResourceCPU:                    resource.MustParse("1"),
+								v1.ResourceMemory:                 resource.MustParse("1Gi"),
+								v1.ResourceName("nvidia.com/gpu"): resource.MustParse("1"),
+							},
+							Annotations: map[string]string{
+								"volcano.sh/card.name": fmt.Sprintf("%s|%s",
+									CardTypeH800, CardTypeTeslaK80),
+							},
+						},
+					},
+					Annotations: map[string]string{
+						"volcano.sh/card.request": fmt.Sprintf(`{"%s|%s": 1}`,
+							CardTypeH800, CardTypeTeslaK80),
+					},
+				}
+
+				fmt.Printf("Test 14: Creating job %d with card priority %s > %s\n",
+					i, CardTypeH800, CardTypeTeslaK80)
+				job := e2eutil.CreateJob(ctx, jobSpec)
+				fmt.Printf("Test 14: Job %s created\n", job.Name)
+				jobs = append(jobs, job)
+
+				defer func(j *batchv1alpha1.Job) {
+					e2eutil.DeleteJob(ctx, j)
+					fmt.Printf("Test 14: Job %s cleaned up\n", j.Name)
+				}(job)
+
+				// Wait for job to be ready
+				err := e2eutil.WaitJobReady(ctx, job)
+				Expect(err).NotTo(HaveOccurred())
+				fmt.Printf("Test 14: Job %s is ready\n", job.Name)
+			}
+
+			// Verify all jobs were scheduled to the highest priority card type
+			fmt.Printf("Test 14: Verifying all jobs were scheduled to highest priority card type\n")
+			verifyCardPriority := []string{CardTypeH800, CardTypeTeslaK80}
+
+			totalScheduledCardTypes := make(map[string]int)
+			for _, job := range jobs {
+				jobScheduledCardTypes := verifyPodScheduledToHighestPriorityCardType(
+					ctx, job.Name, verifyCardPriority, 1, fmt.Sprintf("Test 14 (Job %s)", job.Name))
+
+				// Accumulate card type counts across all jobs
+				for cardType, count := range jobScheduledCardTypes {
+					totalScheduledCardTypes[cardType] += count
+				}
+			}
+
+			fmt.Printf("Test 14: All jobs scheduled. Total card type distribution: %v\n", totalScheduledCardTypes)
+			fmt.Printf("Test 14: All jobs scheduled successfully with card type priority\n")
+		})
+
+		// Test 15: Node ordering with custom weight configuration
+		It("Node Ordering with Custom Weight Configuration", func() {
+			randomSuffix := generateRandomSuffix()
+			fmt.Printf("Test 15: Generated random suffix %s\n", randomSuffix)
+			ctx := e2eutil.InitTestContext(e2eutil.Options{
+				Namespace: fmt.Sprintf("custom-weight-test-%s", randomSuffix),
+			})
+			fmt.Printf("Test 15: Test context initialized, namespace %s\n", ctx.Namespace)
+			defer e2eutil.CleanupTestContext(ctx)
+
+			// Create queue for testing
+			queueSpec := &e2eutil.QueueSpec{
+				Name:   fmt.Sprintf("weight-test-queue-%s", randomSuffix),
+				Weight: 10,
+				Capacity: v1.ResourceList{
+					v1.ResourceCPU:    resource.MustParse("16"),
+					v1.ResourceMemory: resource.MustParse("32Gi"),
+				},
+				Annotations: map[string]string{
+					"volcano.sh/card.quota": fmt.Sprintf(`{"%s": 8, "%s": 8}`,
+						CardTypeRTX4090, CardTypeTeslaK80),
+				},
+			}
+
+			fmt.Printf("Test 15: Creating queue %s\n", queueSpec.Name)
+			e2eutil.CreateQueueWithQueueSpec(ctx, queueSpec)
+			fmt.Printf("Test 15: Queue created with card quotas\n")
+
+			defer func() {
+				e2eutil.DeleteQueue(ctx, queueSpec.Name)
+				fmt.Printf("Test 15: Queue cleaned up\n")
+			}()
+
+			// Wait for queue to become open
+			queueOpenErr := e2eutil.WaitQueueStatus(func() (bool, error) {
+				queue, err := ctx.Vcclient.SchedulingV1beta1().Queues().Get(context.TODO(), queueSpec.Name, metav1.GetOptions{})
+				if err != nil {
+					return false, err
+				}
+				return queue.Status.State == schedulingv1beta1.QueueStateOpen, nil
+			})
+			Expect(queueOpenErr).NotTo(HaveOccurred())
+			fmt.Printf("Test 15: Queue is open\n")
+
+			// Create job with multi-card type annotation
+			// The scheduler with nodeOrderWeight should prefer RTX4090 over TeslaK80
+			jobSpec := &e2eutil.JobSpec{
+				Name:  fmt.Sprintf("weighted-ordering-job-%s", randomSuffix),
+				Queue: queueSpec.Name,
+				Tasks: []e2eutil.TaskSpec{
+					{
+						Name: "task",
+						Min:  1,
+						Rep:  2,
+						Img:  e2eutil.DefaultNginxImage,
+						Req: v1.ResourceList{
+							v1.ResourceCPU:                    resource.MustParse("1"),
+							v1.ResourceMemory:                 resource.MustParse("1Gi"),
+							v1.ResourceName("nvidia.com/gpu"): resource.MustParse("1"),
+						},
+						Limit: v1.ResourceList{
+							v1.ResourceCPU:                    resource.MustParse("1"),
+							v1.ResourceMemory:                 resource.MustParse("1Gi"),
+							v1.ResourceName("nvidia.com/gpu"): resource.MustParse("1"),
+						},
+						Annotations: map[string]string{
+							"volcano.sh/card.name": fmt.Sprintf("%s|%s",
+								CardTypeRTX4090, CardTypeTeslaK80),
+						},
+					},
+				},
+				Annotations: map[string]string{
+					"volcano.sh/card.request": fmt.Sprintf(`{"%s|%s": 1}`,
+						CardTypeRTX4090, CardTypeTeslaK80),
+				},
+			}
+
+			fmt.Printf("Test 15: Creating job with card type priority: %s > %s\n",
+				CardTypeRTX4090, CardTypeTeslaK80)
+			job := e2eutil.CreateJob(ctx, jobSpec)
+			fmt.Printf("Test 15: Job %s created\n", job.Name)
+
+			defer func() {
+				e2eutil.DeleteJob(ctx, job)
+				fmt.Printf("Test 15: Job cleaned up\n")
+			}()
+
+			// Wait for job to be ready
+			fmt.Printf("Test 15: Waiting for job to be ready\n")
+			err := e2eutil.WaitJobReady(ctx, job)
+			Expect(err).NotTo(HaveOccurred())
+			fmt.Printf("Test 15: Job %s is ready\n", job.Name)
+
+			// Verify pods were scheduled to the highest priority card type
+			fmt.Printf("Test 15: Verifying pods were scheduled to highest priority card type\n")
+			expectedCardPriority := []string{CardTypeRTX4090, CardTypeTeslaK80}
+			scheduledCardTypes := verifyPodScheduledToHighestPriorityCardType(ctx, job.Name, expectedCardPriority, 1, "Test 15")
+
+			// Assert: Verify we got 2 pods scheduled
+			totalPods := 0
+			for _, count := range scheduledCardTypes {
+				totalPods += count
+			}
+			Expect(totalPods).To(Equal(2), "Expected 2 pods to be scheduled")
+
+			fmt.Printf("Test 15: Scheduling with node ordering verified successfully\n")
+		})
+
+		// Test 16: Verify leftmost card type gets highest priority
+		It("Leftmost Card Type Gets Highest Score", func() {
+			randomSuffix := generateRandomSuffix()
+			fmt.Printf("Test 16: Generated random suffix %s\n", randomSuffix)
+			ctx := e2eutil.InitTestContext(e2eutil.Options{
+				Namespace: fmt.Sprintf("leftmost-priority-test-%s", randomSuffix),
+			})
+			fmt.Printf("Test 16: Test context initialized, namespace %s\n", ctx.Namespace)
+			defer e2eutil.CleanupTestContext(ctx)
+
+			// Create queue
+			queueSpec := &e2eutil.QueueSpec{
+				Name:   fmt.Sprintf("leftmost-queue-%s", randomSuffix),
+				Weight: 10,
+				Capacity: v1.ResourceList{
+					v1.ResourceCPU:    resource.MustParse("8"),
+					v1.ResourceMemory: resource.MustParse("16Gi"),
+				},
+				Annotations: map[string]string{
+					"volcano.sh/card.quota": fmt.Sprintf(`{"%s": 4, "%s": 4, "%s": 4}`,
+						CardTypeTeslaK80, CardTypeRTX4090, CardTypeH800),
+				},
+			}
+
+			fmt.Printf("Test 16: Creating queue\n")
+			e2eutil.CreateQueueWithQueueSpec(ctx, queueSpec)
+
+			defer func() {
+				e2eutil.DeleteQueue(ctx, queueSpec.Name)
+				fmt.Printf("Test 16: Queue cleaned up\n")
+			}()
+
+			// Wait for queue to open
+			queueOpenErr := e2eutil.WaitQueueStatus(func() (bool, error) {
+				queue, err := ctx.Vcclient.SchedulingV1beta1().Queues().Get(context.TODO(), queueSpec.Name, metav1.GetOptions{})
+				if err != nil {
+					return false, err
+				}
+				return queue.Status.State == schedulingv1beta1.QueueStateOpen, nil
+			})
+			Expect(queueOpenErr).NotTo(HaveOccurred())
+			fmt.Printf("Test 16: Queue is open\n")
+
+			// Create job with card types in specific order
+			// Leftmost should have highest priority
+			jobSpec := &e2eutil.JobSpec{
+				Name:  fmt.Sprintf("leftmost-test-job-%s", randomSuffix),
+				Queue: queueSpec.Name,
+				Tasks: []e2eutil.TaskSpec{
+					{
+						Name: "task",
+						Min:  1,
+						Rep:  1,
+						Img:  e2eutil.DefaultNginxImage,
+						Req: v1.ResourceList{
+							v1.ResourceCPU:                    resource.MustParse("1"),
+							v1.ResourceMemory:                 resource.MustParse("1Gi"),
+							v1.ResourceName("nvidia.com/gpu"): resource.MustParse("1"),
+						},
+						Limit: v1.ResourceList{
+							v1.ResourceCPU:                    resource.MustParse("1"),
+							v1.ResourceMemory:                 resource.MustParse("1Gi"),
+							v1.ResourceName("nvidia.com/gpu"): resource.MustParse("1"),
+						},
+						Annotations: map[string]string{
+							// TeslaK80 is leftmost, should have highest priority
+							"volcano.sh/card.name": fmt.Sprintf("%s|%s|%s",
+								CardTypeTeslaK80, CardTypeRTX4090, CardTypeH800),
+						},
+					},
+				},
+				Annotations: map[string]string{
+					"volcano.sh/card.request": fmt.Sprintf(`{"%s|%s|%s": 1}`,
+						CardTypeTeslaK80, CardTypeRTX4090, CardTypeH800),
+				},
+			}
+
+			fmt.Printf("Test 16: Creating job with card priority: %s (leftmost, score=100) > %s (score=50) > %s (score=25)\n",
+				CardTypeTeslaK80, CardTypeRTX4090, CardTypeH800)
+			job := e2eutil.CreateJob(ctx, jobSpec)
+
+			defer func() {
+				e2eutil.DeleteJob(ctx, job)
+				fmt.Printf("Test 16: Job cleaned up\n")
+			}()
+
+			// Wait for job to be ready
+			err := e2eutil.WaitJobReady(ctx, job)
+			Expect(err).NotTo(HaveOccurred())
+			fmt.Printf("Test 16: Job scheduled successfully\n")
+
+			// Verify pod was scheduled to the leftmost (highest priority) card type
+			fmt.Printf("Test 16: Verifying pod was scheduled to LEFTMOST (highest priority) card type\n")
+			expectedCardPriority := []string{CardTypeTeslaK80, CardTypeRTX4090, CardTypeH800}
+			verifyPodScheduledToHighestPriorityCardType(ctx, job.Name, expectedCardPriority, 1, "Test 16")
+			fmt.Printf("Test 16: Leftmost card type priority verified with assertions\n")
+		})
+	})
+
+	Context("Capacity Card - Enqueue Mode Multi-Card Quota Sum", func() {
+		// Test 17: Enqueue mode multi-card quota sum check
+		It("Enqueue Mode Multi-Card Quota Sum Allows Different Tasks To Use Different Card Types", func() {
+			randomSuffix := generateRandomSuffix()
+			fmt.Printf("Test 17: Generated random suffix %s\n", randomSuffix)
+			ctx := e2eutil.InitTestContext(e2eutil.Options{
+				Namespace: fmt.Sprintf("enqueue-multicard-sum-test-%s", randomSuffix),
+			})
+			fmt.Printf("Test 17: Test context initialized, namespace %s\n", ctx.Namespace)
+			defer e2eutil.CleanupTestContext(ctx)
+
+			// Create queue with card quotas: TeslaK80: 4, RTX4090: 4 (total: 8)
+			queueSpec := &e2eutil.QueueSpec{
+				Name:   fmt.Sprintf("enqueue-sum-queue-%s", randomSuffix),
+				Weight: 10,
+				Capacity: v1.ResourceList{
+					v1.ResourceCPU:    resource.MustParse("10"),
+					v1.ResourceMemory: resource.MustParse("10Gi"),
+				},
+				Annotations: map[string]string{
+					"volcano.sh/card.quota": fmt.Sprintf(`{"%s": 4, "%s": 4}`,
+						CardTypeTeslaK80, CardTypeRTX4090),
+				},
+			}
+
+			fmt.Printf("Test 17: Creating queue %s with card quotas: %s=4, %s=4 (sum=8)\n",
+				queueSpec.Name, CardTypeTeslaK80, CardTypeRTX4090)
+			e2eutil.CreateQueueWithQueueSpec(ctx, queueSpec)
+
+			defer func() {
+				e2eutil.DeleteQueue(ctx, queueSpec.Name)
+				fmt.Printf("Test 17: Queue %s cleaned up\n", queueSpec.Name)
+			}()
+
+			// Wait for queue to become open
+			fmt.Printf("Test 17: Waiting for queue %s to become open\n", queueSpec.Name)
+			queueOpenErr := e2eutil.WaitQueueStatus(func() (bool, error) {
+				queue, err := ctx.Vcclient.SchedulingV1beta1().Queues().Get(context.TODO(), queueSpec.Name, metav1.GetOptions{})
+				if err != nil {
+					return false, err
+				}
+				return queue.Status.State == schedulingv1beta1.QueueStateOpen, nil
+			})
+			Expect(queueOpenErr).NotTo(HaveOccurred(), "Queue failed to become open")
+			fmt.Printf("Test 17: Queue %s is now open\n", queueSpec.Name)
+
+			// Create a job requesting multi-card type with 6 cards total (within sum capacity of 8)
+			// Job annotation uses multi-card format for enqueue check
+			jobSpec := &e2eutil.JobSpec{
+				Name:  fmt.Sprintf("enqueue-multicard-job-%s", randomSuffix),
+				Queue: queueSpec.Name,
+				Tasks: []e2eutil.TaskSpec{
+					{
+						Name: "tesla-task",
+						Min:  1,
+						Rep:  3,
+						Img:  e2eutil.DefaultNginxImage,
+						Req: v1.ResourceList{
+							v1.ResourceCPU:                    resource.MustParse("1"),
+							v1.ResourceMemory:                 resource.MustParse("1Gi"),
+							v1.ResourceName("nvidia.com/gpu"): resource.MustParse("1"),
+						},
+						Limit: v1.ResourceList{
+							v1.ResourceCPU:                    resource.MustParse("1"),
+							v1.ResourceMemory:                 resource.MustParse("1Gi"),
+							v1.ResourceName("nvidia.com/gpu"): resource.MustParse("1"),
+						},
+						Annotations: map[string]string{
+							"volcano.sh/card.name": CardTypeTeslaK80,
+						},
+					},
+					{
+						Name: "rtx-task",
+						Min:  1,
+						Rep:  3,
+						Img:  e2eutil.DefaultNginxImage,
+						Req: v1.ResourceList{
+							v1.ResourceCPU:                    resource.MustParse("1"),
+							v1.ResourceMemory:                 resource.MustParse("1Gi"),
+							v1.ResourceName("nvidia.com/gpu"): resource.MustParse("1"),
+						},
+						Limit: v1.ResourceList{
+							v1.ResourceCPU:                    resource.MustParse("1"),
+							v1.ResourceMemory:                 resource.MustParse("1Gi"),
+							v1.ResourceName("nvidia.com/gpu"): resource.MustParse("1"),
+						},
+						Annotations: map[string]string{
+							"volcano.sh/card.name": CardTypeRTX4090,
+						},
+					},
+				},
+				Annotations: map[string]string{
+					// Using multi-card format in job request for enqueue check
+					// This tells enqueue to check sum of quotas (4+4=8) >= 6
+					"volcano.sh/card.request": fmt.Sprintf(`{"%s|%s": 6}`,
+						CardTypeTeslaK80, CardTypeRTX4090),
+				},
+			}
+
+			fmt.Printf("Test 17: Creating job requesting 6 cards with multi-card format (%s|%s)\n",
+				CardTypeTeslaK80, CardTypeRTX4090)
+			fmt.Printf("Test 17: Job has 2 task types: 3x%s + 3x%s = 6 total cards\n",
+				CardTypeTeslaK80, CardTypeRTX4090)
+			job := e2eutil.CreateJob(ctx, jobSpec)
+
+			defer func() {
+				e2eutil.DeleteJob(ctx, job)
+				fmt.Printf("Test 17: Job %s cleaned up\n", job.Name)
+			}()
+
+			// Job should be enqueued successfully because sum check: 6 <= (4+4)=8
+			fmt.Printf("Test 17: Waiting for job to be ready (enqueue should succeed with sum check)\n")
+			err := e2eutil.WaitJobReady(ctx, job)
+			Expect(err).NotTo(HaveOccurred(), "Job should be enqueued successfully with multi-card quota sum check")
+			fmt.Printf("Test 17: Job %s is ready - enqueue sum check passed!\n", job.Name)
+
+			// Verify pods are scheduled correctly to different card types
+			pods, err := ctx.Kubeclient.CoreV1().Pods(ctx.Namespace).List(context.TODO(), metav1.ListOptions{
+				LabelSelector: fmt.Sprintf("volcano.sh/job-name=%s", job.Name),
+			})
+			Expect(err).NotTo(HaveOccurred())
+			fmt.Printf("Test 17: Found %d pods for job %s\n", len(pods.Items), job.Name)
+
+			teslaCount := 0
+			rtxCount := 0
+			for _, pod := range pods.Items {
+				if pod.Annotations["volcano.sh/card.name"] == CardTypeTeslaK80 {
+					teslaCount++
+				} else if pod.Annotations["volcano.sh/card.name"] == CardTypeRTX4090 {
+					rtxCount++
+				}
+			}
+			fmt.Printf("Test 17: Card distribution: %s=%d, %s=%d\n",
+				CardTypeTeslaK80, teslaCount, CardTypeRTX4090, rtxCount)
+			Expect(teslaCount).To(Equal(3), "Should have 3 TeslaK80 pods")
+			Expect(rtxCount).To(Equal(3), "Should have 3 RTX4090 pods")
+
+			fmt.Printf("Test 17: ✓ Enqueue mode multi-card quota sum check verified successfully\n")
+			fmt.Printf("Test 17: ✓ Different tasks using different card types confirmed\n")
+		})
+
+		// Test 18: Enqueue mode multi-card quota sum exceeds total
+		It("Enqueue Mode Multi-Card Quota Sum Rejects When Exceeding Total", func() {
+			randomSuffix := generateRandomSuffix()
+			fmt.Printf("Test 18: Generated random suffix %s\n", randomSuffix)
+			ctx := e2eutil.InitTestContext(e2eutil.Options{
+				Namespace: fmt.Sprintf("enqueue-multicard-exceed-test-%s", randomSuffix),
+			})
+			fmt.Printf("Test 18: Test context initialized, namespace %s\n", ctx.Namespace)
+			defer e2eutil.CleanupTestContext(ctx)
+
+			// Create queue with card quotas: TeslaK80: 3, RTX4090: 3 (total: 6)
+			queueSpec := &e2eutil.QueueSpec{
+				Name:   fmt.Sprintf("enqueue-exceed-queue-%s", randomSuffix),
+				Weight: 10,
+				Capacity: v1.ResourceList{
+					v1.ResourceCPU:    resource.MustParse("10"),
+					v1.ResourceMemory: resource.MustParse("10Gi"),
+				},
+				Annotations: map[string]string{
+					"volcano.sh/card.quota": fmt.Sprintf(`{"%s": 3, "%s": 3}`,
+						CardTypeTeslaK80, CardTypeRTX4090),
+				},
+			}
+
+			fmt.Printf("Test 18: Creating queue %s with card quotas: %s=3, %s=3 (sum=6)\n",
+				queueSpec.Name, CardTypeTeslaK80, CardTypeRTX4090)
+			e2eutil.CreateQueueWithQueueSpec(ctx, queueSpec)
+
+			defer func() {
+				e2eutil.DeleteQueue(ctx, queueSpec.Name)
+				fmt.Printf("Test 18: Queue %s cleaned up\n", queueSpec.Name)
+			}()
+
+			// Wait for queue to become open
+			fmt.Printf("Test 18: Waiting for queue %s to become open\n", queueSpec.Name)
+			queueOpenErr := e2eutil.WaitQueueStatus(func() (bool, error) {
+				queue, err := ctx.Vcclient.SchedulingV1beta1().Queues().Get(context.TODO(), queueSpec.Name, metav1.GetOptions{})
+				if err != nil {
+					return false, err
+				}
+				return queue.Status.State == schedulingv1beta1.QueueStateOpen, nil
+			})
+			Expect(queueOpenErr).NotTo(HaveOccurred(), "Queue failed to become open")
+			fmt.Printf("Test 18: Queue %s is now open\n", queueSpec.Name)
+
+			// Create a job requesting 8 cards (exceeds sum capacity of 6)
+			jobSpec := &e2eutil.JobSpec{
+				Name:  fmt.Sprintf("enqueue-exceed-job-%s", randomSuffix),
+				Queue: queueSpec.Name,
+				Tasks: []e2eutil.TaskSpec{
+					{
+						Name: "task-1",
+						Min:  1,
+						Rep:  8,
+						Img:  e2eutil.DefaultNginxImage,
+						Req: v1.ResourceList{
+							v1.ResourceCPU:                    resource.MustParse("1"),
+							v1.ResourceMemory:                 resource.MustParse("1Gi"),
+							v1.ResourceName("nvidia.com/gpu"): resource.MustParse("1"),
+						},
+						Limit: v1.ResourceList{
+							v1.ResourceCPU:                    resource.MustParse("1"),
+							v1.ResourceMemory:                 resource.MustParse("1Gi"),
+							v1.ResourceName("nvidia.com/gpu"): resource.MustParse("1"),
+						},
+						Annotations: map[string]string{
+							"volcano.sh/card.name": fmt.Sprintf("%s|%s", CardTypeTeslaK80, CardTypeRTX4090),
+						},
+					},
+				},
+				Annotations: map[string]string{
+					"volcano.sh/card.request": fmt.Sprintf(`{"%s|%s": 8}`,
+						CardTypeTeslaK80, CardTypeRTX4090),
+				},
+			}
+
+			fmt.Printf("Test 18: Creating job requesting 8 cards (exceeds sum quota of 6)\n")
+			job := e2eutil.CreateJob(ctx, jobSpec)
+
+			defer func() {
+				e2eutil.DeleteJob(ctx, job)
+				fmt.Printf("Test 18: Job %s cleaned up\n", job.Name)
+			}()
+
+			// Job should fail to enqueue because sum check: 8 > (3+3)=6
+			fmt.Printf("Test 18: Verifying job fails to enqueue (8 > 6)\n")
+			time.Sleep(JobProcessTimeout / 2)
+			e2eutil.CheckJobSchedulingFailed(ctx, job)
+			fmt.Printf("Test 18: ✓ Job correctly rejected when exceeding multi-card quota sum\n")
+		})
+
+		// Test 19: Tasks with multi-card annotation can be scheduled to different card types
+		It("Tasks With Multi-Card Annotation Can Use Different Card Types In Same Job", func() {
+			randomSuffix := generateRandomSuffix()
+			fmt.Printf("Test 19: Generated random suffix %s\n", randomSuffix)
+			ctx := e2eutil.InitTestContext(e2eutil.Options{
+				Namespace: fmt.Sprintf("multi-card-tasks-test-%s", randomSuffix),
+			})
+			fmt.Printf("Test 19: Test context initialized, namespace %s\n", ctx.Namespace)
+			defer e2eutil.CleanupTestContext(ctx)
+
+			// Create queue with card quotas: TeslaK80: 6, RTX4090: 6 (total: 12)
+			queueSpec := &e2eutil.QueueSpec{
+				Name:   fmt.Sprintf("multi-card-tasks-queue-%s", randomSuffix),
+				Weight: 10,
+				Capacity: v1.ResourceList{
+					v1.ResourceCPU:    resource.MustParse("10"),
+					v1.ResourceMemory: resource.MustParse("10Gi"),
+				},
+				Annotations: map[string]string{
+					"volcano.sh/card.quota": fmt.Sprintf(`{"%s": 3, "%s": 3}`,
+						CardTypeTeslaK80, CardTypeRTX4090),
+				},
+			}
+
+			fmt.Printf("Test 19: Creating queue %s with card quotas: %s=3, %s=3\n",
+				queueSpec.Name, CardTypeTeslaK80, CardTypeRTX4090)
+			e2eutil.CreateQueueWithQueueSpec(ctx, queueSpec)
+
+			defer func() {
+				e2eutil.DeleteQueue(ctx, queueSpec.Name)
+				fmt.Printf("Test 19: Queue %s cleaned up\n", queueSpec.Name)
+			}()
+
+			// Wait for queue to become open
+			fmt.Printf("Test 19: Waiting for queue %s to become open\n", queueSpec.Name)
+			queueOpenErr := e2eutil.WaitQueueStatus(func() (bool, error) {
+				queue, err := ctx.Vcclient.SchedulingV1beta1().Queues().Get(context.TODO(), queueSpec.Name, metav1.GetOptions{})
+				if err != nil {
+					return false, err
+				}
+				return queue.Status.State == schedulingv1beta1.QueueStateOpen, nil
+			})
+			Expect(queueOpenErr).NotTo(HaveOccurred(), "Queue failed to become open")
+			fmt.Printf("Test 19: Queue %s is now open\n", queueSpec.Name)
+
+			// Create a job with all tasks using multi-card annotation
+			// Each task will be scheduled to one of the card types based on availability
+			jobSpec := &e2eutil.JobSpec{
+				Name:  fmt.Sprintf("multi-card-tasks-job-%s", randomSuffix),
+				Queue: queueSpec.Name,
+				Tasks: []e2eutil.TaskSpec{
+					{
+						Name: "worker",
+						Min:  1,
+						Rep:  6,
+						Img:  e2eutil.DefaultNginxImage,
+						Req: v1.ResourceList{
+							v1.ResourceCPU:                    resource.MustParse("1"),
+							v1.ResourceMemory:                 resource.MustParse("1Gi"),
+							v1.ResourceName("nvidia.com/gpu"): resource.MustParse("1"),
+						},
+						Limit: v1.ResourceList{
+							v1.ResourceCPU:                    resource.MustParse("1"),
+							v1.ResourceMemory:                 resource.MustParse("1Gi"),
+							v1.ResourceName("nvidia.com/gpu"): resource.MustParse("1"),
+						},
+						Annotations: map[string]string{
+							// Multi-card annotation - can use either TeslaK80 or RTX4090
+							"volcano.sh/card.name": fmt.Sprintf("%s|%s", CardTypeTeslaK80, CardTypeRTX4090),
+						},
+					},
+				},
+				Annotations: map[string]string{
+					// Job-level multi-card request for enqueue check (6 cards total)
+					"volcano.sh/card.request": fmt.Sprintf(`{"%s|%s": 6}`,
+						CardTypeTeslaK80, CardTypeRTX4090),
+				},
+			}
+
+			fmt.Printf("Test 19: Creating job with 6 tasks, all using multi-card annotation (%s|%s)\n",
+				CardTypeTeslaK80, CardTypeRTX4090)
+			job := e2eutil.CreateJob(ctx, jobSpec)
+
+			defer func() {
+				e2eutil.DeleteJob(ctx, job)
+				fmt.Printf("Test 19: Job %s cleaned up\n", job.Name)
+			}()
+
+			// Job should be enqueued and scheduled successfully
+			fmt.Printf("Test 19: Waiting for job to be ready\n")
+			err := e2eutil.WaitJobReady(ctx, job)
+			Expect(err).NotTo(HaveOccurred(), "Job should be scheduled successfully")
+			fmt.Printf("Test 19: Job %s is ready\n", job.Name)
+		})
+	})
+})
+
+// Helper function: int32 pointer
+func int32Ptr(i int32) *int32 {
+	return &i
+}
+
+// verifyPodScheduledToHighestPriorityCardType verifies that pods are scheduled to nodes
+// with the highest priority card type available in the cluster.
+// It returns the card type distribution for further assertions.
+func verifyPodScheduledToHighestPriorityCardType(
+	ctx *e2eutil.TestContext,
+	jobName string,
+	expectedCardPriority []string,
+	minGPUCount int64,
+	testName string,
+) map[string]int {
+	// Step 1: Get all nodes and group them by card type
+	nodes, err := ctx.Kubeclient.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
+	Expect(err).NotTo(HaveOccurred())
+
+	cardTypeToNodes := make(map[string][]string) // card type -> node names
+
+	for _, node := range nodes.Items {
+		// Check if node has enough GPU capacity
+		gpuCapacity, hasGPU := node.Status.Allocatable["nvidia.com/gpu"]
+		if !hasGPU || gpuCapacity.Value() < minGPUCount {
+			continue
+		}
+
+		// Find card type from node labels
+		for labelKey, labelValue := range node.Labels {
+			if labelKey == "nvidia.com/gpu.product" || labelKey == "nvidia.com/card.product" {
+				cardTypeToNodes[labelValue] = append(cardTypeToNodes[labelValue], node.Name)
+				fmt.Printf("%s: Found node %s with card type %s (%d GPUs)\n",
+					testName, node.Name, labelValue, gpuCapacity.Value())
+				break
+			}
+		}
+	}
+
+	// Step 2: Determine which nodes should be used (highest priority card type)
+	expectedNodes := make(map[string]bool) // expected node names
+	expectedCardType := ""
+	expectedPriorityIndex := -1
+
+	for idx, cardType := range expectedCardPriority {
+		if nodeNames, exists := cardTypeToNodes[cardType]; exists && len(nodeNames) > 0 {
+			expectedCardType = cardType
+			expectedPriorityIndex = idx
+			for _, nodeName := range nodeNames {
+				expectedNodes[nodeName] = true
+			}
+			expectedScore := 100.0 * math.Pow(0.5, float64(idx))
+			fmt.Printf("%s: Highest priority card type: %s (index: %d, score: %.2f), nodes: %v\n",
+				testName, cardType, idx, expectedScore, nodeNames)
+			break
+		}
+	}
+
+	if expectedCardType == "" {
+		fmt.Printf("%s: Warning - No nodes with expected card types found\n", testName)
+		return make(map[string]int)
+	}
+
+	// Step 3: Get pods and verify they are scheduled to expected nodes
+	pods, err := ctx.Kubeclient.CoreV1().Pods(ctx.Namespace).List(context.TODO(), metav1.ListOptions{
+		LabelSelector: fmt.Sprintf("volcano.sh/job-name=%s", jobName),
+	})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(len(pods.Items)).To(BeNumerically(">", 0), "Expected at least one pod")
+
+	scheduledCardTypes := make(map[string]int)
+
+	// Step 4: Verify each pod is scheduled to an expected node
+	for _, pod := range pods.Items {
+		Expect(pod.Spec.NodeName).NotTo(BeEmpty(), "Pod should be scheduled")
+
+		// Assert: Pod must be scheduled to one of the expected nodes
+		_, isExpectedNode := expectedNodes[pod.Spec.NodeName]
+		Expect(isExpectedNode).To(BeTrue(),
+			"Pod %s MUST be scheduled to a node with highest priority card type %s (expected nodes: %v), but scheduled to node %s",
+			pod.Name, expectedCardType, getMapKeys(expectedNodes), pod.Spec.NodeName)
+
+		// Track card type distribution
+		scheduledCardTypes[expectedCardType]++
+		fmt.Printf("%s: ✓ Pod %s CORRECTLY scheduled to node %s (card type: %s, priority index: %d)\n",
+			testName, pod.Name, pod.Spec.NodeName, expectedCardType, expectedPriorityIndex)
+	}
+
+	fmt.Printf("%s: Card type distribution: %v\n", testName, scheduledCardTypes)
+	return scheduledCardTypes
+}
+
+// getMapKeys returns the keys of a string->bool map as a slice
+func getMapKeys(m map[string]bool) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	return keys
+}

--- a/test/e2e/capacitycard/e2e_test.go
+++ b/test/e2e/capacitycard/e2e_test.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2025 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package capacitycard
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestE2E(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Volcano Capacity Card Test Suite")
+}

--- a/test/e2e/capacitycard/main_test.go
+++ b/test/e2e/capacitycard/main_test.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2025 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package capacitycard
+
+import (
+	"os"
+	"testing"
+
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+
+	vcclient "volcano.sh/apis/pkg/client/clientset/versioned"
+	e2eutil "volcano.sh/volcano/test/e2e/util"
+)
+
+func TestMain(m *testing.M) {
+	home := e2eutil.HomeDir()
+	configPath := e2eutil.KubeconfigPath(home)
+	config, _ := clientcmd.BuildConfigFromFlags(e2eutil.MasterURL(), configPath)
+	e2eutil.VcClient = vcclient.NewForConfigOrDie(config)
+	e2eutil.KubeClient = kubernetes.NewForConfigOrDie(config)
+	os.Exit(m.Run())
+}

--- a/test/e2e/util/job.go
+++ b/test/e2e/util/job.go
@@ -48,6 +48,7 @@ type TaskSpec struct {
 	Limit                 v1.ResourceList
 	Affinity              *v1.Affinity
 	Labels                map[string]string
+	Annotations           map[string]string
 	Policies              []batchv1alpha1.LifecyclePolicy
 	RestartPolicy         v1.RestartPolicy
 	Tolerations           []v1.Toleration
@@ -75,6 +76,7 @@ type JobSpec struct {
 	MaxRetry int32
 	// network topology mode hard or soft
 	NetworkTopology *batchv1alpha1.NetworkTopologySpec
+	Annotations     map[string]string
 }
 
 func Namespace(context *TestContext, job *JobSpec) string {
@@ -193,8 +195,9 @@ func CreateJobInner(ctx *TestContext, jobSpec *JobSpec) (*batchv1alpha1.Job, err
 
 	job := &batchv1alpha1.Job{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      jobSpec.Name,
-			Namespace: ns,
+			Name:        jobSpec.Name,
+			Namespace:   ns,
+			Annotations: jobSpec.Annotations,
 		},
 		Spec: batchv1alpha1.JobSpec{
 			SchedulerName:           "volcano",
@@ -232,8 +235,9 @@ func CreateJobInner(ctx *TestContext, jobSpec *JobSpec) (*batchv1alpha1.Job, err
 			MaxRetry: maxRetry,
 			Template: v1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:   name,
-					Labels: task.Labels,
+					Name:        name,
+					Labels:      task.Labels,
+					Annotations: task.Annotations,
 				},
 				Spec: v1.PodSpec{
 					RestartPolicy:     restartPolicy,
@@ -862,4 +866,33 @@ func RemovePodSchGates(ctx *TestContext, targetJob *batchv1alpha1.Job) error {
 func DeleteJob(ctx *TestContext, job *batchv1alpha1.Job) {
 	err := ctx.Vcclient.BatchV1alpha1().Jobs(job.Namespace).Delete(context.TODO(), job.Name, metav1.DeleteOptions{})
 	Expect(err).NotTo(HaveOccurred(), "failed to delete job %s", job.Name)
+}
+
+func CheckJobSchedulingFailed(ctx *TestContext, job *batchv1alpha1.Job) {
+	// Check job status
+	jobUpdated, err := ctx.Vcclient.BatchV1alpha1().Jobs(ctx.Namespace).Get(context.TODO(), job.Name, metav1.GetOptions{})
+	Expect(err).NotTo(HaveOccurred(), "Failed to get job status")
+	fmt.Printf("Job %s current status: %s, Running: %d, Pending: %d\n",
+		jobUpdated.Status.State, jobUpdated.Status.Running, jobUpdated.Status.Pending)
+
+	// Verify job status: should have no running pods due to exceeding quota
+	Expect(jobUpdated.Status.Running).To(Equal(int32(0)), "Job should not have running pods because it exceeded queue quota")
+
+	// Check pods associated with job
+	pods, err := ctx.Kubeclient.CoreV1().Pods(ctx.Namespace).List(context.TODO(), metav1.ListOptions{
+		LabelSelector: fmt.Sprintf("volcano.sh/job-name=%s", job.Name),
+	})
+	Expect(err).NotTo(HaveOccurred(), "Failed to get pod list for job")
+
+	// Print pod status information
+	for _, pod := range pods.Items {
+		fmt.Printf("Pod %s of job status: %s\n", pod.Name, pod.Status.Phase)
+	}
+
+	// Verify pod status: job pods should be in Pending state (cannot be scheduled)
+	for _, pod := range pods.Items {
+		Expect(pod.Status.Phase).To(Equal(v1.PodPending), "Job pods should be in Pending state due to insufficient resource quota")
+	}
+
+	fmt.Printf("Job %s validation completed - correctly failed to schedule due to quota limit\n", job.Name)
 }

--- a/test/e2e/util/queue.go
+++ b/test/e2e/util/queue.go
@@ -34,6 +34,8 @@ type QueueSpec struct {
 	Name              string
 	Weight            int32
 	GuaranteeResource v1.ResourceList
+	Annotations       map[string]string
+	Capacity          v1.ResourceList
 }
 
 func CreateQueueWithQueueSpec(ctx *TestContext, queueSpec *QueueSpec) {
@@ -47,9 +49,22 @@ func CreateQueueWithQueueSpec(ctx *TestContext, queueSpec *QueueSpec) {
 				Weight: queueSpec.Weight,
 			},
 		}
+
+		// set annotations
+		if queueSpec.Annotations != nil {
+			queue.ObjectMeta.Annotations = queueSpec.Annotations
+		}
+
+		// set guarantee resource
 		if len(queueSpec.GuaranteeResource) != 0 {
 			queue.Spec.Guarantee.Resource = queueSpec.GuaranteeResource
 		}
+
+		// set capacity
+		if len(queueSpec.Capacity) != 0 {
+			queue.Spec.Capability = queueSpec.Capacity
+		}
+
 		_, err := ctx.Vcclient.SchedulingV1beta1().Queues().Create(context.TODO(), queue, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred(), "failed to create queue %s", queueSpec.Name)
 	}


### PR DESCRIPTION
Introduce new plugin `capacity-card` to provide fine-grained GPU, NPU and other accelerator card resource management and scheduling capabilities in heterogeneous computing clusters

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This PR introduces a new scheduler plugin called **capacity-card** that enables fine-grained management and scheduling of heterogeneous GPU/NPU/accelerator card resources in Volcano.

**Key capabilities:**
- **Fine-grained card quota management**: Queue-level resource quotas for different card types (e.g., A100, H100, V100) via annotations
- **Multi-card selection**: Jobs can specify multiple acceptable card types (e.g., "A100|H100") for flexible scheduling
- **Mixed GPU sharing modes**: Support for whole cards, MPS (Multi-Process Service), and MIG (Multi-Instance GPU) in the same cluster
- **Card resource discovery**: Automatic detection of card types and resources from node labels
- **Fast feedback**: Pre-validation of job card requests before enqueueing

**Main components:**
- Core plugin implementation with event handling and resource tracking
- Queue annotation `volcano.sh/card.quota` for card quota specification
- Job annotation `volcano.sh/card.request` for card request validation
- Task annotation `volcano.sh/card.name` for card type selection (supports multi-card syntax with `|`)
- Comprehensive unit tests (9,000+ lines) and E2E tests
- Design documentation and usage examples

**Changes summary:**
- 31 files changed, 11,713+ insertions
- Plugin implementation: 2,400+ lines
- Tests: 9,000+ lines
- Documentation and E2E tests

#### Which issue(s) this PR fixes:

<!--

*Automatically closes linked issue when PR is merged.

Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Notice that do not add `Fixes` if the issue is associated with multiple PRs.

-->

Fixes #

#### Special notes for your reviewer:

1. **Plugin compatibility**: This plugin should NOT be enabled simultaneously with the standard `capacity` or `proportion` plugin to avoid scheduling conflicts.

2. **Node label requirements**: Proper node labels (e.g., `nvidia.com/gpu.product`, `nvidia.com/gpu.count`) must be configured for card discovery to work correctly. These are typically set by GPU operators like NVIDIA GPU Operator.

3. **Configuration option**: The plugin supports `cardUnlimitedCpuMemory` configuration to bypass CPU/Memory quota checks when card resources are the primary constraint.

4. **Extensive test coverage**: The PR includes comprehensive unit tests (~9,000 lines) and E2E tests to ensure reliability.

5. **Design document**: Please review `docs/design/capacity-card.md` for detailed architecture, API design, and usage scenarios.

#### Does this PR introduce a user-facing change?

<!--

If no, just write "NONE" in the release-note block below.

If yes, a release note is required.

-->

```release-note
New scheduler plugin `capacity-card` for fine-grained GPU/NPU/accelerator card resource management in heterogeneous clusters. Supports multi-card selection, MPS/MIG sharing modes, and queue-level card quotas via annotations.
```
