### PR TITLE
[Cherry-pick 1.12] Fix scheduler panic by moving InitKubeSchedulerRelatedMetrics outside…

### DIFF
--- a/cmd/scheduler/app/server.go
+++ b/cmd/scheduler/app/server.go
@@ -70,8 +70,11 @@ func Run(opt *options.ServerOption) error {
 		panic(err)
 	}
 
+	// InitKubeSchedulerRelatedMetrics must always be called to initialize
+	// k8smetrics.Goroutines which is used by Kubernetes scheduler framework plugins
+	metrics.InitKubeSchedulerRelatedMetrics()
+
 	if opt.EnableMetrics || opt.EnablePprof {
-		metrics.InitKubeSchedulerRelatedMetrics()
 		go startMetricsServer(opt)
 	}
 


### PR DESCRIPTION
Cherry-picks #4731 for `release-1.12`.

#### What type of PR is this?
Bug fix

#### What this PR does / why we need it:

Scheduler panics with nil pointer dereference during pod scheduling when started without `--enable-metrics=true`. The Kubernetes scheduler framework plugins unconditionally access `k8smetrics.Goroutines`, which was only initialized when metrics were enabled.

**Changes:**
- Moved `metrics.InitKubeSchedulerRelatedMetrics()` outside the `if opt.EnableMetrics || opt.EnablePprof` block in `cmd/scheduler/app/server.go`
- Ensures `k8smetrics.Goroutines` is always initialized before scheduler starts

```go
// Before: InitKubeSchedulerRelatedMetrics only called when metrics enabled
if opt.EnableMetrics || opt.EnablePprof {
    metrics.InitKubeSchedulerRelatedMetrics()
    go startMetricsServer(opt)
}

// After: Always initialize required metrics
metrics.InitKubeSchedulerRelatedMetrics()

if opt.EnableMetrics || opt.EnablePprof {
    go startMetricsServer(opt)
}
```

#### Which issue(s) this PR fixes:

Fixes #4729 

#### Special notes for your reviewer:

The panic occurs in `k8s.io/kubernetes/pkg/scheduler/framework/parallelize.Parallelizer.Until` at line 57 when calling `Goroutines.WithLabelValues()`. This metric must be initialized regardless of whether metrics export is enabled.

#### Does this PR introduce a user-facing change?

`release-note
Fix scheduler panic when starting without --enable-metrics=true flag
`