### PR TITLE
job controller should keep terminating pod in job

### DIFF
--- a/pkg/controllers/job/job_controller_handler.go
+++ b/pkg/controllers/job/job_controller_handler.go
@@ -182,11 +182,6 @@ func (cc *jobcontroller) addPod(obj interface{}) {
 		return
 	}
 
-	if pod.DeletionTimestamp != nil {
-		cc.deletePod(pod)
-		return
-	}
-
 	req := apis.Request{
 		Namespace:   pod.Namespace,
 		JobName:     jobName,
@@ -230,11 +225,6 @@ func (cc *jobcontroller) updatePod(oldObj, newObj interface{}) {
 	}
 
 	if newPod.ResourceVersion == oldPod.ResourceVersion {
-		return
-	}
-
-	if newPod.DeletionTimestamp != nil {
-		cc.deletePod(newObj)
 		return
 	}
 

--- a/pkg/controllers/job/job_controller_handler_test.go
+++ b/pkg/controllers/job/job_controller_handler_test.go
@@ -334,6 +334,31 @@ func TestAddPodFunc(t *testing.T) {
 			},
 			ExpectedValue: 1,
 		},
+		{
+			// This case ensures a pod that is already terminating (has DeletionTimestamp)
+			// is still added to the job cache correctly.
+			Name: "AddPod Success when pod is terminating",
+			Job: &batch.Job{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "job1",
+					Namespace: namespace,
+				},
+			},
+			pods: []*v1.Pod{
+				func() *v1.Pod {
+					p := buildPod(namespace, "pod1", v1.PodPending, nil)
+					now := metav1.Now()
+					p.DeletionTimestamp = &now
+					return p
+				}(),
+			},
+			Annotation: map[string]string{
+				batch.JobNameKey:  "job1",
+				batch.JobVersion:  "0",
+				batch.TaskSpecKey: "task1",
+			},
+			ExpectedValue: 1,
+		},
 	}
 
 	for i, testcase := range testcases {
@@ -408,6 +433,30 @@ func TestUpdatePodFunc(t *testing.T) {
 				batch.TaskSpecKey: "task1",
 			},
 			ExpectedValue: v1.PodFailed,
+		},
+		{
+			// This case verifies that when the updated pod has a DeletionTimestamp
+			// (terminating), it remains in the job cache instead of being removed.
+			Name: "UpdatePod keeps terminating pod in cache",
+			Job: &batch.Job{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "job1",
+					Namespace: namespace,
+				},
+			},
+			oldPod: buildPod(namespace, "pod1", v1.PodRunning, nil),
+			newPod: func() *v1.Pod {
+				p := buildPod(namespace, "pod1", v1.PodRunning, nil)
+				now := metav1.Now()
+				p.DeletionTimestamp = &now
+				return p
+			}(),
+			Annotation: map[string]string{
+				batch.JobNameKey:  "job1",
+				batch.JobVersion:  "0",
+				batch.TaskSpecKey: "task1",
+			},
+			ExpectedValue: v1.PodRunning,
 		},
 	}
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Currently, when a Job is aborted and enters the `Aborting` phase, its Pods start to be deleted.  
On Pod update, as soon as a Pod has a non-nil `DeletionTimestamp` (i.e. it becomes `Terminating`), the controller removes that Pod from the Job cache.  

In the `Aborting` state, the transition logic checks `status.Terminating`, `status.Pending`, and `status.Running` from the cached Job status:

```go
// If any "alive" pods, still in Aborting phase
if status.Terminating != 0 || status.Pending != 0 || status.Running != 0 {
    return false
}
status.State.Phase = vcbatch.Aborted
```

Because terminating Pods are removed from the cache too early, `status.Terminating` becomes `0` while the Pods are still terminating in the cluster, and the Job transitions to `Aborted` prematurely.

This PR changes the behavior so that **Pods in `Terminating` state are kept in the job cache and are not removed on the update event**. Instead, they stay in the cache (and in the Job status) until the actual Pod delete event is received.  
With this change:

- The Job remains in `Aborting` while there are still terminating Pods.
- The Job only transitions to `Aborted` after all “alive” Pods (including terminating ones) are gone, making the Job state consistent with the real Pod lifecycle in the cluster.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Notice that do not add `Fixes` if the issue is associated with multiple PRs.
-->
Fixes #4828

#### Special notes for your reviewer:

- The main behavioral change is that we **no longer delete Pods from the job cache on update when they have a `DeletionTimestamp`**; we rely on the Pod delete event to remove them from the cache.  
- This ensures that `status.Terminating` correctly reflects the presence of terminating Pods and prevents the Job from leaving `Aborting` too early.  
- Please pay attention to any places that assume terminating Pods are already removed from the cache; the new behavior should be more consistent with the actual cluster state, but it’s worth double-checking for side effects.  
- If necessary, I can add/extend tests to cover the scenario where a Job stays in `Aborting` while Pods are in `Terminating` and only moves to `Aborted` once all Pods are fully deleted.

#### Does this PR introduce a user-facing change?

```release-note
Fix a bug where Jobs in the Aborting phase could transition to Aborted while some Pods were still terminating by keeping terminating Pods in the job cache until they are fully deleted.
```