### PR TITLE
fix restart task/partition when pod evicted

### DIFF
--- a/pkg/controllers/apis/job_info.go
+++ b/pkg/controllers/apis/job_info.go
@@ -229,6 +229,25 @@ func (ji *JobInfo) DeletePod(pod *v1.Pod) error {
 	return nil
 }
 
+// HasPod checks whether the given k8s pod exists in the JobInfo struct.
+func (ji *JobInfo) HasPod(pod *v1.Pod) bool {
+	taskName, found := pod.Annotations[batch.TaskSpecKey]
+	if !found {
+		return false
+	}
+	_, found = pod.Annotations[batch.JobVersion]
+	if !found {
+		return false
+	}
+
+	pods, found := ji.Pods[taskName]
+	if !found {
+		return false
+	}
+	_, found = pods[pod.Name]
+	return found
+}
+
 func GetPartitionID(pod *v1.Pod) string {
 	value, ok := pod.Labels[batch.TaskPartitionID]
 	if ok {

--- a/pkg/controllers/cache/cache.go
+++ b/pkg/controllers/cache/cache.go
@@ -250,6 +250,23 @@ func (jc *jobCache) DeletePod(pod *v1.Pod) error {
 	return nil
 }
 
+func (jc *jobCache) HasPod(pod *v1.Pod) bool {
+	jc.Lock()
+	defer jc.Unlock()
+
+	key, err := jobKeyOfPod(pod)
+	if err != nil {
+		return false
+	}
+
+	job, found := jc.jobs[key]
+	if !found {
+		return false
+	}
+
+	return job.HasPod(pod)
+}
+
 func (jc *jobCache) Run(stopCh <-chan struct{}) {
 	wait.Until(jc.worker, 0, stopCh)
 }

--- a/pkg/controllers/cache/interface.go
+++ b/pkg/controllers/cache/interface.go
@@ -36,6 +36,7 @@ type Cache interface {
 	AddPod(pod *v1.Pod) error
 	UpdatePod(pod *v1.Pod) error
 	DeletePod(pod *v1.Pod) error
+	HasPod(pod *v1.Pod) bool
 
 	TaskCompleted(jobKey, taskName string) bool
 	TaskFailed(jobKey, taskName string) bool

--- a/pkg/controllers/job/job_controller_actions.go
+++ b/pkg/controllers/job/job_controller_actions.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2"
 
 	batch "volcano.sh/apis/pkg/apis/batch/v1alpha1"
@@ -175,6 +176,20 @@ func (cc *jobcontroller) killPods(jobInfo *apis.JobInfo, podRetainPhase state.Ph
 		}
 	}
 
+	for podName, pod := range podsToKill {
+		_, err := cc.kubeClient.CoreV1().Pods(pod.Namespace).Patch(context.TODO(), pod.Name, types.JSONPatchType,
+			jobhelpers.OutOfSyncJSONPatch(), metav1.PatchOptions{})
+		if err != nil && !apierrors.IsNotFound(err) {
+			// record the error, and then collect the pod info like retained pod
+			errs = append(errs, err)
+			// If we fail to patch the pod, we should not delete it,
+			// as it would cause the restart loop. The action will be retried.
+			delete(podsToKill, podName)
+		} else {
+			klog.V(3).InfoS("Marked Pod as out-of-sync", "Pod", klog.KObj(pod), "UID", pod.UID)
+		}
+	}
+
 	for _, pod := range podsToKill {
 		if pod.DeletionTimestamp != nil {
 			klog.Infof("Pod <%s/%s> is terminating", pod.Namespace, pod.Name)
@@ -184,10 +199,11 @@ func (cc *jobcontroller) killPods(jobInfo *apis.JobInfo, podRetainPhase state.Ph
 
 		err := cc.deleteJobPod(job.Name, pod)
 		if err == nil {
+			klog.V(3).InfoS("Deleted Pod of Job", "Job", klog.KObj(job), "Pod", klog.KObj(pod), "UID", pod.UID)
 			terminating++
 			continue
 		}
-		// record the err, and then collect the pod info like retained pod
+		// record the error, and then collect the pod info like retained pod
 		errs = append(errs, err)
 		cc.resyncTask(pod)
 
@@ -466,13 +482,17 @@ func (cc *jobcontroller) syncJob(jobInfo *apis.JobInfo, updateStatus state.Updat
 					continue
 				}
 
+				if jobhelpers.IsOutOfSyncPod(pod) {
+					podToDelete = append(podToDelete, pod) // delete out-of-sync pods
+				}
+
 				classifyAndAddUpPodBaseOnPhase(pod, &pending, &running, &succeeded, &failed, &unknown)
 				calcPodStatus(pod, taskStatusCount)
 			}
 		}
 		podToCreate[ts.Name] = podToCreateEachTask
 		for _, pod := range pods {
-			podToDelete = append(podToDelete, pod)
+			podToDelete = append(podToDelete, pod) // delete pods excceeding desired replicas
 		}
 	}
 
@@ -509,8 +529,7 @@ func (cc *jobcontroller) syncJob(jobInfo *apis.JobInfo, updateStatus state.Updat
 					} else {
 						classifyAndAddUpPodBaseOnPhase(newPod, &pending, &running, &succeeded, &failed, &unknown)
 						calcPodStatus(newPod, taskStatusCount)
-						klog.V(5).Infof("Created Task <%s> of Job <%s/%s>",
-							pod.Name, job.Namespace, job.Name)
+						klog.V(5).InfoS("Created Pod for Job", "Job", klog.KObj(job), "Pod", klog.KObj(pod), "err", err)
 					}
 				}(pod)
 			}
