### PR TITLE
fix hypernode ut error logs

### DIFF
--- a/pkg/scheduler/plugins/network-topology-aware/network_topology_aware.go
+++ b/pkg/scheduler/plugins/network-topology-aware/network_topology_aware.go
@@ -221,8 +221,8 @@ func (nta *networkTopologyAwarePlugin) OnSessionOpen(ssn *framework.Session) {
 		if hardMode, highestAllowedTier := subJob.IsHardTopologyMode(); hardMode {
 			result, err := nta.hyperNodeGradientFn(ssn, hyperNode, highestAllowedTier, subJob.AllocatedHyperNode)
 			if err != nil {
-				klog.ErrorS(err, "build hyperNode gradient fail", "subJob", subJob.UID, "hyperNode", hyperNode.Name,
-					"highestAllowedTier", highestAllowedTier, "allocatedHyperNode", subJob.AllocatedHyperNode)
+				klog.Warningf("build hyperNode gradient fail, subJob: %s, hyperNode: %s, highestAllowedTier: %d, allocatedHyperNode: %s, %v", subJob.UID, hyperNode.Name,
+					highestAllowedTier, subJob.AllocatedHyperNode, err)
 				return nil
 			}
 			return result


### PR DESCRIPTION
as shown in https://github.com/volcano-sh/volcano/issues/4788, When assigning hypernode A to a subJob, if no intersection can be found between hypernode A and the already assigned hypernode B, an error log will be output. This can be changed to a warning log.