### PR TITLE
Add waiting time for pytorch worker pods to avoid pod crash

### DIFF
--- a/docs/user-guide/how_to_use_pytorch_plugin.md
+++ b/docs/user-guide/how_to_use_pytorch_plugin.md
@@ -6,21 +6,25 @@
 
 ## How the Pytorch Plugin Works
 
-The Pytorch Plugin will do three things:
+The Pytorch Plugin will do the following:
 
 * Open ports used by Pytorch for all containers of the job
 * Force open `svc` plugins
 * Add some envs such like `MASTER_ADDR`, `MASTER_PORT`, `WORLD_SIZE`, `RANK` which pytorch distributed training needed to containers automatically
+* Add an init container to worker pods to wait for the master node to be ready before starting (ensures master starts first)
 
 ## Parameters of the Pytorch Plugin
 
 ### Arguments
 
-| ID   | Name   | Type   | Default Value | Required | Description                        | Example            |
-| ---- | ------ | ------ | ------------- | -------- | ---------------------------------- | ------------------ |
-| 1    | master | string | master        | No       | Name of Pytorch master             | --master=master    |
-| 2    | worker | string | worker        | No       | Name of Pytorch worker             | --worker=worker    |
-| 3    | port   | string | 23456         | No       | The port to open for the container | --port=23456       |
+| ID   | Name                 | Type   | Default Value      | Required | Description                                                                          | Example                                |
+| ---- | -------------------- | ------ | ------------------ | -------- | ------------------------------------------------------------------------------------ | -------------------------------------- |
+| 1    | master               | string | master             | No       | Name of Pytorch master                                                               | --master=master                        |
+| 2    | worker               | string | worker             | No       | Name of Pytorch worker                                                               | --worker=worker                        |
+| 3    | port                 | int    | 23456              | No       | The port to open for the container                                                   | --port=23456                           |
+| 4    | wait-master-enabled  | bool   | false              | No       | Enable init container to wait for master                                             | --wait-master-enabled=true             |
+| 5    | wait-master-timeout  | int    | 300                | No       | Timeout in seconds for waiting master (only effective when wait-master-enabled=true) | --wait-master-timeout=600              |
+| 6    | wait-master-image    | string | busybox:1.36.1     | No       | Image for wait-for-master init container (only effective when wait-master-enabled=true) | --wait-master-image=busybox:latest  |
 
 ## Examples
 
@@ -33,7 +37,14 @@ spec:
   minAvailable: 1
   schedulerName: volcano
   plugins:
-    pytorch: ["--master=master","--worker=worker","--port=23456"] # Pytorch plugin register
+    pytorch: [
+      "--master=master",
+      "--worker=worker",
+      "--port=23456",
+      "--wait-master-enabled=true",          # Enable init container to wait for master (optional, default: false)
+      "--wait-master-timeout=600",           # Timeout in seconds (optional, default: 300)
+      "--wait-master-image=busybox:1.36.1"   # Init container image (optional, default: busybox:1.36.1)
+    ]
   tasks:
     - replicas: 1
       name: master
