### PR TITLE
fix vgpu warning

### DIFF
--- a/pkg/scheduler/api/shared_device_pool.go
+++ b/pkg/scheduler/api/shared_device_pool.go
@@ -81,11 +81,7 @@ var _ Devices = new(vgpu.GPUDevices)
 var _ Devices = new(vnpu.NPUDevices)
 var _ Devices = new(hami.AscendDevices)
 
-var RegisteredDevices = []string{
-	gpushare.DeviceName,
-	vgpu.DeviceName,
-	vnpu.DeviceName,
-}
+var RegisteredDevices = []string{}
 
 func RegisterDevice(deviceName string) {
 	for _, name := range RegisteredDevices {


### PR DESCRIPTION
as shown in #4788, If the vGPU switch is not enabled, devices will not be added to `ni.Other`, but  the device names already included in `RegisteredDevices` at the time of its definition.  so there are some warnings as below

https://github.com/volcano-sh/volcano/blob/b72ae8b96f7a6b03ea4c0f3f8a0ccc872e5442b5/pkg/scheduler/plugins/predicates/predicates.go#L220-L233