### PR TITLE
Support task level network topology constrain with minSubGroups

### DIFF
--- a/pkg/scheduler/api/job_info_test.go
+++ b/pkg/scheduler/api/job_info_test.go
@@ -81,8 +81,10 @@ func TestAddTaskInfo(t *testing.T) {
 						case01Task4.UID: case01Task4,
 					},
 				},
+				MinSubJobs: make(map[SubJobGID]int32),
 				SubJobs: map[SubJobID]*SubJobInfo{
 					SubJobID(case01UID): {
+						GID:          SubJobGID(case01UID),
 						UID:          SubJobID(case01UID),
 						Job:          case01UID,
 						MinAvailable: 0,
@@ -187,8 +189,10 @@ func TestDeleteTaskInfo(t *testing.T) {
 					Pending: {case01Task1.UID: case01Task1},
 					Running: {case01Task3.UID: case01Task3},
 				},
+				MinSubJobs: make(map[SubJobGID]int32),
 				SubJobs: map[SubJobID]*SubJobInfo{
 					SubJobID(case01UID): {
+						GID:          SubJobGID(case01UID),
 						UID:          SubJobID(case01UID),
 						Job:          case01UID,
 						MinAvailable: 0,
@@ -239,8 +243,10 @@ func TestDeleteTaskInfo(t *testing.T) {
 						case02Task3.UID: case02Task3,
 					},
 				},
+				MinSubJobs: make(map[SubJobGID]int32),
 				SubJobs: map[SubJobID]*SubJobInfo{
 					SubJobID(case02UID): {
+						GID:          SubJobGID(case02UID),
 						UID:          SubJobID(case02UID),
 						Job:          case02UID,
 						MinAvailable: 0,

--- a/pkg/scheduler/api/sub_job_info.go
+++ b/pkg/scheduler/api/sub_job_info.go
@@ -35,7 +35,10 @@ import (
 
 type SubJobID types.UID
 
+type SubJobGID types.UID // All subgroups within a SubGroupPolicy have the same SubJobGID.
+
 type SubJobInfo struct {
+	GID SubJobGID
 	UID SubJobID
 	Job JobID
 
@@ -52,8 +55,9 @@ type SubJobInfo struct {
 	networkTopology *scheduling.NetworkTopologySpec
 }
 
-func NewSubJobInfo(uid SubJobID, job JobID, policy *scheduling.SubGroupPolicySpec, matchValues []string) *SubJobInfo {
+func NewSubJobInfo(gid SubJobGID, uid SubJobID, job JobID, policy *scheduling.SubGroupPolicySpec, matchValues []string) *SubJobInfo {
 	sji := &SubJobInfo{
+		GID:             gid,
 		UID:             uid,
 		Job:             job,
 		MinAvailable:    1,
@@ -193,6 +197,10 @@ func getSubJobMatchValues(policy scheduling.SubGroupPolicySpec, pod *v1.Pod) []s
 	// Log when no matching rules are configured, using default group
 	klog.V(4).Infof("No MatchLabelKeys configured for policy, pod %s/%s uses default subjob group", pod.Namespace, pod.Name)
 	return matchValues
+}
+
+func getSubJobGID(job JobID, policy string) SubJobGID {
+	return SubJobGID(fmt.Sprintf("%s/%s", job, policy))
 }
 
 func getSubJobID(job JobID, policy string, matchValues []string) SubJobID {

--- a/pkg/scheduler/api/sub_job_info_test.go
+++ b/pkg/scheduler/api/sub_job_info_test.go
@@ -30,6 +30,7 @@ import (
 
 func TestNewSubJobInfo(t *testing.T) {
 	type args struct {
+		gid         SubJobGID
 		uid         SubJobID
 		job         JobID
 		policy      *scheduling.SubGroupPolicySpec
@@ -43,6 +44,7 @@ func TestNewSubJobInfo(t *testing.T) {
 		{
 			name: "All field provided",
 			args: args{
+				gid: "test-gid",
 				uid: "test-uid",
 				job: "test-job",
 				policy: &scheduling.SubGroupPolicySpec{
@@ -55,6 +57,7 @@ func TestNewSubJobInfo(t *testing.T) {
 				matchValues: []string{"1"},
 			},
 			want: &SubJobInfo{
+				GID:             "test-gid",
 				UID:             "test-uid",
 				Job:             "test-job",
 				MinAvailable:    4,
@@ -71,12 +74,14 @@ func TestNewSubJobInfo(t *testing.T) {
 		{
 			name: "No policy provided",
 			args: args{
+				gid:         "test-gid",
 				uid:         "test-uid",
 				job:         "test-job",
 				policy:      nil,
 				matchValues: []string{"1"},
 			},
 			want: &SubJobInfo{
+				GID:             "test-gid",
 				UID:             "test-uid",
 				Job:             "test-job",
 				MinAvailable:    1,
@@ -90,6 +95,7 @@ func TestNewSubJobInfo(t *testing.T) {
 		{
 			name: "No SubGroupSize provided",
 			args: args{
+				gid: "test-gid",
 				uid: "test-uid",
 				job: "test-job",
 				policy: &scheduling.SubGroupPolicySpec{
@@ -101,6 +107,7 @@ func TestNewSubJobInfo(t *testing.T) {
 				matchValues: []string{"1"},
 			},
 			want: &SubJobInfo{
+				GID:             "test-gid",
 				UID:             "test-uid",
 				Job:             "test-job",
 				MinAvailable:    1,
@@ -117,6 +124,7 @@ func TestNewSubJobInfo(t *testing.T) {
 		{
 			name: "No networkTopology provided",
 			args: args{
+				gid: "test-gid",
 				uid: "test-uid",
 				job: "test-job",
 				policy: &scheduling.SubGroupPolicySpec{
@@ -126,6 +134,7 @@ func TestNewSubJobInfo(t *testing.T) {
 				matchValues: []string{},
 			},
 			want: &SubJobInfo{
+				GID:             "test-gid",
 				UID:             "test-uid",
 				Job:             "test-job",
 				MinAvailable:    2,
@@ -138,8 +147,8 @@ func TestNewSubJobInfo(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := NewSubJobInfo(tt.args.uid, tt.args.job, tt.args.policy, tt.args.matchValues)
-			assert.Equalf(t, tt.want, got, "NewSubJobInfo(%v, %v, %v, %v)", tt.args.uid, tt.args.job, tt.args.policy, tt.args.matchValues)
+			got := NewSubJobInfo(tt.args.gid, tt.args.uid, tt.args.job, tt.args.policy, tt.args.matchValues)
+			assert.Equalf(t, tt.want, got, "NewSubJobInfo(%v, %v, %v, %v, %v)", tt.args.gid, tt.args.uid, tt.args.job, tt.args.policy, tt.args.matchValues)
 		})
 	}
 }

--- a/pkg/scheduler/util/test_utils.go
+++ b/pkg/scheduler/util/test_utils.go
@@ -333,6 +333,10 @@ func BuildSubGroupPolicy(name string, matchLabelKeys []string, mode string, high
 }
 
 func BuildSubGroupPolicyWithSubGroupSize(name string, matchLabelKeys []string, mode string, highestTierAllowed int, subGroupSize int32) schedulingv1beta1.SubGroupPolicySpec {
+	return BuildSubGroupPolicyWithMinSubGroups(name, matchLabelKeys, mode, highestTierAllowed, subGroupSize, 0)
+}
+
+func BuildSubGroupPolicyWithMinSubGroups(name string, matchLabelKeys []string, mode string, highestTierAllowed int, subGroupSize, minSubGroups int32) schedulingv1beta1.SubGroupPolicySpec {
 	subGroupPolicy := schedulingv1beta1.SubGroupPolicySpec{
 		Name: name,
 		NetworkTopology: &schedulingv1beta1.NetworkTopologySpec{
@@ -340,6 +344,7 @@ func BuildSubGroupPolicyWithSubGroupSize(name string, matchLabelKeys []string, m
 			HighestTierAllowed: &highestTierAllowed,
 		},
 		SubGroupSize: &subGroupSize,
+		MinSubGroups: &minSubGroups,
 	}
 	subGroupPolicy.MatchLabelKeys = matchLabelKeys
 	return subGroupPolicy

--- a/pkg/webhooks/admission/jobs/mutate/mutate_job.go
+++ b/pkg/webhooks/admission/jobs/mutate/mutate_job.go
@@ -202,7 +202,7 @@ func mutateSpec(tasks []v1alpha1.TaskSpec, basePath string, job *v1alpha1.Job) *
 			tasks[index].Template.Spec.DNSPolicy = v1.DNSClusterFirstWithHostNet
 		}
 
-		if tasks[index].MinAvailable == nil {
+		if tasks[index].MinAvailable == nil && (tasks[index].PartitionPolicy == nil || tasks[index].PartitionPolicy.MinPartitions == 0) {
 			patched = true
 			minAvailable := tasks[index].Replicas
 			tasks[index].MinAvailable = &minAvailable

--- a/pkg/webhooks/admission/jobs/validate/admit_job.go
+++ b/pkg/webhooks/admission/jobs/validate/admit_job.go
@@ -172,6 +172,9 @@ func validateJobCreate(job *v1alpha1.Job, reviewResponse *admissionv1.AdmissionR
 			} else if *task.MinAvailable > task.Replicas {
 				msg += fmt.Sprintf(" 'minAvailable' is greater than 'replicas' in task: %s, job: %s;", task.Name, job.Name)
 			}
+			if task.PartitionPolicy != nil && task.PartitionPolicy.MinPartitions != 0 {
+				msg += fmt.Sprintf("must not specify 'minAvailable' and 'partitionPolicy.minPartitions' simultaneously in task: %s, job: %s;", task.Name, job.Name)
+			}
 		}
 
 		// count replicas


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
Volcano supports setting up two-level Gang scheduling capabilities through PodGroup, while Kthena integrates with PodGroup to implement role-level elastic scheduling capabilities.

#### Which issue(s) this PR fixes:
Partial fixes for #4188 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
Example YAML for vcJob after modification
```yaml
apiVersion: batch.volcano.sh/v1alpha1
kind: Job
metadata:
  name: network-topology-job
spec:
  minAvailable: 3
  schedulerName: volcano
  networkTopology:
    mode: hard
    highestTierAllowed: 2
  tasks:
    - replicas: 6
      name: "task"
      partitionPolicy:
        totalPartitions: 2
        partitionSize: 3
        minPartitions: 1 //
        networkTopology:
            mode: hard
            highestTierAllowed: 1
      template:
        metadata:
          name: task
        spec:
          containers:
            - image: ubuntu
              imagePullPolicy: IfNotPresent
              name: task
              resources:
                requests:
                  cpu: "2"
                  memory: 2Gi
          restartPolicy: OnFailure
```
Example YAML for podGroup after modification, Minimum requirement: 2rolea and 1roleb
```yaml
apiVersion: scheduling.volcano.sh/v1beta1
kind: PodGroup
metadata:
  name: network-topology-podgroup
spec:
  minMember: 10
  networkTopology:
    mode: hard 
    highestTierAllowed: 2
  subGroupPolicy: 
    - subGroupSize: 4
      minSubGroups: 2
      name: rolea
      labelSelector:
        matchLabels:
          volcano.sh/task-spec: rolea
      matchLabelKeys:
        - volcano.sh/partiton-id
      networkTopology:
        mode: hard 
        highestTierAllowed: 1
    - subGroupSize: 2
      minSubGroups: 1
      name: roleb
      labelSelector:
        matchLabels:
          volcano.sh/task-spec: roleb
      matchLabelKeys:
        - volcano.sh/partition-id
      networkTopology:
        mode: hard 
        highestTierAllowed: 1
```