### PR TITLE
# [Feature] Add Liveness and Readiness Probes to Core Deployments

### DIFF
--- a/installer/README.md
+++ b/installer/README.md
@@ -90,6 +90,7 @@ The following are the list configurable parameters of Volcano Chart and their de
 |`basic.admission_app_name`|Admission Controller App Name|`volcano-admission`|
 |`basic.controller_app_name`|Controller App Name|`volcano-controller`|
 |`basic.scheduler_app_name`|Scheduler App Name|`volcano-scheduler`|
+|`basic.healthz_port`| Pod Health port | `11251` |
 |`custom.metrics_enable`|Whether to Enable Metrics|`false`|
 |`custom.admission_enable`|Whether to Enable Admission|`true`|
 |`custom.admission_replicas`|The number of Admission pods to run|`1`|
@@ -133,6 +134,36 @@ The following are the list configurable parameters of Volcano Chart and their de
 |`custom.scheduler_log_level`|Settings log print level for Scheduler|`3`|
 |`custom.scheduler_plugins_dir`| Settings dir for the Scheduler to load custom plugins|``|
 |`custom.webhooks_namespace_selector_expressions`|Additional namespace selector expressions for Volcano admission webhooks|`~`|
+|`custom.admission_livenessProbe.initialDelaySeconds`|Time to wait before starting liveness checks|`10`|
+|`custom.admission_livenessProbe.periodSeconds`|How often the liveness probe runs|`20`|
+|`custom.admission_livenessProbe.timeoutSeconds`|Max time the liveness probe waits before timing out|`5`|
+|`custom.admission_livenessProbe.failureThreshold`|Number of failed checks before the container is restarted|`3`|
+|`custom.admission_livenessProbe.successThreshold`|Number of successes required to mark container healthy|`1`|
+|`custom.admission_readinessProbe.initialDelaySeconds`|Delay before starting readiness checks|`10`|
+|`custom.admission_readinessProbe.periodSeconds`|How often the readiness probe runs|`20`|
+|`custom.admission_readinessProbe.timeoutSeconds`|Max time the readiness probe waits before timing out|`5`|
+|`custom.admission_readinessProbe.failureThreshold`|Number of failed checks before marking container not ready|`3`|
+|`custom.admission_readinessProbe.successThreshold`|Successes required to mark container ready|`1`|
+|`custom.controller_livenessProbe.initialDelaySeconds`|Time to wait before starting liveness checks|`10`|
+|`custom.controller_livenessProbe.periodSeconds`|How often the liveness probe runs|`20`|
+|`custom.controller_livenessProbe.timeoutSeconds`|Max time the liveness probe waits before timing out|`5`|
+|`custom.controller_livenessProbe.failureThreshold`|Number of failed checks before the container is restarted|`3`|
+|`custom.controller_livenessProbe.successThreshold`|Number of successes required to mark container healthy|`1`|
+|`custom.controller_readinessProbe.initialDelaySeconds`|Delay before starting readiness checks|`10`|
+|`custom.controller_readinessProbe.periodSeconds`|How often the readiness probe runs|`20`|
+|`custom.controller_readinessProbe.timeoutSeconds`|Max time the readiness probe waits before timing out|`5`|
+|`custom.controller_readinessProbe.failureThreshold`|Number of failed checks before marking container not ready|`3`|
+|`custom.controller_readinessProbe.successThreshold`|Successes required to mark container ready|`1`|
+|`custom.scheduler_livenessProbe.initialDelaySeconds`|Time to wait before starting liveness checks|`10`|
+|`custom.scheduler_livenessProbe.periodSeconds`|How often the liveness probe runs|`20`|
+|`custom.scheduler_livenessProbe.timeoutSeconds`|Max time the liveness probe waits before timing out|`5`|
+|`custom.scheduler_livenessProbe.failureThreshold`|Number of failed checks before the container is restarted|`3`|
+|`custom.scheduler_livenessProbe.successThreshold`|Number of successes required to mark container healthy|`1`|
+|`custom.scheduler_readinessProbe.initialDelaySeconds`|Delay before starting readiness checks|`10`|
+|`custom.scheduler_readinessProbe.periodSeconds`|How often the readiness probe runs|`20`|
+|`custom.scheduler_readinessProbe.timeoutSeconds`|Max time the readiness probe waits before timing out|`5`|
+|`custom.scheduler_readinessProbe.failureThreshold`|Number of failed checks before marking container not ready|`3`|
+|`custom.scheduler_readinessProbe.successThreshold`|Successes required to mark container ready|`1`|
 |`service.ipFamilyPolicy`|Settings service the family policy|``|
 |`service.ipFamilies`|Settings service the address families|`[]`|
 

