### PR TITLE
support ttl metrics for volcano-scheduler.

### DIFF
--- a/cmd/scheduler/app/server.go
+++ b/cmd/scheduler/app/server.go
@@ -94,6 +94,8 @@ func Run(opt *options.ServerOption) error {
 	}
 
 	ctx := signals.SetupSignalContext()
+	metrics.InitTTLQueueMetrics(ctx)
+	metrics.InitTTLJobMetrics(ctx)
 	run := func(ctx context.Context) {
 		sched.Run(ctx.Done())
 		<-ctx.Done()

--- a/pkg/scheduler/actions/allocate/allocate_test.go
+++ b/pkg/scheduler/actions/allocate/allocate_test.go
@@ -22,6 +22,7 @@ limitations under the License.
 package allocate
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"testing"
@@ -44,6 +45,7 @@ import (
 	"volcano.sh/volcano/pkg/scheduler/api"
 	"volcano.sh/volcano/pkg/scheduler/conf"
 	"volcano.sh/volcano/pkg/scheduler/framework"
+	"volcano.sh/volcano/pkg/scheduler/metrics"
 	"volcano.sh/volcano/pkg/scheduler/plugins/binpack"
 	"volcano.sh/volcano/pkg/scheduler/plugins/drf"
 	"volcano.sh/volcano/pkg/scheduler/plugins/gang"
@@ -57,6 +59,9 @@ import (
 
 func TestMain(m *testing.M) {
 	options.Default()
+	metrics.InitTTLQueueMetrics(context.Background())
+	metrics.InitTTLJobMetrics(context.Background())
+
 	os.Exit(m.Run())
 }
 

--- a/pkg/scheduler/actions/backfill/backfill_test.go
+++ b/pkg/scheduler/actions/backfill/backfill_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package backfill
 
 import (
+	"context"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -31,10 +33,18 @@ import (
 	"volcano.sh/volcano/pkg/scheduler/cache"
 	"volcano.sh/volcano/pkg/scheduler/conf"
 	"volcano.sh/volcano/pkg/scheduler/framework"
+	"volcano.sh/volcano/pkg/scheduler/metrics"
 	"volcano.sh/volcano/pkg/scheduler/plugins/drf"
 	"volcano.sh/volcano/pkg/scheduler/plugins/priority"
 	"volcano.sh/volcano/pkg/scheduler/util"
 )
+
+func TestMain(m *testing.M) {
+	metrics.InitTTLQueueMetrics(context.Background())
+	metrics.InitTTLJobMetrics(context.Background())
+
+	os.Exit(m.Run())
+}
 
 func TestPickUpPendingTasks(t *testing.T) {
 	framework.RegisterPluginBuilder("priority", priority.New)

--- a/pkg/scheduler/actions/enqueue/enqueue_test.go
+++ b/pkg/scheduler/actions/enqueue/enqueue_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package enqueue
 
 import (
+	"context"
+	"os"
 	"testing"
 
 	v1 "k8s.io/api/core/v1"
@@ -27,6 +29,7 @@ import (
 	"volcano.sh/volcano/pkg/scheduler/api"
 	"volcano.sh/volcano/pkg/scheduler/conf"
 	"volcano.sh/volcano/pkg/scheduler/framework"
+	"volcano.sh/volcano/pkg/scheduler/metrics"
 	"volcano.sh/volcano/pkg/scheduler/plugins/drf"
 	"volcano.sh/volcano/pkg/scheduler/plugins/gang"
 	"volcano.sh/volcano/pkg/scheduler/plugins/proportion"
@@ -34,6 +37,13 @@ import (
 	"volcano.sh/volcano/pkg/scheduler/uthelper"
 	"volcano.sh/volcano/pkg/scheduler/util"
 )
+
+func TestMain(m *testing.M) {
+	metrics.InitTTLQueueMetrics(context.Background())
+	metrics.InitTTLJobMetrics(context.Background())
+
+	os.Exit(m.Run())
+}
 
 func TestEnqueue(t *testing.T) {
 	plugins := map[string]framework.PluginBuilder{

--- a/pkg/scheduler/actions/preempt/preempt_test.go
+++ b/pkg/scheduler/actions/preempt/preempt_test.go
@@ -22,19 +22,21 @@ limitations under the License.
 package preempt
 
 import (
+	"context"
 	"flag"
+	"k8s.io/klog/v2"
+	"os"
 	"testing"
 
 	v1 "k8s.io/api/core/v1"
 	schedulingv1 "k8s.io/api/scheduling/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/klog/v2"
-
 	schedulingv1beta1 "volcano.sh/apis/pkg/apis/scheduling/v1beta1"
 	"volcano.sh/volcano/cmd/scheduler/app/options"
 	"volcano.sh/volcano/pkg/scheduler/api"
 	"volcano.sh/volcano/pkg/scheduler/conf"
 	"volcano.sh/volcano/pkg/scheduler/framework"
+	"volcano.sh/volcano/pkg/scheduler/metrics"
 	"volcano.sh/volcano/pkg/scheduler/plugins/conformance"
 	"volcano.sh/volcano/pkg/scheduler/plugins/gang"
 	"volcano.sh/volcano/pkg/scheduler/plugins/predicates"
@@ -44,10 +46,15 @@ import (
 	"volcano.sh/volcano/pkg/scheduler/util"
 )
 
-func init() {
+func TestMain(m *testing.M) {
 	options.Default()
 	klog.InitFlags(nil)
 	flag.Set("v", "4")
+
+	metrics.InitTTLQueueMetrics(context.Background())
+	metrics.InitTTLJobMetrics(context.Background())
+
+	os.Exit(m.Run())
 }
 
 func TestPreempt(t *testing.T) {

--- a/pkg/scheduler/actions/reclaim/reclaim_test.go
+++ b/pkg/scheduler/actions/reclaim/reclaim_test.go
@@ -21,6 +21,8 @@ limitations under the License.
 package reclaim
 
 import (
+	"context"
+	"os"
 	"testing"
 
 	v1 "k8s.io/api/core/v1"
@@ -30,6 +32,7 @@ import (
 	"volcano.sh/volcano/pkg/scheduler/api"
 	"volcano.sh/volcano/pkg/scheduler/conf"
 	"volcano.sh/volcano/pkg/scheduler/framework"
+	"volcano.sh/volcano/pkg/scheduler/metrics"
 	"volcano.sh/volcano/pkg/scheduler/plugins/capacity"
 	"volcano.sh/volcano/pkg/scheduler/plugins/conformance"
 	"volcano.sh/volcano/pkg/scheduler/plugins/gang"
@@ -38,6 +41,13 @@ import (
 	"volcano.sh/volcano/pkg/scheduler/uthelper"
 	"volcano.sh/volcano/pkg/scheduler/util"
 )
+
+func TestMain(m *testing.M) {
+	metrics.InitTTLQueueMetrics(context.Background())
+	metrics.InitTTLJobMetrics(context.Background())
+
+	os.Exit(m.Run())
+}
 
 func TestReclaim(t *testing.T) {
 	tests := []uthelper.TestCommonStruct{

--- a/pkg/scheduler/actions/shuffle/shuffle_test.go
+++ b/pkg/scheduler/actions/shuffle/shuffle_test.go
@@ -17,6 +17,8 @@
 package shuffle
 
 import (
+	"context"
+	"os"
 	"testing"
 
 	"github.com/golang/mock/gomock"
@@ -27,9 +29,17 @@ import (
 	"volcano.sh/volcano/pkg/scheduler/conf"
 	"volcano.sh/volcano/pkg/scheduler/framework"
 	mock_framework "volcano.sh/volcano/pkg/scheduler/framework/mock_gen"
+	"volcano.sh/volcano/pkg/scheduler/metrics"
 	"volcano.sh/volcano/pkg/scheduler/uthelper"
 	"volcano.sh/volcano/pkg/scheduler/util"
 )
+
+func TestMain(m *testing.M) {
+	metrics.InitTTLQueueMetrics(context.Background())
+	metrics.InitTTLJobMetrics(context.Background())
+
+	os.Exit(m.Run())
+}
 
 func TestShuffle(t *testing.T) {
 	var highPriority int32

--- a/pkg/scheduler/cache/main_test.go
+++ b/pkg/scheduler/cache/main_test.go
@@ -17,13 +17,17 @@ limitations under the License.
 package cache
 
 import (
+	"context"
 	"os"
 	"testing"
 
 	"volcano.sh/volcano/cmd/scheduler/app/options"
+	"volcano.sh/volcano/pkg/scheduler/metrics"
 )
 
 func TestMain(m *testing.M) {
 	options.Default()
+	metrics.InitTTLQueueMetrics(context.Background())
+	metrics.InitTTLJobMetrics(context.Background())
 	os.Exit(m.Run())
 }

--- a/pkg/scheduler/framework/session_plugins_test.go
+++ b/pkg/scheduler/framework/session_plugins_test.go
@@ -17,7 +17,9 @@ limitations under the License.
 package framework
 
 import (
+	"context"
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -26,8 +28,15 @@ import (
 	schedulingv1 "volcano.sh/apis/pkg/apis/scheduling/v1beta1"
 	"volcano.sh/volcano/pkg/scheduler/api"
 	"volcano.sh/volcano/pkg/scheduler/cache"
+	"volcano.sh/volcano/pkg/scheduler/metrics"
 	"volcano.sh/volcano/pkg/scheduler/util"
 )
+
+func TestMain(m *testing.M) {
+	metrics.InitTTLQueueMetrics(context.Background())
+	metrics.InitTTLJobMetrics(context.Background())
+	os.Exit(m.Run())
+}
 
 func newFitErr(taskName, nodeName string, sts ...*api.Status) *api.FitError {
 	return api.NewFitErrWithStatus(&api.TaskInfo{Name: taskName}, &api.NodeInfo{Name: nodeName}, sts...)

--- a/pkg/scheduler/metrics/queue.go
+++ b/pkg/scheduler/metrics/queue.go
@@ -17,165 +17,246 @@ limitations under the License.
 package metrics
 
 import (
+	"context"
 	"sync"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promauto" // auto-registry collectors in default registry
 	v1 "k8s.io/api/core/v1"
+
+	"volcano.sh/volcano/pkg/util"
 )
 
 var (
-	queueAllocatedMilliCPU = promauto.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Subsystem: VolcanoSubSystemName,
-			Name:      "queue_allocated_milli_cpu",
-			Help:      "Allocated CPU count for one queue",
-		}, []string{"queue_name"},
-	)
-
-	queueAllocatedMemory = promauto.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Subsystem: VolcanoSubSystemName,
-			Name:      "queue_allocated_memory_bytes",
-			Help:      "Allocated memory for one queue",
-		}, []string{"queue_name"},
-	)
-
-	queueAllocatedScalarResource = promauto.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Subsystem: VolcanoSubSystemName,
-			Name:      "queue_allocated_scalar_resources",
-			Help:      "Allocated scalar resources for one queue",
-		}, []string{"queue_name", "resource"},
-	)
-
-	queueRequestMilliCPU = promauto.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Subsystem: VolcanoSubSystemName,
-			Name:      "queue_request_milli_cpu",
-			Help:      "Request CPU count for one queue",
-		}, []string{"queue_name"},
-	)
-
-	queueRequestMemory = promauto.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Subsystem: VolcanoSubSystemName,
-			Name:      "queue_request_memory_bytes",
-			Help:      "Request memory for one queue",
-		}, []string{"queue_name"},
-	)
-
-	queueRequestScalarResource = promauto.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Subsystem: VolcanoSubSystemName,
-			Name:      "queue_request_scalar_resources",
-			Help:      "Request scalar resources for one queue",
-		}, []string{"queue_name", "resource"},
-	)
-
-	queueDeservedMilliCPU = promauto.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Subsystem: VolcanoSubSystemName,
-			Name:      "queue_deserved_milli_cpu",
-			Help:      "Deserved CPU count for one queue",
-		}, []string{"queue_name"},
-	)
-
-	queueDeservedMemory = promauto.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Subsystem: VolcanoSubSystemName,
-			Name:      "queue_deserved_memory_bytes",
-			Help:      "Deserved memory for one queue",
-		}, []string{"queue_name"},
-	)
-
-	queueDeservedScalarResource = promauto.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Subsystem: VolcanoSubSystemName,
-			Name:      "queue_deserved_scalar_resources",
-			Help:      "Deserved scalar resources for one queue",
-		}, []string{"queue_name", "resource"},
-	)
-
-	queueShare = promauto.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Subsystem: VolcanoSubSystemName,
-			Name:      "queue_share",
-			Help:      "Share for one queue",
-		}, []string{"queue_name"},
-	)
-
-	queueWeight = promauto.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Subsystem: VolcanoSubSystemName,
-			Name:      "queue_weight",
-			Help:      "Weight for one queue",
-		}, []string{"queue_name"},
-	)
-
-	queueOverused = promauto.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Subsystem: VolcanoSubSystemName,
-			Name:      "queue_overused",
-			Help:      "If one queue is overused",
-		}, []string{"queue_name"},
-	)
-
-	queueCapacityMilliCPU = promauto.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Subsystem: VolcanoSubSystemName,
-			Name:      "queue_capacity_milli_cpu",
-			Help:      "Capacity CPU count for one queue",
-		}, []string{"queue_name"},
-	)
-
-	queueCapacityMemory = promauto.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Subsystem: VolcanoSubSystemName,
-			Name:      "queue_capacity_memory_bytes",
-			Help:      "Capacity memory for one queue",
-		}, []string{"queue_name"},
-	)
-
-	queueCapacityScalarResource = promauto.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Subsystem: VolcanoSubSystemName,
-			Name:      "queue_capacity_scalar_resources",
-			Help:      "Capacity scalar resources for one queue",
-		}, []string{"queue_name", "resource"},
-	)
-
-	queueRealCapacityMilliCPU = promauto.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Subsystem: VolcanoSubSystemName,
-			Name:      "queue_real_capacity_milli_cpu",
-			Help:      "Capacity CPU count for one queue",
-		}, []string{"queue_name"},
-	)
-
-	queueRealCapacityMemory = promauto.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Subsystem: VolcanoSubSystemName,
-			Name:      "queue_real_capacity_memory_bytes",
-			Help:      "Capacity memory for one queue",
-		}, []string{"queue_name"},
-	)
-
-	queueRealCapacityScalarResource = promauto.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Subsystem: VolcanoSubSystemName,
-			Name:      "queue_real_capacity_scalar_resources",
-			Help:      "Capacity scalar resources for one queue",
-		}, []string{"queue_name", "resource"},
-	)
+	queueAllocatedMilliCPU          *util.TTLCollectorWrapper
+	queueAllocatedMemory            *util.TTLCollectorWrapper
+	queueAllocatedScalarResource    *util.TTLCollectorWrapper
+	queueRequestMilliCPU            *util.TTLCollectorWrapper
+	queueRequestMemory              *util.TTLCollectorWrapper
+	queueRequestScalarResource      *util.TTLCollectorWrapper
+	queueDeservedMilliCPU           *util.TTLCollectorWrapper
+	queueDeservedMemory             *util.TTLCollectorWrapper
+	queueDeservedScalarResource     *util.TTLCollectorWrapper
+	queueShare                      *util.TTLCollectorWrapper
+	queueWeight                     *util.TTLCollectorWrapper
+	queueOverused                   *util.TTLCollectorWrapper
+	queueCapacityMilliCPU           *util.TTLCollectorWrapper
+	queueCapacityMemory             *util.TTLCollectorWrapper
+	queueCapacityScalarResource     *util.TTLCollectorWrapper
+	queueRealCapacityMilliCPU       *util.TTLCollectorWrapper
+	queueRealCapacityMemory         *util.TTLCollectorWrapper
+	queueRealCapacityScalarResource *util.TTLCollectorWrapper
 
 	// Track all known scalar resources for each queue
 	knownScalarResources     = make(map[string]map[string]struct{})
 	knownScalarResourcesLock sync.RWMutex
 )
 
