### PR TITLE
[release-1.12] Cherry-pick #4786 and #4792

### DIFF
--- a/pkg/controllers/podgroup/pg_controller.go
+++ b/pkg/controllers/podgroup/pg_controller.go
@@ -132,7 +132,7 @@ func (pg *pgcontroller) Run(stopCh <-chan struct{}) {
 		}
 	}
 
-	for i := 0; i < int(pg.workers); i++ {
+	for range int(pg.workers) {
 		go wait.Until(pg.worker, 0, stopCh)
 	}
 

--- a/pkg/controllers/podgroup/pg_controller_handler.go
+++ b/pkg/controllers/podgroup/pg_controller_handler.go
@@ -104,6 +104,11 @@ func (pg *pgcontroller) addReplicaSet(obj interface{}) {
 				klog.V(4).Infof("Pod %s field SchedulerName is not matched", klog.KObj(&pod))
 				return
 			}
+			// If the pod is already associated with a podgroup, skip creating a new one.
+			if pgName := pod.Annotations[scheduling.KubeGroupNameAnnotationKey]; pgName != "" {
+				klog.V(4).Infof("Pod %s is already associated with a podgroup %s", klog.KObj(&pod), pgName)
+				return
+			}
 			// In the upgrade scenario, need to synchronize and update the podgroup-related information.
 			// For example, if you update `scheduling.volcano.sh/group-min-member: "2"`, the podgroup's `minMember` needs to be updated to 2.
 			err := pg.createOrUpdateNormalPodPG(&pod)


### PR DESCRIPTION
#### What type of PR is this?
Cherry-picking to the release-1.12 branch:
Relevant part of:
https://github.com/volcano-sh/volcano/pull/4792
and:
https://github.com/volcano-sh/volcano/pull/4786 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Notice that do not add `Fixes` if the issue is associated with multiple PRs.
-->
Fixes #4827 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
fix(pg_controller): replicaset update did not synchronize the new podgroup informations
fix(pg_controller): replicasets were creating an unnecessary podgroup even though KubeGroupNameAnnotation was present
```