--- a/installer/README.md
+++ b/installer/README.md
@@ -134,35 +134,35 @@ The following are the list configurable parameters of Volcano Chart and their de
 |`custom.scheduler_log_level`|Settings log print level for Scheduler|`3`|
 |`custom.scheduler_plugins_dir`| Settings dir for the Scheduler to load custom plugins|``|
 |`custom.webhooks_namespace_selector_expressions`|Additional namespace selector expressions for Volcano admission webhooks|`~`|
-|`custom.admission_livenessProbe.initialDelaySeconds`|Time to wait before starting liveness checks|`10`|
-|`custom.admission_livenessProbe.periodSeconds`|How often the liveness probe runs|`20`|
+|`custom.admission_livenessProbe.initialDelaySeconds`|Time to wait before starting liveness checks|`30`|
+|`custom.admission_livenessProbe.periodSeconds`|How often the liveness probe runs|`10`|
 |`custom.admission_livenessProbe.timeoutSeconds`|Max time the liveness probe waits before timing out|`5`|
-|`custom.admission_livenessProbe.failureThreshold`|Number of failed checks before the container is restarted|`3`|
+|`custom.admission_livenessProbe.failureThreshold`|Number of failed checks before the container is restarted|`5`|
 |`custom.admission_livenessProbe.successThreshold`|Number of successes required to mark container healthy|`1`|
 |`custom.admission_readinessProbe.initialDelaySeconds`|Delay before starting readiness checks|`10`|
-|`custom.admission_readinessProbe.periodSeconds`|How often the readiness probe runs|`20`|
+|`custom.admission_readinessProbe.periodSeconds`|How often the readiness probe runs|`10`|
 |`custom.admission_readinessProbe.timeoutSeconds`|Max time the readiness probe waits before timing out|`5`|
-|`custom.admission_readinessProbe.failureThreshold`|Number of failed checks before marking container not ready|`3`|
+|`custom.admission_readinessProbe.failureThreshold`|Number of failed checks before marking container not ready|`5`|
 |`custom.admission_readinessProbe.successThreshold`|Successes required to mark container ready|`1`|
-|`custom.controller_livenessProbe.initialDelaySeconds`|Time to wait before starting liveness checks|`10`|
-|`custom.controller_livenessProbe.periodSeconds`|How often the liveness probe runs|`20`|
+|`custom.controller_livenessProbe.initialDelaySeconds`|Time to wait before starting liveness checks|`30`|
+|`custom.controller_livenessProbe.periodSeconds`|How often the liveness probe runs|`10`|
 |`custom.controller_livenessProbe.timeoutSeconds`|Max time the liveness probe waits before timing out|`5`|
-|`custom.controller_livenessProbe.failureThreshold`|Number of failed checks before the container is restarted|`3`|
+|`custom.controller_livenessProbe.failureThreshold`|Number of failed checks before the container is restarted|`5`|
 |`custom.controller_livenessProbe.successThreshold`|Number of successes required to mark container healthy|`1`|
 |`custom.controller_readinessProbe.initialDelaySeconds`|Delay before starting readiness checks|`10`|
-|`custom.controller_readinessProbe.periodSeconds`|How often the readiness probe runs|`20`|
+|`custom.controller_readinessProbe.periodSeconds`|How often the readiness probe runs|`10`|
 |`custom.controller_readinessProbe.timeoutSeconds`|Max time the readiness probe waits before timing out|`5`|