+func InitTTLQueueMetrics(ctx context.Context) {
+	expirationTime := time.Hour * 2
+	checkIntervalTime := time.Hour
+
+	queueAllocatedMilliCPU = util.NewTTLGaugeVec(
+		prometheus.GaugeOpts{
+			Subsystem: VolcanoSubSystemName,
+			Name:      "queue_allocated_milli_cpu",
+			Help:      "Allocated CPU count for one queue",
+		}, []string{"queue_name"},
+		expirationTime,
+		checkIntervalTime,
+		ctx,
+	)
+
+	queueAllocatedMemory = util.NewTTLGaugeVec(
+		prometheus.GaugeOpts{
+			Subsystem: VolcanoSubSystemName,
+			Name:      "queue_allocated_memory_bytes",
+			Help:      "Allocated memory for one queue",
+		}, []string{"queue_name"},
+		expirationTime,
+		checkIntervalTime,
+		ctx,
+	)
+
+	queueAllocatedScalarResource = util.NewTTLGaugeVec(
+		prometheus.GaugeOpts{
+			Subsystem: VolcanoSubSystemName,
+			Name:      "queue_allocated_scalar_resources",
+			Help:      "Allocated scalar resources for one queue",
+		}, []string{"queue_name", "resource"},
+		expirationTime,
+		checkIntervalTime,
+		ctx,
+	)
+
+	queueRequestMilliCPU = util.NewTTLGaugeVec(
+		prometheus.GaugeOpts{
+			Subsystem: VolcanoSubSystemName,
+			Name:      "queue_request_milli_cpu",
+			Help:      "Request CPU count for one queue",
+		}, []string{"queue_name"},
+		expirationTime,
+		checkIntervalTime,
+		ctx,
+	)
+
+	queueRequestMemory = util.NewTTLGaugeVec(
+		prometheus.GaugeOpts{
+			Subsystem: VolcanoSubSystemName,
+			Name:      "queue_request_memory_bytes",
+			Help:      "Request memory for one queue",
+		}, []string{"queue_name"},
+		expirationTime,
+		checkIntervalTime,
+		ctx,
+	)
+
+	queueRequestScalarResource = util.NewTTLGaugeVec(
+		prometheus.GaugeOpts{
+			Subsystem: VolcanoSubSystemName,
+			Name:      "queue_request_scalar_resources",
+			Help:      "Request scalar resources for one queue",
+		}, []string{"queue_name", "resource"},
+		expirationTime,
+		checkIntervalTime,
+		ctx,
+	)
+
+	queueDeservedMilliCPU = util.NewTTLGaugeVec(
+		prometheus.GaugeOpts{
+			Subsystem: VolcanoSubSystemName,
+			Name:      "queue_deserved_milli_cpu",
+			Help:      "Deserved CPU count for one queue",
+		}, []string{"queue_name"},
+		expirationTime,
+		checkIntervalTime,
+		ctx,
+	)
+
+	queueDeservedMemory = util.NewTTLGaugeVec(
+		prometheus.GaugeOpts{
+			Subsystem: VolcanoSubSystemName,
+			Name:      "queue_deserved_memory_bytes",
+			Help:      "Deserved memory for one queue",
+		}, []string{"queue_name"},
+		expirationTime,
+		checkIntervalTime,
+		ctx,
+	)
+
+	queueDeservedScalarResource = util.NewTTLGaugeVec(
+		prometheus.GaugeOpts{
+			Subsystem: VolcanoSubSystemName,
+			Name:      "queue_deserved_scalar_resources",
+			Help:      "Deserved scalar resources for one queue",
+		}, []string{"queue_name", "resource"},
+		expirationTime,
+		checkIntervalTime,
+		ctx,
+	)
+
+	queueShare = util.NewTTLGaugeVec(
+		prometheus.GaugeOpts{
+			Subsystem: VolcanoSubSystemName,
+			Name:      "queue_share",
+			Help:      "Share for one queue",
+		}, []string{"queue_name"},
+		expirationTime,
+		checkIntervalTime,
+		ctx,
+	)
+
+	queueWeight = util.NewTTLGaugeVec(
+		prometheus.GaugeOpts{
+			Subsystem: VolcanoSubSystemName,
+			Name:      "queue_weight",
+			Help:      "Weight for one queue",
+		}, []string{"queue_name"},
+		expirationTime,
+		checkIntervalTime,
+		ctx,
+	)
+
+	queueOverused = util.NewTTLGaugeVec(
+		prometheus.GaugeOpts{
+			Subsystem: VolcanoSubSystemName,
+			Name:      "queue_overused",
+			Help:      "If one queue is overused",
+		}, []string{"queue_name"},
+		expirationTime,
+		checkIntervalTime,
+		ctx,
+	)
+
+	queueCapacityMilliCPU = util.NewTTLGaugeVec(
+		prometheus.GaugeOpts{
+			Subsystem: VolcanoSubSystemName,
+			Name:      "queue_capacity_milli_cpu",
+			Help:      "Capacity CPU count for one queue",
+		}, []string{"queue_name"},
+		expirationTime,
+		checkIntervalTime,
+		ctx,
+	)
+
+	queueCapacityMemory = util.NewTTLGaugeVec(
+		prometheus.GaugeOpts{
+			Subsystem: VolcanoSubSystemName,
+			Name:      "queue_capacity_memory_bytes",
+			Help:      "Capacity memory for one queue",
+		}, []string{"queue_name"},
+		expirationTime,
+		checkIntervalTime,
+		ctx,
+	)
+
+	queueCapacityScalarResource = util.NewTTLGaugeVec(
+		prometheus.GaugeOpts{
+			Subsystem: VolcanoSubSystemName,
+			Name:      "queue_capacity_scalar_resources",
+			Help:      "Capacity scalar resources for one queue",
+		}, []string{"queue_name", "resource"},
+		expirationTime,
+		checkIntervalTime,
+		ctx,
+	)
+
+	queueRealCapacityMilliCPU = util.NewTTLGaugeVec(
+		prometheus.GaugeOpts{
+			Subsystem: VolcanoSubSystemName,
+			Name:      "queue_real_capacity_milli_cpu",
+			Help:      "Capacity CPU count for one queue",
+		}, []string{"queue_name"},
+		expirationTime,
+		checkIntervalTime,
+		ctx,
+	)
+
+	queueRealCapacityMemory = util.NewTTLGaugeVec(
+		prometheus.GaugeOpts{
+			Subsystem: VolcanoSubSystemName,
+			Name:      "queue_real_capacity_memory_bytes",
+			Help:      "Capacity memory for one queue",
+		}, []string{"queue_name"},
+		expirationTime,
+		checkIntervalTime,
+		ctx,
+	)
+
+	queueRealCapacityScalarResource = util.NewTTLGaugeVec(
+		prometheus.GaugeOpts{
+			Subsystem: VolcanoSubSystemName,
+			Name:      "queue_real_capacity_scalar_resources",
+			Help:      "Capacity scalar resources for one queue",
+		}, []string{"queue_name", "resource"},
+		expirationTime,
+		checkIntervalTime,
+		ctx,
+	)
+}
+
 // helper to update knownScalarResources and delete metrics for removed resources
