### PR TITLE
Optimize the copy performance of PriorityQueue

### DIFF
--- a/pkg/scheduler/util/priority_queue.go
+++ b/pkg/scheduler/util/priority_queue.go
@@ -71,15 +71,14 @@ func (q *PriorityQueue) Len() int {
 }
 
 func (q *PriorityQueue) Clone() *PriorityQueue {
+	items := make([]interface{}, len(q.queue.items), cap(q.queue.items))
+	copy(items, q.queue.items)
+
 	newPq := &PriorityQueue{
 		queue: priorityQueue{
-			items:  make([]interface{}, 0),
+			items:  items,
 			lessFn: q.queue.lessFn,
 		},
-	}
-
-	for _, it := range q.queue.items {
-		newPq.Push(it)
 	}
 	return newPq
 }
@@ -95,7 +94,7 @@ func (pq *priorityQueue) Less(i, j int) bool {
 	return pq.lessFn(pq.items[i], pq.items[j])
 }
 
-func (pq priorityQueue) Swap(i, j int) {
+func (pq *priorityQueue) Swap(i, j int) {
 	pq.items[i], pq.items[j] = pq.items[j], pq.items[i]
 }
 


### PR DESCRIPTION
#### What type of PR is this?
/kind feature
/kind performance
#### What this PR does / why we need it:
In the current implementation, the `PriorityQueue` copy operation reorders items according to the `lessFn` function. However, in reality, the items in the source queue are already sorted, so they only need to be copied in their existing order.
In the **Network Topology Aware Scheduling** scenario, there are many copy operations for `PriorityQueue`, and calling `lessFn` for sorting during each copy may lead to inefficient scheduling.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Notice that do not add `Fixes` if the issue is associated with multiple PRs.
-->
Fixes #4188 

#### Special notes for your reviewer:
@wangyang0616 @JesseStutler @hzxuzhonghu 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```