### PR TITLE
[fix] when update replicaSet, need to synchronize and update the podgroup-related information

### DIFF
--- a/pkg/controllers/podgroup/pg_controller_handler.go
+++ b/pkg/controllers/podgroup/pg_controller_handler.go
@@ -105,9 +105,11 @@ func (pg *pgcontroller) addReplicaSet(obj interface{}) {
 				klog.V(4).Infof("Pod %s field SchedulerName is not matched", klog.KObj(&pod))
 				return
 			}
-			err := pg.createNormalPodPGIfNotExist(&pod)
+			// In the upgrade scenario, need to synchronize and update the podgroup-related information.
+			// For example, if you update `scheduling.volcano.sh/group-min-member: "2"`, the podgroup's `minMember` needs to be updated to 2.
+			err := pg.createOrUpdateNormalPodPG(&pod)
 			if err != nil {
-				klog.Errorf("Failed to create PodGroup for pod %s: %v", klog.KObj(&pod), err)
+				klog.Errorf("Failed to create or update PodGroup for pod %s: %v", klog.KObj(&pod), err)
 			}
 		}
 	}


### PR DESCRIPTION
#### What type of PR is this?
fix

#### What this PR does / why we need it:
In the replicaSet upgrade scenario,  update the podgroup information if needed.

current use "createNormalPodPGIfNotExist", when updating deployment or replicaSet info, won't update the related podgroup info .  In the upgrade scenario, need to synchronize and update the podgroup-related information.
For example, if you update `scheduling.volcano.sh/group-min-member: "2"`, the podgroup's `minMember` needs to be updated to 2.


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Notice that do not add `Fixes` if the issue is associated with multiple PRs.
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```