### PR TITLE
Fix: Changes to task members in a PodGroup caused task validity checks to fail during scheduling

### DIFF
--- a/pkg/scheduler/api/job_info.go
+++ b/pkg/scheduler/api/job_info.go
@@ -543,6 +543,7 @@ func (ji *JobInfo) extractBudget(pg *PodGroup) *DisruptionBudget {
 // 2. calculate sum of all roles' min members and set to TaskMinAvailableTotal
 func (ji *JobInfo) ParseMinMemberInfo(pg *PodGroup) {
 	taskMinAvailableTotal := int32(0)
+	clear(ji.TaskMinAvailable)
 	for task, member := range pg.Spec.MinTaskMember {
 		ji.TaskMinAvailable[task] = member
 		taskMinAvailableTotal += member

--- a/pkg/scheduler/api/job_info_test.go
+++ b/pkg/scheduler/api/job_info_test.go
@@ -610,3 +610,105 @@ func TestHasTopologyHardConstrain(t *testing.T) {
 		})
 	}
 }
+
+func TestParseMinMemberInfoChanged(t *testing.T) {
+	tests := []struct {
+		name                          string
+		minTaskMemberInitial          map[string]int32
+		minTaskMemberChanged          map[string]int32
+		expectedTaskMinAvailable      map[string]int32
+		expectedTaskMinAvailableTotal int32
+	}{
+		{
+			name: "task member changed from single to multiple roles",
+			minTaskMemberInitial: map[string]int32{
+				"worker": 3,
+			},
+			minTaskMemberChanged: map[string]int32{
+				"master": 1,
+				"worker": 2,
+				"gpu":    1,
+			},
+			expectedTaskMinAvailable: map[string]int32{
+				"master": 1,
+				"worker": 2,
+				"gpu":    1,
+			},
+			expectedTaskMinAvailableTotal: 4,
+		},
+		{
+			name: "task member decreased",
+			minTaskMemberInitial: map[string]int32{
+				"master": 2,
+				"worker": 5,
+				"gpu":    3,
+			},
+			minTaskMemberChanged: map[string]int32{
+				"master": 1,
+				"worker": 2,
+			},
+			expectedTaskMinAvailable: map[string]int32{
+				"master": 1,
+				"worker": 2,
+			},
+			expectedTaskMinAvailableTotal: 3,
+		},
+		{
+			name: "task member increased",
+			minTaskMemberInitial: map[string]int32{
+				"worker": 2,
+			},
+			minTaskMemberChanged: map[string]int32{
+				"master": 2,
+				"worker": 5,
+				"gpu":    3,
+			},
+			expectedTaskMinAvailable: map[string]int32{
+				"master": 2,
+				"worker": 5,
+				"gpu":    3,
+			},
+			expectedTaskMinAvailableTotal: 10,
+		},
+		{
+			name: "task member replaced completely",
+			minTaskMemberInitial: map[string]int32{
+				"old-master": 1,
+				"old-worker": 3,
+			},
+			minTaskMemberChanged: map[string]int32{
+				"new-master": 1,
+				"new-worker": 3,
+			},
+			expectedTaskMinAvailable: map[string]int32{
+				"new-master": 1,
+				"new-worker": 3,
+			},
+			expectedTaskMinAvailableTotal: 4,
+		},
+		{
+			name: "task member changed to empty",
+			minTaskMemberInitial: map[string]int32{
+				"master": 1,
+				"worker": 3,
+			},
+			minTaskMemberChanged:          map[string]int32{},
+			expectedTaskMinAvailable:      map[string]int32{},
+			expectedTaskMinAvailableTotal: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			jobInfo := NewJobInfo("test-job")
+			pg := &PodGroup{}
+			pg.Spec.MinTaskMember = tt.minTaskMemberInitial
+			jobInfo.ParseMinMemberInfo(pg)
+			pg.Spec.MinTaskMember = tt.minTaskMemberChanged
+			jobInfo.ParseMinMemberInfo(pg)
+
+			assert.Equal(t, tt.expectedTaskMinAvailable, jobInfo.TaskMinAvailable)
+			assert.Equal(t, tt.expectedTaskMinAvailableTotal, jobInfo.TaskMinAvailableTotal)
+		})
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
#### What this PR does / why we need it:
In the scheduler cache, stale `taskMinAvailable` records are cleared when updating PodGroups.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Notice that do not add `Fixes` if the issue is associated with multiple PRs.
-->
Fixes #4802 

#### Special notes for your reviewer:
@wangyang0616 @JesseStutler 
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```