### PR TITLE
Feature/fix reclaimed res

### DIFF
--- a/pkg/scheduler/actions/reclaim/reclaim_test.go
+++ b/pkg/scheduler/actions/reclaim/reclaim_test.go
@@ -218,6 +218,43 @@ func TestReclaim(t *testing.T) {
 			ExpectEvictNum: 0,
 			ExpectEvicted:  []string{},
 		},
+		{
+			Name: "Reclaimed resources plus node available resources",
+			Plugins: map[string]framework.PluginBuilder{
+				conformance.PluginName: conformance.New,
+				gang.PluginName:        gang.New,
+				priority.PluginName:    priority.New,
+				proportion.PluginName:  proportion.New,
+			},
+			PriClass: []*schedulingv1.PriorityClass{
+				util.BuildPriorityClass("low-priority", 100),
+				util.BuildPriorityClass("mid-priority", 500),
+				util.BuildPriorityClass("high-priority", 1000),
+			},
+			PodGroups: []*schedulingv1beta1.PodGroup{
+				util.BuildPodGroupWithPrio("pg1", "c1", "q1", 1, nil, schedulingv1beta1.PodGroupInqueue, "mid-priority"),
+				util.BuildPodGroupWithPrio("pg2", "c1", "q2", 1, nil, schedulingv1beta1.PodGroupInqueue, "mid-priority"),
+				util.BuildPodGroupWithPrio("pg3", "c1", "q3", 1, nil, schedulingv1beta1.PodGroupInqueue, "mid-priority"),
+			},
+			Pods: []*v1.Pod{
+				util.BuildPod("c1", "preemptee1-1", "n1", v1.PodRunning, api.BuildResourceList("1", "1G"), "pg1", map[string]string{schedulingv1beta1.PodPreemptable: "true"}, make(map[string]string)),
+				util.BuildPod("c1", "preemptee1-2", "n1", v1.PodRunning, api.BuildResourceList("1", "1G"), "pg1", map[string]string{schedulingv1beta1.PodPreemptable: "true"}, make(map[string]string)),
+				util.BuildPod("c1", "preemptee2-1", "n1", v1.PodRunning, api.BuildResourceList("1", "1G"), "pg2", map[string]string{schedulingv1beta1.PodPreemptable: "true"}, make(map[string]string)),
+				util.BuildPod("c1", "preemptee2-2", "n1", v1.PodRunning, api.BuildResourceList("1", "1G"), "pg2", map[string]string{schedulingv1beta1.PodPreemptable: "true"}, make(map[string]string)),
+				util.BuildPod("c1", "preemptor1", "", v1.PodPending, api.BuildResourceList("4", "1G"), "pg3", make(map[string]string), make(map[string]string)),
+			},
+			Nodes: []*v1.Node{
+				util.BuildNode("n1", api.BuildResourceList("10", "4Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), make(map[string]string)),
+			},
+			Queues: []*schedulingv1beta1.Queue{
+				util.BuildQueueWithPriorityAndResourcesQuantity("q1", 1, nil, nil),
+				util.BuildQueueWithPriorityAndResourcesQuantity("q2", 2, nil, nil),
+				util.BuildQueueWithPriorityAndResourcesQuantity("q3", 3, nil, nil),
+			},
+			ExpectEvictNum: 1,
+			// cpu resource is enough in node, memory resource is not enough, need 1G memory to schedule preemptor1
+			ExpectEvicted: []string{"c1/preemptee1-1"},
+		},
 	}
 
 	reclaim := New()


### PR DESCRIPTION
What type of PR is this?
fix

What this PR does / why we need it:
The reclaimed resources should be added to the remaining available resources of the nodes to avoid over-reclaiming.



Which issue(s) this PR fixes:
Example: The reclaimer requires 10 cores and 1 GPU to run a task, and the reclaimed task has the resource requirement of 1 core and 1 GPU. If the node has 100 cores and 0 GPUs remaining, in this scenario, 10 tasks would currently be reclaimed to meet the 10 cores and 1 GPU resource requirement. However, only 1 GPU is actually needed, so reclaiming one task would suffice.
Fixes #

Special notes for your reviewer:
Does this PR introduce a user-facing change?