-|`custom.controller_readinessProbe.failureThreshold`|Number of failed checks before marking container not ready|`3`|
+|`custom.controller_readinessProbe.failureThreshold`|Number of failed checks before marking container not ready|`5`|
 |`custom.controller_readinessProbe.successThreshold`|Successes required to mark container ready|`1`|
-|`custom.scheduler_livenessProbe.initialDelaySeconds`|Time to wait before starting liveness checks|`10`|
-|`custom.scheduler_livenessProbe.periodSeconds`|How often the liveness probe runs|`20`|
+|`custom.scheduler_livenessProbe.initialDelaySeconds`|Time to wait before starting liveness checks|`30`|
+|`custom.scheduler_livenessProbe.periodSeconds`|How often the liveness probe runs|`10`|
 |`custom.scheduler_livenessProbe.timeoutSeconds`|Max time the liveness probe waits before timing out|`5`|
-|`custom.scheduler_livenessProbe.failureThreshold`|Number of failed checks before the container is restarted|`3`|
+|`custom.scheduler_livenessProbe.failureThreshold`|Number of failed checks before the container is restarted|`5`|
 |`custom.scheduler_livenessProbe.successThreshold`|Number of successes required to mark container healthy|`1`|
 |`custom.scheduler_readinessProbe.initialDelaySeconds`|Delay before starting readiness checks|`10`|
-|`custom.scheduler_readinessProbe.periodSeconds`|How often the readiness probe runs|`20`|
+|`custom.scheduler_readinessProbe.periodSeconds`|How often the readiness probe runs|`10`|
 |`custom.scheduler_readinessProbe.timeoutSeconds`|Max time the readiness probe waits before timing out|`5`|
-|`custom.scheduler_readinessProbe.failureThreshold`|Number of failed checks before marking container not ready|`3`|
+|`custom.scheduler_readinessProbe.failureThreshold`|Number of failed checks before marking container not ready|`5`|
 |`custom.scheduler_readinessProbe.successThreshold`|Successes required to mark container ready|`1`|
 |`service.ipFamilyPolicy`|Settings service the family policy|``|
 |`service.ipFamilies`|Settings service the address families|`[]`|

--- a/installer/helm/chart/volcano/templates/_helpers.tpl
+++ b/installer/helm/chart/volcano/templates/_helpers.tpl
@@ -11,19 +11,37 @@ v1beta1
 {{- end -}}
 
 {{/*
-A reusable template to generate a Kubernetes Liveness or Readiness probe configuration.
-Context MUST be the custom probe values for that specific component/probe.
+A reusable template to generate a Kubernetes Readiness probe configuration.
+Context MUST be the custom probe values for that specific component.
 Example Call: 
-{{ include "volcano.probe" (dict "values" .Values.admission_liveness "scheme" "HTTPS" "port" 8080) }}
+{{- include "volcano.readiness.probe" (dict "port" ( .Values.basic.healthz_port | default 11251 ) "scheme" "HTTPS" "values" .Values.custom.admission_readinessProbe) }}
 */}}
-{{- define "volcano.probe" -}}
+{{- define "volcano.readiness.probe" -}}
 httpGet:
   path: /healthz
   port: {{ .port }}
   scheme: {{ .scheme }}
 initialDelaySeconds: {{ .values.initialDelaySeconds | default 10 }}
-periodSeconds: {{ .values.periodSeconds | default 20 }}
+periodSeconds: {{ .values.periodSeconds | default 10 }}
 timeoutSeconds: {{ .values.timeoutSeconds | default 5 }}
