### PR TITLE
feat: add errtasks rate limited for retryResync task.

### DIFF
--- a/pkg/scheduler/cache/cache.go
+++ b/pkg/scheduler/cache/cache.go
@@ -1092,6 +1092,12 @@ func (sc *SchedulerCache) processCleanupJob() {
 
 func (sc *SchedulerCache) resyncTask(task *schedulingapi.TaskInfo) {
 	key := sc.generateErrTaskKey(task)
+	sc.errTasks.Add(key)
+}
+
+func (sc *SchedulerCache) retryResyncTask(task *schedulingapi.TaskInfo) {
+	klog.V(3).Infof("Retry to resync task <%v:%v/%v>", task.UID, task.Namespace, task.Name)
+	key := sc.generateErrTaskKey(task)
 	sc.errTasks.AddRateLimited(key)
 }
 
@@ -1147,7 +1153,7 @@ func (sc *SchedulerCache) processResyncTask() {
 	reSynced := false
 	if err := sc.syncTask(task); err != nil {
 		klog.ErrorS(err, "Failed to sync task, retry it", "namespace", task.Namespace, "name", task.Name)
-		sc.resyncTask(task)
+		sc.retryResyncTask(task)
 		reSynced = true
 	} else {
 		klog.V(4).Infof("Successfully synced task <%s/%s>", task.Namespace, task.Name)


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

This PR is the resolution of the below github issue. Please review and do the needful.

#### What this PR does / why we need it:

**Reduced memory overhead in the client-go workqueue channel.**

We changed queue elements from pointers to string keys and increase the rateLimiter for deletedJob.

We now invoke AddRateLimited only for retry items, reducing duplicate data stored in the workqueue channel and lowering memory usage. When a large number of items are added to the workqueue using AddRateLimited, client-go will apply rate limiting. If rate limiting is triggered, the items are placed into internal Go channels, which can result in additional memory overhead in Go.

#### Which issue(s) this PR fixes:

Fixes [volcano-scheduler memory leak problem](https://github.com/volcano-sh/volcano/issues/4745)

#### Special notes for your reviewer:
NONE 

#### Does this PR introduce a user-facing change?
NONE

```release-note

```