### PR TITLE
fix: support for aborted job state in garbage collector

### DIFF
--- a/pkg/controllers/garbagecollector/garbagecollector.go
+++ b/pkg/controllers/garbagecollector/garbagecollector.go
@@ -271,7 +271,8 @@ func needsCleanup(j *v1alpha1.Job) bool {
 func isJobFinished(job *v1alpha1.Job) bool {
 	return job.Status.State.Phase == v1alpha1.Completed ||
 		job.Status.State.Phase == v1alpha1.Failed ||
-		job.Status.State.Phase == v1alpha1.Terminated
+		job.Status.State.Phase == v1alpha1.Terminated ||
+		job.Status.State.Phase == v1alpha1.Aborted
 }
 
 func getFinishAndExpireTime(j *v1alpha1.Job) (*time.Time, *time.Time, error) {

--- a/pkg/controllers/garbagecollector/garbagecollector_test.go
+++ b/pkg/controllers/garbagecollector/garbagecollector_test.go
@@ -191,6 +191,21 @@ func TestGarbageCollector_IsJobFinished(t *testing.T) {
 			ExpectedVal: true,
 		},
 		{
+			Name: "Aborted Case",
+			Job: &v1alpha1.Job{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "job1",
+					Namespace: namespace,
+				},
+				Status: v1alpha1.JobStatus{
+					State: v1alpha1.JobState{
+						Phase: v1alpha1.Aborted,
+					},
+				},
+			},
+			ExpectedVal: true,
+		},
+		{
 			Name: "False Case",
 			Job: &v1alpha1.Job{
 				ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
#### What type of PR is this?
This PR is the fix of #4736 

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Notice that do not add `Fixes` if the issue is associated with multiple PRs.
-->
Fixes #4736 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
The vcjob that was aborted will be garbage collected normally
```