### PR TITLE
Update metrics_client_prometheus.go

### DIFF
--- a/pkg/scheduler/metrics/source/metrics_client_prometheus.go
+++ b/pkg/scheduler/metrics/source/metrics_client_prometheus.go
@@ -79,7 +79,7 @@ func (p *PrometheusMetricsClient) NodeMetricsAvg(ctx context.Context, nodeName s
 	}
 	v1api := prometheusv1.NewAPI(client)
 	nodeMetrics := &NodeMetrics{}
-	cpuQueryStr := fmt.Sprintf("avg_over_time((100 - (avg by (instance) (irate(node_cpu_seconds_total{mode=\"idle\",instance=\"%s\"}[5m])) * 100))[%s:30s])", nodeName, NODE_METRICS_PERIOD)
+	cpuQueryStr := fmt.Sprintf(`avg_over_time(clamp_min(100 - (avg by (instance) (rate(node_cpu_seconds_total{mode="idle",instance="%s"}[5m])) * 100), 0)[%s:30s])`, nodeName, NODE_METRICS_PERIOD)
 	memQueryStr := fmt.Sprintf("100*avg_over_time(((1-node_memory_MemAvailable_bytes{instance=\"%s\"}/node_memory_MemTotal_bytes{instance=\"%s\"}))[%s:30s])", nodeName, nodeName, NODE_METRICS_PERIOD)
 
 	for _, metric := range []string{cpuQueryStr, memQueryStr} {


### PR DESCRIPTION
#### What type of PR is this?

This PR is the resolution of the below github issue. Please review and do the needful.
https://github.com/volcano-sh/volcano/issues/4685

#### What this PR does / why we need it:

When using the usage plugin with the metrics endpoint configured against VictoriaMetrics vmselect, the scheduler periodically reports negative CPU usage in logs such as:

I1017 12:15:47.433614       1 usage.go:121] node:io-16, cpu usage:map[10m:-5035.937500138729], mem usage:map[10m:55.25365070508814]
I1017 12:15:47.433631       1 usage.go:121] node:io-35, cpu usage:map[10m:-24565.178572592726], mem usage:map[10m:2.2509139279284374]

This occurs even though the nodes are healthy and utilization metrics inside Prometheus/Grafana show valid positive CPU values.

This leads to the scheduler misjudging available resources, affecting job placement decisions


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Notice that do not add `Fixes` if the issue is associated with multiple PRs.
-->
Fixes #

I debugged it. Using rate() instead of irate() inside avg_over_time() fixed the issue of the negative CPU.

Before:

```
wget -qO- 'http://0.0.0.0:8481/select/0/prometheus/api/v1/query?query=avg_over_time%28%28100%20-%20%28avg%20by%20%28instance%29%20%28irate%28
node_cpu_seconds_total%7Bmode%3D"idle"%2Cinstance%3D"io-23"%7D%5B5m%5D%29%29%20*%20100%29%29%5B10m%5D%29'

{"status":"success","isPartial":false,"data":{"resultType":"vector","result":[{"metric":{"instance":"io-23"},"value":[1761890760,"-2465.27777787091"]}]}}/ #
```

After:

```
wget -qO- 'http://0.0.0.0:8481/select/0/prometheus/api/v1/query?query=avg_over_time%28%28100%20-%20%28avg%20by%20%28instance%29%20%28rate%28n
ode_cpu_seconds_total%7Bmode%3D%22idle%22%2Cinstance%3D%22io-23%22%7D%5B5m%5D%29%29%20*%20100%29%29%5B10m%5D%29'

{"status":"success","isPartial":false,"data":{"resultType":"vector","result":[{"metric":{"instance":"io-23"},"value":[1761890818,"7.674041666657047"]}]}}/ # 
```

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```