### PR TITLE
fix potential panic on numa resources info updating in snapshot

### DIFF
--- a/pkg/scheduler/api/node_info.go
+++ b/pkg/scheduler/api/node_info.go
@@ -191,16 +191,20 @@ func (ni *NodeInfo) RefreshNumaSchedulerInfoByCrd() {
 	}
 
 	tmp := ni.NumaInfo.DeepCopy()
-	if ni.NumaChgFlag == NumaInfoMoreFlag {
+	if ni.NumaSchedulerInfo == nil || ni.NumaChgFlag == NumaInfoMoreFlag {
 		ni.NumaSchedulerInfo = tmp
 	} else if ni.NumaChgFlag == NumaInfoLessFlag {
 		numaResMap := ni.NumaSchedulerInfo.NumaResMap
 		for resName, resInfo := range tmp.NumaResMap {
-			klog.V(5).Infof("resource %s Allocatable : current %v new %v on node %s",
-				resName, numaResMap[resName], resInfo, ni.Name)
-			if numaResMap[resName].Allocatable.Size() >= resInfo.Allocatable.Size() {
-				numaResMap[resName].Allocatable = resInfo.Allocatable.Clone()
-				numaResMap[resName].Capacity = resInfo.Capacity
+			if resourceInfo, ok := numaResMap[resName]; ok {
+				klog.V(5).Infof("resource %s Allocatable : current %v new %v on node %s",
+					resName, resourceInfo, resInfo, ni.Name)
+				if resourceInfo.Allocatable.Size() >= resInfo.Allocatable.Size() {
+					resourceInfo.Allocatable = resInfo.Allocatable.Clone()
+					resourceInfo.Capacity = resInfo.Capacity
+				}
+			} else {
+				numaResMap[resName] = resInfo
 			}
 		}
 	}


### PR DESCRIPTION
#### What type of PR is this?
bug
#### What this PR does / why we need it:
There is panic risk in snapshot when numatopology is added and updated in short time before snapshot
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Notice that do not add `Fixes` if the issue is associated with multiple PRs.
-->
Fixes #
https://github.com/volcano-sh/volcano/issues/4891
#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```