### PR TITLE
Fixed memory leak caused by metrics remaining due to race conditions

### DIFF
--- a/pkg/scheduler/cache/cache.go
+++ b/pkg/scheduler/cache/cache.go
@@ -1100,6 +1100,16 @@ func (sc *SchedulerCache) processCleanupJob() {
 	}
 }
 
+func (sc *SchedulerCache) IsJobTerminated(jobId schedulingapi.JobID) bool {
+	sc.Mutex.Lock()
+	defer sc.Mutex.Unlock()
+	job, exists := sc.Jobs[jobId]
+	if !exists || job == nil {
+		return true
+	}
+	return schedulingapi.JobTerminated(job)
+}
+
 func (sc *SchedulerCache) generateDeletedJobsKey(job *schedulingapi.JobInfo) string {
 	// Job UID is namespace + / +name, for example: theNs/theJob
 	// Job PgUID is derived from the Job PgUID, for example: d336abea-4f14-42c7-8a6b-092959a31407

--- a/pkg/scheduler/cache/interface.go
+++ b/pkg/scheduler/cache/interface.go
@@ -92,6 +92,9 @@ type Cache interface {
 
 	// SharedDRAManager returns the shared DRAManager
 	SharedDRAManager() framework.SharedDRAManager
+
+	// IsJobTerminated returns if the job was terminated
+	IsJobTerminated(jobId api.JobID) bool
 }
 
 // Binder interface for binding task and hostname

--- a/pkg/scheduler/framework/session.go
+++ b/pkg/scheduler/framework/session.go
@@ -1058,3 +1058,7 @@ func (ssn *Session) String() string {
 
 	return msg
 }
+
+func (ssn *Session) IsJobTerminated(jobId api.JobID) bool {
+	return ssn.cache.IsJobTerminated(jobId)
+}

--- a/pkg/scheduler/plugins/drf/drf.go
+++ b/pkg/scheduler/plugins/drf/drf.go
@@ -205,7 +205,10 @@ func (drf *drfPlugin) OnSessionOpen(ssn *framework.Session) {
 		}
 
 		// Calculate the init share of Job
-		drf.updateJobShare(job.Namespace, job.Name, attr)
+		drf.updateShare(attr)
+		if !ssn.IsJobTerminated(job.UID) {
+			metrics.UpdateJobShare(job.Namespace, job.Name, attr.share)
+		}
 
 		drf.jobAttrs[job.UID] = attr
 
@@ -350,7 +353,10 @@ func (drf *drfPlugin) OnSessionOpen(ssn *framework.Session) {
 			attr.allocated.Add(event.Task.Resreq)
 
 			job := ssn.Jobs[event.Task.Job]
-			drf.updateJobShare(job.Namespace, job.Name, attr)
+			drf.updateShare(attr)
+			if !ssn.IsJobTerminated(job.UID) {
+				metrics.UpdateJobShare(job.Namespace, job.Name, attr.share)
+			}
 
 			nsShare := -1.0
 			if hierarchyEnabled {
@@ -368,7 +374,10 @@ func (drf *drfPlugin) OnSessionOpen(ssn *framework.Session) {
 			attr.allocated.Sub(event.Task.Resreq)
 
 			job := ssn.Jobs[event.Task.Job]
-			drf.updateJobShare(job.Namespace, job.Name, attr)
+			drf.updateShare(attr)
+			if !ssn.IsJobTerminated(job.UID) {
+				metrics.UpdateJobShare(job.Namespace, job.Name, attr.share)
+			}
 
 			nsShare := -1.0
 
@@ -487,11 +496,6 @@ func (drf *drfPlugin) UpdateHierarchicalShare(root *hierarchicalNode, totalAlloc
 	}
 	drf.buildHierarchy(root, job, attr, hierarchy, hierarchicalWeights)
 	drf.updateHierarchicalShare(root, demandingResources)
-}
-
-func (drf *drfPlugin) updateJobShare(jobNs, jobName string, attr *drfAttr) {
-	drf.updateShare(attr)
-	metrics.UpdateJobShare(jobNs, jobName, attr.share)
 }
 
 func (drf *drfPlugin) updateShare(attr *drfAttr) {

--- a/pkg/scheduler/plugins/gang/gang.go
+++ b/pkg/scheduler/plugins/gang/gang.go
@@ -230,7 +230,9 @@ func (gp *gangPlugin) OnSessionClose(ssn *framework.Session) {
 				unreadyTaskCount, len(job.Tasks), job.FitError())
 
 			unScheduleJobCount++
-			metrics.RegisterJobRetries(job.Name)
+			if !ssn.IsJobTerminated(job.UID) {
+				metrics.RegisterJobRetries(job.Name)
+			}
 
 			// TODO: If the Job is gang-unschedulable due to scheduling gates
 			// we need a new message and reason to tell users
@@ -263,7 +265,9 @@ func (gp *gangPlugin) OnSessionClose(ssn *framework.Session) {
 					job.Namespace, job.Name, err)
 			}
 		}
-		metrics.UpdateUnscheduleTaskCount(job.Name, int(unreadyTaskCount))
+		if !ssn.IsJobTerminated(job.UID) {
+			metrics.UpdateUnscheduleTaskCount(job.Name, int(unreadyTaskCount))
+		}
 		unreadyTaskCount = 0
 	}
 


### PR DESCRIPTION
Verify that the job still exists before set job's metrics.

#### What type of PR is this?
/kind bug
#### What this PR does / why we need it:

Before writing the `unschedule_task_count`, `job_share`, and `job_retry_counts` metrics, check if the job exists to prevent leftover metrics.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Notice that do not add `Fixes` if the issue is associated with multiple PRs.
-->
Fixes #4821 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```