@@ -58,3 +69,24 @@ spec:
               workingDir: /home
           restartPolicy: OnFailure
 ```
+
+## Notes
+
+* The `wait-for-master` init container feature is **disabled by default**. Enable it by setting `--wait-master-enabled=true`
+* When enabled, an init container will be added to worker pods to ensure the master is ready before starting workers
+* Default init container image is `busybox:1.36.1`, can be customized via `--wait-master-image`
+* Workers will wait for the master to become ready with a configurable timeout (default 300 seconds / 5 minutes)
+* If the master doesn't become ready within the timeout, the worker pod will fail with an error message
+* The init container checks the master's port connectivity using multiple fallback methods:
+  1. `nc -z` (netcat) if available
+  2. `/dev/tcp` with timeout command if available
+  3. `/dev/tcp` direct connection as fallback
+* **Note**: The parameters `--wait-master-timeout` and `--wait-master-image` are only effective when `--wait-master-enabled=true`
+* **Image Requirements**: The custom image should have at least one of the following:
+  * `nc` (netcat) command - recommended, available in busybox, alpine
+  * `/dev/tcp` support in shell - available in bash/sh
+  * Recommended images: `busybox:1.36.1`, `alpine:latest`, `bash:latest`
+* Customization examples:
+  * Enable feature: `--wait-master-enabled=true`
+  * Custom timeout: `--wait-master-enabled=true --wait-master-timeout=600` (10 minutes)
+  * Custom image: `--wait-master-enabled=true --wait-master-image=busybox:latest`

--- a/pkg/controllers/job/plugins/distributed-framework/pytorch/pytorch_test.go
+++ b/pkg/controllers/job/plugins/distributed-framework/pytorch/pytorch_test.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -28,7 +29,7 @@ import (
 	pluginsinterface "volcano.sh/volcano/pkg/controllers/job/plugins/interface"
 )
 
-func TestPytorch(t *testing.T) {
+func TestPytorchPodEnvAndPort(t *testing.T) {
 	plugins := make(map[string][]string)
 	plugins[PytorchPluginName] = []string{"--port=5000"}
 
@@ -398,6 +399,282 @@ func TestPytorch(t *testing.T) {
 
 			if !equality.Semantic.DeepEqual(testcase.Pod.Spec.Containers[0].Env, testcase.envs) {
 				t.Errorf("Case %d (%s): wrong envs, got %v, expected %v", index, testcase.Name, testcase.Pod.Spec.Containers[0].Env, testcase.envs)
+			}
+		})
+	}
+}
+
+func TestPytorchInitContainer(t *testing.T) {
+	// Create plugin with wait-master enabled to generate expected script
+	ppEnabled := New(pluginsinterface.PluginClientset{}, []string{"--wait-master-enabled=true"}).(*pytorchPlugin)
+	expectedScript := ppEnabled.generateWaitForMasterScript("test-pytorch-master-0.test-pytorch")
+
+	testcases := []struct {
+		Name                 string
+		PluginArgs           []string
+		Job                  *v1alpha1.Job
+		Pod                  *v1.Pod
+		expectInitContainers []v1.Container
+	}{
+		{
+			Name:       "worker pod with wait-master enabled should have init container",
+			PluginArgs: []string{"--wait-master-enabled=true"},
+			Job: &v1alpha1.Job{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-pytorch"},
+				Spec: v1alpha1.JobSpec{
+					Tasks: []v1alpha1.TaskSpec{
+						{
+							Name:     "master",
+							Replicas: 1,
+							Template: v1.PodTemplateSpec{},
+						},
+						{
+							Name:     "worker",
+							Replicas: 2,
+							Template: v1.PodTemplateSpec{},
+						},
+					},
+				},
+			},
+			Pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-pytorch-worker-0",
+					Annotations: map[string]string{
+						v1alpha1.TaskSpecKey: "worker",
+					},
+				},
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{Name: "worker"},
+					},
+				},
+			},
+			expectInitContainers: []v1.Container{
+				{
+					Name:  "wait-for-master",
+					Image: "busybox:1.36.1",
+					Command: []string{
+						"sh",
+						"-c",
+						expectedScript,
+					},
+					Resources: v1.ResourceRequirements{},
+				},
+			},
+		},
+		{
+			Name:       "worker pod with wait-master disabled should not have init container",
+			PluginArgs: []string{"--wait-master-enabled=false"},
+			Job: &v1alpha1.Job{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-pytorch"},
+				Spec: v1alpha1.JobSpec{
+					Tasks: []v1alpha1.TaskSpec{
+						{
+							Name:     "master",
+							Replicas: 1,
+							Template: v1.PodTemplateSpec{},
+						},
+						{
+							Name:     "worker",
+							Replicas: 2,
+							Template: v1.PodTemplateSpec{},
+						},
+					},
+				},
+			},
+			Pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-pytorch-worker-0",
+					Annotations: map[string]string{
+						v1alpha1.TaskSpecKey: "worker",
+					},
+				},
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{Name: "worker"},
+					},
+				},
+			},
+			expectInitContainers: nil,
+		},
+		{
+			Name:       "master pod should not have wait-for-master init container",
+			PluginArgs: []string{"--wait-master-enabled=true"},
+			Job: &v1alpha1.Job{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-pytorch"},
+				Spec: v1alpha1.JobSpec{
+					Tasks: []v1alpha1.TaskSpec{
+						{
+							Name:     "master",
+							Replicas: 1,
+							Template: v1.PodTemplateSpec{},
+						},
+						{
+							Name:     "worker",
+							Replicas: 2,
+							Template: v1.PodTemplateSpec{},
+						},
+					},
+				},
+			},
+			Pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-pytorch-master-0",
+					Annotations: map[string]string{
+						v1alpha1.TaskSpecKey: "master",
+					},
+				},
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{Name: "master"},
+					},
+				},
+			},
+			expectInitContainers: nil,
+		},
+		{
+			Name:       "pod without master task should not have init container",
+			PluginArgs: []string{"--wait-master-enabled=true"},
+			Job: &v1alpha1.Job{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-pytorch"},
+				Spec: v1alpha1.JobSpec{
+					Tasks: []v1alpha1.TaskSpec{
+						{
+							Name:     "worker",
+							Replicas: 1,
+							Template: v1.PodTemplateSpec{},
+						},
+					},
+				},
+			},
+			Pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-pytorch-worker-0",
+					Annotations: map[string]string{
+						v1alpha1.TaskSpecKey: "worker",
+					},
+				},
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{Name: "worker"},
+					},
+				},
+			},
+			expectInitContainers: nil,
+		},
+		{
+			Name:       "worker pod with existing wait-for-master init container should not add duplicate",
+			PluginArgs: []string{"--wait-master-enabled=true"},
+			Job: &v1alpha1.Job{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-pytorch"},
+				Spec: v1alpha1.JobSpec{
+					Tasks: []v1alpha1.TaskSpec{
+						{
+							Name:     "master",
+							Replicas: 1,
+							Template: v1.PodTemplateSpec{},
+						},
+						{
+							Name:     "worker",
+							Replicas: 2,
+							Template: v1.PodTemplateSpec{},
+						},
+					},
+				},
+			},
+			Pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-pytorch-worker-0",
+					Annotations: map[string]string{
+						v1alpha1.TaskSpecKey: "worker",
+					},
+				},
+				Spec: v1.PodSpec{
+					InitContainers: []v1.Container{
+						{
+							Name:  "wait-for-master",
+							Image: "busybox:1.36.1",
+							Command: []string{
+								"sh",
+								"-c",
+								"echo 'already exists'",
+							},
+						},
+					},
+					Containers: []v1.Container{
+						{Name: "worker"},
+					},
+				},
+			},
+			expectInitContainers: []v1.Container{
+				{
+					Name:  "wait-for-master",
+					Image: "busybox:1.36.1",
+					Command: []string{
+						"sh",
+						"-c",
+						"echo 'already exists'",
+					},
+				},
+			},
+		},
+		{
+			Name:       "worker pod with custom image and timeout",
+			PluginArgs: []string{"--wait-master-enabled=true", "--wait-master-image=alpine:latest", "--wait-master-timeout=600"},
+			Job: &v1alpha1.Job{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-pytorch"},
+				Spec: v1alpha1.JobSpec{
+					Tasks: []v1alpha1.TaskSpec{
+						{
+							Name:     "master",
+							Replicas: 1,
+							Template: v1.PodTemplateSpec{},
+						},
+						{
+							Name:     "worker",
+							Replicas: 2,
+							Template: v1.PodTemplateSpec{},
+						},
+					},
+				},
+			},
+			Pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-pytorch-worker-0",
+					Annotations: map[string]string{
+						v1alpha1.TaskSpecKey: "worker",
+					},
+				},
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{Name: "worker"},
+					},
+				},
+			},
+			expectInitContainers: []v1.Container{
+				{
+					Name:  "wait-for-master",
+					Image: "alpine:latest",
+					Command: []string{
+						"sh",
+						"-c",
+						New(pluginsinterface.PluginClientset{}, []string{"--wait-master-enabled=true", "--wait-master-timeout=600"}).(*pytorchPlugin).generateWaitForMasterScript("test-pytorch-master-0.test-pytorch"),
+					},
+					Resources: v1.ResourceRequirements{},
+				},
+			},
+		},
+	}
+
+	for index, testcase := range testcases {
+		t.Run(testcase.Name, func(t *testing.T) {
+			pp := New(pluginsinterface.PluginClientset{}, testcase.PluginArgs)
+			if err := pp.OnPodCreate(testcase.Pod, testcase.Job); err != nil {
+				t.Errorf("Case %d (%s): expect no error, but got error %v", index, testcase.Name, err)
+			}
+
+			if diff := cmp.Diff(testcase.expectInitContainers, testcase.Pod.Spec.InitContainers); diff != "" {
+				t.Errorf("Case %d (%s): init containers mismatch (-want +got):\n%s", index, testcase.Name, diff)
 			}
 		})
 	}


### PR DESCRIPTION
#### What type of PR is this?
/kind feature
#### What this PR does / why we need it:
Pytorch worker pods will connect master pod when startup, worker pods should wait master pod ready or it the pods will crachloop, the start up order is important.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Notice that do not add `Fixes` if the issue is associated with multiple PRs.
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
An init container is automatically added to worker pods to wait for the master pod to be ready in PyTorch jobs
```