### PR TITLE
Remove TODO in allocate.go regarding checking pod availability

### DIFF
--- a/pkg/agentscheduler/actions/allocate/allocate.go
+++ b/pkg/agentscheduler/actions/allocate/allocate.go
@@ -87,7 +87,6 @@ func (alloc *Action) allocateTask(schedCtx *agentapi.SchedulingContext) error {
 
 	nodes := alloc.fwk.VolcanoNodeInfos()
 
-	// TODO: check is pod allocatable
 	klog.V(3).Infof("There are <%d> nodes for task <%v/%v>", len(nodes), task.Namespace, task.Name)
 
 	if err := alloc.fwk.PrePredicateFn(task); err != nil {


### PR DESCRIPTION
#### What type of PR is this?

#### What this PR does / why we need it:
This PR removes a `TODO` comment left in `allocate.go` in the `allocateTask` function to check if the pods are allocatable. This has already been implemented in the `prioritizeNodes` function in the same file, hence this TODO is not needed.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Notice that do not add `Fixes` if the issue is associated with multiple PRs.
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```