### PR TITLE
feat: add context dumping for failed e2e tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,8 +81,9 @@ network_closure.sh
 /_tmp/
 /doc_tmp/
 
-# Test artifacts produced by Jenkins jobs
+# Test artifacts
 /_artifacts/
+/test-artifacts/
 
 # Go dependencies installed on Jenkins
 /_gopath/

--- a/hack/run-e2e-kind.sh
+++ b/hack/run-e2e-kind.sh
@@ -18,6 +18,8 @@
 
 export VK_ROOT=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/..
 export VC_BIN=${VK_ROOT}/${BIN_DIR}/${BIN_OSARCH}
+export TAG=${TAG:-$(git -C "${VK_ROOT}" rev-parse --verify HEAD 2>/dev/null || echo "latest")}
+export IMAGE_PREFIX=${IMAGE_PREFIX:-volcanosh}
 export LOG_LEVEL=3
 export CLEANUP_CLUSTER=${CLEANUP_CLUSTER:-1}
 export E2E_TYPE=${E2E_TYPE:-"ALL"}

--- a/test/e2e/jobseq/job_error_handling.go
+++ b/test/e2e/jobseq/job_error_handling.go
@@ -36,13 +36,18 @@ import (
 )
 
 var _ = Describe("Job Error Handling", func() {
+	var testCtx *e2eutil.TestContext
+
+	JustAfterEach(func() {
+		e2eutil.DumpTestContextIfFailed(testCtx, CurrentSpecReport())
+	})
 	It("job level LifecyclePolicy, Event: PodFailed; Action: RestartJob", func() {
 		By("init test context")
-		context := e2eutil.InitTestContext(e2eutil.Options{})
-		defer e2eutil.CleanupTestContext(context)
+		testCtx = e2eutil.InitTestContext(e2eutil.Options{})
+		defer e2eutil.CleanupTestContext(testCtx)
 
 		By("create job")
-		job := e2eutil.CreateJob(context, &e2eutil.JobSpec{
+		job := e2eutil.CreateJob(testCtx, &e2eutil.JobSpec{
 			Name: "failed-restart-job",
 			Policies: []vcbatch.LifecyclePolicy{
 				{
@@ -69,17 +74,17 @@ var _ = Describe("Job Error Handling", func() {
 		})
 
 		// job phase: pending -> running -> restarting
-		err := e2eutil.WaitJobPhases(context, job, []vcbatch.JobPhase{vcbatch.Pending, vcbatch.Running, vcbatch.Restarting})
+		err := e2eutil.WaitJobPhases(testCtx, job, []vcbatch.JobPhase{vcbatch.Pending, vcbatch.Running, vcbatch.Restarting})
 		Expect(err).NotTo(HaveOccurred())
 	})
 
 	It("job level LifecyclePolicy, Event: PodFailed; Action: TerminateJob", func() {
 		By("init test context")
-		context := e2eutil.InitTestContext(e2eutil.Options{})
-		defer e2eutil.CleanupTestContext(context)
+		testCtx = e2eutil.InitTestContext(e2eutil.Options{})
+		defer e2eutil.CleanupTestContext(testCtx)
 
 		By("create job")
-		job := e2eutil.CreateJob(context, &e2eutil.JobSpec{
+		job := e2eutil.CreateJob(testCtx, &e2eutil.JobSpec{
 			Name: "failed-terminate-job",
 			Policies: []vcbatch.LifecyclePolicy{
 				{
@@ -106,16 +111,16 @@ var _ = Describe("Job Error Handling", func() {
 		})
 
 		// job phase: pending -> running -> Terminating -> Terminated
-		err := e2eutil.WaitJobPhases(context, job, []vcbatch.JobPhase{vcbatch.Pending, vcbatch.Running, vcbatch.Terminating, vcbatch.Terminated})
+		err := e2eutil.WaitJobPhases(testCtx, job, []vcbatch.JobPhase{vcbatch.Pending, vcbatch.Running, vcbatch.Terminating, vcbatch.Terminated})
 		Expect(err).NotTo(HaveOccurred())
 	})
 
 	It("job level LifecyclePolicy, Event: PodFailed; Action: AbortJob", func() {
-		ctx := e2eutil.InitTestContext(e2eutil.Options{})
-		defer e2eutil.CleanupTestContext(ctx)
+		testCtx = e2eutil.InitTestContext(e2eutil.Options{})
+		defer e2eutil.CleanupTestContext(testCtx)
 
 		By("create job")
-		job := e2eutil.CreateJob(ctx, &e2eutil.JobSpec{
+		job := e2eutil.CreateJob(testCtx, &e2eutil.JobSpec{
 			Name: "failed-abort-job",
 			Policies: []vcbatch.LifecyclePolicy{
 				{
@@ -142,17 +147,17 @@ var _ = Describe("Job Error Handling", func() {
 		})
 
 		// job phase: pending -> running -> Aborting -> Aborted
-		err := e2eutil.WaitJobPhases(ctx, job, []vcbatch.JobPhase{vcbatch.Pending, vcbatch.Running, vcbatch.Aborting, vcbatch.Aborted})
+		err := e2eutil.WaitJobPhases(testCtx, job, []vcbatch.JobPhase{vcbatch.Pending, vcbatch.Running, vcbatch.Aborting, vcbatch.Aborted})
 		Expect(err).NotTo(HaveOccurred())
 	})
 
 	It("job level LifecyclePolicy, Event: PodFailed, Action: RestartPod; Event PodEvicted, Action: TerminateJob, Timeout: 5m", func() {
 		By("init test context")
-		context := e2eutil.InitTestContext(e2eutil.Options{})
-		defer e2eutil.CleanupTestContext(context)
+		testCtx = e2eutil.InitTestContext(e2eutil.Options{})
+		defer e2eutil.CleanupTestContext(testCtx)
 
 		By("create job")
-		job := e2eutil.CreateJob(context, &e2eutil.JobSpec{
+		job := e2eutil.CreateJob(testCtx, &e2eutil.JobSpec{
 			Name: "failed-restart-job",
 			Policies: []vcbatch.LifecyclePolicy{
 				{
@@ -186,16 +191,16 @@ var _ = Describe("Job Error Handling", func() {
 		})
 
 		// job phase: pending -> running -> restarting -> running
-		err := e2eutil.WaitJobPhases(context, job, []vcbatch.JobPhase{vcbatch.Pending, vcbatch.Running, vcbatch.Restarting, vcbatch.Running})
+		err := e2eutil.WaitJobPhases(testCtx, job, []vcbatch.JobPhase{vcbatch.Pending, vcbatch.Running, vcbatch.Restarting, vcbatch.Running})
 		Expect(err).NotTo(HaveOccurred())
 	})
 
 	It("job level LifecyclePolicy, Event: PodEvicted; Action: RestartJob", func() {
-		ctx := e2eutil.InitTestContext(e2eutil.Options{})
-		defer e2eutil.CleanupTestContext(ctx)
+		testCtx = e2eutil.InitTestContext(e2eutil.Options{})
+		defer e2eutil.CleanupTestContext(testCtx)
 
 		By("create job")
-		job := e2eutil.CreateJob(ctx, &e2eutil.JobSpec{
+		job := e2eutil.CreateJob(testCtx, &e2eutil.JobSpec{
 			Name: "evicted-restart-job",
 			Policies: []vcbatch.LifecyclePolicy{
 				{
@@ -220,25 +225,25 @@ var _ = Describe("Job Error Handling", func() {
 		})
 
 		// job phase: pending -> running
-		err := e2eutil.WaitJobPhases(ctx, job, []vcbatch.JobPhase{vcbatch.Pending, vcbatch.Running})
+		err := e2eutil.WaitJobPhases(testCtx, job, []vcbatch.JobPhase{vcbatch.Pending, vcbatch.Running})
 		Expect(err).NotTo(HaveOccurred())
 
 		By("delete one pod of job")
 		podName := jobctl.MakePodName(job.Name, "delete", 0)
-		err = ctx.Kubeclient.CoreV1().Pods(job.Namespace).Delete(context.TODO(), podName, metav1.DeleteOptions{})
+		err = testCtx.Kubeclient.CoreV1().Pods(job.Namespace).Delete(context.TODO(), podName, metav1.DeleteOptions{})
 		Expect(err).NotTo(HaveOccurred())
 
 		// job phase: Restarting -> Running
-		err = e2eutil.WaitJobPhases(ctx, job, []vcbatch.JobPhase{vcbatch.Restarting, vcbatch.Pending, vcbatch.Running})
+		err = e2eutil.WaitJobPhases(testCtx, job, []vcbatch.JobPhase{vcbatch.Restarting, vcbatch.Pending, vcbatch.Running})
 		Expect(err).NotTo(HaveOccurred())
 	})
 
 	It("job level LifecyclePolicy, Event: PodEvicted; Action: TerminateJob", func() {
-		ctx := e2eutil.InitTestContext(e2eutil.Options{})
-		defer e2eutil.CleanupTestContext(ctx)
+		testCtx = e2eutil.InitTestContext(e2eutil.Options{})
+		defer e2eutil.CleanupTestContext(testCtx)
 
 		By("create job")
-		job := e2eutil.CreateJob(ctx, &e2eutil.JobSpec{
+		job := e2eutil.CreateJob(testCtx, &e2eutil.JobSpec{
 			Name: "evicted-terminate-job",
 			Policies: []vcbatch.LifecyclePolicy{
 				{
@@ -263,25 +268,25 @@ var _ = Describe("Job Error Handling", func() {
 		})
 
 		// job phase: pending -> running
-		err := e2eutil.WaitJobPhases(ctx, job, []vcbatch.JobPhase{vcbatch.Pending, vcbatch.Running})
+		err := e2eutil.WaitJobPhases(testCtx, job, []vcbatch.JobPhase{vcbatch.Pending, vcbatch.Running})
 		Expect(err).NotTo(HaveOccurred())
 
 		By("delete one pod of job")
 		podName := jobctl.MakePodName(job.Name, "delete", 0)
-		err = ctx.Kubeclient.CoreV1().Pods(job.Namespace).Delete(context.TODO(), podName, metav1.DeleteOptions{})
+		err = testCtx.Kubeclient.CoreV1().Pods(job.Namespace).Delete(context.TODO(), podName, metav1.DeleteOptions{})
 		Expect(err).NotTo(HaveOccurred())
 
 		// job phase: Terminating -> Terminated
-		err = e2eutil.WaitJobPhases(ctx, job, []vcbatch.JobPhase{vcbatch.Terminating, vcbatch.Terminated})
+		err = e2eutil.WaitJobPhases(testCtx, job, []vcbatch.JobPhase{vcbatch.Terminating, vcbatch.Terminated})
 		Expect(err).NotTo(HaveOccurred())
 	})
 
 	It("job level LifecyclePolicy, Event: PodEvicted; Action: AbortJob", func() {
-		ctx := e2eutil.InitTestContext(e2eutil.Options{})
-		defer e2eutil.CleanupTestContext(ctx)
+		testCtx = e2eutil.InitTestContext(e2eutil.Options{})
+		defer e2eutil.CleanupTestContext(testCtx)
 
 		By("create job")
-		job := e2eutil.CreateJob(ctx, &e2eutil.JobSpec{
+		job := e2eutil.CreateJob(testCtx, &e2eutil.JobSpec{
 			Name: "evicted-abort-job",
 			Policies: []vcbatch.LifecyclePolicy{
 				{
@@ -306,25 +311,25 @@ var _ = Describe("Job Error Handling", func() {
 		})
 
 		// job phase: pending -> running
-		err := e2eutil.WaitJobPhases(ctx, job, []vcbatch.JobPhase{vcbatch.Pending, vcbatch.Running})
+		err := e2eutil.WaitJobPhases(testCtx, job, []vcbatch.JobPhase{vcbatch.Pending, vcbatch.Running})
 		Expect(err).NotTo(HaveOccurred())
 
 		By("delete one pod of job")
 		podName := jobctl.MakePodName(job.Name, "delete", 0)
-		err = ctx.Kubeclient.CoreV1().Pods(job.Namespace).Delete(context.TODO(), podName, metav1.DeleteOptions{})
+		err = testCtx.Kubeclient.CoreV1().Pods(job.Namespace).Delete(context.TODO(), podName, metav1.DeleteOptions{})
 		Expect(err).NotTo(HaveOccurred())
 
 		// job phase: Aborting -> Aborted
-		err = e2eutil.WaitJobPhases(ctx, job, []vcbatch.JobPhase{vcbatch.Aborting, vcbatch.Aborted})
+		err = e2eutil.WaitJobPhases(testCtx, job, []vcbatch.JobPhase{vcbatch.Aborting, vcbatch.Aborted})
 		Expect(err).NotTo(HaveOccurred())
 	})
 
 	It("job level LifecyclePolicy, Event: Any; Action: RestartJob", func() {
-		ctx := e2eutil.InitTestContext(e2eutil.Options{})
-		defer e2eutil.CleanupTestContext(ctx)
+		testCtx = e2eutil.InitTestContext(e2eutil.Options{})
+		defer e2eutil.CleanupTestContext(testCtx)
 
 		By("create job")
-		job := e2eutil.CreateJob(ctx, &e2eutil.JobSpec{
+		job := e2eutil.CreateJob(testCtx, &e2eutil.JobSpec{
 			Name: "any-restart-job",
 			Policies: []vcbatch.LifecyclePolicy{
 				{
@@ -349,28 +354,28 @@ var _ = Describe("Job Error Handling", func() {
 		})
 
 		// job phase: pending -> running
-		err := e2eutil.WaitJobPhases(ctx, job, []vcbatch.JobPhase{vcbatch.Pending, vcbatch.Running})
+		err := e2eutil.WaitJobPhases(testCtx, job, []vcbatch.JobPhase{vcbatch.Pending, vcbatch.Running})
 		Expect(err).NotTo(HaveOccurred())
 
 		By("delete one pod of job")
 		podName := jobctl.MakePodName(job.Name, "delete", 0)
-		err = ctx.Kubeclient.CoreV1().Pods(job.Namespace).Delete(context.TODO(), podName, metav1.DeleteOptions{})
+		err = testCtx.Kubeclient.CoreV1().Pods(job.Namespace).Delete(context.TODO(), podName, metav1.DeleteOptions{})
 		Expect(err).NotTo(HaveOccurred())
 
 		// job phase: Restarting -> Running
-		err = e2eutil.WaitJobPhases(ctx, job, []vcbatch.JobPhase{vcbatch.Restarting, vcbatch.Pending, vcbatch.Running})
+		err = e2eutil.WaitJobPhases(testCtx, job, []vcbatch.JobPhase{vcbatch.Restarting, vcbatch.Pending, vcbatch.Running})
 		Expect(err).NotTo(HaveOccurred())
 	})
 
 	It("Job error handling: Restart job when job is unschedulable", func() {
 		By("init test context")
-		ctx := e2eutil.InitTestContext(e2eutil.Options{})
-		defer e2eutil.CleanupTestContext(ctx)
-		rep := e2eutil.ClusterSize(ctx, e2eutil.OneCPU)
+		testCtx = e2eutil.InitTestContext(e2eutil.Options{})
+		defer e2eutil.CleanupTestContext(testCtx)
+		rep := e2eutil.ClusterSize(testCtx, e2eutil.OneCPU)
 
 		jobSpec := &e2eutil.JobSpec{
 			Name:      "job-restart-when-unschedulable",
-			Namespace: ctx.Namespace,
+			Namespace: testCtx.Namespace,
 			Policies: []vcbatch.LifecyclePolicy{
 				{
 					Event:  vcbus.JobUnknownEvent,
@@ -388,8 +393,8 @@ var _ = Describe("Job Error Handling", func() {
 			},
 		}
 		By("Create the Job")
-		job := e2eutil.CreateJob(ctx, jobSpec)
-		err := e2eutil.WaitJobReady(ctx, job)
+		job := e2eutil.CreateJob(testCtx, jobSpec)
+		err := e2eutil.WaitJobReady(testCtx, job)
 		Expect(err).NotTo(HaveOccurred())
 
 		By("Taint all nodes")
@@ -400,35 +405,35 @@ var _ = Describe("Job Error Handling", func() {
 				Effect: v1.TaintEffectNoSchedule,
 			},
 		}
-		err = e2eutil.TaintAllNodes(ctx, taints)
+		err = e2eutil.TaintAllNodes(testCtx, taints)
 		Expect(err).NotTo(HaveOccurred())
 
 		podName := jobctl.MakePodName(job.Name, "test", 0)
 		By("Kill one of the pod in order to trigger unschedulable status")
-		err = ctx.Kubeclient.CoreV1().Pods(job.Namespace).Delete(context.TODO(), podName, metav1.DeleteOptions{})
+		err = testCtx.Kubeclient.CoreV1().Pods(job.Namespace).Delete(context.TODO(), podName, metav1.DeleteOptions{})
 		Expect(err).NotTo(HaveOccurred())
 
 		By("Job is restarting")
-		err = e2eutil.WaitJobPhases(ctx, job, []vcbatch.JobPhase{
+		err = e2eutil.WaitJobPhases(testCtx, job, []vcbatch.JobPhase{
 			vcbatch.Restarting, vcbatch.Pending})
 		Expect(err).NotTo(HaveOccurred())
 
 		By("Untaint all nodes")
-		err = e2eutil.RemoveTaintsFromAllNodes(ctx, taints)
+		err = e2eutil.RemoveTaintsFromAllNodes(testCtx, taints)
 		Expect(err).NotTo(HaveOccurred())
 		By("Job is running again")
-		err = e2eutil.WaitJobPhases(ctx, job, []vcbatch.JobPhase{vcbatch.Running})
+		err = e2eutil.WaitJobPhases(testCtx, job, []vcbatch.JobPhase{vcbatch.Running})
 		Expect(err).NotTo(HaveOccurred())
 	})
 
 	It("Job error handling: Abort job when job is unschedulable", func() {
-		ctx := e2eutil.InitTestContext(e2eutil.Options{})
-		defer e2eutil.CleanupTestContext(ctx)
-		rep := e2eutil.ClusterSize(ctx, e2eutil.OneCPU)
+		testCtx = e2eutil.InitTestContext(e2eutil.Options{})
+		defer e2eutil.CleanupTestContext(testCtx)
+		rep := e2eutil.ClusterSize(testCtx, e2eutil.OneCPU)
 
 		jobSpec := &e2eutil.JobSpec{
 			Name:      "job-abort-when-unschedulable",
-			Namespace: ctx.Namespace,
+			Namespace: testCtx.Namespace,
 			Policies: []vcbatch.LifecyclePolicy{
 				{
 					Event:  vcbus.JobUnknownEvent,
@@ -446,8 +451,8 @@ var _ = Describe("Job Error Handling", func() {
 			},
 		}
 		By("Create the Job")
-		job := e2eutil.CreateJob(ctx, jobSpec)
-		err := e2eutil.WaitJobReady(ctx, job)
+		job := e2eutil.CreateJob(testCtx, jobSpec)
+		err := e2eutil.WaitJobReady(testCtx, job)
 		Expect(err).NotTo(HaveOccurred())
 
 		By("Taint all nodes")
@@ -458,32 +463,32 @@ var _ = Describe("Job Error Handling", func() {
 				Effect: v1.TaintEffectNoSchedule,
 			},
 		}
-		err = e2eutil.TaintAllNodes(ctx, taints)
+		err = e2eutil.TaintAllNodes(testCtx, taints)
 		Expect(err).NotTo(HaveOccurred())
 
 		podName := jobctl.MakePodName(job.Name, "test", 0)
 		By("Kill one of the pod in order to trigger unschedulable status")
-		err = ctx.Kubeclient.CoreV1().Pods(job.Namespace).Delete(context.TODO(), podName, metav1.DeleteOptions{})
+		err = testCtx.Kubeclient.CoreV1().Pods(job.Namespace).Delete(context.TODO(), podName, metav1.DeleteOptions{})
 		Expect(err).NotTo(HaveOccurred())
 
 		By("Job is aborted")
-		err = e2eutil.WaitJobPhases(ctx, job, []vcbatch.JobPhase{
+		err = e2eutil.WaitJobPhases(testCtx, job, []vcbatch.JobPhase{
 			vcbatch.Aborting, vcbatch.Aborted})
 		Expect(err).NotTo(HaveOccurred())
 
-		err = e2eutil.RemoveTaintsFromAllNodes(ctx, taints)
+		err = e2eutil.RemoveTaintsFromAllNodes(testCtx, taints)
 		Expect(err).NotTo(HaveOccurred())
 	})
 
 	It("job level LifecyclePolicy, Event: TaskCompleted; Action: CompletedJob", func() {
 		By("init test context")
-		ctx := e2eutil.InitTestContext(e2eutil.Options{})
-		defer e2eutil.CleanupTestContext(ctx)
+		testCtx = e2eutil.InitTestContext(e2eutil.Options{})
+		defer e2eutil.CleanupTestContext(testCtx)
 
 		By("create job")
-		job := e2eutil.CreateJob(ctx, &e2eutil.JobSpec{
+		job := e2eutil.CreateJob(testCtx, &e2eutil.JobSpec{
 			Name:      "any-complete-job",
-			Namespace: ctx.Namespace,
+			Namespace: testCtx.Namespace,
 			Policies: []vcbatch.LifecyclePolicy{
 				{
 					Action: vcbus.CompleteJobAction,
@@ -511,7 +516,7 @@ var _ = Describe("Job Error Handling", func() {
 		By("job scheduled, then task 'completed_task' finished and job finally complete")
 		// job phase: pending -> running -> completing -> completed
 		// TODO: skip running -> completing for the github CI pool performance
-		err := e2eutil.WaitJobPhases(ctx, job, []vcbatch.JobPhase{
+		err := e2eutil.WaitJobPhases(testCtx, job, []vcbatch.JobPhase{
 			vcbatch.Pending, vcbatch.Completed})
 		Expect(err).NotTo(HaveOccurred())
 
@@ -519,13 +524,13 @@ var _ = Describe("Job Error Handling", func() {
 
 	It("job level LifecyclePolicy, Event: TaskFailed; Action: TerminateJob", func() {
 		By("init test context")
-		ctx := e2eutil.InitTestContext(e2eutil.Options{})
-		defer e2eutil.CleanupTestContext(ctx)
+		testCtx = e2eutil.InitTestContext(e2eutil.Options{})
+		defer e2eutil.CleanupTestContext(testCtx)
 
 		By("create job")
-		job := e2eutil.CreateJob(ctx, &e2eutil.JobSpec{
+		job := e2eutil.CreateJob(testCtx, &e2eutil.JobSpec{
 			Name:      "task-failed-terminate-job",
-			Namespace: ctx.Namespace,
+			Namespace: testCtx.Namespace,
 			Policies: []vcbatch.LifecyclePolicy{
 				{
 					Action: vcbus.TerminateJobAction,
@@ -554,34 +559,34 @@ var _ = Describe("Job Error Handling", func() {
 		})
 
 		// job phase: Pending -> Running
-		err := e2eutil.WaitJobPhases(ctx, job, []vcbatch.JobPhase{vcbatch.Pending, vcbatch.Running})
+		err := e2eutil.WaitJobPhases(testCtx, job, []vcbatch.JobPhase{vcbatch.Pending, vcbatch.Running})
 		Expect(err).NotTo(HaveOccurred())
 
 		By("update one pod of job")
 		podName := jobctl.MakePodName(job.Name, "failed", 0)
-		pod, err := ctx.Kubeclient.CoreV1().Pods(job.Namespace).Get(context.TODO(), podName, metav1.GetOptions{})
+		pod, err := testCtx.Kubeclient.CoreV1().Pods(job.Namespace).Get(context.TODO(), podName, metav1.GetOptions{})
 		Expect(err).NotTo(HaveOccurred())
 
 		pod.Status.ContainerStatuses = []v1.ContainerStatus{{RestartCount: 4}}
-		_, err = ctx.Kubeclient.CoreV1().Pods(job.Namespace).UpdateStatus(context.TODO(), pod, metav1.UpdateOptions{})
+		_, err = testCtx.Kubeclient.CoreV1().Pods(job.Namespace).UpdateStatus(context.TODO(), pod, metav1.UpdateOptions{})
 		Expect(err).NotTo(HaveOccurred())
 
 		// job phase: Terminating -> Terminated
-		err = e2eutil.WaitJobPhases(ctx, job, []vcbatch.JobPhase{vcbatch.Terminating, vcbatch.Terminated})
+		err = e2eutil.WaitJobPhases(testCtx, job, []vcbatch.JobPhase{vcbatch.Terminating, vcbatch.Terminated})
 		Expect(err).NotTo(HaveOccurred())
 
 	})
 
 	It("job level LifecyclePolicy, error code: 3; Action: RestartJob", func() {
 		By("init test context")
-		ctx := e2eutil.InitTestContext(e2eutil.Options{})
-		defer e2eutil.CleanupTestContext(ctx)
+		testCtx = e2eutil.InitTestContext(e2eutil.Options{})
+		defer e2eutil.CleanupTestContext(testCtx)
 
 		By("create job")
 		var erroCode int32 = 3
-		job := e2eutil.CreateJob(ctx, &e2eutil.JobSpec{
+		job := e2eutil.CreateJob(testCtx, &e2eutil.JobSpec{
 			Name:      "errorcode-restart-job",
-			Namespace: ctx.Namespace,
+			Namespace: testCtx.Namespace,
 			Policies: []vcbatch.LifecyclePolicy{
 				{
 					Action:   vcbus.RestartJobAction,
@@ -607,16 +612,16 @@ var _ = Describe("Job Error Handling", func() {
 		})
 
 		// job phase: pending -> running -> restarting
-		err := e2eutil.WaitJobPhases(ctx, job, []vcbatch.JobPhase{vcbatch.Pending, vcbatch.Running, vcbatch.Restarting})
+		err := e2eutil.WaitJobPhases(testCtx, job, []vcbatch.JobPhase{vcbatch.Pending, vcbatch.Running, vcbatch.Restarting})
 		Expect(err).NotTo(HaveOccurred())
 	})
 
 	It("job level LifecyclePolicy, Event[]: PodEvicted, PodFailed; Action: TerminateJob", func() {
-		ctx := e2eutil.InitTestContext(e2eutil.Options{})
-		defer e2eutil.CleanupTestContext(ctx)
+		testCtx = e2eutil.InitTestContext(e2eutil.Options{})
+		defer e2eutil.CleanupTestContext(testCtx)
 
 		By("create job")
-		job := e2eutil.CreateJob(ctx, &e2eutil.JobSpec{
+		job := e2eutil.CreateJob(testCtx, &e2eutil.JobSpec{
 			Name: "evicted-terminate-job",
 			Policies: []vcbatch.LifecyclePolicy{
 				{
@@ -644,25 +649,25 @@ var _ = Describe("Job Error Handling", func() {
 		})
 
 		// job phase: pending -> running
-		err := e2eutil.WaitJobPhases(ctx, job, []vcbatch.JobPhase{vcbatch.Pending, vcbatch.Running})
+		err := e2eutil.WaitJobPhases(testCtx, job, []vcbatch.JobPhase{vcbatch.Pending, vcbatch.Running})
 		Expect(err).NotTo(HaveOccurred())
 
 		By("delete one pod of job")
 		podName := jobctl.MakePodName(job.Name, "delete", 0)
-		err = ctx.Kubeclient.CoreV1().Pods(job.Namespace).Delete(context.TODO(), podName, metav1.DeleteOptions{})
+		err = testCtx.Kubeclient.CoreV1().Pods(job.Namespace).Delete(context.TODO(), podName, metav1.DeleteOptions{})
 		Expect(err).NotTo(HaveOccurred())
 
 		// job phase: Terminating -> Terminated
-		err = e2eutil.WaitJobPhases(ctx, job, []vcbatch.JobPhase{vcbatch.Terminating, vcbatch.Terminated})
+		err = e2eutil.WaitJobPhases(testCtx, job, []vcbatch.JobPhase{vcbatch.Terminating, vcbatch.Terminated})
 		Expect(err).NotTo(HaveOccurred())
 	})
 	It("Task level LifecyclePolicy, Event: PodFailed; Action: RestartJob", func() {
 		By("init test context")
-		context := e2eutil.InitTestContext(e2eutil.Options{})
-		defer e2eutil.CleanupTestContext(context)
+		testCtx = e2eutil.InitTestContext(e2eutil.Options{})
+		defer e2eutil.CleanupTestContext(testCtx)
 
 		By("create job")
-		job := e2eutil.CreateJob(context, &e2eutil.JobSpec{
+		job := e2eutil.CreateJob(testCtx, &e2eutil.JobSpec{
 			Name: "failed-restart-job",
 			Tasks: []e2eutil.TaskSpec{
 				{
@@ -689,15 +694,15 @@ var _ = Describe("Job Error Handling", func() {
 		})
 
 		// job phase: pending -> running -> restarting
-		err := e2eutil.WaitJobPhases(context, job, []vcbatch.JobPhase{vcbatch.Pending, vcbatch.Running, vcbatch.Restarting})
+		err := e2eutil.WaitJobPhases(testCtx, job, []vcbatch.JobPhase{vcbatch.Pending, vcbatch.Running, vcbatch.Restarting})
 		Expect(err).NotTo(HaveOccurred())
 	})
 	It("Task level LifecyclePolicy, Event: PodEvicted; Action: RestartJob", func() {
-		ctx := e2eutil.InitTestContext(e2eutil.Options{})
-		defer e2eutil.CleanupTestContext(ctx)
+		testCtx = e2eutil.InitTestContext(e2eutil.Options{})
+		defer e2eutil.CleanupTestContext(testCtx)
 
 		By("create job")
-		job := e2eutil.CreateJob(ctx, &e2eutil.JobSpec{
+		job := e2eutil.CreateJob(testCtx, &e2eutil.JobSpec{
 			Name: "evicted-restart-job",
 
 			Tasks: []e2eutil.TaskSpec{
@@ -723,24 +728,24 @@ var _ = Describe("Job Error Handling", func() {
 		})
 
 		// job phase: pending -> running
-		err := e2eutil.WaitJobPhases(ctx, job, []vcbatch.JobPhase{vcbatch.Pending, vcbatch.Running})
+		err := e2eutil.WaitJobPhases(testCtx, job, []vcbatch.JobPhase{vcbatch.Pending, vcbatch.Running})
 		Expect(err).NotTo(HaveOccurred())
 
 		By("delete one pod of job")
 		podName := jobctl.MakePodName(job.Name, "delete", 0)
-		err = ctx.Kubeclient.CoreV1().Pods(job.Namespace).Delete(context.TODO(), podName, metav1.DeleteOptions{})
+		err = testCtx.Kubeclient.CoreV1().Pods(job.Namespace).Delete(context.TODO(), podName, metav1.DeleteOptions{})
 		Expect(err).NotTo(HaveOccurred())
 
 		// job phase: Restarting -> Running
-		err = e2eutil.WaitJobPhases(ctx, job, []vcbatch.JobPhase{vcbatch.Restarting, vcbatch.Pending, vcbatch.Running})
+		err = e2eutil.WaitJobPhases(testCtx, job, []vcbatch.JobPhase{vcbatch.Restarting, vcbatch.Pending, vcbatch.Running})
 		Expect(err).NotTo(HaveOccurred())
 	})
 	It("Task level LifecyclePolicy, Event: PodEvicted; Action: TerminateJob", func() {
-		ctx := e2eutil.InitTestContext(e2eutil.Options{})
-		defer e2eutil.CleanupTestContext(ctx)
+		testCtx = e2eutil.InitTestContext(e2eutil.Options{})
+		defer e2eutil.CleanupTestContext(testCtx)
 
 		By("create job")
-		job := e2eutil.CreateJob(ctx, &e2eutil.JobSpec{
+		job := e2eutil.CreateJob(testCtx, &e2eutil.JobSpec{
 			Name: "evicted-terminate-job",
 			Tasks: []e2eutil.TaskSpec{
 				{
@@ -765,24 +770,24 @@ var _ = Describe("Job Error Handling", func() {
 		})
 
 		// job phase: pending -> running
-		err := e2eutil.WaitJobPhases(ctx, job, []vcbatch.JobPhase{vcbatch.Pending, vcbatch.Running})
+		err := e2eutil.WaitJobPhases(testCtx, job, []vcbatch.JobPhase{vcbatch.Pending, vcbatch.Running})
 		Expect(err).NotTo(HaveOccurred())
 
 		By("delete one pod of job")
 		podName := jobctl.MakePodName(job.Name, "delete", 0)
-		err = ctx.Kubeclient.CoreV1().Pods(job.Namespace).Delete(context.TODO(), podName, metav1.DeleteOptions{})
+		err = testCtx.Kubeclient.CoreV1().Pods(job.Namespace).Delete(context.TODO(), podName, metav1.DeleteOptions{})
 		Expect(err).NotTo(HaveOccurred())
 
 		// job phase: Terminating -> Terminated
-		err = e2eutil.WaitJobPhases(ctx, job, []vcbatch.JobPhase{vcbatch.Terminating, vcbatch.Terminated})
+		err = e2eutil.WaitJobPhases(testCtx, job, []vcbatch.JobPhase{vcbatch.Terminating, vcbatch.Terminated})
 		Expect(err).NotTo(HaveOccurred())
 	})
 	It("Task level LifecyclePolicy, Event: TaskCompleted; Action: CompletedJob", func() {
-		ctx := e2eutil.InitTestContext(e2eutil.Options{})
-		defer e2eutil.CleanupTestContext(ctx)
+		testCtx = e2eutil.InitTestContext(e2eutil.Options{})
+		defer e2eutil.CleanupTestContext(testCtx)
 
 		By("create job")
-		job := e2eutil.CreateJob(ctx, &e2eutil.JobSpec{
+		job := e2eutil.CreateJob(testCtx, &e2eutil.JobSpec{
 			Name: "any-complete-job",
 			Tasks: []e2eutil.TaskSpec{
 				{
@@ -810,7 +815,7 @@ var _ = Describe("Job Error Handling", func() {
 
 		By("job scheduled, then task 'completed_task' finished and job finally complete")
 		// job phase: pending -> running -> completing -> completed
-		err := e2eutil.WaitJobPhases(ctx, job, []vcbatch.JobPhase{
+		err := e2eutil.WaitJobPhases(testCtx, job, []vcbatch.JobPhase{
 			vcbatch.Pending, vcbatch.Completed})
 		Expect(err).NotTo(HaveOccurred())
 
@@ -818,11 +823,11 @@ var _ = Describe("Job Error Handling", func() {
 
 	It("job level LifecyclePolicy, Event: PodFailed; Action: AbortJob and Task level lifecyclePolicy, Event : PodFailed; Action: RestartJob", func() {
 		By("init test context")
-		context := e2eutil.InitTestContext(e2eutil.Options{})
-		defer e2eutil.CleanupTestContext(context)
+		testCtx = e2eutil.InitTestContext(e2eutil.Options{})
+		defer e2eutil.CleanupTestContext(testCtx)
 
 		By("create job")
-		job := e2eutil.CreateJob(context, &e2eutil.JobSpec{
+		job := e2eutil.CreateJob(testCtx, &e2eutil.JobSpec{
 			Name: "failed-restart-job",
 			Policies: []vcbatch.LifecyclePolicy{
 				{
@@ -855,24 +860,24 @@ var _ = Describe("Job Error Handling", func() {
 		})
 
 		// job phase: pending -> running -> Restarting
-		err := e2eutil.WaitJobPhases(context, job, []vcbatch.JobPhase{vcbatch.Pending, vcbatch.Running, vcbatch.Restarting})
+		err := e2eutil.WaitJobPhases(testCtx, job, []vcbatch.JobPhase{vcbatch.Pending, vcbatch.Running, vcbatch.Restarting})
 		Expect(err).NotTo(HaveOccurred())
 	})
 
 	It("Task Priority", func() {
 		By("init test context")
-		context := e2eutil.InitTestContext(e2eutil.Options{
+		testCtx = e2eutil.InitTestContext(e2eutil.Options{
 			PriorityClasses: map[string]int32{
 				e2eutil.MasterPriority: e2eutil.MasterPriorityValue,
 				e2eutil.WorkerPriority: e2eutil.WorkerPriorityValue,
 			},
 		})
-		defer e2eutil.CleanupTestContext(context)
+		defer e2eutil.CleanupTestContext(testCtx)
 
-		rep := e2eutil.ClusterSize(context, e2eutil.OneCPU)
-		nodecount := e2eutil.ClusterNodeNumber(context)
+		rep := e2eutil.ClusterSize(testCtx, e2eutil.OneCPU)
+		nodecount := e2eutil.ClusterNodeNumber(testCtx)
 		By("create job")
-		job := e2eutil.CreateJob(context, &e2eutil.JobSpec{
+		job := e2eutil.CreateJob(testCtx, &e2eutil.JobSpec{
 			Name: "task-priority-job",
 			Min:  int32(nodecount),
 			Tasks: []e2eutil.TaskSpec{
@@ -894,14 +899,14 @@ var _ = Describe("Job Error Handling", func() {
 		})
 
 		// job phase: pending -> running
-		err := e2eutil.WaitJobPhases(context, job, []vcbatch.JobPhase{vcbatch.Pending, vcbatch.Running})
+		err := e2eutil.WaitJobPhases(testCtx, job, []vcbatch.JobPhase{vcbatch.Pending, vcbatch.Running})
 		Expect(err).NotTo(HaveOccurred())
 		expteced := map[string]int{
 			e2eutil.MasterPriority: nodecount,
 			e2eutil.WorkerPriority: 0,
 		}
 
-		err = e2eutil.WaitTasksReadyEx(context, job, expteced)
+		err = e2eutil.WaitTasksReadyEx(testCtx, job, expteced)
 		Expect(err).NotTo(HaveOccurred())
 	})
 

--- a/test/e2e/jobseq/mpi.go
+++ b/test/e2e/jobseq/mpi.go
@@ -27,9 +27,15 @@ import (
 )
 
 var _ = Describe("MPI E2E Test", func() {
+	var testCtx *e2eutil.TestContext
+
+	JustAfterEach(func() {
+		e2eutil.DumpTestContextIfFailed(testCtx, CurrentSpecReport())
+	})
+
 	It("will run and complete finally", func() {
-		context := e2eutil.InitTestContext(e2eutil.Options{})
-		defer e2eutil.CleanupTestContext(context)
+		testCtx = e2eutil.InitTestContext(e2eutil.Options{})
+		defer e2eutil.CleanupTestContext(testCtx)
 
 		slot := e2eutil.OneCPU
 
@@ -71,9 +77,9 @@ mpiexec --allow-run-as-root --hostfile /etc/volcano/mpiworker.host -np 2 mpi_hel
 			},
 		}
 
-		job := e2eutil.CreateJob(context, spec)
+		job := e2eutil.CreateJob(testCtx, spec)
 
-		err := e2eutil.WaitJobPhases(context, job, []vcbatch.JobPhase{
+		err := e2eutil.WaitJobPhases(testCtx, job, []vcbatch.JobPhase{
 			vcbatch.Pending, vcbatch.Running, vcbatch.Completing, vcbatch.Completed})
 		Expect(err).NotTo(HaveOccurred())
 	})

--- a/test/e2e/jobseq/mpi_plugin.go
+++ b/test/e2e/jobseq/mpi_plugin.go
@@ -25,9 +25,15 @@ import (
 )
 
 var _ = Describe("MPI Plugin E2E Test", func() {
+	var testCtx *e2eutil.TestContext
+
+	JustAfterEach(func() {
+		e2eutil.DumpTestContextIfFailed(testCtx, CurrentSpecReport())
+	})
+
 	It("will run and complete finally", func() {
-		context := e2eutil.InitTestContext(e2eutil.Options{})
-		defer e2eutil.CleanupTestContext(context)
+		testCtx = e2eutil.InitTestContext(e2eutil.Options{})
+		defer e2eutil.CleanupTestContext(testCtx)
 
 		slot := e2eutil.OneCPU
 
@@ -67,8 +73,8 @@ mpiexec --allow-run-as-root --host ${MPI_HOST} -np 2 mpi_hello_world > /home/re`
 			},
 		}
 
-		job := e2eutil.CreateJob(context, spec)
-		err := e2eutil.WaitJobPhases(context, job, []vcbatch.JobPhase{
+		job := e2eutil.CreateJob(testCtx, spec)
+		err := e2eutil.WaitJobPhases(testCtx, job, []vcbatch.JobPhase{
 			vcbatch.Pending, vcbatch.Running, vcbatch.Completing, vcbatch.Completed})
 		Expect(err).NotTo(HaveOccurred())
 	})

--- a/test/e2e/jobseq/pytorch_plugin.go
+++ b/test/e2e/jobseq/pytorch_plugin.go
@@ -25,11 +25,17 @@ import (
 )
 
 var _ = Describe("Pytorch Plugin E2E Test", func() {
+	var testCtx *e2eutil.TestContext
+
+	JustAfterEach(func() {
+		e2eutil.DumpTestContextIfFailed(testCtx, CurrentSpecReport())
+	})
+
 	It("will run and complete finally", func() {
 		// Community CI can skip this use case, and enable this use case verification when releasing the version.
 		Skip("Pytorch's test image download fails probabilistically, causing the current use case to fail. ")
-		context := e2eutil.InitTestContext(e2eutil.Options{})
-		defer e2eutil.CleanupTestContext(context)
+		testCtx = e2eutil.InitTestContext(e2eutil.Options{})
+		defer e2eutil.CleanupTestContext(testCtx)
 
 		slot := e2eutil.OneCPU
 
@@ -68,8 +74,8 @@ var _ = Describe("Pytorch Plugin E2E Test", func() {
 			},
 		}
 
-		job := e2eutil.CreateJob(context, spec)
-		err := e2eutil.WaitJobPhases(context, job, []vcbatch.JobPhase{
+		job := e2eutil.CreateJob(testCtx, spec)
+		err := e2eutil.WaitJobPhases(testCtx, job, []vcbatch.JobPhase{
 			vcbatch.Pending, vcbatch.Running, vcbatch.Completed})
 		Expect(err).NotTo(HaveOccurred())
 	})

--- a/test/e2e/jobseq/queue_job_status.go
+++ b/test/e2e/jobseq/queue_job_status.go
@@ -36,9 +36,14 @@ import (
 
 var _ = Describe("Queue Job Status Transition", func() {
 
-	var ctx *e2eutil.TestContext
+	var testCtx *e2eutil.TestContext
+
+	JustAfterEach(func() {
+		e2eutil.DumpTestContextIfFailed(testCtx, CurrentSpecReport())
+	})
+
 	AfterEach(func() {
-		e2eutil.CleanupTestContext(ctx)
+		e2eutil.CleanupTestContext(testCtx)
 	})
 
 	XIt("Transform from inqueque to running should succeed", func() {
@@ -46,11 +51,11 @@ var _ = Describe("Queue Job Status Transition", func() {
 		var q1 string
 		var rep int32
 		q1 = "queue-jobs-status-transition"
-		ctx = e2eutil.InitTestContext(e2eutil.Options{
+		testCtx = e2eutil.InitTestContext(e2eutil.Options{
 			Queues: []string{q1},
 		})
 		slot := e2eutil.HalfCPU
-		rep = e2eutil.ClusterSize(ctx, slot)
+		rep = e2eutil.ClusterSize(testCtx, slot)
 
 		if rep < 4 {
 			err := fmt.Errorf("You need at least 2 logical cpu for this test case, please skip 'Queue Job Status Transition' when you see this message")
@@ -71,19 +76,19 @@ var _ = Describe("Queue Job Status Transition", func() {
 			}
 			spec.Name = "queue-job-status-transition-test-job-" + strconv.Itoa(i)
 			spec.Queue = q1
-			e2eutil.CreateJob(ctx, spec)
+			e2eutil.CreateJob(testCtx, spec)
 		}
 
 		By("Verify queue have pod groups inqueue")
 		err := e2eutil.WaitQueueStatus(func() (bool, error) {
-			pgStats := e2eutil.GetPodGroupStatistics(ctx, ctx.Namespace, q1)
+			pgStats := e2eutil.GetPodGroupStatistics(testCtx, testCtx.Namespace, q1)
 			return pgStats.Inqueue > 0, nil
 		})
 		Expect(err).NotTo(HaveOccurred(), "Error waiting for queue inqueue")
 
 		By("Verify queue have pod groups running")
 		err = e2eutil.WaitQueueStatus(func() (bool, error) {
-			pgStats := e2eutil.GetPodGroupStatistics(ctx, ctx.Namespace, q1)
+			pgStats := e2eutil.GetPodGroupStatistics(testCtx, testCtx.Namespace, q1)
 			return pgStats.Running > 0, nil
 		})
 		Expect(err).NotTo(HaveOccurred(), "Error waiting for queue running")
@@ -97,12 +102,12 @@ var _ = Describe("Queue Job Status Transition", func() {
 		var firstJobName string
 
 		q1 = "queue-jobs-status-transition"
-		ctx = e2eutil.InitTestContext(e2eutil.Options{
+		testCtx = e2eutil.InitTestContext(e2eutil.Options{
 			Queues: []string{q1},
 		})
-		podNamespace = ctx.Namespace
+		podNamespace = testCtx.Namespace
 		slot := e2eutil.HalfCPU
-		rep = e2eutil.ClusterSize(ctx, slot)
+		rep = e2eutil.ClusterSize(testCtx, slot)
 
 		if rep < 4 {
 			err := fmt.Errorf("You need at least 2 logical cpu for this test case, please skip 'Queue Job Status Transition' when you see this message")
@@ -126,27 +131,27 @@ var _ = Describe("Queue Job Status Transition", func() {
 				firstJobName = spec.Name
 			}
 			spec.Queue = q1
-			e2eutil.CreateJob(ctx, spec)
+			e2eutil.CreateJob(testCtx, spec)
 		}
 
 		By("Verify queue have pod groups running")
 		err := e2eutil.WaitQueueStatus(func() (bool, error) {
-			pgStats := e2eutil.GetPodGroupStatistics(ctx, ctx.Namespace, q1)
+			pgStats := e2eutil.GetPodGroupStatistics(testCtx, testCtx.Namespace, q1)
 			return pgStats.Running > 0, nil
 		})
 		Expect(err).NotTo(HaveOccurred(), "Error waiting for queue running")
 
-		clusterPods, err := ctx.Kubeclient.CoreV1().Pods(podNamespace).List(context.TODO(), metav1.ListOptions{})
+		clusterPods, err := testCtx.Kubeclient.CoreV1().Pods(podNamespace).List(context.TODO(), metav1.ListOptions{})
 		for _, pod := range clusterPods.Items {
 			if pod.Labels["volcano.sh/job-name"] == firstJobName {
-				err = ctx.Kubeclient.CoreV1().Pods(podNamespace).Delete(context.TODO(), pod.Name, metav1.DeleteOptions{})
+				err = testCtx.Kubeclient.CoreV1().Pods(podNamespace).Delete(context.TODO(), pod.Name, metav1.DeleteOptions{})
 				Expect(err).NotTo(HaveOccurred(), "Failed to delete pod %s", pod.Name)
 			}
 		}
 
 		By("Verify queue have pod groups Pending")
 		err = e2eutil.WaitQueueStatus(func() (bool, error) {
-			pgStats := e2eutil.GetPodGroupStatistics(ctx, ctx.Namespace, q1)
+			pgStats := e2eutil.GetPodGroupStatistics(testCtx, testCtx.Namespace, q1)
 			return pgStats.Pending > 0, nil
 		})
 		Expect(err).NotTo(HaveOccurred(), "Error waiting for queue Pending")
@@ -159,12 +164,12 @@ var _ = Describe("Queue Job Status Transition", func() {
 		var rep int32
 
 		q1 = "queue-jobs-status-transition"
-		ctx = e2eutil.InitTestContext(e2eutil.Options{
+		testCtx = e2eutil.InitTestContext(e2eutil.Options{
 			Queues: []string{q1},
 		})
-		podNamespace = ctx.Namespace
+		podNamespace = testCtx.Namespace
 		slot := e2eutil.HalfCPU
-		rep = e2eutil.ClusterSize(ctx, slot)
+		rep = e2eutil.ClusterSize(testCtx, slot)
 
 		if rep < 4 {
 			err := fmt.Errorf("You need at least 2 logical cpu for this test case, please skip 'Queue Job Status Transition' when you see this message")
@@ -185,12 +190,12 @@ var _ = Describe("Queue Job Status Transition", func() {
 			}
 			spec.Name = "queue-job-status-transition-test-job-" + strconv.Itoa(i)
 			spec.Queue = q1
-			e2eutil.CreateJob(ctx, spec)
+			e2eutil.CreateJob(testCtx, spec)
 		}
 
 		By("Verify queue have pod groups running")
 		err := e2eutil.WaitQueueStatus(func() (bool, error) {
-			pgStats := e2eutil.GetPodGroupStatistics(ctx, ctx.Namespace, q1)
+			pgStats := e2eutil.GetPodGroupStatistics(testCtx, testCtx.Namespace, q1)
 			return pgStats.Running > 0, nil
 		})
 		Expect(err).NotTo(HaveOccurred(), "Error waiting for queue running")
@@ -198,13 +203,13 @@ var _ = Describe("Queue Job Status Transition", func() {
 		By("Delete some of pod which will case pod group status transform from running to unknown.")
 		podDeleteNum := 0
 
-		err = e2eutil.WaitPodPhaseRunningMoreThanNum(ctx, podNamespace, 2)
+		err = e2eutil.WaitPodPhaseRunningMoreThanNum(testCtx, podNamespace, 2)
 		Expect(err).NotTo(HaveOccurred(), "Failed waiting for pods")
 
-		clusterPods, err := ctx.Kubeclient.CoreV1().Pods(podNamespace).List(context.TODO(), metav1.ListOptions{})
+		clusterPods, err := testCtx.Kubeclient.CoreV1().Pods(podNamespace).List(context.TODO(), metav1.ListOptions{})
 		for _, pod := range clusterPods.Items {
 			if pod.Status.Phase == corev1.PodRunning {
-				err = ctx.Kubeclient.CoreV1().Pods(podNamespace).Delete(context.TODO(), pod.Name, metav1.DeleteOptions{})
+				err = testCtx.Kubeclient.CoreV1().Pods(podNamespace).Delete(context.TODO(), pod.Name, metav1.DeleteOptions{})
 				Expect(err).NotTo(HaveOccurred(), "Failed to delete pod %s", pod.Name)
 				podDeleteNum = podDeleteNum + 1
 			}
@@ -216,7 +221,7 @@ var _ = Describe("Queue Job Status Transition", func() {
 		By("Verify queue have pod groups unknown")
 		w := &cache.ListWatch{
 			WatchFunc: func(options metav1.ListOptions) (i watch.Interface, e error) {
-				return ctx.Vcclient.SchedulingV1beta1().PodGroups(podNamespace).Watch(context.TODO(), options)
+				return testCtx.Vcclient.SchedulingV1beta1().PodGroups(podNamespace).Watch(context.TODO(), options)
 			},
 		}
 		wctx, cancel := watchtools.ContextWithOptionalTimeout(context.Background(), 5*time.Minute)

--- a/test/e2e/jobseq/ray_plugin.go
+++ b/test/e2e/jobseq/ray_plugin.go
@@ -28,6 +28,8 @@ import (
 )
 
 var _ = Describe("Ray Plugin E2E Test", func() {
+	var testCtx *e2eutil.TestContext
+
 	BeforeEach(func() {
 		By("Prune images before test")
 		PruneUnusedImagesOnAllNodes(e2eutil.KubeClient)
@@ -37,9 +39,13 @@ var _ = Describe("Ray Plugin E2E Test", func() {
 		PruneUnusedImagesOnAllNodes(e2eutil.KubeClient)
 	})
 
+	JustAfterEach(func() {
+		e2eutil.DumpTestContextIfFailed(testCtx, CurrentSpecReport())
+	})
+
 	It("Will Start in pending state and  get running phase", func() {
-		ctx := e2eutil.InitTestContext(e2eutil.Options{})
-		defer e2eutil.CleanupTestContext(ctx)
+		testCtx = e2eutil.InitTestContext(e2eutil.Options{})
+		defer e2eutil.CleanupTestContext(testCtx)
 
 		slot := e2eutil.OneCPU
 
@@ -74,17 +80,17 @@ var _ = Describe("Ray Plugin E2E Test", func() {
 			},
 		}
 
-		job := e2eutil.CreateJob(ctx, spec)
+		job := e2eutil.CreateJob(testCtx, spec)
 
 		By("checking if Service for ray job is created")
 		Eventually(func() error {
-			_, err := ctx.Kubeclient.CoreV1().
+			_, err := testCtx.Kubeclient.CoreV1().
 				Services(job.Namespace).
 				Get(context.TODO(), job.Name, metav1.GetOptions{})
 			return err
 		}, "60s", "2s").Should(Succeed())
 
-		err := e2eutil.WaitJobPhases(ctx, job, []vcbatch.JobPhase{
+		err := e2eutil.WaitJobPhases(testCtx, job, []vcbatch.JobPhase{
 			vcbatch.Pending, vcbatch.Running})
 		Expect(err).NotTo(HaveOccurred())
 	})

--- a/test/e2e/jobseq/tensorflow.go
+++ b/test/e2e/jobseq/tensorflow.go
@@ -32,9 +32,15 @@ import (
 )
 
 var _ = Describe("TensorFlow E2E Test", func() {
+	var testCtx *e2eutil.TestContext
+
+	JustAfterEach(func() {
+		e2eutil.DumpTestContextIfFailed(testCtx, CurrentSpecReport())
+	})
+
 	It("Will Start in pending state and goes through other phases to get complete phase", func() {
-		ctx := e2eutil.InitTestContext(e2eutil.Options{})
-		defer e2eutil.CleanupTestContext(ctx)
+		testCtx = e2eutil.InitTestContext(e2eutil.Options{})
+		defer e2eutil.CleanupTestContext(testCtx)
 
 		jobName := "tensorflow-dist-mnist"
 
@@ -118,10 +124,10 @@ var _ = Describe("TensorFlow E2E Test", func() {
 			},
 		}
 
-		created, err := ctx.Vcclient.BatchV1alpha1().Jobs(ctx.Namespace).Create(context.TODO(), job, metav1.CreateOptions{})
+		created, err := testCtx.Vcclient.BatchV1alpha1().Jobs(testCtx.Namespace).Create(context.TODO(), job, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
 
-		err = e2eutil.WaitJobStates(ctx, created, []vcbatch.JobPhase{vcbatch.Pending, vcbatch.Running, vcbatch.Completed}, e2eutil.FiveMinute)
+		err = e2eutil.WaitJobStates(testCtx, created, []vcbatch.JobPhase{vcbatch.Pending, vcbatch.Running, vcbatch.Completed}, e2eutil.FiveMinute)
 		Expect(err).NotTo(HaveOccurred())
 	})
 

--- a/test/e2e/jobseq/tensorflow_plugin.go
+++ b/test/e2e/jobseq/tensorflow_plugin.go
@@ -32,9 +32,15 @@ import (
 )
 
 var _ = Describe("TensorFlow Plugin E2E Test", func() {
+	var testCtx *e2eutil.TestContext
+
+	JustAfterEach(func() {
+		e2eutil.DumpTestContextIfFailed(testCtx, CurrentSpecReport())
+	})
+
 	It("Will Start in pending state and goes through other phases to get complete phase", func() {
-		ctx := e2eutil.InitTestContext(e2eutil.Options{})
-		defer e2eutil.CleanupTestContext(ctx)
+		testCtx = e2eutil.InitTestContext(e2eutil.Options{})
+		defer e2eutil.CleanupTestContext(testCtx)
 
 		jobName := "tensorflow-dist-mnist"
 
@@ -117,10 +123,10 @@ var _ = Describe("TensorFlow Plugin E2E Test", func() {
 			},
 		}
 
-		created, err := ctx.Vcclient.BatchV1alpha1().Jobs(ctx.Namespace).Create(context.TODO(), job, metav1.CreateOptions{})
+		created, err := testCtx.Vcclient.BatchV1alpha1().Jobs(testCtx.Namespace).Create(context.TODO(), job, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
 
-		err = e2eutil.WaitJobStates(ctx, created, []vcbatch.JobPhase{vcbatch.Pending, vcbatch.Running, vcbatch.Completed}, e2eutil.FiveMinute)
+		err = e2eutil.WaitJobStates(testCtx, created, []vcbatch.JobPhase{vcbatch.Pending, vcbatch.Running, vcbatch.Completed}, e2eutil.FiveMinute)
 		Expect(err).NotTo(HaveOccurred())
 	})
 


### PR DESCRIPTION
I've implemented automatic collection and dumping of K8s resources when e2e tests fail. This addresses issue #4764 by:

- Adding DumpTestContext function in test/e2e/util/util.go that collects and dumps all relevant Kubernetes resources (pods, podgroups, queues, priorityclasses, VCJobs, VCronJobs, K8s jobs, cronjobs, deployments, statefulsets) to YAML files
- Adding JustAfterEach hooks in all jobseq test files to trigger context dumping when tests fail
- Using ARTIFACTS_PATH environment variable (defaults to ./artifacts) to specify dump location, organized by namespace
- Fixing TAG and IMAGE_PREFIX environment variables in run-e2e-kind.sh to prevent Docker image reference errors

This makes debugging flaky tests much easier by providing complete context information about the cluster state when a test fails.

Fixes #4764

