### PR TITLE
[Colocation] Make monitor interval and high usage limit configurable

### DIFF
--- a/pkg/agent/config/api/types.go
+++ b/pkg/agent/config/api/types.go
@@ -117,6 +117,10 @@ type Evicting struct {
 	EvictingCPULowWatermark *int `json:"evictingCPULowWatermark,omitempty"`
 	// EvictingMemoryLowWatermark defines the low watermark percent of memory usage when the node could recover schedule pods.
 	EvictingMemoryLowWatermark *int `json:"evictingMemoryLowWatermark,omitempty"`
+	// MonitorInterval defines the interval (in seconds) for monitoring node resource usage.
+	MonitorInterval *int `json:"monitorInterval,omitempty"`
+	// HighUsageCountLimit defines how many consecutive high usage detections trigger eviction.
+	HighUsageCountLimit *int `json:"highUsageCountLimit,omitempty"`
 }
 
 type CPUThrottling struct {

--- a/pkg/agent/config/api/validate.go
+++ b/pkg/agent/config/api/validate.go
@@ -35,6 +35,8 @@ var (
 	EvictingCPULowWatermarkHigherThanHighWatermark               = "cpu evicting low watermark is higher than high watermark"
 	EvictingMemoryLowWatermarkHigherThanHighWatermark            = "memory evicting low watermark is higher than high watermark"
 	IllegalOverSubscriptionTypes                                 = "overSubscriptionType(%s) is not supported, only supports cpu/memory"
+	IllegalMonitorInterval                                       = "monitorInterval must be a positive number"
+	IllegalHighUsageCountLimit                                   = "highUsageCountLimit must be a positive number"
 	IllegalCPUThrottlingThreshold                                = "cpuThrottlingThreshold must be a positive number between 1 and 100"
 	IllegalCPUJitterLimitPercent                                 = "cpuJitterLimitPercent must be a non-negative number between 1 and 100"
 	IllegalCPURecoverLimitPercent                                = "cpuRecoverLimitPercent must be a positive number between 1 and 100"
@@ -128,6 +130,12 @@ func (e *Evicting) Validate() []error {
 	}
 	if e.EvictingMemoryLowWatermark != nil && e.EvictingMemoryHighWatermark != nil && (*e.EvictingMemoryLowWatermark > *e.EvictingMemoryHighWatermark) {
 		errs = append(errs, errors.New(EvictingMemoryLowWatermarkHigherThanHighWatermark))
+	}
+	if e.MonitorInterval != nil && *e.MonitorInterval <= 0 {
+		errs = append(errs, errors.New(IllegalMonitorInterval))
+	}
+	if e.HighUsageCountLimit != nil && *e.HighUsageCountLimit <= 0 {
+		errs = append(errs, errors.New(IllegalHighUsageCountLimit))
 	}
 	return errs
 }

--- a/pkg/agent/config/api/validate_test.go
+++ b/pkg/agent/config/api/validate_test.go
@@ -140,6 +140,71 @@ func TestColocationConfigValidate(t *testing.T) {
 			},
 			expectedErr: []error{errors.New(EvictingCPULowWatermarkHigherThanHighWatermark), errors.New(EvictingMemoryLowWatermarkHigherThanHighWatermark)},
 		},
