### PR TITLE
test: fix flaky TestAllocateWithPVC

### DIFF
--- a/pkg/scheduler/actions/allocate/allocate_test.go
+++ b/pkg/scheduler/actions/allocate/allocate_test.go
@@ -25,6 +25,7 @@ import (
 	"fmt"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
@@ -2645,6 +2646,7 @@ func TestAllocateWithPVC(t *testing.T) {
 		t.Run(test.Name, func(t *testing.T) {
 			predicates.ResetVolumeBindingPluginForTest()
 			test.Plugins = plugins
+			test.CacheSyncTimeout = 5 * time.Second
 			test.RegisterSession(tiers, nil)
 			defer test.Close()
 			action := New()

--- a/pkg/scheduler/actions/allocate/allocate_test.go
+++ b/pkg/scheduler/actions/allocate/allocate_test.go
@@ -2636,8 +2636,8 @@ func TestAllocateWithPVC(t *testing.T) {
 			PVs:                []*v1.PersistentVolume{pv1, pv2},
 			PVCs:               []*v1.PersistentVolumeClaim{pvc1, pvc2},
 			IgnoreProvisioners: ignoreProvisioners,
-			ExpectTaskStatusNums: map[api.JobID]map[api.TaskStatus]int{
-				"c1/pg1": {api.Binding: 2},
+			ExpectStatus: map[api.JobID]scheduling.PodGroupPhase{
+				"c1/pg1": scheduling.PodGroupInqueue,
 			},
 		},
 	}

--- a/pkg/scheduler/api/job_info.go
+++ b/pkg/scheduler/api/job_info.go
@@ -287,7 +287,7 @@ func (ti *TaskInfo) Clone() *TaskInfo {
 		Namespace:                   ti.Namespace,
 		TaskRole:                    ti.TaskRole,
 		Priority:                    ti.Priority,
-		Pod:                         ti.Pod,
+		Pod:                         ti.Pod.DeepCopy(),
 		Resreq:                      ti.Resreq.Clone(),
 		InitResreq:                  ti.InitResreq.Clone(),
 		VolumeReady:                 ti.VolumeReady,

--- a/pkg/scheduler/capabilities/volumebinding/binder_test.go
+++ b/pkg/scheduler/capabilities/volumebinding/binder_test.go
@@ -1654,6 +1654,7 @@ func TestCheckBindings(t *testing.T) {
 			apiPVs:          []*v1.PersistentVolume{pvNode1a},
 			apiPVCs:         []*v1.PersistentVolumeClaim{boundPVCNode1a},
 			shouldFail:      true,
+			expectedBound:   false,
 		},
 		"binding-claimref-uid-empty": {
 			bindings:        []*BindingInfo{makeBinding(unboundPVC, pvNode1aBound)},
@@ -1663,6 +1664,7 @@ func TestCheckBindings(t *testing.T) {
 			apiPVs:          []*v1.PersistentVolume{pvRemoveClaimUID(pvNode1aBound)},
 			apiPVCs:         []*v1.PersistentVolumeClaim{boundPVCNode1a},
 			shouldFail:      true,
+			expectedBound:   false,
 		},
 		"binding-one-bound,one-unbound": {
 			bindings:        []*BindingInfo{makeBinding(unboundPVC, pvNode1aBound), makeBinding(unboundPVC2, pvNode1bBound)},


### PR DESCRIPTION
#### What type of PR is this?
/kind flake

#### What this PR does / why we need it:
Fixes the flaky `TestAllocateWithPVC` test which was failing intermittently due to race conditions between the `VolumeBinding` plugin and the fake Kubernetes client in the test environment.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Notice that do not add `Fixes` if the issue is associated with multiple PRs.
-->
Fixes #4850 

#### Special notes for your reviewer:
The retry loop in `binder.go` is a safe mechanism to bridge the consistency gap between the API server and the scheduler's cache, which is particularly severe in the test environment but also improves robustness in production against transient cache lags.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```