### PR TITLE
feat: change the queue elements from pointers to string keys for deletedJobs workqueue.

### DIFF
--- a/pkg/scheduler/cache/cache_mock.go
+++ b/pkg/scheduler/cache/cache_mock.go
@@ -123,7 +123,7 @@ func newMockSchedulerCache(schedulerName string) *SchedulerCache {
 		PriorityClasses:     make(map[string]*schedulingv1.PriorityClass),
 		errTasks:            workqueue.NewTypedRateLimitingQueue[string](workqueue.DefaultTypedControllerRateLimiter[string]()),
 		nodeQueue:           workqueue.NewTypedRateLimitingQueue[string](workqueue.DefaultTypedControllerRateLimiter[string]()),
-		DeletedJobs:         workqueue.NewTypedRateLimitingQueue[*schedulingapi.JobInfo](workqueue.DefaultTypedControllerRateLimiter[*schedulingapi.JobInfo]()),
+		DeletedJobs:         workqueue.NewTypedRateLimitingQueue[string](workqueue.DefaultTypedControllerRateLimiter[string]()),
 		hyperNodesQueue:     workqueue.NewTypedRateLimitingQueue[string](workqueue.DefaultTypedControllerRateLimiter[string]()),
 		kubeClient:          fake.NewSimpleClientset(),
 		vcClient:            fakevcClient.NewSimpleClientset(),

--- a/pkg/scheduler/cache/event_handlers_test.go
+++ b/pkg/scheduler/cache/event_handlers_test.go
@@ -434,7 +434,7 @@ func TestSchedulerCache_DeletePodGroupV1beta1(t *testing.T) {
 			Nodes: make(map[string]*api.NodeInfo),
 		}
 
-		cache.DeletedJobs = workqueue.NewTypedRateLimitingQueue[*schedulingapi.JobInfo](workqueue.DefaultTypedControllerRateLimiter[*schedulingapi.JobInfo]())
+		cache.DeletedJobs = workqueue.NewTypedRateLimitingQueue[string](workqueue.DefaultTypedControllerRateLimiter[string]())
 
 		for _, n := range test.Nodes {
 			cache.AddOrUpdateNode(n)


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

This PR is the resolution of the below github issue. Please review and do the needful.

#### What this PR does / why we need it:

**Reduced memory overhead in the client-go workqueue channel.**

We changed queue elements from pointers to string keys and increase the rateLimiter for deletedJob.

When a large number of items are added to the workqueue using AddRateLimited, client-go will apply rate limiting. If rate limiting is triggered, the items are placed into internal Go channels, which can result in additional memory overhead in Go.

#### Which issue(s) this PR fixes:

Fixes [volcano-scheduler memory leak problem](https://github.com/volcano-sh/volcano/issues/4745)

#### Special notes for your reviewer:
NONE 

#### Does this PR introduce a user-facing change?
NONE

```release-note

```