### PR TITLE
fix: prevent cluster-wide scheduling failure due to queue hierarchy validation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,8 +106,27 @@ images:
 		docker buildx build -t "${IMAGE_PREFIX}/vc-$$name:$(TAG)" . -f ./installer/dockerfile/$$name/Dockerfile --output=type=${BUILDX_OUTPUT_TYPE} --platform ${DOCKER_PLATFORMS} --build-arg APK_MIRROR=${APK_MIRROR} --build-arg OPEN_EULER_IMAGE_TAG=${OPEN_EULER_IMAGE_TAG}; \
 	done
 
+# Define a reusable build function for individual component images
+define build_component_image
+	docker buildx build -t "${IMAGE_PREFIX}/vc-$(1):$(TAG)" . \
+		-f ./installer/dockerfile/$(1)/Dockerfile \
+		--output=type=${BUILDX_OUTPUT_TYPE} \
+		--platform ${DOCKER_PLATFORMS} \
+		--build-arg APK_MIRROR=${APK_MIRROR} \
+		--build-arg OPEN_EULER_IMAGE_TAG=${OPEN_EULER_IMAGE_TAG}
+endef
+
+vc-controller-manager-image:
+	$(call build_component_image,controller-manager)
+
+vc-scheduler-image:
+	$(call build_component_image,scheduler)
+
+vc-webhook-manager-image:
+	$(call build_component_image,webhook-manager)
+
 vc-agent-image:
-	docker buildx build -t "${IMAGE_PREFIX}/vc-agent:$(TAG)" . -f ./installer/dockerfile/agent/Dockerfile --output=type=${BUILDX_OUTPUT_TYPE} --platform ${DOCKER_PLATFORMS} --build-arg APK_MIRROR=${APK_MIRROR} --build-arg OPEN_EULER_IMAGE_TAG=${OPEN_EULER_IMAGE_TAG}
+	$(call build_component_image,agent)
 
 generate-code:
 	./hack/update-gencode.sh

--- a/installer/helm/chart/volcano/policy/queues-validating.yaml
+++ b/installer/helm/chart/volcano/policy/queues-validating.yaml
@@ -83,18 +83,19 @@ spec:
       message: "guarantee should less equal than capability"
       reason: Invalid
     # Validate guarantee <= deserved (guarantee should less equal than deserved)
+    # When guarantee is set, deserved must also be set
     - expression: |
-        !has(object.spec) || !has(object.spec.deserved) || !has(object.spec.guarantee) ||
-        !has(object.spec.guarantee.resource) || size(object.spec.deserved) == 0 ||
-        size(object.spec.guarantee.resource) == 0 ||
-        object.spec.deserved.all(resourceName,
-          !(resourceName in object.spec.guarantee.resource) ||
-          quantity(object.spec.deserved[resourceName]).compareTo(quantity(object.spec.guarantee.resource[resourceName])) >= 0
-        ) &&
-        object.spec.guarantee.resource.all(resourceName,
-          resourceName in object.spec.deserved &&
-          quantity(object.spec.guarantee.resource[resourceName]).compareTo(quantity(object.spec.deserved[resourceName])) <= 0
-        )
+        !has(object.spec) || !has(object.spec.guarantee) ||
+        !has(object.spec.guarantee.resource) || size(object.spec.guarantee.resource) == 0 ||
+        (has(object.spec.deserved) && size(object.spec.deserved) > 0 &&
+         object.spec.deserved.all(resourceName,
+           !(resourceName in object.spec.guarantee.resource) ||
+           quantity(object.spec.deserved[resourceName]).compareTo(quantity(object.spec.guarantee.resource[resourceName])) >= 0
+         ) &&
+         object.spec.guarantee.resource.all(resourceName,
+           resourceName in object.spec.deserved &&
+           quantity(object.spec.guarantee.resource[resourceName]).compareTo(quantity(object.spec.deserved[resourceName])) <= 0
+         ))
       message: "guarantee should less equal than deserved"
       reason: Invalid
     # Validate hierarchical attributes - path and weights length must match

