### PR TITLE
fix(enqueue): capacity plugin job enqueueable

### DIFF
--- a/pkg/scheduler/actions/enqueue/enqueue.go
+++ b/pkg/scheduler/actions/enqueue/enqueue.go
@@ -91,7 +91,8 @@ func (enqueue *Action) Execute(ssn *framework.Session) {
 			continue
 		}
 		job := jobs.Pop().(*api.JobInfo)
-
+		klog.V(5).Infof("Try to enqueue Job <%s/%s>, minresources <%v> into Queue <%s>",
+			job.Namespace, job.Name, job.GetMinResources().String(), queue.Name)
 		if job.PodGroup.Spec.MinResources == nil || ssn.JobEnqueueable(job) {
 			ssn.JobEnqueued(job)
 			job.PodGroup.Status.Phase = scheduling.PodGroupInqueue

--- a/pkg/scheduler/plugins/capacity/capacity_test.go
+++ b/pkg/scheduler/plugins/capacity/capacity_test.go
@@ -21,7 +21,6 @@ import (
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
 	"volcano.sh/apis/pkg/apis/scheduling"
 	schedulingv1beta1 "volcano.sh/apis/pkg/apis/scheduling/v1beta1"
 	"volcano.sh/volcano/cmd/scheduler/app/options"
@@ -396,14 +395,14 @@ func Test_capacityPlugin_OnSessionOpenWithHierarchy(t *testing.T) {
 	// podgroup
 	pg1 := util.BuildPodGroup("pg1", "ns1", "q11", 1, nil, schedulingv1beta1.PodGroupInqueue)
 	// queue
-	root := buildQueueWithParents("root", "", nil, nil)
-	root1 := buildQueueWithParents("root", "", nil, api.BuildResourceList("16", "16Gi"))
-	root2 := buildQueueWithParents("root", "", api.BuildResourceList("16", "16Gi", []api.ScalarResource{{Name: "nvidia.com/a100", Value: "4"}, {Name: "rdma", Value: "1000"}}...), nil)
-	root3 := buildQueueWithParents("root", "", api.BuildResourceList("32", "32Gi", []api.ScalarResource{{Name: "nvidia.com/a100", Value: "10"}, {Name: "rdma", Value: "1000"}}...), nil)
-	queue1 := buildQueueWithParents("q1", "root", nil, api.BuildResourceList("4", "4Gi"))
-	queue2 := buildQueueWithParents("q2", "root", nil, api.BuildResourceList("4", "4Gi"))
-	queue11 := buildQueueWithParents("q11", "q1", nil, api.BuildResourceList("1", "1Gi"))
-	queue12 := buildQueueWithParents("q12", "q1", nil, api.BuildResourceList("3", "3Gi"))
+	root := util.BuildQueueWithParents("root", "", nil, nil)
+	root1 := util.BuildQueueWithParents("root", "", nil, api.BuildResourceList("16", "16Gi"))
+	root2 := util.BuildQueueWithParents("root", "", api.BuildResourceList("16", "16Gi", []api.ScalarResource{{Name: "nvidia.com/a100", Value: "4"}, {Name: "rdma", Value: "1000"}}...), nil)
+	root3 := util.BuildQueueWithParents("root", "", api.BuildResourceList("32", "32Gi", []api.ScalarResource{{Name: "nvidia.com/a100", Value: "10"}, {Name: "rdma", Value: "1000"}}...), nil)
+	queue1 := util.BuildQueueWithParents("q1", "root", nil, api.BuildResourceList("4", "4Gi"))
+	queue2 := util.BuildQueueWithParents("q2", "root", nil, api.BuildResourceList("4", "4Gi"))
+	queue11 := util.BuildQueueWithParents("q11", "q1", nil, api.BuildResourceList("1", "1Gi"))
+	queue12 := util.BuildQueueWithParents("q12", "q1", nil, api.BuildResourceList("3", "3Gi"))
 
 	// resources for test case 1
 	// pod
@@ -418,11 +417,11 @@ func Test_capacityPlugin_OnSessionOpenWithHierarchy(t *testing.T) {
 	// podgroup
 	pg3 := util.BuildPodGroup("pg3", "ns1", "q31", 2, nil, schedulingv1beta1.PodGroupInqueue)
 	// queue
-	queue3 := buildQueueWithParents("q3", "root", api.BuildResourceList("4", "4Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), api.BuildResourceList("4", "4Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...))
-	queue4 := buildQueueWithParents("q4", "root", api.BuildResourceList("2", "2Gi", []api.ScalarResource{{Name: "pods", Value: "1"}}...), api.BuildResourceList("4", "4Gi", []api.ScalarResource{{Name: "pods", Value: "4"}}...))
-	queue31 := buildQueueWithParents("q31", "q3", api.BuildResourceList("2", "2Gi", []api.ScalarResource{{Name: "pods", Value: "2"}}...), api.BuildResourceList("4", "4Gi", []api.ScalarResource{{Name: "pods", Value: "4"}}...))
-	queue32 := buildQueueWithParents("q32", "q3", api.BuildResourceList("2", "2Gi", []api.ScalarResource{{Name: "pods", Value: "2"}}...), api.BuildResourceList("4", "4Gi", []api.ScalarResource{{Name: "pods", Value: "4"}}...))
-	queue33 := buildQueueWithParents("q33", "q3", api.BuildResourceList("0", "0Gi", []api.ScalarResource{{Name: "pods", Value: "2"}}...), api.BuildResourceList("4", "4Gi", []api.ScalarResource{{Name: "pods", Value: "4"}}...))
+	queue3 := util.BuildQueueWithParents("q3", "root", api.BuildResourceList("4", "4Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), api.BuildResourceList("4", "4Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...))
+	queue4 := util.BuildQueueWithParents("q4", "root", api.BuildResourceList("2", "2Gi", []api.ScalarResource{{Name: "pods", Value: "1"}}...), api.BuildResourceList("4", "4Gi", []api.ScalarResource{{Name: "pods", Value: "4"}}...))
+	queue31 := util.BuildQueueWithParents("q31", "q3", api.BuildResourceList("2", "2Gi", []api.ScalarResource{{Name: "pods", Value: "2"}}...), api.BuildResourceList("4", "4Gi", []api.ScalarResource{{Name: "pods", Value: "4"}}...))
+	queue32 := util.BuildQueueWithParents("q32", "q3", api.BuildResourceList("2", "2Gi", []api.ScalarResource{{Name: "pods", Value: "2"}}...), api.BuildResourceList("4", "4Gi", []api.ScalarResource{{Name: "pods", Value: "4"}}...))
+	queue33 := util.BuildQueueWithParents("q33", "q3", api.BuildResourceList("0", "0Gi", []api.ScalarResource{{Name: "pods", Value: "2"}}...), api.BuildResourceList("4", "4Gi", []api.ScalarResource{{Name: "pods", Value: "4"}}...))
 
 	// resources for test case 3
 	// pod
@@ -442,8 +441,8 @@ func Test_capacityPlugin_OnSessionOpenWithHierarchy(t *testing.T) {
 
 	// resources for test case 5
 	// queue
-	queue5 := buildQueueWithParents("q5", "root", nil, api.BuildResourceList("", "4Gi", []api.ScalarResource{}...))
-	queue51 := buildQueueWithParents("q51", "q5", nil, api.BuildResourceList("", "2Gi", []api.ScalarResource{}...))
+	queue5 := util.BuildQueueWithParents("q5", "root", nil, api.BuildResourceList("", "4Gi", []api.ScalarResource{}...))
+	queue51 := util.BuildQueueWithParents("q51", "q5", nil, api.BuildResourceList("", "2Gi", []api.ScalarResource{}...))
 	// podgroup
 	pg9 := util.BuildPodGroup("pg9", "ns1", "q51", 1, nil, schedulingv1beta1.PodGroupRunning)
 	// pod
@@ -451,37 +450,25 @@ func Test_capacityPlugin_OnSessionOpenWithHierarchy(t *testing.T) {
 
 	// resources for test case 6
 	// queue
-	queue6 := buildQueueWithParents("q6", "root", nil, api.BuildResourceList("2", "4Gi", []api.ScalarResource{}...))
+	queue6 := util.BuildQueueWithParents("q6", "root", nil, api.BuildResourceList("2", "4Gi", []api.ScalarResource{}...))
 	// sub queue 61 and 62's capability is not specified, should be inherited from parent queue
-	queue61 := buildQueueWithParents("q61", "q6", nil, nil)
-	queue62 := buildQueueWithParents("q62", "q6", nil, nil)
+	queue61 := util.BuildQueueWithParents("q61", "q6", nil, nil)
+	queue62 := util.BuildQueueWithParents("q62", "q6", nil, nil)
 	// podgroup
 	pg10 := util.BuildPodGroupWithMinResources("pg10", "ns1", "q61", 1, nil, api.BuildResourceList("2", "4Gi"), schedulingv1beta1.PodGroupPending)
 	pg11 := util.BuildPodGroupWithMinResources("pg11", "ns1", "q62", 1, nil, api.BuildResourceList("2", "4Gi"), schedulingv1beta1.PodGroupPending)
 
 	// resources for test case 7
 	// queue
-	queue7 := buildQueueWithParents("q7", "root", nil, api.BuildResourceList("6", "4Gi", []api.ScalarResource{}...))
+	queue7 := util.BuildQueueWithParents("q7", "root", nil, api.BuildResourceList("6", "4Gi", []api.ScalarResource{}...))
 	// the sum of sub queue 71 and 72's guarantee exceeds the capacity of queue7, but should not panic
-	queue71 := buildQueueWithParents("q71", "q7", nil, api.BuildResourceList("6", "4Gi", []api.ScalarResource{}...))
-	queue72 := buildQueueWithParents("q72", "q7", nil, api.BuildResourceList("6", "4Gi", []api.ScalarResource{}...))
-	queue71.Spec.Guarantee = schedulingv1beta1.Guarantee{
-		Resource: corev1.ResourceList{
-			corev1.ResourceCPU:    resource.MustParse("4"),
-			corev1.ResourceMemory: resource.MustParse("3Gi"),
-		},
-	}
-	queue72.Spec.Guarantee = schedulingv1beta1.Guarantee{
-		Resource: corev1.ResourceList{
-			corev1.ResourceCPU:    resource.MustParse("4"),
-			corev1.ResourceMemory: resource.MustParse("3Gi"),
-		},
-	}
+	queue71 := util.BuildQueueWithParentsAndGuarantee("q71", "q7", api.BuildResourceList("4", "3Gi", []api.ScalarResource{}...), nil, api.BuildResourceList("6", "4Gi", []api.ScalarResource{}...))
+	queue72 := util.BuildQueueWithParentsAndGuarantee("q72", "q7", api.BuildResourceList("4", "3Gi", []api.ScalarResource{}...), nil, api.BuildResourceList("6", "4Gi", []api.ScalarResource{}...))
 
 	// resources for test case 8
-	queue8 := buildQueueWithParents("q8", "root", api.BuildResourceList("4", "4Gi", []api.ScalarResource{{Name: "nvidia.com/gpu", Value: "8"}}...), nil)
-	queue81 := buildQueueWithParents("q81", "q8", api.BuildResourceList("2", "2Gi", []api.ScalarResource{{Name: "nvidia.com/gpu", Value: "4"}}...), nil)
-	queue82 := buildQueueWithParents("q82", "q8", api.BuildResourceList("2", "2Gi", []api.ScalarResource{{Name: "nvidia.com/gpu", Value: "4"}}...), nil)
+	queue8 := util.BuildQueueWithParents("q8", "root", api.BuildResourceList("4", "4Gi", []api.ScalarResource{{Name: "nvidia.com/gpu", Value: "8"}}...), nil)
+	queue81 := util.BuildQueueWithParents("q81", "q8", api.BuildResourceList("2", "2Gi", []api.ScalarResource{{Name: "nvidia.com/gpu", Value: "4"}}...), nil)
+	queue82 := util.BuildQueueWithParents("q82", "q8", api.BuildResourceList("2", "2Gi", []api.ScalarResource{{Name: "nvidia.com/gpu", Value: "4"}}...), nil)
 	// node
 	gpuNode := util.BuildNode("n-gpu", api.BuildResourceList("8", "8Gi", []api.ScalarResource{{Name: "nvidia.com/gpu", Value: "8"}, {Name: "pods", Value: "10"}}...), map[string]string{})
 	// podgroup
@@ -490,8 +477,8 @@ func Test_capacityPlugin_OnSessionOpenWithHierarchy(t *testing.T) {
 	p12 := util.BuildPod("ns1", "p12", "", corev1.PodPending, api.BuildResourceList("2", "2Gi", []api.ScalarResource{{Name: "nvidia.com/gpu", Value: "1"}}...), "pg12", make(map[string]string), make(map[string]string))
 
 	// resources for test case 9
-	queue9 := buildQueueWithParents("q9", "root", api.BuildResourceList("2", "2Gi", []api.ScalarResource{{Name: "nvidia.com/gpu", Value: "8"}, {Name: "hugepages-1Gi", Value: "0"}}...), nil)
-	queue91 := buildQueueWithParents("q91", "q9", api.BuildResourceList("2", "2Gi", []api.ScalarResource{{Name: "nvidia.com/gpu", Value: "4"}, {Name: "hugepages-1Gi", Value: "0"}}...), nil)
+	queue9 := util.BuildQueueWithParents("q9", "root", api.BuildResourceList("2", "2Gi", []api.ScalarResource{{Name: "nvidia.com/gpu", Value: "8"}, {Name: "hugepages-1Gi", Value: "0"}}...), nil)
+	queue91 := util.BuildQueueWithParents("q91", "q9", api.BuildResourceList("2", "2Gi", []api.ScalarResource{{Name: "nvidia.com/gpu", Value: "4"}, {Name: "hugepages-1Gi", Value: "0"}}...), nil)
 	// node
 	n2 := util.BuildNode("n2", api.BuildResourceList("8", "8Gi", []api.ScalarResource{{Name: "nvidia.com/gpu", Value: "8"}, {Name: "pods", Value: "10"}, {Name: "hugepages-1Gi", Value: "0"}}...), map[string]string{})
 	// podgroup
@@ -499,13 +486,13 @@ func Test_capacityPlugin_OnSessionOpenWithHierarchy(t *testing.T) {
 	// pod
 	p13 := util.BuildPod("ns1", "p13", "", corev1.PodPending, api.BuildResourceList("2", "2Gi", []api.ScalarResource{{Name: "nvidia.com/gpu", Value: "1"}}...), "pg13", make(map[string]string), make(map[string]string))
 	// queue
-	queue10 := buildQueueWithParents("q10", "root", nil, api.BuildResourceList("10", "4Gi", []api.ScalarResource{}...))
+	queue10 := util.BuildQueueWithParents("q10", "root", nil, api.BuildResourceList("10", "4Gi", []api.ScalarResource{}...))
 
 	// resources for test case 11
 	// queue
-	case11_queue1 := buildQueueWithParents("case11_queue1", "root", nil, nil)
-	case11_queue11 := buildQueueWithParents("case11_queue11", "case11_queue1", nil, api.BuildResourceList("4", "4Gi", []api.ScalarResource{{Name: "nvidia.com/gpu", Value: "4"}}...))
-	case11_queue12 := buildQueueWithParents("case11_queue12", "case11_queue1", nil, api.BuildResourceList("4", "4Gi", []api.ScalarResource{{Name: "nvidia.com/gpu", Value: "4"}}...))
+	case11_queue1 := util.BuildQueueWithParents("case11_queue1", "root", nil, nil)
+	case11_queue11 := util.BuildQueueWithParents("case11_queue11", "case11_queue1", nil, api.BuildResourceList("4", "4Gi", []api.ScalarResource{{Name: "nvidia.com/gpu", Value: "4"}}...))
+	case11_queue12 := util.BuildQueueWithParents("case11_queue12", "case11_queue1", nil, api.BuildResourceList("4", "4Gi", []api.ScalarResource{{Name: "nvidia.com/gpu", Value: "4"}}...))
 
 	// podgroup
 	pg14 := util.BuildPodGroup("pg14", "ns1", "case11_queue11", 1, nil, schedulingv1beta1.PodGroupInqueue)
@@ -517,9 +504,9 @@ func Test_capacityPlugin_OnSessionOpenWithHierarchy(t *testing.T) {
 
 	// resources for test case 12
 	// queue
-	case12_queue1 := buildQueueWithParents("case12_queue1", "root", api.BuildResourceList("", "", []api.ScalarResource{{Name: "nvidia.com/a100", Value: "2"}}...), nil)
-	case12_queue11 := buildQueueWithParents("case12_queue11", "case12_queue1", api.BuildResourceList("", "", []api.ScalarResource{{Name: "nvidia.com/a100", Value: "2"}}...), nil)
-	case12_queue12 := buildQueueWithParents("case12_queue12", "case12_queue1", nil, nil)
+	case12_queue1 := util.BuildQueueWithParents("case12_queue1", "root", api.BuildResourceList("", "", []api.ScalarResource{{Name: "nvidia.com/a100", Value: "2"}}...), nil)
+	case12_queue11 := util.BuildQueueWithParents("case12_queue11", "case12_queue1", api.BuildResourceList("", "", []api.ScalarResource{{Name: "nvidia.com/a100", Value: "2"}}...), nil)
+	case12_queue12 := util.BuildQueueWithParents("case12_queue12", "case12_queue1", nil, nil)
 
 	// node
 	n3 := util.BuildNode("n3", api.BuildResourceList("16", "16Gi", []api.ScalarResource{{Name: "nvidia.com/a100", Value: "5"}, {Name: "rdma/hca", Value: "1001"}, {Name: "pods", Value: "11"}}...), map[string]string{})
@@ -536,9 +523,9 @@ func Test_capacityPlugin_OnSessionOpenWithHierarchy(t *testing.T) {
 
 	// case 13 - allow enqueue below guarantee
 	// queue
-	case13_queue1 := buildQueueWithParentsWithGuarantee("case13_queue1", "root", api.BuildResourceList("32", "32Gi", []api.ScalarResource{{Name: "nvidia.com/a100", Value: "10"}}...), nil, nil)
-	case13_queue11 := buildQueueWithParentsWithGuarantee("case13_queue11", "case13_queue1", api.BuildResourceList("16", "16Gi", []api.ScalarResource{{Name: "nvidia.com/a100", Value: "5"}}...), nil, nil)
-	case13_queue12 := buildQueueWithParentsWithGuarantee("case13_queue12", "case13_queue1", api.BuildResourceList("16", "16Gi", []api.ScalarResource{{Name: "nvidia.com/a100", Value: "5"}}...), nil, nil)
+	case13_queue1 := util.BuildQueueWithParentsAndGuarantee("case13_queue1", "root", api.BuildResourceList("32", "32Gi", []api.ScalarResource{{Name: "nvidia.com/a100", Value: "10"}}...), nil, nil)
+	case13_queue11 := util.BuildQueueWithParentsAndGuarantee("case13_queue11", "case13_queue1", api.BuildResourceList("16", "16Gi", []api.ScalarResource{{Name: "nvidia.com/a100", Value: "5"}}...), nil, nil)
+	case13_queue12 := util.BuildQueueWithParentsAndGuarantee("case13_queue12", "case13_queue1", api.BuildResourceList("16", "16Gi", []api.ScalarResource{{Name: "nvidia.com/a100", Value: "5"}}...), nil, nil)
 
 	// podgroup
 	pg19 := util.BuildPodGroupWithMinResources("pg19", "ns1", "case13_queue11", 1, nil, api.BuildResourceList("16", "16Gi", []api.ScalarResource{{Name: "nvidia.com/a100", Value: "5"}, {Name: "rdma/hca", Value: "1"}}...), schedulingv1beta1.PodGroupPending)
@@ -549,15 +536,15 @@ func Test_capacityPlugin_OnSessionOpenWithHierarchy(t *testing.T) {
 	p20 := util.BuildPod("ns1", "p20", "n3", corev1.PodRunning, api.BuildResourceList("16", "16Gi", []api.ScalarResource{{Name: "nvidia.com/a100", Value: "5"}, {Name: "rdma/hca", Value: "1"}}...), "pg20", make(map[string]string), map[string]string{})
 
 	// case 14 - not allow to enqueue above guarantee when cluster is full (reusing case13 queues)
-	case14_queue := buildQueueWithParentsWithGuarantee("case14_queue", "case13_queue1", api.BuildResourceList("", "", []api.ScalarResource{{Name: "nvidia.com/a100", Value: "4"}}...), nil, nil)
+	case14_queue := util.BuildQueueWithParentsAndGuarantee("case14_queue", "case13_queue1", api.BuildResourceList("", "", []api.ScalarResource{{Name: "nvidia.com/a100", Value: "4"}}...), nil, nil)
 	pg21 := util.BuildPodGroupWithMinResources("pg21", "ns1", "case14_queue", 1, nil, api.BuildResourceList("16", "16Gi", []api.ScalarResource{{Name: "nvidia.com/a100", Value: "5"}, {Name: "rdma/hca", Value: "1"}}...), schedulingv1beta1.PodGroupPending)
 	p21 := util.BuildPod("ns1", "p21", "", corev1.PodPending, api.BuildResourceList("16", "16Gi", []api.ScalarResource{{Name: "nvidia.com/a100", Value: "5"}, {Name: "rdma/hca", Value: "1"}}...), "pg21", make(map[string]string), map[string]string{})
 
 	// case 15 - allow enqueue below deserved no guarantee on the cluster
 	// queue
-	case15_queue1 := buildQueueWithParents("case15_queue1", "root", api.BuildResourceList("32", "32Gi", []api.ScalarResource{{Name: "nvidia.com/a100", Value: "10"}}...), nil)
-	case15_queue11 := buildQueueWithParents("case15_queue11", "case15_queue1", api.BuildResourceList("16", "16Gi", []api.ScalarResource{{Name: "nvidia.com/a100", Value: "5"}}...), nil)
-	case15_queue12 := buildQueueWithParents("case15_queue12", "case15_queue1", api.BuildResourceList("16", "16Gi", []api.ScalarResource{{Name: "nvidia.com/a100", Value: "5"}}...), nil)
+	case15_queue1 := util.BuildQueueWithParents("case15_queue1", "root", api.BuildResourceList("32", "32Gi", []api.ScalarResource{{Name: "nvidia.com/a100", Value: "10"}}...), nil)
+	case15_queue11 := util.BuildQueueWithParents("case15_queue11", "case15_queue1", api.BuildResourceList("16", "16Gi", []api.ScalarResource{{Name: "nvidia.com/a100", Value: "5"}}...), nil)
+	case15_queue12 := util.BuildQueueWithParents("case15_queue12", "case15_queue1", api.BuildResourceList("16", "16Gi", []api.ScalarResource{{Name: "nvidia.com/a100", Value: "5"}}...), nil)
 
 	// podgroup
 	pg22 := util.BuildPodGroupWithMinResources("pg22", "ns1", "case15_queue11", 1, nil, api.BuildResourceList("16", "16Gi", []api.ScalarResource{{Name: "nvidia.com/a100", Value: "5"}, {Name: "rdma/hca", Value: "1"}}...), schedulingv1beta1.PodGroupPending)
@@ -568,7 +555,7 @@ func Test_capacityPlugin_OnSessionOpenWithHierarchy(t *testing.T) {
 	p23 := util.BuildPod("ns1", "p23", "n3", corev1.PodRunning, api.BuildResourceList("16", "16Gi", []api.ScalarResource{{Name: "nvidia.com/a100", Value: "5"}, {Name: "rdma/hca", Value: "1"}}...), "pg23", make(map[string]string), map[string]string{})
 
 	// case 16 - not allow to enqueue above deserved when cluster is full and no guarantee on the cluster (reusing case15 queues)
-	case16_queue := buildQueueWithParents("case16_queue", "case15_queue1", api.BuildResourceList("", "", []api.ScalarResource{{Name: "nvidia.com/a100", Value: "4"}}...), nil)
+	case16_queue := util.BuildQueueWithParents("case16_queue", "case15_queue1", api.BuildResourceList("", "", []api.ScalarResource{{Name: "nvidia.com/a100", Value: "4"}}...), nil)
 	pg24 := util.BuildPodGroupWithMinResources("pg24", "ns1", "case16_queue", 1, nil, api.BuildResourceList("16", "16Gi", []api.ScalarResource{{Name: "nvidia.com/a100", Value: "5"}, {Name: "rdma/hca", Value: "1"}}...), schedulingv1beta1.PodGroupPending)
 	p24 := util.BuildPod("ns1", "p24", "", corev1.PodPending, api.BuildResourceList("16", "16Gi", []api.ScalarResource{{Name: "nvidia.com/a100", Value: "5"}, {Name: "rdma/hca", Value: "1"}}...), "pg24", make(map[string]string), map[string]string{})
 
@@ -799,17 +786,4 @@ func Test_capacityPlugin_OnSessionOpenWithHierarchy(t *testing.T) {
 			}
 		})
 	}
-}
-
-func buildQueueWithParents(name string, parent string, deserved corev1.ResourceList, cap corev1.ResourceList) *schedulingv1beta1.Queue {
-	queue := util.BuildQueueWithResourcesQuantity(name, deserved, cap)
-	queue.Spec.Parent = parent
-	return queue
-}
-
-func buildQueueWithParentsWithGuarantee(name string, parent string, guarantee corev1.ResourceList, deserved corev1.ResourceList, cap corev1.ResourceList) *schedulingv1beta1.Queue {
-	queue := util.BuildQueueWithResourcesQuantity(name, deserved, cap)
-	queue.Spec.Parent = parent
-	queue.Spec.Guarantee.Resource = guarantee
-	return queue
 }

--- a/pkg/scheduler/util/test_utils.go
+++ b/pkg/scheduler/util/test_utils.go
@@ -469,6 +469,21 @@ func BuildQueueWithPriorityAndResourcesQuantity(qname string, priority int32, de
 	return queue
 }
 
+// BuildQueueWithPriorityAndResourcesQuantity return a queue with parents, deserved and capability resources quantity.
+func BuildQueueWithParents(name string, parent string, deserved v1.ResourceList, cap v1.ResourceList) *schedulingv1beta1.Queue {
+	queue := BuildQueueWithResourcesQuantity(name, deserved, cap)
+	queue.Spec.Parent = parent
+	return queue
+}
+
+// BuildQueueWithParentsAndGuarantee return a queue with parents, guarantee, deserved and capability resources quantity.
+func BuildQueueWithParentsAndGuarantee(name string, parent string, guarantee v1.ResourceList, deserved v1.ResourceList, cap v1.ResourceList) *schedulingv1beta1.Queue {
+	queue := BuildQueueWithResourcesQuantity(name, deserved, cap)
+	queue.Spec.Parent = parent
+	queue.Spec.Guarantee.Resource = guarantee
+	return queue
+}
+
 // ////// build in resource //////
 // BuildPriorityClass return pc
 func BuildPriorityClass(name string, value int32) *schedulingv1.PriorityClass {


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/kind enhancement

#### What this PR does / why we need it:
The PR contains some enhancements and a bugfix regarding the capacity plugin's enqueue process.
Currently in the capacity plugin we rely purely on realCapability to decide wheter a job shall enqueue or not.

This is a little bit problematic, as there are cases when we want to enqueue below deserved or guarantee directly as
[zjj2wry](https://github.com/zjj2wry) points out here: https://github.com/volcano-sh/volcano/issues/4817#issuecomment-3659765366
For example, when we have a queue structure where:
```
# Cluster: 100 CPU
parent (guarantee = 100 CPU, capability = 100 CPU)
├── leaf-1:
│   - guarantee = 60 CPU
│   - deserved = 60 CPU
│   - allocated = 100 CPU (overused by 40 CPU)
│
└── leaf-2:
    - guarantee = 40 CPU
    - deserved = 40 CPU
    - allocated = 0 CPU
    - wants 40 CPU
```
The leaf-2 queue cannot enqueue, although having guaranteed resources on the cluster. 
There can be use cases where we don't `guarantee` resources on the cluster to any queues, rather than we are slicing the cluster on `deserved` values, for example if we omit guarantee in the above example:

```
# Cluster: 100 CPU
parent (guarantee = 100 CPU, capability = 100 CPU)
├── leaf-1:
│   - deserved = 60 CPU
│   - allocated = 100 CPU (overused by 40 CPU)
│
└── leaf-2:
    - deserved = 40 CPU
    - allocated = 0 CPU
    - wants 40 CPU
```
leaf-2 in this case will not able to enqueue too due to maxed out cluster capacity, although it would deserve 40
For this use case (when no guarantee is specified) we should enqueue too I think.

The comparision uses `LessEqualPartlyWithDimensionZeroFiltered` so if there exists any dimension that is below or equal
in `deserved`/`guarantee` we still enqueue. This means in theory that there can be dimensions where the job's minResources will increase the `allocated`+ `inqueued` queue resources above the queue capability value, which is fine I think as this is the realm of `allocate` rather than `enqueue`, so the principle that we don't let resources to be created in a queue above the capability is not harmed.

Additionally, these examples are for hierarchical queues, but the causes and the induction is true for the non-hierarchical cases too.

Minor enhancement in the `enqueue` action logging and the `capacity` plugins tests has been added to the PR.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Notice that do not add `Fixes` if the issue is associated with multiple PRs.
-->
Fixes #4817

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
fix(enqueue): capacity plugin job enqueueable
A bug has been fixed in the capacity plugin's enqueue logic, which prohibited legitimate jobs to move from `Pending` to `Inqueue`.
Additionally we added a new logic which will let the jobs to enqueue below `deserved`, when no `guarantee` value is provided in any of the queues across cluster.
```