-failureThreshold: {{ .values.failureThreshold | default 3 }}
+failureThreshold: {{ .values.failureThreshold | default 5 }}
+successThreshold: {{ .values.successThreshold | default 1 }}
+{{- end -}}
+
+{{/*
+A reusable template to generate a Kubernetes Liveness probe configuration.
+Context MUST be the custom probe values for that specific component.
+Example Call: 
+{{- include "volcano.liveness.probe" (dict "port" ( .Values.basic.healthz_port | default 11251 ) "scheme" "HTTPS" "values" .Values.custom.admission_livenessProbe) }}
+*/}}
+{{- define "volcano.liveness.probe" -}}
+httpGet:
+  path: /healthz
+  port: {{ .port }}
+  scheme: {{ .scheme }}
+initialDelaySeconds: {{ .values.initialDelaySeconds | default 30 }}
+periodSeconds: {{ .values.periodSeconds | default 10 }}
+timeoutSeconds: {{ .values.timeoutSeconds | default 5 }}
+failureThreshold: {{ .values.failureThreshold | default 5 }}
 successThreshold: {{ .values.successThreshold | default 1 }}
 {{- end -}}

--- a/installer/helm/chart/volcano/templates/_helpers.tpl
+++ b/installer/helm/chart/volcano/templates/_helpers.tpl
@@ -9,3 +9,21 @@ bases
 v1beta1
 {{- end -}}
 {{- end -}}
+
+{{/*
+A reusable template to generate a Kubernetes Liveness or Readiness probe configuration.
+Context MUST be the custom probe values for that specific component/probe.
+Example Call: 
+{{ include "volcano.probe" (dict "values" .Values.admission_liveness "scheme" "HTTPS" "port" 8080) }}
+*/}}
+{{- define "volcano.probe" -}}
+httpGet:
+  path: /healthz
+  port: {{ .port }}
+  scheme: {{ .scheme }}
+initialDelaySeconds: {{ .values.initialDelaySeconds | default 10 }}
+periodSeconds: {{ .values.periodSeconds | default 20 }}
+timeoutSeconds: {{ .values.timeoutSeconds | default 5 }}
+failureThreshold: {{ .values.failureThreshold | default 3 }}
+successThreshold: {{ .values.successThreshold | default 1 }}
+{{- end -}}

--- a/installer/helm/chart/volcano/templates/admission.yaml
+++ b/installer/helm/chart/volcano/templates/admission.yaml
@@ -154,9 +154,9 @@ spec:
           imagePullPolicy: {{ .Values.basic.image_pull_policy }}
           name: admission
           livenessProbe:
-            {{- include "volcano.probe" (dict "port" ( .Values.basic.healthz_port | default 11251 ) "scheme" "HTTPS" "values" .Values.custom.admission_livenessProbe) | nindent 12 }}
+            {{- include "volcano.liveness.probe" (dict "port" ( .Values.basic.healthz_port | default 11251 ) "scheme" "HTTPS" "values" .Values.custom.admission_livenessProbe) | nindent 12 }}
           readinessProbe:
-            {{- include "volcano.probe" (dict "port" ( .Values.basic.healthz_port | default 11251 ) "scheme" "HTTPS" "values" .Values.custom.admission_readinessProbe) | nindent 12 }}
+            {{- include "volcano.readiness.probe" (dict "port" ( .Values.basic.healthz_port | default 11251 ) "scheme" "HTTPS" "values" .Values.custom.admission_readinessProbe) | nindent 12 }}
           {{- if .Values.custom.admission_resources }}
           resources:
           {{- toYaml .Values.custom.admission_resources | nindent 12 }}

--- a/installer/helm/chart/volcano/templates/admission.yaml
+++ b/installer/helm/chart/volcano/templates/admission.yaml
@@ -153,6 +153,10 @@ spec:
           image: {{ .Values.basic.image_registry }}/{{.Values.basic.admission_image_name}}:{{.Values.basic.image_tag_version}}
           imagePullPolicy: {{ .Values.basic.image_pull_policy }}
           name: admission
+          livenessProbe:
+            {{- include "volcano.probe" (dict "port" ( .Values.basic.healthz_port | default 11251 ) "scheme" "HTTPS" "values" .Values.custom.admission_livenessProbe) | nindent 12 }}
+          readinessProbe:
+            {{- include "volcano.probe" (dict "port" ( .Values.basic.healthz_port | default 11251 ) "scheme" "HTTPS" "values" .Values.custom.admission_readinessProbe) | nindent 12 }}
           {{- if .Values.custom.admission_resources }}
           resources:
           {{- toYaml .Values.custom.admission_resources | nindent 12 }}