--- a/pkg/scheduler/api/resource_info.go
+++ b/pkg/scheduler/api/resource_info.go
@@ -24,6 +24,7 @@ package api
 import (
 	"fmt"
 	"math"
+	"sort"
 	"strings"
 
 	v1 "k8s.io/api/core/v1"
@@ -158,8 +159,14 @@ func (r *Resource) Clone() *Resource {
 // String returns resource details in string format
 func (r *Resource) String() string {
 	str := fmt.Sprintf("cpu %0.2f, memory %0.2f", r.MilliCPU, r.Memory)
-	for rName, rQuant := range r.ScalarResources {
-		str = fmt.Sprintf("%s, %s %0.2f", str, rName, rQuant)
+	// Sort scalar resource names to ensure consistent string output
+	var resourceNames []string
+	for rName := range r.ScalarResources {
+		resourceNames = append(resourceNames, string(rName))
+	}
+	sort.Strings(resourceNames)
+	for _, rName := range resourceNames {
+		str = fmt.Sprintf("%s, %s %0.2f", str, rName, r.ScalarResources[v1.ResourceName(rName)])
 	}
 	return str
 }

--- a/pkg/scheduler/plugins/capacity/capacity.go
+++ b/pkg/scheduler/plugins/capacity/capacity.go
@@ -596,13 +596,9 @@ func (cp *capacityPlugin) buildHierarchicalQueueAttrs(ssn *framework.Session) bo
 		rootQueueAttr.deserved = cp.totalResource
 	}
 	rootQueueAttr.realCapability = cp.totalResource
-	// Check the hierarchical structure of queues
-	err := cp.checkHierarchicalQueue(rootQueueAttr)
-	if err != nil {
-		klog.Errorf("Failed to check queue's hierarchical structure, error: %v", err)
-		return false
-	}
-	klog.V(4).Infof("Successfully checked queue's hierarchical structure.")
+	// checkHierarchicalQueue only logs warnings and never returns errors
+	// to avoid aborting the entire scheduling cycle due to configuration issues
+	cp.checkHierarchicalQueue(rootQueueAttr)
 
 	// update session attributes
 	ssn.TotalGuarantee = cp.totalGuarantee
@@ -744,7 +740,7 @@ func (cp *capacityPlugin) updateAncestors(queue *api.QueueInfo, ssn *framework.S
 	return nil
 }
 
-func (cp *capacityPlugin) checkHierarchicalQueue(attr *queueAttr) error {
+func (cp *capacityPlugin) checkHierarchicalQueue(attr *queueAttr) {
 	totalGuarantee := api.EmptyResource()
 	totalDeserved := api.EmptyResource()
 	for _, childAttr := range attr.children {
@@ -772,8 +768,9 @@ func (cp *capacityPlugin) checkHierarchicalQueue(attr *queueAttr) error {
 
 		// Check if the parent queue's capability is less than the child queue's capability
 		if attr.capability.LessPartly(childAttr.capability, api.Zero) {
-			return fmt.Errorf("queue <%s> capability <%s> is less than its child queue <%s> capability <%s>",
-				attr.name, attr.capability, childAttr.name, childAttr.capability)
+			klog.V(3).Infof("Child queue %s capability (%s) exceeds parent queue %s capability (%s). "+
+				"Child's effective capability will be limited by parent.",
+				childAttr.name, childAttr.capability, attr.name, attr.capability)
 		}
 	}
 
@@ -801,23 +798,22 @@ func (cp *capacityPlugin) checkHierarchicalQueue(attr *queueAttr) error {
 
 	// Check if the parent queue's deserved resources are less than the total deserved resources of child queues
 	if attr.deserved.LessPartly(totalDeserved, api.Zero) {
-		return fmt.Errorf("queue <%s> deserved resources <%s> are less than the sum of its child queues' deserved resources <%s>",
-			attr.name, attr.deserved, totalDeserved)
+		klog.V(3).Infof("Sum of child queue deserved (%s) exceeds parent queue %s deserved (%s). "+
+			"This may affect resource distribution during scheduling.",
+			totalDeserved, attr.name, attr.deserved)
 	}
 
 	// Check if the parent queue's guarantee resources are less than the total guarantee resources of child queues
 	if attr.guarantee.LessPartly(totalGuarantee, api.Zero) {
-		return fmt.Errorf("queue <%s> guarantee resources <%s> are less than the sum of its child queues' guarantee resources <%s>",
-			attr.name, attr.guarantee, totalGuarantee)
+		klog.V(3).Infof("Sum of child queue guarantees (%s) exceeds parent queue %s guarantee (%s). "+
+			"Not all child guarantees can be satisfied simultaneously.",
+			totalGuarantee, attr.name, attr.guarantee)
 	}
 
+	// Recursively check child queues
 	for _, childAttr := range attr.children {
-		err := cp.checkHierarchicalQueue(childAttr)
-		if err != nil {
-			return err
-		}
+		cp.checkHierarchicalQueue(childAttr)
 	}
-	return nil
 }
 
 // compareShareWithDeserved compares two queueAttr by share; when shares are equal,

--- a/pkg/webhooks/router/indexer.go
+++ b/pkg/webhooks/router/indexer.go
@@ -1,0 +1,87 @@
+/*
+Copyright 2025 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package router
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/labels"
+
+	schedulingv1beta1 "volcano.sh/apis/pkg/apis/scheduling/v1beta1"
+)
+
+const (
+	// QueueParentIndexName is the name of the index for parent queue lookup
+	QueueParentIndexName = "queueParent"
+)
+
+// QueueParentIndexFunc is an index function that indexes queues by their parent name
+// This allows efficient lookup of all children of a given parent queue
+func QueueParentIndexFunc(obj interface{}) ([]string, error) {
+	queue, ok := obj.(*schedulingv1beta1.Queue)
+	if !ok {
+		return []string{}, nil
+	}
+
+	// Index by parent name
+	if queue.Spec.Parent != "" {
+		return []string{queue.Spec.Parent}, nil
+	}
+
+	// Root queue or queues without parent
+	return []string{}, nil
+}
+
+// GetQueuesByParent returns all queues that have the specified parent using the queue parent index.
+// This method leverages the informer's indexer for efficient lookups when available,
+// falling back to listing all queues if the informer is not initialized (e.g., in tests).
+func (asc *AdmissionServiceConfig) GetQueuesByParent(parentName string) ([]*schedulingv1beta1.Queue, error) {
+	// If informer is available, use the efficient index-based lookup
+	if asc.QueueInformer != nil {
+		objs, err := asc.QueueInformer.GetIndexer().ByIndex(QueueParentIndexName, parentName)
+		if err != nil {
+			return nil, fmt.Errorf("failed to query index %s for parent %s: %v", QueueParentIndexName, parentName, err)
+		}
+
+		queues := make([]*schedulingv1beta1.Queue, 0, len(objs))
+		for _, obj := range objs {
+			queue, ok := obj.(*schedulingv1beta1.Queue)
+			if !ok {
+				continue
+			}
+			queues = append(queues, queue)
+		}
+
+		return queues, nil
+	}
+
+	// Fallback: list all queues and filter (for backward compatibility and tests)
+	// This is less efficient but ensures functionality when informer is not available
+	allQueues, err := asc.QueueLister.List(labels.Everything())
+	if err != nil {
+		return nil, fmt.Errorf("failed to list queues: %v", err)
+	}
+
+	queues := make([]*schedulingv1beta1.Queue, 0)
+	for _, queue := range allQueues {
+		if queue.Spec.Parent == parentName {
+			queues = append(queues, queue)
+		}
+	}
+
+	return queues, nil
+}

--- a/pkg/webhooks/router/interface.go
+++ b/pkg/webhooks/router/interface.go
@@ -20,6 +20,7 @@ import (
 	admissionv1 "k8s.io/api/admission/v1"
 	whv1 "k8s.io/api/admissionregistration/v1"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 
 	"volcano.sh/apis/pkg/client/clientset/versioned"
@@ -35,6 +36,7 @@ type AdmissionServiceConfig struct {
 	KubeClient     kubernetes.Interface
 	VolcanoClient  versioned.Interface
 	QueueLister    schedulinglister.QueueLister
+	QueueInformer  cache.SharedIndexInformer
 	Recorder       record.EventRecorder
 	ConfigData     *config.AdmissionConfiguration
 }

--- a/test/e2e/admission/queue_validation_test.go
+++ b/test/e2e/admission/queue_validation_test.go
@@ -176,7 +176,7 @@ var _ = ginkgo.Describe("Queue Validating E2E Test", func() {
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	})
 
-	ginkgo.It("Should allow queue creation with only guarantee resource", func() {
+	ginkgo.It("Should reject queue creation with only guarantee resource (deserved required)", func() {
 		testCtx := util.InitTestContext(util.Options{})
 		defer util.CleanupTestContext(testCtx)
 
@@ -196,11 +196,8 @@ var _ = ginkgo.Describe("Queue Validating E2E Test", func() {
 		}
 
 		_, err := testCtx.Vcclient.SchedulingV1beta1().Queues().Create(context.TODO(), queue, metav1.CreateOptions{})
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
-		// Cleanup
-		err = testCtx.Vcclient.SchedulingV1beta1().Queues().Delete(context.TODO(), queue.Name, metav1.DeleteOptions{})
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(err).To(gomega.HaveOccurred())
+		gomega.Expect(err.Error()).To(gomega.ContainSubstring("guarantee should less equal than deserved"))
 	})
 
 	ginkgo.It("Should reject queue creation with capability less than deserved", func() {


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
Scheduler crashes and blocks all scheduling when queue hierarchy validation fails. Invalid queue configurations (child capability > parent, sum of children's guarantee > parent's guarantee) could be created via kubectl, causing cluster-wide scheduling failures. 
- Added webhook validation - Validates hierarchical queue constraints at admission time:
    - Child capability ≤ parent capability
    - Sum of siblings/children guarantee ≤ parent guarantee
- Changed scheduler behavior - checkHierarchicalQueue() now only logs warnings instead of returning errors, preventing cluster-wide scheduling failures

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Notice that do not add `Fixes` if the issue is associated with multiple PRs.
-->
Fixes #4818 #4819

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```