### PR TITLE
Fix gpu resource error.

### DIFF
--- a/pkg/scheduler/api/devices/nvidia/vgpu/device_info.go
+++ b/pkg/scheduler/api/devices/nvidia/vgpu/device_info.go
@@ -179,6 +179,34 @@ func (gs *GPUDevices) addResource(annotations map[string]string, pod *v1.Pod) {
 	}
 }
 
+func (gs *GPUDevices) addToPodMap(annotations map[string]string, pod *v1.Pod) {
+    ids, ok := annotations[AssignedIDsAnnotations]
+    if !ok {
+        klog.Errorf("pod %s has no annotation volcano.sh/devices-to-allocate", pod.Name)
+        return
+    }
+    podDev := decodePodDevices(ids)
+    for _, val := range podDev {
+        for _, deviceused := range val {
+            for index, gsdevice := range gs.Device {
+                if strings.Contains(deviceused.UUID, gsdevice.UUID) {
+                    podUID := string(pod.UID)
+                    _, ok := gsdevice.PodMap[podUID]
+                    if !ok {
+                        gsdevice.PodMap[podUID] = &GPUUsage{
+                            UsedMem:  0,
+                            UsedCore: 0,
+                        }
+                    }
+
+                    gsdevice.PodMap[podUID].UsedMem += deviceused.Usedmem
+                    gsdevice.PodMap[podUID].UsedCore += deviceused.Usedcores
+                }
+            }
+        }
+    }
+}
+
 // SubResource frees the gpu hold by the pod
 func (gs *GPUDevices) SubResource(pod *v1.Pod) {
 	if gs == nil {
@@ -254,7 +282,7 @@ func (gs *GPUDevices) Allocate(kubeClient kubernetes.Interface, pod *v1.Pod) err
 		annotations[DeviceBindPhase] = "allocating"
 		annotations[BindTimeAnnotations] = strconv.FormatInt(time.Now().Unix(), 10)
 		// To avoid that the pod allocated info updating latency, add it first
-		gs.addResource(annotations, pod)
+		gs.addToPodMap(annotations, pod)
 		err = patchPodAnnotations(kubeClient, pod, annotations)
 		if err != nil {
 			return err

--- a/pkg/scheduler/plugins/capacity/capacity.go
+++ b/pkg/scheduler/plugins/capacity/capacity.go
@@ -128,7 +128,8 @@ func (cp *capacityPlugin) OnSessionOpen(ssn *framework.Session) {
 			exceptReclaimee := allocated.Clone().Sub(reclaimee.Resreq)
 			// When scalar resource not specified in deserved such as "pods", we should skip it and consider it as infinity,
 			// so the following first condition will be true and the current queue will not be reclaimed.
-			if allocated.LessEqual(attr.deserved, api.Infinity) || !attr.guarantee.LessEqual(exceptReclaimee, api.Zero) {
+            ok, _ := allocated.LessEqualWithResourcesName(attr.deserved, api.Infinity)
+            if ok || !attr.guarantee.LessEqual(exceptReclaimee, api.Zero) {
 				continue
 			}
 			allocated.Sub(reclaimee.Resreq)


### PR DESCRIPTION
At allocate state, the function checkNodeGPUSharingPredicateAndScore will add the used mem/core to the structure. For avoiding the pod allocated info updating latency, we use addResource it to add the pod the pod map. But it also add the used mem/core. To address this, we new a function that only add pod the map.

#### What type of PR is this?
Bug fix

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Notice that do not add `Fixes` if the issue is associated with multiple PRs.
-->
Fixes # https://github.com/volcano-sh/volcano/issues/4809

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```