### PR TITLE
[Colocation] Convert containerID to cgroup dir name when setting systemd as driver

### DIFF
--- a/pkg/agent/events/handlers/resources/resources.go
+++ b/pkg/agent/events/handlers/resources/resources.go
@@ -85,7 +85,15 @@ func (r *ResourcesHandle) Handle(event interface{}) error {
 			errs = append(errs, err)
 		}
 
-		filePath := path.Join(cgroupPath, cr.ContainerID, cr.SubPath)
+		var filePath string
+		if cr.ContainerID == "" {
+			// Pod-level: file is directly under pod cgroup directory
+			filePath = path.Join(cgroupPath, cr.SubPath)
+		} else {
+			// Container-level: file is under container subdirectory
+			containerCgroupName := r.cgroupMgr.BuildContainerCgroupName(cr.ContainerID)
+			filePath = path.Join(cgroupPath, containerCgroupName, cr.SubPath)
+		}
 
 		if cgroupVersion == cgroup.CgroupV2 && cr.Value == -1 {
 			if cr.SubPath == cgroup.CPUQuotaTotalFileV2 {

--- a/pkg/agent/utils/cgroup/cgroup_test.go
+++ b/pkg/agent/utils/cgroup/cgroup_test.go
@@ -1,0 +1,85 @@
+/*
+Copyright 2025 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cgroup
+
+import (
+	"testing"
+)
+
+func TestBuildContainerCgroupName(t *testing.T) {
+	tests := []struct {
+		name         string
+		cgroupDriver string
+		containerID  string
+		expected     string
+	}{
+		{
+			name:         "cgroupfs with containerd",
+			cgroupDriver: CgroupDriverCgroupfs,
+			containerID:  "containerd://abc123",
+			expected:     "abc123",
+		},
+		{
+			name:         "cgroupfs with docker",
+			cgroupDriver: CgroupDriverCgroupfs,
+			containerID:  "docker://xyz789",
+			expected:     "xyz789",
+		},
+		{
+			name:         "cgroupfs with pure ID",
+			cgroupDriver: CgroupDriverCgroupfs,
+			containerID:  "abc123",
+			expected:     "abc123",
+		},
+		{
+			name:         "systemd with containerd",
+			cgroupDriver: CgroupDriverSystemd,
+			containerID:  "containerd://abc123",
+			expected:     "cri-containerd-abc123.scope",
+		},
+		{
+			name:         "systemd with docker",
+			cgroupDriver: CgroupDriverSystemd,
+			containerID:  "docker://xyz789",
+			expected:     "docker-xyz789.scope",
+		},
+		{
+			name:         "systemd with cri-o",
+			cgroupDriver: CgroupDriverSystemd,
+			containerID:  "cri-o://def456",
+			expected:     "crio-def456.scope",
+		},
+		{
+			name:         "systemd with pure ID",
+			cgroupDriver: CgroupDriverSystemd,
+			containerID:  "abc123",
+			expected:     "abc123",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mgr := &CgroupManagerImpl{
+				cgroupDriver: tt.cgroupDriver,
+			}
+			got := mgr.BuildContainerCgroupName(tt.containerID)
+			if got != tt.expected {
+				t.Errorf("BuildContainerCgroupName() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}

--- a/pkg/agent/utils/pod/resources_test.go
+++ b/pkg/agent/utils/pod/resources_test.go
@@ -77,13 +77,13 @@ func TestCalculateExtendResources(t *testing.T) {
 				// container-1
 				{
 					CgroupSubSystem: "cpu",
-					ContainerID:     "111",
+					ContainerID:     "containerd://111",
 					SubPath:         "cpu.shares",
 					Value:           512,
 				},
 				{
 					CgroupSubSystem: "cpu",
-					ContainerID:     "111",
+					ContainerID:     "containerd://111",
 					SubPath:         "cpu.cfs_quota_us",
 					Value:           1000,
 				},
@@ -91,13 +91,13 @@ func TestCalculateExtendResources(t *testing.T) {
 				// container-2
 				{
 					CgroupSubSystem: "cpu",
-					ContainerID:     "222",
+					ContainerID:     "docker://222",
 					SubPath:         "cpu.cfs_quota_us",
 					Value:           100000,
 				},
 				{
 					CgroupSubSystem: "memory",
-					ContainerID:     "222",
+					ContainerID:     "docker://222",
 					SubPath:         "memory.limit_in_bytes",
 					Value:           200,
 				},


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/area colocation

#### What this PR does / why we need it:
In https://github.com/volcano-sh/volcano/pull/4632, we already support cgroup v2 mode and systemd as the option driver(auto detect), but currently when I try to deploy volcano agent on the kind cluster and test colocation features, I met some errors:
1. When the driver is systemd and container runtime is containerd, the volcano-agent can's correctly set the cgroup, because the cgroup path is different with cgroupfs as the driver(for example, it's `cri-containerd-[containerid].scope` for container path when the driver is systemd), therefore we need to convert the containerID to correct cgroup path based on the container runtime and driver
2. In current cgroup v2 mode, the volcano agent will also set cgroup value for those pods didn't request over-sold resources(for example, system pods), it's incorrect, and also when a pod requests CPU resources in the request (without specifying the limit), it's also necessary to set pod-level `cpu.shares`(cgroup v1) or `cpu.weight`(cgroup v2).
3. Add more specific logs

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Notice that do not add `Fixes` if the issue is associated with multiple PRs.
-->
Fixes https://github.com/volcano-sh/volcano/issues/4912

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```