--- a/installer/helm/chart/volcano/templates/controllers.yaml
+++ b/installer/helm/chart/volcano/templates/controllers.yaml
@@ -173,9 +173,9 @@ spec:
             {{- end }}
           image: {{ .Values.basic.image_registry }}/{{.Values.basic.controller_image_name}}:{{.Values.basic.image_tag_version}}
           livenessProbe:
-            {{- include "volcano.probe" (dict "port" ( .Values.basic.healthz_port | default 11251 ) "scheme" "HTTP" "values" .Values.custom.controller_livenessProbe) | nindent 12 }}
+            {{- include "volcano.liveness.probe" (dict "port" ( .Values.basic.healthz_port | default 11251 ) "scheme" "HTTP" "values" .Values.custom.controller_livenessProbe) | nindent 12 }}
           readinessProbe:
-            {{- include "volcano.probe" (dict "port" ( .Values.basic.healthz_port | default 11251 ) "scheme" "HTTP" "values" .Values.custom.controller_readinessProbe) | nindent 12 }}
+            {{- include "volcano.readiness.probe" (dict "port" ( .Values.basic.healthz_port | default 11251 ) "scheme" "HTTP" "values" .Values.custom.controller_readinessProbe) | nindent 12 }}
           args:
             - --logtostderr
             - --enable-healthz=true

--- a/installer/helm/chart/volcano/templates/controllers.yaml
+++ b/installer/helm/chart/volcano/templates/controllers.yaml
@@ -172,6 +172,10 @@ spec:
             {{- toYaml .Values.custom.controller_resources | nindent 14 }}
             {{- end }}
           image: {{ .Values.basic.image_registry }}/{{.Values.basic.controller_image_name}}:{{.Values.basic.image_tag_version}}
+          livenessProbe:
+            {{- include "volcano.probe" (dict "port" ( .Values.basic.healthz_port | default 11251 ) "scheme" "HTTP" "values" .Values.custom.controller_livenessProbe) | nindent 12 }}
+          readinessProbe:
+            {{- include "volcano.probe" (dict "port" ( .Values.basic.healthz_port | default 11251 ) "scheme" "HTTP" "values" .Values.custom.controller_readinessProbe) | nindent 12 }}
           args:
             - --logtostderr
             - --enable-healthz=true

--- a/installer/helm/chart/volcano/templates/scheduler.yaml
+++ b/installer/helm/chart/volcano/templates/scheduler.yaml
@@ -193,6 +193,10 @@ spec:
       containers:
         - name: {{ .Release.Name }}-scheduler
           image: {{ .Values.basic.image_registry }}/{{.Values.basic.scheduler_image_name}}:{{.Values.basic.image_tag_version}}
+          livenessProbe:
+            {{- include "volcano.probe" (dict "port" ( .Values.basic.healthz_port | default 11251 ) "scheme" "HTTP" "values" .Values.custom.scheduler_livenessProbe) | nindent 12 }}
+          readinessProbe:
+            {{- include "volcano.probe" (dict "port" ( .Values.basic.healthz_port | default 11251 ) "scheme" "HTTP" "values" .Values.custom.scheduler_readinessProbe) | nindent 12 }}
           {{- if .Values.custom.scheduler_resources }}
           resources:
           {{- toYaml .Values.custom.scheduler_resources | nindent 12 }}

--- a/installer/helm/chart/volcano/templates/scheduler.yaml
+++ b/installer/helm/chart/volcano/templates/scheduler.yaml
@@ -194,9 +194,9 @@ spec:
         - name: {{ .Release.Name }}-scheduler
           image: {{ .Values.basic.image_registry }}/{{.Values.basic.scheduler_image_name}}:{{.Values.basic.image_tag_version}}
           livenessProbe:
-            {{- include "volcano.probe" (dict "port" ( .Values.basic.healthz_port | default 11251 ) "scheme" "HTTP" "values" .Values.custom.scheduler_livenessProbe) | nindent 12 }}
+            {{- include "volcano.liveness.probe" (dict "port" ( .Values.basic.healthz_port | default 11251 ) "scheme" "HTTP" "values" .Values.custom.scheduler_livenessProbe) | nindent 12 }}
           readinessProbe:
-            {{- include "volcano.probe" (dict "port" ( .Values.basic.healthz_port | default 11251 ) "scheme" "HTTP" "values" .Values.custom.scheduler_readinessProbe) | nindent 12 }}
+            {{- include "volcano.readiness.probe" (dict "port" ( .Values.basic.healthz_port | default 11251 ) "scheme" "HTTP" "values" .Values.custom.scheduler_readinessProbe) | nindent 12 }}
           {{- if .Values.custom.scheduler_resources }}
           resources:
           {{- toYaml .Values.custom.scheduler_resources | nindent 12 }}

--- a/installer/helm/chart/volcano/values.yaml
+++ b/installer/helm/chart/volcano/values.yaml
@@ -13,6 +13,7 @@ basic:
   image_tag_version: "latest"
   admission_port: 8443
   image_registry: "docker.io"
+  healthz_port: 11251
 custom:
   go_memlimit_enable: false
   metrics_enable: false
@@ -260,6 +261,35 @@ custom:
 
   # Specify feature gates for components
   scheduler_feature_gates: ~
+
+  # Example probe configuration:
+# livenessProbe:
+#   httpGet:
+#     path: /healthz
+#     port: 11251
+#     scheme: HTTPS
+#   initialDelaySeconds: 10
+#   periodSeconds: 20
+#   timeoutSeconds: 5
+#   failureThreshold: 3
+#   successThreshold: 1
+#
+# readinessProbe:
+#   httpGet:
+#     path: /healthz
+#     port: 11251
+#     scheme: HTTPS
+#   initialDelaySeconds: 10
+#   periodSeconds: 20
+#   timeoutSeconds: 5
+#   failureThreshold: 3
+#   successThreshold: 1
+  controller_readinessProbe: {}
+  controller_livenessProbe: {}
+  scheduler_readinessProbe: {}
+  scheduler_livenessProbe: {}
+  admission_readinessProbe: {}
+  admission_livenessProbe: {}
 
 # Specify options for scheduler sharding
   agent_scheduler_sharding_mode: ~

--- a/installer/volcano-development.yaml
+++ b/installer/volcano-development.yaml
@@ -162,10 +162,10 @@ spec:
               path: /healthz
               port: 11251
               scheme: HTTPS
-            initialDelaySeconds: 10
-            periodSeconds: 20
+            initialDelaySeconds: 30
+            periodSeconds: 10
             timeoutSeconds: 5
-            failureThreshold: 3
+            failureThreshold: 5
             successThreshold: 1
           readinessProbe:
             httpGet:
@@ -173,9 +173,9 @@ spec:
               port: 11251
               scheme: HTTPS
             initialDelaySeconds: 10
-            periodSeconds: 20
+            periodSeconds: 10
             timeoutSeconds: 5
-            failureThreshold: 3
+            failureThreshold: 5
             successThreshold: 1
           volumeMounts:
             - mountPath: /admission.local.config/certificates
@@ -9061,10 +9061,10 @@ spec:
               path: /healthz
               port: 11251
               scheme: HTTP
-            initialDelaySeconds: 10
-            periodSeconds: 20
+            initialDelaySeconds: 30
+            periodSeconds: 10
             timeoutSeconds: 5
-            failureThreshold: 3
+            failureThreshold: 5
             successThreshold: 1
           readinessProbe:
             httpGet:
@@ -9072,9 +9072,9 @@ spec:
               port: 11251
               scheme: HTTP
             initialDelaySeconds: 10
-            periodSeconds: 20
+            periodSeconds: 10
             timeoutSeconds: 5
-            failureThreshold: 3
+            failureThreshold: 5
             successThreshold: 1
           args:
             - --logtostderr
