### PR TITLE
Use GOMEMLIMIT for memory soft limit.

### DIFF
--- a/installer/helm/chart/volcano/templates/admission.yaml
+++ b/installer/helm/chart/volcano/templates/admission.yaml
@@ -163,6 +163,14 @@ spec:
               readOnly: true
             - mountPath: /admission.local.config/configmap
               name: admission-config
+          {{- if .Values.custom.go_memlimit_enable }}
+          env:
+            - name: GOMEMLIMIT
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.memory
+                  divisor: "1"
+          {{- end }}
           {{- if $admission_main_csc }}
           securityContext:
             {{- toYaml $admission_main_csc | nindent 12 }}

--- a/installer/helm/chart/volcano/templates/controllers.yaml
+++ b/installer/helm/chart/volcano/templates/controllers.yaml
@@ -206,6 +206,13 @@ spec:
             value: {{ .Release.Namespace }}
           - name: HELM_RELEASE_NAME
             value: {{ .Release.Name }}
+          {{- if .Values.custom.go_memlimit_enable }}
+          - name: GOMEMLIMIT
+            valueFrom:
+              resourceFieldRef:
+                resource: limits.memory
+                divisor: "1"
+          {{- end }}
 ---
 apiVersion: v1
 kind: Service

--- a/installer/helm/chart/volcano/templates/scheduler.yaml
+++ b/installer/helm/chart/volcano/templates/scheduler.yaml
@@ -234,6 +234,13 @@ spec:
           env:
             - name: DEBUG_SOCKET_DIR
               value: /tmp/klog-socks
+            {{- if .Values.custom.go_memlimit_enable }}
+            - name: GOMEMLIMIT
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.memory
+                  divisor: "1"
+            {{- end }}
           imagePullPolicy: {{ .Values.basic.image_pull_policy }}
           volumeMounts:
             - name: scheduler-config

--- a/installer/helm/chart/volcano/values.yaml
+++ b/installer/helm/chart/volcano/values.yaml
@@ -12,6 +12,7 @@ basic:
   admission_port: 8443
   image_registry: "docker.io"
 custom:
+  go_memlimit_enable: false
   metrics_enable: false
   admission_enable: true
   admission_replicas: 1


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

This PR is the resolution of the below github issue. Please review and do the needful.

#### What this PR does / why we need it:
**Introduced a soft memory limit using GOMEMLIMIT.**

The Go runtime enforces this limit by capping heap growth, adjusting GC frequency more aggressively, and returning memory back to the OS. This helps prevent excessive heap allocations that could exceed system memory limits and cause the process to be killed.

#### Which issue(s) this PR fixes:

Fixes [volcano-scheduler memory leak problem](https://github.com/volcano-sh/volcano/issues/4745)

#### Special notes for your reviewer:
NONE 

#### Does this PR introduce a user-facing change?
NONE

```release-note

```