+
+		{
+			name: "illegal EvictingConfig && negative monitorInterval",
+			colocationCfg: &ColocationConfig{
+				EvictingConfig: &Evicting{
+					MonitorInterval: utilpointer.Int(-10),
+				},
+			},
+			expectedErr: []error{errors.New(IllegalMonitorInterval)},
+		},
+
+		{
+			name: "illegal EvictingConfig && zero monitorInterval",
+			colocationCfg: &ColocationConfig{
+				EvictingConfig: &Evicting{
+					MonitorInterval: utilpointer.Int(0),
+				},
+			},
+			expectedErr: []error{errors.New(IllegalMonitorInterval)},
+		},
+
+		{
+			name: "illegal EvictingConfig && negative highUsageCountLimit",
+			colocationCfg: &ColocationConfig{
+				EvictingConfig: &Evicting{
+					HighUsageCountLimit: utilpointer.Int(-6),
+				},
+			},
+			expectedErr: []error{errors.New(IllegalHighUsageCountLimit)},
+		},
+
+		{
+			name: "illegal EvictingConfig && zero highUsageCountLimit",
+			colocationCfg: &ColocationConfig{
+				EvictingConfig: &Evicting{
+					HighUsageCountLimit: utilpointer.Int(0),
+				},
+			},
+			expectedErr: []error{errors.New(IllegalHighUsageCountLimit)},
+		},
+
+		{
+			name: "illegal EvictingConfig && both monitorInterval and highUsageCountLimit negative",
+			colocationCfg: &ColocationConfig{
+				EvictingConfig: &Evicting{
+					MonitorInterval:     utilpointer.Int(-10),
+					HighUsageCountLimit: utilpointer.Int(-6),
+				},
+			},
+			expectedErr: []error{errors.New(IllegalMonitorInterval), errors.New(IllegalHighUsageCountLimit)},
+		},
+
+		{
+			name: "legal EvictingConfig with valid monitorInterval and highUsageCountLimit",
+			colocationCfg: &ColocationConfig{
+				EvictingConfig: &Evicting{
+					EvictingCPUHighWatermark:    utilpointer.Int(80),
+					EvictingMemoryHighWatermark: utilpointer.Int(60),
+					EvictingCPULowWatermark:     utilpointer.Int(30),
+					EvictingMemoryLowWatermark:  utilpointer.Int(30),
+					MonitorInterval:             utilpointer.Int(10),
+					HighUsageCountLimit:         utilpointer.Int(6),
+				},
+			},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/pkg/agent/config/configmgr.go
+++ b/pkg/agent/config/configmgr.go
@@ -143,6 +143,8 @@ func (m *ConfigManager) updateConfigMap(cm *corev1.ConfigMap) error {
 			EvictingMemoryHighWatermark: utilpointer.Int(utils.DefaultEvictingMemoryHighWatermark),
 			EvictingCPULowWatermark:     utilpointer.Int(utils.DefaultEvictingCPULowWatermark),
 			EvictingMemoryLowWatermark:  utilpointer.Int(utils.DefaultEvictingMemoryLowWatermark),
+			MonitorInterval:             utilpointer.Int(utils.DefaultMonitorInterval),
+			HighUsageCountLimit:         utilpointer.Int(utils.DefaultHighUsageCountLimit),
 		}
 	}
 	if !changed {

--- a/pkg/agent/config/configmgr_test.go
+++ b/pkg/agent/config/configmgr_test.go
@@ -131,6 +131,8 @@ func defaultCfg() *api.VolcanoAgentConfig {
 			EvictingMemoryHighWatermark: utilpointer.Int(utils.DefaultEvictingMemoryHighWatermark),
 			EvictingCPULowWatermark:     utilpointer.Int(utils.DefaultEvictingCPULowWatermark),
 			EvictingMemoryLowWatermark:  utilpointer.Int(utils.DefaultEvictingMemoryLowWatermark),
+			MonitorInterval:             utilpointer.Int(utils.DefaultMonitorInterval),
+			HighUsageCountLimit:         utilpointer.Int(utils.DefaultHighUsageCountLimit),
 		},
 	}}
 }

--- a/pkg/agent/config/utils/utils.go
+++ b/pkg/agent/config/utils/utils.go
@@ -52,6 +52,8 @@ const (
 	DefaultEvictingMemoryHighWatermark = 60
 	DefaultEvictingCPULowWatermark     = 30
 	DefaultEvictingMemoryLowWatermark  = 30
+	DefaultMonitorInterval             = 10
+	DefaultHighUsageCountLimit         = 6
 )
 
 const (
@@ -89,7 +91,9 @@ const (
             "evictingCPUHighWatermark":80,
             "evictingMemoryHighWatermark":60,
             "evictingCPULowWatermark":30,
-            "evictingMemoryLowWatermark":30
+            "evictingMemoryLowWatermark":30,
+            "monitorInterval":10,
+            "highUsageCountLimit":6
         },
 		"cpuThrottlingConfig":{
             "enable":false
@@ -130,6 +134,8 @@ func DefaultColocationConfig() *api.ColocationConfig {
 			EvictingMemoryHighWatermark: utilpointer.Int(DefaultEvictingMemoryHighWatermark),
 			EvictingCPULowWatermark:     utilpointer.Int(DefaultEvictingCPULowWatermark),
 			EvictingMemoryLowWatermark:  utilpointer.Int(DefaultEvictingMemoryLowWatermark),
+			MonitorInterval:             utilpointer.Int(DefaultMonitorInterval),
+			HighUsageCountLimit:         utilpointer.Int(DefaultHighUsageCountLimit),
 		},
 		CPUThrottlingConfig: &api.CPUThrottling{
 			Enable: utilpointer.Bool(false),

--- a/pkg/agent/events/probes/nodemonitor/node_monitor_test.go
+++ b/pkg/agent/events/probes/nodemonitor/node_monitor_test.go
@@ -127,6 +127,7 @@ func Test_monitor_detect(t *testing.T) {
 				getNodeFunc:             tt.getNodeFunc,
 				getPodsFunc:             tt.getPodsFunc,
 				usageGetter:             tt.usageGetter,
+				highUsageCountLimit:     6,
 			}
 			m.detectEviction()
 			assert.Equalf(t, tt.expectedLen, queue.Len(), "detect()")


### PR DESCRIPTION
#### What type of PR is this?
kind/feature
area colocation 

#### What this PR does / why we need it:
Currently, the node monitor uses hardcoded values for monitoring
interval (10 seconds) and high usage count limit (6 consecutive
detections).
This change adds two new configurable parameters to EvictingConfig: 
- monitorInterval: controls how often node resources are monitored
- highUsageCountLimit: defines consecutive high readings before eviction

Both parameters maintain backward compatibility with defaults of
10 seconds and 6 times respectively.  The values are validated to
ensure they are positive numbers and can be configured via the
volcano-agent ConfigMap. 


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Notice that do not add `Fixes` if the issue is associated with multiple PRs.
-->
Fixes #4911 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```