### PR TITLE
agent scheduler: bring in 3rd dependency for agent scheduling queue

### DIFF
--- a/third_party/kubernetes/pkg/scheduler/backend/queue/README.md
+++ b/third_party/kubernetes/pkg/scheduler/backend/queue/README.md
@@ -1,0 +1,54 @@
+# Scheduling Queue for Volcano Agent Scheduler
+
+This directory contains the scheduling queue implementation copied from Kubernetes kube-scheduler.
+
+## Purpose
+
+Volcano agent scheduler requires a fast and reliable pod queue mechanism. We deeply respect and appreciate the work of Kubernetes kube-scheduler and all contributors who have built this sophisticated scheduling queue over the years. Their proven, battle-tested implementation serves as an excellent foundation.
+
+Rather than reinventing the wheel, Volcano adopts this mature queue logic and continues to iterate upon it with Volcano-specific enhancements. This approach honors the upstream work while enabling us to build features tailored to volcano agent scheduler.
+
+## Source
+
+- **Repository**: `https://github.com/kubernetes/kubernetes`
+- **Version**: `v1.34`
+- **Source Package**: `pkg/scheduler/backend/queue`
+- **Copied Files**:
+    - `scheduling_queue.go` - Main scheduling queue implementation
+    - `active_queue.go` - Active queue for ready-to-schedule pods
+    - `backoff_queue.go` - Backoff queue for retry with exponential backoff
+    - `unschedulable_pods.go` - Unschedulable pods management
+    - `*_test.go` - Corresponding unit tests
+
+## Modifications
+
+- Removed all `NominatedNode` related code and pod nomination logic.
+
+## Upgrade
+
+Since this is a manual copy, upgrading requires manual intervention.
+
+### Option 1: Apply Diff
+
+For small version bumps:
+
+```bash
+# In kubernetes repo
+git diff v1.34.0..v1.35.0 -- pkg/scheduler/backend/queue
+```
+
+Then manually apply changes.
+
+### Option 2: Replace Files
+
+For major version changes:
+
+1. Delete all files in this directory
+2. Copy new files from upstream `pkg/scheduler/backend/queue`
+3. Re-apply modifications (remove `NominatedNode` code)
+
+Remember to update the version number in this README.
+
+## License
+
+Apache License 2.0 (same as Kubernetes project).

--- a/third_party/kubernetes/pkg/scheduler/backend/queue/active_queue.go
+++ b/third_party/kubernetes/pkg/scheduler/backend/queue/active_queue.go
@@ -1,0 +1,512 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package queue
+
+import (
+	"container/list"
+	"fmt"
+	"sync"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/klog/v2"
+	fwk "k8s.io/kube-scheduler/framework"
+	"k8s.io/kubernetes/pkg/scheduler/backend/heap"
+	"k8s.io/kubernetes/pkg/scheduler/framework"
+	"k8s.io/kubernetes/pkg/scheduler/metrics"
+)
+
+// activeQueuer is a wrapper for activeQ related operations.
+// Its methods take the lock inside.
+type activeQueuer interface {
+	underLock(func(unlockedActiveQ unlockedActiveQueuer))
+	underRLock(func(unlockedActiveQ unlockedActiveQueueReader))
+
+	delete(pInfo *framework.QueuedPodInfo) error
+	pop(logger klog.Logger) (*framework.QueuedPodInfo, error)
+	list() []*v1.Pod
+	len() int
+	has(pInfo *framework.QueuedPodInfo) bool
+
+	listInFlightEvents() []interface{}
+	listInFlightPods() []*v1.Pod
+	clusterEventsForPod(logger klog.Logger, pInfo *framework.QueuedPodInfo) ([]*clusterEvent, error)
+	addEventsIfPodInFlight(oldPod, newPod *v1.Pod, events []fwk.ClusterEvent) bool
+	addEventIfAnyInFlight(oldObj, newObj interface{}, event fwk.ClusterEvent) bool
+
+	schedulingCycle() int64
+	done(pod types.UID)
+	close()
+	broadcast()
+}
+
+// unlockedActiveQueuer defines activeQ methods that are not protected by the lock itself.
+// underLock() method should be used to protect these methods.
+type unlockedActiveQueuer interface {
+	unlockedActiveQueueReader
+	// add adds a new pod to the activeQ.
+	// The event should show which event triggered this addition and is used for the metric recording.
+	// This method should be called in activeQueue.underLock().
+	add(logger klog.Logger, pInfo *framework.QueuedPodInfo, event string)
+	// update updates the pod in activeQ if oldPodInfo is already in the queue.
+	// It returns new pod info if updated, nil otherwise.
+	update(newPod *v1.Pod, oldPodInfo *framework.QueuedPodInfo) *framework.QueuedPodInfo
+	// addEventsIfPodInFlight adds events to inFlightEvents if the newPod is in inFlightPods.
+	// It returns true if pushed the event to the inFlightEvents.
+	addEventsIfPodInFlight(oldPod, newPod *v1.Pod, events []fwk.ClusterEvent) bool
+}
+
+// unlockedActiveQueueReader defines activeQ read-only methods that are not protected by the lock itself.
+// underLock() or underRLock() method should be used to protect these methods.
+type unlockedActiveQueueReader interface {
+	// get returns the pod matching pInfo inside the activeQ.
+	// Returns false if the pInfo doesn't exist in the queue.
+	// This method should be called in activeQueue.underLock() or activeQueue.underRLock().
+	get(pInfo *framework.QueuedPodInfo) (*framework.QueuedPodInfo, bool)
+	// has returns if pInfo exists in the queue.
+	// This method should be called in activeQueue.underLock() or activeQueue.underRLock().
+	has(pInfo *framework.QueuedPodInfo) bool
+}
+
+// unlockedActiveQueue defines activeQ methods that are not protected by the lock itself.
+// activeQueue.underLock() or activeQueue.underRLock() method should be used to protect these methods.
+type unlockedActiveQueue struct {
+	queue           *heap.Heap[*framework.QueuedPodInfo]
+	inFlightPods    map[types.UID]*list.Element
+	inFlightEvents  *list.List
+	metricsRecorder *metrics.MetricAsyncRecorder
+}
+
+func newUnlockedActiveQueue(queue *heap.Heap[*framework.QueuedPodInfo], inFlightPods map[types.UID]*list.Element, inFlightEvents *list.List, metricsRecorder *metrics.MetricAsyncRecorder) *unlockedActiveQueue {
+	return &unlockedActiveQueue{
+		queue:           queue,
+		inFlightPods:    inFlightPods,
+		inFlightEvents:  inFlightEvents,
+		metricsRecorder: metricsRecorder,
+	}
+}
+
+// add adds a new pod to the activeQ.
+// The event should show which event triggered this addition and is used for the metric recording.
+// This method should be called in activeQueue.underLock().
+func (uaq *unlockedActiveQueue) add(logger klog.Logger, pInfo *framework.QueuedPodInfo, event string) {
+	uaq.queue.AddOrUpdate(pInfo)
+	metrics.SchedulerQueueIncomingPods.WithLabelValues("active", event).Inc()
+	logger.V(5).Info("Pod moved to an internal scheduling queue", "pod", klog.KObj(pInfo.Pod), "event", event, "queue", activeQ)
+}
+
+// update updates the pod in activeQ if oldPodInfo is already in the queue.
+// It returns new pod info if updated, nil otherwise.
+func (uaq *unlockedActiveQueue) update(newPod *v1.Pod, oldPodInfo *framework.QueuedPodInfo) *framework.QueuedPodInfo {
+	if pInfo, exists := uaq.queue.Get(oldPodInfo); exists {
+		_ = pInfo.Update(newPod)
+		uaq.queue.AddOrUpdate(pInfo)
+		return pInfo
+	}
+	return nil
+}
+
+// addEventsIfPodInFlight adds events to inFlightEvents if the newPod is in inFlightPods.
+// It returns true if pushed the event to the inFlightEvents.
+func (uaq *unlockedActiveQueue) addEventsIfPodInFlight(oldPod, newPod *v1.Pod, events []fwk.ClusterEvent) bool {
+	_, ok := uaq.inFlightPods[newPod.UID]
+	if ok {
+		for _, event := range events {
+			uaq.metricsRecorder.ObserveInFlightEventsAsync(event.Label(), 1, false)
+			uaq.inFlightEvents.PushBack(&clusterEvent{
+				event:  event,
+				oldObj: oldPod,
+				newObj: newPod,
+			})
+		}
+	}
+	return ok
+}
+
+// get returns the pod matching pInfo inside the activeQ.
+// Returns false if the pInfo doesn't exist in the queue.
+// This method should be called in activeQueue.underLock() or activeQueue.underRLock().
+func (uaq *unlockedActiveQueue) get(pInfo *framework.QueuedPodInfo) (*framework.QueuedPodInfo, bool) {
+	return uaq.queue.Get(pInfo)
+}
+
+// has returns if pInfo exists in the queue.
+// This method should be called in activeQueue.underLock() or activeQueue.underRLock().
+func (uaq *unlockedActiveQueue) has(pInfo *framework.QueuedPodInfo) bool {
+	return uaq.queue.Has(pInfo)
+}
+
+// backoffQPopper defines method that is used to pop from the backoffQ when the activeQ is empty.
+type backoffQPopper interface {
+	// popBackoff pops the pInfo from the podBackoffQ.
+	popBackoff() (*framework.QueuedPodInfo, error)
+	// len returns length of the podBackoffQ queue.
+	lenBackoff() int
+}
+
+// activeQueue implements activeQueuer. All of the fields have to be protected using the lock.
+type activeQueue struct {
+	// lock synchronizes all operations related to activeQ.
+	// It protects activeQ, inFlightPods, inFlightEvents, schedulingCycle and closed fields.
+	// Caution: DO NOT take "SchedulingQueue.lock" after taking "lock".
+	// You should always take "SchedulingQueue.lock" first, otherwise the queue could end up in deadlock.
+	// "lock" should not be taken after taking "backoffQueue.lock".
+	// Correct locking order is: SchedulingQueue.lock > lock > backoffQueue.lock.
+	lock sync.RWMutex
+
+	// activeQ is heap structure that scheduler actively looks at to find pods to
+	// schedule. Head of heap is the highest priority pod.
+	queue *heap.Heap[*framework.QueuedPodInfo]
+
+	// unlockedQueue is a wrapper of queue providing methods that are not locked themselves
+	// and can be used in the underLock() or underRLock().
+	unlockedQueue *unlockedActiveQueue
+
+	// cond is a condition that is notified when the pod is added to activeQ.
+	// When SchedulerPopFromBackoffQ feature is enabled,
+	// condition is also notified when the pod is added to backoffQ.
+	// It is used with lock.
+	cond sync.Cond
+
+	// inFlightPods holds the UID of all pods which have been popped out for which Done
+	// hasn't been called yet - in other words, all pods that are currently being
+	// processed (being scheduled, in permit, or in the binding cycle).
+	//
+	// The values in the map are the entry of each pod in the inFlightEvents list.
+	// The value of that entry is the *v1.Pod at the time that scheduling of that
+	// pod started, which can be useful for logging or debugging.
+	inFlightPods map[types.UID]*list.Element
+
+	// inFlightEvents holds the events received by the scheduling queue
+	// (entry value is clusterEvent) together with in-flight pods (entry
+	// value is *v1.Pod). Entries get added at the end while the mutex is
+	// locked, so they get serialized.
+	//
+	// The pod entries are added in Pop and used to track which events
+	// occurred after the pod scheduling attempt for that pod started.
+	// They get removed when the scheduling attempt is done, at which
+	// point all events that occurred in the meantime are processed.
+	//
+	// After removal of a pod, events at the start of the list are no
+	// longer needed because all of the other in-flight pods started
+	// later. Those events can be removed.
+	inFlightEvents *list.List
+
+	// schedCycle represents sequence number of scheduling cycle and is incremented
+	// when a pod is popped.
+	schedCycle int64
+
+	// closed indicates that the queue is closed.
+	// It is mainly used to let Pop() exit its control loop while waiting for an item.
+	closed bool
+
+	// isSchedulingQueueHintEnabled indicates whether the feature gate for the scheduling queue is enabled.
+	isSchedulingQueueHintEnabled bool
+
+	metricsRecorder *metrics.MetricAsyncRecorder
+
+	// backoffQPopper is used to pop from backoffQ when activeQ is empty.
+	// It is non-nil only when SchedulerPopFromBackoffQ feature is enabled.
+	backoffQPopper backoffQPopper
+}
+
+func newActiveQueue(queue *heap.Heap[*framework.QueuedPodInfo], isSchedulingQueueHintEnabled bool, metricRecorder *metrics.MetricAsyncRecorder, backoffQPopper backoffQPopper) *activeQueue {
+	aq := &activeQueue{
+		queue:                        queue,
+		inFlightPods:                 make(map[types.UID]*list.Element),
+		inFlightEvents:               list.New(),
+		isSchedulingQueueHintEnabled: isSchedulingQueueHintEnabled,
+		metricsRecorder:              metricRecorder,
+		backoffQPopper:               backoffQPopper,
+	}
+	aq.cond.L = &aq.lock
+	aq.unlockedQueue = newUnlockedActiveQueue(queue, aq.inFlightPods, aq.inFlightEvents, metricRecorder)
+
+	return aq
+}
+
+// underLock runs the fn function under the lock.Lock.
+// fn can run unlockedActiveQueuer methods but should NOT run any other activeQueue method,
+// as it would end up in deadlock.
+func (aq *activeQueue) underLock(fn func(unlockedActiveQ unlockedActiveQueuer)) {
+	aq.lock.Lock()
+	defer aq.lock.Unlock()
+	fn(aq.unlockedQueue)
+}
+
+// underLock runs the fn function under the lock.RLock.
+// fn can run unlockedActiveQueueReader methods but should NOT run any other activeQueue method,
+// as it would end up in deadlock.
+func (aq *activeQueue) underRLock(fn func(unlockedActiveQ unlockedActiveQueueReader)) {
+	aq.lock.RLock()
+	defer aq.lock.RUnlock()
+	fn(aq.unlockedQueue)
+}
+
+// delete deletes the pod info from activeQ.
+func (aq *activeQueue) delete(pInfo *framework.QueuedPodInfo) error {
+	aq.lock.Lock()
+	defer aq.lock.Unlock()
+
+	return aq.queue.Delete(pInfo)
+}
+
+// pop removes the head of the queue and returns it.
+// It blocks if the queue is empty and waits until a new item is added to the queue.
+// It increments scheduling cycle when a pod is popped.
+func (aq *activeQueue) pop(logger klog.Logger) (*framework.QueuedPodInfo, error) {
+	aq.lock.Lock()
+	defer aq.lock.Unlock()
+
+	return aq.unlockedPop(logger)
+}
+
+func (aq *activeQueue) unlockedPop(logger klog.Logger) (*framework.QueuedPodInfo, error) {
+	var pInfo *framework.QueuedPodInfo
+	for aq.queue.Len() == 0 {
+		// backoffQPopper is non-nil only if SchedulerPopFromBackoffQ feature is enabled.
+		// In case of non-empty backoffQ, try popping from there.
+		if aq.backoffQPopper != nil && aq.backoffQPopper.lenBackoff() != 0 {
+			break
+		}
+		// When the queue is empty, invocation of Pop() is blocked until new item is enqueued.
+		// When Close() is called, the p.closed is set and the condition is broadcast,
+		// which causes this loop to continue and return from the Pop().
+		if aq.closed {
+			logger.V(2).Info("Scheduling queue is closed")
+			return nil, nil
+		}
+		aq.cond.Wait()
+	}
+	pInfo, err := aq.queue.Pop()
+	if err != nil {
+		if aq.backoffQPopper == nil {
+			return nil, err
+		}
+		// Try to pop from backoffQ when activeQ is empty.
+		pInfo, err = aq.backoffQPopper.popBackoff()
+		if err != nil {
+			return nil, err
+		}
+		metrics.SchedulerQueueIncomingPods.WithLabelValues("active", framework.PopFromBackoffQ).Inc()
+	}
+	pInfo.Attempts++
+	// In flight, no concurrent events yet.
+	if aq.isSchedulingQueueHintEnabled {
+		// If the pod is already in the map, we shouldn't overwrite the inFlightPods otherwise it'd lead to a memory leak.
+		// https://github.com/kubernetes/kubernetes/pull/127016
+		if _, ok := aq.inFlightPods[pInfo.Pod.UID]; ok {
+			// Just report it as an error, but no need to stop the scheduler
+			// because it likely doesn't cause any visible issues from the scheduling perspective.
+			utilruntime.HandleErrorWithLogger(logger, nil, "The same pod is tracked in multiple places in the scheduler, and just discard it", "pod", klog.KObj(pInfo.Pod))
+			// Just ignore/discard this duplicated pod and try to pop the next one.
+			return aq.unlockedPop(logger)
+		}
+
+		aq.metricsRecorder.ObserveInFlightEventsAsync(metrics.PodPoppedInFlightEvent, 1, false)
+		aq.inFlightPods[pInfo.Pod.UID] = aq.inFlightEvents.PushBack(pInfo.Pod)
+	}
+	aq.schedCycle++
+
+	// Update metrics and reset the set of unschedulable plugins for the next attempt.
+	for plugin := range pInfo.UnschedulablePlugins.Union(pInfo.PendingPlugins) {
+		metrics.UnschedulableReason(plugin, pInfo.Pod.Spec.SchedulerName).Dec()
+	}
+	pInfo.UnschedulablePlugins.Clear()
+	pInfo.PendingPlugins.Clear()
+	pInfo.GatingPlugin = ""
+	pInfo.GatingPluginEvents = nil
+
+	return pInfo, nil
+}
+
+// list returns all pods that are in the queue.
+func (aq *activeQueue) list() []*v1.Pod {
+	aq.lock.RLock()
+	defer aq.lock.RUnlock()
+	var result []*v1.Pod
+	for _, pInfo := range aq.queue.List() {
+		result = append(result, pInfo.GetPod())
+	}
+	return result
+}
+
+// len returns length of the queue.
+func (aq *activeQueue) len() int {
+	return aq.queue.Len()
+}
+
+// has inform if pInfo exists in the queue.
+func (aq *activeQueue) has(pInfo *framework.QueuedPodInfo) bool {
+	aq.lock.RLock()
+	defer aq.lock.RUnlock()
+	return aq.queue.Has(pInfo)
+}
+
+// listInFlightEvents returns all inFlightEvents.
+func (aq *activeQueue) listInFlightEvents() []interface{} {
+	aq.lock.RLock()
+	defer aq.lock.RUnlock()
+	var values []interface{}
+	for event := aq.inFlightEvents.Front(); event != nil; event = event.Next() {
+		values = append(values, event.Value)
+	}
+	return values
+}
+
+// listInFlightPods returns all inFlightPods.
+func (aq *activeQueue) listInFlightPods() []*v1.Pod {
+	aq.lock.RLock()
+	defer aq.lock.RUnlock()
+	var pods []*v1.Pod
+	for _, obj := range aq.inFlightPods {
+		pods = append(pods, obj.Value.(*v1.Pod))
+	}
+	return pods
+}
+
+// clusterEventsForPod gets all cluster events that have happened during pod for pInfo is being scheduled.
+func (aq *activeQueue) clusterEventsForPod(logger klog.Logger, pInfo *framework.QueuedPodInfo) ([]*clusterEvent, error) {
+	aq.lock.RLock()
+	defer aq.lock.RUnlock()
+	logger.V(5).Info("Checking events for in-flight pod", "pod", klog.KObj(pInfo.Pod), "unschedulablePlugins", pInfo.UnschedulablePlugins, "inFlightEventsSize", aq.inFlightEvents.Len(), "inFlightPodsSize", len(aq.inFlightPods))
+
+	// AddUnschedulableIfNotPresent is called with the Pod at the end of scheduling or binding.
+	// So, given pInfo should have been Pop()ed before,
+	// we can assume pInfo must be recorded in inFlightPods and thus inFlightEvents.
+	inFlightPod, ok := aq.inFlightPods[pInfo.Pod.UID]
+	if !ok {
+		return nil, fmt.Errorf("in flight Pod isn't found in the scheduling queue. If you see this error log, it's likely a bug in the scheduler")
+	}
+
+	var events []*clusterEvent
+	for event := inFlightPod.Next(); event != nil; event = event.Next() {
+		e, ok := event.Value.(*clusterEvent)
+		if !ok {
+			// Must be another in-flight Pod (*v1.Pod). Can be ignored.
+			continue
+		}
+		events = append(events, e)
+	}
+	return events, nil
+}
+
+// addEventsIfPodInFlight adds events to inFlightEvents if the newPod is in inFlightPods.
+// It returns true if pushed the event to the inFlightEvents.
+func (aq *activeQueue) addEventsIfPodInFlight(oldPod, newPod *v1.Pod, events []fwk.ClusterEvent) bool {
+	aq.lock.Lock()
+	defer aq.lock.Unlock()
+
+	return aq.unlockedQueue.addEventsIfPodInFlight(oldPod, newPod, events)
+}
+
+// addEventIfAnyInFlight adds clusterEvent to inFlightEvents if any pod is in inFlightPods.
+// It returns true if pushed the event to the inFlightEvents.
+func (aq *activeQueue) addEventIfAnyInFlight(oldObj, newObj interface{}, event fwk.ClusterEvent) bool {
+	aq.lock.Lock()
+	defer aq.lock.Unlock()
+
+	if len(aq.inFlightPods) != 0 {
+		aq.metricsRecorder.ObserveInFlightEventsAsync(event.Label(), 1, false)
+		aq.inFlightEvents.PushBack(&clusterEvent{
+			event:  event,
+			oldObj: oldObj,
+			newObj: newObj,
+		})
+		return true
+	}
+	return false
+}
+
+func (aq *activeQueue) schedulingCycle() int64 {
+	aq.lock.RLock()
+	defer aq.lock.RUnlock()
+	return aq.schedCycle
+}
+
+// done must be called for pod returned by Pop. This allows the queue to
+// keep track of which pods are currently being processed.
+func (aq *activeQueue) done(pod types.UID) {
+	aq.lock.Lock()
+	defer aq.lock.Unlock()
+
+	aq.unlockedDone(pod)
+}
+
+// unlockedDone is used by the activeQueue internally and doesn't take the lock itself.
+// It assumes the lock is already taken outside before the method is called.
+func (aq *activeQueue) unlockedDone(pod types.UID) {
+	inFlightPod, ok := aq.inFlightPods[pod]
+	if !ok {
+		// This Pod is already done()ed.
+		return
+	}
+	delete(aq.inFlightPods, pod)
+
+	// Remove the pod from the list.
+	aq.inFlightEvents.Remove(inFlightPod)
+
+	aggrMetricsCounter := map[string]int{}
+	// Remove events which are only referred to by this Pod
+	// so that the inFlightEvents list doesn't grow infinitely.
+	// If the pod was at the head of the list, then all
+	// events between it and the next pod are no longer needed
+	// and can be removed.
+	for {
+		e := aq.inFlightEvents.Front()
+		if e == nil {
+			// Empty list.
+			break
+		}
+		ev, ok := e.Value.(*clusterEvent)
+		if !ok {
+			// A pod, must stop pruning.
+			break
+		}
+		aq.inFlightEvents.Remove(e)
+		aggrMetricsCounter[ev.event.Label()]--
+	}
+
+	for evLabel, count := range aggrMetricsCounter {
+		aq.metricsRecorder.ObserveInFlightEventsAsync(evLabel, float64(count), false)
+	}
+
+	aq.metricsRecorder.ObserveInFlightEventsAsync(metrics.PodPoppedInFlightEvent, -1,
+		// If it's the last Pod in inFlightPods, we should force-flush the metrics.
+		// Otherwise, especially in small clusters, which don't get a new Pod frequently,
+		// the metrics might not be flushed for a long time.
+		len(aq.inFlightPods) == 0)
+}
+
+// close closes the activeQueue.
+func (aq *activeQueue) close() {
+	aq.lock.Lock()
+	defer aq.lock.Unlock()
+	// We should call done() for all in-flight pods to clean up the inFlightEvents metrics.
+	// It's safe even if the binding cycle running asynchronously calls done() afterwards
+	// done() will just be a no-op.
+	for pod := range aq.inFlightPods {
+		aq.unlockedDone(pod)
+	}
+	aq.closed = true
+}
+
+// broadcast notifies the pop() operation that new pod(s) was added to the activeQueue.
+func (aq *activeQueue) broadcast() {
+	aq.cond.Broadcast()
+}

--- a/third_party/kubernetes/pkg/scheduler/backend/queue/active_queue_test.go
+++ b/third_party/kubernetes/pkg/scheduler/backend/queue/active_queue_test.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package queue
+
+import (
+	"testing"
+	"time"
+
+	"k8s.io/klog/v2/ktesting"
+	"k8s.io/kubernetes/pkg/scheduler/backend/heap"
+	"k8s.io/kubernetes/pkg/scheduler/framework"
+	"k8s.io/kubernetes/pkg/scheduler/metrics"
+	st "k8s.io/kubernetes/pkg/scheduler/testing"
+)
+
+func TestClose(t *testing.T) {
+	logger, ctx := ktesting.NewTestContext(t)
+	rr := metrics.NewMetricsAsyncRecorder(10, time.Second, ctx.Done())
+	aq := newActiveQueue(heap.NewWithRecorder(podInfoKeyFunc, heap.LessFunc[*framework.QueuedPodInfo](convertLessFn(newDefaultQueueSort())), metrics.NewActivePodsRecorder()), true, rr, nil)
+
+	aq.underLock(func(unlockedActiveQ unlockedActiveQueuer) {
+		unlockedActiveQ.add(logger, &framework.QueuedPodInfo{PodInfo: &framework.PodInfo{Pod: st.MakePod().Namespace("foo").Name("p1").UID("p1").Obj()}}, framework.EventUnscheduledPodAdd.Label())
+		unlockedActiveQ.add(logger, &framework.QueuedPodInfo{PodInfo: &framework.PodInfo{Pod: st.MakePod().Namespace("bar").Name("p2").UID("p2").Obj()}}, framework.EventUnscheduledPodAdd.Label())
+	})
+
+	_, err := aq.pop(logger)
+	if err != nil {
+		t.Fatalf("unexpected error while pop(): %v", err)
+	}
+	_, err = aq.pop(logger)
+	if err != nil {
+		t.Fatalf("unexpected error while pop(): %v", err)
+	}
+	aq.addEventIfAnyInFlight(nil, nil, nodeAdd)
+	aq.addEventIfAnyInFlight(nil, nil, csiNodeUpdate)
+
+	if len(aq.listInFlightEvents()) != 4 {
+		t.Fatalf("unexpected number of in-flight events: %v", len(aq.listInFlightEvents()))
+	}
+	if len(aq.listInFlightPods()) != 2 {
+		t.Fatalf("unexpected number of in-flight pods: %v", len(aq.listInFlightPods()))
+	}
+
+	aq.close()
+
+	// make sure the in-flight events and pods are cleaned up by close()
+
+	if len(aq.listInFlightEvents()) != 0 {
+		t.Fatalf("in-flight events should be cleaned up, but %v item(s) is remaining", len(aq.listInFlightEvents()))
+	}
+
+	if len(aq.listInFlightPods()) != 0 {
+		t.Fatalf("in-flight pods should be cleaned up, but %v pod(s) is remaining", len(aq.listInFlightPods()))
+	}
+}

--- a/third_party/kubernetes/pkg/scheduler/backend/queue/backoff_queue.go
+++ b/third_party/kubernetes/pkg/scheduler/backend/queue/backoff_queue.go
@@ -1,0 +1,415 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package queue
+
+import (
+	"sync"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/klog/v2"
+	"k8s.io/kubernetes/pkg/scheduler/backend/heap"
+	"k8s.io/kubernetes/pkg/scheduler/framework"
+	fwk "k8s.io/kubernetes/pkg/scheduler/framework"
+	"k8s.io/kubernetes/pkg/scheduler/metrics"
+	"k8s.io/utils/clock"
+)
+
+// backoffQOrderingWindowDuration is a duration of an ordering window in the podBackoffQ.
+// In each window, represented as a whole second, pods are ordered by priority.
+// It is the same as interval of flushing the pods from the podBackoffQ to the activeQ, to flush the whole windows there.
+// This works only if PopFromBackoffQ feature is enabled.
+// See the KEP-5142 (http://kep.k8s.io/5142) for rationale.
+const backoffQOrderingWindowDuration = time.Second
+
+// backoffQueuer is a wrapper for backoffQ related operations.
+// Its methods that relies on the queues, take the lock inside.
+type backoffQueuer interface {
+	// isPodBackingoff returns true if a pod is still waiting for its backoff timer.
+	// If this returns true, the pod should not be re-tried.
+	// If the pod backoff time is in the actual ordering window, it should still be backing off.
+	isPodBackingoff(podInfo *framework.QueuedPodInfo) bool
+	// popAllBackoffCompleted pops all pods from podBackoffQ and podErrorBackoffQ that completed backoff.
+	popAllBackoffCompleted(logger klog.Logger) []*framework.QueuedPodInfo
+
+	// podInitialBackoffDuration returns initial backoff duration that pod can get.
+	podInitialBackoffDuration() time.Duration
+	// podMaxBackoffDuration returns maximum backoff duration that pod can get.
+	podMaxBackoffDuration() time.Duration
+	// waitUntilAlignedWithOrderingWindow waits until the time reaches a multiple of backoffQOrderingWindowDuration.
+	// It then runs the f function at the backoffQOrderingWindowDuration interval using a ticker.
+	// It's important to align the flushing time, because podBackoffQ's ordering is based on the windows
+	// and whole windows have to be flushed at one time without a visible latency.
+	waitUntilAlignedWithOrderingWindow(f func(), stopCh <-chan struct{})
+
+	// add adds the pInfo to backoffQueue.
+	// The event should show which event triggered this addition and is used for the metric recording.
+	// It also ensures that pInfo is not in both queues.
+	add(logger klog.Logger, pInfo *framework.QueuedPodInfo, event string)
+	// update updates the pod in backoffQueue if oldPodInfo is already in the queue.
+	// It returns new pod info if updated, nil otherwise.
+	update(newPod *v1.Pod, oldPodInfo *framework.QueuedPodInfo) *framework.QueuedPodInfo
+	// delete deletes the pInfo from backoffQueue.
+	// It returns true if the pod was deleted.
+	delete(pInfo *framework.QueuedPodInfo) bool
+	// get returns the pInfo matching given pInfoLookup, if exists.
+	get(pInfoLookup *framework.QueuedPodInfo) (*framework.QueuedPodInfo, bool)
+	// has inform if pInfo exists in the queue.
+	has(pInfo *framework.QueuedPodInfo) bool
+	// list returns all pods that are in the queue.
+	list() []*v1.Pod
+	// len returns length of the queue.
+	len() int
+}
+
+// backoffQueue implements backoffQueuer and wraps two queues inside,
+// providing seamless access as if it were one queue.
+type backoffQueue struct {
+	// lock synchronizes all operations related to backoffQ.
+	// It protects both podBackoffQ and podErrorBackoffQ.
+	// Caution: DO NOT take "SchedulingQueue.lock" or "activeQueue.lock" after taking "lock".
+	// You should always take "SchedulingQueue.lock" and "activeQueue.lock" first, otherwise the queue could end up in deadlock.
+	// Correct locking order is: SchedulingQueue.lock > activeQueue.lock > lock
+	lock sync.RWMutex
+
+	clock clock.WithTicker
+
+	// podBackoffQ is a heap ordered by backoff expiry. Pods which have completed backoff
+	// are popped from this heap before the scheduler looks at activeQ
+	podBackoffQ *heap.Heap[*framework.QueuedPodInfo]
+	// podErrorBackoffQ is a heap ordered by error backoff expiry. Pods which have completed backoff
+	// are popped from this heap before the scheduler looks at activeQ
+	podErrorBackoffQ *heap.Heap[*framework.QueuedPodInfo]
+
+	podInitialBackoff time.Duration
+	podMaxBackoff     time.Duration
+	// activeQLessFn is used as an eventual less function if two backoff times are equal,
+	// when the SchedulerPopFromBackoffQ feature is enabled.
+	activeQLessFn fwk.LessFunc
+
+	// isPopFromBackoffQEnabled indicates whether the feature gate SchedulerPopFromBackoffQ is enabled.
+	isPopFromBackoffQEnabled bool
+}
+
+func newBackoffQueue(clock clock.WithTicker, podInitialBackoffDuration time.Duration, podMaxBackoffDuration time.Duration, activeQLessFn fwk.LessFunc, popFromBackoffQEnabled bool) *backoffQueue {
+	bq := &backoffQueue{
+		clock:                    clock,
+		podInitialBackoff:        podInitialBackoffDuration,
+		podMaxBackoff:            podMaxBackoffDuration,
+		isPopFromBackoffQEnabled: popFromBackoffQEnabled,
+		activeQLessFn:            activeQLessFn,
+	}
+	podBackoffQLessFn := bq.lessBackoffCompleted
+	if popFromBackoffQEnabled {
+		podBackoffQLessFn = bq.lessBackoffCompletedWithPriority
+	}
+	bq.podBackoffQ = heap.NewWithRecorder(podInfoKeyFunc, podBackoffQLessFn, metrics.NewBackoffPodsRecorder())
+	bq.podErrorBackoffQ = heap.NewWithRecorder(podInfoKeyFunc, bq.lessBackoffCompleted, metrics.NewBackoffPodsRecorder())
+
+	return bq
+}
+
+// podInitialBackoffDuration returns initial backoff duration that pod can get.
+func (bq *backoffQueue) podInitialBackoffDuration() time.Duration {
+	return bq.podInitialBackoff
+}
+
+// podMaxBackoffDuration returns maximum backoff duration that pod can get.
+func (bq *backoffQueue) podMaxBackoffDuration() time.Duration {
+	return bq.podMaxBackoff
+}
+
+// alignToWindow truncates the provided time to the podBackoffQ ordering window.
+// It returns the lowest possible timestamp in the window.
+func (bq *backoffQueue) alignToWindow(t time.Time) time.Time {
+	if !bq.isPopFromBackoffQEnabled {
+		return t
+	}
+	return t.Truncate(backoffQOrderingWindowDuration)
+}
+
+// waitUntilAlignedWithOrderingWindow waits until the time reaches a multiple of backoffQOrderingWindowDuration.
+// It then runs the f function at the backoffQOrderingWindowDuration interval using a ticker.
+// It's important to align the flushing time, because podBackoffQ's ordering is based on the windows
+// and whole windows have to be flushed at one time without a visible latency.
+func (bq *backoffQueue) waitUntilAlignedWithOrderingWindow(f func(), stopCh <-chan struct{}) {
+	now := bq.clock.Now()
+	// Wait until the time reaches the multiple of backoffQOrderingWindowDuration.
+	durationToNextWindow := bq.alignToWindow(now.Add(backoffQOrderingWindowDuration)).Sub(now)
+	timer := bq.clock.NewTimer(durationToNextWindow)
+	select {
+	case <-stopCh:
+		timer.Stop()
+		return
+	case <-timer.C():
+	}
+
+	// Run a ticker to make sure the invocations of f function
+	// are aligned with the backoffQ's ordering window.
+	ticker := bq.clock.NewTicker(backoffQOrderingWindowDuration)
+	for {
+		select {
+		case <-stopCh:
+			return
+		default:
+		}
+
+		f()
+
+		// NOTE: b/c there is no priority selection in golang
+		// it is possible for this to race, meaning we could
+		// trigger ticker.C and stopCh, and ticker.C select falls through.
+		// In order to mitigate we re-check stopCh at the beginning
+		// of every loop to prevent extra executions of f().
+		select {
+		case <-stopCh:
+			ticker.Stop()
+			return
+		case <-ticker.C():
+		}
+	}
+}
+
+// lessBackoffCompletedWithPriority is a less function of podBackoffQ if PopFromBackoffQ feature is enabled.
+// It orders the pods in the same BackoffOrderingWindow the same as the activeQ will do to improve popping order from backoffQ when activeQ is empty.
+func (bq *backoffQueue) lessBackoffCompletedWithPriority(pInfo1, pInfo2 *framework.QueuedPodInfo) bool {
+	bo1 := bq.getBackoffTime(pInfo1)
+	bo2 := bq.getBackoffTime(pInfo2)
+	if !bo1.Equal(bo2) {
+		return bo1.Before(bo2)
+	}
+	// If the backoff time is the same, sort the pod in the same manner as activeQ does.
+	return bq.activeQLessFn(pInfo1, pInfo2)
+}
+
+// lessBackoffCompleted is a less function of podErrorBackoffQ.
+func (bq *backoffQueue) lessBackoffCompleted(pInfo1, pInfo2 *framework.QueuedPodInfo) bool {
+	bo1 := bq.getBackoffTime(pInfo1)
+	bo2 := bq.getBackoffTime(pInfo2)
+	return bo1.Before(bo2)
+}
+
+// isPodBackingoff returns true if a pod is still waiting for its backoff timer.
+// If this returns true, the pod should not be re-tried.
+// If the pod backoff time is in the actual ordering window, it should still be backing off.
+func (bq *backoffQueue) isPodBackingoff(podInfo *framework.QueuedPodInfo) bool {
+	boTime := bq.getBackoffTime(podInfo)
+	// Don't use After, because in case of windows equality we want to return true.
+	return !boTime.Before(bq.alignToWindow(bq.clock.Now()))
+}
+
+// getBackoffTime returns the time that podInfo completes backoff.
+// It caches the result in podInfo.BackoffExpiration and returns this value in subsequent calls.
+// The cache will be cleared when this pod is poped from the scheduling queue again (i.e., at activeQ's pop),
+// because of the fact that the backoff time is calculated based on podInfo.Attempts,
+// which doesn't get changed until the pod's scheduling is retried.
+func (bq *backoffQueue) getBackoffTime(podInfo *framework.QueuedPodInfo) time.Time {
+	if bq.podMaxBackoff == 0 {
+		// If podMaxBackoff is set to 0, the backoff should be disabled completely.
+		return time.Time{}
+	}
+	count := podInfo.UnschedulableCount
+	if podInfo.ConsecutiveErrorsCount > 0 {
+		// This Pod has experienced an error status at the last scheduling cycle,
+		// and we should consider the error count for the backoff duration.
+		count = podInfo.ConsecutiveErrorsCount
+	}
+
+	if count == 0 {
+		// When the Pod hasn't experienced any scheduling attempts,
+		// they don't have to get a backoff.
+		return time.Time{}
+	}
+
+	if podInfo.BackoffExpiration.IsZero() {
+		duration := bq.calculateBackoffDuration(count)
+		podInfo.BackoffExpiration = bq.alignToWindow(podInfo.Timestamp.Add(duration))
+	}
+
+	return podInfo.BackoffExpiration
+}
+
+// calculateBackoffDuration is a helper function for calculating the backoffDuration
+// based on the number of attempts the pod has made.
+func (bq *backoffQueue) calculateBackoffDuration(count int) time.Duration {
+	if count == 0 {
+		return 0
+	}
+
+	shift := count - 1
+	if bq.podInitialBackoff > bq.podMaxBackoff>>shift {
+		return bq.podMaxBackoff
+	}
+	return time.Duration(bq.podInitialBackoff << shift)
+}
+
+func (bq *backoffQueue) popAllBackoffCompletedWithQueue(logger klog.Logger, queue *heap.Heap[*framework.QueuedPodInfo]) []*framework.QueuedPodInfo {
+	var poppedPods []*framework.QueuedPodInfo
+	for {
+		pInfo, ok := queue.Peek()
+		if !ok || pInfo == nil {
+			break
+		}
+		pod := pInfo.Pod
+		if bq.isPodBackingoff(pInfo) {
+			break
+		}
+		_, err := queue.Pop()
+		if err != nil {
+			utilruntime.HandleErrorWithLogger(logger, err, "Unable to pop pod from backoff queue despite backoff completion", "pod", klog.KObj(pod))
+			break
+		}
+		poppedPods = append(poppedPods, pInfo)
+	}
+	return poppedPods
+}
+
+// popAllBackoffCompleted pops all pods from podBackoffQ and podErrorBackoffQ that completed backoff.
+func (bq *backoffQueue) popAllBackoffCompleted(logger klog.Logger) []*framework.QueuedPodInfo {
+	bq.lock.Lock()
+	defer bq.lock.Unlock()
+
+	// Ensure both queues are called
+	return append(bq.popAllBackoffCompletedWithQueue(logger, bq.podBackoffQ), bq.popAllBackoffCompletedWithQueue(logger, bq.podErrorBackoffQ)...)
+}
+
+// add adds the pInfo to backoffQueue.
+// The event should show which event triggered this addition and is used for the metric recording.
+// It also ensures that pInfo is not in both queues.
+func (bq *backoffQueue) add(logger klog.Logger, pInfo *framework.QueuedPodInfo, event string) {
+	bq.lock.Lock()
+	defer bq.lock.Unlock()
+
+	// If pod has empty both unschedulable plugins and pending plugins,
+	// it means that it failed because of error and should be moved to podErrorBackoffQ.
+	if pInfo.UnschedulablePlugins.Len() == 0 && pInfo.PendingPlugins.Len() == 0 {
+		bq.podErrorBackoffQ.AddOrUpdate(pInfo)
+		// Ensure the pod is not in the podBackoffQ and report the error if it happens.
+		err := bq.podBackoffQ.Delete(pInfo)
+		if err == nil {
+			logger.Error(nil, "BackoffQueue add() was called with a pod that was already in the podBackoffQ", "pod", klog.KObj(pInfo.Pod))
+			return
+		}
+		metrics.SchedulerQueueIncomingPods.WithLabelValues("backoff", event).Inc()
+		logger.V(5).Info("Pod moved to an internal scheduling queue", "pod", klog.KObj(pInfo.Pod), "event", event, "queue", backoffQ)
+		return
+	}
+	bq.podBackoffQ.AddOrUpdate(pInfo)
+	// Ensure the pod is not in the podErrorBackoffQ and report the error if it happens.
+	err := bq.podErrorBackoffQ.Delete(pInfo)
+	if err == nil {
+		logger.Error(nil, "BackoffQueue add() was called with a pod that was already in the podErrorBackoffQ", "pod", klog.KObj(pInfo.Pod))
+		return
+	}
+	metrics.SchedulerQueueIncomingPods.WithLabelValues("backoff", event).Inc()
+	logger.V(5).Info("Pod moved to an internal scheduling queue", "pod", klog.KObj(pInfo.Pod), "event", event, "queue", backoffQ)
+}
+
+// update updates the pod in backoffQueue if oldPodInfo is already in the queue.
+// It returns new pod info if updated, nil otherwise.
+func (bq *backoffQueue) update(newPod *v1.Pod, oldPodInfo *framework.QueuedPodInfo) *framework.QueuedPodInfo {
+	bq.lock.Lock()
+	defer bq.lock.Unlock()
+
+	// If the pod is in the backoff queue, update it there.
+	if pInfo, exists := bq.podBackoffQ.Get(oldPodInfo); exists {
+		_ = pInfo.Update(newPod)
+		bq.podBackoffQ.AddOrUpdate(pInfo)
+		return pInfo
+	}
+	// If the pod is in the error backoff queue, update it there.
+	if pInfo, exists := bq.podErrorBackoffQ.Get(oldPodInfo); exists {
+		_ = pInfo.Update(newPod)
+		bq.podErrorBackoffQ.AddOrUpdate(pInfo)
+		return pInfo
+	}
+	return nil
+}
+
+// delete deletes the pInfo from backoffQueue.
+// It returns true if the pod was deleted.
+func (bq *backoffQueue) delete(pInfo *framework.QueuedPodInfo) bool {
+	bq.lock.Lock()
+	defer bq.lock.Unlock()
+
+	if bq.podBackoffQ.Delete(pInfo) == nil {
+		return true
+	}
+	return bq.podErrorBackoffQ.Delete(pInfo) == nil
+}
+
+// popBackoff pops the pInfo from the podBackoffQ.
+// It returns error if the queue is empty.
+// This doesn't pop the pods from the podErrorBackoffQ.
+func (bq *backoffQueue) popBackoff() (*framework.QueuedPodInfo, error) {
+	bq.lock.Lock()
+	defer bq.lock.Unlock()
+
+	return bq.podBackoffQ.Pop()
+}
+
+// get returns the pInfo matching given pInfoLookup, if exists.
+func (bq *backoffQueue) get(pInfoLookup *framework.QueuedPodInfo) (*framework.QueuedPodInfo, bool) {
+	bq.lock.RLock()
+	defer bq.lock.RUnlock()
+
+	pInfo, exists := bq.podBackoffQ.Get(pInfoLookup)
+	if exists {
+		return pInfo, true
+	}
+	return bq.podErrorBackoffQ.Get(pInfoLookup)
+}
+
+// has inform if pInfo exists in the queue.
+func (bq *backoffQueue) has(pInfo *framework.QueuedPodInfo) bool {
+	bq.lock.RLock()
+	defer bq.lock.RUnlock()
+
+	return bq.podBackoffQ.Has(pInfo) || bq.podErrorBackoffQ.Has(pInfo)
+}
+
+// list returns all pods that are in the queue.
+func (bq *backoffQueue) list() []*v1.Pod {
+	bq.lock.RLock()
+	defer bq.lock.RUnlock()
+
+	var result []*v1.Pod
+	for _, pInfo := range bq.podBackoffQ.List() {
+		result = append(result, pInfo.Pod)
+	}
+	for _, pInfo := range bq.podErrorBackoffQ.List() {
+		result = append(result, pInfo.Pod)
+	}
+	return result
+}
+
+// len returns length of the queue.
+func (bq *backoffQueue) len() int {
+	bq.lock.RLock()
+	defer bq.lock.RUnlock()
+
+	return bq.podBackoffQ.Len() + bq.podErrorBackoffQ.Len()
+}
+
+// lenBackoff returns length of the podBackoffQ.
+func (bq *backoffQueue) lenBackoff() int {
+	bq.lock.RLock()
+	defer bq.lock.RUnlock()
+
+	return bq.podBackoffQ.Len()
+}

--- a/third_party/kubernetes/pkg/scheduler/backend/queue/backoff_queue_test.go
+++ b/third_party/kubernetes/pkg/scheduler/backend/queue/backoff_queue_test.go
@@ -1,0 +1,329 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package queue
+
+import (
+	"fmt"
+	"math"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/klog/v2/ktesting"
+	"k8s.io/kubernetes/pkg/scheduler/framework"
+	st "k8s.io/kubernetes/pkg/scheduler/testing"
+	"k8s.io/utils/clock"
+	testingclock "k8s.io/utils/clock/testing"
+)
+
+func TestBackoffQueue_getBackoffTime(t *testing.T) {
+	tests := []struct {
+		name                   string
+		initialBackoffDuration time.Duration
+		maxBackoffDuration     time.Duration
+		podInfo                *framework.QueuedPodInfo
+		want                   time.Time
+	}{
+		{
+			name:                   "no backoff",
+			initialBackoffDuration: 1 * time.Second,
+			maxBackoffDuration:     32 * time.Second,
+			podInfo:                &framework.QueuedPodInfo{UnschedulableCount: 0, Timestamp: time.Date(2023, 10, 1, 0, 0, 0, 0, time.UTC)},
+			want:                   time.Time{},
+		},
+		{
+			name:                   "backoff is returned from the cache",
+			initialBackoffDuration: 1 * time.Second,
+			maxBackoffDuration:     32 * time.Second,
+			podInfo:                &framework.QueuedPodInfo{UnschedulableCount: 1, Timestamp: time.Date(2023, 10, 1, 0, 0, 0, 0, time.UTC), BackoffExpiration: time.Date(2023, 10, 1, 0, 0, 0, 1, time.UTC)},
+			want:                   time.Date(2023, 10, 1, 0, 0, 0, 1, time.UTC),
+		},
+		{
+			name:                   "backoff by UnschedulableCount",
+			initialBackoffDuration: 1 * time.Second,
+			maxBackoffDuration:     32 * time.Second,
+			podInfo:                &framework.QueuedPodInfo{UnschedulableCount: 16, Timestamp: time.Date(2023, 10, 1, 0, 0, 0, 0, time.UTC)},
+			want:                   time.Date(2023, 10, 1, 0, 0, 32, 0, time.UTC),
+		},
+		{
+			name:                   "backoff is calculated with ConsecutiveErrorsCount",
+			initialBackoffDuration: 1 * time.Second,
+			maxBackoffDuration:     32 * time.Second,
+			podInfo:                &framework.QueuedPodInfo{UnschedulableCount: 5, ConsecutiveErrorsCount: 16, Timestamp: time.Date(2023, 10, 1, 0, 0, 0, 0, time.UTC)},
+			want:                   time.Date(2023, 10, 1, 0, 0, 32, 0, time.UTC),
+		},
+		{
+			name:                   "zero maxBackoffDuration means no backoff",
+			initialBackoffDuration: 0,
+			maxBackoffDuration:     0,
+			podInfo:                &framework.QueuedPodInfo{UnschedulableCount: 16, Timestamp: time.Date(2023, 10, 1, 0, 0, 0, 0, time.UTC)},
+			want:                   time.Time{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			bq := newBackoffQueue(clock.RealClock{}, tt.initialBackoffDuration, tt.maxBackoffDuration, newDefaultQueueSort(), true)
+			if got := bq.getBackoffTime(tt.podInfo); got != tt.want {
+				t.Errorf("backoffQueue.getBackoffTime() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBackoffQueue_calculateBackoffDuration(t *testing.T) {
+	tests := []struct {
+		name                   string
+		initialBackoffDuration time.Duration
+		maxBackoffDuration     time.Duration
+		count                  int
+		want                   time.Duration
+	}{
+		{
+			name:                   "no backoff",
+			initialBackoffDuration: 1 * time.Nanosecond,
+			maxBackoffDuration:     32 * time.Nanosecond,
+			count:                  0,
+			want:                   0,
+		},
+		{
+			name:                   "normal",
+			initialBackoffDuration: 3 * time.Nanosecond,
+			maxBackoffDuration:     1000 * time.Nanosecond,
+			count:                  5,
+			want:                   48 * time.Nanosecond, // 3 * 2^4 = 48
+		},
+		{
+			name:                   "hitting max backoff duration",
+			initialBackoffDuration: 1 * time.Nanosecond,
+			maxBackoffDuration:     32 * time.Nanosecond,
+			count:                  16,
+			want:                   32 * time.Nanosecond,
+		},
+		{
+			name:                   "overflow_32bit",
+			initialBackoffDuration: 1 * time.Nanosecond,
+			maxBackoffDuration:     math.MaxInt32 * time.Nanosecond,
+			count:                  32,
+			want:                   math.MaxInt32 * time.Nanosecond,
+		},
+		{
+			name:                   "overflow_64bit",
+			initialBackoffDuration: 1 * time.Nanosecond,
+			maxBackoffDuration:     math.MaxInt64 * time.Nanosecond,
+			count:                  64,
+			want:                   math.MaxInt64 * time.Nanosecond,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			bq := newBackoffQueue(clock.RealClock{}, tt.initialBackoffDuration, tt.maxBackoffDuration, newDefaultQueueSort(), true)
+			if got := bq.calculateBackoffDuration(tt.count); got != tt.want {
+				t.Errorf("backoffQueue.calculateBackoffDuration() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBackoffQueue_popAllBackoffCompleted(t *testing.T) {
+	fakeClock := testingclock.NewFakeClock(time.Now())
+	podInfos := map[string]*framework.QueuedPodInfo{
+		"pod0": {
+			PodInfo: &framework.PodInfo{
+				Pod: st.MakePod().Name("pod0").Obj(),
+			},
+			Timestamp:            fakeClock.Now().Add(-2 * time.Second),
+			UnschedulableCount:   1,
+			UnschedulablePlugins: sets.New("plugin"),
+		},
+		"pod1": {
+			PodInfo: &framework.PodInfo{
+				Pod: st.MakePod().Name("pod1").Obj(),
+			},
+			Timestamp:            fakeClock.Now().Add(time.Second),
+			UnschedulableCount:   1,
+			UnschedulablePlugins: sets.New("plugin"),
+		},
+		"pod2": {
+			PodInfo: &framework.PodInfo{
+				Pod: st.MakePod().Name("pod2").Obj(),
+			},
+			Timestamp:              fakeClock.Now().Add(-2 * time.Second),
+			ConsecutiveErrorsCount: 1,
+		},
+		"pod3": {
+			PodInfo: &framework.PodInfo{
+				Pod: st.MakePod().Name("pod3").Obj(),
+			},
+			Timestamp:              fakeClock.Now().Add(time.Second),
+			ConsecutiveErrorsCount: 1,
+		},
+	}
+	tests := []struct {
+		name          string
+		podsInBackoff []string
+		wantPods      []string
+	}{
+		{
+			name:          "Both queues empty, no pods moved to activeQ",
+			podsInBackoff: []string{},
+			wantPods:      nil,
+		},
+		{
+			name:          "Pods only in backoffQ, some pods moved to activeQ",
+			podsInBackoff: []string{"pod0", "pod1"},
+			wantPods:      []string{"pod0"},
+		},
+		{
+			name:          "Pods only in errorBackoffQ, some pods moved to activeQ",
+			podsInBackoff: []string{"pod2", "pod3"},
+			wantPods:      []string{"pod2"},
+		},
+		{
+			name:          "Pods in both queues, some pods moved to activeQ",
+			podsInBackoff: []string{"pod0", "pod1", "pod2", "pod3"},
+			wantPods:      []string{"pod0", "pod2"},
+		},
+		{
+			name:          "Pods in both queues, all pods moved to activeQ",
+			podsInBackoff: []string{"pod0", "pod2"},
+			wantPods:      []string{"pod0", "pod2"},
+		},
+		{
+			name:          "Pods in both queues, no pods moved to activeQ",
+			podsInBackoff: []string{"pod1", "pod3"},
+			wantPods:      nil,
+		},
+	}
+	for _, tt := range tests {
+		for _, popFromBackoffQEnabled := range []bool{true, false} {
+			t.Run(fmt.Sprintf("%s popFromBackoffQEnabled(%v)", tt.name, popFromBackoffQEnabled), func(t *testing.T) {
+				logger, _ := ktesting.NewTestContext(t)
+				bq := newBackoffQueue(fakeClock, DefaultPodInitialBackoffDuration, DefaultPodMaxBackoffDuration, newDefaultQueueSort(), popFromBackoffQEnabled)
+				for _, podName := range tt.podsInBackoff {
+					bq.add(logger, podInfos[podName], framework.EventUnscheduledPodAdd.Label())
+				}
+				gotPodInfos := bq.popAllBackoffCompleted(logger)
+				var gotPods []string
+				for _, pInfo := range gotPodInfos {
+					gotPods = append(gotPods, pInfo.Pod.Name)
+				}
+				if diff := cmp.Diff(tt.wantPods, gotPods); diff != "" {
+					t.Errorf("Unexpected pods moved (-want, +got):\n%s", diff)
+				}
+				podsToStayInBackoff := len(tt.podsInBackoff) - len(tt.wantPods)
+				if bq.len() != podsToStayInBackoff {
+					t.Errorf("Expected %v pods to stay in backoffQ, but got: %v", podsToStayInBackoff, bq.len())
+				}
+			})
+		}
+	}
+}
+
+func TestBackoffQueueOrdering(t *testing.T) {
+	// Align the fake clock with ordering window.
+	fakeClock := testingclock.NewFakeClock(time.Now().Truncate(backoffQOrderingWindowDuration))
+	podInfos := []*framework.QueuedPodInfo{
+		{
+			PodInfo: &framework.PodInfo{
+				Pod: st.MakePod().Name("pod0").Priority(1).Obj(),
+			},
+			Timestamp:            fakeClock.Now(),
+			Attempts:             1,
+			UnschedulableCount:   1,
+			UnschedulablePlugins: sets.New("plugin"),
+		},
+		{
+			PodInfo: &framework.PodInfo{
+				Pod: st.MakePod().Name("pod1").Priority(1).Obj(),
+			},
+			Timestamp:            fakeClock.Now().Add(-time.Second),
+			Attempts:             1,
+			UnschedulableCount:   1,
+			UnschedulablePlugins: sets.New("plugin"),
+		},
+		{
+			PodInfo: &framework.PodInfo{
+				Pod: st.MakePod().Name("pod2").Priority(2).Obj(),
+			},
+			Timestamp:            fakeClock.Now().Add(-2*time.Second + time.Millisecond),
+			Attempts:             1,
+			UnschedulableCount:   1,
+			UnschedulablePlugins: sets.New("plugin"),
+		},
+		{
+			PodInfo: &framework.PodInfo{
+				Pod: st.MakePod().Name("pod3").Priority(1).Obj(),
+			},
+			Timestamp:            fakeClock.Now().Add(-2 * time.Second),
+			Attempts:             1,
+			UnschedulableCount:   1,
+			UnschedulablePlugins: sets.New("plugin"),
+		},
+		{
+			PodInfo: &framework.PodInfo{
+				Pod: st.MakePod().Name("pod4").Priority(2).Obj(),
+			},
+			Timestamp:            fakeClock.Now().Add(-2 * time.Second),
+			Attempts:             1,
+			UnschedulableCount:   1,
+			UnschedulablePlugins: sets.New("plugin"),
+		},
+		{
+			PodInfo: &framework.PodInfo{
+				Pod: st.MakePod().Name("pod5").Priority(1).Obj(),
+			},
+			Timestamp:            fakeClock.Now().Add(-3 * time.Second),
+			Attempts:             1,
+			UnschedulableCount:   1,
+			UnschedulablePlugins: sets.New("plugin"),
+		},
+	}
+	tests := []struct {
+		name                   string
+		popFromBackoffQEnabled bool
+		wantPods               []string
+	}{
+		{
+			name:                   "Pods with the same window are ordered by priority if PopFromBackoffQ is enabled",
+			popFromBackoffQEnabled: true,
+			wantPods:               []string{"pod5", "pod4", "pod2", "pod3"},
+		},
+		{
+			name:                   "Pods priority doesn't matter if PopFromBackoffQ is disabled",
+			popFromBackoffQEnabled: false,
+			wantPods:               []string{"pod5", "pod3", "pod4", "pod2"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logger, _ := ktesting.NewTestContext(t)
+			bq := newBackoffQueue(fakeClock, DefaultPodInitialBackoffDuration, DefaultPodMaxBackoffDuration, newDefaultQueueSort(), tt.popFromBackoffQEnabled)
+			for _, podInfo := range podInfos {
+				bq.add(logger, podInfo, framework.EventUnscheduledPodAdd.Label())
+			}
+			gotPodInfos := bq.popAllBackoffCompleted(logger)
+			var gotPods []string
+			for _, pInfo := range gotPodInfos {
+				gotPods = append(gotPods, pInfo.Pod.Name)
+			}
+			if diff := cmp.Diff(tt.wantPods, gotPods); diff != "" {
+				t.Errorf("Unexpected pods moved (-want, +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/third_party/kubernetes/pkg/scheduler/backend/queue/scheduling_queue.go
+++ b/third_party/kubernetes/pkg/scheduler/backend/queue/scheduling_queue.go
@@ -1,0 +1,1374 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This file contains structures that implement scheduling queue types.
+// Scheduling queues hold pods waiting to be scheduled. This file implements a
+// priority queue which has two sub queues and a additional data structure,
+// namely: activeQ, backoffQ and unschedulablePods.
+// - activeQ holds pods that are being considered for scheduling.
+// - backoffQ holds pods that moved from unschedulablePods and will move to
+//   activeQ when their backoff periods complete.
+// - unschedulablePods holds pods that were already attempted for scheduling and
+//   are currently determined to be unschedulable.
+
+package queue
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"reflect"
+	"sync"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/wait"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	"k8s.io/client-go/informers"
+	listersv1 "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2"
+	schedfwk "k8s.io/kube-scheduler/framework"
+	"k8s.io/kubernetes/pkg/features"
+	"k8s.io/kubernetes/pkg/scheduler/backend/heap"
+	"k8s.io/kubernetes/pkg/scheduler/framework"
+	internalfwk "k8s.io/kubernetes/pkg/scheduler/framework"
+	apicalls "k8s.io/kubernetes/pkg/scheduler/framework/api_calls"
+	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/interpodaffinity"
+	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/podtopologyspread"
+	"k8s.io/kubernetes/pkg/scheduler/metrics"
+	"k8s.io/kubernetes/pkg/scheduler/util"
+	"k8s.io/utils/clock"
+)
+
+const (
+	// DefaultPodMaxInUnschedulablePodsDuration is the default value for the maximum
+	// time a pod can stay in unschedulablePods. If a pod stays in unschedulablePods
+	// for longer than this value, the pod will be moved from unschedulablePods to
+	// backoffQ or activeQ. If this value is empty, the default value (5min)
+	// will be used.
+	DefaultPodMaxInUnschedulablePodsDuration time.Duration = 5 * time.Minute
+	// Scheduling queue names
+	activeQ        = "Active"
+	backoffQ       = "Backoff"
+	unschedulableQ = "Unschedulable"
+
+	preEnqueue = "PreEnqueue"
+)
+
+const (
+	// DefaultPodInitialBackoffDuration is the default value for the initial backoff duration
+	// for unschedulable pods. To change the default podInitialBackoffDurationSeconds used by the
+	// scheduler, update the ComponentConfig value in defaults.go
+	DefaultPodInitialBackoffDuration time.Duration = 1 * time.Second
+	// DefaultPodMaxBackoffDuration is the default value for the max backoff duration
+	// for unschedulable pods. To change the default podMaxBackoffDurationSeconds used by the
+	// scheduler, update the ComponentConfig value in defaults.go
+	DefaultPodMaxBackoffDuration time.Duration = 10 * time.Second
+)
+
+// PreEnqueueCheck is a function type. It's used to build functions that
+// run against a Pod and the caller can choose to enqueue or skip the Pod
+// by the checking result.
+type PreEnqueueCheck func(pod *v1.Pod) bool
+
+// SchedulingQueue is an interface for a queue to store pods waiting to be scheduled.
+// The interface follows a pattern similar to cache.FIFO and cache.Heap and
+// makes it easy to use those data structures as a SchedulingQueue.
+type SchedulingQueue interface {
+	Add(logger klog.Logger, pod *v1.Pod)
+	// Activate moves the given pods to activeQ.
+	// If a pod isn't found in unschedulablePods or backoffQ and it's in-flight,
+	// the wildcard event is registered so that the pod will be requeued when it comes back.
+	// But, if a pod isn't found in unschedulablePods or backoffQ and it's not in-flight (i.e., completely unknown pod),
+	// Activate would ignore the pod.
+	Activate(logger klog.Logger, pods map[string]*v1.Pod)
+	// AddUnschedulableIfNotPresent adds an unschedulable pod back to scheduling queue.
+	// The podSchedulingCycle represents the current scheduling cycle number which can be
+	// returned by calling SchedulingCycle().
+	AddUnschedulableIfNotPresent(logger klog.Logger, pod *framework.QueuedPodInfo, podSchedulingCycle int64) error
+	// SchedulingCycle returns the current number of scheduling cycle which is
+	// cached by scheduling queue. Normally, incrementing this number whenever
+	// a pod is popped (e.g. called Pop()) is enough.
+	SchedulingCycle() int64
+	// Pop removes the head of the queue and returns it. It blocks if the
+	// queue is empty and waits until a new item is added to the queue.
+	Pop(logger klog.Logger) (*framework.QueuedPodInfo, error)
+	// Done must be called for pod returned by Pop. This allows the queue to
+	// keep track of which pods are currently being processed.
+	Done(types.UID)
+	Update(logger klog.Logger, oldPod, newPod *v1.Pod)
+	Delete(pod *v1.Pod)
+	// Important Note: preCheck shouldn't include anything that depends on the in-tree plugins' logic.
+	// (e.g., filter Pods based on added/updated Node's capacity, etc.)
+	// We know currently some do, but we'll eventually remove them in favor of the scheduling queue hint.
+	MoveAllToActiveOrBackoffQueue(logger klog.Logger, event schedfwk.ClusterEvent, oldObj, newObj interface{}, preCheck PreEnqueueCheck)
+	AssignedPodAdded(logger klog.Logger, pod *v1.Pod)
+	AssignedPodUpdated(logger klog.Logger, oldPod, newPod *v1.Pod, event schedfwk.ClusterEvent)
+
+	// Close closes the SchedulingQueue so that the goroutine which is
+	// waiting to pop items can exit gracefully.
+	Close()
+	// Run starts the goroutines managing the queue.
+	Run(logger klog.Logger)
+
+	// PatchPodStatus handles the pod status update by sending an update API call through API dispatcher.
+	// This method should be used only if the SchedulerAsyncAPICalls feature gate is enabled.
+	PatchPodStatus(pod *v1.Pod, condition *v1.PodCondition, nominatingInfo *internalfwk.NominatingInfo) (<-chan error, error)
+
+	// The following functions are supposed to be used only for testing or debugging.
+	GetPod(name, namespace string) (*framework.QueuedPodInfo, bool)
+	PendingPods() ([]*v1.Pod, string)
+	InFlightPods() []*v1.Pod
+	PodsInActiveQ() []*v1.Pod
+	// PodsInBackoffQ returns all the Pods in the backoffQ.
+	PodsInBackoffQ() []*v1.Pod
+	UnschedulablePods() []*v1.Pod
+}
+
+// NewSchedulingQueue initializes a priority queue as a new scheduling queue.
+func NewSchedulingQueue(
+	lessFn internalfwk.LessFunc,
+	informerFactory informers.SharedInformerFactory,
+	opts ...Option) SchedulingQueue {
+	return NewPriorityQueue(lessFn, informerFactory, opts...)
+}
+
+// PriorityQueue implements a scheduling queue.
+// The head of PriorityQueue is the highest priority pending pod. This structure
+// has two sub queues and a additional data structure, namely: activeQ,
+// backoffQ and unschedulablePods.
+//   - activeQ holds pods that are being considered for scheduling.
+//   - backoffQ holds pods that moved from unschedulablePods and will move to
+//     activeQ when their backoff periods complete.
+//   - unschedulablePods holds pods that were already attempted for scheduling and
+//     are currently determined to be unschedulable.
+type PriorityQueue struct {
+	stop  chan struct{}
+	clock clock.WithTicker
+
+	// lock takes precedence and should be taken first,
+	// before any other locks in the queue (activeQueue.lock or backoffQueue.lock).
+	// Correct locking order is: lock > activeQueue.lock > backoffQueue.lock.
+	lock sync.RWMutex
+
+	// the maximum time a pod can stay in the unschedulablePods.
+	podMaxInUnschedulablePodsDuration time.Duration
+
+	activeQ  activeQueuer
+	backoffQ backoffQueuer
+	// unschedulablePods holds pods that have been tried and determined unschedulable.
+	unschedulablePods *unschedulablePods
+	// moveRequestCycle caches the sequence number of scheduling cycle when we
+	// received a move request. Unschedulable pods in and before this scheduling
+	// cycle will be put back to activeQueue if we were trying to schedule them
+	// when we received move request.
+	// TODO: this will be removed after SchedulingQueueHint goes to stable and the feature gate is removed.
+	moveRequestCycle int64
+
+	// preEnqueuePluginMap is keyed with profile and plugin name, valued with registered preEnqueue plugins.
+	preEnqueuePluginMap map[string]map[string]internalfwk.PreEnqueuePlugin
+	// queueingHintMap is keyed with profile name, valued with registered queueing hint functions.
+	queueingHintMap QueueingHintMapPerProfile
+	// pluginToEventsMap shows which plugin is interested in which events.
+	pluginToEventsMap map[string][]schedfwk.ClusterEvent
+
+	nsLister listersv1.NamespaceLister
+
+	metricsRecorder *metrics.MetricAsyncRecorder
+	// pluginMetricsSamplePercent is the percentage of plugin metrics to be sampled.
+	pluginMetricsSamplePercent int
+
+	// apiDispatcher is used for the methods that are expected to send API calls.
+	// It's non-nil only if the SchedulerAsyncAPICalls feature gate is enabled.
+	apiDispatcher schedfwk.APIDispatcher
+
+	// isSchedulingQueueHintEnabled indicates whether the feature gate for the scheduling queue is enabled.
+	isSchedulingQueueHintEnabled bool
+	// isPopFromBackoffQEnabled indicates whether the feature gate SchedulerPopFromBackoffQ is enabled.
+	isPopFromBackoffQEnabled bool
+}
+
+// QueueingHintFunction is the wrapper of QueueingHintFn that has PluginName.
+type QueueingHintFunction struct {
+	PluginName     string
+	QueueingHintFn schedfwk.QueueingHintFn
+}
+
+// clusterEvent has the event and involved objects.
+type clusterEvent struct {
+	event schedfwk.ClusterEvent
+	// oldObj is the object that involved this event.
+	oldObj interface{}
+	// newObj is the object that involved this event.
+	newObj interface{}
+}
+
+type priorityQueueOptions struct {
+	clock                             clock.WithTicker
+	podInitialBackoffDuration         time.Duration
+	podMaxBackoffDuration             time.Duration
+	podMaxInUnschedulablePodsDuration time.Duration
+	podLister                         listersv1.PodLister
+	metricsRecorder                   *metrics.MetricAsyncRecorder
+	pluginMetricsSamplePercent        int
+	preEnqueuePluginMap               map[string]map[string]internalfwk.PreEnqueuePlugin
+	queueingHintMap                   QueueingHintMapPerProfile
+	apiDispatcher                     schedfwk.APIDispatcher
+}
+
+// Option configures a PriorityQueue
+type Option func(*priorityQueueOptions)
+
+// WithClock sets clock for PriorityQueue, the default clock is clock.RealClock.
+func WithClock(clock clock.WithTicker) Option {
+	return func(o *priorityQueueOptions) {
+		o.clock = clock
+	}
+}
+
+// WithPodInitialBackoffDuration sets pod initial backoff duration for PriorityQueue.
+func WithPodInitialBackoffDuration(duration time.Duration) Option {
+	return func(o *priorityQueueOptions) {
+		o.podInitialBackoffDuration = duration
+	}
+}
+
+// WithPodMaxBackoffDuration sets pod max backoff duration for PriorityQueue.
+func WithPodMaxBackoffDuration(duration time.Duration) Option {
+	return func(o *priorityQueueOptions) {
+		o.podMaxBackoffDuration = duration
+	}
+}
+
+// WithPodLister sets pod lister for PriorityQueue.
+func WithPodLister(pl listersv1.PodLister) Option {
+	return func(o *priorityQueueOptions) {
+		o.podLister = pl
+	}
+}
+
+// WithPodMaxInUnschedulablePodsDuration sets podMaxInUnschedulablePodsDuration for PriorityQueue.
+func WithPodMaxInUnschedulablePodsDuration(duration time.Duration) Option {
+	return func(o *priorityQueueOptions) {
+		o.podMaxInUnschedulablePodsDuration = duration
+	}
+}
+
+// QueueingHintMapPerProfile is keyed with profile name, valued with queueing hint map registered for the profile.
+type QueueingHintMapPerProfile map[string]QueueingHintMap
+
+// QueueingHintMap is keyed with ClusterEvent, valued with queueing hint functions registered for the event.
+type QueueingHintMap map[schedfwk.ClusterEvent][]*QueueingHintFunction
+
+// WithQueueingHintMapPerProfile sets queueingHintMap for PriorityQueue.
+func WithQueueingHintMapPerProfile(m QueueingHintMapPerProfile) Option {
+	return func(o *priorityQueueOptions) {
+		o.queueingHintMap = m
+	}
+}
+
+// WithPreEnqueuePluginMap sets preEnqueuePluginMap for PriorityQueue.
+func WithPreEnqueuePluginMap(m map[string]map[string]internalfwk.PreEnqueuePlugin) Option {
+	return func(o *priorityQueueOptions) {
+		o.preEnqueuePluginMap = m
+	}
+}
+
+// WithMetricsRecorder sets metrics recorder.
+func WithMetricsRecorder(recorder *metrics.MetricAsyncRecorder) Option {
+	return func(o *priorityQueueOptions) {
+		o.metricsRecorder = recorder
+	}
+}
+
+// WithPluginMetricsSamplePercent sets the percentage of plugin metrics to be sampled.
+func WithPluginMetricsSamplePercent(percent int) Option {
+	return func(o *priorityQueueOptions) {
+		o.pluginMetricsSamplePercent = percent
+	}
+}
+
+// WithAPIDispatcher sets the API dispatcher.
+func WithAPIDispatcher(apiDispatcher schedfwk.APIDispatcher) Option {
+	return func(o *priorityQueueOptions) {
+		o.apiDispatcher = apiDispatcher
+	}
+}
+
+var defaultPriorityQueueOptions = priorityQueueOptions{
+	clock:                             clock.RealClock{},
+	podInitialBackoffDuration:         DefaultPodInitialBackoffDuration,
+	podMaxBackoffDuration:             DefaultPodMaxBackoffDuration,
+	podMaxInUnschedulablePodsDuration: DefaultPodMaxInUnschedulablePodsDuration,
+}
+
+// Making sure that PriorityQueue implements SchedulingQueue.
+var _ SchedulingQueue = &PriorityQueue{}
+
+// newQueuedPodInfoForLookup builds a QueuedPodInfo object for a lookup in the queue.
+func newQueuedPodInfoForLookup(pod *v1.Pod, plugins ...string) *framework.QueuedPodInfo {
+	// Since this is only used for a lookup in the queue, we only need to set the Pod,
+	// and so we avoid creating a full PodInfo, which is expensive to instantiate frequently.
+	return &framework.QueuedPodInfo{
+		PodInfo:              &framework.PodInfo{Pod: pod},
+		UnschedulablePlugins: sets.New(plugins...),
+	}
+}
+
+// NewPriorityQueue creates a PriorityQueue object.
+func NewPriorityQueue(
+	lessFn internalfwk.LessFunc,
+	informerFactory informers.SharedInformerFactory,
+	opts ...Option,
+) *PriorityQueue {
+	options := defaultPriorityQueueOptions
+	if options.podLister == nil {
+		options.podLister = informerFactory.Core().V1().Pods().Lister()
+	}
+	for _, opt := range opts {
+		opt(&options)
+	}
+
+	isSchedulingQueueHintEnabled := utilfeature.DefaultFeatureGate.Enabled(features.SchedulerQueueingHints)
+	isPopFromBackoffQEnabled := utilfeature.DefaultFeatureGate.Enabled(features.SchedulerPopFromBackoffQ)
+	lessConverted := convertLessFn(lessFn)
+
+	backoffQ := newBackoffQueue(options.clock, options.podInitialBackoffDuration, options.podMaxBackoffDuration, lessFn, isPopFromBackoffQEnabled)
+	pq := &PriorityQueue{
+		clock:                             options.clock,
+		stop:                              make(chan struct{}),
+		podMaxInUnschedulablePodsDuration: options.podMaxInUnschedulablePodsDuration,
+		backoffQ:                          backoffQ,
+		unschedulablePods:                 newUnschedulablePods(metrics.NewUnschedulablePodsRecorder(), metrics.NewGatedPodsRecorder()),
+		preEnqueuePluginMap:               options.preEnqueuePluginMap,
+		queueingHintMap:                   options.queueingHintMap,
+		pluginToEventsMap:                 buildEventMap(options.queueingHintMap),
+		metricsRecorder:                   options.metricsRecorder,
+		pluginMetricsSamplePercent:        options.pluginMetricsSamplePercent,
+		moveRequestCycle:                  -1,
+		apiDispatcher:                     options.apiDispatcher,
+		isSchedulingQueueHintEnabled:      isSchedulingQueueHintEnabled,
+		isPopFromBackoffQEnabled:          isPopFromBackoffQEnabled,
+	}
+	var backoffQPopper backoffQPopper
+	if isPopFromBackoffQEnabled {
+		backoffQPopper = backoffQ
+	}
+	pq.activeQ = newActiveQueue(heap.NewWithRecorder(podInfoKeyFunc, heap.LessFunc[*framework.QueuedPodInfo](lessConverted), metrics.NewActivePodsRecorder()), isSchedulingQueueHintEnabled, options.metricsRecorder, backoffQPopper)
+	pq.nsLister = informerFactory.Core().V1().Namespaces().Lister()
+
+	return pq
+}
+
+// Helper function that wraps fwk.LessFunc and converts it to take *framework.QueuedPodInfo as arguments.
+func convertLessFn(lessFn internalfwk.LessFunc) func(podInfo1, podInfo2 *framework.QueuedPodInfo) bool {
+	return func(podInfo1, podInfo2 *framework.QueuedPodInfo) bool {
+		return lessFn(podInfo1, podInfo2)
+	}
+}
+
+func buildEventMap(qHintMap QueueingHintMapPerProfile) map[string][]schedfwk.ClusterEvent {
+	eventMap := make(map[string][]schedfwk.ClusterEvent)
+
+	for _, hintMap := range qHintMap {
+		for event, qHints := range hintMap {
+			for _, qHint := range qHints {
+				eventMap[qHint.PluginName] = append(eventMap[qHint.PluginName], event)
+			}
+		}
+	}
+
+	return eventMap
+}
+
+// Run starts the goroutine to pump from backoffQ to activeQ
+func (p *PriorityQueue) Run(logger klog.Logger) {
+	go p.backoffQ.waitUntilAlignedWithOrderingWindow(func() {
+		p.flushBackoffQCompleted(logger)
+	}, p.stop)
+	go wait.Until(func() {
+		p.flushUnschedulablePodsLeftover(logger)
+	}, 30*time.Second, p.stop)
+}
+
+// queueingStrategy indicates how the scheduling queue should enqueue the Pod from unschedulable pod pool.
+type queueingStrategy int
+
+const (
+	// queueSkip indicates that the scheduling queue should skip requeuing the Pod to activeQ/backoffQ.
+	queueSkip queueingStrategy = iota
+	// queueAfterBackoff indicates that the scheduling queue should requeue the Pod after backoff is completed.
+	queueAfterBackoff
+	// queueImmediately indicates that the scheduling queue should skip backoff and requeue the Pod immediately to activeQ.
+	queueImmediately
+)
+
+// isEventOfInterest returns true if the event is of interest by some plugins.
+func (p *PriorityQueue) isEventOfInterest(logger klog.Logger, event schedfwk.ClusterEvent) bool {
+	if framework.ClusterEventIsWildCard(event) {
+		// Wildcard event moves Pods that failed with any plugins.
+		return true
+	}
+
+	for _, hintMap := range p.queueingHintMap {
+		for eventToMatch := range hintMap {
+			if framework.MatchClusterEvents(eventToMatch, event) {
+				// This event is interested by some plugins.
+				return true
+			}
+		}
+	}
+
+	logger.V(6).Info("receive an event that isn't interested by any enabled plugins", "event", event)
+
+	return false
+}
+
+// isPodWorthRequeuing calls QueueingHintFn of only plugins registered in pInfo.unschedulablePlugins and pInfo.PendingPlugins.
+//
+// If any of pInfo.PendingPlugins return Queue,
+// the scheduling queue is supposed to enqueue this Pod to activeQ, skipping backoffQ.
+// If any of pInfo.unschedulablePlugins return Queue,
+// the scheduling queue is supposed to enqueue this Pod to activeQ/backoffQ depending on the remaining backoff time of the Pod.
+// If all QueueingHintFns returns Skip, the scheduling queue enqueues the Pod back to unschedulable Pod pool
+// because no plugin changes the scheduling result via the event.
+func (p *PriorityQueue) isPodWorthRequeuing(logger klog.Logger, pInfo *framework.QueuedPodInfo, event schedfwk.ClusterEvent, oldObj, newObj interface{}) queueingStrategy {
+	rejectorPlugins := pInfo.UnschedulablePlugins.Union(pInfo.PendingPlugins)
+	if rejectorPlugins.Len() == 0 {
+		logger.V(6).Info("Worth requeuing because no failed plugins", "pod", klog.KObj(pInfo.Pod))
+		return queueAfterBackoff
+	}
+
+	if framework.ClusterEventIsWildCard(event) {
+		// If the wildcard event has a Pod in newObj,
+		// that indicates that the event wants to be effective for the Pod only.
+		// Specifically, EventForceActivate could have a target Pod in newObj.
+		if newObj != nil {
+			if pod, ok := newObj.(*v1.Pod); !ok || pod.UID != pInfo.Pod.UID {
+				// This wildcard event is not for this Pod.
+				if ok {
+					logger.V(6).Info("Not worth requeuing because the event is wildcard, but for another pod", "pod", klog.KObj(pInfo.Pod), "event", event.Label(), "newObj", klog.KObj(pod))
+				}
+				return queueSkip
+			}
+		}
+
+		// If the wildcard event is special one as someone wants to force all Pods to move to activeQ/backoffQ.
+		// We return queueAfterBackoff in this case, while resetting all blocked plugins.
+		logger.V(6).Info("Worth requeuing because the event is wildcard", "pod", klog.KObj(pInfo.Pod), "event", event.Label())
+		return queueAfterBackoff
+	}
+
+	hintMap, ok := p.queueingHintMap[pInfo.Pod.Spec.SchedulerName]
+	if !ok {
+		// shouldn't reach here unless bug.
+		utilruntime.HandleErrorWithLogger(logger, nil, "No QueueingHintMap is registered for this profile", "profile", pInfo.Pod.Spec.SchedulerName, "pod", klog.KObj(pInfo.Pod))
+		return queueAfterBackoff
+	}
+
+	pod := pInfo.Pod
+	queueStrategy := queueSkip
+	for eventToMatch, hintfns := range hintMap {
+		if !framework.MatchClusterEvents(eventToMatch, event) {
+			continue
+		}
+
+		for _, hintfn := range hintfns {
+			if !rejectorPlugins.Has(hintfn.PluginName) {
+				// skip if it's not hintfn from rejectorPlugins.
+				continue
+			}
+
+			start := time.Now()
+			hint, err := hintfn.QueueingHintFn(logger, pod, oldObj, newObj)
+			if err != nil {
+				// If the QueueingHintFn returned an error, we should treat the event as Queue so that we can prevent
+				// the Pod from being stuck in the unschedulable pod pool.
+				oldObjMeta, newObjMeta, asErr := util.As[klog.KMetadata](oldObj, newObj)
+				if asErr != nil {
+					utilruntime.HandleErrorWithLogger(logger, err, "QueueingHintFn returns error", "event", event, "plugin", hintfn.PluginName, "pod", klog.KObj(pod))
+				} else {
+					utilruntime.HandleErrorWithLogger(logger, err, "QueueingHintFn returns error", "event", event, "plugin", hintfn.PluginName, "pod", klog.KObj(pod), "oldObj", klog.KObj(oldObjMeta), "newObj", klog.KObj(newObjMeta))
+				}
+				hint = schedfwk.Queue
+			}
+			p.metricsRecorder.ObserveQueueingHintDurationAsync(hintfn.PluginName, event.Label(), queueingHintToLabel(hint, err), metrics.SinceInSeconds(start))
+
+			if hint == schedfwk.QueueSkip {
+				continue
+			}
+
+			if pInfo.PendingPlugins.Has(hintfn.PluginName) {
+				// interprets Queue from the Pending plugin as queueImmediately.
+				// We can return immediately because queueImmediately is the highest priority.
+				return queueImmediately
+			}
+
+			// interprets Queue from the unschedulable plugin as queueAfterBackoff.
+
+			if pInfo.PendingPlugins.Len() == 0 {
+				// We can return immediately because no Pending plugins, which only can make queueImmediately, registered in this Pod,
+				// and queueAfterBackoff is the second highest priority.
+				return queueAfterBackoff
+			}
+
+			// We can't return immediately because there are some Pending plugins registered in this Pod.
+			// We need to check if those plugins return Queue or not and if they do, we return queueImmediately.
+			queueStrategy = queueAfterBackoff
+		}
+	}
+
+	return queueStrategy
+}
+
+// queueingHintToLabel converts a hint and an error from QHint to a label string.
+func queueingHintToLabel(hint schedfwk.QueueingHint, err error) string {
+	if err != nil {
+		return metrics.QueueingHintResultError
+	}
+
+	switch hint {
+	case schedfwk.Queue:
+		return metrics.QueueingHintResultQueue
+	case schedfwk.QueueSkip:
+		return metrics.QueueingHintResultQueueSkip
+	}
+
+	// Shouldn't reach here.
+	return ""
+}
+
+// runPreEnqueuePlugins iterates PreEnqueue function in each registered PreEnqueuePlugin,
+// and updates pInfo.GatingPlugin and pInfo.UnschedulablePlugins.
+// Note: we need to associate the failed plugin to `pInfo`, so that the pod can be moved back
+// to activeQ by related cluster event.
+func (p *PriorityQueue) runPreEnqueuePlugins(ctx context.Context, pInfo *framework.QueuedPodInfo) {
+	var s *schedfwk.Status
+	pod := pInfo.Pod
+	startTime := p.clock.Now()
+	defer func() {
+		metrics.FrameworkExtensionPointDuration.WithLabelValues(preEnqueue, s.Code().String(), pod.Spec.SchedulerName).Observe(metrics.SinceInSeconds(startTime))
+	}()
+
+	shouldRecordMetric := rand.Intn(100) < p.pluginMetricsSamplePercent
+	logger := klog.FromContext(ctx)
+	gatingPlugin := pInfo.GatingPlugin
+	if gatingPlugin != "" {
+		// Run the gating plugin first
+		s := p.runPreEnqueuePlugin(ctx, logger, p.preEnqueuePluginMap[pod.Spec.SchedulerName][gatingPlugin], pInfo, shouldRecordMetric)
+		if !s.IsSuccess() {
+			// No need to iterate other plugins
+			return
+		}
+	}
+
+	for _, pl := range p.preEnqueuePluginMap[pod.Spec.SchedulerName] {
+		if gatingPlugin != "" && pl.Name() == gatingPlugin {
+			// should be run already above.
+			continue
+		}
+		s := p.runPreEnqueuePlugin(ctx, logger, pl, pInfo, shouldRecordMetric)
+		if !s.IsSuccess() {
+			// No need to iterate other plugins
+			return
+		}
+	}
+	// all plugins passed
+	pInfo.GatingPlugin = ""
+}
+
+// runPreEnqueuePlugin runs the PreEnqueue plugin and update pInfo's fields accordingly if needed.
+func (p *PriorityQueue) runPreEnqueuePlugin(ctx context.Context, logger klog.Logger, pl internalfwk.PreEnqueuePlugin, pInfo *framework.QueuedPodInfo, shouldRecordMetric bool) *schedfwk.Status {
+	pod := pInfo.Pod
+	startTime := p.clock.Now()
+	s := pl.PreEnqueue(ctx, pod)
+	if shouldRecordMetric {
+		p.metricsRecorder.ObservePluginDurationAsync(preEnqueue, pl.Name(), s.Code().String(), p.clock.Since(startTime).Seconds())
+	}
+	if s.IsSuccess() {
+		// No need to change GatingPlugin; it's overwritten by the next PreEnqueue plugin if they gate this pod, or it's overwritten with an empty string if all PreEnqueue plugins pass.
+		return s
+	}
+	pInfo.UnschedulablePlugins.Insert(pl.Name())
+	metrics.UnschedulableReason(pl.Name(), pod.Spec.SchedulerName).Inc()
+	pInfo.GatingPlugin = pl.Name()
+	pInfo.GatingPluginEvents = p.pluginToEventsMap[pInfo.GatingPlugin]
+	if s.Code() == schedfwk.Error {
+		utilruntime.HandleErrorWithContext(ctx, s.AsError(), "Unexpected error running PreEnqueue plugin", "pod", klog.KObj(pod), "plugin", pl.Name())
+	} else {
+		logger.V(4).Info("Status after running PreEnqueue plugin", "pod", klog.KObj(pod), "plugin", pl.Name(), "status", s)
+	}
+
+	return s
+}
+
+// moveToActiveQ tries to add the pod to the active queue.
+// If the pod doesn't pass PreEnqueue plugins, it gets added to unschedulablePods instead.
+// movesFromBackoffQ should be set to true, if the pod directly moves from the backoffQ, so the PreEnqueue call can be skipped.
+// It returns a boolean flag to indicate whether the pod is added successfully.
+func (p *PriorityQueue) moveToActiveQ(logger klog.Logger, pInfo *framework.QueuedPodInfo, event string, movesFromBackoffQ bool) bool {
+	gatedBefore := pInfo.Gated()
+	// If SchedulerPopFromBackoffQ feature gate is enabled,
+	// PreEnqueue plugins were called when the pod was added to the backoffQ.
+	// Don't need to repeat it here when the pod is directly moved from the backoffQ.
+	skipPreEnqueue := p.isPopFromBackoffQEnabled && movesFromBackoffQ
+	if !skipPreEnqueue {
+		p.runPreEnqueuePlugins(context.Background(), pInfo)
+	}
+
+	added := false
+	p.activeQ.underLock(func(unlockedActiveQ unlockedActiveQueuer) {
+		if pInfo.Gated() {
+			// Add the Pod to unschedulablePods if it's not passing PreEnqueuePlugins.
+			if unlockedActiveQ.has(pInfo) {
+				return
+			}
+			if p.backoffQ.has(pInfo) {
+				return
+			}
+			if p.unschedulablePods.get(pInfo.Pod) != nil {
+				return
+			}
+			p.unschedulablePods.addOrUpdate(pInfo, event)
+			logger.V(5).Info("Pod moved to an internal scheduling queue, because the pod is gated", "pod", klog.KObj(pInfo.Pod), "event", event, "queue", unschedulableQ)
+			return
+		}
+		if pInfo.InitialAttemptTimestamp == nil {
+			now := p.clock.Now()
+			pInfo.InitialAttemptTimestamp = &now
+		}
+		p.unschedulablePods.delete(pInfo.Pod, gatedBefore)
+		p.backoffQ.delete(pInfo)
+
+		unlockedActiveQ.add(logger, pInfo, event)
+		added = true
+	})
+	return added
+}
+
+// moveToBackoffQ tries to add the pod to the backoff queue.
+// If SchedulerPopFromBackoffQ feature gate is enabled and the pod doesn't pass PreEnqueue plugins, it gets added to unschedulablePods instead.
+// It returns a boolean flag to indicate whether the pod is added successfully.
+func (p *PriorityQueue) moveToBackoffQ(logger klog.Logger, pInfo *framework.QueuedPodInfo, event string) bool {
+	gatedBefore := pInfo.Gated()
+	// If SchedulerPopFromBackoffQ feature gate is enabled,
+	// PreEnqueue plugins are called on inserting pods to the backoffQ,
+	// not to call them again on popping out.
+	if p.isPopFromBackoffQEnabled {
+		p.runPreEnqueuePlugins(context.Background(), pInfo)
+		if pInfo.Gated() {
+			if p.unschedulablePods.get(pInfo.Pod) == nil {
+				p.unschedulablePods.addOrUpdate(pInfo, event)
+				logger.V(5).Info("Pod moved to an internal scheduling queue", "pod", klog.KObj(pInfo.Pod), "event", event, "queue", unschedulableQ)
+			}
+			return false
+		}
+	}
+	p.unschedulablePods.delete(pInfo.Pod, gatedBefore)
+
+	p.backoffQ.add(logger, pInfo, event)
+	return true
+}
+
+// Add adds a pod to the active queue. It should be called only when a new pod
+// is added so there is no chance the pod is already in active/unschedulable/backoff queues
+func (p *PriorityQueue) Add(logger klog.Logger, pod *v1.Pod) {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+
+	pInfo := p.newQueuedPodInfo(pod)
+	if added := p.moveToActiveQ(logger, pInfo, framework.EventUnscheduledPodAdd.Label(), false); added {
+		p.activeQ.broadcast()
+	}
+}
+
+// Activate moves the given pods to activeQ.
+// If a pod isn't found in unschedulablePods or backoffQ and it's in-flight,
+// the wildcard event is registered so that the pod will be requeued when it comes back.
+// But, if a pod isn't found in unschedulablePods or backoffQ and it's not in-flight (i.e., completely unknown pod),
+// Activate would ignore the pod.
+func (p *PriorityQueue) Activate(logger klog.Logger, pods map[string]*v1.Pod) {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+
+	activated := false
+	for _, pod := range pods {
+		if p.activate(logger, pod) {
+			activated = true
+			continue
+		}
+
+		// If this pod is in-flight, register the activation event (for when QHint is enabled) or update moveRequestCycle (for when QHints is disabled)
+		// so that the pod will be requeued when it comes back.
+		// Specifically in the in-tree plugins, this is for the scenario with the preemption plugin
+		// where the async preemption API calls are all done or fail at some point before the Pod comes back to the queue.
+		p.activeQ.addEventsIfPodInFlight(nil, pod, []schedfwk.ClusterEvent{framework.EventForceActivate})
+		p.moveRequestCycle = p.activeQ.schedulingCycle()
+	}
+
+	if activated {
+		p.activeQ.broadcast()
+	}
+}
+
+func (p *PriorityQueue) activate(logger klog.Logger, pod *v1.Pod) bool {
+	var pInfo *framework.QueuedPodInfo
+	var movesFromBackoffQ bool
+	// Verify if the pod is present in unschedulablePods or backoffQ.
+	if pInfo = p.unschedulablePods.get(pod); pInfo == nil {
+		// If the pod doesn't belong to unschedulablePods or backoffQ, don't activate it.
+		// The pod can be already in activeQ.
+		var exists bool
+		pInfo, exists = p.backoffQ.get(newQueuedPodInfoForLookup(pod))
+		if !exists {
+			return false
+		}
+		// Delete pod from the backoffQ now to make sure it won't be popped from the backoffQ
+		// just before moving it to the activeQ
+		if deleted := p.backoffQ.delete(pInfo); !deleted {
+			// Pod was popped from the backoffQ in the meantime. Don't activate it.
+			return false
+		}
+		movesFromBackoffQ = true
+	}
+
+	if pInfo == nil {
+		// Redundant safe check. We shouldn't reach here.
+		utilruntime.HandleErrorWithLogger(logger, nil, "Internal error: cannot obtain pInfo")
+		return false
+	}
+
+	return p.moveToActiveQ(logger, pInfo, framework.ForceActivate, movesFromBackoffQ)
+}
+
+// SchedulingCycle returns current scheduling cycle.
+func (p *PriorityQueue) SchedulingCycle() int64 {
+	return p.activeQ.schedulingCycle()
+}
+
+// determineSchedulingHintForInFlightPod looks at the unschedulable plugins of the given Pod
+// and determines the scheduling hint for this Pod while checking the events that happened during in-flight.
+func (p *PriorityQueue) determineSchedulingHintForInFlightPod(logger klog.Logger, pInfo *framework.QueuedPodInfo) queueingStrategy {
+	if len(pInfo.UnschedulablePlugins) == 0 && len(pInfo.PendingPlugins) == 0 {
+		// No failed plugins are associated with this Pod.
+		// Meaning something unusual (a temporal failure on kube-apiserver, etc) happened and this Pod gets moved back to the queue.
+		// In this case, we should retry scheduling it because this Pod may not be retried until the next flush.
+		return queueAfterBackoff
+	}
+
+	events, err := p.activeQ.clusterEventsForPod(logger, pInfo)
+	if err != nil {
+		utilruntime.HandleErrorWithLogger(logger, err, "Error getting cluster events for pod", "pod", klog.KObj(pInfo.Pod))
+		return queueAfterBackoff
+	}
+
+	// check if there is an event that makes this Pod schedulable based on pInfo.UnschedulablePlugins.
+	queueingStrategy := queueSkip
+	for _, e := range events {
+		logger.V(5).Info("Checking event for in-flight pod", "pod", klog.KObj(pInfo.Pod), "event", e.event.Label())
+
+		switch p.isPodWorthRequeuing(logger, pInfo, e.event, e.oldObj, e.newObj) {
+		case queueSkip:
+			continue
+		case queueImmediately:
+			// queueImmediately is the highest priority.
+			// No need to go through the rest of the events.
+			return queueImmediately
+		case queueAfterBackoff:
+			// replace schedulingHint with queueAfterBackoff
+			queueingStrategy = queueAfterBackoff
+			if pInfo.PendingPlugins.Len() == 0 {
+				// We can return immediately because no Pending plugins, which only can make queueImmediately, registered in this Pod,
+				// and queueAfterBackoff is the second highest priority.
+				return queueAfterBackoff
+			}
+		}
+	}
+	return queueingStrategy
+}
+
+// addUnschedulableWithoutQueueingHint inserts a pod that cannot be scheduled into
+// the queue, unless it is already in the queue. Normally, PriorityQueue puts
+// unschedulable pods in `unschedulablePods`. But if there has been a recent move
+// request, then the pod is put in `backoffQ`.
+// TODO: This function is called only when p.isSchedulingQueueHintEnabled is false,
+// and this will be removed after SchedulingQueueHint goes to stable and the feature gate is removed.
+func (p *PriorityQueue) addUnschedulableWithoutQueueingHint(logger klog.Logger, pInfo *framework.QueuedPodInfo, podSchedulingCycle int64) error {
+	pod := pInfo.Pod
+
+	// When the queueing hint is enabled, they are used differently.
+	// But, we use all of them as UnschedulablePlugins when the queueing hint isn't enabled so that we don't break the old behaviour.
+	rejectorPlugins := pInfo.UnschedulablePlugins.Union(pInfo.PendingPlugins)
+
+	// If a move request has been received, move it to the BackoffQ, otherwise move
+	// it to unschedulablePods.
+	for plugin := range rejectorPlugins {
+		metrics.UnschedulableReason(plugin, pInfo.Pod.Spec.SchedulerName).Inc()
+	}
+	if p.moveRequestCycle >= podSchedulingCycle || len(rejectorPlugins) == 0 {
+		// Two cases to move a Pod to the active/backoff queue:
+		// - The Pod is rejected by some plugins, but a move request is received after this Pod's scheduling cycle is started.
+		//   In this case, the received event may be make Pod schedulable and we should retry scheduling it.
+		// - No unschedulable plugins are associated with this Pod,
+		//   meaning something unusual (a temporal failure on kube-apiserver, etc) happened and this Pod gets moved back to the queue.
+		//   In this case, we should retry scheduling it because this Pod may not be retried until the next flush.
+		if added := p.moveToBackoffQ(logger, pInfo, framework.ScheduleAttemptFailure); added {
+			if p.isPopFromBackoffQEnabled {
+				p.activeQ.broadcast()
+			}
+		}
+	} else {
+		p.unschedulablePods.addOrUpdate(pInfo, framework.ScheduleAttemptFailure)
+		logger.V(5).Info("Pod moved to an internal scheduling queue", "pod", klog.KObj(pod), "event", framework.ScheduleAttemptFailure, "queue", unschedulableQ)
+	}
+
+	return nil
+}
+
+// AddUnschedulableIfNotPresent inserts a pod that cannot be scheduled into
+// the queue, unless it is already in the queue. Normally, PriorityQueue puts
+// unschedulable pods in `unschedulablePods`. But if there has been a recent move
+// request, then the pod is put in `backoffQ`.
+func (p *PriorityQueue) AddUnschedulableIfNotPresent(logger klog.Logger, pInfo *framework.QueuedPodInfo, podSchedulingCycle int64) error {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+
+	// In any case, this Pod will be moved back to the queue and we should call Done.
+	defer p.Done(pInfo.Pod.UID)
+
+	pod := pInfo.Pod
+	if p.unschedulablePods.get(pod) != nil {
+		return fmt.Errorf("Pod %v is already present in unschedulable queue", klog.KObj(pod))
+	}
+
+	if p.activeQ.has(pInfo) {
+		return fmt.Errorf("Pod %v is already present in the active queue", klog.KObj(pod))
+	}
+	if p.backoffQ.has(pInfo) {
+		return fmt.Errorf("Pod %v is already present in the backoff queue", klog.KObj(pod))
+	}
+
+	if len(pInfo.UnschedulablePlugins) == 0 && len(pInfo.PendingPlugins) == 0 {
+		// This Pod came back because of some unexpected errors (e.g., a network issue).
+		pInfo.ConsecutiveErrorsCount++
+	} else {
+		// This Pod is rejected by some plugins, not coming back due to unexpected errors (e.g., a network issue)
+		pInfo.UnschedulableCount++
+		// We should reset the error count because the error is gone.
+		pInfo.ConsecutiveErrorsCount = 0
+	}
+	// Refresh the timestamp since the pod is re-added.
+	pInfo.Timestamp = p.clock.Now()
+	// We changed ConsecutiveErrorsCount or UnschedulableCount plus Timestamp, and now the calculated backoff time should be different,
+	// removing the cached backoff time.
+	pInfo.BackoffExpiration = time.Time{}
+
+	if !p.isSchedulingQueueHintEnabled {
+		// fall back to the old behavior which doesn't depend on the queueing hint.
+		return p.addUnschedulableWithoutQueueingHint(logger, pInfo, podSchedulingCycle)
+	}
+
+	// If a move request has been received, move it to the BackoffQ, otherwise move
+	// it to unschedulablePods.
+	rejectorPlugins := pInfo.UnschedulablePlugins.Union(pInfo.PendingPlugins)
+	for plugin := range rejectorPlugins {
+		metrics.UnschedulableReason(plugin, pInfo.Pod.Spec.SchedulerName).Inc()
+	}
+
+	// We check whether this Pod may change its scheduling result by any of events that happened during scheduling.
+	schedulingHint := p.determineSchedulingHintForInFlightPod(logger, pInfo)
+
+	// In this case, we try to requeue this Pod to activeQ/backoffQ.
+	queue := p.requeuePodWithQueueingStrategy(logger, pInfo, schedulingHint, framework.ScheduleAttemptFailure)
+	logger.V(3).Info("Pod moved to an internal scheduling queue", "pod", klog.KObj(pod), "event", framework.ScheduleAttemptFailure, "queue", queue, "schedulingCycle", podSchedulingCycle, "hint", schedulingHint, "unschedulable plugins", rejectorPlugins)
+	if queue == activeQ || (p.isPopFromBackoffQEnabled && queue == backoffQ) {
+		// When the Pod is moved to activeQ, need to let p.cond know so that the Pod will be pop()ed out.
+		p.activeQ.broadcast()
+	}
+
+	return nil
+}
+
+// flushBackoffQCompleted Moves all pods from backoffQ which have completed backoff in to activeQ
+func (p *PriorityQueue) flushBackoffQCompleted(logger klog.Logger) {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+	activated := false
+	podsCompletedBackoff := p.backoffQ.popAllBackoffCompleted(logger)
+	for _, pInfo := range podsCompletedBackoff {
+		if added := p.moveToActiveQ(logger, pInfo, framework.BackoffComplete, true); added {
+			activated = true
+		}
+	}
+	if activated {
+		p.activeQ.broadcast()
+	}
+}
+
+// flushUnschedulablePodsLeftover moves pods which stay in unschedulablePods
+// longer than podMaxInUnschedulablePodsDuration to backoffQ or activeQ.
+func (p *PriorityQueue) flushUnschedulablePodsLeftover(logger klog.Logger) {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+
+	var podsToMove []*framework.QueuedPodInfo
+	currentTime := p.clock.Now()
+	for _, pInfo := range p.unschedulablePods.podInfoMap {
+		lastScheduleTime := pInfo.Timestamp
+		if currentTime.Sub(lastScheduleTime) > p.podMaxInUnschedulablePodsDuration {
+			podsToMove = append(podsToMove, pInfo)
+		}
+	}
+
+	if len(podsToMove) > 0 {
+		p.movePodsToActiveOrBackoffQueue(logger, podsToMove, framework.EventUnschedulableTimeout, nil, nil)
+	}
+}
+
+// Pop removes the head of the active queue and returns it. It blocks if the
+// activeQ is empty and waits until a new item is added to the queue. It
+// increments scheduling cycle when a pod is popped.
+// Note: This method should NOT be locked by the p.lock at any moment,
+// as it would lead to scheduling throughput degradation.
+func (p *PriorityQueue) Pop(logger klog.Logger) (*framework.QueuedPodInfo, error) {
+	return p.activeQ.pop(logger)
+}
+
+// Done must be called for pod returned by Pop. This allows the queue to
+// keep track of which pods are currently being processed.
+func (p *PriorityQueue) Done(pod types.UID) {
+	if !p.isSchedulingQueueHintEnabled {
+		// do nothing if schedulingQueueHint is disabled.
+		// In that case, we don't have inFlightPods and inFlightEvents.
+		return
+	}
+	p.activeQ.done(pod)
+}
+
+func (p *PriorityQueue) InFlightPods() []*v1.Pod {
+	if !p.isSchedulingQueueHintEnabled {
+		// do nothing if schedulingQueueHint is disabled.
+		// In that case, we don't have inFlightPods and inFlightEvents.
+		return nil
+	}
+	return p.activeQ.listInFlightPods()
+}
+
+// isPodUpdated checks if the pod is updated in a way that it may have become
+// schedulable. It drops status of the pod and compares it with old version,
+// except for pod.status.resourceClaimStatuses and
+// pod.status.extendedResourceClaimStatus: changing that may have an
+// effect on scheduling.
+func isPodUpdated(oldPod, newPod *v1.Pod) bool {
+	strip := func(pod *v1.Pod) *v1.Pod {
+		p := pod.DeepCopy()
+		p.ResourceVersion = ""
+		p.Generation = 0
+		p.Status = v1.PodStatus{
+			ResourceClaimStatuses:       pod.Status.ResourceClaimStatuses,
+			ExtendedResourceClaimStatus: pod.Status.ExtendedResourceClaimStatus,
+		}
+		p.ManagedFields = nil
+		p.Finalizers = nil
+		return p
+	}
+	return !reflect.DeepEqual(strip(oldPod), strip(newPod))
+}
+
+// Update updates a pod in the active or backoff queue if present. Otherwise, it removes
+// the item from the unschedulable queue if pod is updated in a way that it may
+// become schedulable and adds the updated one to the active queue.
+// If pod is not present in any of the queues, it is added to the active queue.
+func (p *PriorityQueue) Update(logger klog.Logger, oldPod, newPod *v1.Pod) {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+
+	var events []schedfwk.ClusterEvent
+	if p.isSchedulingQueueHintEnabled {
+		events = framework.PodSchedulingPropertiesChange(newPod, oldPod)
+	}
+
+	updated := false
+	// Run the following code under the activeQ lock to make sure that in the meantime pod is not popped from either activeQ or backoffQ.
+	// This way, the event will be registered or the pod will be updated consistently.
+	// Locking only the part of Update method is sufficient, because in the other part the pod is in the unscheduledPods
+	// which is protected by p.lock anyway.
+	p.activeQ.underLock(func(unlockedActiveQ unlockedActiveQueuer) {
+		if p.isSchedulingQueueHintEnabled {
+			// The inflight pod will be requeued using the latest version from the informer cache, which matches what the event delivers.
+			// Record this Pod update because
+			// this update may make the Pod schedulable in case it gets rejected and comes back to the queue.
+			// We can clean it up once we change updatePodInSchedulingQueue to call MoveAllToActiveOrBackoffQueue.
+			// See https://github.com/kubernetes/kubernetes/pull/125578#discussion_r1648338033 for more context.
+			if exists := unlockedActiveQ.addEventsIfPodInFlight(oldPod, newPod, events); exists {
+				logger.V(6).Info("The pod doesn't need to be queued for now because it's being scheduled and will be queued back if necessary", "pod", klog.KObj(newPod))
+				updated = true
+				return
+			}
+		}
+		if oldPod != nil {
+			oldPodInfo := newQueuedPodInfoForLookup(oldPod)
+			// If the pod is already in the active queue, just update it there.
+			if pInfo := unlockedActiveQ.update(newPod, oldPodInfo); pInfo != nil {
+				updated = true
+				return
+			}
+
+			// If the pod is in the backoff queue, update it there.
+			if pInfo := p.backoffQ.update(newPod, oldPodInfo); pInfo != nil {
+				updated = true
+				return
+			}
+		}
+	})
+	if updated {
+		return
+	}
+
+	// If the pod is in the unschedulable queue, updating it may make it schedulable.
+	if pInfo := p.unschedulablePods.get(newPod); pInfo != nil {
+		_ = pInfo.Update(newPod)
+		if p.isSchedulingQueueHintEnabled {
+			// When unscheduled Pods are updated, we check with QueueingHint
+			// whether the update may make the pods schedulable.
+			// Plugins have to implement a QueueingHint for Pod/Update event
+			// if the rejection from them could be resolved by updating unscheduled Pods itself.
+			for _, evt := range events {
+				hint := p.isPodWorthRequeuing(logger, pInfo, evt, oldPod, newPod)
+				queue := p.requeuePodWithQueueingStrategy(logger, pInfo, hint, evt.Label())
+				if queue != unschedulableQ {
+					logger.V(5).Info("Pod moved to an internal scheduling queue because the Pod is updated", "pod", klog.KObj(newPod), "event", evt.Label(), "queue", queue)
+				}
+				if queue == activeQ || (p.isPopFromBackoffQEnabled && queue == backoffQ) {
+					p.activeQ.broadcast()
+					break
+				}
+			}
+			return
+		}
+		if isPodUpdated(oldPod, newPod) {
+			// Pod might have completed its backoff time while being in unschedulablePods,
+			// so we should check isPodBackingoff before moving the pod to backoffQ.
+			if p.backoffQ.isPodBackingoff(pInfo) {
+				if added := p.moveToBackoffQ(logger, pInfo, framework.EventUnscheduledPodUpdate.Label()); added {
+					if p.isPopFromBackoffQEnabled {
+						p.activeQ.broadcast()
+					}
+				}
+				return
+			}
+
+			if added := p.moveToActiveQ(logger, pInfo, framework.EventUnscheduledPodUpdate.Label(), false); added {
+				p.activeQ.broadcast()
+			}
+			return
+		}
+
+		// Pod update didn't make it schedulable, keep it in the unschedulable queue.
+		p.unschedulablePods.addOrUpdate(pInfo, framework.EventUnscheduledPodUpdate.Label())
+		return
+	}
+	// If pod is not in any of the queues, we put it in the active queue.
+	pInfo := p.newQueuedPodInfo(newPod)
+	if added := p.moveToActiveQ(logger, pInfo, framework.EventUnscheduledPodUpdate.Label(), false); added {
+		p.activeQ.broadcast()
+	}
+}
+
+// Delete deletes the item from either of the two queues. It assumes the pod is
+// only in one queue.
+func (p *PriorityQueue) Delete(pod *v1.Pod) {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+	pInfo := newQueuedPodInfoForLookup(pod)
+	if err := p.activeQ.delete(pInfo); err == nil {
+		return
+	}
+	if deleted := p.backoffQ.delete(pInfo); deleted {
+		return
+	}
+	if pInfo = p.unschedulablePods.get(pod); pInfo != nil {
+		p.unschedulablePods.delete(pod, pInfo.Gated())
+	}
+}
+
+// AssignedPodAdded is called when a bound pod is added. Creation of this pod
+// may make pending pods with matching affinity terms schedulable.
+func (p *PriorityQueue) AssignedPodAdded(logger klog.Logger, pod *v1.Pod) {
+	p.lock.Lock()
+
+	// Pre-filter Pods to move by getUnschedulablePodsWithCrossTopologyTerm
+	// because Pod related events shouldn't make Pods that rejected by single-node scheduling requirement schedulable.
+	p.movePodsToActiveOrBackoffQueue(logger, p.getUnschedulablePodsWithCrossTopologyTerm(logger, pod), framework.EventAssignedPodAdd, nil, pod)
+	p.lock.Unlock()
+}
+
+// AssignedPodUpdated is called when a bound pod is updated. Change of labels
+// may make pending pods with matching affinity terms schedulable.
+func (p *PriorityQueue) AssignedPodUpdated(logger klog.Logger, oldPod, newPod *v1.Pod, event schedfwk.ClusterEvent) {
+	p.lock.Lock()
+	if (framework.MatchClusterEvents(schedfwk.ClusterEvent{Resource: schedfwk.Pod, ActionType: schedfwk.UpdatePodScaleDown}, event)) {
+		// In this case, we don't want to pre-filter Pods by getUnschedulablePodsWithCrossTopologyTerm
+		// because Pod related events may make Pods that were rejected by NodeResourceFit schedulable.
+		p.moveAllToActiveOrBackoffQueue(logger, event, oldPod, newPod, nil)
+	} else {
+		// Pre-filter Pods to move by getUnschedulablePodsWithCrossTopologyTerm
+		// because Pod related events only make Pods rejected by cross topology term schedulable.
+		p.movePodsToActiveOrBackoffQueue(logger, p.getUnschedulablePodsWithCrossTopologyTerm(logger, newPod), event, oldPod, newPod)
+	}
+	p.lock.Unlock()
+}
+
+// NOTE: this function assumes a lock has been acquired in the caller.
+// moveAllToActiveOrBackoffQueue moves all pods from unschedulablePods to activeQ or backoffQ.
+// This function adds all pods and then signals the condition variable to ensure that
+// if Pop() is waiting for an item, it receives the signal after all the pods are in the
+// queue and the head is the highest priority pod.
+func (p *PriorityQueue) moveAllToActiveOrBackoffQueue(logger klog.Logger, event schedfwk.ClusterEvent, oldObj, newObj interface{}, preCheck PreEnqueueCheck) {
+	if !p.isEventOfInterest(logger, event) {
+		// No plugin is interested in this event.
+		// Return early before iterating all pods in unschedulablePods for preCheck.
+		return
+	}
+
+	unschedulablePods := make([]*framework.QueuedPodInfo, 0, len(p.unschedulablePods.podInfoMap))
+	for _, pInfo := range p.unschedulablePods.podInfoMap {
+		if preCheck == nil || preCheck(pInfo.Pod) {
+			unschedulablePods = append(unschedulablePods, pInfo)
+		}
+	}
+	p.movePodsToActiveOrBackoffQueue(logger, unschedulablePods, event, oldObj, newObj)
+}
+
+// MoveAllToActiveOrBackoffQueue moves all pods from unschedulablePods to activeQ or backoffQ.
+// This function adds all pods and then signals the condition variable to ensure that
+// if Pop() is waiting for an item, it receives the signal after all the pods are in the
+// queue and the head is the highest priority pod.
+func (p *PriorityQueue) MoveAllToActiveOrBackoffQueue(logger klog.Logger, event schedfwk.ClusterEvent, oldObj, newObj interface{}, preCheck PreEnqueueCheck) {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+	p.moveAllToActiveOrBackoffQueue(logger, event, oldObj, newObj, preCheck)
+}
+
+// requeuePodWithQueueingStrategy tries to requeue Pod to activeQ, backoffQ or unschedulable pod pool based on schedulingHint.
+// It returns the queue name Pod goes.
+//
+// NOTE: this function assumes lock has been acquired in caller
+func (p *PriorityQueue) requeuePodWithQueueingStrategy(logger klog.Logger, pInfo *framework.QueuedPodInfo, strategy queueingStrategy, event string) string {
+	if strategy == queueSkip {
+		p.unschedulablePods.addOrUpdate(pInfo, event)
+		return unschedulableQ
+	}
+
+	// Pod might have completed its backoff time while being in unschedulablePods,
+	// so we should check isPodBackingoff before moving the pod to backoffQ.
+	if strategy == queueAfterBackoff && p.backoffQ.isPodBackingoff(pInfo) {
+		if added := p.moveToBackoffQ(logger, pInfo, event); added {
+			return backoffQ
+		}
+		return unschedulableQ
+	}
+
+	// Reach here if schedulingHint is QueueImmediately, or schedulingHint is Queue but the pod is not backing off.
+	if added := p.moveToActiveQ(logger, pInfo, event, false); added {
+		return activeQ
+	}
+	// Pod is gated. We don't have to push it back to unschedulable queue, because moveToActiveQ should already have done that.
+	return unschedulableQ
+}
+
+// NOTE: this function assumes lock has been acquired in caller
+func (p *PriorityQueue) movePodsToActiveOrBackoffQueue(logger klog.Logger, podInfoList []*framework.QueuedPodInfo, event schedfwk.ClusterEvent, oldObj, newObj interface{}) {
+	if !p.isEventOfInterest(logger, event) {
+		// No plugin is interested in this event.
+		return
+	}
+
+	activated := false
+	for _, pInfo := range podInfoList {
+		if pInfo.Gated() && !framework.MatchAnyClusterEvent(event, pInfo.GatingPluginEvents) {
+			// This event doesn't interest the gating plugin of this Pod,
+			// which means this event never moves this Pod to activeQ.
+			continue
+		}
+
+		schedulingHint := p.isPodWorthRequeuing(logger, pInfo, event, oldObj, newObj)
+		if schedulingHint == queueSkip {
+			// QueueingHintFn determined that this Pod isn't worth putting to activeQ or backoffQ by this event.
+			logger.V(5).Info("Event is not making pod schedulable", "pod", klog.KObj(pInfo.Pod), "event", event.Label())
+			continue
+		}
+
+		p.unschedulablePods.delete(pInfo.Pod, pInfo.Gated())
+		queue := p.requeuePodWithQueueingStrategy(logger, pInfo, schedulingHint, event.Label())
+		if queue == activeQ || (p.isPopFromBackoffQEnabled && queue == backoffQ) {
+			activated = true
+		}
+	}
+
+	p.moveRequestCycle = p.activeQ.schedulingCycle()
+
+	if p.isSchedulingQueueHintEnabled {
+		// AddUnschedulableIfNotPresent might get called for in-flight Pods later, and in
+		// AddUnschedulableIfNotPresent we need to know whether events were
+		// observed while scheduling them.
+		if added := p.activeQ.addEventIfAnyInFlight(oldObj, newObj, event); added {
+			logger.V(5).Info("Event received while pods are in flight", "event", event.Label())
+		}
+	}
+
+	if activated {
+		p.activeQ.broadcast()
+	}
+}
+
+// getUnschedulablePodsWithCrossTopologyTerm returns unschedulable pods which either of following conditions is met:
+// - have any affinity term that matches "pod".
+// - rejected by PodTopologySpread plugin.
+// NOTE: this function assumes lock has been acquired in caller.
+func (p *PriorityQueue) getUnschedulablePodsWithCrossTopologyTerm(logger klog.Logger, pod *v1.Pod) []*framework.QueuedPodInfo {
+	nsLabels := interpodaffinity.GetNamespaceLabelsSnapshot(logger, pod.Namespace, p.nsLister)
+
+	var podsToMove []*framework.QueuedPodInfo
+	for _, pInfo := range p.unschedulablePods.podInfoMap {
+		if pInfo.UnschedulablePlugins.Has(podtopologyspread.Name) && pod.Namespace == pInfo.Pod.Namespace {
+			// This Pod may be schedulable now by this Pod event.
+			podsToMove = append(podsToMove, pInfo)
+			continue
+		}
+
+		for _, term := range pInfo.RequiredAffinityTerms {
+			if term.Matches(pod, nsLabels) {
+				podsToMove = append(podsToMove, pInfo)
+				break
+			}
+		}
+	}
+
+	return podsToMove
+}
+
+// PodsInActiveQ returns all the Pods in the activeQ.
+func (p *PriorityQueue) PodsInActiveQ() []*v1.Pod {
+	return p.activeQ.list()
+}
+
+// PodsInBackoffQ returns all the Pods in the backoffQ.
+func (p *PriorityQueue) PodsInBackoffQ() []*v1.Pod {
+	return p.backoffQ.list()
+}
+
+// UnschedulablePods returns all the pods in unschedulable state.
+func (p *PriorityQueue) UnschedulablePods() []*v1.Pod {
+	var result []*v1.Pod
+	for _, pInfo := range p.unschedulablePods.podInfoMap {
+		result = append(result, pInfo.Pod)
+	}
+	return result
+}
+
+var pendingPodsSummary = "activeQ:%v; backoffQ:%v; unschedulablePods:%v"
+
+// GetPod searches for a pod in the activeQ, backoffQ, and unschedulablePods.
+func (p *PriorityQueue) GetPod(name, namespace string) (pInfo *framework.QueuedPodInfo, ok bool) {
+	p.lock.RLock()
+	defer p.lock.RUnlock()
+
+	pInfoLookup := &framework.QueuedPodInfo{
+		PodInfo: &framework.PodInfo{
+			Pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      name,
+					Namespace: namespace,
+				},
+			},
+		},
+	}
+	if pInfo, ok = p.backoffQ.get(pInfoLookup); ok {
+		return pInfo, true
+	}
+	if pInfo = p.unschedulablePods.get(pInfoLookup.Pod); pInfo != nil {
+		return pInfo, true
+	}
+
+	p.activeQ.underRLock(func(unlockedActiveQ unlockedActiveQueueReader) {
+		pInfo, ok = unlockedActiveQ.get(pInfoLookup)
+	})
+	return
+}
+
+// PendingPods returns all the pending pods in the queue; accompanied by a debugging string
+// recording showing the number of pods in each queue respectively.
+// This function is used for debugging purposes in the scheduler cache dumper and comparer.
+func (p *PriorityQueue) PendingPods() ([]*v1.Pod, string) {
+	p.lock.RLock()
+	defer p.lock.RUnlock()
+	result := p.PodsInActiveQ()
+	activeQLen := len(result)
+	backoffQPods := p.PodsInBackoffQ()
+	backoffQLen := len(backoffQPods)
+	result = append(result, backoffQPods...)
+	for _, pInfo := range p.unschedulablePods.podInfoMap {
+		result = append(result, pInfo.Pod)
+	}
+	return result, fmt.Sprintf(pendingPodsSummary, activeQLen, backoffQLen, len(p.unschedulablePods.podInfoMap))
+}
+
+// PatchPodStatus handles the pod status update by sending an update API call through API dispatcher.
+// This method should be used only if the SchedulerAsyncAPICalls feature gate is enabled.
+func (p *PriorityQueue) PatchPodStatus(pod *v1.Pod, condition *v1.PodCondition, nominatingInfo *internalfwk.NominatingInfo) (<-chan error, error) {
+	// Don't store anything in the cache. This might be extended in the next releases.
+	onFinish := make(chan error, 1)
+	err := p.apiDispatcher.Add(apicalls.Implementations.PodStatusPatch(pod, condition, nominatingInfo), schedfwk.APICallOptions{
+		OnFinish: onFinish,
+	})
+	if schedfwk.IsUnexpectedError(err) {
+		return onFinish, err
+	}
+	return onFinish, nil
+}
+
+// Close closes the priority queue.
+func (p *PriorityQueue) Close() {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+	close(p.stop)
+	p.activeQ.close()
+	p.activeQ.broadcast()
+}
+
+// newQueuedPodInfo builds a QueuedPodInfo object.
+func (p *PriorityQueue) newQueuedPodInfo(pod *v1.Pod, plugins ...string) *framework.QueuedPodInfo {
+	now := p.clock.Now()
+	// ignore this err since apiserver doesn't properly validate affinity terms
+	// and we can't fix the validation for backwards compatibility.
+	podInfo, _ := framework.NewPodInfo(pod)
+	return &framework.QueuedPodInfo{
+		PodInfo:                 podInfo,
+		Timestamp:               now,
+		InitialAttemptTimestamp: nil,
+		UnschedulablePlugins:    sets.New(plugins...),
+	}
+}
+
+func podInfoKeyFunc(pInfo *framework.QueuedPodInfo) string {
+	return cache.NewObjectName(pInfo.Pod.Namespace, pInfo.Pod.Name).String()
+}

--- a/third_party/kubernetes/pkg/scheduler/backend/queue/scheduling_queue_test.go
+++ b/third_party/kubernetes/pkg/scheduler/backend/queue/scheduling_queue_test.go
@@ -1,0 +1,4202 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package queue
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/version"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
+	"k8s.io/component-base/metrics/testutil"
+	"k8s.io/klog/v2"
+	"k8s.io/klog/v2/ktesting"
+	fwk "k8s.io/kube-scheduler/framework"
+	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
+	"k8s.io/kubernetes/pkg/features"
+	"k8s.io/kubernetes/pkg/scheduler/framework"
+	internalfwk "k8s.io/kubernetes/pkg/scheduler/framework"
+	plfeature "k8s.io/kubernetes/pkg/scheduler/framework/plugins/feature"
+	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/names"
+	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/queuesort"
+	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/schedulinggates"
+	"k8s.io/kubernetes/pkg/scheduler/metrics"
+	st "k8s.io/kubernetes/pkg/scheduler/testing"
+	testingclock "k8s.io/utils/clock/testing"
+)
+
+const queueMetricMetadata = `
+		# HELP scheduler_queue_incoming_pods_total [STABLE] Number of pods added to scheduling queues by event and queue type.
+		# TYPE scheduler_queue_incoming_pods_total counter
+	`
+
+var (
+	// nodeAdd is the event when a new node is added to the cluster.
+	nodeAdd = fwk.ClusterEvent{Resource: fwk.Node, ActionType: fwk.Add}
+	// pvAdd is the event when a persistent volume is added in the cluster.
+	pvAdd = fwk.ClusterEvent{Resource: fwk.PersistentVolume, ActionType: fwk.Add}
+	// pvUpdate is the event when a persistent volume is updated in the cluster.
+	pvUpdate = fwk.ClusterEvent{Resource: fwk.PersistentVolume, ActionType: fwk.Update}
+	// pvcAdd is the event when a persistent volume claim is added in the cluster.
+	pvcAdd = fwk.ClusterEvent{Resource: fwk.PersistentVolumeClaim, ActionType: fwk.Add}
+	// csiNodeUpdate is the event when a CSI node is updated in the cluster.
+	csiNodeUpdate = fwk.ClusterEvent{Resource: fwk.CSINode, ActionType: fwk.Update}
+
+	lowPriority, midPriority, highPriority = int32(0), int32(100), int32(1000)
+	mediumPriority                         = (lowPriority + highPriority) / 2
+
+	highPriorityPodInfo = mustNewPodInfo(
+		st.MakePod().Name("hpp").Namespace("ns1").UID("hppns1").Priority(highPriority).Obj(),
+	)
+	highPriNominatedPodInfo = mustNewPodInfo(
+		st.MakePod().Name("hpp").Namespace("ns1").UID("hppns1").Priority(highPriority).NominatedNodeName("node1").Obj(),
+	)
+	medPriorityPodInfo = mustNewPodInfo(
+		st.MakePod().Name("mpp").Namespace("ns2").UID("mppns2").Annotation("annot2", "val2").Priority(mediumPriority).NominatedNodeName("node1").Obj(),
+	)
+	unschedulablePodInfo = mustNewPodInfo(
+		st.MakePod().Name("up").Namespace("ns1").UID("upns1").Annotation("annot2", "val2").Priority(lowPriority).NominatedNodeName("node1").Condition(v1.PodScheduled, v1.ConditionFalse, v1.PodReasonUnschedulable).Obj(),
+	)
+	nonExistentPodInfo = mustNewPodInfo(
+		st.MakePod().Name("ne").Namespace("ns1").UID("nens1").Obj(),
+	)
+	scheduledPodInfo = mustNewPodInfo(
+		st.MakePod().Name("sp").Namespace("ns1").UID("spns1").Node("foo").Obj(),
+	)
+
+	queueHintReturnQueue = func(logger klog.Logger, pod *v1.Pod, oldObj, newObj interface{}) (fwk.QueueingHint, error) {
+		return fwk.Queue, nil
+	}
+	queueHintReturnSkip = func(logger klog.Logger, pod *v1.Pod, oldObj, newObj interface{}) (fwk.QueueingHint, error) {
+		return fwk.QueueSkip, nil
+	}
+)
+
+func init() {
+	metrics.Register()
+}
+
+func setQueuedPodInfoGated(queuedPodInfo *framework.QueuedPodInfo, gatingPlugin string, gatingPluginEvents []fwk.ClusterEvent) *framework.QueuedPodInfo {
+	queuedPodInfo.GatingPlugin = gatingPlugin
+	// GatingPlugin should also be registered in UnschedulablePlugins.
+	queuedPodInfo.UnschedulablePlugins = sets.New(gatingPlugin)
+	queuedPodInfo.GatingPluginEvents = gatingPluginEvents
+	return queuedPodInfo
+}
+
+func getUnschedulablePod(p *PriorityQueue, pod *v1.Pod) *v1.Pod {
+	pInfo := p.unschedulablePods.get(pod)
+	if pInfo != nil {
+		return pInfo.Pod
+	}
+	return nil
+}
+
+// makeEmptyQueueingHintMapPerProfile initializes an empty QueueingHintMapPerProfile for "" profile name.
+func makeEmptyQueueingHintMapPerProfile() QueueingHintMapPerProfile {
+	m := make(QueueingHintMapPerProfile)
+	m[""] = make(QueueingHintMap)
+	return m
+}
+
+func TestPriorityQueue_Add(t *testing.T) {
+	objs := []runtime.Object{medPriorityPodInfo.Pod, unschedulablePodInfo.Pod, highPriorityPodInfo.Pod}
+	logger, ctx := ktesting.NewTestContext(t)
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	q := NewTestQueueWithObjects(ctx, newDefaultQueueSort(), objs)
+	q.Add(logger, medPriorityPodInfo.Pod)
+	q.Add(logger, unschedulablePodInfo.Pod)
+	q.Add(logger, highPriorityPodInfo.Pod)
+	if p, err := q.Pop(logger); err != nil || p.Pod != highPriorityPodInfo.Pod {
+		t.Errorf("Expected: %v after Pop, but got: %v", highPriorityPodInfo.Pod.Name, p.Pod.Name)
+	}
+	if p, err := q.Pop(logger); err != nil || p.Pod != medPriorityPodInfo.Pod {
+		t.Errorf("Expected: %v after Pop, but got: %v", medPriorityPodInfo.Pod.Name, p.Pod.Name)
+	}
+	if p, err := q.Pop(logger); err != nil || p.Pod != unschedulablePodInfo.Pod {
+		t.Errorf("Expected: %v after Pop, but got: %v", unschedulablePodInfo.Pod.Name, p.Pod.Name)
+	}
+}
+
+func newDefaultQueueSort() internalfwk.LessFunc {
+	sort := &queuesort.PrioritySort{}
+	return sort.Less
+}
+
+func TestPriorityQueue_AddWithReversePriorityLessFunc(t *testing.T) {
+	objs := []runtime.Object{medPriorityPodInfo.Pod, highPriorityPodInfo.Pod}
+	logger, ctx := ktesting.NewTestContext(t)
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	q := NewTestQueueWithObjects(ctx, newDefaultQueueSort(), objs)
+	q.Add(logger, medPriorityPodInfo.Pod)
+	q.Add(logger, highPriorityPodInfo.Pod)
+	if p, err := q.Pop(logger); err != nil || p.Pod != highPriorityPodInfo.Pod {
+		t.Errorf("Expected: %v after Pop, but got: %v", highPriorityPodInfo.Pod.Name, p.Pod.Name)
+	}
+	if p, err := q.Pop(logger); err != nil || p.Pod != medPriorityPodInfo.Pod {
+		t.Errorf("Expected: %v after Pop, but got: %v", medPriorityPodInfo.Pod.Name, p.Pod.Name)
+	}
+}
+
+func Test_InFlightPods(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
+	pod1 := st.MakePod().Name("targetpod").UID("pod1").Obj()
+	pod2 := st.MakePod().Name("targetpod2").UID("pod2").Obj()
+	pod3 := st.MakePod().Name("targetpod3").UID("pod3").Obj()
+	var poppedPod, poppedPod2 *framework.QueuedPodInfo
+
+	type action struct {
+		// ONLY ONE of the following should be set.
+		eventHappens *fwk.ClusterEvent
+		podPopped    *v1.Pod
+		// podCreated is the Pod that is created and inserted into the activeQ.
+		podCreated *v1.Pod
+		// podEnqueued is the Pod that is enqueued back to activeQ.
+		podEnqueued *framework.QueuedPodInfo
+		callback    func(t *testing.T, q *PriorityQueue)
+	}
+
+	tests := []struct {
+		name            string
+		queueingHintMap QueueingHintMapPerProfile
+		// initialPods is the initial Pods in the activeQ.
+		initialPods                  []*v1.Pod
+		actions                      []action
+		wantInFlightPods             []*v1.Pod
+		wantInFlightEvents           []interface{}
+		wantActiveQPodNames          []string
+		wantBackoffQPodNames         []string
+		wantUnschedPodPoolPodNames   []string
+		isSchedulingQueueHintEnabled bool
+	}{
+		{
+			name:        "when SchedulingQueueHint is disabled, inFlightPods and inFlightEvents should be empty",
+			initialPods: []*v1.Pod{pod1},
+			actions: []action{
+				// This Pod shouldn't be added to inFlightPods because SchedulingQueueHint is disabled.
+				{podPopped: pod1},
+				// This event shouldn't be added to inFlightEvents because SchedulingQueueHint is disabled.
+				{eventHappens: &pvAdd},
+			},
+			wantInFlightPods:   nil,
+			wantInFlightEvents: nil,
+			queueingHintMap: QueueingHintMapPerProfile{
+				"": {
+					pvAdd: {
+						{
+							PluginName:     "fooPlugin1",
+							QueueingHintFn: queueHintReturnQueue,
+						},
+					},
+				},
+			},
+		},
+		{
+			name:                         "Pod and interested events are registered in inFlightPods/inFlightEvents",
+			isSchedulingQueueHintEnabled: true,
+			initialPods:                  []*v1.Pod{pod1},
+			actions: []action{
+				// This won't be added to inFlightEvents because no inFlightPods at this point.
+				{eventHappens: &pvcAdd},
+				{podPopped: pod1},
+				// This gets added for the pod.
+				{eventHappens: &pvAdd},
+				// This doesn't get added because no plugin is interested in PvUpdate.
+				{eventHappens: &pvUpdate},
+			},
+			wantInFlightPods:   []*v1.Pod{pod1},
+			wantInFlightEvents: []interface{}{pod1, pvAdd},
+			queueingHintMap: QueueingHintMapPerProfile{
+				"": {
+					pvAdd: {
+						{
+							PluginName:     "fooPlugin1",
+							QueueingHintFn: queueHintReturnQueue,
+						},
+					},
+				},
+			},
+		},
+		{
+			name:                         "Pod, registered in inFlightPods, is enqueued back to backoffQ",
+			isSchedulingQueueHintEnabled: true,
+			initialPods:                  []*v1.Pod{pod1, pod2},
+			actions: []action{
+				// This won't be added to inFlightEvents because no inFlightPods at this point.
+				{eventHappens: &pvcAdd},
+				{podPopped: pod1},
+				{eventHappens: &pvAdd},
+				{podPopped: pod2},
+				{eventHappens: &nodeAdd},
+				// This pod will be requeued to backoffQ immediately because no plugin is registered as unschedulable plugin,
+				// which means the pod encountered an unexpected error (e.g., a network error).
+				{podEnqueued: newQueuedPodInfoForLookup(pod1)},
+			},
+			wantBackoffQPodNames: []string{"targetpod"},
+			wantInFlightPods:     []*v1.Pod{pod2}, // only pod2 is registered because pod is already enqueued back.
+			wantInFlightEvents:   []interface{}{pod2, nodeAdd},
+			queueingHintMap: QueueingHintMapPerProfile{
+				"": {
+					pvAdd: {
+						{
+							PluginName:     "fooPlugin1",
+							QueueingHintFn: queueHintReturnQueue,
+						},
+					},
+					nodeAdd: {
+						{
+							PluginName:     "fooPlugin1",
+							QueueingHintFn: queueHintReturnQueue,
+						},
+					},
+					pvcAdd: {
+						{
+							PluginName:     "fooPlugin1",
+							QueueingHintFn: queueHintReturnQueue,
+						},
+					},
+				},
+			},
+		},
+		{
+			name:                         "All Pods registered in inFlightPods are enqueued back to activeQ",
+			isSchedulingQueueHintEnabled: true,
+			initialPods:                  []*v1.Pod{pod1, pod2},
+			actions: []action{
+				// This won't be added to inFlightEvents because no inFlightPods at this point.
+				{eventHappens: &pvcAdd},
+				{podPopped: pod1},
+				{eventHappens: &pvAdd},
+				{podPopped: pod2},
+				{eventHappens: &nodeAdd},
+				// This pod will be requeued to backoffQ immediately because no plugin is registered as unschedulable plugin,
+				// which means the pod encountered an unexpected error (e.g., a network error).
+				{podEnqueued: newQueuedPodInfoForLookup(pod1)},
+				{eventHappens: &csiNodeUpdate},
+				// This pod will be requeued to backoffQ immediately because no plugin is registered as unschedulable plugin,
+				// which means the pod encountered an unexpected error (e.g., a network error).
+				{podEnqueued: newQueuedPodInfoForLookup(pod2)},
+			},
+			wantBackoffQPodNames: []string{"targetpod", "targetpod2"},
+			wantInFlightPods:     nil, // empty
+			queueingHintMap: QueueingHintMapPerProfile{
+				"": {
+					pvAdd: {
+						{
+							PluginName:     "fooPlugin1",
+							QueueingHintFn: queueHintReturnQueue,
+						},
+					},
+					nodeAdd: {
+						{
+							PluginName:     "fooPlugin1",
+							QueueingHintFn: queueHintReturnQueue,
+						},
+					},
+					pvcAdd: {
+						{
+							PluginName:     "fooPlugin1",
+							QueueingHintFn: queueHintReturnQueue,
+						},
+					},
+					csiNodeUpdate: {
+						{
+							PluginName:     "fooPlugin1",
+							QueueingHintFn: queueHintReturnQueue,
+						},
+					},
+				},
+			},
+		},
+		{
+			name:                         "One intermediate Pod registered in inFlightPods is enqueued back to activeQ",
+			isSchedulingQueueHintEnabled: true,
+			initialPods:                  []*v1.Pod{pod1, pod2, pod3},
+			actions: []action{
+				// This won't be added to inFlightEvents because no inFlightPods at this point.
+				{eventHappens: &pvcAdd},
+				{podPopped: pod1},
+				{eventHappens: &pvAdd},
+				{podPopped: pod2},
+				{eventHappens: &nodeAdd},
+				// This Pod won't be requeued again.
+				{podPopped: pod3},
+				{eventHappens: &framework.EventAssignedPodAdd},
+				// This pod will be requeued to backoffQ immediately because no plugin is registered as unschedulable plugin,
+				// which means the pod encountered an unexpected error (e.g., a network error).
+				{podEnqueued: newQueuedPodInfoForLookup(pod2)},
+			},
+			wantBackoffQPodNames: []string{"targetpod2"},
+			wantInFlightPods:     []*v1.Pod{pod1, pod3},
+			wantInFlightEvents:   []interface{}{pod1, pvAdd, nodeAdd, pod3, framework.EventAssignedPodAdd},
+			queueingHintMap: QueueingHintMapPerProfile{
+				"": {
+					pvAdd: {
+						{
+							PluginName:     "fooPlugin1",
+							QueueingHintFn: queueHintReturnQueue,
+						},
+					},
+					nodeAdd: {
+						{
+							PluginName:     "fooPlugin1",
+							QueueingHintFn: queueHintReturnQueue,
+						},
+					},
+					framework.EventAssignedPodAdd: {
+						{
+							PluginName:     "fooPlugin1",
+							QueueingHintFn: queueHintReturnQueue,
+						},
+					},
+				},
+			},
+		},
+		{
+			name:        "pod is enqueued to queue without QueueingHint when SchedulingQueueHint is disabled",
+			initialPods: []*v1.Pod{pod1},
+			actions: []action{
+				{podPopped: pod1},
+				{eventHappens: &framework.EventAssignedPodAdd},
+				{podEnqueued: newQueuedPodInfoForLookup(pod1, "fooPlugin1")},
+			},
+			wantBackoffQPodNames: []string{"targetpod"},
+			wantInFlightPods:     nil,
+			wantInFlightEvents:   nil,
+			queueingHintMap: QueueingHintMapPerProfile{
+				"": {
+					// This hint fn tells that this event doesn't make a Pod schedulable.
+					// However, this QueueingHintFn will be ignored actually because SchedulingQueueHint is disabled.
+					framework.EventAssignedPodAdd: {
+						{
+							PluginName:     "fooPlugin1",
+							QueueingHintFn: queueHintReturnSkip,
+						},
+					},
+				},
+			},
+		},
+		{
+			name:                         "events before popping Pod are ignored when Pod is enqueued back to queue",
+			isSchedulingQueueHintEnabled: true,
+			initialPods:                  []*v1.Pod{pod1},
+			actions: []action{
+				{eventHappens: &framework.EventUnschedulableTimeout},
+				{podPopped: pod1},
+				{eventHappens: &framework.EventAssignedPodAdd},
+				// This Pod won't be requeued to activeQ/backoffQ because fooPlugin1 returns QueueSkip.
+				{podEnqueued: newQueuedPodInfoForLookup(pod1, "fooPlugin1")},
+			},
+			wantUnschedPodPoolPodNames: []string{"targetpod"},
+			wantInFlightPods:           nil,
+			wantInFlightEvents:         nil,
+			queueingHintMap: QueueingHintMapPerProfile{
+				"": {
+					// fooPlugin1 has a queueing hint function for framework.AssignedPodAdd,
+					// but hint fn tells that this event doesn't make a Pod scheudlable.
+					framework.EventAssignedPodAdd: {
+						{
+							PluginName:     "fooPlugin1",
+							QueueingHintFn: queueHintReturnSkip,
+						},
+					},
+				},
+			},
+		},
+		{
+			name:                         "pod is enqueued to backoff if no failed plugin",
+			isSchedulingQueueHintEnabled: true,
+			initialPods:                  []*v1.Pod{pod1},
+			actions: []action{
+				{podPopped: pod1},
+				{eventHappens: &framework.EventAssignedPodAdd},
+				// This pod will be requeued to backoffQ immediately because no plugin is registered as unschedulable plugin,
+				// which means the pod encountered an unexpected error (e.g., a network error).
+				{podEnqueued: newQueuedPodInfoForLookup(pod1)},
+			},
+			wantBackoffQPodNames: []string{"targetpod"},
+			wantInFlightPods:     nil,
+			wantInFlightEvents:   nil,
+			queueingHintMap: QueueingHintMapPerProfile{
+				"": {
+					// It will be ignored because no failed plugin.
+					framework.EventAssignedPodAdd: {
+						{
+							PluginName:     "fooPlugin1",
+							QueueingHintFn: queueHintReturnQueue,
+						},
+					},
+				},
+			},
+		},
+		{
+			name:                         "pod is enqueued to unschedulable pod pool if no events that can make the pod schedulable",
+			isSchedulingQueueHintEnabled: true,
+			initialPods:                  []*v1.Pod{pod1},
+			actions: []action{
+				{podPopped: pod1},
+				{eventHappens: &nodeAdd},
+				{podEnqueued: newQueuedPodInfoForLookup(pod1, "fooPlugin1")},
+			},
+			wantUnschedPodPoolPodNames: []string{"targetpod"},
+			wantInFlightPods:           nil,
+			wantInFlightEvents:         nil,
+			queueingHintMap: QueueingHintMapPerProfile{
+				"": {
+					// fooPlugin1 has no queueing hint function for NodeAdd.
+					framework.EventAssignedPodAdd: {
+						{
+							// It will be ignored because the event is not NodeAdd.
+							PluginName:     "fooPlugin1",
+							QueueingHintFn: queueHintReturnQueue,
+						},
+					},
+				},
+			},
+		},
+		{
+			name:                         "pod is enqueued to unschedulable pod pool because the failed plugin has a hint fn but it returns Skip",
+			isSchedulingQueueHintEnabled: true,
+			initialPods:                  []*v1.Pod{pod1},
+			actions: []action{
+				{podPopped: pod1},
+				{eventHappens: &framework.EventAssignedPodAdd},
+				{podEnqueued: newQueuedPodInfoForLookup(pod1, "fooPlugin1")},
+			},
+			wantUnschedPodPoolPodNames: []string{"targetpod"},
+			wantInFlightPods:           nil,
+			wantInFlightEvents:         nil,
+			queueingHintMap: QueueingHintMapPerProfile{
+				"": {
+					// fooPlugin1 has a queueing hint function for framework.AssignedPodAdd,
+					// but hint fn tells that this event doesn't make a Pod scheudlable.
+					framework.EventAssignedPodAdd: {
+						{
+							PluginName:     "fooPlugin1",
+							QueueingHintFn: queueHintReturnSkip,
+						},
+					},
+				},
+			},
+		},
+		{
+			name:                         "pod is enqueued to activeQ because the Pending plugins has a hint fn and it returns Queue",
+			isSchedulingQueueHintEnabled: true,
+			initialPods:                  []*v1.Pod{pod1},
+			actions: []action{
+				{podPopped: pod1},
+				{eventHappens: &framework.EventAssignedPodAdd},
+				{podEnqueued: &framework.QueuedPodInfo{
+					PodInfo:              mustNewPodInfo(pod1),
+					UnschedulablePlugins: sets.New("fooPlugin2", "fooPlugin3"),
+					PendingPlugins:       sets.New("fooPlugin1"),
+				}},
+			},
+			wantActiveQPodNames: []string{"targetpod"},
+			wantInFlightPods:    nil,
+			wantInFlightEvents:  nil,
+			queueingHintMap: QueueingHintMapPerProfile{
+				"": {
+					framework.EventAssignedPodAdd: {
+						{
+							PluginName:     "fooPlugin3",
+							QueueingHintFn: queueHintReturnSkip,
+						},
+						{
+							PluginName:     "fooPlugin2",
+							QueueingHintFn: queueHintReturnQueue,
+						},
+						{
+							// The hint fn tells that this event makes a Pod scheudlable immediately.
+							PluginName:     "fooPlugin1",
+							QueueingHintFn: queueHintReturnQueue,
+						},
+					},
+				},
+			},
+		},
+		{
+			name:                         "pod is enqueued to backoffQ because the failed plugin has a hint fn and it returns Queue",
+			isSchedulingQueueHintEnabled: true,
+			initialPods:                  []*v1.Pod{pod1},
+			actions: []action{
+				{podPopped: pod1},
+				{eventHappens: &framework.EventAssignedPodAdd},
+				{podEnqueued: newQueuedPodInfoForLookup(pod1, "fooPlugin1", "fooPlugin2")},
+			},
+			wantBackoffQPodNames: []string{"targetpod"},
+			wantInFlightPods:     nil,
+			wantInFlightEvents:   nil,
+			queueingHintMap: QueueingHintMapPerProfile{
+				"": {
+					framework.EventAssignedPodAdd: {
+						{
+							// it will be ignored because the hint fn returns Skip that is weaker than queueHintReturnQueue from fooPlugin1.
+							PluginName:     "fooPlugin2",
+							QueueingHintFn: queueHintReturnSkip,
+						},
+						{
+							// The hint fn tells that this event makes a Pod schedulable.
+							PluginName:     "fooPlugin1",
+							QueueingHintFn: queueHintReturnQueue,
+						},
+					},
+				},
+			},
+		},
+		{
+			name:                         "pod is enqueued to activeQ because the pending plugin has a hint fn and it returns Queue for a concurrent event that was received while some other pod was in flight",
+			isSchedulingQueueHintEnabled: true,
+			initialPods:                  []*v1.Pod{pod1, pod2},
+			actions: []action{
+				{callback: func(t *testing.T, q *PriorityQueue) { poppedPod = popPod(t, logger, q, pod1) }},
+				{eventHappens: &nodeAdd},
+				{callback: func(t *testing.T, q *PriorityQueue) { poppedPod2 = popPod(t, logger, q, pod2) }},
+				{eventHappens: &framework.EventAssignedPodAdd},
+				{callback: func(t *testing.T, q *PriorityQueue) {
+					logger, _ := ktesting.NewTestContext(t)
+					// This pod will be requeued to backoffQ immediately because no plugin is registered as unschedulable plugin,
+					// which means the pod encountered an unexpected error (e.g., a network error).
+					err := q.AddUnschedulableIfNotPresent(logger, poppedPod, q.SchedulingCycle())
+					if err != nil {
+						t.Fatalf("unexpected error from AddUnschedulableIfNotPresent: %v", err)
+					}
+				}},
+				{callback: func(t *testing.T, q *PriorityQueue) {
+					logger, _ := ktesting.NewTestContext(t)
+					poppedPod2.UnschedulablePlugins = sets.New("fooPlugin2", "fooPlugin3")
+					poppedPod2.PendingPlugins = sets.New("fooPlugin1")
+					err := q.AddUnschedulableIfNotPresent(logger, poppedPod2, q.SchedulingCycle())
+					if err != nil {
+						t.Fatalf("unexpected error from AddUnschedulableIfNotPresent: %v", err)
+					}
+				}},
+			},
+			wantActiveQPodNames:  []string{pod2.Name},
+			wantBackoffQPodNames: []string{pod1.Name},
+			wantInFlightPods:     nil,
+			wantInFlightEvents:   nil,
+			queueingHintMap: QueueingHintMapPerProfile{
+				"": {
+					framework.EventAssignedPodAdd: {
+						{
+							// it will be ignored because the hint fn returns QueueSkip that is weaker than queueHintReturnQueueImmediately from fooPlugin1.
+							PluginName:     "fooPlugin3",
+							QueueingHintFn: queueHintReturnSkip,
+						},
+						{
+							// it will be ignored because the fooPlugin2 is registered in UnschedulablePlugins and it's interpret as Queue that is weaker than QueueImmediately from fooPlugin1.
+							PluginName:     "fooPlugin2",
+							QueueingHintFn: queueHintReturnQueue,
+						},
+						{
+							// The hint fn tells that this event makes a Pod scheudlable.
+							// Given fooPlugin1 is registered as Pendings, we interpret Queue as queueImmediately.
+							PluginName:     "fooPlugin1",
+							QueueingHintFn: queueHintReturnQueue,
+						},
+					},
+				},
+			},
+		},
+		{
+			name:                         "popped pod must have empty UnschedulablePlugins and PendingPlugins",
+			isSchedulingQueueHintEnabled: true,
+			initialPods:                  []*v1.Pod{pod1},
+			actions: []action{
+				{callback: func(t *testing.T, q *PriorityQueue) { poppedPod = popPod(t, logger, q, pod1) }},
+				{callback: func(t *testing.T, q *PriorityQueue) {
+					logger, _ := ktesting.NewTestContext(t)
+					// Unschedulable due to PendingPlugins.
+					poppedPod.PendingPlugins = sets.New("fooPlugin1")
+					poppedPod.UnschedulablePlugins = sets.New("fooPlugin2")
+					if err := q.AddUnschedulableIfNotPresent(logger, poppedPod, q.SchedulingCycle()); err != nil {
+						t.Errorf("Unexpected error from AddUnschedulableIfNotPresent: %v", err)
+					}
+				}},
+				{eventHappens: &pvAdd}, // Active again.
+				{callback: func(t *testing.T, q *PriorityQueue) {
+					poppedPod = popPod(t, logger, q, pod1)
+					if len(poppedPod.UnschedulablePlugins) > 0 {
+						t.Errorf("QueuedPodInfo from Pop should have empty UnschedulablePlugins, got instead: %+v", poppedPod)
+					}
+				}},
+				{callback: func(t *testing.T, q *PriorityQueue) {
+					logger, _ := ktesting.NewTestContext(t)
+					// Failed (i.e. no UnschedulablePlugins). Should go to backoff.
+					if err := q.AddUnschedulableIfNotPresent(logger, poppedPod, q.SchedulingCycle()); err != nil {
+						t.Errorf("Unexpected error from AddUnschedulableIfNotPresent: %v", err)
+					}
+				}},
+			},
+			queueingHintMap: QueueingHintMapPerProfile{
+				"": {
+					pvAdd: {
+						{
+							// The hint fn tells that this event makes a Pod scheudlable immediately.
+							PluginName:     "fooPlugin1",
+							QueueingHintFn: queueHintReturnQueue,
+						},
+					},
+				},
+			},
+		},
+		{
+			// This scenario shouldn't happen unless we make the similar bug like https://github.com/kubernetes/kubernetes/issues/118226.
+			// But, given the bug could make a serious memory leak and likely would be hard to detect,
+			// we should have a safe guard from the same bug so that, at least, we can prevent the memory leak.
+			name:                         "Pop is made twice for the same Pod, but the cleanup still happen correctly",
+			isSchedulingQueueHintEnabled: true,
+			initialPods:                  []*v1.Pod{pod1, pod2},
+			actions: []action{
+				// This won't be added to inFlightEvents because no inFlightPods at this point.
+				{eventHappens: &pvcAdd},
+				{podPopped: pod1},
+				{eventHappens: &pvAdd},
+				{podPopped: pod2},
+				// Simulate a bug, putting pod into activeQ, while pod is being scheduled.
+				{callback: func(t *testing.T, q *PriorityQueue) {
+					q.activeQ.underLock(func(unlocked unlockedActiveQueuer) {
+						unlocked.add(logger, newQueuedPodInfoForLookup(pod1), framework.EventUnscheduledPodAdd.Label())
+					})
+				}},
+				// At this point, in the activeQ, we have pod1 and pod3 in this order.
+				{podCreated: pod3},
+				// pod3 is poped, not pod1.
+				// In detail, this Pop() first tries to pop pod1, but it's already being scheduled and hence discarded.
+				// Then, it pops the next pod, pod3.
+				{podPopped: pod3},
+				{callback: func(t *testing.T, q *PriorityQueue) {
+					// Make sure that pod1 is discarded and hence no pod in activeQ.
+					if len(q.activeQ.list()) != 0 {
+						t.Fatalf("activeQ should be empty, but got: %v", q.activeQ.list())
+					}
+				}},
+				{eventHappens: &nodeAdd},
+				// This pod will be requeued to backoffQ immediately because no plugin is registered as unschedulable plugin,
+				// which means the pod encountered an unexpected error (e.g., a network error).
+				{podEnqueued: newQueuedPodInfoForLookup(pod1)},
+				{eventHappens: &csiNodeUpdate},
+				// This pod will be requeued to backoffQ immediately because no plugin is registered as unschedulable plugin,
+				// which means the pod encountered an unexpected error (e.g., a network error).
+				{podEnqueued: newQueuedPodInfoForLookup(pod2)},
+				// This pod will be requeued to backoffQ immediately because no plugin is registered as unschedulable plugin,
+				// which means the pod encountered an unexpected error (e.g., a network error).
+				{podEnqueued: newQueuedPodInfoForLookup(pod3)},
+			},
+			wantBackoffQPodNames: []string{"targetpod", "targetpod2", "targetpod3"},
+			wantInFlightPods:     nil, // should be empty
+			queueingHintMap: QueueingHintMapPerProfile{
+				"": {
+					pvAdd: {
+						{
+							PluginName:     "fooPlugin1",
+							QueueingHintFn: queueHintReturnQueue,
+						},
+					},
+					nodeAdd: {
+						{
+							PluginName:     "fooPlugin1",
+							QueueingHintFn: queueHintReturnQueue,
+						},
+					},
+					pvcAdd: {
+						{
+							PluginName:     "fooPlugin1",
+							QueueingHintFn: queueHintReturnQueue,
+						},
+					},
+					csiNodeUpdate: {
+						{
+							PluginName:     "fooPlugin1",
+							QueueingHintFn: queueHintReturnQueue,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if !test.isSchedulingQueueHintEnabled {
+				featuregatetesting.SetFeatureGateEmulationVersionDuringTest(t, utilfeature.DefaultFeatureGate, version.MustParse("1.33"))
+				featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.SchedulerQueueingHints, false)
+			}
+
+			logger, ctx := ktesting.NewTestContext(t)
+			ctx, cancel := context.WithCancel(ctx)
+			defer cancel()
+			obj := make([]runtime.Object, 0, len(test.initialPods))
+			for _, p := range test.initialPods {
+				obj = append(obj, p)
+			}
+			fakeClock := testingclock.NewFakeClock(time.Now())
+			q := NewTestQueueWithObjects(ctx, newDefaultQueueSort(), obj, WithQueueingHintMapPerProfile(test.queueingHintMap), WithClock(fakeClock))
+			sortOpt := cmpopts.SortSlices(func(a, b string) bool { return a < b })
+
+			// When a Pod is added to the queue, the QueuedPodInfo will have a new timestamp.
+			// On Windows, time.Now() is not as precise, 2 consecutive calls may return the same timestamp.
+			// Thus, all the QueuedPodInfos can have the same timestamps, which can be an issue
+			// when we're expecting them to be popped in a certain order (the Less function
+			// sorts them by Timestamps if they have the same Pod Priority).
+			// Using a fake clock for the queue and incrementing it after each added Pod will
+			// solve this issue on Windows unit test runs.
+			// For more details on the Windows clock resolution issue, see: https://github.com/golang/go/issues/8687
+			for _, p := range test.initialPods {
+				q.Add(logger, p)
+				fakeClock.Step(time.Second)
+			}
+
+			for _, action := range test.actions {
+				switch {
+				case action.podCreated != nil:
+					q.Add(logger, action.podCreated)
+				case action.podPopped != nil:
+					popPod(t, logger, q, action.podPopped)
+				case action.eventHappens != nil:
+					q.MoveAllToActiveOrBackoffQueue(logger, *action.eventHappens, nil, nil, nil)
+				case action.podEnqueued != nil:
+					err := q.AddUnschedulableIfNotPresent(logger, action.podEnqueued, q.SchedulingCycle())
+					if err != nil {
+						t.Fatalf("unexpected error from AddUnschedulableIfNotPresent: %v", err)
+					}
+				case action.callback != nil:
+					action.callback(t, q)
+				}
+			}
+
+			actualInFlightPods := make(map[types.UID]*v1.Pod)
+			for _, pod := range q.activeQ.listInFlightPods() {
+				actualInFlightPods[pod.UID] = pod
+			}
+			wantInFlightPods := make(map[types.UID]*v1.Pod)
+			for _, pod := range test.wantInFlightPods {
+				wantInFlightPods[pod.UID] = pod
+			}
+			if diff := cmp.Diff(wantInFlightPods, actualInFlightPods); diff != "" {
+				t.Errorf("Unexpected diff in inFlightPods (-want, +got):\n%s", diff)
+			}
+
+			var wantInFlightEvents []interface{}
+			for _, value := range test.wantInFlightEvents {
+				if event, ok := value.(fwk.ClusterEvent); ok {
+					value = &clusterEvent{event: event}
+				}
+				wantInFlightEvents = append(wantInFlightEvents, value)
+			}
+			if diff := cmp.Diff(wantInFlightEvents, q.activeQ.listInFlightEvents(), cmp.AllowUnexported(clusterEvent{}), cmpopts.EquateComparable(fwk.ClusterEvent{})); diff != "" {
+				t.Errorf("Unexpected diff in inFlightEvents (-want, +got):\n%s", diff)
+			}
+
+			if test.wantActiveQPodNames != nil {
+				pods := q.activeQ.list()
+				var podNames []string
+				for _, pod := range pods {
+					podNames = append(podNames, pod.Name)
+				}
+				if diff := cmp.Diff(test.wantActiveQPodNames, podNames, sortOpt); diff != "" {
+					t.Fatalf("Unexpected diff of activeQ pod names (-want, +got):\n%s", diff)
+				}
+
+				wantPodNames := sets.New(test.wantActiveQPodNames...)
+				for _, pod := range pods {
+					if !wantPodNames.Has(pod.Name) {
+						t.Fatalf("Pod %v was not expected to be in the activeQ.", pod.Name)
+					}
+				}
+			}
+
+			if test.wantBackoffQPodNames != nil {
+				pods := q.backoffQ.list()
+				var podNames []string
+				for _, pod := range pods {
+					podNames = append(podNames, pod.Name)
+				}
+				if diff := cmp.Diff(test.wantBackoffQPodNames, podNames, sortOpt); diff != "" {
+					t.Fatalf("Unexpected diff of backoffQ pod names (-want, +got):\n%s", diff)
+				}
+
+				wantPodNames := sets.New(test.wantBackoffQPodNames...)
+				for _, podGotFromBackoffQ := range pods {
+					if !wantPodNames.Has(podGotFromBackoffQ.Name) {
+						t.Fatalf("Pod %v was not expected to be in the backoffQ.", podGotFromBackoffQ.Name)
+					}
+				}
+			}
+
+			for _, podName := range test.wantUnschedPodPoolPodNames {
+				p := getUnschedulablePod(q, &st.MakePod().Name(podName).Pod)
+				if p == nil {
+					t.Fatalf("Pod %v was not found in the unschedulablePods.", podName)
+				}
+			}
+		})
+	}
+}
+
+func popPod(t *testing.T, logger klog.Logger, q *PriorityQueue, pod *v1.Pod) *framework.QueuedPodInfo {
+	p, err := q.Pop(logger)
+	if err != nil {
+		t.Fatalf("Pop failed: %v", err)
+	}
+	if p.Pod.UID != pod.UID {
+		t.Errorf("Unexpected popped pod: %v", p)
+	}
+	return p
+}
+
+func TestPop(t *testing.T) {
+	pod := st.MakePod().Name("targetpod").UID("pod1").Obj()
+	queueingHintMap := QueueingHintMapPerProfile{
+		"": {
+			pvAdd: {
+				{
+					// The hint fn tells that this event makes a Pod scheudlable.
+					PluginName:     "fooPlugin1",
+					QueueingHintFn: queueHintReturnQueue,
+				},
+			},
+		},
+	}
+
+	for name, isSchedulingQueueHintEnabled := range map[string]bool{"with-hints": true, "without-hints": false} {
+		t.Run(name, func(t *testing.T) {
+			if !isSchedulingQueueHintEnabled {
+				featuregatetesting.SetFeatureGateEmulationVersionDuringTest(t, utilfeature.DefaultFeatureGate, version.MustParse("1.33"))
+				featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.SchedulerQueueingHints, false)
+			}
+
+			logger, ctx := ktesting.NewTestContext(t)
+			ctx, cancel := context.WithCancel(ctx)
+			defer cancel()
+			q := NewTestQueueWithObjects(ctx, newDefaultQueueSort(), []runtime.Object{pod}, WithQueueingHintMapPerProfile(queueingHintMap))
+			q.Add(logger, pod)
+
+			// Simulate failed attempt that makes the pod unschedulable.
+			poppedPod := popPod(t, logger, q, pod)
+			// We put register the plugin to PendingPlugins so that it's interpreted as queueImmediately and skip backoff.
+			poppedPod.PendingPlugins = sets.New("fooPlugin1")
+			if err := q.AddUnschedulableIfNotPresent(logger, poppedPod, q.SchedulingCycle()); err != nil {
+				t.Errorf("Unexpected error from AddUnschedulableIfNotPresent: %v", err)
+			}
+
+			// Activate it again.
+			q.MoveAllToActiveOrBackoffQueue(logger, pvAdd, nil, nil, nil)
+
+			// Now check result of Pop.
+			poppedPod = popPod(t, logger, q, pod)
+			if len(poppedPod.PendingPlugins) > 0 {
+				t.Errorf("QueuedPodInfo from Pop should have empty PendingPlugins, got instead: %+v", poppedPod)
+			}
+		})
+	}
+}
+
+func TestPriorityQueue_AddUnschedulableIfNotPresent(t *testing.T) {
+	objs := []runtime.Object{highPriNominatedPodInfo.Pod, unschedulablePodInfo.Pod}
+	logger, ctx := ktesting.NewTestContext(t)
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	q := NewTestQueueWithObjects(ctx, newDefaultQueueSort(), objs)
+	// insert unschedulablePodInfo and pop right after that
+	// because the scheduling queue records unschedulablePod as in-flight Pod.
+	q.Add(logger, unschedulablePodInfo.Pod)
+	if p, err := q.Pop(logger); err != nil || p.Pod != unschedulablePodInfo.Pod {
+		t.Errorf("Expected: %v after Pop, but got: %v", unschedulablePodInfo.Pod.Name, p.Pod.Name)
+	}
+
+	q.Add(logger, highPriNominatedPodInfo.Pod)
+	err := q.AddUnschedulableIfNotPresent(logger, newQueuedPodInfoForLookup(unschedulablePodInfo.Pod, "plugin"), q.SchedulingCycle())
+	if err != nil {
+		t.Fatalf("unexpected error from AddUnschedulableIfNotPresent: %v", err)
+	}
+	if p, err := q.Pop(logger); err != nil || p.Pod != highPriNominatedPodInfo.Pod {
+		t.Errorf("Expected: %v after Pop, but got: %v", highPriNominatedPodInfo.Pod.Name, p.Pod.Name)
+	}
+	// unschedulablePodInfo is inserted to unschedulable pod pool because no events happened during scheduling.
+	if getUnschedulablePod(q, unschedulablePodInfo.Pod) != unschedulablePodInfo.Pod {
+		t.Errorf("Pod %v was not found in the unschedulablePods.", unschedulablePodInfo.Pod.Name)
+	}
+}
+
+// TestPriorityQueue_AddUnschedulableIfNotPresent_Backoff tests the scenarios when
+// AddUnschedulableIfNotPresent is called asynchronously.
+// Pods in and before current scheduling cycle will be put back to activeQueue
+// if we were trying to schedule them when we received move request.
+func TestPriorityQueue_AddUnschedulableIfNotPresent_Backoff(t *testing.T) {
+	logger, ctx := ktesting.NewTestContext(t)
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	q := NewTestQueue(ctx, newDefaultQueueSort(), WithClock(testingclock.NewFakeClock(time.Now())))
+	totalNum := 10
+	expectedPods := make([]v1.Pod, 0, totalNum)
+	for i := 0; i < totalNum; i++ {
+		priority := int32(i)
+		p := st.MakePod().Name(fmt.Sprintf("pod%d", i)).Namespace(fmt.Sprintf("ns%d", i)).UID(fmt.Sprintf("upns%d", i)).Priority(priority).Obj()
+		expectedPods = append(expectedPods, *p)
+		// priority is to make pods ordered in the PriorityQueue
+		q.Add(logger, p)
+	}
+
+	// Pop all pods except for the first one
+	for i := totalNum - 1; i > 0; i-- {
+		p, _ := q.Pop(logger)
+		if diff := cmp.Diff(&expectedPods[i], p.Pod); diff != "" {
+			t.Errorf("Unexpected pod (-want, +got):\n%s", diff)
+		}
+	}
+
+	// move all pods to active queue when we were trying to schedule them
+	q.MoveAllToActiveOrBackoffQueue(logger, framework.EventUnschedulableTimeout, nil, nil, nil)
+	oldCycle := q.SchedulingCycle()
+
+	firstPod, _ := q.Pop(logger)
+	if diff := cmp.Diff(&expectedPods[0], firstPod.Pod); diff != "" {
+		t.Errorf("Unexpected pod (-want, +got):\n%s", diff)
+	}
+
+	// mark pods[1] ~ pods[totalNum-1] as unschedulable and add them back
+	for i := 1; i < totalNum; i++ {
+		unschedulablePod := expectedPods[i].DeepCopy()
+		unschedulablePod.Status = v1.PodStatus{
+			Conditions: []v1.PodCondition{
+				{
+					Type:   v1.PodScheduled,
+					Status: v1.ConditionFalse,
+					Reason: v1.PodReasonUnschedulable,
+				},
+			},
+		}
+
+		err := q.AddUnschedulableIfNotPresent(logger, newQueuedPodInfoForLookup(unschedulablePod, "plugin"), oldCycle)
+		if err != nil {
+			t.Fatalf("unexpected error from AddUnschedulableIfNotPresent: %v", err)
+		}
+	}
+
+	// Since there was a move request at the same cycle as "oldCycle", these pods
+	// should be in the backoff queue.
+	for i := 1; i < totalNum; i++ {
+		if !q.backoffQ.has(newQueuedPodInfoForLookup(&expectedPods[i])) {
+			t.Errorf("Expected %v to be added to backoffQ.", expectedPods[i].Name)
+		}
+	}
+}
+
+// tryPop tries to pop one pod from the queue and returns it.
+// It waits 5 seconds before timing out, assuming the queue is then empty.
+func tryPop(t *testing.T, logger klog.Logger, q *PriorityQueue) *framework.QueuedPodInfo {
+	t.Helper()
+
+	var gotPod *framework.QueuedPodInfo
+	popped := make(chan struct{}, 1)
+	go func() {
+		pod, err := q.Pop(logger)
+		if err != nil {
+			t.Errorf("Failed to pop pod from scheduling queue: %s", err)
+		}
+		if pod != nil {
+			gotPod = pod
+		}
+		popped <- struct{}{}
+	}()
+
+	timer := time.NewTimer(5 * time.Second)
+	select {
+	case <-timer.C:
+		q.Close()
+	case <-popped:
+		timer.Stop()
+	}
+	return gotPod
+}
+
+func TestPriorityQueue_Pop(t *testing.T) {
+	highPriorityPodInfo2 := mustNewPodInfo(
+		st.MakePod().Name("hpp2").Namespace("ns1").UID("hpp2ns1").Priority(highPriority).Obj(),
+	)
+	objs := []runtime.Object{medPriorityPodInfo.Pod, highPriorityPodInfo.Pod, highPriorityPodInfo2.Pod, unschedulablePodInfo.Pod}
+	tests := []struct {
+		name                   string
+		popFromBackoffQEnabled bool
+		wantPods               []string
+	}{
+		{
+			name:                   "Pop pods from both activeQ and backoffQ when PopFromBackoffQ is enabled",
+			popFromBackoffQEnabled: true,
+			wantPods:               []string{medPriorityPodInfo.Pod.Name, highPriorityPodInfo.Pod.Name},
+		},
+		{
+			name:                   "Pop pod only from activeQ when PopFromBackoffQ is disabled",
+			popFromBackoffQEnabled: false,
+			wantPods:               []string{medPriorityPodInfo.Pod.Name},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.SchedulerPopFromBackoffQ, tt.popFromBackoffQEnabled)
+			logger, ctx := ktesting.NewTestContext(t)
+			ctx, cancel := context.WithCancel(ctx)
+			defer cancel()
+			q := NewTestQueueWithObjects(ctx, newDefaultQueueSort(), objs)
+
+			// Add medium priority pod to the activeQ
+			q.Add(logger, medPriorityPodInfo.Pod)
+			// Add high priority pod to the backoffQ
+			backoffPodInfo := q.newQueuedPodInfo(highPriorityPodInfo.Pod, "plugin")
+			q.backoffQ.add(logger, backoffPodInfo, framework.EventUnscheduledPodAdd.Label())
+			// Add high priority pod to the errorBackoffQ
+			errorBackoffPodInfo := q.newQueuedPodInfo(highPriorityPodInfo2.Pod)
+			q.backoffQ.add(logger, errorBackoffPodInfo, framework.EventUnscheduledPodAdd.Label())
+			// Add pod to the unschedulablePods
+			unschedulablePodInfo := q.newQueuedPodInfo(unschedulablePodInfo.Pod, "plugin")
+			q.unschedulablePods.addOrUpdate(unschedulablePodInfo, framework.EventUnscheduledPodAdd.Label())
+
+			var gotPods []string
+			for i := 0; i < len(tt.wantPods)+1; i++ {
+				gotPod := tryPop(t, logger, q)
+				if gotPod == nil {
+					break
+				}
+				gotPods = append(gotPods, gotPod.Pod.Name)
+			}
+			if diff := cmp.Diff(tt.wantPods, gotPods); diff != "" {
+				t.Errorf("Unexpected popped pods (-want, +got): %s", diff)
+			}
+		})
+	}
+}
+
+func TestPriorityQueue_Update(t *testing.T) {
+	c := testingclock.NewFakeClock(time.Now())
+
+	queuePlugin := "queuePlugin"
+	skipPlugin := "skipPlugin"
+	queueingHintMap := QueueingHintMapPerProfile{
+		"": {
+			framework.EventUnscheduledPodUpdate: {
+				{
+					PluginName:     queuePlugin,
+					QueueingHintFn: queueHintReturnQueue,
+				},
+				{
+					PluginName:     skipPlugin,
+					QueueingHintFn: queueHintReturnSkip,
+				},
+			},
+		},
+	}
+
+	notInAnyQueue := "NotInAnyQueue"
+	tests := []struct {
+		name  string
+		wantQ string
+		// prepareFunc is the function called to prepare pods in the queue before the test case calls Update().
+		// This function returns three values;
+		// - oldPod/newPod: each test will call Update() with these oldPod and newPod.
+		prepareFunc func(t *testing.T, logger klog.Logger, q *PriorityQueue) (oldPod, newPod *v1.Pod)
+		// schedulingHintsEnablement shows which value of QHint feature gate we test a test case with.
+		schedulingHintsEnablement []bool
+	}{
+		{
+			name:  "Update pod that didn't exist in the queue",
+			wantQ: activeQ,
+			prepareFunc: func(t *testing.T, logger klog.Logger, q *PriorityQueue) (oldPod, newPod *v1.Pod) {
+				updatedPod := medPriorityPodInfo.Pod.DeepCopy()
+				updatedPod.Annotations["foo"] = "test"
+				return medPriorityPodInfo.Pod, updatedPod
+			},
+			schedulingHintsEnablement: []bool{false, true},
+		},
+		{
+			name:  "When updating a pod that is already in activeQ, the pod should remain in activeQ after Update()",
+			wantQ: activeQ,
+			prepareFunc: func(t *testing.T, logger klog.Logger, q *PriorityQueue) (oldPod, newPod *v1.Pod) {
+				q.Add(logger, highPriorityPodInfo.Pod)
+				return highPriorityPodInfo.Pod, highPriorityPodInfo.Pod
+			},
+			schedulingHintsEnablement: []bool{false, true},
+		},
+		{
+			name:  "When updating a pod that is in backoff queue and is still backing off, it will be updated in backoff queue",
+			wantQ: backoffQ,
+			prepareFunc: func(t *testing.T, logger klog.Logger, q *PriorityQueue) (oldPod, newPod *v1.Pod) {
+				podInfo := q.newQueuedPodInfo(medPriorityPodInfo.Pod)
+				q.backoffQ.add(logger, podInfo, framework.EventUnscheduledPodAdd.Label())
+				return podInfo.Pod, podInfo.Pod
+			},
+			schedulingHintsEnablement: []bool{false, true},
+		},
+		{
+			name:  "when updating a pod which is in unschedulable queue and is backing off, it will be moved to backoff queue",
+			wantQ: backoffQ,
+			prepareFunc: func(t *testing.T, logger klog.Logger, q *PriorityQueue) (oldPod, newPod *v1.Pod) {
+				pInfo := q.newQueuedPodInfo(medPriorityPodInfo.Pod, queuePlugin)
+				// needs to increment to make the pod backing off
+				pInfo.UnschedulableCount++
+				q.unschedulablePods.addOrUpdate(pInfo, framework.EventUnscheduledPodAdd.Label())
+				updatedPod := medPriorityPodInfo.Pod.DeepCopy()
+				updatedPod.Annotations["foo"] = "test"
+				return medPriorityPodInfo.Pod, updatedPod
+			},
+			schedulingHintsEnablement: []bool{false, true},
+		},
+		{
+			name:  "when updating a pod which is in unschedulable queue and is not backing off, it will be moved to active queue",
+			wantQ: activeQ,
+			prepareFunc: func(t *testing.T, logger klog.Logger, q *PriorityQueue) (oldPod, newPod *v1.Pod) {
+				pInfo := q.newQueuedPodInfo(medPriorityPodInfo.Pod, queuePlugin)
+				// needs to increment to make the pod backing off
+				pInfo.UnschedulableCount++
+				q.unschedulablePods.addOrUpdate(pInfo, framework.EventUnscheduledPodAdd.Label())
+				updatedPod := medPriorityPodInfo.Pod.DeepCopy()
+				updatedPod.Annotations["foo"] = "test1"
+				// Move clock by podMaxBackoffDuration, so that pods in the unschedulablePods would pass the backing off,
+				// and the pods will be moved into activeQ.
+				c.Step(q.backoffQ.podMaxBackoffDuration())
+				return medPriorityPodInfo.Pod, updatedPod
+			},
+			schedulingHintsEnablement: []bool{false, true},
+		},
+		{
+			name:  "when updating a pod which is in unschedulable pods but the plugin returns skip, it will remain in unschedulablePods",
+			wantQ: unschedulableQ,
+			prepareFunc: func(t *testing.T, logger klog.Logger, q *PriorityQueue) (oldPod, newPod *v1.Pod) {
+				q.unschedulablePods.addOrUpdate(q.newQueuedPodInfo(medPriorityPodInfo.Pod, skipPlugin), framework.EventUnscheduledPodAdd.Label())
+				updatedPod := medPriorityPodInfo.Pod.DeepCopy()
+				updatedPod.Annotations["foo"] = "test1"
+				return medPriorityPodInfo.Pod, updatedPod
+			},
+			schedulingHintsEnablement: []bool{true},
+		},
+		{
+			name:  "when updating a pod which is in flightPods, the pod will not be added to any queue",
+			wantQ: notInAnyQueue,
+			prepareFunc: func(t *testing.T, logger klog.Logger, q *PriorityQueue) (oldPod, newPod *v1.Pod) {
+				// We need to once add this Pod to activeQ and Pop() it so that this Pod is registered correctly in inFlightPods.
+				q.Add(logger, medPriorityPodInfo.Pod)
+				if p, err := q.Pop(logger); err != nil || p.Pod != medPriorityPodInfo.Pod {
+					t.Errorf("Expected: %v after Pop, but got: %v", medPriorityPodInfo.Pod.Name, p.Pod.Name)
+				}
+				updatedPod := medPriorityPodInfo.Pod.DeepCopy()
+				updatedPod.Annotations["foo"] = "bar"
+				return medPriorityPodInfo.Pod, updatedPod
+			},
+			schedulingHintsEnablement: []bool{true},
+		},
+	}
+
+	for _, tt := range tests {
+		for _, qHintEnabled := range tt.schedulingHintsEnablement {
+			t.Run(fmt.Sprintf("%s, with queuehint(%v)", tt.name, qHintEnabled), func(t *testing.T) {
+				if !qHintEnabled {
+					featuregatetesting.SetFeatureGateEmulationVersionDuringTest(t, utilfeature.DefaultFeatureGate, version.MustParse("1.33"))
+					featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.SchedulerQueueingHints, false)
+				}
+
+				logger, ctx := ktesting.NewTestContext(t)
+				objs := []runtime.Object{highPriorityPodInfo.Pod, unschedulablePodInfo.Pod, medPriorityPodInfo.Pod}
+				ctx, cancel := context.WithCancel(ctx)
+				defer cancel()
+				q := NewTestQueueWithObjects(ctx, newDefaultQueueSort(), objs, WithClock(c), WithQueueingHintMapPerProfile(queueingHintMap))
+
+				oldPod, newPod := tt.prepareFunc(t, logger, q)
+
+				q.Update(logger, oldPod, newPod)
+
+				var pInfo *framework.QueuedPodInfo
+
+				// validate expected queue
+				if pInfoFromBackoff, exists := q.backoffQ.get(newQueuedPodInfoForLookup(newPod)); exists {
+					if tt.wantQ != backoffQ {
+						t.Errorf("expected pod %s not to be queued to backoffQ, but it was", newPod.Name)
+					}
+					pInfo = pInfoFromBackoff
+				}
+
+				q.activeQ.underRLock(func(unlockedActiveQ unlockedActiveQueueReader) {
+					if pInfoFromActive, exists := unlockedActiveQ.get(newQueuedPodInfoForLookup(newPod)); exists {
+						if tt.wantQ != activeQ {
+							t.Errorf("expected pod %s not to be queued to activeQ, but it was", newPod.Name)
+						}
+						pInfo = pInfoFromActive
+					}
+				})
+
+				if pInfoFromUnsched := q.unschedulablePods.get(newPod); pInfoFromUnsched != nil {
+					if tt.wantQ != unschedulableQ {
+						t.Errorf("expected pod %s to not be queued to unschedulablePods, but it was", newPod.Name)
+					}
+					pInfo = pInfoFromUnsched
+				}
+
+				if tt.wantQ == notInAnyQueue {
+					// skip the rest of the test if pod is not expected to be in any of the queues.
+					return
+				}
+
+				if diff := cmp.Diff(newPod, pInfo.PodInfo.Pod); diff != "" {
+					t.Errorf("Unexpected updated pod diff (-want, +got): %s", diff)
+				}
+			})
+		}
+	}
+}
+
+// TestPriorityQueue_UpdateWhenInflight ensures to requeue a Pod back to activeQ/backoffQ
+// if it actually got an update that may make it schedulable while being scheduled.
+// See https://github.com/kubernetes/kubernetes/pull/125578#discussion_r1648338033 for more context.
+func TestPriorityQueue_UpdateWhenInflight(t *testing.T) {
+	logger, ctx := ktesting.NewTestContext(t)
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	m := makeEmptyQueueingHintMapPerProfile()
+	// fakePlugin could change its scheduling result by any updates in Pods.
+	m[""][framework.EventUnscheduledPodUpdate] = []*QueueingHintFunction{
+		{
+			PluginName:     "fakePlugin",
+			QueueingHintFn: queueHintReturnQueue,
+		},
+	}
+	c := testingclock.NewFakeClock(time.Now())
+	q := NewTestQueue(ctx, newDefaultQueueSort(), WithQueueingHintMapPerProfile(m), WithClock(c))
+
+	// test-pod is created and popped out from the queue
+	testPod := st.MakePod().Name("test-pod").Namespace("test-ns").UID("test-uid").Obj()
+	q.Add(logger, testPod)
+	if p, err := q.Pop(logger); err != nil || p.Pod != testPod {
+		t.Errorf("Expected: %v after Pop, but got: %v", testPod.Name, p.Pod.Name)
+	}
+
+	// testPod is updated while being scheduled.
+	updatedPod := testPod.DeepCopy()
+	updatedPod.Spec.Tolerations = []v1.Toleration{
+		{
+			Key:    "foo",
+			Effect: v1.TaintEffectNoSchedule,
+		},
+	}
+
+	q.Update(logger, testPod, updatedPod)
+	// test-pod got rejected by fakePlugin,
+	// but the update event that it just got may change this scheduling result,
+	// and hence we should put this pod to activeQ/backoffQ.
+	err := q.AddUnschedulableIfNotPresent(logger, newQueuedPodInfoForLookup(updatedPod, "fakePlugin"), q.SchedulingCycle())
+	if err != nil {
+		t.Fatalf("unexpected error from AddUnschedulableIfNotPresent: %v", err)
+	}
+
+	pInfo, exists := q.backoffQ.get(newQueuedPodInfoForLookup(updatedPod))
+	if !exists {
+		t.Fatalf("expected pod %s to be queued to backoffQ, but it wasn't.", updatedPod.Name)
+	}
+	if diff := cmp.Diff(updatedPod, pInfo.PodInfo.Pod); diff != "" {
+		t.Errorf("Unexpected updated pod diff (-want, +got): %s", diff)
+	}
+}
+
+func TestPriorityQueue_Delete(t *testing.T) {
+	objs := []runtime.Object{highPriorityPodInfo.Pod, unschedulablePodInfo.Pod}
+	logger, ctx := ktesting.NewTestContext(t)
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	q := NewTestQueueWithObjects(ctx, newDefaultQueueSort(), objs)
+	q.Update(logger, highPriorityPodInfo.Pod, highPriNominatedPodInfo.Pod)
+	q.Add(logger, unschedulablePodInfo.Pod)
+	q.Delete(highPriNominatedPodInfo.Pod)
+	if !q.activeQ.has(newQueuedPodInfoForLookup(unschedulablePodInfo.Pod)) {
+		t.Errorf("Expected %v to be in activeQ.", unschedulablePodInfo.Pod.Name)
+	}
+	if q.activeQ.has(newQueuedPodInfoForLookup(highPriNominatedPodInfo.Pod)) {
+		t.Errorf("Didn't expect %v to be in activeQ.", highPriorityPodInfo.Pod.Name)
+	}
+}
+
+func TestPriorityQueue_Activate(t *testing.T) {
+	metrics.Register()
+	tests := []struct {
+		name                        string
+		qPodInfoInUnschedulablePods []*framework.QueuedPodInfo
+		qPodInfoInBackoffQ          []*framework.QueuedPodInfo
+		qPodInActiveQ               []*v1.Pod
+		qPodInfoToActivate          *framework.QueuedPodInfo
+		qPodInInFlightPod           *v1.Pod
+		expectedInFlightEvent       *clusterEvent
+		want                        []*framework.QueuedPodInfo
+		qHintEnabled                bool
+	}{
+		{
+			name:               "pod already in activeQ",
+			qPodInActiveQ:      []*v1.Pod{highPriNominatedPodInfo.Pod},
+			qPodInfoToActivate: &framework.QueuedPodInfo{PodInfo: highPriNominatedPodInfo},
+			want:               []*framework.QueuedPodInfo{{PodInfo: highPriNominatedPodInfo}}, // 1 already active
+		},
+		{
+			name:               "pod not in unschedulablePods/backoffQ",
+			qPodInfoToActivate: &framework.QueuedPodInfo{PodInfo: highPriNominatedPodInfo},
+			want:               []*framework.QueuedPodInfo{},
+		},
+		{
+			name:                  "[QHint] pod not in unschedulablePods/backoffQ but in-flight",
+			qPodInfoToActivate:    &framework.QueuedPodInfo{PodInfo: highPriNominatedPodInfo},
+			qPodInInFlightPod:     highPriNominatedPodInfo.Pod,
+			expectedInFlightEvent: &clusterEvent{oldObj: (*v1.Pod)(nil), newObj: highPriNominatedPodInfo.Pod, event: framework.EventForceActivate},
+			want:                  []*framework.QueuedPodInfo{},
+			qHintEnabled:          true,
+		},
+		{
+			name:               "[QHint] pod not in unschedulablePods/backoffQ and not in-flight",
+			qPodInfoToActivate: &framework.QueuedPodInfo{PodInfo: highPriNominatedPodInfo},
+			qPodInInFlightPod:  medPriorityPodInfo.Pod, // different pod is in-flight
+			want:               []*framework.QueuedPodInfo{},
+			qHintEnabled:       true,
+		},
+		{
+			name:                        "pod in unschedulablePods",
+			qPodInfoInUnschedulablePods: []*framework.QueuedPodInfo{{PodInfo: highPriNominatedPodInfo}},
+			qPodInfoToActivate:          &framework.QueuedPodInfo{PodInfo: highPriNominatedPodInfo},
+			want:                        []*framework.QueuedPodInfo{{PodInfo: highPriNominatedPodInfo}},
+		},
+		{
+			name:               "pod in backoffQ",
+			qPodInfoInBackoffQ: []*framework.QueuedPodInfo{{PodInfo: highPriNominatedPodInfo}},
+			qPodInfoToActivate: &framework.QueuedPodInfo{PodInfo: highPriNominatedPodInfo},
+			want:               []*framework.QueuedPodInfo{{PodInfo: highPriNominatedPodInfo}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if !tt.qHintEnabled {
+				featuregatetesting.SetFeatureGateEmulationVersionDuringTest(t, utilfeature.DefaultFeatureGate, version.MustParse("1.33"))
+				featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.SchedulerQueueingHints, false)
+			}
+
+			var objs []runtime.Object
+			logger, ctx := ktesting.NewTestContext(t)
+			ctx, cancel := context.WithCancel(ctx)
+			defer cancel()
+			q := NewTestQueueWithObjects(ctx, newDefaultQueueSort(), objs)
+
+			if tt.qPodInInFlightPod != nil {
+				// Put -> Pop the Pod to make it registered in inFlightPods.
+				q.activeQ.underLock(func(unlockedActiveQ unlockedActiveQueuer) {
+					unlockedActiveQ.add(logger, newQueuedPodInfoForLookup(tt.qPodInInFlightPod), framework.EventUnscheduledPodAdd.Label())
+				})
+				p, err := q.activeQ.pop(logger)
+				if err != nil {
+					t.Fatalf("Pop failed: %v", err)
+				}
+				if p.Pod.Name != tt.qPodInInFlightPod.Name {
+					t.Errorf("Unexpected popped pod: %v", p.Pod.Name)
+				}
+				if len(q.activeQ.listInFlightEvents()) != 1 {
+					t.Fatal("Expected the pod to be recorded in in-flight events, but it doesn't")
+				}
+			}
+
+			// Prepare activeQ/unschedulablePods/backoffQ according to the table
+			for _, qPod := range tt.qPodInActiveQ {
+				q.Add(logger, qPod)
+			}
+
+			for _, qPodInfo := range tt.qPodInfoInUnschedulablePods {
+				q.unschedulablePods.addOrUpdate(qPodInfo, framework.EventUnscheduledPodAdd.Label())
+			}
+
+			for _, qPodInfo := range tt.qPodInfoInBackoffQ {
+				q.backoffQ.add(logger, qPodInfo, framework.EventUnscheduledPodAdd.Label())
+			}
+
+			// Activate specific pod according to the table
+			q.Activate(logger, map[string]*v1.Pod{"test_pod": tt.qPodInfoToActivate.PodInfo.Pod})
+
+			// Check the result after activation by the length of activeQ
+			if wantLen := len(tt.want); q.activeQ.len() != wantLen {
+				t.Fatalf("length compare: want %v, got %v", wantLen, q.activeQ.len())
+			}
+
+			if tt.expectedInFlightEvent != nil {
+				if len(q.activeQ.listInFlightEvents()) != 2 {
+					t.Fatalf("Expected two in-flight event to be recorded, but got %v events", len(q.activeQ.listInFlightEvents()))
+				}
+				found := false
+				for _, e := range q.activeQ.listInFlightEvents() {
+					event, ok := e.(*clusterEvent)
+					if !ok {
+						continue
+					}
+
+					if d := cmp.Diff(tt.expectedInFlightEvent, event, cmpopts.EquateComparable(clusterEvent{})); d != "" {
+						t.Fatalf("Unexpected in-flight event (-want, +got):\n%s", d)
+					}
+					found = true
+				}
+
+				if !found {
+					t.Fatalf("Expected in-flight event to be recorded, but it wasn't.")
+				}
+			}
+
+			// Check if the specific pod exists in activeQ
+			for _, want := range tt.want {
+				if !q.activeQ.has(newQueuedPodInfoForLookup(want.PodInfo.Pod)) {
+					t.Errorf("podInfo not exist in activeQ: want %v", want.PodInfo.Pod.Name)
+				}
+			}
+		})
+	}
+}
+
+type preEnqueuePlugin struct {
+	allowlists []string
+}
+
+func (pl *preEnqueuePlugin) Name() string {
+	return "preEnqueuePlugin"
+}
+
+func (pl *preEnqueuePlugin) PreEnqueue(ctx context.Context, p *v1.Pod) *fwk.Status {
+	for _, allowed := range pl.allowlists {
+		for label := range p.Labels {
+			if label == allowed {
+				return nil
+			}
+		}
+	}
+	return fwk.NewStatus(fwk.UnschedulableAndUnresolvable, "pod name not in allowlists")
+}
+
+func TestPriorityQueue_moveToActiveQ(t *testing.T) {
+	tests := []struct {
+		name                   string
+		plugins                []internalfwk.PreEnqueuePlugin
+		pod                    *v1.Pod
+		event                  string
+		movesFromBackoffQ      bool
+		popFromBackoffQEnabled []bool
+		wantUnschedulablePods  int
+		wantSuccess            bool
+	}{
+		{
+			name:                  "no plugins registered",
+			pod:                   st.MakePod().Name("p").Label("p", "").Obj(),
+			event:                 framework.EventUnscheduledPodAdd.Label(),
+			wantUnschedulablePods: 0,
+			wantSuccess:           true,
+		},
+		{
+			name:                  "preEnqueue plugin registered, pod name not in allowlists",
+			plugins:               []internalfwk.PreEnqueuePlugin{&preEnqueuePlugin{}, &preEnqueuePlugin{}},
+			pod:                   st.MakePod().Name("p").Label("p", "").Obj(),
+			event:                 framework.EventUnscheduledPodAdd.Label(),
+			wantUnschedulablePods: 1,
+			wantSuccess:           false,
+		},
+		{
+			name: "preEnqueue plugin registered, pod failed one preEnqueue plugin",
+			plugins: []internalfwk.PreEnqueuePlugin{
+				&preEnqueuePlugin{allowlists: []string{"foo", "bar"}},
+				&preEnqueuePlugin{allowlists: []string{"foo"}},
+			},
+			pod:                   st.MakePod().Name("bar").Label("bar", "").Obj(),
+			event:                 framework.EventUnscheduledPodAdd.Label(),
+			wantUnschedulablePods: 1,
+			wantSuccess:           false,
+		},
+		{
+			name: "preEnqueue plugin registered, preEnqueue rejects the pod, even if it is after backoff",
+			plugins: []internalfwk.PreEnqueuePlugin{
+				&preEnqueuePlugin{allowlists: []string{"foo", "bar"}},
+				&preEnqueuePlugin{allowlists: []string{"foo"}},
+			},
+			pod:                    st.MakePod().Name("bar").Label("bar", "").Obj(),
+			event:                  framework.BackoffComplete,
+			popFromBackoffQEnabled: []bool{false},
+			wantUnschedulablePods:  1,
+			wantSuccess:            false,
+		},
+		{
+			// With SchedulerPopFromBackoffQ enabled, the queue assumes the pod has already passed PreEnqueue,
+			// and it doesn't run PreEnqueue again, always puts the pod to activeQ.
+			name: "preEnqueue plugin registered, pod would fail one preEnqueue plugin, but it is moved from backoffQ after completing backoff, so preEnqueue is not executed",
+			plugins: []internalfwk.PreEnqueuePlugin{
+				&preEnqueuePlugin{allowlists: []string{"foo", "bar"}},
+				&preEnqueuePlugin{allowlists: []string{"foo"}},
+			},
+			pod:                    st.MakePod().Name("bar").Label("bar", "").Obj(),
+			event:                  framework.BackoffComplete,
+			movesFromBackoffQ:      true,
+			popFromBackoffQEnabled: []bool{true},
+			wantUnschedulablePods:  0,
+			wantSuccess:            true,
+		},
+		{
+			name: "preEnqueue plugin registered, pod failed one preEnqueue plugin when activated from unschedulablePods",
+			plugins: []internalfwk.PreEnqueuePlugin{
+				&preEnqueuePlugin{allowlists: []string{"foo", "bar"}},
+				&preEnqueuePlugin{allowlists: []string{"foo"}},
+			},
+			pod:                    st.MakePod().Name("bar").Label("bar", "").Obj(),
+			event:                  framework.ForceActivate,
+			movesFromBackoffQ:      false,
+			popFromBackoffQEnabled: []bool{true},
+			wantUnschedulablePods:  1,
+			wantSuccess:            false,
+		},
+		{
+			name: "preEnqueue plugin registered, pod would fail one preEnqueue plugin, but was activated from backoffQ, so preEnqueue is not executed",
+			plugins: []internalfwk.PreEnqueuePlugin{
+				&preEnqueuePlugin{allowlists: []string{"foo", "bar"}},
+				&preEnqueuePlugin{allowlists: []string{"foo"}},
+			},
+			pod:                    st.MakePod().Name("bar").Label("bar", "").Obj(),
+			event:                  framework.ForceActivate,
+			movesFromBackoffQ:      true,
+			popFromBackoffQEnabled: []bool{true},
+			wantUnschedulablePods:  0,
+			wantSuccess:            true,
+		},
+		{
+			name: "preEnqueue plugin registered, pod passed all preEnqueue plugins",
+			plugins: []internalfwk.PreEnqueuePlugin{
+				&preEnqueuePlugin{allowlists: []string{"foo", "bar"}},
+				&preEnqueuePlugin{allowlists: []string{"bar"}},
+			},
+			pod:                   st.MakePod().Name("bar").Label("bar", "").Obj(),
+			event:                 framework.EventUnscheduledPodAdd.Label(),
+			wantUnschedulablePods: 0,
+			wantSuccess:           true,
+		},
+	}
+
+	for _, tt := range tests {
+		if tt.popFromBackoffQEnabled == nil {
+			tt.popFromBackoffQEnabled = []bool{true, false}
+		}
+		for _, popFromBackoffQEnabled := range tt.popFromBackoffQEnabled {
+			t.Run(fmt.Sprintf("%s popFromBackoffQEnabled(%v)", tt.name, popFromBackoffQEnabled), func(t *testing.T) {
+				featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.SchedulerPopFromBackoffQ, popFromBackoffQEnabled)
+				logger, ctx := ktesting.NewTestContext(t)
+				ctx, cancel := context.WithCancel(ctx)
+				defer cancel()
+
+				m := map[string]map[string]internalfwk.PreEnqueuePlugin{"": make(map[string]internalfwk.PreEnqueuePlugin, len(tt.plugins))}
+				for _, plugin := range tt.plugins {
+					m[""][plugin.Name()] = plugin
+				}
+				q := NewTestQueueWithObjects(ctx, newDefaultQueueSort(), []runtime.Object{tt.pod}, WithPreEnqueuePluginMap(m),
+					WithPodInitialBackoffDuration(time.Second*30), WithPodMaxBackoffDuration(time.Second*60))
+				got := q.moveToActiveQ(logger, q.newQueuedPodInfo(tt.pod), tt.event, tt.movesFromBackoffQ)
+				if got != tt.wantSuccess {
+					t.Errorf("Unexpected result: want %v, but got %v", tt.wantSuccess, got)
+				}
+				if tt.wantUnschedulablePods != len(q.unschedulablePods.podInfoMap) {
+					t.Errorf("Unexpected unschedulablePods: want %v, but got %v", tt.wantUnschedulablePods, len(q.unschedulablePods.podInfoMap))
+				}
+
+				// Simulate an update event.
+				clone := tt.pod.DeepCopy()
+				metav1.SetMetaDataAnnotation(&clone.ObjectMeta, "foo", "")
+				q.Update(logger, tt.pod, clone)
+				// Ensure the pod is still located in unschedulablePods.
+				if tt.wantUnschedulablePods != len(q.unschedulablePods.podInfoMap) {
+					t.Errorf("Unexpected unschedulablePods: want %v, but got %v", tt.wantUnschedulablePods, len(q.unschedulablePods.podInfoMap))
+				}
+			})
+		}
+	}
+}
+
+func TestPriorityQueue_moveToBackoffQ(t *testing.T) {
+	tests := []struct {
+		name                   string
+		plugins                []internalfwk.PreEnqueuePlugin
+		pod                    *v1.Pod
+		popFromBackoffQEnabled []bool
+		wantSuccess            bool
+	}{
+		{
+			name:        "no plugins registered",
+			pod:         st.MakePod().Name("p").Label("p", "").Obj(),
+			wantSuccess: true,
+		},
+		{
+			name:                   "preEnqueue plugin registered, pod name would not be in allowlists",
+			plugins:                []internalfwk.PreEnqueuePlugin{&preEnqueuePlugin{}, &preEnqueuePlugin{}},
+			pod:                    st.MakePod().Name("p").Label("p", "").Obj(),
+			popFromBackoffQEnabled: []bool{false},
+			wantSuccess:            true,
+		},
+		{
+			name:                   "preEnqueue plugin registered, pod name not in allowlists",
+			plugins:                []internalfwk.PreEnqueuePlugin{&preEnqueuePlugin{}, &preEnqueuePlugin{}},
+			pod:                    st.MakePod().Name("p").Label("p", "").Obj(),
+			popFromBackoffQEnabled: []bool{true},
+			wantSuccess:            false,
+		},
+		{
+			name: "preEnqueue plugin registered, preEnqueue plugin would reject the pod, but isn't run",
+			plugins: []internalfwk.PreEnqueuePlugin{
+				&preEnqueuePlugin{allowlists: []string{"foo", "bar"}},
+				&preEnqueuePlugin{allowlists: []string{"foo"}},
+			},
+			pod:                    st.MakePod().Name("bar").Label("bar", "").Obj(),
+			popFromBackoffQEnabled: []bool{false},
+			wantSuccess:            true,
+		},
+		{
+			name: "preEnqueue plugin registered, pod failed one preEnqueue plugin",
+			plugins: []internalfwk.PreEnqueuePlugin{
+				&preEnqueuePlugin{allowlists: []string{"foo", "bar"}},
+				&preEnqueuePlugin{allowlists: []string{"foo"}},
+			},
+			pod:                    st.MakePod().Name("bar").Label("bar", "").Obj(),
+			popFromBackoffQEnabled: []bool{true},
+			wantSuccess:            false,
+		},
+		{
+			name: "preEnqueue plugin registered, pod passed all preEnqueue plugins",
+			plugins: []internalfwk.PreEnqueuePlugin{
+				&preEnqueuePlugin{allowlists: []string{"foo", "bar"}},
+				&preEnqueuePlugin{allowlists: []string{"bar"}},
+			},
+			pod:         st.MakePod().Name("bar").Label("bar", "").Obj(),
+			wantSuccess: true,
+		},
+	}
+
+	for _, tt := range tests {
+		if tt.popFromBackoffQEnabled == nil {
+			tt.popFromBackoffQEnabled = []bool{true, false}
+		}
+		for _, popFromBackoffQEnabled := range tt.popFromBackoffQEnabled {
+			t.Run(fmt.Sprintf("%s popFromBackoffQEnabled(%v)", tt.name, popFromBackoffQEnabled), func(t *testing.T) {
+				featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.SchedulerPopFromBackoffQ, popFromBackoffQEnabled)
+				logger, ctx := ktesting.NewTestContext(t)
+				ctx, cancel := context.WithCancel(ctx)
+				defer cancel()
+
+				m := map[string]map[string]internalfwk.PreEnqueuePlugin{"": make(map[string]internalfwk.PreEnqueuePlugin, len(tt.plugins))}
+				for _, plugin := range tt.plugins {
+					m[""][plugin.Name()] = plugin
+				}
+				q := NewTestQueueWithObjects(ctx, newDefaultQueueSort(), []runtime.Object{tt.pod}, WithPreEnqueuePluginMap(m),
+					WithPodInitialBackoffDuration(time.Second*30), WithPodMaxBackoffDuration(time.Second*60))
+				pInfo := q.newQueuedPodInfo(tt.pod)
+				got := q.moveToBackoffQ(logger, pInfo, framework.EventUnscheduledPodAdd.Label())
+				if got != tt.wantSuccess {
+					t.Errorf("Unexpected result: want %v, but got %v", tt.wantSuccess, got)
+				}
+				if tt.wantSuccess {
+					if !q.backoffQ.has(pInfo) {
+						t.Errorf("Expected pod to be in backoffQ, but it isn't")
+					}
+					if q.unschedulablePods.get(pInfo.Pod) != nil {
+						t.Errorf("Expected pod not to be in unschedulablePods, but it is")
+					}
+				} else {
+					if q.backoffQ.has(pInfo) {
+						t.Errorf("Expected pod not to be in backoffQ, but it is")
+					}
+					if q.unschedulablePods.get(pInfo.Pod) == nil {
+						t.Errorf("Expected pod to be in unschedulablePods, but it isn't")
+					}
+				}
+			})
+		}
+	}
+}
+
+func BenchmarkMoveAllToActiveOrBackoffQueue(b *testing.B) {
+	tests := []struct {
+		name      string
+		moveEvent fwk.ClusterEvent
+	}{
+		{
+			name:      "baseline",
+			moveEvent: framework.EventUnschedulableTimeout,
+		},
+		{
+			name:      "worst",
+			moveEvent: nodeAdd,
+		},
+		{
+			name: "random",
+			// leave "moveEvent" unspecified
+		},
+	}
+
+	podTemplates := []*v1.Pod{
+		highPriorityPodInfo.Pod, highPriNominatedPodInfo.Pod,
+		medPriorityPodInfo.Pod, unschedulablePodInfo.Pod,
+	}
+
+	events := []fwk.ClusterEvent{
+		{Resource: fwk.Node, ActionType: fwk.Add},
+		{Resource: fwk.Node, ActionType: fwk.UpdateNodeTaint},
+		{Resource: fwk.Node, ActionType: fwk.UpdateNodeAllocatable},
+		{Resource: fwk.Node, ActionType: fwk.UpdateNodeCondition},
+		{Resource: fwk.Node, ActionType: fwk.UpdateNodeLabel},
+		{Resource: fwk.Node, ActionType: fwk.UpdateNodeAnnotation},
+		{Resource: fwk.PersistentVolumeClaim, ActionType: fwk.Add},
+		{Resource: fwk.PersistentVolumeClaim, ActionType: fwk.Update},
+		{Resource: fwk.PersistentVolume, ActionType: fwk.Add},
+		{Resource: fwk.PersistentVolume, ActionType: fwk.Update},
+		{Resource: fwk.StorageClass, ActionType: fwk.Add},
+		{Resource: fwk.StorageClass, ActionType: fwk.Update},
+		{Resource: fwk.CSINode, ActionType: fwk.Add},
+		{Resource: fwk.CSINode, ActionType: fwk.Update},
+		{Resource: fwk.CSIDriver, ActionType: fwk.Add},
+		{Resource: fwk.CSIDriver, ActionType: fwk.Update},
+		{Resource: fwk.CSIStorageCapacity, ActionType: fwk.Add},
+		{Resource: fwk.CSIStorageCapacity, ActionType: fwk.Update},
+	}
+
+	pluginNum := 20
+	var plugins []string
+	// Mimic that we have 20 plugins loaded in runtime.
+	for i := 0; i < pluginNum; i++ {
+		plugins = append(plugins, fmt.Sprintf("fake-plugin-%v", i))
+	}
+
+	for _, tt := range tests {
+		for _, podsInUnschedulablePods := range []int{1000, 5000} {
+			b.Run(fmt.Sprintf("%v-%v", tt.name, podsInUnschedulablePods), func(b *testing.B) {
+				logger, ctx := ktesting.NewTestContext(b)
+				for i := 0; i < b.N; i++ {
+					b.StopTimer()
+					c := testingclock.NewFakeClock(time.Now())
+
+					m := makeEmptyQueueingHintMapPerProfile()
+					// - All plugins registered for events[0], which is NodeAdd.
+					// - 1/2 of plugins registered for events[1]
+					// - 1/3 of plugins registered for events[2]
+					// - ...
+					for j := 0; j < len(events); j++ {
+						for k := 0; k < len(plugins); k++ {
+							if (k+1)%(j+1) == 0 {
+								m[""][events[j]] = append(m[""][events[j]], &QueueingHintFunction{
+									PluginName:     plugins[k],
+									QueueingHintFn: queueHintReturnQueue,
+								})
+							}
+						}
+					}
+
+					ctx, cancel := context.WithCancel(ctx)
+					defer cancel()
+					q := NewTestQueue(ctx, newDefaultQueueSort(), WithClock(c), WithQueueingHintMapPerProfile(m))
+
+					// Init pods in unschedulablePods.
+					for j := 0; j < podsInUnschedulablePods; j++ {
+						p := podTemplates[j%len(podTemplates)].DeepCopy()
+						p.Name, p.UID = fmt.Sprintf("%v-%v", p.Name, j), types.UID(fmt.Sprintf("%v-%v", p.UID, j))
+						var podInfo *framework.QueuedPodInfo
+						// The ultimate goal of composing each PodInfo is to cover the path that intersects
+						// (unschedulable) plugin names with the plugins that register the moveEvent,
+						// here the rational is:
+						// - in baseline case, don't inject unschedulable plugin names, so podMatchesEvent()
+						//   never gets executed.
+						// - in worst case, make both ends (of the intersection) a big number,i.e.,
+						//   M intersected with N instead of M with 1 (or 1 with N)
+						// - in random case, each pod failed by a random plugin, and also the moveEvent
+						//   is randomized.
+						if tt.name == "baseline" {
+							podInfo = q.newQueuedPodInfo(p)
+						} else if tt.name == "worst" {
+							// Each pod failed by all plugins.
+							podInfo = q.newQueuedPodInfo(p, plugins...)
+						} else {
+							// Random case.
+							podInfo = q.newQueuedPodInfo(p, plugins[j%len(plugins)])
+						}
+						err := q.AddUnschedulableIfNotPresent(logger, podInfo, q.SchedulingCycle())
+						if err != nil {
+							b.Fatalf("unexpected error from AddUnschedulableIfNotPresent: %v", err)
+						}
+					}
+
+					b.StartTimer()
+					if tt.moveEvent.Resource != "" {
+						q.MoveAllToActiveOrBackoffQueue(logger, tt.moveEvent, nil, nil, nil)
+					} else {
+						// Random case.
+						q.MoveAllToActiveOrBackoffQueue(logger, events[i%len(events)], nil, nil, nil)
+					}
+				}
+			})
+		}
+	}
+}
+
+func TestPriorityQueue_MoveAllToActiveOrBackoffQueueWithQueueingHint(t *testing.T) {
+	now := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	p := st.MakePod().Name("pod1").Namespace("ns1").UID("1").Label("foo", "bar").Obj()
+	tests := []struct {
+		name    string
+		podInfo *framework.QueuedPodInfo
+		hint    fwk.QueueingHintFn
+		// duration is the duration that the Pod has been in the unschedulable queue.
+		duration time.Duration
+		// expectedQ is the queue name (activeQ, backoffQ, or unschedulablePods) that this Pod should be quened to.
+		expectedQ string
+	}{
+		{
+			name: "Queue queues pod to activeQ",
+			// This pod has PendingPlugins and hence will be pushed directly to activeQ
+			podInfo:   &framework.QueuedPodInfo{PodInfo: mustNewPodInfo(p), PendingPlugins: sets.New("foo")},
+			hint:      queueHintReturnQueue,
+			expectedQ: activeQ,
+		},
+		{
+			name: "Queue queues pod to backoffQ if Pod is backing off",
+			// needs UnschedulableCount to make it backing off.
+			podInfo:   &framework.QueuedPodInfo{PodInfo: mustNewPodInfo(p), UnschedulablePlugins: sets.New("foo")},
+			hint:      queueHintReturnQueue,
+			expectedQ: backoffQ,
+		},
+		{
+			name:    "Queue queues pod to activeQ if Pod is not backing off",
+			podInfo: &framework.QueuedPodInfo{PodInfo: mustNewPodInfo(p), UnschedulablePlugins: sets.New("foo")},
+			hint:    queueHintReturnQueue,
+			// The pod is assumed to failed the scheduling cycle once, which would get DefaultPodInitialBackoffDuration as the penalty.
+			// To finish the backoff, waiting for DefaultPodInitialBackoffDuration isn't enough, need to wait for +1
+			// because the pod is determined to be still backing off if `{backoff expiration time} == trancate({current time})`
+			duration:  DefaultPodInitialBackoffDuration + time.Second,
+			expectedQ: activeQ,
+		},
+		{
+			name:      "Skip queues pod to unschedulablePods",
+			podInfo:   &framework.QueuedPodInfo{PodInfo: mustNewPodInfo(p), UnschedulablePlugins: sets.New("foo")},
+			hint:      queueHintReturnSkip,
+			expectedQ: unschedulableQ,
+		},
+		{
+			name:    "QueueHintFunction is not called when Pod is gated by the plugin that isn't interested in the event",
+			podInfo: setQueuedPodInfoGated(&framework.QueuedPodInfo{PodInfo: mustNewPodInfo(p)}, names.SchedulingGates, []fwk.ClusterEvent{framework.EventUnscheduledPodUpdate}),
+			// The hintFn should not be called as the pod is gated by SchedulingGates plugin,
+			// the scheduling gate isn't interested in the node add event,
+			// and the queue should keep this Pod in the unschedQ without calling the hintFn.
+			hint: func(logger klog.Logger, pod *v1.Pod, oldObj, newObj interface{}) (fwk.QueueingHint, error) {
+				return fwk.Queue, fmt.Errorf("QueueingHintFn should not be called as pod is gated")
+			},
+			expectedQ: unschedulableQ,
+		},
+		{
+			name:    "QueueHintFunction is called when Pod is gated by the plugin that is interested in the event",
+			podInfo: setQueuedPodInfoGated(&framework.QueuedPodInfo{PodInfo: mustNewPodInfo(p)}, "foo", []fwk.ClusterEvent{nodeAdd}),
+			// In this case, the hintFn should be called as the pod is gated by foo plugin that is interested in the NodeAdd event.
+			hint: queueHintReturnQueue,
+			// and, as a result, this pod should be queued to backoffQ.
+			expectedQ: backoffQ,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			logger, ctx := ktesting.NewTestContext(t)
+			m := makeEmptyQueueingHintMapPerProfile()
+			m[""][nodeAdd] = []*QueueingHintFunction{
+				{
+					PluginName:     "foo",
+					QueueingHintFn: test.hint,
+				},
+			}
+			m[""][framework.EventUnscheduledPodUpdate] = []*QueueingHintFunction{
+				{
+					PluginName:     names.SchedulingGates,
+					QueueingHintFn: queueHintReturnQueue,
+				},
+			}
+			cl := testingclock.NewFakeClock(now)
+			plugin, _ := schedulinggates.New(ctx, nil, nil, plfeature.Features{})
+			preEnqM := map[string]map[string]internalfwk.PreEnqueuePlugin{"": {
+				names.SchedulingGates: plugin.(internalfwk.PreEnqueuePlugin),
+				"foo":                 &preEnqueuePlugin{allowlists: []string{"foo"}},
+			}}
+			q := NewTestQueue(ctx, newDefaultQueueSort(), WithQueueingHintMapPerProfile(m), WithClock(cl), WithPreEnqueuePluginMap(preEnqM))
+			q.Add(logger, test.podInfo.Pod)
+			if p, err := q.Pop(logger); err != nil || p.Pod != test.podInfo.Pod {
+				t.Errorf("Expected: %v after Pop, but got: %v", test.podInfo.Pod.Name, p.Pod.Name)
+			}
+			// add to unsched pod pool
+			err := q.AddUnschedulableIfNotPresent(logger, test.podInfo, q.SchedulingCycle())
+			if err != nil {
+				t.Fatalf("unexpected error from AddUnschedulableIfNotPresent: %v", err)
+			}
+			cl.Step(test.duration)
+
+			q.MoveAllToActiveOrBackoffQueue(logger, nodeAdd, nil, nil, nil)
+
+			if q.backoffQ.len() == 0 && test.expectedQ == backoffQ {
+				t.Fatalf("expected pod to be queued to backoffQ, but it was not")
+			}
+
+			if q.activeQ.len() == 0 && test.expectedQ == activeQ {
+				t.Fatalf("expected pod to be queued to activeQ, but it was not")
+			}
+
+			if q.unschedulablePods.get(test.podInfo.Pod) == nil && test.expectedQ == unschedulableQ {
+				t.Fatalf("expected pod to be queued to unschedulablePods, but it was not")
+			}
+		})
+	}
+}
+
+func TestPriorityQueue_MoveAllToActiveOrBackoffQueue(t *testing.T) {
+	c := testingclock.NewFakeClock(time.Now())
+	logger, ctx := ktesting.NewTestContext(t)
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	m := makeEmptyQueueingHintMapPerProfile()
+
+	m[""][nodeAdd] = []*QueueingHintFunction{
+		{
+			PluginName:     "fooPlugin",
+			QueueingHintFn: queueHintReturnQueue,
+		},
+	}
+	q := NewTestQueue(ctx, newDefaultQueueSort(), WithClock(c), WithQueueingHintMapPerProfile(m))
+	// To simulate the pod is failed in scheduling in the real world, Pop() the pod from activeQ before AddUnschedulableIfNotPresent()s below.
+	q.Add(logger, unschedulablePodInfo.Pod)
+	if p, err := q.Pop(logger); err != nil || p.Pod != unschedulablePodInfo.Pod {
+		t.Errorf("Expected: %v after Pop, but got: %v", unschedulablePodInfo.Pod.Name, p.Pod.Name)
+	}
+	expectInFlightPods(t, q, unschedulablePodInfo.Pod.UID)
+	q.Add(logger, highPriorityPodInfo.Pod)
+	if p, err := q.Pop(logger); err != nil || p.Pod != highPriorityPodInfo.Pod {
+		t.Errorf("Expected: %v after Pop, but got: %v", highPriorityPodInfo.Pod.Name, p.Pod.Name)
+	}
+	expectInFlightPods(t, q, unschedulablePodInfo.Pod.UID, highPriorityPodInfo.Pod.UID)
+	err := q.AddUnschedulableIfNotPresent(logger, q.newQueuedPodInfo(unschedulablePodInfo.Pod, "fooPlugin"), q.SchedulingCycle())
+	if err != nil {
+		t.Fatalf("unexpected error from AddUnschedulableIfNotPresent: %v", err)
+	}
+	err = q.AddUnschedulableIfNotPresent(logger, q.newQueuedPodInfo(highPriorityPodInfo.Pod, "fooPlugin"), q.SchedulingCycle())
+	if err != nil {
+		t.Fatalf("unexpected error from AddUnschedulableIfNotPresent: %v", err)
+	}
+	expectInFlightPods(t, q)
+	// Construct a Pod, but don't associate its scheduler failure to any plugin
+	hpp1 := clonePod(highPriorityPodInfo.Pod, "hpp1")
+	q.Add(logger, hpp1)
+	if p, err := q.Pop(logger); err != nil || p.Pod != hpp1 {
+		t.Errorf("Expected: %v after Pop, but got: %v", hpp1, p.Pod.Name)
+	}
+	expectInFlightPods(t, q, hpp1.UID)
+	// This Pod will go to backoffQ because no failure plugin is associated with it.
+	hpp1PodInfo := q.newQueuedPodInfo(hpp1)
+	hpp1PodInfo.UnschedulableCount++
+	err = q.AddUnschedulableIfNotPresent(logger, hpp1PodInfo, q.SchedulingCycle())
+	if err != nil {
+		t.Fatalf("unexpected error from AddUnschedulableIfNotPresent: %v", err)
+	}
+	expectInFlightPods(t, q)
+	// Construct another Pod, and associate its scheduler failure to plugin "barPlugin".
+	hpp2 := clonePod(highPriorityPodInfo.Pod, "hpp2")
+	q.Add(logger, hpp2)
+	if p, err := q.Pop(logger); err != nil || p.Pod != hpp2 {
+		t.Errorf("Expected: %v after Pop, but got: %v", hpp2, p.Pod.Name)
+	}
+	expectInFlightPods(t, q, hpp2.UID)
+	// This Pod will go to the unschedulable Pod pool.
+	err = q.AddUnschedulableIfNotPresent(logger, q.newQueuedPodInfo(hpp2, "barPlugin"), q.SchedulingCycle())
+	if err != nil {
+		t.Fatalf("unexpected error from AddUnschedulableIfNotPresent: %v", err)
+	}
+	expectInFlightPods(t, q)
+	// This NodeAdd event moves unschedulablePodInfo and highPriorityPodInfo to the backoffQ,
+	// because of the queueing hint function registered for NodeAdd/fooPlugin.
+	q.MoveAllToActiveOrBackoffQueue(logger, nodeAdd, nil, nil, nil)
+	q.Add(logger, medPriorityPodInfo.Pod)
+	if q.activeQ.len() != 1 {
+		t.Errorf("Expected 1 item to be in activeQ, but got: %v", q.activeQ.len())
+	}
+	// Pop out the medPriorityPodInfo in activeQ.
+	if p, err := q.Pop(logger); err != nil || p.Pod != medPriorityPodInfo.Pod {
+		t.Errorf("Expected: %v after Pop, but got: %v", medPriorityPodInfo.Pod, p.Pod.Name)
+	}
+	expectInFlightPods(t, q, medPriorityPodInfo.Pod.UID)
+	// hpp2 won't be moved.
+	if q.backoffQ.len() != 3 {
+		t.Fatalf("Expected 3 items to be in backoffQ, but got: %v", q.backoffQ.len())
+	}
+
+	// pop out the pods in the backoffQ.
+	// This doesn't make them in-flight pods.
+	c.Step(q.backoffQ.podMaxBackoffDuration())
+	_ = q.backoffQ.popAllBackoffCompleted(logger)
+	expectInFlightPods(t, q, medPriorityPodInfo.Pod.UID)
+
+	q.Add(logger, unschedulablePodInfo.Pod)
+	if p, err := q.Pop(logger); err != nil || p.Pod != unschedulablePodInfo.Pod {
+		t.Errorf("Expected: %v after Pop, but got: %v", unschedulablePodInfo.Pod.Name, p.Pod.Name)
+	}
+	expectInFlightPods(t, q, medPriorityPodInfo.Pod.UID, unschedulablePodInfo.Pod.UID)
+	q.Add(logger, highPriorityPodInfo.Pod)
+	if p, err := q.Pop(logger); err != nil || p.Pod != highPriorityPodInfo.Pod {
+		t.Errorf("Expected: %v after Pop, but got: %v", highPriorityPodInfo.Pod.Name, p.Pod.Name)
+	}
+	expectInFlightPods(t, q, medPriorityPodInfo.Pod.UID, unschedulablePodInfo.Pod.UID, highPriorityPodInfo.Pod.UID)
+	q.Add(logger, hpp1)
+	if p, err := q.Pop(logger); err != nil || p.Pod != hpp1 {
+		t.Errorf("Expected: %v after Pop, but got: %v", hpp1, p.Pod.Name)
+	}
+	unschedulableQueuedPodInfo := q.newQueuedPodInfo(unschedulablePodInfo.Pod, "fooPlugin")
+	highPriorityQueuedPodInfo := q.newQueuedPodInfo(highPriorityPodInfo.Pod, "fooPlugin")
+	hpp1QueuedPodInfo := q.newQueuedPodInfo(hpp1)
+	expectInFlightPods(t, q, medPriorityPodInfo.Pod.UID, unschedulablePodInfo.Pod.UID, highPriorityPodInfo.Pod.UID, hpp1.UID)
+	err = q.AddUnschedulableIfNotPresent(logger, unschedulableQueuedPodInfo, q.SchedulingCycle())
+	if err != nil {
+		t.Fatalf("unexpected error from AddUnschedulableIfNotPresent: %v", err)
+	}
+	expectInFlightPods(t, q, medPriorityPodInfo.Pod.UID, highPriorityPodInfo.Pod.UID, hpp1.UID)
+	err = q.AddUnschedulableIfNotPresent(logger, highPriorityQueuedPodInfo, q.SchedulingCycle())
+	if err != nil {
+		t.Fatalf("unexpected error from AddUnschedulableIfNotPresent: %v", err)
+	}
+	expectInFlightPods(t, q, medPriorityPodInfo.Pod.UID, hpp1.UID)
+	err = q.AddUnschedulableIfNotPresent(logger, hpp1QueuedPodInfo, q.SchedulingCycle())
+	if err != nil {
+		t.Fatalf("unexpected error from AddUnschedulableIfNotPresent: %v", err)
+	}
+	expectInFlightPods(t, q, medPriorityPodInfo.Pod.UID)
+	q.Add(logger, medPriorityPodInfo.Pod)
+	// hpp1 will go to backoffQ because no failure plugin is associated with it.
+	// All plugins other than hpp1 are enqueued to the unschedulable Pod pool.
+	for _, pod := range []*v1.Pod{unschedulablePodInfo.Pod, highPriorityPodInfo.Pod, hpp2} {
+		if q.unschedulablePods.get(pod) == nil {
+			t.Errorf("Expected %v in the unschedulablePods", pod.Name)
+		}
+	}
+	if !q.backoffQ.has(hpp1QueuedPodInfo) {
+		t.Errorf("Expected %v in the backoffQ", hpp1.Name)
+	}
+	// all the remaining Pods should be in activeQ.
+	if q.activeQ.len() != 1 {
+		t.Errorf("Expected %v in the activeQ", medPriorityPodInfo.Pod.Name)
+	}
+
+	// Move clock by podMaxBackoffDuration, so that pods in the unschedulablePods would pass the backing off,
+	// and the pods will be moved into activeQ.
+	c.Step(q.backoffQ.podMaxBackoffDuration())
+	q.flushBackoffQCompleted(logger) // flush the completed backoffQ to move hpp1 to activeQ.
+	q.MoveAllToActiveOrBackoffQueue(logger, nodeAdd, nil, nil, nil)
+	if q.activeQ.len() != 4 {
+		t.Errorf("Expected 4 items to be in activeQ, but got: %v", q.activeQ.len())
+	}
+	if q.backoffQ.len() != 0 {
+		t.Errorf("Expected 0 item to be in backoffQ, but got: %v", q.backoffQ.len())
+	}
+	expectInFlightPods(t, q, medPriorityPodInfo.Pod.UID)
+	if len(q.unschedulablePods.podInfoMap) != 1 {
+		// hpp2 won't be moved regardless of its backoff timer.
+		t.Errorf("Expected 1 item to be in unschedulablePods, but got: %v", len(q.unschedulablePods.podInfoMap))
+	}
+}
+
+func TestPriorityQueue_MoveAllToActiveOrBackoffQueueWithoutQueueingHint(t *testing.T) {
+	c := testingclock.NewFakeClock(time.Now())
+	logger, ctx := ktesting.NewTestContext(t)
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	m := makeEmptyQueueingHintMapPerProfile()
+	featuregatetesting.SetFeatureGateEmulationVersionDuringTest(t, utilfeature.DefaultFeatureGate, version.MustParse("1.33"))
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.SchedulerQueueingHints, false)
+	m[""][nodeAdd] = []*QueueingHintFunction{
+		{
+			PluginName:     "fooPlugin",
+			QueueingHintFn: queueHintReturnQueue,
+		},
+	}
+	q := NewTestQueue(ctx, newDefaultQueueSort(), WithClock(c), WithQueueingHintMapPerProfile(m))
+	// To simulate the pod is failed in scheduling in the real world, Pop() the pod from activeQ before AddUnschedulableIfNotPresent()s below.
+	q.Add(logger, medPriorityPodInfo.Pod)
+
+	err := q.AddUnschedulableIfNotPresent(logger, q.newQueuedPodInfo(unschedulablePodInfo.Pod, "fooPlugin"), q.SchedulingCycle())
+	if err != nil {
+		t.Fatalf("unexpected error from AddUnschedulableIfNotPresent: %v", err)
+	}
+	err = q.AddUnschedulableIfNotPresent(logger, q.newQueuedPodInfo(highPriorityPodInfo.Pod, "fooPlugin"), q.SchedulingCycle())
+	if err != nil {
+		t.Fatalf("unexpected error from AddUnschedulableIfNotPresent: %v", err)
+	}
+	// Construct a Pod, but don't associate its scheduler failure to any plugin
+	hpp1 := clonePod(highPriorityPodInfo.Pod, "hpp1")
+	// This Pod will go to backoffQ because no failure plugin is associated with it.
+	hpp1PodInfo := q.newQueuedPodInfo(hpp1)
+	hpp1PodInfo.UnschedulableCount++
+	err = q.AddUnschedulableIfNotPresent(logger, hpp1PodInfo, q.SchedulingCycle())
+	if err != nil {
+		t.Fatalf("unexpected error from AddUnschedulableIfNotPresent: %v", err)
+	}
+	// Construct another Pod, and associate its scheduler failure to plugin "barPlugin".
+	hpp2 := clonePod(highPriorityPodInfo.Pod, "hpp2")
+	// This Pod will go to the unschedulable Pod pool.
+	err = q.AddUnschedulableIfNotPresent(logger, q.newQueuedPodInfo(hpp2, "barPlugin"), q.SchedulingCycle())
+	if err != nil {
+		t.Fatalf("unexpected error from AddUnschedulableIfNotPresent: %v", err)
+	}
+	// This NodeAdd event moves unschedulablePodInfo and highPriorityPodInfo to the backoffQ,
+	// because of the queueing hint function registered for NodeAdd/fooPlugin.
+	q.MoveAllToActiveOrBackoffQueue(logger, nodeAdd, nil, nil, nil)
+	if q.activeQ.len() != 1 {
+		t.Errorf("Expected 1 item to be in activeQ, but got: %v", q.activeQ.len())
+	}
+	// Pop out the medPriorityPodInfo in activeQ.
+	if p, err := q.Pop(logger); err != nil || p.Pod != medPriorityPodInfo.Pod {
+		t.Errorf("Expected: %v after Pop, but got: %v", medPriorityPodInfo.Pod, p.Pod.Name)
+	}
+	// hpp2 won't be moved.
+	if q.backoffQ.len() != 3 {
+		t.Fatalf("Expected 3 items to be in backoffQ, but got: %v", q.backoffQ.len())
+	}
+
+	// pop out the pods in the backoffQ.
+	// This doesn't make them in-flight pods.
+	c.Step(q.backoffQ.podMaxBackoffDuration())
+	_ = q.backoffQ.popAllBackoffCompleted(logger)
+
+	unschedulableQueuedPodInfo := q.newQueuedPodInfo(unschedulablePodInfo.Pod, "fooPlugin")
+	highPriorityQueuedPodInfo := q.newQueuedPodInfo(highPriorityPodInfo.Pod, "fooPlugin")
+	hpp1QueuedPodInfo := q.newQueuedPodInfo(hpp1)
+	err = q.AddUnschedulableIfNotPresent(logger, unschedulableQueuedPodInfo, q.SchedulingCycle())
+	if err != nil {
+		t.Fatalf("unexpected error from AddUnschedulableIfNotPresent: %v", err)
+	}
+	err = q.AddUnschedulableIfNotPresent(logger, highPriorityQueuedPodInfo, q.SchedulingCycle())
+	if err != nil {
+		t.Fatalf("unexpected error from AddUnschedulableIfNotPresent: %v", err)
+	}
+	err = q.AddUnschedulableIfNotPresent(logger, hpp1QueuedPodInfo, q.SchedulingCycle())
+	if err != nil {
+		t.Fatalf("unexpected error from AddUnschedulableIfNotPresent: %v", err)
+	}
+	q.Add(logger, medPriorityPodInfo.Pod)
+	// hpp1 will go to backoffQ because no failure plugin is associated with it.
+	// All plugins other than hpp1 are enqueued to the unschedulable Pod pool.
+	for _, pod := range []*v1.Pod{unschedulablePodInfo.Pod, highPriorityPodInfo.Pod, hpp2} {
+		if q.unschedulablePods.get(pod) == nil {
+			t.Errorf("Expected %v in the unschedulablePods", pod.Name)
+		}
+	}
+	if !q.backoffQ.has(hpp1QueuedPodInfo) {
+		t.Errorf("Expected %v in the backoffQ", hpp1.Name)
+	}
+
+	// the remaining Pods should be in activeQ.
+	if q.activeQ.len() != 1 {
+		t.Errorf("Expected %v in the activeQ", medPriorityPodInfo.Pod.Name)
+	}
+
+	// Move clock by podMaxBackoffDuration, so that pods in the unschedulablePods would pass the backing off,
+	// and the pods will be moved into activeQ.
+	c.Step(q.backoffQ.podMaxBackoffDuration())
+	q.flushBackoffQCompleted(logger) // flush the completed backoffQ to move hpp1 to activeQ.
+	q.MoveAllToActiveOrBackoffQueue(logger, nodeAdd, nil, nil, nil)
+	if q.activeQ.len() != 4 {
+		t.Errorf("Expected 4 items to be in activeQ, but got: %v", q.activeQ.len())
+	}
+	if q.backoffQ.len() != 0 {
+		t.Errorf("Expected 0 item to be in backoffQ, but got: %v", q.backoffQ.len())
+	}
+	if len(q.unschedulablePods.podInfoMap) != 1 {
+		// hpp2 won't be moved regardless of its backoff timer.
+		t.Errorf("Expected 1 item to be in unschedulablePods, but got: %v", len(q.unschedulablePods.podInfoMap))
+	}
+}
+
+func clonePod(pod *v1.Pod, newName string) *v1.Pod {
+	pod = pod.DeepCopy()
+	pod.Name = newName
+	pod.UID = types.UID(pod.Name + pod.Namespace)
+	return pod
+}
+
+func expectInFlightPods(t *testing.T, q *PriorityQueue, uids ...types.UID) {
+	t.Helper()
+	var actualUIDs []types.UID
+	for _, pod := range q.activeQ.listInFlightPods() {
+		actualUIDs = append(actualUIDs, pod.UID)
+	}
+	sortUIDs := cmpopts.SortSlices(func(a, b types.UID) bool { return a < b })
+	if diff := cmp.Diff(uids, actualUIDs, sortUIDs); diff != "" {
+		t.Fatalf("Unexpected content of inFlightPods (-want, +have):\n%s", diff)
+	}
+	actualUIDs = nil
+	events := q.activeQ.listInFlightEvents()
+	for _, e := range events {
+		if pod, ok := e.(*v1.Pod); ok {
+			actualUIDs = append(actualUIDs, pod.UID)
+		}
+	}
+	if diff := cmp.Diff(uids, actualUIDs, sortUIDs); diff != "" {
+		t.Fatalf("Unexpected pods in inFlightEvents (-want, +have):\n%s", diff)
+	}
+}
+
+// TestPriorityQueue_AssignedPodAdded tests AssignedPodAdded. It checks that
+// when a pod with pod affinity is in unschedulablePods and another pod with a
+// matching label is added, the unschedulable pod is moved to activeQ.
+func TestPriorityQueue_AssignedPodAdded_(t *testing.T) {
+	tests := []struct {
+		name               string
+		unschedPod         *v1.Pod
+		unschedPlugin      string
+		updatedAssignedPod *v1.Pod
+		wantToRequeue      bool
+	}{
+		{
+			name:               "Pod rejected by pod affinity is requeued with matching Pod's update",
+			unschedPod:         st.MakePod().Name("afp").Namespace("ns1").UID("afp").Annotation("annot2", "val2").PodAffinityExists("service", "region", st.PodAffinityWithRequiredReq).Obj(),
+			unschedPlugin:      names.InterPodAffinity,
+			updatedAssignedPod: st.MakePod().Name("lbp").Namespace("ns1").Label("service", "securityscan").Node("node1").Obj(),
+			wantToRequeue:      true,
+		},
+		{
+			name:               "Pod rejected by pod affinity isn't requeued with unrelated Pod's update",
+			unschedPod:         st.MakePod().Name("afp").Namespace("ns1").UID("afp").Annotation("annot2", "val2").PodAffinityExists("service", "region", st.PodAffinityWithRequiredReq).Obj(),
+			unschedPlugin:      names.InterPodAffinity,
+			updatedAssignedPod: st.MakePod().Name("lbp").Namespace("unrelated").Label("unrelated", "unrelated").Node("node1").Obj(),
+			wantToRequeue:      false,
+		},
+		{
+			name:               "Pod rejected by pod topology spread is requeued with Pod's update in the same namespace",
+			unschedPod:         st.MakePod().Name("tsp").Namespace("ns1").UID("tsp").SpreadConstraint(1, "node", v1.DoNotSchedule, nil, nil, nil, nil, nil).Obj(),
+			unschedPlugin:      names.PodTopologySpread,
+			updatedAssignedPod: st.MakePod().Name("lbp").Namespace("ns1").Label("service", "securityscan").Node("node1").Obj(),
+			wantToRequeue:      true,
+		},
+		{
+			name:               "Pod rejected by pod topology spread isn't requeued with unrelated Pod's update",
+			unschedPod:         st.MakePod().Name("afp").Namespace("ns1").UID("afp").Annotation("annot2", "val2").PodAffinityExists("service", "region", st.PodAffinityWithRequiredReq).Obj(),
+			unschedPlugin:      names.PodTopologySpread,
+			updatedAssignedPod: st.MakePod().Name("lbp").Namespace("unrelated").Label("unrelated", "unrelated").Node("node1").Obj(),
+			wantToRequeue:      false,
+		},
+		{
+			name:               "Pod rejected by other plugins isn't requeued with any Pod's update",
+			unschedPod:         st.MakePod().Name("afp").Namespace("ns1").UID("afp").Annotation("annot2", "val2").Obj(),
+			unschedPlugin:      "fakePlugin",
+			updatedAssignedPod: st.MakePod().Name("lbp").Namespace("unrelated").Label("unrelated", "unrelated").Node("node1").Obj(),
+			wantToRequeue:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logger, ctx := ktesting.NewTestContext(t)
+			ctx, cancel := context.WithCancel(ctx)
+			defer cancel()
+
+			c := testingclock.NewFakeClock(time.Now())
+			m := makeEmptyQueueingHintMapPerProfile()
+			m[""][framework.EventAssignedPodAdd] = []*QueueingHintFunction{
+				{
+					PluginName:     "fakePlugin",
+					QueueingHintFn: queueHintReturnQueue,
+				},
+				{
+					PluginName:     names.InterPodAffinity,
+					QueueingHintFn: queueHintReturnQueue,
+				},
+				{
+					PluginName:     names.PodTopologySpread,
+					QueueingHintFn: queueHintReturnQueue,
+				},
+			}
+			q := NewTestQueue(ctx, newDefaultQueueSort(), WithClock(c), WithQueueingHintMapPerProfile(m))
+
+			// To simulate the pod is failed in scheduling in the real world, Pop() the pod from activeQ before AddUnschedulableIfNotPresent()s below.
+			q.Add(logger, tt.unschedPod)
+			if p, err := q.Pop(logger); err != nil || p.Pod != tt.unschedPod {
+				t.Errorf("Expected: %v after Pop, but got: %v", tt.unschedPod.Name, p.Pod.Name)
+			}
+
+			err := q.AddUnschedulableIfNotPresent(logger, q.newQueuedPodInfo(tt.unschedPod, tt.unschedPlugin), q.SchedulingCycle())
+			if err != nil {
+				t.Fatalf("unexpected error from AddUnschedulableIfNotPresent: %v", err)
+			}
+
+			// Move clock to make the unschedulable pods complete backoff.
+			c.Step(DefaultPodInitialBackoffDuration + time.Second)
+
+			q.AssignedPodAdded(logger, tt.updatedAssignedPod)
+
+			if q.activeQ.has(newQueuedPodInfoForLookup(tt.unschedPod)) != tt.wantToRequeue {
+				t.Fatalf("unexpected Pod move: Pod should be requeued: %v. Pod is actually requeued: %v", tt.wantToRequeue, !tt.wantToRequeue)
+			}
+		})
+	}
+}
+
+func TestPriorityQueue_AssignedPodUpdated(t *testing.T) {
+	tests := []struct {
+		name               string
+		unschedPod         *v1.Pod
+		unschedPlugin      string
+		updatedAssignedPod *v1.Pod
+		event              fwk.ClusterEvent
+		wantToRequeue      bool
+	}{
+		{
+			name:               "Pod rejected by pod affinity is requeued with matching Pod's update",
+			unschedPod:         st.MakePod().Name("afp").Namespace("ns1").UID("afp").Annotation("annot2", "val2").PodAffinityExists("service", "region", st.PodAffinityWithRequiredReq).Obj(),
+			unschedPlugin:      names.InterPodAffinity,
+			event:              fwk.ClusterEvent{Resource: fwk.Pod, ActionType: fwk.UpdatePodLabel},
+			updatedAssignedPod: st.MakePod().Name("lbp").Namespace("ns1").Label("service", "securityscan").Node("node1").Obj(),
+			wantToRequeue:      true,
+		},
+		{
+			name:               "Pod rejected by pod affinity isn't requeued with unrelated Pod's update",
+			unschedPod:         st.MakePod().Name("afp").Namespace("ns1").UID("afp").Annotation("annot2", "val2").PodAffinityExists("service", "region", st.PodAffinityWithRequiredReq).Obj(),
+			unschedPlugin:      names.InterPodAffinity,
+			event:              fwk.ClusterEvent{Resource: fwk.Pod, ActionType: fwk.UpdatePodLabel},
+			updatedAssignedPod: st.MakePod().Name("lbp").Namespace("unrelated").Label("unrelated", "unrelated").Node("node1").Obj(),
+			wantToRequeue:      false,
+		},
+		{
+			name:               "Pod rejected by pod topology spread is requeued with Pod's update in the same namespace",
+			unschedPod:         st.MakePod().Name("tsp").Namespace("ns1").UID("tsp").SpreadConstraint(1, "node", v1.DoNotSchedule, nil, nil, nil, nil, nil).Obj(),
+			unschedPlugin:      names.PodTopologySpread,
+			event:              fwk.ClusterEvent{Resource: fwk.Pod, ActionType: fwk.UpdatePodLabel},
+			updatedAssignedPod: st.MakePod().Name("lbp").Namespace("ns1").Label("service", "securityscan").Node("node1").Obj(),
+			wantToRequeue:      true,
+		},
+		{
+			name:               "Pod rejected by pod topology spread isn't requeued with unrelated Pod's update",
+			unschedPod:         st.MakePod().Name("afp").Namespace("ns1").UID("afp").Annotation("annot2", "val2").PodAffinityExists("service", "region", st.PodAffinityWithRequiredReq).Obj(),
+			unschedPlugin:      names.PodTopologySpread,
+			event:              fwk.ClusterEvent{Resource: fwk.Pod, ActionType: fwk.UpdatePodLabel},
+			updatedAssignedPod: st.MakePod().Name("lbp").Namespace("unrelated").Label("unrelated", "unrelated").Node("node1").Obj(),
+			wantToRequeue:      false,
+		},
+		{
+			name:               "Pod rejected by resource fit is requeued with assigned Pod's scale down",
+			unschedPod:         st.MakePod().Name("rp").Namespace("ns1").UID("afp").Annotation("annot2", "val2").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Obj(),
+			unschedPlugin:      names.NodeResourcesFit,
+			event:              fwk.ClusterEvent{Resource: fwk.EventResource("AssignedPod"), ActionType: fwk.UpdatePodScaleDown},
+			updatedAssignedPod: st.MakePod().Name("lbp").Namespace("ns2").Node("node1").Obj(),
+			wantToRequeue:      true,
+		},
+		{
+			name:               "Pod rejected by other plugins isn't requeued with any Pod's update",
+			unschedPod:         st.MakePod().Name("afp").Namespace("ns1").UID("afp").Annotation("annot2", "val2").Obj(),
+			unschedPlugin:      "fakePlugin",
+			event:              fwk.ClusterEvent{Resource: fwk.Pod, ActionType: fwk.UpdatePodLabel},
+			updatedAssignedPod: st.MakePod().Name("lbp").Namespace("unrelated").Label("unrelated", "unrelated").Node("node1").Obj(),
+			wantToRequeue:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logger, ctx := ktesting.NewTestContext(t)
+			ctx, cancel := context.WithCancel(ctx)
+			defer cancel()
+
+			c := testingclock.NewFakeClock(time.Now())
+			m := makeEmptyQueueingHintMapPerProfile()
+			m[""] = map[fwk.ClusterEvent][]*QueueingHintFunction{
+				{Resource: fwk.Pod, ActionType: fwk.UpdatePodLabel}: {
+					{
+						PluginName:     "fakePlugin",
+						QueueingHintFn: queueHintReturnQueue,
+					},
+					{
+						PluginName:     names.InterPodAffinity,
+						QueueingHintFn: queueHintReturnQueue,
+					},
+					{
+						PluginName:     names.PodTopologySpread,
+						QueueingHintFn: queueHintReturnQueue,
+					},
+				},
+				{Resource: fwk.Pod, ActionType: fwk.UpdatePodScaleDown}: {
+					{
+						PluginName:     names.NodeResourcesFit,
+						QueueingHintFn: queueHintReturnQueue,
+					},
+				},
+			}
+			q := NewTestQueue(ctx, newDefaultQueueSort(), WithClock(c), WithQueueingHintMapPerProfile(m))
+
+			// To simulate the pod is failed in scheduling in the real world, Pop() the pod from activeQ before AddUnschedulableIfNotPresent()s below.
+			q.Add(logger, tt.unschedPod)
+			if p, err := q.Pop(logger); err != nil || p.Pod != tt.unschedPod {
+				t.Errorf("Expected: %v after Pop, but got: %v", tt.unschedPod.Name, p.Pod.Name)
+			}
+
+			err := q.AddUnschedulableIfNotPresent(logger, q.newQueuedPodInfo(tt.unschedPod, tt.unschedPlugin), q.SchedulingCycle())
+			if err != nil {
+				t.Fatalf("unexpected error from AddUnschedulableIfNotPresent: %v", err)
+			}
+
+			// Move clock to make the unschedulable pods complete backoff.
+			c.Step(DefaultPodInitialBackoffDuration + time.Second)
+
+			q.AssignedPodUpdated(logger, nil, tt.updatedAssignedPod, tt.event)
+
+			if q.activeQ.has(newQueuedPodInfoForLookup(tt.unschedPod)) != tt.wantToRequeue {
+				t.Fatalf("unexpected Pod move: Pod should be requeued: %v. Pod is actually requeued: %v", tt.wantToRequeue, !tt.wantToRequeue)
+			}
+		})
+	}
+}
+
+func TestPriorityQueue_PendingPods(t *testing.T) {
+	makeSet := func(pods []*v1.Pod) map[*v1.Pod]struct{} {
+		pendingSet := map[*v1.Pod]struct{}{}
+		for _, p := range pods {
+			pendingSet[p] = struct{}{}
+		}
+		return pendingSet
+	}
+
+	logger, ctx := ktesting.NewTestContext(t)
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	q := NewTestQueue(ctx, newDefaultQueueSort())
+	// To simulate the pod is failed in scheduling in the real world, Pop() the pod from activeQ before AddUnschedulableIfNotPresent()s below.
+	q.Add(logger, unschedulablePodInfo.Pod)
+	if p, err := q.Pop(logger); err != nil || p.Pod != unschedulablePodInfo.Pod {
+		t.Errorf("Expected: %v after Pop, but got: %v", unschedulablePodInfo.Pod.Name, p.Pod.Name)
+	}
+	q.Add(logger, highPriorityPodInfo.Pod)
+	if p, err := q.Pop(logger); err != nil || p.Pod != highPriorityPodInfo.Pod {
+		t.Errorf("Expected: %v after Pop, but got: %v", highPriorityPodInfo.Pod.Name, p.Pod.Name)
+	}
+	q.Add(logger, medPriorityPodInfo.Pod)
+	err := q.AddUnschedulableIfNotPresent(logger, q.newQueuedPodInfo(unschedulablePodInfo.Pod, "plugin"), q.SchedulingCycle())
+	if err != nil {
+		t.Fatalf("unexpected error from AddUnschedulableIfNotPresent: %v", err)
+	}
+	err = q.AddUnschedulableIfNotPresent(logger, q.newQueuedPodInfo(highPriorityPodInfo.Pod, "plugin"), q.SchedulingCycle())
+	if err != nil {
+		t.Fatalf("unexpected error from AddUnschedulableIfNotPresent: %v", err)
+	}
+
+	expectedSet := makeSet([]*v1.Pod{medPriorityPodInfo.Pod, unschedulablePodInfo.Pod, highPriorityPodInfo.Pod})
+	gotPods, gotSummary := q.PendingPods()
+	if diff := cmp.Diff(expectedSet, makeSet(gotPods)); diff != "" {
+		t.Errorf("Unexpected list of pending Pods (-want, +got):\n%s", diff)
+	}
+	if wantSummary := fmt.Sprintf(pendingPodsSummary, 1, 0, 2); wantSummary != gotSummary {
+		t.Errorf("Unexpected pending pods summary: want %v, but got %v.", wantSummary, gotSummary)
+	}
+	// Move all to active queue. We should still see the same set of pods.
+	q.MoveAllToActiveOrBackoffQueue(logger, framework.EventUnschedulableTimeout, nil, nil, nil)
+	gotPods, gotSummary = q.PendingPods()
+	if diff := cmp.Diff(expectedSet, makeSet(gotPods)); diff != "" {
+		t.Errorf("Unexpected list of pending Pods (-want, +got):\n%s", diff)
+	}
+	if wantSummary := fmt.Sprintf(pendingPodsSummary, 1, 2, 0); wantSummary != gotSummary {
+		t.Errorf("Unexpected pending pods summary: want %v, but got %v.", wantSummary, gotSummary)
+	}
+}
+
+func TestPriorityQueue_NewWithOptions(t *testing.T) {
+	_, ctx := ktesting.NewTestContext(t)
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	q := NewTestQueue(ctx,
+		newDefaultQueueSort(),
+		WithPodInitialBackoffDuration(2*time.Second),
+		WithPodMaxBackoffDuration(20*time.Second),
+	)
+
+	if q.backoffQ.podInitialBackoffDuration() != 2*time.Second {
+		t.Errorf("Unexpected pod backoff initial duration. Expected: %v, got: %v", 2*time.Second, q.backoffQ.podInitialBackoffDuration())
+	}
+
+	if q.backoffQ.podMaxBackoffDuration() != 20*time.Second {
+		t.Errorf("Unexpected pod backoff max duration. Expected: %v, got: %v", 2*time.Second, q.backoffQ.podMaxBackoffDuration())
+	}
+}
+
+func TestSchedulingQueue_Close(t *testing.T) {
+	logger, ctx := ktesting.NewTestContext(t)
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	q := NewTestQueue(ctx, newDefaultQueueSort())
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		pod, err := q.Pop(logger)
+		if err != nil {
+			t.Errorf("Expected nil err from Pop() if queue is closed, but got %q", err.Error())
+		}
+		if pod != nil {
+			t.Errorf("Expected pod nil from Pop() if queue is closed, but got: %v", pod)
+		}
+	}()
+	q.Close()
+	wg.Wait()
+}
+
+// TestRecentlyTriedPodsGoBack tests that pods which are recently tried and are
+// unschedulable go behind other pods with the same priority. This behavior
+// ensures that an unschedulable pod does not block head of the queue when there
+// are frequent events that move pods to the active queue.
+func TestRecentlyTriedPodsGoBack(t *testing.T) {
+	c := testingclock.NewFakeClock(time.Now())
+	logger, ctx := ktesting.NewTestContext(t)
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	q := NewTestQueue(ctx, newDefaultQueueSort(), WithClock(c))
+	// Add a few pods to priority queue.
+	for i := 0; i < 5; i++ {
+		p := st.MakePod().Name(fmt.Sprintf("test-pod-%v", i)).Namespace("ns1").UID(fmt.Sprintf("tp00%v", i)).Priority(highPriority).Node("node1").NominatedNodeName("node1").Obj()
+		q.Add(logger, p)
+	}
+	c.Step(time.Microsecond)
+	// Simulate a pod being popped by the scheduler, determined unschedulable, and
+	// then moved back to the active queue.
+	p1, err := q.Pop(logger)
+	if err != nil {
+		t.Errorf("Error while popping the head of the queue: %v", err)
+	}
+	// Update pod condition to unschedulable.
+	podutil.UpdatePodCondition(&p1.PodInfo.Pod.Status, &v1.PodCondition{
+		Type:          v1.PodScheduled,
+		Status:        v1.ConditionFalse,
+		Reason:        v1.PodReasonUnschedulable,
+		Message:       "fake scheduling failure",
+		LastProbeTime: metav1.Now(),
+	})
+	p1.UnschedulablePlugins = sets.New("plugin")
+	// Put in the unschedulable queue.
+	err = q.AddUnschedulableIfNotPresent(logger, p1, q.SchedulingCycle())
+	if err != nil {
+		t.Fatalf("unexpected error from AddUnschedulableIfNotPresent: %v", err)
+	}
+	c.Step(q.backoffQ.podMaxBackoffDuration())
+	// Move all unschedulable pods to the active queue.
+	q.MoveAllToActiveOrBackoffQueue(logger, framework.EventUnschedulableTimeout, nil, nil, nil)
+	// Simulation is over. Now let's pop all pods. The pod popped first should be
+	// the last one we pop here.
+	for i := 0; i < 5; i++ {
+		p, err := q.Pop(logger)
+		if err != nil {
+			t.Errorf("Error while popping pods from the queue: %v", err)
+		}
+		if (i == 4) != (p1 == p) {
+			t.Errorf("A pod tried before is not the last pod popped: i: %v, pod name: %v", i, p.PodInfo.Pod.Name)
+		}
+	}
+}
+
+// TestPodFailedSchedulingMultipleTimesDoesNotBlockNewerPod tests
+// that a pod determined as unschedulable multiple times doesn't block any newer pod.
+// This behavior ensures that an unschedulable pod does not block head of the queue when there
+// are frequent events that move pods to the active queue.
+func TestPodFailedSchedulingMultipleTimesDoesNotBlockNewerPod(t *testing.T) {
+	c := testingclock.NewFakeClock(time.Now())
+	logger, ctx := ktesting.NewTestContext(t)
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	q := NewTestQueue(ctx, newDefaultQueueSort(), WithClock(c))
+
+	// Add an unschedulable pod to a priority queue.
+	// This makes a situation that the pod was tried to schedule
+	// and had been determined unschedulable so far
+	unschedulablePod := st.MakePod().Name("test-pod-unscheduled").Namespace("ns1").UID("tp001").Priority(highPriority).NominatedNodeName("node1").Obj()
+
+	// Update pod condition to unschedulable.
+	podutil.UpdatePodCondition(&unschedulablePod.Status, &v1.PodCondition{
+		Type:    v1.PodScheduled,
+		Status:  v1.ConditionFalse,
+		Reason:  v1.PodReasonUnschedulable,
+		Message: "fake scheduling failure",
+	})
+
+	// To simulate the pod is failed in scheduling in the real world, Pop() the pod from activeQ before AddUnschedulableIfNotPresent() below.
+	q.Add(logger, unschedulablePod)
+	if p, err := q.Pop(logger); err != nil || p.Pod != unschedulablePod {
+		t.Errorf("Expected: %v after Pop, but got: %v", unschedulablePod.Name, p.Pod.Name)
+	}
+	// Put in the unschedulable queue
+	err := q.AddUnschedulableIfNotPresent(logger, newQueuedPodInfoForLookup(unschedulablePod, "plugin"), q.SchedulingCycle())
+	if err != nil {
+		t.Fatalf("unexpected error from AddUnschedulableIfNotPresent: %v", err)
+	}
+	// Move clock to make the unschedulable pods complete backoff.
+	c.Step(DefaultPodInitialBackoffDuration + time.Second)
+	// Move all unschedulable pods to the active queue.
+	q.MoveAllToActiveOrBackoffQueue(logger, framework.EventUnschedulableTimeout, nil, nil, nil)
+
+	// Simulate a pod being popped by the scheduler,
+	// At this time, unschedulable pod should be popped.
+	p1, err := q.Pop(logger)
+	if err != nil {
+		t.Errorf("Error while popping the head of the queue: %v", err)
+	}
+	if p1.Pod != unschedulablePod {
+		t.Errorf("Expected that test-pod-unscheduled was popped, got %v", p1.Pod.Name)
+	}
+
+	// Assume newer pod was added just after unschedulable pod
+	// being popped and before being pushed back to the queue.
+	newerPod := st.MakePod().Name("test-newer-pod").Namespace("ns1").UID("tp002").CreationTimestamp(metav1.Now()).Priority(highPriority).NominatedNodeName("node1").Obj()
+	q.Add(logger, newerPod)
+
+	// And then unschedulablePodInfo was determined as unschedulable AGAIN.
+	podutil.UpdatePodCondition(&unschedulablePod.Status, &v1.PodCondition{
+		Type:    v1.PodScheduled,
+		Status:  v1.ConditionFalse,
+		Reason:  v1.PodReasonUnschedulable,
+		Message: "fake scheduling failure",
+	})
+
+	// And then, put unschedulable pod to the unschedulable queue
+	err = q.AddUnschedulableIfNotPresent(logger, newQueuedPodInfoForLookup(unschedulablePod, "plugin"), q.SchedulingCycle())
+	if err != nil {
+		t.Fatalf("unexpected error from AddUnschedulableIfNotPresent: %v", err)
+	}
+	// Move clock to make the unschedulable pods complete backoff.
+	c.Step(DefaultPodInitialBackoffDuration + time.Second)
+	// Move all unschedulable pods to the active queue.
+	q.MoveAllToActiveOrBackoffQueue(logger, framework.EventUnschedulableTimeout, nil, nil, nil)
+
+	// At this time, newerPod should be popped
+	// because it is the oldest tried pod.
+	p2, err2 := q.Pop(logger)
+	if err2 != nil {
+		t.Errorf("Error while popping the head of the queue: %v", err2)
+	}
+	if p2.Pod != newerPod {
+		t.Errorf("Expected that test-newer-pod was popped, got %v", p2.Pod.Name)
+	}
+}
+
+// TestHighPriorityBackoff tests that a high priority pod does not block
+// other pods if it is unschedulable
+func TestHighPriorityBackoff(t *testing.T) {
+	logger, ctx := ktesting.NewTestContext(t)
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	q := NewTestQueue(ctx, newDefaultQueueSort())
+
+	midPod := st.MakePod().Name("test-midpod").Namespace("ns1").UID("tp-mid").Priority(midPriority).NominatedNodeName("node1").Obj()
+	highPod := st.MakePod().Name("test-highpod").Namespace("ns1").UID("tp-high").Priority(highPriority).NominatedNodeName("node1").Obj()
+	q.Add(logger, midPod)
+	q.Add(logger, highPod)
+	// Simulate a pod being popped by the scheduler, determined unschedulable, and
+	// then moved back to the active queue.
+	p, err := q.Pop(logger)
+	if err != nil {
+		t.Errorf("Error while popping the head of the queue: %v", err)
+	}
+	if p.Pod != highPod {
+		t.Errorf("Expected to get high priority pod, got: %v", p)
+	}
+	// Update pod condition to unschedulable.
+	podutil.UpdatePodCondition(&p.Pod.Status, &v1.PodCondition{
+		Type:    v1.PodScheduled,
+		Status:  v1.ConditionFalse,
+		Reason:  v1.PodReasonUnschedulable,
+		Message: "fake scheduling failure",
+	})
+	// Put in the unschedulable queue.
+	err = q.AddUnschedulableIfNotPresent(logger, newQueuedPodInfoForLookup(p.Pod, "fooPlugin"), q.SchedulingCycle())
+	if err != nil {
+		t.Fatalf("unexpected error from AddUnschedulableIfNotPresent: %v", err)
+	}
+	// Move all unschedulable pods to the active/backoff queue.
+	q.MoveAllToActiveOrBackoffQueue(logger, framework.EventUnschedulableTimeout, nil, nil, nil)
+
+	p, err = q.Pop(logger)
+	if err != nil {
+		t.Errorf("Error while popping the head of the queue: %v", err)
+	}
+	if p.Pod != midPod {
+		// high pod should be in backoffQ
+		t.Errorf("Expected to get mid priority pod, got: %v", p.Pod.Name)
+	}
+}
+
+// TestHighPriorityFlushUnschedulablePodsLeftover tests that pods will be moved to
+// activeQ after one minutes if it is in unschedulablePods.
+func TestHighPriorityFlushUnschedulablePodsLeftover(t *testing.T) {
+	c := testingclock.NewFakeClock(time.Now())
+	m := makeEmptyQueueingHintMapPerProfile()
+	m[""][nodeAdd] = []*QueueingHintFunction{
+		{
+			PluginName:     "fakePlugin",
+			QueueingHintFn: queueHintReturnQueue,
+		},
+	}
+	logger, ctx := ktesting.NewTestContext(t)
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	q := NewTestQueue(ctx, newDefaultQueueSort(), WithClock(c), WithQueueingHintMapPerProfile(m))
+	midPod := st.MakePod().Name("test-midpod").Namespace("ns1").UID("tp-mid").Priority(midPriority).NominatedNodeName("node1").Obj()
+	highPod := st.MakePod().Name("test-highpod").Namespace("ns1").UID("tp-high").Priority(highPriority).NominatedNodeName("node1").Obj()
+
+	// Update pod condition to highPod.
+	podutil.UpdatePodCondition(&highPod.Status, &v1.PodCondition{
+		Type:    v1.PodScheduled,
+		Status:  v1.ConditionFalse,
+		Reason:  v1.PodReasonUnschedulable,
+		Message: "fake scheduling failure",
+	})
+
+	// Update pod condition to midPod.
+	podutil.UpdatePodCondition(&midPod.Status, &v1.PodCondition{
+		Type:    v1.PodScheduled,
+		Status:  v1.ConditionFalse,
+		Reason:  v1.PodReasonUnschedulable,
+		Message: "fake scheduling failure",
+	})
+
+	// To simulate the pod is failed in scheduling in the real world, Pop() the pod from activeQ before AddUnschedulableIfNotPresent()s below.
+	q.Add(logger, highPod)
+	if p, err := q.Pop(logger); err != nil || p.Pod != highPod {
+		t.Errorf("Expected: %v after Pop, but got: %v", highPod.Name, p.Pod.Name)
+	}
+	q.Add(logger, midPod)
+	if p, err := q.Pop(logger); err != nil || p.Pod != midPod {
+		t.Errorf("Expected: %v after Pop, but got: %v", midPod.Name, p.Pod.Name)
+	}
+	err := q.AddUnschedulableIfNotPresent(logger, q.newQueuedPodInfo(highPod, "fakePlugin"), q.SchedulingCycle())
+	if err != nil {
+		t.Fatalf("unexpected error from AddUnschedulableIfNotPresent: %v", err)
+	}
+	err = q.AddUnschedulableIfNotPresent(logger, q.newQueuedPodInfo(midPod, "fakePlugin"), q.SchedulingCycle())
+	if err != nil {
+		t.Fatalf("unexpected error from AddUnschedulableIfNotPresent: %v", err)
+	}
+	c.Step(DefaultPodMaxInUnschedulablePodsDuration + time.Second)
+	q.flushUnschedulablePodsLeftover(logger)
+
+	if p, err := q.Pop(logger); err != nil || p.Pod != highPod {
+		t.Errorf("Expected: %v after Pop, but got: %v", highPriorityPodInfo.Pod.Name, p.Pod.Name)
+	}
+	if p, err := q.Pop(logger); err != nil || p.Pod != midPod {
+		t.Errorf("Expected: %v after Pop, but got: %v", medPriorityPodInfo.Pod.Name, p.Pod.Name)
+	}
+}
+
+func TestPriorityQueue_initPodMaxInUnschedulablePodsDuration(t *testing.T) {
+	pod1 := st.MakePod().Name("test-pod-1").Namespace("ns1").UID("tp-1").NominatedNodeName("node1").Obj()
+	pod2 := st.MakePod().Name("test-pod-2").Namespace("ns2").UID("tp-2").NominatedNodeName("node2").Obj()
+
+	var timestamp = time.Now()
+	pInfo1 := &framework.QueuedPodInfo{
+		PodInfo:   mustNewTestPodInfo(t, pod1),
+		Timestamp: timestamp.Add(-time.Second),
+	}
+	pInfo2 := &framework.QueuedPodInfo{
+		PodInfo:   mustNewTestPodInfo(t, pod2),
+		Timestamp: timestamp.Add(-2 * time.Second),
+	}
+
+	tests := []struct {
+		name                              string
+		podMaxInUnschedulablePodsDuration time.Duration
+		operations                        []operation
+		operands                          []*framework.QueuedPodInfo
+		expected                          []*framework.QueuedPodInfo
+	}{
+		{
+			name: "New priority queue by the default value of podMaxInUnschedulablePodsDuration",
+			operations: []operation{
+				addPodUnschedulablePods,
+				addPodUnschedulablePods,
+				flushUnscheduledQ,
+			},
+			operands: []*framework.QueuedPodInfo{pInfo1, pInfo2, nil},
+			expected: []*framework.QueuedPodInfo{pInfo2, pInfo1},
+		},
+		{
+			name:                              "New priority queue by user-defined value of podMaxInUnschedulablePodsDuration",
+			podMaxInUnschedulablePodsDuration: 30 * time.Second,
+			operations: []operation{
+				addPodUnschedulablePods,
+				addPodUnschedulablePods,
+				flushUnscheduledQ,
+			},
+			operands: []*framework.QueuedPodInfo{pInfo1, pInfo2, nil},
+			expected: []*framework.QueuedPodInfo{pInfo2, pInfo1},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			logger, ctx := ktesting.NewTestContext(t)
+			ctx, cancel := context.WithCancel(ctx)
+			defer cancel()
+			var queue *PriorityQueue
+			if test.podMaxInUnschedulablePodsDuration > 0 {
+				queue = NewTestQueue(ctx, newDefaultQueueSort(),
+					WithClock(testingclock.NewFakeClock(timestamp)),
+					WithPodMaxInUnschedulablePodsDuration(test.podMaxInUnschedulablePodsDuration))
+			} else {
+				queue = NewTestQueue(ctx, newDefaultQueueSort(),
+					WithClock(testingclock.NewFakeClock(timestamp)))
+			}
+
+			var podInfoList []*framework.QueuedPodInfo
+
+			for i, op := range test.operations {
+				op(t, logger, queue, test.operands[i])
+			}
+
+			expectedLen := len(test.expected)
+			if queue.activeQ.len() != expectedLen {
+				t.Fatalf("Expected %v items to be in activeQ, but got: %v", expectedLen, queue.activeQ.len())
+			}
+
+			for i := 0; i < expectedLen; i++ {
+				if pInfo, err := queue.activeQ.pop(logger); err != nil {
+					t.Errorf("Error while popping the head of the queue: %v", err)
+				} else {
+					podInfoList = append(podInfoList, pInfo)
+					// Cleanup attempts counter incremented in activeQ.pop()
+					pInfo.Attempts = 0
+				}
+			}
+
+			if diff := cmp.Diff(test.expected, podInfoList, cmpopts.IgnoreUnexported(framework.PodInfo{})); diff != "" {
+				t.Errorf("Unexpected QueuedPodInfo list (-want, +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+type operation func(t *testing.T, logger klog.Logger, queue *PriorityQueue, pInfo *framework.QueuedPodInfo)
+
+var (
+	add = func(t *testing.T, logger klog.Logger, queue *PriorityQueue, pInfo *framework.QueuedPodInfo) {
+		queue.Add(logger, pInfo.Pod)
+	}
+	popAndRequeueAsUnschedulable = func(t *testing.T, logger klog.Logger, queue *PriorityQueue, pInfo *framework.QueuedPodInfo) {
+		// To simulate the pod is failed in scheduling in the real world, Pop() the pod from activeQ before AddUnschedulableIfNotPresent() below.
+		// UnschedulablePlugins will get cleared by Pop, so make a copy first.
+		unschedulablePlugins := pInfo.UnschedulablePlugins.Clone()
+		queue.Add(logger, pInfo.Pod)
+		p, err := queue.Pop(logger)
+		if err != nil {
+			t.Fatalf("Unexpected error during Pop: %v", err)
+		}
+		if p.Pod != pInfo.Pod {
+			t.Fatalf("Expected: %v after Pop, but got: %v", pInfo.Pod.Name, p.Pod.Name)
+		}
+		// Simulate plugins that are waiting for some events.
+		p.UnschedulablePlugins = unschedulablePlugins
+		if err := queue.AddUnschedulableIfNotPresent(logger, p, 1); err != nil {
+			t.Fatalf("Unexpected error during AddUnschedulableIfNotPresent: %v", err)
+		}
+	}
+	popAndRequeueAsBackoff = func(t *testing.T, logger klog.Logger, queue *PriorityQueue, pInfo *framework.QueuedPodInfo) {
+		// To simulate the pod is failed in scheduling in the real world, Pop() the pod from activeQ before AddUnschedulableIfNotPresent() below.
+		queue.Add(logger, pInfo.Pod)
+		p, err := queue.Pop(logger)
+		if err != nil {
+			t.Fatalf("Unexpected error during Pop: %v", err)
+		}
+		if p.Pod != pInfo.Pod {
+			t.Fatalf("Expected: %v after Pop, but got: %v", pInfo.Pod.Name, p.Pod.Name)
+		}
+		// needs to increment it to make it backoff
+		p.UnschedulableCount++
+		// When there is no known unschedulable plugin, pods always go to the backoff queue.
+		if err := queue.AddUnschedulableIfNotPresent(logger, p, 1); err != nil {
+			t.Fatalf("Unexpected error during AddUnschedulableIfNotPresent: %v", err)
+		}
+	}
+	addPodActiveQ = func(t *testing.T, logger klog.Logger, queue *PriorityQueue, pInfo *framework.QueuedPodInfo) {
+		queue.Add(logger, pInfo.Pod)
+	}
+	addPodActiveQDirectly = func(t *testing.T, logger klog.Logger, queue *PriorityQueue, pInfo *framework.QueuedPodInfo) {
+		queue.activeQ.underLock(func(unlockedActiveQ unlockedActiveQueuer) {
+			unlockedActiveQ.add(logger, pInfo, framework.EventUnscheduledPodAdd.Label())
+		})
+	}
+	addPodUnschedulablePods = func(t *testing.T, logger klog.Logger, queue *PriorityQueue, pInfo *framework.QueuedPodInfo) {
+		if !pInfo.Gated() {
+			// Update pod condition to unschedulable.
+			podutil.UpdatePodCondition(&pInfo.Pod.Status, &v1.PodCondition{
+				Type:    v1.PodScheduled,
+				Status:  v1.ConditionFalse,
+				Reason:  v1.PodReasonUnschedulable,
+				Message: "fake scheduling failure",
+			})
+			// needs to increment it to make it backoff
+			pInfo.UnschedulableCount++
+		}
+		queue.unschedulablePods.addOrUpdate(pInfo, framework.EventUnscheduledPodAdd.Label())
+	}
+	deletePod = func(t *testing.T, _ klog.Logger, queue *PriorityQueue, pInfo *framework.QueuedPodInfo) {
+		queue.Delete(pInfo.Pod)
+	}
+	updatePodQueueable = func(t *testing.T, logger klog.Logger, queue *PriorityQueue, pInfo *framework.QueuedPodInfo) {
+		newPod := pInfo.Pod.DeepCopy()
+		newPod.Labels = map[string]string{"queueable": ""}
+		queue.Update(logger, pInfo.Pod, newPod)
+	}
+	addPodBackoffQ = func(t *testing.T, logger klog.Logger, queue *PriorityQueue, pInfo *framework.QueuedPodInfo) {
+		queue.backoffQ.add(logger, pInfo, framework.EventUnscheduledPodAdd.Label())
+	}
+	moveAllToActiveOrBackoffQ = func(t *testing.T, logger klog.Logger, queue *PriorityQueue, _ *framework.QueuedPodInfo) {
+		queue.MoveAllToActiveOrBackoffQueue(logger, framework.EventUnschedulableTimeout, nil, nil, nil)
+	}
+	flushBackoffQ = func(t *testing.T, logger klog.Logger, queue *PriorityQueue, _ *framework.QueuedPodInfo) {
+		queue.clock.(*testingclock.FakeClock).Step(3 * time.Second)
+		queue.flushBackoffQCompleted(logger)
+	}
+	moveClockForward = func(t *testing.T, logger klog.Logger, queue *PriorityQueue, _ *framework.QueuedPodInfo) {
+		queue.clock.(*testingclock.FakeClock).Step(3 * time.Second)
+	}
+	flushUnscheduledQ = func(t *testing.T, logger klog.Logger, queue *PriorityQueue, _ *framework.QueuedPodInfo) {
+		queue.clock.(*testingclock.FakeClock).Step(queue.podMaxInUnschedulablePodsDuration)
+		queue.flushUnschedulablePodsLeftover(logger)
+	}
+)
+
+// TestPodTimestamp tests the operations related to QueuedPodInfo.
+func TestPodTimestamp(t *testing.T) {
+	pod1 := st.MakePod().Name("test-pod-1").Namespace("ns1").UID("tp-1").NominatedNodeName("node1").Obj()
+	pod2 := st.MakePod().Name("test-pod-2").Namespace("ns2").UID("tp-2").NominatedNodeName("node2").Obj()
+
+	var timestamp = time.Now()
+	pInfo1 := &framework.QueuedPodInfo{
+		PodInfo:   mustNewTestPodInfo(t, pod1),
+		Timestamp: timestamp,
+	}
+	pInfo2 := &framework.QueuedPodInfo{
+		PodInfo:   mustNewTestPodInfo(t, pod2),
+		Timestamp: timestamp.Add(time.Second),
+	}
+
+	tests := []struct {
+		name       string
+		operations []operation
+		operands   []*framework.QueuedPodInfo
+		expected   []*framework.QueuedPodInfo
+	}{
+		{
+			name: "add two pod to activeQ and sort them by the timestamp",
+			operations: []operation{
+				// Need to add the pods directly to the activeQ to override the timestamps.
+				addPodActiveQDirectly,
+				addPodActiveQDirectly,
+			},
+			operands: []*framework.QueuedPodInfo{pInfo2, pInfo1},
+			expected: []*framework.QueuedPodInfo{pInfo1, pInfo2},
+		},
+		{
+			name: "add two pod to unschedulablePods then move them to activeQ and sort them by the timestamp",
+			operations: []operation{
+				addPodUnschedulablePods,
+				addPodUnschedulablePods,
+				moveClockForward,
+				moveAllToActiveOrBackoffQ,
+			},
+			operands: []*framework.QueuedPodInfo{pInfo2, pInfo1, nil, nil},
+			expected: []*framework.QueuedPodInfo{pInfo1, pInfo2},
+		},
+		{
+			name: "add one pod to BackoffQ and move it to activeQ",
+			operations: []operation{
+				// Need to add the pods directly to activeQ to override the timestamps.
+				addPodActiveQDirectly,
+				addPodBackoffQ,
+				flushBackoffQ,
+				moveAllToActiveOrBackoffQ,
+			},
+			operands: []*framework.QueuedPodInfo{pInfo2, pInfo1, nil, nil},
+			expected: []*framework.QueuedPodInfo{pInfo1, pInfo2},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			logger, ctx := ktesting.NewTestContext(t)
+			ctx, cancel := context.WithCancel(ctx)
+			defer cancel()
+			queue := NewTestQueue(ctx, newDefaultQueueSort(), WithClock(testingclock.NewFakeClock(timestamp)))
+			var podInfoList []*framework.QueuedPodInfo
+
+			for i, op := range test.operations {
+				op(t, logger, queue, test.operands[i])
+			}
+
+			expectedLen := len(test.expected)
+			if queue.activeQ.len() != expectedLen {
+				t.Fatalf("Expected %v items to be in activeQ, but got: %v", expectedLen, queue.activeQ.len())
+			}
+
+			for i := 0; i < expectedLen; i++ {
+				if pInfo, err := queue.activeQ.pop(logger); err != nil {
+					t.Errorf("Error while popping the head of the queue: %v", err)
+				} else {
+					podInfoList = append(podInfoList, pInfo)
+					// Cleanup attempts counter incremented in activeQ.pop()
+					pInfo.Attempts = 0
+				}
+			}
+
+			if diff := cmp.Diff(test.expected, podInfoList, cmpopts.IgnoreUnexported(framework.PodInfo{})); diff != "" {
+				t.Errorf("Unexpected QueuedPodInfo list (-want, +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+// TestPendingPodsMetric tests Prometheus metrics related with pending pods
+func TestPendingPodsMetric(t *testing.T) {
+	timestamp := time.Now()
+	preenqueuePluginName := "preEnqueuePlugin"
+	metrics.Register()
+	total := 60
+	queueableNum := 50
+	queueable, failme := "queueable", "failme"
+	// First 50 Pods are queueable.
+	pInfos := makeQueuedPodInfos(queueableNum, "x", queueable, timestamp)
+	// The last 10 Pods are not queueable.
+	gated := makeQueuedPodInfos(total-queueableNum, "y", failme, timestamp)
+	// Manually mark them as gated=true.
+	for _, pInfo := range gated {
+		setQueuedPodInfoGated(pInfo, preenqueuePluginName, []fwk.ClusterEvent{framework.EventUnscheduledPodUpdate})
+	}
+	pInfos = append(pInfos, gated...)
+	totalWithDelay := 20
+	pInfosWithDelay := makeQueuedPodInfos(totalWithDelay, "z", queueable, timestamp.Add(2*time.Second))
+
+	resetPodInfos := func() {
+		// reset PodInfo's Attempts because they influence the backoff time calculation.
+		for i := range pInfos {
+			pInfos[i].Attempts = 0
+			pInfos[i].UnschedulableCount = 0
+		}
+		for i := range pInfosWithDelay {
+			pInfosWithDelay[i].Attempts = 0
+			pInfosWithDelay[i].UnschedulableCount = 0
+		}
+	}
+
+	tests := []struct {
+		name                       string
+		operations                 []operation
+		operands                   [][]*framework.QueuedPodInfo
+		metricsName                string
+		pluginMetricsSamplePercent int
+		wants                      string
+	}{
+		{
+			name: "add pods to activeQ and unschedulablePods",
+			operations: []operation{
+				addPodActiveQ,
+				addPodUnschedulablePods,
+			},
+			operands: [][]*framework.QueuedPodInfo{
+				pInfos[:30],
+				pInfos[30:],
+			},
+			metricsName: "scheduler_pending_pods",
+			wants: `
+# HELP scheduler_pending_pods [STABLE] Number of pending pods, by the queue type. 'active' means number of pods in activeQ; 'backoff' means number of pods in backoffQ; 'unschedulable' means number of pods in unschedulablePods that the scheduler attempted to schedule and failed; 'gated' is the number of unschedulable pods that the scheduler never attempted to schedule because they are gated.
+# TYPE scheduler_pending_pods gauge
+scheduler_pending_pods{queue="active"} 30
+scheduler_pending_pods{queue="backoff"} 0
+scheduler_pending_pods{queue="gated"} 10
+scheduler_pending_pods{queue="unschedulable"} 20
+`,
+		},
+		{
+			name: "add pods to all kinds of queues",
+			operations: []operation{
+				addPodActiveQ,
+				addPodBackoffQ,
+				addPodUnschedulablePods,
+			},
+			operands: [][]*framework.QueuedPodInfo{
+				pInfos[:15],
+				pInfos[15:40],
+				pInfos[40:],
+			},
+			metricsName: "scheduler_pending_pods",
+			wants: `
+# HELP scheduler_pending_pods [STABLE] Number of pending pods, by the queue type. 'active' means number of pods in activeQ; 'backoff' means number of pods in backoffQ; 'unschedulable' means number of pods in unschedulablePods that the scheduler attempted to schedule and failed; 'gated' is the number of unschedulable pods that the scheduler never attempted to schedule because they are gated.
+# TYPE scheduler_pending_pods gauge
+scheduler_pending_pods{queue="active"} 15
+scheduler_pending_pods{queue="backoff"} 25
+scheduler_pending_pods{queue="gated"} 10
+scheduler_pending_pods{queue="unschedulable"} 10
+`,
+		},
+		{
+			name: "add pods to unschedulablePods and then move all to activeQ",
+			operations: []operation{
+				addPodUnschedulablePods,
+				moveClockForward,
+				moveAllToActiveOrBackoffQ,
+			},
+			operands: [][]*framework.QueuedPodInfo{
+				pInfos[:total],
+				{nil},
+				{nil},
+			},
+			metricsName: "scheduler_pending_pods",
+			wants: `
+# HELP scheduler_pending_pods [STABLE] Number of pending pods, by the queue type. 'active' means number of pods in activeQ; 'backoff' means number of pods in backoffQ; 'unschedulable' means number of pods in unschedulablePods that the scheduler attempted to schedule and failed; 'gated' is the number of unschedulable pods that the scheduler never attempted to schedule because they are gated.
+# TYPE scheduler_pending_pods gauge
+scheduler_pending_pods{queue="active"} 50
+scheduler_pending_pods{queue="backoff"} 0
+scheduler_pending_pods{queue="gated"} 10
+scheduler_pending_pods{queue="unschedulable"} 0
+`,
+		},
+		{
+			name: "make some pods subject to backoff, add pods to unschedulablePods, and then move all to activeQ",
+			operations: []operation{
+				addPodUnschedulablePods,
+				moveClockForward,
+				addPodUnschedulablePods,
+				moveAllToActiveOrBackoffQ,
+			},
+			operands: [][]*framework.QueuedPodInfo{
+				pInfos[20:total],
+				{nil},
+				pInfosWithDelay[:20],
+				{nil},
+			},
+			metricsName: "scheduler_pending_pods",
+			wants: `
+# HELP scheduler_pending_pods [STABLE] Number of pending pods, by the queue type. 'active' means number of pods in activeQ; 'backoff' means number of pods in backoffQ; 'unschedulable' means number of pods in unschedulablePods that the scheduler attempted to schedule and failed; 'gated' is the number of unschedulable pods that the scheduler never attempted to schedule because they are gated.
+# TYPE scheduler_pending_pods gauge
+scheduler_pending_pods{queue="active"} 30
+scheduler_pending_pods{queue="backoff"} 20
+scheduler_pending_pods{queue="gated"} 10
+scheduler_pending_pods{queue="unschedulable"} 0
+`,
+		},
+		{
+			name: "make some pods subject to backoff, add pods to unschedulablePods/activeQ, move all to activeQ, and finally flush backoffQ",
+			operations: []operation{
+				addPodUnschedulablePods,
+				addPodActiveQ,
+				moveAllToActiveOrBackoffQ,
+				flushBackoffQ,
+			},
+			operands: [][]*framework.QueuedPodInfo{
+				pInfos[:40],
+				pInfos[40:50],
+				{nil},
+				{nil},
+			},
+			metricsName: "scheduler_pending_pods",
+			wants: `
+# HELP scheduler_pending_pods [STABLE] Number of pending pods, by the queue type. 'active' means number of pods in activeQ; 'backoff' means number of pods in backoffQ; 'unschedulable' means number of pods in unschedulablePods that the scheduler attempted to schedule and failed; 'gated' is the number of unschedulable pods that the scheduler never attempted to schedule because they are gated.
+# TYPE scheduler_pending_pods gauge
+scheduler_pending_pods{queue="active"} 50
+scheduler_pending_pods{queue="backoff"} 0
+scheduler_pending_pods{queue="gated"} 0
+scheduler_pending_pods{queue="unschedulable"} 0
+`,
+		},
+		{
+			name: "add pods to activeQ/unschedulablePods and then delete some Pods",
+			operations: []operation{
+				addPodActiveQ,
+				addPodUnschedulablePods,
+				deletePod,
+				deletePod,
+				deletePod,
+			},
+			operands: [][]*framework.QueuedPodInfo{
+				pInfos[:30],
+				pInfos[30:],
+				pInfos[:2],
+				pInfos[30:33],
+				pInfos[50:54],
+			},
+			metricsName: "scheduler_pending_pods",
+			wants: `
+# HELP scheduler_pending_pods [STABLE] Number of pending pods, by the queue type. 'active' means number of pods in activeQ; 'backoff' means number of pods in backoffQ; 'unschedulable' means number of pods in unschedulablePods that the scheduler attempted to schedule and failed; 'gated' is the number of unschedulable pods that the scheduler never attempted to schedule because they are gated.
+# TYPE scheduler_pending_pods gauge
+scheduler_pending_pods{queue="active"} 28
+scheduler_pending_pods{queue="backoff"} 0
+scheduler_pending_pods{queue="gated"} 6
+scheduler_pending_pods{queue="unschedulable"} 17
+`,
+		},
+		{
+			name: "add pods to activeQ/unschedulablePods and then update some Pods as queueable",
+			operations: []operation{
+				addPodActiveQ,
+				addPodUnschedulablePods,
+				updatePodQueueable,
+			},
+			operands: [][]*framework.QueuedPodInfo{
+				pInfos[:30],
+				pInfos[30:],
+				pInfos[50:55],
+			},
+			metricsName: "scheduler_pending_pods",
+			wants: `
+# HELP scheduler_pending_pods [STABLE] Number of pending pods, by the queue type. 'active' means number of pods in activeQ; 'backoff' means number of pods in backoffQ; 'unschedulable' means number of pods in unschedulablePods that the scheduler attempted to schedule and failed; 'gated' is the number of unschedulable pods that the scheduler never attempted to schedule because they are gated.
+# TYPE scheduler_pending_pods gauge
+scheduler_pending_pods{queue="active"} 35
+scheduler_pending_pods{queue="backoff"} 0
+scheduler_pending_pods{queue="gated"} 5
+scheduler_pending_pods{queue="unschedulable"} 20
+`,
+		},
+		{
+			name: "the metrics should not be recorded (pluginMetricsSamplePercent=0)",
+			operations: []operation{
+				add,
+			},
+			operands: [][]*framework.QueuedPodInfo{
+				pInfos[:1],
+			},
+			metricsName:                "scheduler_plugin_execution_duration_seconds",
+			pluginMetricsSamplePercent: 0,
+			wants: `
+# HELP scheduler_plugin_execution_duration_seconds [ALPHA] Duration for running a plugin at a specific extension point.
+# TYPE scheduler_plugin_execution_duration_seconds histogram
+`, // the observed value will always be 0, because we don't proceed the fake clock.
+		},
+		{
+			name: "the metrics should be recorded (pluginMetricsSamplePercent=100)",
+			operations: []operation{
+				add,
+			},
+			operands: [][]*framework.QueuedPodInfo{
+				pInfos[:1],
+			},
+			metricsName:                "scheduler_plugin_execution_duration_seconds",
+			pluginMetricsSamplePercent: 100,
+			wants: `
+# HELP scheduler_plugin_execution_duration_seconds [ALPHA] Duration for running a plugin at a specific extension point.
+# TYPE scheduler_plugin_execution_duration_seconds histogram
+scheduler_plugin_execution_duration_seconds_bucket{extension_point="PreEnqueue",plugin="preEnqueuePlugin",status="Success",le="1e-05"} 1
+scheduler_plugin_execution_duration_seconds_bucket{extension_point="PreEnqueue",plugin="preEnqueuePlugin",status="Success",le="1.5000000000000002e-05"} 1
+scheduler_plugin_execution_duration_seconds_bucket{extension_point="PreEnqueue",plugin="preEnqueuePlugin",status="Success",le="2.2500000000000005e-05"} 1
+scheduler_plugin_execution_duration_seconds_bucket{extension_point="PreEnqueue",plugin="preEnqueuePlugin",status="Success",le="3.375000000000001e-05"} 1
+scheduler_plugin_execution_duration_seconds_bucket{extension_point="PreEnqueue",plugin="preEnqueuePlugin",status="Success",le="5.062500000000001e-05"} 1
+scheduler_plugin_execution_duration_seconds_bucket{extension_point="PreEnqueue",plugin="preEnqueuePlugin",status="Success",le="7.593750000000002e-05"} 1
+scheduler_plugin_execution_duration_seconds_bucket{extension_point="PreEnqueue",plugin="preEnqueuePlugin",status="Success",le="0.00011390625000000003"} 1
+scheduler_plugin_execution_duration_seconds_bucket{extension_point="PreEnqueue",plugin="preEnqueuePlugin",status="Success",le="0.00017085937500000006"} 1
+scheduler_plugin_execution_duration_seconds_bucket{extension_point="PreEnqueue",plugin="preEnqueuePlugin",status="Success",le="0.0002562890625000001"} 1
+scheduler_plugin_execution_duration_seconds_bucket{extension_point="PreEnqueue",plugin="preEnqueuePlugin",status="Success",le="0.00038443359375000017"} 1
+scheduler_plugin_execution_duration_seconds_bucket{extension_point="PreEnqueue",plugin="preEnqueuePlugin",status="Success",le="0.0005766503906250003"} 1
+scheduler_plugin_execution_duration_seconds_bucket{extension_point="PreEnqueue",plugin="preEnqueuePlugin",status="Success",le="0.0008649755859375004"} 1
+scheduler_plugin_execution_duration_seconds_bucket{extension_point="PreEnqueue",plugin="preEnqueuePlugin",status="Success",le="0.0012974633789062506"} 1
+scheduler_plugin_execution_duration_seconds_bucket{extension_point="PreEnqueue",plugin="preEnqueuePlugin",status="Success",le="0.0019461950683593758"} 1
+scheduler_plugin_execution_duration_seconds_bucket{extension_point="PreEnqueue",plugin="preEnqueuePlugin",status="Success",le="0.0029192926025390638"} 1
+scheduler_plugin_execution_duration_seconds_bucket{extension_point="PreEnqueue",plugin="preEnqueuePlugin",status="Success",le="0.004378938903808595"} 1
+scheduler_plugin_execution_duration_seconds_bucket{extension_point="PreEnqueue",plugin="preEnqueuePlugin",status="Success",le="0.006568408355712893"} 1
+scheduler_plugin_execution_duration_seconds_bucket{extension_point="PreEnqueue",plugin="preEnqueuePlugin",status="Success",le="0.009852612533569338"} 1
+scheduler_plugin_execution_duration_seconds_bucket{extension_point="PreEnqueue",plugin="preEnqueuePlugin",status="Success",le="0.014778918800354007"} 1
+scheduler_plugin_execution_duration_seconds_bucket{extension_point="PreEnqueue",plugin="preEnqueuePlugin",status="Success",le="0.02216837820053101"} 1
+scheduler_plugin_execution_duration_seconds_bucket{extension_point="PreEnqueue",plugin="preEnqueuePlugin",status="Success",le="+Inf"} 1
+scheduler_plugin_execution_duration_seconds_sum{extension_point="PreEnqueue",plugin="preEnqueuePlugin",status="Success"} 0
+scheduler_plugin_execution_duration_seconds_count{extension_point="PreEnqueue",plugin="preEnqueuePlugin",status="Success"} 1
+`, // the observed value will always be 0, because we don't proceed the fake clock.
+		},
+	}
+
+	resetMetrics := func() {
+		metrics.ActivePods().Set(0)
+		metrics.BackoffPods().Set(0)
+		metrics.UnschedulablePods().Set(0)
+		metrics.GatedPods().Set(0)
+		metrics.PluginExecutionDuration.Reset()
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			logger, ctx := ktesting.NewTestContext(t)
+			ctx, cancel := context.WithCancel(ctx)
+			defer cancel()
+			resetMetrics()
+			resetPodInfos()
+
+			m := makeEmptyQueueingHintMapPerProfile()
+			m[""][framework.EventUnscheduledPodUpdate] = []*QueueingHintFunction{
+				{
+					PluginName:     preenqueuePluginName,
+					QueueingHintFn: queueHintReturnQueue,
+				},
+			}
+			preenq := map[string]map[string]internalfwk.PreEnqueuePlugin{"": {(&preEnqueuePlugin{}).Name(): &preEnqueuePlugin{allowlists: []string{queueable}}}}
+			recorder := metrics.NewMetricsAsyncRecorder(3, 20*time.Microsecond, ctx.Done())
+			queue := NewTestQueue(ctx, newDefaultQueueSort(), WithClock(testingclock.NewFakeClock(timestamp)), WithPreEnqueuePluginMap(preenq), WithPluginMetricsSamplePercent(test.pluginMetricsSamplePercent), WithMetricsRecorder(recorder), WithQueueingHintMapPerProfile(m))
+			for i, op := range test.operations {
+				for _, pInfo := range test.operands[i] {
+					op(t, logger, queue, pInfo)
+				}
+			}
+
+			recorder.FlushMetrics()
+
+			if err := testutil.GatherAndCompare(metrics.GetGather(), strings.NewReader(test.wants), test.metricsName); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
+// TestPerPodSchedulingMetrics makes sure pod schedule attempts is updated correctly while
+// initialAttemptTimestamp stays the same during multiple add/pop operations.
+func TestPerPodSchedulingMetrics(t *testing.T) {
+	timestamp := time.Now()
+
+	logger, ctx := ktesting.NewTestContext(t)
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	tests := []struct {
+		name                            string
+		perPodSchedulingMetricsScenario func(*testingclock.FakeClock, *PriorityQueue, *v1.Pod)
+		wantAttempts                    int
+		wantInitialAttemptTs            time.Time
+	}{
+		{
+			// The queue operations are Add -> Pop.
+			name: "pod is created and scheduled after 1 attempt",
+			perPodSchedulingMetricsScenario: func(c *testingclock.FakeClock, queue *PriorityQueue, pod *v1.Pod) {
+				queue.Add(logger, pod)
+			},
+			wantAttempts:         1,
+			wantInitialAttemptTs: timestamp,
+		},
+		{
+			// The queue operations are Add -> Pop -> AddUnschedulableIfNotPresent -> flushUnschedulablePodsLeftover -> Pop.
+			name: "pod is created and scheduled after 2 attempts",
+			perPodSchedulingMetricsScenario: func(c *testingclock.FakeClock, queue *PriorityQueue, pod *v1.Pod) {
+				queue.Add(logger, pod)
+				pInfo, err := queue.Pop(logger)
+				if err != nil {
+					t.Fatalf("Failed to pop a pod %v", err)
+				}
+
+				pInfo.UnschedulablePlugins = sets.New("plugin")
+				queue.AddUnschedulableIfNotPresent(logger, pInfo, 1)
+				// Override clock to exceed the DefaultPodMaxInUnschedulablePodsDuration so that unschedulable pods
+				// will be moved to activeQ
+				c.SetTime(timestamp.Add(DefaultPodMaxInUnschedulablePodsDuration + 1))
+				queue.flushUnschedulablePodsLeftover(logger)
+			},
+			wantAttempts:         2,
+			wantInitialAttemptTs: timestamp,
+		},
+		{
+			// The queue operations are Add -> Pop -> AddUnschedulableIfNotPresent -> flushUnschedulablePodsLeftover -> Update -> Pop.
+			name: "pod is created and scheduled after 2 attempts but before the second pop, call update",
+			perPodSchedulingMetricsScenario: func(c *testingclock.FakeClock, queue *PriorityQueue, pod *v1.Pod) {
+				queue.Add(logger, pod)
+				pInfo, err := queue.Pop(logger)
+				if err != nil {
+					t.Fatalf("Failed to pop a pod %v", err)
+				}
+
+				pInfo.UnschedulablePlugins = sets.New("plugin")
+				queue.AddUnschedulableIfNotPresent(logger, pInfo, 1)
+				// Override clock to exceed the DefaultPodMaxInUnschedulablePodsDuration so that unschedulable pods
+				// will be moved to activeQ
+				updatedTimestamp := timestamp
+				c.SetTime(updatedTimestamp.Add(DefaultPodMaxInUnschedulablePodsDuration + 1))
+				queue.flushUnschedulablePodsLeftover(logger)
+				newPod := pod.DeepCopy()
+				newPod.Generation = 1
+				queue.Update(logger, pod, newPod)
+			},
+			wantAttempts:         2,
+			wantInitialAttemptTs: timestamp,
+		},
+		{
+			// The queue operations are Add gated pod -> check unschedulablePods -> lift gate & update pod -> Pop.
+			name: "A gated pod is created and scheduled after lifting gate",
+			perPodSchedulingMetricsScenario: func(c *testingclock.FakeClock, queue *PriorityQueue, pod *v1.Pod) {
+				// Create a queue with PreEnqueuePlugin
+				queue.preEnqueuePluginMap = map[string]map[string]internalfwk.PreEnqueuePlugin{"": {(&preEnqueuePlugin{}).Name(): &preEnqueuePlugin{allowlists: []string{"foo"}}}}
+				queue.pluginMetricsSamplePercent = 0
+				queue.Add(logger, pod)
+				// Check pod is added to the unschedulablePods queue.
+				if getUnschedulablePod(queue, pod) != pod {
+					t.Errorf("Pod %v was not found in the unschedulablePods.", pod.Name)
+				}
+				// Override clock to get different InitialAttemptTimestamp
+				c.Step(1 * time.Minute)
+
+				// Update pod with the required label to get it out of unschedulablePods queue.
+				updateGatedPod := pod.DeepCopy()
+				updateGatedPod.Labels = map[string]string{"foo": ""}
+				queue.Update(logger, pod, updateGatedPod)
+			},
+			wantAttempts:         1,
+			wantInitialAttemptTs: timestamp.Add(1 * time.Minute),
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+
+			c := testingclock.NewFakeClock(timestamp)
+			pod := st.MakePod().Name("test-pod").Namespace("test-ns").UID("test-uid").Obj()
+			queue := NewTestQueue(ctx, newDefaultQueueSort(), WithClock(c))
+
+			test.perPodSchedulingMetricsScenario(c, queue, pod)
+			podInfo, err := queue.Pop(logger)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if podInfo.Attempts != test.wantAttempts {
+				t.Errorf("Pod schedule attempt unexpected, got %v, want %v", podInfo.Attempts, test.wantAttempts)
+			}
+			if *podInfo.InitialAttemptTimestamp != test.wantInitialAttemptTs {
+				t.Errorf("Pod initial schedule attempt timestamp unexpected, got %v, want %v", *podInfo.InitialAttemptTimestamp, test.wantInitialAttemptTs)
+			}
+		})
+	}
+}
+
+func TestIncomingPodsMetrics(t *testing.T) {
+	timestamp := time.Now()
+	unschedulablePlg := "unschedulable_plugin"
+	var pInfos = make([]*framework.QueuedPodInfo, 0, 3)
+
+	for i := 1; i <= 3; i++ {
+		p := &framework.QueuedPodInfo{
+			PodInfo: mustNewTestPodInfo(t,
+				st.MakePod().Name(fmt.Sprintf("test-pod-%d", i)).Namespace(fmt.Sprintf("ns%d", i)).UID(fmt.Sprintf("tp-%d", i)).Obj()),
+			Timestamp:            timestamp,
+			UnschedulablePlugins: sets.New(unschedulablePlg),
+		}
+		pInfos = append(pInfos, p)
+	}
+	tests := []struct {
+		name       string
+		operations []operation
+		want       string
+	}{
+		{
+			name: "add pods to activeQ",
+			operations: []operation{
+				add,
+			},
+			want: `
+            scheduler_queue_incoming_pods_total{event="UnschedulablePodAdd",queue="active"} 3
+`,
+		},
+		{
+			name: "add pods to unschedulablePods",
+			operations: []operation{
+				popAndRequeueAsUnschedulable,
+			},
+			want: `scheduler_queue_incoming_pods_total{event="UnschedulablePodAdd",queue="active"} 3
+             scheduler_queue_incoming_pods_total{event="ScheduleAttemptFailure",queue="unschedulable"} 3
+`,
+		},
+		{
+			name: "add pods to unschedulablePods and then move all to backoffQ",
+			operations: []operation{
+				popAndRequeueAsUnschedulable,
+				moveAllToActiveOrBackoffQ,
+			},
+			want: `scheduler_queue_incoming_pods_total{event="UnschedulablePodAdd",queue="active"} 3
+			scheduler_queue_incoming_pods_total{event="ScheduleAttemptFailure",queue="unschedulable"} 3
+            scheduler_queue_incoming_pods_total{event="UnschedulableTimeout",queue="backoff"} 3
+`,
+		},
+		{
+			name: "add pods to unschedulablePods and then move all to activeQ",
+			operations: []operation{
+				popAndRequeueAsUnschedulable,
+				moveClockForward,
+				moveAllToActiveOrBackoffQ,
+			},
+			want: `scheduler_queue_incoming_pods_total{event="UnschedulablePodAdd",queue="active"} 3
+			scheduler_queue_incoming_pods_total{event="ScheduleAttemptFailure",queue="unschedulable"} 3
+            scheduler_queue_incoming_pods_total{event="UnschedulableTimeout",queue="active"} 3
+`,
+		},
+		{
+			name: "make some pods subject to backoff and add them to backoffQ, then flush backoffQ",
+			operations: []operation{
+				popAndRequeueAsBackoff,
+				moveClockForward,
+				flushBackoffQ,
+			},
+			want: `scheduler_queue_incoming_pods_total{event="UnschedulablePodAdd",queue="active"} 3
+			scheduler_queue_incoming_pods_total{event="BackoffComplete",queue="active"} 3
+            scheduler_queue_incoming_pods_total{event="ScheduleAttemptFailure",queue="backoff"} 3
+`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			logger, ctx := ktesting.NewTestContext(t)
+			ctx, cancel := context.WithCancel(ctx)
+			defer cancel()
+			metrics.SchedulerQueueIncomingPods.Reset()
+			queue := NewTestQueue(ctx, newDefaultQueueSort(), WithClock(testingclock.NewFakeClock(timestamp)))
+			for _, op := range test.operations {
+				for _, pInfo := range pInfos {
+					op(t, logger, queue, pInfo)
+				}
+			}
+			metricName := metrics.SchedulerSubsystem + "_" + metrics.SchedulerQueueIncomingPods.Name
+			if err := testutil.CollectAndCompare(metrics.SchedulerQueueIncomingPods, strings.NewReader(queueMetricMetadata+test.want), metricName); err != nil {
+				t.Errorf("unexpected collecting result:\n%s", err)
+			}
+
+		})
+	}
+}
+
+func TestBackOffFlow(t *testing.T) {
+	cl := testingclock.NewFakeClock(time.Now())
+	logger, ctx := ktesting.NewTestContext(t)
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	steps := []struct {
+		wantBackoff time.Duration
+	}{
+		{wantBackoff: time.Second},
+		{wantBackoff: 2 * time.Second},
+		{wantBackoff: 4 * time.Second},
+		{wantBackoff: 8 * time.Second},
+		{wantBackoff: 10 * time.Second},
+		{wantBackoff: 10 * time.Second},
+		{wantBackoff: 10 * time.Second},
+	}
+	for _, popFromBackoffQEnabled := range []bool{true, false} {
+		featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.SchedulerPopFromBackoffQ, popFromBackoffQEnabled)
+
+		q := NewTestQueue(ctx, newDefaultQueueSort(), WithClock(cl))
+
+		pod := st.MakePod().Name("test-pod").Namespace("test-ns").UID("test-uid").Obj()
+		podID := types.NamespacedName{
+			Namespace: pod.Namespace,
+			Name:      pod.Name,
+		}
+		q.Add(logger, pod)
+
+		for i, step := range steps {
+			t.Run(fmt.Sprintf("step %d popFromBackoffQEnabled(%v)", i, popFromBackoffQEnabled), func(t *testing.T) {
+				timestamp := cl.Now()
+				// Simulate schedule attempt.
+				podInfo, err := q.Pop(logger)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if podInfo.Attempts != i+1 {
+					t.Errorf("got attempts %d, want %d", podInfo.Attempts, i+1)
+				}
+				podInfo.UnschedulablePlugins.Insert("unsched-plugin")
+				err = q.AddUnschedulableIfNotPresent(logger, podInfo, int64(i))
+				if err != nil {
+					t.Fatalf("unexpected error from AddUnschedulableIfNotPresent: %v", err)
+				}
+
+				// An event happens.
+				q.MoveAllToActiveOrBackoffQueue(logger, framework.EventUnschedulableTimeout, nil, nil, nil)
+
+				if !q.backoffQ.has(podInfo) {
+					t.Errorf("pod %v is not in the backoff queue", podID)
+				}
+
+				// Check backoff duration.
+				deadline := podInfo.BackoffExpiration
+				backoff := deadline.Sub(timestamp)
+				if popFromBackoffQEnabled {
+					// If popFromBackoffQEnabled, the actual backoff can be calculated by rounding up to the ordering window duration.
+					backoff = backoff.Truncate(backoffQOrderingWindowDuration) + backoffQOrderingWindowDuration
+				}
+				if backoff != step.wantBackoff {
+					t.Errorf("got backoff %s, want %s", backoff, step.wantBackoff)
+				}
+
+				// Simulate routine that continuously flushes the backoff queue.
+				cl.Step(backoffQOrderingWindowDuration)
+				q.flushBackoffQCompleted(logger)
+				// Still in backoff queue after an early flush.
+				if !q.backoffQ.has(podInfo) {
+					t.Errorf("pod %v is not in the backoff queue", podID)
+				}
+				// Moved out of the backoff queue after timeout.
+				cl.Step(backoff)
+				q.flushBackoffQCompleted(logger)
+				if q.backoffQ.has(podInfo) {
+					t.Errorf("pod %v is still in the backoff queue", podID)
+				}
+			})
+		}
+	}
+}
+
+func TestMoveAllToActiveOrBackoffQueue_PreEnqueueChecks(t *testing.T) {
+	var podInfos []*framework.QueuedPodInfo
+	for i := 0; i < 5; i++ {
+		pInfo := newQueuedPodInfoForLookup(
+			st.MakePod().Name(fmt.Sprintf("p%d", i)).Priority(int32(i)).Obj(),
+		)
+		podInfos = append(podInfos, pInfo)
+	}
+
+	tests := []struct {
+		name            string
+		preEnqueueCheck PreEnqueueCheck
+		podInfos        []*framework.QueuedPodInfo
+		event           fwk.ClusterEvent
+		want            sets.Set[string]
+	}{
+		{
+			name:     "nil PreEnqueueCheck",
+			podInfos: podInfos,
+			event:    framework.EventUnschedulableTimeout,
+			want:     sets.New("p0", "p1", "p2", "p3", "p4"),
+		},
+		{
+			name:            "move Pods with priority greater than 2",
+			podInfos:        podInfos,
+			event:           framework.EventUnschedulableTimeout,
+			preEnqueueCheck: func(pod *v1.Pod) bool { return *pod.Spec.Priority >= 2 },
+			want:            sets.New("p2", "p3", "p4"),
+		},
+		{
+			name:     "move Pods with even priority and greater than 2",
+			podInfos: podInfos,
+			event:    framework.EventUnschedulableTimeout,
+			preEnqueueCheck: func(pod *v1.Pod) bool {
+				return *pod.Spec.Priority%2 == 0 && *pod.Spec.Priority >= 2
+			},
+			want: sets.New("p2", "p4"),
+		},
+		{
+			name:     "move Pods with even and negative priority",
+			podInfos: podInfos,
+			event:    framework.EventUnschedulableTimeout,
+			preEnqueueCheck: func(pod *v1.Pod) bool {
+				return *pod.Spec.Priority%2 == 0 && *pod.Spec.Priority < 0
+			},
+		},
+		{
+			name:     "preCheck isn't called if the event is not interested by any plugins",
+			podInfos: podInfos,
+			event:    pvAdd, // No plugin is interested in this event.
+			preEnqueueCheck: func(pod *v1.Pod) bool {
+				panic("preCheck shouldn't be called")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := testingclock.NewFakeClock(time.Now().Truncate(backoffQOrderingWindowDuration))
+			logger, ctx := ktesting.NewTestContext(t)
+			ctx, cancel := context.WithCancel(ctx)
+			defer cancel()
+			q := NewTestQueue(ctx, newDefaultQueueSort(), WithClock(c))
+			for _, podInfo := range tt.podInfos {
+				// To simulate the pod is failed in scheduling in the real world, Pop() the pod from activeQ before AddUnschedulableIfNotPresent() below.
+				q.Add(logger, podInfo.Pod)
+				if p, err := q.Pop(logger); err != nil || p.Pod != podInfo.Pod {
+					t.Errorf("Expected: %v after Pop, but got: %v", podInfo.Pod.Name, p.Pod.Name)
+				}
+				podInfo.UnschedulablePlugins = sets.New("plugin")
+				err := q.AddUnschedulableIfNotPresent(logger, podInfo, q.activeQ.schedulingCycle())
+				if err != nil {
+					t.Fatalf("unexpected error from AddUnschedulableIfNotPresent: %v", err)
+				}
+			}
+			q.MoveAllToActiveOrBackoffQueue(logger, tt.event, nil, nil, tt.preEnqueueCheck)
+			got := sets.New[string]()
+			c.Step(2 * q.backoffQ.podMaxBackoffDuration())
+			gotPodInfos := q.backoffQ.popAllBackoffCompleted(logger)
+			for _, pInfo := range gotPodInfos {
+				got.Insert(pInfo.Pod.Name)
+			}
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("Unexpected diff (-want, +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func makeQueuedPodInfos(num int, namePrefix, label string, timestamp time.Time) []*framework.QueuedPodInfo {
+	var pInfos = make([]*framework.QueuedPodInfo, 0, num)
+	for i := 1; i <= num; i++ {
+		p := &framework.QueuedPodInfo{
+			PodInfo: mustNewPodInfo(
+				st.MakePod().Name(fmt.Sprintf("%v-%d", namePrefix, i)).Namespace(fmt.Sprintf("ns%d", i)).Label(label, "").UID(fmt.Sprintf("tp-%d", i)).Obj()),
+			Timestamp:            timestamp,
+			UnschedulablePlugins: sets.New[string](),
+		}
+		pInfos = append(pInfos, p)
+	}
+	return pInfos
+}
+
+func mustNewTestPodInfo(t *testing.T, pod *v1.Pod) *framework.PodInfo {
+	podInfo, err := framework.NewPodInfo(pod)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return podInfo
+}
+
+func mustNewPodInfo(pod *v1.Pod) *framework.PodInfo {
+	podInfo, err := framework.NewPodInfo(pod)
+	if err != nil {
+		panic(err)
+	}
+	return podInfo
+}
+
+// Test_isPodWorthRequeuing tests isPodWorthRequeuing function.
+func Test_isPodWorthRequeuing(t *testing.T) {
+	metrics.Register()
+	count := 0
+	queueHintReturnQueue := func(logger klog.Logger, pod *v1.Pod, oldObj, newObj interface{}) (fwk.QueueingHint, error) {
+		count++
+		return fwk.Queue, nil
+	}
+	queueHintReturnSkip := func(logger klog.Logger, pod *v1.Pod, oldObj, newObj interface{}) (fwk.QueueingHint, error) {
+		count++
+		return fwk.QueueSkip, nil
+	}
+	queueHintReturnErr := func(logger klog.Logger, pod *v1.Pod, oldObj, newObj interface{}) (fwk.QueueingHint, error) {
+		count++
+		return fwk.QueueSkip, fmt.Errorf("unexpected error")
+	}
+
+	tests := []struct {
+		name                   string
+		podInfo                *framework.QueuedPodInfo
+		event                  fwk.ClusterEvent
+		oldObj                 interface{}
+		newObj                 interface{}
+		expected               queueingStrategy
+		expectedExecutionCount int // expected total execution count of queueing hint function
+		queueingHintMap        QueueingHintMapPerProfile
+	}{
+		{
+			name: "return Queue when no queueing hint function is registered for the event",
+			podInfo: &framework.QueuedPodInfo{
+				UnschedulablePlugins: sets.New("fooPlugin1"),
+				PodInfo:              mustNewPodInfo(st.MakePod().Name("pod1").Namespace("ns1").UID("1").Obj()),
+			},
+			event:                  nodeAdd,
+			oldObj:                 nil,
+			newObj:                 st.MakeNode().Obj(),
+			expected:               queueSkip,
+			expectedExecutionCount: 0,
+			queueingHintMap: QueueingHintMapPerProfile{
+				"": {
+					// no queueing hint function for NodeAdd.
+					framework.EventAssignedPodAdd: {
+						{
+							// It will be ignored because the event is not NodeAdd.
+							PluginName:     "fooPlugin1",
+							QueueingHintFn: queueHintReturnQueue,
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Treat the event as Queue when QueueHintFn returns error",
+			podInfo: &framework.QueuedPodInfo{
+				UnschedulablePlugins: sets.New("fooPlugin1"),
+				PodInfo:              mustNewPodInfo(st.MakePod().Name("pod1").Namespace("ns1").UID("1").Obj()),
+			},
+			event:                  nodeAdd,
+			oldObj:                 nil,
+			newObj:                 st.MakeNode().Obj(),
+			expected:               queueAfterBackoff,
+			expectedExecutionCount: 1,
+			queueingHintMap: QueueingHintMapPerProfile{
+				"": {
+					nodeAdd: {
+						{
+							PluginName:     "fooPlugin1",
+							QueueingHintFn: queueHintReturnErr,
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "return Queue when the event is wildcard",
+			podInfo: &framework.QueuedPodInfo{
+				UnschedulablePlugins: sets.New("fooPlugin1"),
+				PodInfo:              mustNewPodInfo(st.MakePod().Name("pod1").Namespace("ns1").UID("1").Obj()),
+			},
+			event:                  framework.EventUnschedulableTimeout,
+			oldObj:                 nil,
+			newObj:                 nil,
+			expected:               queueAfterBackoff,
+			expectedExecutionCount: 0,
+			queueingHintMap:        QueueingHintMapPerProfile{},
+		},
+		{
+			name: "return Queue when the event is wildcard and the wildcard targets the pod to be requeued right now",
+			podInfo: &framework.QueuedPodInfo{
+				UnschedulablePlugins: sets.New("fooPlugin1"),
+				PodInfo:              mustNewPodInfo(st.MakePod().Name("pod1").Namespace("ns1").UID("1").Obj()),
+			},
+			event:                  framework.EventForceActivate,
+			oldObj:                 nil,
+			newObj:                 st.MakePod().Name("pod1").Namespace("ns1").UID("1").Obj(),
+			expected:               queueAfterBackoff,
+			expectedExecutionCount: 0,
+			queueingHintMap:        QueueingHintMapPerProfile{},
+		},
+		{
+			name: "return Skip when the event is wildcard, but the wildcard targets a different pod",
+			podInfo: &framework.QueuedPodInfo{
+				UnschedulablePlugins: sets.New("fooPlugin1"),
+				PodInfo:              mustNewPodInfo(st.MakePod().Name("pod1").Namespace("ns1").UID("1").Obj()),
+			},
+			event:                  framework.EventForceActivate,
+			oldObj:                 nil,
+			newObj:                 st.MakePod().Name("pod-different").Namespace("ns2").UID("2").Obj(),
+			expected:               queueSkip,
+			expectedExecutionCount: 0,
+			queueingHintMap:        QueueingHintMapPerProfile{},
+		},
+		{
+			name: "interprets Queue from the Pending plugin as queueImmediately",
+			podInfo: &framework.QueuedPodInfo{
+				UnschedulablePlugins: sets.New("fooPlugin1", "fooPlugin3"),
+				PendingPlugins:       sets.New("fooPlugin2"),
+				PodInfo:              mustNewPodInfo(st.MakePod().Name("pod1").Namespace("ns1").UID("1").Obj()),
+			},
+			event:                  nodeAdd,
+			oldObj:                 nil,
+			newObj:                 st.MakeNode().Node,
+			expected:               queueImmediately,
+			expectedExecutionCount: 2,
+			queueingHintMap: QueueingHintMapPerProfile{
+				"": {
+					nodeAdd: {
+						{
+							PluginName: "fooPlugin1",
+							// It returns Queue and it's interpreted as queueAfterBackoff.
+							// But, the function continues to run other hints because the Pod has PendingPlugins, which can result in queueImmediately.
+							QueueingHintFn: queueHintReturnQueue,
+						},
+						{
+							PluginName: "fooPlugin2",
+							// It's interpreted as queueImmediately.
+							// The function doesn't run other hints because queueImmediately is the highest priority.
+							QueueingHintFn: queueHintReturnQueue,
+						},
+						{
+							PluginName:     "fooPlugin3",
+							QueueingHintFn: queueHintReturnQueue,
+						},
+						{
+							PluginName:     "fooPlugin4",
+							QueueingHintFn: queueHintReturnErr,
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "interprets Queue from the Unschedulable plugin as queueAfterBackoff",
+			podInfo: &framework.QueuedPodInfo{
+				UnschedulablePlugins: sets.New("fooPlugin1", "fooPlugin2"),
+				PodInfo:              mustNewPodInfo(st.MakePod().Name("pod1").Namespace("ns1").UID("1").Obj()),
+			},
+			event:                  nodeAdd,
+			oldObj:                 nil,
+			newObj:                 st.MakeNode().Obj(),
+			expected:               queueAfterBackoff,
+			expectedExecutionCount: 2,
+			queueingHintMap: QueueingHintMapPerProfile{
+				"": {
+					nodeAdd: {
+						{
+							// Skip will be ignored
+							PluginName:     "fooPlugin1",
+							QueueingHintFn: queueHintReturnSkip,
+						},
+						{
+							// Skip will be ignored
+							PluginName:     "fooPlugin2",
+							QueueingHintFn: queueHintReturnQueue,
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Queueing hint function that isn't from the plugin in UnschedulablePlugins/PendingPlugins is ignored",
+			podInfo: &framework.QueuedPodInfo{
+				UnschedulablePlugins: sets.New("fooPlugin1", "fooPlugin2"),
+				PodInfo:              mustNewPodInfo(st.MakePod().Name("pod1").Namespace("ns1").UID("1").Obj()),
+			},
+			event:                  nodeAdd,
+			oldObj:                 nil,
+			newObj:                 st.MakeNode().Node,
+			expected:               queueSkip,
+			expectedExecutionCount: 2,
+			queueingHintMap: QueueingHintMapPerProfile{
+				"": {
+					nodeAdd: {
+						{
+							PluginName:     "fooPlugin1",
+							QueueingHintFn: queueHintReturnSkip,
+						},
+						{
+							PluginName:     "fooPlugin2",
+							QueueingHintFn: queueHintReturnSkip,
+						},
+						{
+							PluginName:     "fooPlugin3",
+							QueueingHintFn: queueHintReturnQueue, // It'll be ignored.
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "If event is specific Node update event, queueing hint function for NodeUpdate/UpdateNodeLabel is also executed",
+			podInfo: &framework.QueuedPodInfo{
+				UnschedulablePlugins: sets.New("fooPlugin1", "fooPlugin2"),
+				PodInfo:              mustNewPodInfo(st.MakePod().Name("pod1").Namespace("ns1").UID("1").Obj()),
+			},
+			event:                  fwk.ClusterEvent{Resource: fwk.Node, ActionType: fwk.UpdateNodeLabel},
+			oldObj:                 nil,
+			newObj:                 st.MakeNode().Obj(),
+			expected:               queueAfterBackoff,
+			expectedExecutionCount: 1,
+			queueingHintMap: QueueingHintMapPerProfile{
+				"": {
+					fwk.ClusterEvent{Resource: fwk.Node, ActionType: fwk.UpdateNodeLabel}: {
+						{
+							PluginName: "fooPlugin1",
+							// It's only executed and interpreted as queueAfterBackoff.
+							// The function doesn't run other hints because this Pod doesn't have PendingPlugins.
+							QueueingHintFn: queueHintReturnQueue,
+						},
+						{
+							PluginName:     "fooPlugin2",
+							QueueingHintFn: queueHintReturnQueue,
+						},
+					},
+					fwk.ClusterEvent{Resource: fwk.Node, ActionType: fwk.Update}: {
+						{
+							PluginName:     "fooPlugin1",
+							QueueingHintFn: queueHintReturnQueue,
+						},
+					},
+					nodeAdd: { // not executed because NodeAdd is unrelated.
+						{
+							PluginName:     "fooPlugin1",
+							QueueingHintFn: queueHintReturnQueue,
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "If event with '*' Resource, queueing hint function for specified Resource is also executed",
+			podInfo: &framework.QueuedPodInfo{
+				UnschedulablePlugins: sets.New("fooPlugin1"),
+				PodInfo:              mustNewPodInfo(st.MakePod().Name("pod1").Namespace("ns1").UID("1").Obj()),
+			},
+			event:                  fwk.ClusterEvent{Resource: fwk.Node, ActionType: fwk.Add},
+			oldObj:                 nil,
+			newObj:                 st.MakeNode().Obj(),
+			expected:               queueAfterBackoff,
+			expectedExecutionCount: 1,
+			queueingHintMap: QueueingHintMapPerProfile{
+				"": {
+					fwk.ClusterEvent{Resource: fwk.WildCard, ActionType: fwk.Add}: {
+						{
+							PluginName:     "fooPlugin1",
+							QueueingHintFn: queueHintReturnQueue,
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "If event is a wildcard one, queueing hint function for all kinds of events is executed",
+			podInfo: &framework.QueuedPodInfo{
+				UnschedulablePlugins: sets.New("fooPlugin1"),
+				PodInfo:              mustNewPodInfo(st.MakePod().Name("pod1").Namespace("ns1").UID("1").Obj()),
+			},
+			event:                  fwk.ClusterEvent{Resource: fwk.Node, ActionType: fwk.UpdateNodeLabel | fwk.UpdateNodeTaint},
+			oldObj:                 nil,
+			newObj:                 st.MakeNode().Obj(),
+			expected:               queueAfterBackoff,
+			expectedExecutionCount: 1,
+			queueingHintMap: QueueingHintMapPerProfile{
+				"": {
+					fwk.ClusterEvent{Resource: fwk.WildCard, ActionType: fwk.All}: {
+						{
+							PluginName:     "fooPlugin1",
+							QueueingHintFn: queueHintReturnQueue,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			count = 0 // reset count every time
+			logger, ctx := ktesting.NewTestContext(t)
+			q := NewTestQueue(ctx, newDefaultQueueSort(), WithQueueingHintMapPerProfile(test.queueingHintMap))
+			actual := q.isPodWorthRequeuing(logger, test.podInfo, test.event, test.oldObj, test.newObj)
+			if actual != test.expected {
+				t.Errorf("isPodWorthRequeuing() = %v, want %v", actual, test.expected)
+			}
+			if count != test.expectedExecutionCount {
+				t.Errorf("isPodWorthRequeuing() executed queueing hint functions %v times, expected: %v", count, test.expectedExecutionCount)
+			}
+		})
+	}
+}
+
+func Test_queuedPodInfo_gatedSetUponCreationAndUnsetUponUpdate(t *testing.T) {
+	logger, ctx := ktesting.NewTestContext(t)
+	plugin, _ := schedulinggates.New(ctx, nil, nil, plfeature.Features{})
+	m := map[string]map[string]internalfwk.PreEnqueuePlugin{"": {names.SchedulingGates: plugin.(internalfwk.PreEnqueuePlugin)}}
+	q := NewTestQueue(ctx, newDefaultQueueSort(), WithPreEnqueuePluginMap(m))
+
+	gatedPod := st.MakePod().SchedulingGates([]string{"hello world"}).Obj()
+	q.Add(logger, gatedPod)
+
+	if !q.unschedulablePods.get(gatedPod).Gated() {
+		t.Error("Expected pod to be gated")
+	}
+
+	ungatedPod := gatedPod.DeepCopy()
+	ungatedPod.Spec.SchedulingGates = nil
+	q.Update(logger, gatedPod, ungatedPod)
+
+	ungatedPodInfo, _ := q.Pop(logger)
+	if ungatedPodInfo.Gated() {
+		t.Error("Expected pod to be ungated")
+	}
+}
+
+func TestPriorityQueue_GetPod(t *testing.T) {
+	activeQPod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pod1",
+			Namespace: "default",
+		},
+	}
+	backoffQPod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pod2",
+			Namespace: "default",
+		},
+	}
+	unschedPod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pod3",
+			Namespace: "default",
+		},
+	}
+
+	logger, ctx := ktesting.NewTestContext(t)
+	q := NewTestQueue(ctx, newDefaultQueueSort())
+	q.activeQ.underLock(func(unlockedActiveQ unlockedActiveQueuer) {
+		unlockedActiveQ.add(logger, newQueuedPodInfoForLookup(activeQPod), framework.EventUnscheduledPodAdd.Label())
+	})
+	q.backoffQ.add(logger, newQueuedPodInfoForLookup(backoffQPod), framework.EventUnscheduledPodAdd.Label())
+	q.unschedulablePods.addOrUpdate(newQueuedPodInfoForLookup(unschedPod), framework.EventUnscheduledPodAdd.Label())
+
+	tests := []struct {
+		name        string
+		podName     string
+		namespace   string
+		expectedPod *v1.Pod
+		expectedOK  bool
+	}{
+		{
+			name:        "pod is found in activeQ",
+			podName:     "pod1",
+			namespace:   "default",
+			expectedPod: activeQPod,
+			expectedOK:  true,
+		},
+		{
+			name:        "pod is found in backoffQ",
+			podName:     "pod2",
+			namespace:   "default",
+			expectedPod: backoffQPod,
+			expectedOK:  true,
+		},
+		{
+			name:        "pod is found in unschedulablePods",
+			podName:     "pod3",
+			namespace:   "default",
+			expectedPod: unschedPod,
+			expectedOK:  true,
+		},
+		{
+			name:        "pod is not found",
+			podName:     "pod4",
+			namespace:   "default",
+			expectedPod: nil,
+			expectedOK:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pInfo, ok := q.GetPod(tt.podName, tt.namespace)
+			if ok != tt.expectedOK {
+				t.Errorf("Expected ok=%v, but got ok=%v", tt.expectedOK, ok)
+			}
+
+			if tt.expectedPod == nil {
+				if pInfo == nil {
+					return
+				}
+				t.Fatalf("Expected pod is empty, but got pod=%v", pInfo.Pod)
+			}
+
+			if !cmp.Equal(pInfo.Pod, tt.expectedPod) {
+				t.Errorf("Expected pod=%v, but got pod=%v", tt.expectedPod, pInfo.Pod)
+			}
+		})
+	}
+}

--- a/third_party/kubernetes/pkg/scheduler/backend/queue/testing.go
+++ b/third_party/kubernetes/pkg/scheduler/backend/queue/testing.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package queue
+
+import (
+	"context"
+	"time"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes/fake"
+	internalfwk "k8s.io/kubernetes/pkg/scheduler/framework"
+	"k8s.io/kubernetes/pkg/scheduler/metrics"
+)
+
+// NewTestQueue creates a priority queue with an empty informer factory.
+func NewTestQueue(ctx context.Context, lessFn internalfwk.LessFunc, opts ...Option) *PriorityQueue {
+	return NewTestQueueWithObjects(ctx, lessFn, nil, opts...)
+}
+
+// NewTestQueueWithObjects creates a priority queue with an informer factory
+// populated with the provided objects.
+func NewTestQueueWithObjects(
+	ctx context.Context,
+	lessFn internalfwk.LessFunc,
+	objs []runtime.Object,
+	opts ...Option,
+) *PriorityQueue {
+	informerFactory := informers.NewSharedInformerFactory(fake.NewClientset(objs...), 0)
+
+	// Because some major functions (e.g., Pop) requires the metric recorder to be set,
+	// we always set a metric recorder here.
+	recorder := metrics.NewMetricsAsyncRecorder(10, 20*time.Microsecond, ctx.Done())
+	// We set it before the options that users provide, so that users can override it.
+	opts = append([]Option{WithMetricsRecorder(recorder)}, opts...)
+	return NewTestQueueWithInformerFactory(ctx, lessFn, informerFactory, opts...)
+}
+
+func NewTestQueueWithInformerFactory(
+	ctx context.Context,
+	lessFn internalfwk.LessFunc,
+	informerFactory informers.SharedInformerFactory,
+	opts ...Option,
+) *PriorityQueue {
+	pq := NewPriorityQueue(lessFn, informerFactory, opts...)
+	informerFactory.Start(ctx.Done())
+	informerFactory.WaitForCacheSync(ctx.Done())
+	return pq
+}

--- a/third_party/kubernetes/pkg/scheduler/backend/queue/unschedulable_pods.go
+++ b/third_party/kubernetes/pkg/scheduler/backend/queue/unschedulable_pods.go
@@ -1,0 +1,94 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package queue
+
+import (
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/kubernetes/pkg/scheduler/framework"
+	"k8s.io/kubernetes/pkg/scheduler/metrics"
+	"k8s.io/kubernetes/pkg/scheduler/util"
+)
+
+// unschedulablePods holds pods that cannot be scheduled.
+type unschedulablePods struct {
+	// podInfoMap is a map key by a pod's full-name and the value is a pointer to the QueuedPodInfo.
+	podInfoMap map[string]*framework.QueuedPodInfo
+	keyFunc    func(*v1.Pod) string
+	// unschedulableRecorder/gatedRecorder updates the counter when elements of an unschedulablePods
+	// get added or removed, and it does nothing if it's nil.
+	unschedulableRecorder, gatedRecorder metrics.MetricRecorder
+}
+
+// newUnschedulablePods initializes a new object of unschedulablePods.
+func newUnschedulablePods(unschedulableRecorder, gatedRecorder metrics.MetricRecorder) *unschedulablePods {
+	return &unschedulablePods{
+		podInfoMap:            make(map[string]*framework.QueuedPodInfo),
+		keyFunc:               util.GetPodFullName,
+		unschedulableRecorder: unschedulableRecorder,
+		gatedRecorder:         gatedRecorder,
+	}
+}
+
+// addOrUpdate adds a pod to the unschedulable podInfoMap.
+// The event should show which event triggered the addition and is used for the metric recording.
+func (u *unschedulablePods) addOrUpdate(pInfo *framework.QueuedPodInfo, event string) {
+	podID := u.keyFunc(pInfo.Pod)
+	if _, exists := u.podInfoMap[podID]; !exists {
+		if pInfo.Gated() && u.gatedRecorder != nil {
+			u.gatedRecorder.Inc()
+		} else if !pInfo.Gated() && u.unschedulableRecorder != nil {
+			u.unschedulableRecorder.Inc()
+		}
+		metrics.SchedulerQueueIncomingPods.WithLabelValues("unschedulable", event).Inc()
+	}
+	u.podInfoMap[podID] = pInfo
+}
+
+// delete deletes a pod from the unschedulable podInfoMap.
+// The `gated` parameter is used to figure out which metric should be decreased.
+func (u *unschedulablePods) delete(pod *v1.Pod, gated bool) {
+	podID := u.keyFunc(pod)
+	if _, exists := u.podInfoMap[podID]; exists {
+		if gated && u.gatedRecorder != nil {
+			u.gatedRecorder.Dec()
+		} else if !gated && u.unschedulableRecorder != nil {
+			u.unschedulableRecorder.Dec()
+		}
+	}
+	delete(u.podInfoMap, podID)
+}
+
+// get returns the QueuedPodInfo if a pod with the same key as the key of the given "pod"
+// is found in the map. It returns nil otherwise.
+func (u *unschedulablePods) get(pod *v1.Pod) *framework.QueuedPodInfo {
+	podKey := u.keyFunc(pod)
+	if pInfo, exists := u.podInfoMap[podKey]; exists {
+		return pInfo
+	}
+	return nil
+}
+
+// clear removes all the entries from the unschedulable podInfoMap.
+func (u *unschedulablePods) clear() {
+	u.podInfoMap = make(map[string]*framework.QueuedPodInfo)
+	if u.unschedulableRecorder != nil {
+		u.unschedulableRecorder.Clear()
+	}
+	if u.gatedRecorder != nil {
+		u.gatedRecorder.Clear()
+	}
+}

--- a/third_party/kubernetes/pkg/scheduler/backend/queue/unschedulable_pods_test.go
+++ b/third_party/kubernetes/pkg/scheduler/backend/queue/unschedulable_pods_test.go
@@ -1,0 +1,138 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package queue
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/kubernetes/pkg/scheduler/framework"
+	st "k8s.io/kubernetes/pkg/scheduler/testing"
+	"k8s.io/kubernetes/pkg/scheduler/util"
+)
+
+func TestUnschedulablePods(t *testing.T) {
+	var pods = []*v1.Pod{
+		st.MakePod().Name("p0").Namespace("ns1").Annotation("annot1", "val1").NominatedNodeName("node1").Obj(),
+		st.MakePod().Name("p1").Namespace("ns1").Annotation("annot", "val").Obj(),
+		st.MakePod().Name("p2").Namespace("ns2").Annotation("annot2", "val2").Annotation("annot3", "val3").NominatedNodeName("node3").Obj(),
+		st.MakePod().Name("p3").Namespace("ns4").Annotation("annot2", "val2").Annotation("annot3", "val3").NominatedNodeName("node1").Obj(),
+	}
+	var updatedPods = make([]*v1.Pod, len(pods))
+	updatedPods[0] = pods[0].DeepCopy()
+	updatedPods[1] = pods[1].DeepCopy()
+	updatedPods[3] = pods[3].DeepCopy()
+
+	tests := []struct {
+		name                   string
+		podsToAdd              []*v1.Pod
+		expectedMapAfterAdd    map[string]*framework.QueuedPodInfo
+		podsToUpdate           []*v1.Pod
+		expectedMapAfterUpdate map[string]*framework.QueuedPodInfo
+		podsToDelete           []*v1.Pod
+		expectedMapAfterDelete map[string]*framework.QueuedPodInfo
+	}{
+		{
+			name:      "create, update, delete subset of pods",
+			podsToAdd: []*v1.Pod{pods[0], pods[1], pods[2], pods[3]},
+			expectedMapAfterAdd: map[string]*framework.QueuedPodInfo{
+				util.GetPodFullName(pods[0]): {PodInfo: mustNewTestPodInfo(t, pods[0]), UnschedulablePlugins: sets.New[string]()},
+				util.GetPodFullName(pods[1]): {PodInfo: mustNewTestPodInfo(t, pods[1]), UnschedulablePlugins: sets.New[string]()},
+				util.GetPodFullName(pods[2]): {PodInfo: mustNewTestPodInfo(t, pods[2]), UnschedulablePlugins: sets.New[string]()},
+				util.GetPodFullName(pods[3]): {PodInfo: mustNewTestPodInfo(t, pods[3]), UnschedulablePlugins: sets.New[string]()},
+			},
+			podsToUpdate: []*v1.Pod{updatedPods[0]},
+			expectedMapAfterUpdate: map[string]*framework.QueuedPodInfo{
+				util.GetPodFullName(pods[0]): {PodInfo: mustNewTestPodInfo(t, updatedPods[0]), UnschedulablePlugins: sets.New[string]()},
+				util.GetPodFullName(pods[1]): {PodInfo: mustNewTestPodInfo(t, pods[1]), UnschedulablePlugins: sets.New[string]()},
+				util.GetPodFullName(pods[2]): {PodInfo: mustNewTestPodInfo(t, pods[2]), UnschedulablePlugins: sets.New[string]()},
+				util.GetPodFullName(pods[3]): {PodInfo: mustNewTestPodInfo(t, pods[3]), UnschedulablePlugins: sets.New[string]()},
+			},
+			podsToDelete: []*v1.Pod{pods[0], pods[1]},
+			expectedMapAfterDelete: map[string]*framework.QueuedPodInfo{
+				util.GetPodFullName(pods[2]): {PodInfo: mustNewTestPodInfo(t, pods[2]), UnschedulablePlugins: sets.New[string]()},
+				util.GetPodFullName(pods[3]): {PodInfo: mustNewTestPodInfo(t, pods[3]), UnschedulablePlugins: sets.New[string]()},
+			},
+		},
+		{
+			name:      "create, update, delete all",
+			podsToAdd: []*v1.Pod{pods[0], pods[3]},
+			expectedMapAfterAdd: map[string]*framework.QueuedPodInfo{
+				util.GetPodFullName(pods[0]): {PodInfo: mustNewTestPodInfo(t, pods[0]), UnschedulablePlugins: sets.New[string]()},
+				util.GetPodFullName(pods[3]): {PodInfo: mustNewTestPodInfo(t, pods[3]), UnschedulablePlugins: sets.New[string]()},
+			},
+			podsToUpdate: []*v1.Pod{updatedPods[3]},
+			expectedMapAfterUpdate: map[string]*framework.QueuedPodInfo{
+				util.GetPodFullName(pods[0]): {PodInfo: mustNewTestPodInfo(t, pods[0]), UnschedulablePlugins: sets.New[string]()},
+				util.GetPodFullName(pods[3]): {PodInfo: mustNewTestPodInfo(t, updatedPods[3]), UnschedulablePlugins: sets.New[string]()},
+			},
+			podsToDelete:           []*v1.Pod{pods[0], pods[3]},
+			expectedMapAfterDelete: map[string]*framework.QueuedPodInfo{},
+		},
+		{
+			name:      "delete non-existing and existing pods",
+			podsToAdd: []*v1.Pod{pods[1], pods[2]},
+			expectedMapAfterAdd: map[string]*framework.QueuedPodInfo{
+				util.GetPodFullName(pods[1]): {PodInfo: mustNewTestPodInfo(t, pods[1]), UnschedulablePlugins: sets.New[string]()},
+				util.GetPodFullName(pods[2]): {PodInfo: mustNewTestPodInfo(t, pods[2]), UnschedulablePlugins: sets.New[string]()},
+			},
+			podsToUpdate: []*v1.Pod{updatedPods[1]},
+			expectedMapAfterUpdate: map[string]*framework.QueuedPodInfo{
+				util.GetPodFullName(pods[1]): {PodInfo: mustNewTestPodInfo(t, updatedPods[1]), UnschedulablePlugins: sets.New[string]()},
+				util.GetPodFullName(pods[2]): {PodInfo: mustNewTestPodInfo(t, pods[2]), UnschedulablePlugins: sets.New[string]()},
+			},
+			podsToDelete: []*v1.Pod{pods[2], pods[3]},
+			expectedMapAfterDelete: map[string]*framework.QueuedPodInfo{
+				util.GetPodFullName(pods[1]): {PodInfo: mustNewTestPodInfo(t, updatedPods[1]), UnschedulablePlugins: sets.New[string]()},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			upm := newUnschedulablePods(nil, nil)
+			for _, p := range test.podsToAdd {
+				upm.addOrUpdate(newQueuedPodInfoForLookup(p), framework.EventUnscheduledPodAdd.Label())
+			}
+			if diff := cmp.Diff(test.expectedMapAfterAdd, upm.podInfoMap, cmpopts.IgnoreUnexported(framework.PodInfo{})); diff != "" {
+				t.Errorf("Unexpected map after adding pods(-want, +got):\n%s", diff)
+			}
+
+			if len(test.podsToUpdate) > 0 {
+				for _, p := range test.podsToUpdate {
+					upm.addOrUpdate(newQueuedPodInfoForLookup(p), framework.EventUnscheduledPodUpdate.Label())
+				}
+				if diff := cmp.Diff(test.expectedMapAfterUpdate, upm.podInfoMap, cmpopts.IgnoreUnexported(framework.PodInfo{})); diff != "" {
+					t.Errorf("Unexpected map after updating pods (-want, +got):\n%s", diff)
+				}
+			}
+			for _, p := range test.podsToDelete {
+				upm.delete(p, false)
+			}
+			if diff := cmp.Diff(test.expectedMapAfterDelete, upm.podInfoMap, cmpopts.IgnoreUnexported(framework.PodInfo{})); diff != "" {
+				t.Errorf("Unexpected map after deleting pods (-want, +got):\n%s", diff)
+			}
+			upm.clear()
+			if len(upm.podInfoMap) != 0 {
+				t.Errorf("Expected the map to be empty, but has %v elements.", len(upm.podInfoMap))
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?
feature
#### What this PR does / why we need it:
Create a new scheduler to execute fast path scheduling for workload like AI agent. A scheduling queue is introduced to cache pending Pods and dispatch Pods to different Workers for fast scheduling. This PR include 3rd dependency for this scheduling queue

For more details about agent scheduler please refer to: [proposal](https://docs.google.com/document/d/1NDTEGulhQ__sdZ_c2kN3ojtJIZie5O7_GyZyKIOLz-g/edit?tab=t.0) | [design doc](https://github.com/qi-min/volcano/blob/agent-scheduler-design/docs/design/agent-scheduler.md)
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Notice that do not add `Fixes` if the issue is associated with multiple PRs.
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```