### PR TITLE
cherrypick 4829 to release 1.11: keep terminating pod in job

### DIFF
--- a/pkg/controllers/job/job_controller_handler.go
+++ b/pkg/controllers/job/job_controller_handler.go
@@ -175,11 +175,6 @@ func (cc *jobcontroller) addPod(obj interface{}) {
 		return
 	}
 
-	if pod.DeletionTimestamp != nil {
-		cc.deletePod(pod)
-		return
-	}
-
 	req := apis.Request{
 		Namespace: pod.Namespace,
 		JobName:   jobName,
@@ -222,11 +217,6 @@ func (cc *jobcontroller) updatePod(oldObj, newObj interface{}) {
 	}
 
 	if newPod.ResourceVersion == oldPod.ResourceVersion {
-		return
-	}
-
-	if newPod.DeletionTimestamp != nil {
-		cc.deletePod(newObj)
 		return
 	}
 

--- a/pkg/controllers/job/job_controller_handler_test.go
+++ b/pkg/controllers/job/job_controller_handler_test.go
@@ -333,6 +333,31 @@ func TestAddPodFunc(t *testing.T) {
 			},
 			ExpectedValue: 1,
 		},
+		{
+			// This case ensures a pod that is already terminating (has DeletionTimestamp)
+			// is still added to the job cache correctly.
+			Name: "AddPod Success when pod is terminating",
+			Job: &batch.Job{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "job1",
+					Namespace: namespace,
+				},
+			},
+			pods: []*v1.Pod{
+				func() *v1.Pod {
+					p := buildPod(namespace, "pod1", v1.PodPending, nil)
+					now := metav1.Now()
+					p.DeletionTimestamp = &now
+					return p
+				}(),
+			},
+			Annotation: map[string]string{
+				batch.JobNameKey:  "job1",
+				batch.JobVersion:  "0",
+				batch.TaskSpecKey: "task1",
+			},
+			ExpectedValue: 1,
+		},
 	}
 
 	for i, testcase := range testcases {
@@ -407,6 +432,30 @@ func TestUpdatePodFunc(t *testing.T) {
 				batch.TaskSpecKey: "task1",
 			},
 			ExpectedValue: v1.PodFailed,
+		},
+		{
+			// This case verifies that when the updated pod has a DeletionTimestamp
+			// (terminating), it remains in the job cache instead of being removed.
+			Name: "UpdatePod keeps terminating pod in cache",
+			Job: &batch.Job{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "job1",
+					Namespace: namespace,
+				},
+			},
+			oldPod: buildPod(namespace, "pod1", v1.PodRunning, nil),
+			newPod: func() *v1.Pod {
+				p := buildPod(namespace, "pod1", v1.PodRunning, nil)
+				now := metav1.Now()
+				p.DeletionTimestamp = &now
+				return p
+			}(),
+			Annotation: map[string]string{
+				batch.JobNameKey:  "job1",
+				batch.JobVersion:  "0",
+				batch.TaskSpecKey: "task1",
+			},
+			ExpectedValue: v1.PodRunning,
 		},
 	}
 


### PR DESCRIPTION
#### What type of PR is this?
cherrypick #4829 to release 1.11:
#### What this PR does / why we need it:
Fixes #4828
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Notice that do not add `Fixes` if the issue is associated with multiple PRs.
-->
Fixes #4828

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
Fix a bug where Jobs in the Aborting phase could transition to Aborted while some Pods were still terminating by keeping terminating Pods in the job cache until they are fully deleted.
```