@@ -9298,10 +9298,10 @@ spec:
               path: /healthz
               port: 11251
               scheme: HTTP
-            initialDelaySeconds: 10
-            periodSeconds: 20
+            initialDelaySeconds: 30
+            periodSeconds: 10
             timeoutSeconds: 5
-            failureThreshold: 3
+            failureThreshold: 5
             successThreshold: 1
           readinessProbe:
             httpGet:
@@ -9309,9 +9309,9 @@ spec:
               port: 11251
               scheme: HTTP
             initialDelaySeconds: 10
-            periodSeconds: 20
+            periodSeconds: 10
             timeoutSeconds: 5
-            failureThreshold: 3
+            failureThreshold: 5
             successThreshold: 1
           args:
             - --logtostderr

--- a/installer/volcano-development.yaml
+++ b/installer/volcano-development.yaml
@@ -157,6 +157,26 @@ spec:
           image: docker.io/volcanosh/vc-webhook-manager:latest
           imagePullPolicy: Always
           name: admission
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 11251
+              scheme: HTTPS
+            initialDelaySeconds: 10
+            periodSeconds: 20
+            timeoutSeconds: 5
+            failureThreshold: 3
+            successThreshold: 1
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 11251
+              scheme: HTTPS
+            initialDelaySeconds: 10
+            periodSeconds: 20
+            timeoutSeconds: 5
+            failureThreshold: 3
+            successThreshold: 1
           volumeMounts:
             - mountPath: /admission.local.config/certificates
               name: admission-certs
@@ -9036,6 +9056,26 @@ spec:
       containers:
         - name: volcano-controllers
           image: docker.io/volcanosh/vc-controller-manager:latest
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 11251
+              scheme: HTTP
+            initialDelaySeconds: 10
+            periodSeconds: 20
+            timeoutSeconds: 5
+            failureThreshold: 3
+            successThreshold: 1
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 11251
+              scheme: HTTP
+            initialDelaySeconds: 10
+            periodSeconds: 20
+            timeoutSeconds: 5
+            failureThreshold: 3
+            successThreshold: 1
           args:
             - --logtostderr
             - --enable-healthz=true
@@ -9253,6 +9293,26 @@ spec:
       containers:
         - name: volcano-scheduler
           image: docker.io/volcanosh/vc-scheduler:latest
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 11251
+              scheme: HTTP
+            initialDelaySeconds: 10
+            periodSeconds: 20
+            timeoutSeconds: 5
+            failureThreshold: 3
+            successThreshold: 1
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 11251
+              scheme: HTTP
+            initialDelaySeconds: 10
+            periodSeconds: 20
+            timeoutSeconds: 5
+            failureThreshold: 3
+            successThreshold: 1
           args:
             - --logtostderr
             - --scheduler-conf=/volcano.scheduler/volcano-scheduler.conf


### PR DESCRIPTION
This PR introduces default and customisable `livenessProbe` and `readinessProbe` configurations for the `volcano-admission`, `volcano-controller`, and `volcano-scheduler` deployments.

## Motivation
Volcano is a critical control plane component in environments that use batch scheduling. To enhance the project's operational maturity, stability, and adherence to Kubernetes best practices, implementing standard health checks is essential.

## Key Benefits
*   **Increased Resilience:** Liveness probes enable Kubernetes to automatically detect and restart unhealthy components (e.g., those experiencing deadlocks or network stalls), ensuring self-healing capabilities.
*   **Improved Availability:** Readiness probes ensure that the components do not receive traffic or attempt scheduling operations until they are fully initialized, preventing spurious errors during startup or transient failures.
*   **Production Readiness:** This change aligns Volcano with standard cloud-native deployment practices, making it more robust and easier to manage in production environments.
*   **Enhanced Observability:** Operators can leverage standard Kubernetes tooling to monitor the health status of Volcano pods more effectively.

## Proposed Changes
Probes are configured to use the existing `/healthz` endpoints on their respective ports. The default values chosen prioritize safety and tolerance for transient issues