### PR TITLE
Fix Infinity Mode Logic in Resource Comparison Functions

### DIFF
--- a/pkg/scheduler/api/resource_info.go
+++ b/pkg/scheduler/api/resource_info.go
@@ -374,14 +374,6 @@ func (r *Resource) Less(rr *Resource, defaultValue DimensionDefaultValue) bool {
 		return false
 	}
 
-	if defaultValue == Infinity {
-		for name := range rr.ScalarResources {
-			if _, ok := r.ScalarResources[name]; !ok {
-				return false
-			}
-		}
-	}
-
 	for resourceName, leftValue := range r.ScalarResources {
 		rightValue, ok := rr.ScalarResources[resourceName]
 		if !ok && defaultValue == Infinity {
@@ -411,14 +403,6 @@ func (r *Resource) LessEqual(rr *Resource, defaultValue DimensionDefaultValue) b
 	}
 	if !lessEqualFunc(r.Memory, rr.Memory, minResource) {
 		return false
-	}
-
-	if defaultValue == Infinity {
-		for name := range rr.ScalarResources {
-			if _, ok := r.ScalarResources[name]; !ok {
-				return false
-			}
-		}
 	}
 
 	for resourceName, leftValue := range r.ScalarResources {

--- a/pkg/scheduler/api/resource_info_test.go
+++ b/pkg/scheduler/api/resource_info_test.go
@@ -562,7 +562,7 @@ func TestLess(t *testing.T) {
 				Memory:          2000,
 				ScalarResources: map[v1.ResourceName]float64{"scalar.test/scalar1": 1000, "hugepages-test": 2000},
 			},
-			expected: false,
+			expected: true,
 		},
 		{
 			resource1: &Resource{
@@ -706,7 +706,7 @@ func TestLessEqual(t *testing.T) {
 				Memory:          2000,
 				ScalarResources: map[v1.ResourceName]float64{"scalar.test/scalar1": 1000, "hugepages-test": 2000},
 			},
-			expected: false,
+			expected: true,
 		},
 		{
 			resource1: &Resource{
@@ -727,7 +727,7 @@ func TestLessEqual(t *testing.T) {
 				Memory:          2000,
 				ScalarResources: map[v1.ResourceName]float64{"scalar.test/scalar1": 1000, "hugepages-test": 2000},
 			},
-			expected: false,
+			expected: true,
 		},
 		{
 			resource1: &Resource{


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
#### What this PR does / why we need it:
The `LessEqual` and `Less`(even though it's no longer used anywhere.) functions in `pkg/scheduler/api/resource_info.go` have an incorrect logic when using `Infinity` mode. When the left resource (`r`) is missing a scalar resource dimension (e.g., GPU) but the right resource (`rr`) has it, the function incorrectly returns `false`.

##### Expected Behavior
When `r` doesn't have a dimension that `rr` has, it should be treated as `r[dimension] = 0`, and the comparison should continue (e.g., `0 <= rr[dimension]` returns `true`).

##### Actual Behavior (Before Fix)
The function returns `false` immediately, treating the missing dimension as if `r` exceeds `rr`, which is semantically incorrect.

##### Root Cause

The problematic code :
https://github.com/volcano-sh/volcano/blob/3568eee68aae751b78acfdc857479c1222b217b5/pkg/scheduler/api/resource_info.go#L416-L422
This logic enforces that `r` must contain all dimensions present in `rr`.

##### Impact and Necessity of Fix

###### 1. **Incorrect Eviction in Capacity Plugin**

The most critical impact is in the capacity plugin's reclaim logic:
https://github.com/volcano-sh/volcano/blob/3568eee68aae751b78acfdc857479c1222b217b5/pkg/scheduler/plugins/capacity/capacity.go#L123-L127

**Bug Scenario:**
```go
allocated := {CPU: 2000m, Memory: 4Gi}           // No GPU requested
deserved  := {CPU: 4000m, Memory: 8Gi, GPU: 2}  // GPU configured

// Before fix:
allocated.LessEqual(deserved, Infinity) = false  // Wrong!
→ Continue to guarantee check
→ May incorrectly reclaim resources
→ **Causes unexpected pod eviction**

// After fix:
allocated.LessEqual(deserved, Infinity) = true   // Correct!
→ Skip reclamation
→ **Avoids incorrect eviction**
```


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Notice that do not add `Fixes` if the issue is associated with multiple PRs.
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
Fixed unexpected pod evictions caused by unused resource types in queue quota configuration.
```