### PR TITLE
 Optimize ancestor queue resource updates using delta propagation in capacity plugin

### DIFF
--- a/pkg/scheduler/plugins/capacity/capacity.go
+++ b/pkg/scheduler/plugins/capacity/capacity.go
@@ -574,12 +574,16 @@ func (cp *capacityPlugin) buildHierarchicalQueueAttrs(ssn *framework.Session) bo
 		}
 		attr.elastic.Add(job.GetElasticResources())
 
+		allocatedDelta := attr.allocated.Clone().Sub(oldAllocated)
+		requestDelta := attr.request.Clone().Sub(oldRequest)
+		inqueueDelta := attr.inqueue.Clone().Sub(oldInqueue)
+		elasticDelta := attr.elastic.Clone().Sub(oldElastic)
 		for _, ancestor := range attr.ancestors {
 			ancestorAttr := cp.queueOpts[ancestor]
-			ancestorAttr.allocated.Add(attr.allocated.Clone().Sub(oldAllocated))
-			ancestorAttr.request.Add(attr.request.Clone().Sub(oldRequest))
-			ancestorAttr.inqueue.Add(attr.inqueue.Clone().Sub(oldInqueue))
-			ancestorAttr.elastic.Add(attr.elastic.Clone().Sub(oldElastic))
+			ancestorAttr.allocated.Add(allocatedDelta)
+			ancestorAttr.request.Add(requestDelta)
+			ancestorAttr.inqueue.Add(inqueueDelta)
+			ancestorAttr.elastic.Add(elasticDelta)
 		}
 
 		klog.V(5).Infof("Queue %s allocated <%s> request <%s> inqueue <%s> elastic <%s>",


### PR DESCRIPTION
#### What type of PR is this?

/kind improvement

#### What this PR does / why we need it:

This PR optimizes the resource update mechanism for ancestor queues in hierarchical queue structures within the capacity plugin.

**Optimization Details:**
- Instead of recalculating all ancestor queue resources from scratch, this implementation calculates the resource deltas (differences) once for each job update
- The deltas are then efficiently propagated to all ancestor queues in the hierarchy
- This approach reduces computational overhead, especially in deep hierarchical queue structures with multiple ancestors

**Performance Benefits:**
- Reduces redundant calculations when updating ancestor queue resources
- Improves scheduler performance when dealing with hierarchical queues
- Scales better with deeper queue hierarchies

The optimization applies to four resource metrics:
- `allocated`: Resources currently allocated to pods
- `request`: Total resources requested
- `inqueue`: Resources waiting in queue
- `elastic`: Elastic resources available

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

- The logic preserves the same behavior as before, only optimizing the calculation method
- Old values are cloned at the beginning (lines 544-547) to calculate accurate deltas
- The delta propagation loop (lines 581-587) efficiently updates all ancestors

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