@@ -541,8 +560,7 @@ func (cc *jobcontroller) syncJob(jobInfo *apis.JobInfo, updateStatus state.Updat
 				appendError(&deletionErrs, err)
 				cc.resyncTask(pod)
 			} else {
-				klog.V(3).Infof("Deleted Task <%s> of Job <%s/%s>",
-					pod.Name, job.Namespace, job.Name)
+				klog.V(3).InfoS("Deleted Pod of Job", "Job", klog.KObj(job), "Pod", klog.KObj(pod), "UID", pod.UID)
 				atomic.AddInt32(&terminating, 1)
 			}
 		}(pod)

--- a/pkg/controllers/job/job_controller_handler_test.go
+++ b/pkg/controllers/job/job_controller_handler_test.go
@@ -79,6 +79,7 @@ func buildPod(namespace, name string, p v1.PodPhase, labels map[string]string) *
 			Name:            name,
 			Namespace:       namespace,
 			Labels:          labels,
+			Annotations:     map[string]string{"foo": "bar"},
 			ResourceVersion: string(uuid.NewUUID()),
 			OwnerReferences: []metav1.OwnerReference{
 				{


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
#### What this PR does / why we need it:
When a vcjob is configured with the policy `PodEvicted` -> `RestartTask`/`RestartPartition`, evicting a pod will trigger `RestartTask`/`RestartPartition`, which deletes all pods in that task/partition. The pods deleted this way then retrigger the restart action, causing repeated self-triggered restarts until the maximum retry limit is reached and the job enters the `Failed` status.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Notice that do not add `Fixes` if the issue is associated with multiple PRs.
-->
Fixes #4814 

#### Special notes for your reviewer:
@wangyang0616 @JesseStutler 
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```
#### After fixing:
create the vcjob:
```
task0:
	vjtest-task0-0
	vjtest-task0-1
task1:
	partition0:
		vjtest-task1-0
		vjtest-task1-1
	partition1:
		vjtest-task1-2
		vjtest-task1-3
```
```shell
# kubectl get po
NAME             READY   STATUS    RESTARTS   AGE
vjtest-task0-0   1/1     Running   0          5s
vjtest-task0-1   1/1     Running   0          5s
vjtest-task1-0   1/1     Running   0          5s
vjtest-task1-1   1/1     Running   0          5s
vjtest-task1-2   1/1     Running   0          5s
vjtest-task1-3   1/1     Running   0          5s
```

**Scenario 1: `PodEvicted` -> `RestartTask`**
Kill one pod in task `task0`, all pods in the task are restarted, and the **Retry Count** in vcjob status increases to 1.
```shell
# kubectl delete po vjtest-task0-1
pod "vjtest-task0-1" deleted from default namespace

# kubectl get po
NAME             READY   STATUS    RESTARTS   AGE
vjtest-task0-0   1/1     Running   0          6s
vjtest-task0-1   1/1     Running   0          6s
vjtest-task1-0   1/1     Running   0          18s
vjtest-task1-1   1/1     Running   0          18s
vjtest-task1-2   1/1     Running   0          18s
vjtest-task1-3   1/1     Running   0          18s

# kubectl describe vj vjtest
...
Status:
  ...
  Min Available:           1
  Retry Count:             1
  Running:                 6
  State:
    Last Transition Time:  2025-12-15T12:16:55Z
    Phase:                 Running
  Task Status Count:
    task0:
      Phase:
        Running:  2
    task1:
      Phase:
        Running:  4
Events:
  Type     Reason         Age   From                   Message
  ----     ------         ----  ----                   -------
  Normal   ExecuteAction  11s   vc-controller-manager  Start to execute action RestartTask
```

**Scenario 2: `PodEvicted` -> `RestartPartition`**
Kill one pod in task `task1` partion `partition1`, all pods in the partition are restarted, and the **Retry Count** in vcjob status increases to 2.
```shell
# kubectl delete po vjtest-task1-2
pod "vjtest-task1-2" deleted from default namespace

# kubectl get po
NAME             READY   STATUS    RESTARTS   AGE
vjtest-task0-0   1/1     Running   0          23s
vjtest-task0-1   1/1     Running   0          23s
vjtest-task1-0   1/1     Running   0          35s
vjtest-task1-1   1/1     Running   0          35s
vjtest-task1-2   1/1     Running   0          3s
vjtest-task1-3   1/1     Running   0          3s

# kubectl describe vj vjtest
...
Status:
  ...
  Min Available:           1
  Retry Count:             2
  Running:                 6
  State:
    Last Transition Time:  2025-12-15T12:17:15Z
    Phase:                 Running
  Task Status Count:
    task0:
      Phase:
        Running:  2
    task1:
      Phase:
        Running:  4
Events:
  Type     Reason         Age   From                   Message
  ----     ------         ----  ----                   -------
  Normal   ExecuteAction  31s   vc-controller-manager  Start to execute action RestartTask
  Normal   ExecuteAction  11s   vc-controller-manager  Start to execute action RestartPartition
```
