### PR TITLE
Force minAvailable to match minPartitions*partitionSize to avoid semantic inconsistencies.

### DIFF
--- a/pkg/controllers/job/job_controller_actions.go
+++ b/pkg/controllers/job/job_controller_actions.go
@@ -1083,6 +1083,7 @@ func getSubGroupPolicy(taskSpec batch.TaskSpec) scheduling.SubGroupPolicySpec {
 	subGroupPolicy := scheduling.SubGroupPolicySpec{
 		Name:         taskSpec.Name,
 		SubGroupSize: &taskSpec.PartitionPolicy.PartitionSize,
+		MinSubGroups: &taskSpec.PartitionPolicy.MinPartitions,
 	}
 
 	// Set LabelSelector

--- a/pkg/webhooks/admission/jobs/mutate/mutate_job.go
+++ b/pkg/webhooks/admission/jobs/mutate/mutate_job.go
@@ -202,10 +202,15 @@ func mutateSpec(tasks []v1alpha1.TaskSpec, basePath string, job *v1alpha1.Job) *
 			tasks[index].Template.Spec.DNSPolicy = v1.DNSClusterFirstWithHostNet
 		}
 
-		if tasks[index].MinAvailable == nil && (tasks[index].PartitionPolicy == nil || tasks[index].PartitionPolicy.MinPartitions == 0) {
+		if tasks[index].MinAvailable == nil {
 			patched = true
-			minAvailable := tasks[index].Replicas
-			tasks[index].MinAvailable = &minAvailable
+			if tasks[index].PartitionPolicy != nil {
+				minAvailable := tasks[index].PartitionPolicy.MinPartitions * tasks[index].PartitionPolicy.PartitionSize
+				tasks[index].MinAvailable = &minAvailable
+			} else {
+				minAvailable := tasks[index].Replicas
+				tasks[index].MinAvailable = &minAvailable
+			}
 		}
 
 		if tasks[index].MaxRetry == 0 {

--- a/pkg/webhooks/admission/jobs/mutate/mutate_job_test.go
+++ b/pkg/webhooks/admission/jobs/mutate/mutate_job_test.go
@@ -170,8 +170,9 @@ func TestCreatePatchExecution(t *testing.T) {
 					},
 				},
 				{
-					Name:     v1alpha1.DefaultTaskSpec + "2",
-					Replicas: 1,
+					Name:         v1alpha1.DefaultTaskSpec + "2",
+					Replicas:     1,
+					MinAvailable: ptr.To(int32(1)),
 					PartitionPolicy: &v1alpha1.PartitionPolicySpec{
 						TotalPartitions: 1,
 						MinPartitions:   1,
@@ -198,7 +199,7 @@ func TestCreatePatchExecution(t *testing.T) {
 				{
 					Name:         v1alpha1.DefaultTaskSpec + "3",
 					Replicas:     1,
-					MinAvailable: ptr.To(int32(1)),
+					MinAvailable: ptr.To(int32(0)),
 					PartitionPolicy: &v1alpha1.PartitionPolicySpec{
 						TotalPartitions: 1,
 						PartitionSize:   1,
@@ -265,4 +266,171 @@ func TestCreatePatchExecution(t *testing.T) {
 		}
 	}
 
+}
+
+func TestMutateSpecPartitionPolicyDefaults(t *testing.T) {
+	namespace := "test"
+
+	testCases := []struct {
+		Name          string
+		InputTasks    []v1alpha1.TaskSpec
+		ExpectedTasks []v1alpha1.TaskSpec
+		ShouldMutate  bool
+		Description   string
+	}{
+		{
+			Name: "MinAvailable is set to MinPartitions * PartitionSize when PartitionPolicy exists",
+			InputTasks: []v1alpha1.TaskSpec{
+				{
+					Name:     "task-1",
+					Replicas: 9,
+					PartitionPolicy: &v1alpha1.PartitionPolicySpec{
+						TotalPartitions: 3,
+						MinPartitions:   2,
+						PartitionSize:   3,
+					},
+					Template: v1.PodTemplateSpec{
+						Spec: v1.PodSpec{
+							Containers: []v1.Container{
+								{Name: "test", Image: "busybox:1.24"},
+							},
+						},
+					},
+				},
+			},
+			ExpectedTasks: []v1alpha1.TaskSpec{
+				{
+					Name:     "task-1",
+					Replicas: 9,
+					PartitionPolicy: &v1alpha1.PartitionPolicySpec{
+						TotalPartitions: 3,
+						MinPartitions:   2,
+						PartitionSize:   3,
+					},
+					MinAvailable: ptr.To(int32(6)), // 2 * 3
+					MaxRetry:     defaultMaxRetry,
+					Template: v1.PodTemplateSpec{
+						Spec: v1.PodSpec{
+							Containers: []v1.Container{
+								{Name: "test", Image: "busybox:1.24"},
+							},
+						},
+					},
+				},
+			},
+			ShouldMutate: true,
+			Description:  "MinAvailable should be set to MinPartitions * PartitionSize",
+		},
+		{
+			Name: "MinAvailable is set to Replicas when no PartitionPolicy",
+			InputTasks: []v1alpha1.TaskSpec{
+				{
+					Name:     "task-1",
+					Replicas: 5,
+					Template: v1.PodTemplateSpec{
+						Spec: v1.PodSpec{
+							Containers: []v1.Container{
+								{Name: "test", Image: "busybox:1.24"},
+							},
+						},
+					},
+				},
+			},
+			ExpectedTasks: []v1alpha1.TaskSpec{
+				{
+					Name:         "task-1",
+					Replicas:     5,
+					MinAvailable: ptr.To(int32(5)), // Should equal Replicas
+					MaxRetry:     defaultMaxRetry,
+					Template: v1.PodTemplateSpec{
+						Spec: v1.PodSpec{
+							Containers: []v1.Container{
+								{Name: "test", Image: "busybox:1.24"},
+							},
+						},
+					},
+				},
+			},
+			ShouldMutate: true,
+			Description:  "MinAvailable should be set to Replicas when no PartitionPolicy",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			job := &v1alpha1.Job{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-job",
+					Namespace: namespace,
+				},
+				Spec: v1alpha1.JobSpec{
+					Tasks: tc.InputTasks,
+				},
+			}
+
+			result := mutateSpec(job.Spec.Tasks, "/spec/tasks", job)
+
+			if tc.ShouldMutate && result == nil {
+				t.Errorf("%s: Expected mutation but got nil", tc.Description)
+				return
+			}
+
+			if !tc.ShouldMutate && result != nil {
+				t.Errorf("%s: Expected no mutation but got result", tc.Description)
+				return
+			}
+
+			if result != nil {
+				actualTasks, ok := result.Value.([]v1alpha1.TaskSpec)
+				if !ok {
+					t.Errorf("%s: Expected result value to be []v1alpha1.TaskSpec", tc.Description)
+					return
+				}
+
+				for i, expectedTask := range tc.ExpectedTasks {
+					if i >= len(actualTasks) {
+						t.Errorf("%s: Missing task at index %d", tc.Description, i)
+						continue
+					}
+
+					actualTask := actualTasks[i]
+
+					// Check PartitionPolicy.MinPartitions
+					if expectedTask.PartitionPolicy != nil {
+						if actualTask.PartitionPolicy == nil {
+							t.Errorf("%s: Expected PartitionPolicy but got nil", tc.Description)
+							continue
+						}
+						if actualTask.PartitionPolicy.MinPartitions != expectedTask.PartitionPolicy.MinPartitions {
+							t.Errorf("%s: Expected MinPartitions=%d, got %d",
+								tc.Description,
+								expectedTask.PartitionPolicy.MinPartitions,
+								actualTask.PartitionPolicy.MinPartitions)
+						}
+					}
+
+					// Check MinAvailable
+					if expectedTask.MinAvailable != nil {
+						if actualTask.MinAvailable == nil {
+							t.Errorf("%s: Expected MinAvailable=%d, got nil",
+								tc.Description, *expectedTask.MinAvailable)
+						} else if *actualTask.MinAvailable != *expectedTask.MinAvailable {
+							t.Errorf("%s: Expected MinAvailable=%d, got %d",
+								tc.Description,
+								*expectedTask.MinAvailable,
+								*actualTask.MinAvailable)
+						}
+					}
+
+					// Check MaxRetry
+					if actualTask.MaxRetry != expectedTask.MaxRetry {
+						t.Errorf("%s: Expected MaxRetry=%d, got %d",
+							tc.Description,
+							expectedTask.MaxRetry,
+							actualTask.MaxRetry)
+					}
+				}
+			}
+		})
+	}
 }

--- a/pkg/webhooks/admission/jobs/validate/admit_job.go
+++ b/pkg/webhooks/admission/jobs/validate/admit_job.go
@@ -172,9 +172,6 @@ func validateJobCreate(job *v1alpha1.Job, reviewResponse *admissionv1.AdmissionR
 			} else if *task.MinAvailable > task.Replicas {
 				msg += fmt.Sprintf(" 'minAvailable' is greater than 'replicas' in task: %s, job: %s;", task.Name, job.Name)
 			}
-			if task.PartitionPolicy != nil && task.PartitionPolicy.MinPartitions != 0 {
-				msg += fmt.Sprintf("must not specify 'minAvailable' and 'partitionPolicy.minPartitions' simultaneously in task: %s, job: %s;", task.Name, job.Name)
-			}
 		}
 
 		// count replicas
@@ -346,6 +343,8 @@ func validatePartitionPolicy(task v1alpha1.TaskSpec, job *v1alpha1.Job) string {
 			msg += fmt.Sprintf("'PartitionSize' must be greater than 0 in task: %s, job: %s", task.Name, job.Name)
 		} else if task.Replicas != task.PartitionPolicy.TotalPartitions*task.PartitionPolicy.PartitionSize {
 			msg += fmt.Sprintf("'Replicas' are not equal to TotalPartitions*PartitionSize in task: %s, job: %s", task.Name, job.Name)
+		} else if task.MinAvailable != nil && task.PartitionPolicy.MinPartitions*task.PartitionPolicy.PartitionSize != *task.MinAvailable {
+			msg += fmt.Sprintf("'MinAvailable' is not equal to MinPartitions*PartitionSize in task: %s, job: %s", task.Name, job.Name)
 		}
 		msg += validateNetworkTopology(task.PartitionPolicy.NetworkTopology)
 	}


### PR DESCRIPTION
#### What this PR does / why we need it:

Force minAvailable to match minPartitions*partitionSize to avoid semantic inconsistencies.

#### Which issue(s) this PR fixes:

Fixes #4867 

#### Special notes for your reviewer:

The following changes:
* Allow setting `minAvailable`, but if set, ensure that `minAvailable = partitionSize * minPartitions`.
* If `minAvailable` is not set, set it to `partitionSize * minPartitions`.
* Fixed the issue where `MinSubGroups` was not set.

#### Does this PR introduce a user-facing change?

NONE