-func updateScalarResourceMetrics(metric *prometheus.GaugeVec, queueName string, scalarResources map[v1.ResourceName]float64) {
+func updateScalarResourceMetrics(metric *util.TTLCollectorWrapper, queueName string, scalarResources map[v1.ResourceName]float64) {
 	knownScalarResourcesLock.Lock()
 	defer knownScalarResourcesLock.Unlock()
 	if knownScalarResources[queueName] == nil {
@@ -186,45 +267,45 @@ func updateScalarResourceMetrics(metric *prometheus.GaugeVec, queueName string, 
 		name := string(resource)
 		current[name] = struct{}{}
 		knownScalarResources[queueName][name] = struct{}{}
-		metric.WithLabelValues(queueName, name).Set(scalarResources[resource])
+		metric.ObserveWithLabelValues(scalarResources[resource], queueName, name)
 	}
 	// For all known resources, that are not present in the current update set the value to zero
 	for name := range knownScalarResources[queueName] {
 		if _, ok := current[name]; !ok {
-			metric.WithLabelValues(queueName, name).Set(0)
+			metric.ObserveWithLabelValues(0, queueName, name)
 		}
 	}
 }
 
 // UpdateQueueAllocated records allocated resources for one queue
 func UpdateQueueAllocated(queueName string, milliCPU, memory float64, scalarResources map[v1.ResourceName]float64) {
-	queueAllocatedMilliCPU.WithLabelValues(queueName).Set(milliCPU)
-	queueAllocatedMemory.WithLabelValues(queueName).Set(memory)
+	queueAllocatedMilliCPU.ObserveWithLabelValues(milliCPU, queueName)
+	queueAllocatedMemory.ObserveWithLabelValues(float64(memory), queueName)
 	updateScalarResourceMetrics(queueAllocatedScalarResource, queueName, scalarResources)
 }
 
 // UpdateQueueRequest records request resources for one queue
 func UpdateQueueRequest(queueName string, milliCPU, memory float64, scalarResources map[v1.ResourceName]float64) {
-	queueRequestMilliCPU.WithLabelValues(queueName).Set(milliCPU)
-	queueRequestMemory.WithLabelValues(queueName).Set(memory)
+	queueRequestMilliCPU.ObserveWithLabelValues(milliCPU, queueName)
+	queueRequestMemory.ObserveWithLabelValues(memory, queueName)
 	updateScalarResourceMetrics(queueRequestScalarResource, queueName, scalarResources)
 }
 
 // UpdateQueueDeserved records deserved resources for one queue
 func UpdateQueueDeserved(queueName string, milliCPU, memory float64, scalarResources map[v1.ResourceName]float64) {
-	queueDeservedMilliCPU.WithLabelValues(queueName).Set(milliCPU)
-	queueDeservedMemory.WithLabelValues(queueName).Set(memory)
+	queueDeservedMilliCPU.ObserveWithLabelValues(milliCPU, queueName)
+	queueDeservedMemory.ObserveWithLabelValues(memory, queueName)
 	updateScalarResourceMetrics(queueDeservedScalarResource, queueName, scalarResources)
 }
 
 // UpdateQueueShare records share for one queue
 func UpdateQueueShare(queueName string, share float64) {
-	queueShare.WithLabelValues(queueName).Set(share)
+	queueShare.ObserveWithLabelValues(share, queueName)
 }
 
 // UpdateQueueWeight records weight for one queue
 func UpdateQueueWeight(queueName string, weight int32) {
-	queueWeight.WithLabelValues(queueName).Set(float64(weight))
+	queueWeight.ObserveWithLabelValues(float64(weight), queueName)
 }
 
 // UpdateQueueOverused records if one queue is overused
@@ -235,20 +316,20 @@ func UpdateQueueOverused(queueName string, overused bool) {
 	} else {
 		value = 0
 	}
-	queueOverused.WithLabelValues(queueName).Set(value)
+	queueOverused.ObserveWithLabelValues(value, queueName)
 }
 
 // UpdateQueueCapacity records capacity resources for one queue
 func UpdateQueueCapacity(queueName string, milliCPU, memory float64, scalarResources map[v1.ResourceName]float64) {
-	queueCapacityMilliCPU.WithLabelValues(queueName).Set(milliCPU)
-	queueCapacityMemory.WithLabelValues(queueName).Set(memory)
+	queueCapacityMilliCPU.ObserveWithLabelValues(milliCPU, queueName)
+	queueCapacityMemory.ObserveWithLabelValues(memory, queueName)
 	updateScalarResourceMetrics(queueCapacityScalarResource, queueName, scalarResources)
 }
 
 // UpdateQueueRealCapacity records real capacity resources for one queue
 func UpdateQueueRealCapacity(queueName string, milliCPU, memory float64, scalarResources map[v1.ResourceName]float64) {
-	queueRealCapacityMilliCPU.WithLabelValues(queueName).Set(milliCPU)
-	queueRealCapacityMemory.WithLabelValues(queueName).Set(memory)
+	queueRealCapacityMilliCPU.ObserveWithLabelValues(milliCPU, queueName)
+	queueRealCapacityMemory.ObserveWithLabelValues(memory, queueName)
 	updateScalarResourceMetrics(queueRealCapacityScalarResource, queueName, scalarResources)
 }
 

--- a/pkg/scheduler/metrics/queue_scalar_test.go
+++ b/pkg/scheduler/metrics/queue_scalar_test.go
@@ -1,11 +1,19 @@
 package metrics
 
 import (
+	"context"
+	"os"
 	"testing"
 
-	"github.com/prometheus/client_golang/prometheus/testutil"
 	v1 "k8s.io/api/core/v1"
+	"volcano.sh/volcano/pkg/util"
 )
+
+func TestMain(m *testing.M) {
+	InitTTLQueueMetrics(context.Background())
+	InitTTLJobMetrics(context.Background())
+	os.Exit(m.Run())
+}
 
 func TestUpdateScalarResourceMetrics_ZeroAndCleanup(t *testing.T) {
 	// Reset global state for this test to ensure isolation.
@@ -20,34 +28,34 @@ func TestUpdateScalarResourceMetrics_ZeroAndCleanup(t *testing.T) {
 
 	// 1. Set resourceA to 5, resourceB to 10
 	UpdateQueueAllocated(queueName, 0, 0, map[v1.ResourceName]float64{resourceA: 5, resourceB: 10})
-	if got := testutil.ToFloat64(queueAllocatedScalarResource.WithLabelValues(queueName, string(resourceA))); got != 5 {
+	if got := util.TestutilToFloat64(queueAllocatedScalarResource, queueName, string(resourceA)); got != 5 {
 		t.Errorf("expected %s to be 5, got %v", resourceA, got)
 	}
-	if got := testutil.ToFloat64(queueAllocatedScalarResource.WithLabelValues(queueName, string(resourceB))); got != 10 {
+	if got := util.TestutilToFloat64(queueAllocatedScalarResource, queueName, string(resourceB)); got != 10 {
 		t.Errorf("expected %s to be 10, got %v", resourceB, got)
 	}
 
 	// 2. Update with only resourceA, resourceB should be set to zero
 	UpdateQueueAllocated(queueName, 0, 0, map[v1.ResourceName]float64{resourceA: 3})
-	if got := testutil.ToFloat64(queueAllocatedScalarResource.WithLabelValues(queueName, string(resourceA))); got != 3 {
+	if got := util.TestutilToFloat64(queueAllocatedScalarResource, queueName, string(resourceA)); got != 3 {
 		t.Errorf("expected %s to be 3, got %v", resourceA, got)
 	}
-	if got := testutil.ToFloat64(queueAllocatedScalarResource.WithLabelValues(queueName, string(resourceB))); got != 0 {
+	if got := util.TestutilToFloat64(queueAllocatedScalarResource, queueName, string(resourceB)); got != 0 {
 		t.Errorf("expected %s to be 0 after missing in update, got %v", resourceB, got)
 	}
 
 	// 3. Update with nil scalarResources, all known resources should be set to zero
 	UpdateQueueAllocated(queueName, 0, 0, nil)
-	if got := testutil.ToFloat64(queueAllocatedScalarResource.WithLabelValues(queueName, string(resourceA))); got != 0 {
+	if got := util.TestutilToFloat64(queueAllocatedScalarResource, queueName, string(resourceA)); got != 0 {
 		t.Errorf("expected %s to be 0 after nil update, got %v", resourceA, got)
 	}
-	if got := testutil.ToFloat64(queueAllocatedScalarResource.WithLabelValues(queueName, string(resourceB))); got != 0 {
+	if got := util.TestutilToFloat64(queueAllocatedScalarResource, queueName, string(resourceB)); got != 0 {
 		t.Errorf("expected %s to be 0 after nil update, got %v", resourceB, got)
 	}
 
 	// 4. Delete metrics and ensure they're gone
 	DeleteQueueMetrics(queueName)
-	if count := testutil.CollectAndCount(queueAllocatedScalarResource); count != 0 {
+	if count := util.TestutilToCollectAndCount(queueAllocatedScalarResource); count != 0 {
 		t.Errorf("expected no metrics for queueAllocatedScalarResource after delete, got %d", count)
 	}
 }

--- a/pkg/scheduler/plugins/binpack/binpack_test.go
+++ b/pkg/scheduler/plugins/binpack/binpack_test.go
@@ -17,8 +17,10 @@ limitations under the License.
 package binpack
 
 import (
+	"context"
 	"fmt"
 	"math"
+	"os"
 	"testing"
 
 	v1 "k8s.io/api/core/v1"
@@ -28,6 +30,7 @@ import (
 	"volcano.sh/volcano/pkg/scheduler/api"
 	"volcano.sh/volcano/pkg/scheduler/conf"
 	"volcano.sh/volcano/pkg/scheduler/framework"
+	"volcano.sh/volcano/pkg/scheduler/metrics"
 	"volcano.sh/volcano/pkg/scheduler/uthelper"
 	"volcano.sh/volcano/pkg/scheduler/util"
 )
@@ -35,6 +38,12 @@ import (
 const (
 	eps = 1e-8
 )
+
+func TestMain(m *testing.M) {
+	metrics.InitTTLQueueMetrics(context.Background())
+	metrics.InitTTLJobMetrics(context.Background())
+	os.Exit(m.Run())
+}
 
 func TestArguments(t *testing.T) {
 	framework.RegisterPluginBuilder(PluginName, New)

--- a/pkg/scheduler/plugins/capacity/capacity_test.go
+++ b/pkg/scheduler/plugins/capacity/capacity_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package capacity
 
 import (
+	"context"
 	"os"
 	"testing"
 
@@ -32,6 +33,7 @@ import (
 	"volcano.sh/volcano/pkg/scheduler/api"
 	"volcano.sh/volcano/pkg/scheduler/conf"
 	"volcano.sh/volcano/pkg/scheduler/framework"
+	"volcano.sh/volcano/pkg/scheduler/metrics"
 	"volcano.sh/volcano/pkg/scheduler/plugins/gang"
 	"volcano.sh/volcano/pkg/scheduler/plugins/predicates"
 	"volcano.sh/volcano/pkg/scheduler/uthelper"
@@ -40,6 +42,8 @@ import (
 
 func TestMain(m *testing.M) {
 	options.Default()
+	metrics.InitTTLQueueMetrics(context.Background())
+	metrics.InitTTLJobMetrics(context.Background())
 	os.Exit(m.Run())
 }
 

--- a/pkg/scheduler/plugins/drf/hdrf_test.go
+++ b/pkg/scheduler/plugins/drf/hdrf_test.go
@@ -17,7 +17,9 @@ limitations under the License.
 package drf
 
 import (
+	"context"
 	"fmt"
+	"os"
 	"testing"
 
 	v1 "k8s.io/api/core/v1"
@@ -29,10 +31,17 @@ import (
 	"volcano.sh/volcano/pkg/scheduler/api"
 	"volcano.sh/volcano/pkg/scheduler/conf"
 	"volcano.sh/volcano/pkg/scheduler/framework"
+	"volcano.sh/volcano/pkg/scheduler/metrics"
 	"volcano.sh/volcano/pkg/scheduler/plugins/proportion"
 	"volcano.sh/volcano/pkg/scheduler/uthelper"
 	"volcano.sh/volcano/pkg/scheduler/util"
 )
+
+func TestMain(m *testing.M) {
+	metrics.InitTTLQueueMetrics(context.Background())
+	metrics.InitTTLJobMetrics(context.Background())
+	os.Exit(m.Run())
+}
 
 func makePods(num int, cpu, mem, podGroupName string) []*v1.Pod {
 	pods := []*v1.Pod{}

--- a/pkg/scheduler/plugins/network-topology-aware/network_topology_aware_test.go
+++ b/pkg/scheduler/plugins/network-topology-aware/network_topology_aware_test.go
@@ -17,7 +17,9 @@ limitations under the License.
 package networktopologyaware
 
 import (
+	"context"
 	"math"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -29,6 +31,7 @@ import (
 	"volcano.sh/volcano/pkg/scheduler/api"
 	"volcano.sh/volcano/pkg/scheduler/conf"
 	"volcano.sh/volcano/pkg/scheduler/framework"
+	"volcano.sh/volcano/pkg/scheduler/metrics"
 	"volcano.sh/volcano/pkg/scheduler/uthelper"
 	"volcano.sh/volcano/pkg/scheduler/util"
 )
@@ -36,6 +39,12 @@ import (
 const (
 	eps = 1e-1
 )
+
+func TestMain(m *testing.M) {
+	metrics.InitTTLQueueMetrics(context.Background())
+	metrics.InitTTLJobMetrics(context.Background())
+	os.Exit(m.Run())
+}
 
 func TestArguments(t *testing.T) {
 	framework.RegisterPluginBuilder(PluginName, New)

--- a/pkg/scheduler/plugins/nodegroup/nodegroup_test.go
+++ b/pkg/scheduler/plugins/nodegroup/nodegroup_test.go
@@ -17,17 +17,27 @@ limitations under the License.
 package nodegroup
 
 import (
+	"context"
 	"fmt"
+	"os"
 	"testing"
 
 	v1 "k8s.io/api/core/v1"
+
 	schedulingv1 "volcano.sh/apis/pkg/apis/scheduling/v1beta1"
 	"volcano.sh/volcano/pkg/scheduler/api"
 	"volcano.sh/volcano/pkg/scheduler/conf"
 	"volcano.sh/volcano/pkg/scheduler/framework"
+	"volcano.sh/volcano/pkg/scheduler/metrics"
 	"volcano.sh/volcano/pkg/scheduler/uthelper"
 	"volcano.sh/volcano/pkg/scheduler/util"
 )
+
+func TestMain(m *testing.M) {
+	metrics.InitTTLQueueMetrics(context.Background())
+	metrics.InitTTLJobMetrics(context.Background())
+	os.Exit(m.Run())
+}
 
 func TestNodeGroup(t *testing.T) {
 	plugins := map[string]framework.PluginBuilder{PluginName: New}

--- a/pkg/scheduler/plugins/nodeorder/nodeorder_test.go
+++ b/pkg/scheduler/plugins/nodeorder/nodeorder_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package nodeorder
 
 import (
+	"context"
 	"os"
 	"testing"
 
@@ -29,6 +30,7 @@ import (
 	"volcano.sh/volcano/pkg/scheduler/api"
 	"volcano.sh/volcano/pkg/scheduler/conf"
 	"volcano.sh/volcano/pkg/scheduler/framework"
+	"volcano.sh/volcano/pkg/scheduler/metrics"
 	"volcano.sh/volcano/pkg/scheduler/plugins/gang"
 	"volcano.sh/volcano/pkg/scheduler/uthelper"
 	"volcano.sh/volcano/pkg/scheduler/util"
@@ -37,6 +39,8 @@ import (
 func TestMain(m *testing.M) {
 	options.Default()
 	k8smetrics.Register()
+	metrics.InitTTLQueueMetrics(context.Background())
+	metrics.InitTTLJobMetrics(context.Background())
 	os.Exit(m.Run())
 }
 

--- a/pkg/scheduler/plugins/overcommit/overcommit_test.go
+++ b/pkg/scheduler/plugins/overcommit/overcommit_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package overcommit
 
 import (
+	"context"
+	"os"
 	"testing"
 
 	v1 "k8s.io/api/core/v1"
@@ -27,9 +29,16 @@ import (
 	"volcano.sh/volcano/pkg/scheduler/api"
 	"volcano.sh/volcano/pkg/scheduler/conf"
 	"volcano.sh/volcano/pkg/scheduler/framework"
+	"volcano.sh/volcano/pkg/scheduler/metrics"
 	"volcano.sh/volcano/pkg/scheduler/uthelper"
 	"volcano.sh/volcano/pkg/scheduler/util"
 )
+
+func TestMain(m *testing.M) {
+	metrics.InitTTLQueueMetrics(context.Background())
+	metrics.InitTTLJobMetrics(context.Background())
+	os.Exit(m.Run())
+}
 
 func TestOvercommitPlugin(t *testing.T) {
 	n1 := util.BuildNode("n1", api.BuildResourceList("2", "4Gi"), make(map[string]string))

--- a/pkg/scheduler/plugins/predicates/main_test.go
+++ b/pkg/scheduler/plugins/predicates/main_test.go
@@ -17,13 +17,17 @@ limitations under the License.
 package predicates
 
 import (
+	"context"
 	"os"
 	"testing"
 
 	"volcano.sh/volcano/cmd/scheduler/app/options"
+	"volcano.sh/volcano/pkg/scheduler/metrics"
 )
 
 func TestMain(m *testing.M) {
 	options.Default()
+	metrics.InitTTLQueueMetrics(context.Background())
+	metrics.InitTTLJobMetrics(context.Background())
 	os.Exit(m.Run())
 }

--- a/pkg/scheduler/plugins/priority/priority_test.go
+++ b/pkg/scheduler/plugins/priority/priority_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package priority
 
 import (
+	"context"
 	"testing"
 
 	v1 "k8s.io/api/core/v1"
@@ -29,12 +30,15 @@ import (
 	"volcano.sh/volcano/pkg/scheduler/api"
 	"volcano.sh/volcano/pkg/scheduler/conf"
 	"volcano.sh/volcano/pkg/scheduler/framework"
+	"volcano.sh/volcano/pkg/scheduler/metrics"
 	"volcano.sh/volcano/pkg/scheduler/uthelper"
 	"volcano.sh/volcano/pkg/scheduler/util"
 )
 
 func init() {
 	options.Default()
+	metrics.InitTTLQueueMetrics(context.Background())
+	metrics.InitTTLJobMetrics(context.Background())
 }
 
 var (

--- a/pkg/scheduler/plugins/proportion/proportion_test.go
+++ b/pkg/scheduler/plugins/proportion/proportion_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package proportion
 
 import (
+	"context"
 	"io"
 	"net/http"
 	"os"
@@ -41,6 +42,7 @@ import (
 	"volcano.sh/volcano/pkg/scheduler/cache"
 	"volcano.sh/volcano/pkg/scheduler/conf"
 	"volcano.sh/volcano/pkg/scheduler/framework"
+	"volcano.sh/volcano/pkg/scheduler/metrics"
 	"volcano.sh/volcano/pkg/scheduler/plugins/gang"
 	"volcano.sh/volcano/pkg/scheduler/plugins/priority"
 	"volcano.sh/volcano/pkg/scheduler/uthelper"
@@ -49,6 +51,8 @@ import (
 
 func TestMain(m *testing.M) {
 	options.Default()
+	metrics.InitTTLQueueMetrics(context.Background())
+	metrics.InitTTLJobMetrics(context.Background())
 	os.Exit(m.Run())
 }
 

--- a/pkg/scheduler/plugins/resource-strategy-fit/resource_strategy_fit_test.go
+++ b/pkg/scheduler/plugins/resource-strategy-fit/resource_strategy_fit_test.go
@@ -1,17 +1,42 @@
+/*
+Copyright 2025 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package resourcestrategyfit
 
 import (
+	"context"
 	"fmt"
 	"math"
 	"os"
 	"reflect"
 	"testing"
 
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/kubernetes/pkg/scheduler/apis/config"
+
 	schedulingv1 "volcano.sh/apis/pkg/apis/scheduling/v1beta1"
+
 	"volcano.sh/volcano/cmd/scheduler/app/options"
 	"volcano.sh/volcano/pkg/scheduler/actions/allocate"
+	"volcano.sh/volcano/pkg/scheduler/api"
 	"volcano.sh/volcano/pkg/scheduler/conf"
+	"volcano.sh/volcano/pkg/scheduler/framework"
+	"volcano.sh/volcano/pkg/scheduler/metrics"
 	"volcano.sh/volcano/pkg/scheduler/plugins/drf"
 	"volcano.sh/volcano/pkg/scheduler/plugins/gang"
 	"volcano.sh/volcano/pkg/scheduler/plugins/nodeorder"
@@ -19,13 +44,6 @@ import (
 	"volcano.sh/volcano/pkg/scheduler/plugins/proportion"
 	"volcano.sh/volcano/pkg/scheduler/uthelper"
 	"volcano.sh/volcano/pkg/scheduler/util"
-
-	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/kubernetes/pkg/scheduler/apis/config"
-
-	"volcano.sh/volcano/pkg/scheduler/api"
-	"volcano.sh/volcano/pkg/scheduler/framework"
 )
 
 const (
@@ -34,6 +52,8 @@ const (
 
 func TestMain(m *testing.M) {
 	options.Default()
+	metrics.InitTTLQueueMetrics(context.Background())
+	metrics.InitTTLJobMetrics(context.Background())
 	os.Exit(m.Run())
 }
 

--- a/pkg/scheduler/plugins/resourcequota/resourcequota_test.go
+++ b/pkg/scheduler/plugins/resourcequota/resourcequota_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package resourcequota
 
 import (
+	"context"
+	"os"
 	"testing"
 
 	v1 "k8s.io/api/core/v1"
@@ -27,9 +29,17 @@ import (
 	"volcano.sh/volcano/pkg/scheduler/api"
 	"volcano.sh/volcano/pkg/scheduler/conf"
 	"volcano.sh/volcano/pkg/scheduler/framework"
+	"volcano.sh/volcano/pkg/scheduler/metrics"
 	"volcano.sh/volcano/pkg/scheduler/uthelper"
 	"volcano.sh/volcano/pkg/scheduler/util"
 )
+
+func TestMain(m *testing.M) {
+	metrics.InitTTLQueueMetrics(context.Background())
+	metrics.InitTTLJobMetrics(context.Background())
+
+	os.Exit(m.Run())
+}
 
 func TestResourceQuotaPlugin(t *testing.T) {
 

--- a/pkg/scheduler/plugins/tdm/tdm_test.go
+++ b/pkg/scheduler/plugins/tdm/tdm_test.go
@@ -17,8 +17,10 @@ limitations under the License.
 package tdm
 
 import (
+	"context"
 	"fmt"
 	"math"
+	"os"
 	"testing"
 	"time"
 
@@ -28,6 +30,7 @@ import (
 	"volcano.sh/volcano/pkg/scheduler/api"
 	"volcano.sh/volcano/pkg/scheduler/conf"
 	"volcano.sh/volcano/pkg/scheduler/framework"
+	"volcano.sh/volcano/pkg/scheduler/metrics"
 	"volcano.sh/volcano/pkg/scheduler/uthelper"
 	"volcano.sh/volcano/pkg/scheduler/util"
 )
@@ -35,6 +38,13 @@ import (
 const (
 	eps = 1e-8
 )
+
+func TestMain(m *testing.M) {
+	metrics.InitTTLQueueMetrics(context.Background())
+	metrics.InitTTLJobMetrics(context.Background())
+
+	os.Exit(m.Run())
+}
 
 func Test_parseRevocableZone(t *testing.T) {
 	tests := []struct {

--- a/pkg/scheduler/plugins/usage/usage_test.go
+++ b/pkg/scheduler/plugins/usage/usage_test.go
@@ -17,18 +17,20 @@ limitations under the License.
 package usage
 
 import (
+	"context"
 	"fmt"
+	v1 "k8s.io/api/core/v1"
 	"math"
+	"os"
 	"strings"
 	"testing"
 	"time"
-
-	v1 "k8s.io/api/core/v1"
 
 	schedulingv1 "volcano.sh/apis/pkg/apis/scheduling/v1beta1"
 	"volcano.sh/volcano/pkg/scheduler/api"
 	"volcano.sh/volcano/pkg/scheduler/conf"
 	"volcano.sh/volcano/pkg/scheduler/framework"
+	"volcano.sh/volcano/pkg/scheduler/metrics"
 	"volcano.sh/volcano/pkg/scheduler/metrics/source"
 	"volcano.sh/volcano/pkg/scheduler/uthelper"
 	"volcano.sh/volcano/pkg/scheduler/util"
@@ -57,6 +59,13 @@ func updateNodeUsage(nodesInfo map[string]*api.NodeInfo, nodesUsage map[string]*
 			nodeInfo.ResourceUsage = nodeUsage
 		}
 	}
+}
+
+func TestMain(m *testing.M) {
+	metrics.InitTTLQueueMetrics(context.Background())
+	metrics.InitTTLJobMetrics(context.Background())
+
+	os.Exit(m.Run())
 }
 
 func TestUsage_predicateFn(t *testing.T) {

--- a/pkg/util/metrics_with_ttl.go
+++ b/pkg/util/metrics_with_ttl.go
@@ -1,0 +1,245 @@
+package util
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"k8s.io/klog/v2"
+)
+
+type CollectorWrapper struct {
+	vec        prometheus.Collector
+	labelNames []string
+	Labels     sync.Map // key (joined label values) -> last update time
+}
+
+func NewCollectorWrapper(vec prometheus.Collector) *CollectorWrapper {
+	return &CollectorWrapper{vec: vec}
+}
+
+func NewCollectorWrapperWithLabelNames(vec prometheus.Collector, labelNames []string) *CollectorWrapper {
+	return &CollectorWrapper{vec: vec, labelNames: labelNames}
+}
+
+func (w *CollectorWrapper) ObserveWithLabelValues(value float64, lvs ...string) {
+	switch v := w.vec.(type) {
+	case *prometheus.GaugeVec:
+		v.WithLabelValues(lvs...).Set(value)
+	case *prometheus.CounterVec:
+		v.WithLabelValues(lvs...).Add(value)
+	case *prometheus.HistogramVec:
+		v.WithLabelValues(lvs...).Observe(value)
+	case *prometheus.SummaryVec:
+		v.WithLabelValues(lvs...).Observe(value)
+	}
+	w.Labels.Store(LabelsAsKey(lvs...), time.Now())
+}
+
+func (w *CollectorWrapper) DeleteLabel(key string) {
+	lvs := KeyToLabels(key)
+	switch v := w.vec.(type) {
+	case *prometheus.GaugeVec:
+		v.DeleteLabelValues(lvs...)
+	case *prometheus.CounterVec:
+		v.DeleteLabelValues(lvs...)
+	case *prometheus.HistogramVec:
+		v.DeleteLabelValues(lvs...)
+	case *prometheus.SummaryVec:
+		v.DeleteLabelValues(lvs...)
+	}
+	w.Labels.Delete(key)
+}
+
+// DeleteLabelValues deletes all metrics where the variable labels match the provided label values.
+// It uses the label key order to match correctly.
+func (w *CollectorWrapper) DeleteLabelValues(lvs ...string) {
+	switch v := w.vec.(type) {
+	case *prometheus.GaugeVec:
+		v.DeleteLabelValues(lvs...)
+	case *prometheus.CounterVec:
+		v.DeleteLabelValues(lvs...)
+	case *prometheus.HistogramVec:
+		v.DeleteLabelValues(lvs...)
+	case *prometheus.SummaryVec:
+		v.DeleteLabelValues(lvs...)
+	}
+
+	w.Labels.Delete(LabelsAsKey(lvs...))
+}
+
+// DeletePartialMatch deletes all metrics where the variable labels contain all of those passed in as labels.
+// It uses the label key order to match correctly.
+func (w *CollectorWrapper) DeletePartialMatch(labels prometheus.Labels) {
+	switch v := w.vec.(type) {
+	case *prometheus.GaugeVec:
+		v.DeletePartialMatch(labels)
+	case *prometheus.CounterVec:
+		v.DeletePartialMatch(labels)
+	case *prometheus.HistogramVec:
+		v.DeletePartialMatch(labels)
+	case *prometheus.SummaryVec:
+		v.DeletePartialMatch(labels)
+	}
+
+	// Synchronously remove matching metrics from the cache
+	w.Labels.Range(func(k, _ interface{}) bool {
+		keyLabels := KeyToLabels(k.(string))
+		if w.matchByLabelOrder(keyLabels, labels) {
+			w.Labels.Delete(k)
+		}
+		return true
+	})
+}
+
+func (w *CollectorWrapper) Vec() prometheus.Collector {
+	return w.vec
+}
+
+func (w *CollectorWrapper) Reset() {
+	switch v := w.vec.(type) {
+	case *prometheus.GaugeVec:
+		v.Reset()
+	case *prometheus.CounterVec:
+		v.Reset()
+	case *prometheus.HistogramVec:
+		v.Reset()
+	case *prometheus.SummaryVec:
+		v.Reset()
+	}
+
+	// Synchronously remove matching metrics from the cache
+	w.Labels.Range(func(k, _ interface{}) bool {
+		w.Labels.Delete(k)
+		return true
+	})
+}
+
+func (w *CollectorWrapper) LabelNames() []string {
+	return w.labelNames
+}
+
+// matchByLabelOrder checks whether the given labels (map) match the stored label values
+// according to the wrapper's labelNames order.
+func (w *CollectorWrapper) matchByLabelOrder(keyLabels []string, matchLabels prometheus.Labels) bool {
+	if len(w.labelNames) == 0 || len(keyLabels) != len(w.labelNames) {
+		return false
+	}
+
+	for i, labelName := range w.labelNames {
+		matchVal, ok := matchLabels[labelName]
+		if ok && matchVal != keyLabels[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// TTLCollectorWrapper prometheus.collector with ttl
+type TTLCollectorWrapper struct {
+	*CollectorWrapper
+	expiration    time.Duration
+	checkInterval time.Duration
+	ctx           context.Context
+}
+
+func NewTTLCollectorWrapper(vec prometheus.Collector, labelNames []string, expiration, checkInterval time.Duration, ctx context.Context) *TTLCollectorWrapper {
+	wrapper := &TTLCollectorWrapper{
+		CollectorWrapper: NewCollectorWrapperWithLabelNames(vec, labelNames),
+		expiration:       expiration,
+		checkInterval:    checkInterval,
+		ctx:              ctx,
+	}
+	go wrapper.Start()
+	return wrapper
+}
+
+func (w *TTLCollectorWrapper) ObserveWithLabelValues(value float64, lvs ...string) {
+	w.CollectorWrapper.ObserveWithLabelValues(value, lvs...)
+}
+
+func (w *TTLCollectorWrapper) DeletePartialMatch(labels prometheus.Labels) {
+	w.CollectorWrapper.DeletePartialMatch(labels)
+}
+
+func (w *TTLCollectorWrapper) DeleteLabelValues(lvs ...string) {
+	w.CollectorWrapper.DeleteLabelValues(lvs...)
+}
+
+func (w *TTLCollectorWrapper) Vec() prometheus.Collector {
+	return w.vec
+}
+
+func (w *TTLCollectorWrapper) LabelNames() []string {
+	return w.labelNames
+}
+
+func (w *TTLCollectorWrapper) checkTTL() {
+	start := time.Now()
+	count := 0
+	w.Labels.Range(func(k, v interface{}) bool {
+		if lastUpdated, ok := v.(time.Time); ok && start.Sub(lastUpdated) > w.expiration {
+			w.CollectorWrapper.DeleteLabel(k.(string))
+			count++
+		}
+		return true
+	})
+	cost := time.Since(start).Milliseconds()
+	klog.V(3).Infof("clear %d timeouted metrics, cost %d(ms)", count, cost)
+}
+
+func (w *TTLCollectorWrapper) Start() {
+	ticker := time.NewTicker(w.checkInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			w.checkTTL()
+		case <-w.ctx.Done():
+			klog.V(3).Infof("stop check ttl for ttl metrics")
+			return
+		}
+	}
+}
+
+func LabelsAsKey(lvs ...string) string {
+	return strings.Join(lvs, ",")
+}
+
+func KeyToLabels(key string) []string {
+	if key == "" {
+		return []string{}
+	}
+	return strings.Split(key, ",")
+}
+
+func NewTTLGaugeVec(opts prometheus.GaugeOpts, labelNames []string, expiration, checkInterval time.Duration, ctx context.Context) *TTLCollectorWrapper {
+	return NewTTLCollectorWrapper(promauto.NewGaugeVec(opts, labelNames), labelNames, expiration, checkInterval, ctx)
+}
+
+func NewTTLGaugeVecWithRegister(register prometheus.Registerer, opts prometheus.GaugeOpts, labelNames []string, expiration, checkInterval time.Duration, ctx context.Context) *TTLCollectorWrapper {
+	return NewTTLCollectorWrapper(promauto.With(register).NewGaugeVec(opts, labelNames), labelNames, expiration, checkInterval, ctx)
+}
+
+func NewGaugeVecWithRegister(register prometheus.Registerer, opts prometheus.GaugeOpts, labelNames []string) *CollectorWrapper {
+	return NewCollectorWrapperWithLabelNames(promauto.With(register).NewGaugeVec(opts, labelNames), labelNames)
+}
+
+func TestutilToFloat64(w *TTLCollectorWrapper, lvs ...string) float64 {
+	switch v := w.vec.(type) {
+	case *prometheus.GaugeVec:
+		return testutil.ToFloat64(v.WithLabelValues(lvs...))
+	case *prometheus.CounterVec:
+		return testutil.ToFloat64(v.WithLabelValues(lvs...))
+	}
+	return -1
+}
+
+func TestutilToCollectAndCount(w *TTLCollectorWrapper, lvs ...string) int {
+	return testutil.CollectAndCount(w.vec, lvs...)
+}

--- a/pkg/util/metrics_with_ttl_test.go
+++ b/pkg/util/metrics_with_ttl_test.go
@@ -1,0 +1,174 @@
+package util
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+)
+
+func TestTTLCollectorWrapperBench100000(t *testing.T) {
+	stopCh := make(chan struct{})
+	w := NewTTLGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: "foo",
+			Subsystem: "bar",
+			Name:      "test",
+			Help:      "test with ttl",
+		},
+		[]string{"id", "name"},
+		time.Second*2,
+		time.Second*3,
+		context.Background(),
+	)
+
+	now := time.Now()
+	for i := 0; i < 100000; i++ {
+		w.ObserveWithLabelValues(float64(i), fmt.Sprintf("id-%d", i), fmt.Sprintf("name-%d", i))
+	}
+	fmt.Println("ObserveWithLabelValues cost: ", time.Since(now).Milliseconds())
+
+	if v, ok := w.vec.(*prometheus.GaugeVec); ok {
+		metricChan := make(chan prometheus.Metric)
+		go func() {
+			v.Collect(metricChan)
+			close(metricChan)
+		}()
+		count := 0
+		for range metricChan {
+			count++
+		}
+		if count != 100000 {
+			t.Errorf("Expected 100000 metrics, got %d", count)
+		}
+	} else {
+		t.Errorf("Failed to cast vec to GaugeVec")
+	}
+
+	timer := time.NewTimer(time.Second * 6)
+	<-timer.C
+
+	if v, ok := w.vec.(*prometheus.GaugeVec); ok {
+		metricChan := make(chan prometheus.Metric)
+		go func() {
+			v.Collect(metricChan)
+			close(metricChan)
+		}()
+		count := 0
+		for range metricChan {
+			count++
+		}
+		if count != 0 {
+			t.Errorf("Expected 0 metrics after 5 seconds, got %d", count)
+		}
+	}
+
+	close(stopCh)
+	time.Sleep(time.Second * 1)
+}
+
+func TestTTLCollectorWrapper_DeletePartialMatch(t *testing.T) {
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+
+	labelNames := []string{"region", "status"}
+
+	// create TTLCollectorWrapper
+	gaugeVec := prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "test_metric",
+		Help: "metric for testing DeletePartialMatch",
+	}, labelNames)
+
+	ttlWrapper := NewTTLCollectorWrapper(
+		gaugeVec,
+		labelNames,
+		time.Minute,
+		time.Second*5,
+		context.Background(),
+	)
+
+	// observe three metrics with different label combinations
+	ttlWrapper.ObserveWithLabelValues(1.0, "cn", "success")
+	ttlWrapper.ObserveWithLabelValues(2.0, "us", "failed")
+	ttlWrapper.ObserveWithLabelValues(3.0, "cn", "failed")
+
+	// check initial number of metrics
+	if count := countMapKeys(ttlWrapper.CollectorWrapper); count != 3 {
+		t.Fatalf("expected 3 metrics, got %d", count)
+	}
+
+	// delete metrics partially matching region=cn
+	matchLabels := prometheus.Labels{"region": "cn"}
+	ttlWrapper.DeletePartialMatch(matchLabels)
+
+	// verify that matched keys are deleted
+	if hasKey(ttlWrapper.CollectorWrapper, "cn,success") {
+		t.Errorf("expected metric 'cn,success' to be deleted, but it still exists")
+	}
+	if hasKey(ttlWrapper.CollectorWrapper, "cn,failed") {
+		t.Errorf("expected metric 'cn,failed' to be deleted, but it still exists")
+	}
+
+	// verify that unmatched key still exists
+	if !hasKey(ttlWrapper.CollectorWrapper, "us,failed") {
+		t.Errorf("expected metric 'us,failed' to remain, but it was deleted")
+	}
+
+	// final number of metrics should be 1
+	if count := countMapKeys(ttlWrapper.CollectorWrapper); count != 1 {
+		t.Fatalf("expected 1 metric remaining, got %d", count)
+	}
+}
+
+func TestDeleteLabelValues(t *testing.T) {
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+
+	labelNames := []string{"label1", "label2"}
+	vec := prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "test_metric",
+		Help: "A test metric",
+	}, labelNames)
+
+	w := NewTTLCollectorWrapper(
+		vec,
+		labelNames,
+		time.Minute,
+		time.Second*5,
+		context.Background(),
+	)
+
+	w.ObserveWithLabelValues(1.0, "a", "b")
+
+	// Delete the metric
+	w.DeleteLabelValues("a", "b")
+
+	key := LabelsAsKey("a", "b")
+	// Check cache is removed
+	if _, ok := w.Labels.Load(key); ok {
+		t.Errorf("expected key %s to be deleted from cache", key)
+	}
+
+	if val := testutil.ToFloat64(w.vec.(*prometheus.GaugeVec).WithLabelValues("a", "b")); val != 0 {
+		t.Errorf("expected metric to be deleted or zero, got %v", val)
+	}
+}
+
+// helper function: count the number of keys in CollectorWrapper's Labels map
+func countMapKeys(m *CollectorWrapper) int {
+	count := 0
+	m.Labels.Range(func(_, _ interface{}) bool {
+		count++
+		return true
+	})
+	return count
+}
+
+// helper function: check whether a key exists in Labels map
+func hasKey(m *CollectorWrapper, key string) bool {
+	_, ok := m.Labels.Load(key)
+	return ok
+}


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

This PR is the resolution of the below github issue. Please review and do the needful.

#### What this PR does / why we need it:

**Added a TTL mechanism to the scheduler’s Metrics.**

volcano-scheduler stores Kubernetes objects in a local cache during scheduling. When scheduling begins, it takes a snapshot of this cache and executes scheduling logic based on configured plugins, during which metrics are recorded. If the snapshot and the local cache become inconsistent, metrics can leak. The TTL feature prevents this.

#### Which issue(s) this PR fixes:

Fixes [volcano-scheduler memory leak problem](https://github.com/volcano-sh/volcano/issues/4745)

#### Special notes for your reviewer:
NONE 

#### Does this PR introduce a user-facing change?
NONE

```release-note

```