### PR TITLE
refactor: use single queue for all workers in job controller

### DIFF
--- a/pkg/controllers/job/job_controller_handler.go
+++ b/pkg/controllers/job/job_controller_handler.go
@@ -68,9 +68,7 @@ func (cc *jobcontroller) addJob(obj interface{}) {
 		klog.Errorf("Failed to add job <%s/%s>: %v in cache",
 			job.Namespace, job.Name, err)
 	}
-	key := jobhelpers.GetJobKeyByReq(&req)
-	queue := cc.getWorkerQueue(key)
-	queue.Add(req)
+	cc.queue.Add(req)
 }
 
 func (cc *jobcontroller) updateJob(oldObj, newObj interface{}) {
@@ -109,9 +107,7 @@ func (cc *jobcontroller) updateJob(oldObj, newObj interface{}) {
 		JobName:   newJob.Name,
 		Event:     bus.OutOfSyncEvent,
 	}
-	key := jobhelpers.GetJobKeyByReq(&req)
-	queue := cc.getWorkerQueue(key)
-	queue.Add(req)
+	cc.queue.Add(req)
 }
 
 func (cc *jobcontroller) deleteJob(obj interface{}) {
@@ -203,9 +199,7 @@ func (cc *jobcontroller) addPod(obj interface{}) {
 		klog.Errorf("Failed to add Pod <%s/%s>: %v to cache",
 			pod.Namespace, pod.Name, err)
 	}
-	key := jobhelpers.GetJobKeyByReq(&req)
-	queue := cc.getWorkerQueue(key)
-	queue.Add(req)
+	cc.queue.Add(req)
 }
 
 func (cc *jobcontroller) updatePod(oldObj, newObj interface{}) {
@@ -317,9 +311,7 @@ func (cc *jobcontroller) updatePod(oldObj, newObj interface{}) {
 		JobVersion:  int32(dVersion),
 	}
 
-	key := jobhelpers.GetJobKeyByReq(&req)
-	queue := cc.getWorkerQueue(key)
-	queue.Add(req)
+	cc.queue.Add(req)
 }
 
 func (cc *jobcontroller) deletePod(obj interface{}) {
@@ -396,9 +388,7 @@ func (cc *jobcontroller) deletePod(obj interface{}) {
 			pod.Namespace, pod.Name, err)
 	}
 
-	key := jobhelpers.GetJobKeyByReq(&req)
-	queue := cc.getWorkerQueue(key)
-	queue.Add(req)
+	cc.queue.Add(req)
 }
 
 func (cc *jobcontroller) recordJobEvent(namespace, name string, event batch.JobEvent, message string) {
@@ -442,9 +432,7 @@ func (cc *jobcontroller) processNextCommand() bool {
 		Action:    bus.Action(cmd.Action),
 	}
 
-	key := jobhelpers.GetJobKeyByReq(&req)
-	queue := cc.getWorkerQueue(key)
-	queue.Add(req)
+	cc.queue.Add(req)
 
 	return true
 }
@@ -485,9 +473,7 @@ func (cc *jobcontroller) updatePodGroup(oldObj, newObj interface{}) {
 		case scheduling.PodGroupUnknown:
 			req.Event = bus.JobUnknownEvent
 		}
-		key := jobhelpers.GetJobKeyByReq(&req)
-		queue := cc.getWorkerQueue(key)
-		queue.Add(req)
+		cc.queue.Add(req)
 	}
 }
 

--- a/pkg/controllers/job/job_controller_handler_test.go
+++ b/pkg/controllers/job/job_controller_handler_test.go
@@ -180,8 +180,7 @@ func TestJobAddFunc(t *testing.T) {
 			if job == nil || err != nil {
 				t.Errorf("Error while Adding Job in case %d with error %s", i, err)
 			}
-			queue := controller.queue
-			len := queue.Len()
+			len := controller.queue.Len()
 			if testcase.ExpectValue != len {
 				t.Errorf("case %d (%s): expected: %v, got %v ", i, testcase.Name, testcase.ExpectValue, len)
 			}
@@ -614,8 +613,7 @@ func TestUpdatePodGroupFunc(t *testing.T) {
 		t.Run(testcase.Name, func(t *testing.T) {
 			controller := newController()
 			controller.updatePodGroup(testcase.oldPodGroup, testcase.newPodGroup)
-			queue := controller.queue
-			len := queue.Len()
+			len := controller.queue.Len()
 			if testcase.ExpectValue != len {
 				t.Errorf("case %d (%s): expected: %v, got %v ", i, testcase.Name, testcase.ExpectValue, len)
 			}

--- a/pkg/controllers/job/job_controller_handler_test.go
+++ b/pkg/controllers/job/job_controller_handler_test.go
@@ -180,7 +180,7 @@ func TestJobAddFunc(t *testing.T) {
 			if job == nil || err != nil {
 				t.Errorf("Error while Adding Job in case %d with error %s", i, err)
 			}
-			queue := controller.getWorkerQueue(key)
+			queue := controller.queue
 			len := queue.Len()
 			if testcase.ExpectValue != len {
 				t.Errorf("case %d (%s): expected: %v, got %v ", i, testcase.Name, testcase.ExpectValue, len)
@@ -614,8 +614,7 @@ func TestUpdatePodGroupFunc(t *testing.T) {
 		t.Run(testcase.Name, func(t *testing.T) {
 			controller := newController()
 			controller.updatePodGroup(testcase.oldPodGroup, testcase.newPodGroup)
-			key := fmt.Sprintf("%s/%s", testcase.oldPodGroup.Namespace, testcase.oldPodGroup.Name)
-			queue := controller.getWorkerQueue(key)
+			queue := controller.queue
 			len := queue.Len()
 			if testcase.ExpectValue != len {
 				t.Errorf("case %d (%s): expected: %v, got %v ", i, testcase.Name, testcase.ExpectValue, len)


### PR DESCRIPTION
#### What type of PR is this?
/kind feature
/kind cleanup

#### What this PR does / why we need it:
The job controller previously created multiple queues, one per worker, which introduced unnecessary complexity. Since workqueue is concurrent-safe for reading and writing, we can simplify the code by using a single shared queue for all workers.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Notice that do not add `Fixes` if the issue is associated with multiple PRs.
-->
Fixes #4835 

#### Special notes for your reviewer:
This is a refactoring change that maintains the same functionality. The workqueue is designed to be used concurrently by multiple goroutines, so this change is safe. All existing tests continue to pass.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```