### PR TITLE
fix(capacity): ensure allocated resources remain above deserved after evction

### DIFF
--- a/pkg/scheduler/plugins/capacity/capacity.go
+++ b/pkg/scheduler/plugins/capacity/capacity.go
@@ -142,8 +142,8 @@ func (cp *capacityPlugin) OnSessionOpen(ssn *framework.Session) {
 			}
 			allocated := allocations[job.Queue]
 
-			// Check guarantee
-			if satisfies, _ := cp.checkGuaranteeConstraint(allocated, reclaimee, attr.guarantee); !satisfies {
+			// Check if removing the reclaimee would violate the queue's deserved.
+			if satisfies, _ := cp.checkDeservedConstraint(allocated, reclaimee, reclaimer, attr.deserved); !satisfies {
 				continue
 			}
 
@@ -1109,15 +1109,16 @@ func (cp *capacityPlugin) shouldSkipReclaimee(reclaimee, reclaimer *api.TaskInfo
 	return false, ""
 }
 
-// checkGuaranteeConstraint checks if removing the reclaimee would violate the queue's guarantee.
-// Returns true if the guarantee constraint is satisfied (i.e., reclaim is allowed).
-func (cp *capacityPlugin) checkGuaranteeConstraint(
+// checkDeservedConstraint checks if removing the reclaimee would violate the queue's deserved.
+// Returns true if the deserved constraint is satisfied (i.e., reclaim is allowed).
+func (cp *capacityPlugin) checkDeservedConstraint(
 	allocated *api.Resource,
 	reclaimee *api.TaskInfo,
-	guarantee *api.Resource,
+	reclaimer *api.TaskInfo,
+	deserved *api.Resource,
 ) (bool, *api.Resource) {
 	exceptReclaimee := allocated.Clone().Sub(reclaimee.Resreq)
-	reclaimable := guarantee.LessEqual(exceptReclaimee, api.Zero)
+	reclaimable, _ := deserved.LessEqualWithDimensionAndResourcesName(exceptReclaimee, reclaimer.Resreq)
 	return reclaimable, exceptReclaimee
 }
 

--- a/pkg/scheduler/plugins/capacity/capacity_test.go
+++ b/pkg/scheduler/plugins/capacity/capacity_test.go
@@ -183,7 +183,7 @@ func Test_capacityPlugin_OnSessionOpenWithoutHierarchy(t *testing.T) {
 	pg26 := util.BuildPodGroup("pg26", "ns1", "queue17", 1, nil, schedulingv1beta1.PodGroupRunning)
 	pg27 := util.BuildPodGroup("pg27", "ns1", "queue17", 1, nil, schedulingv1beta1.PodGroupRunning)
 	pg28 := util.BuildPodGroup("pg28", "ns1", "queue17", 1, nil, schedulingv1beta1.PodGroupRunning)
-	queue17 := util.BuildQueueWithResourcesQuantity("queue17", api.BuildResourceList("2", "2Gi"), nil)
+	queue17 := util.BuildQueueWithResourcesQuantity("queue17", api.BuildResourceList("1", "2Gi"), nil)
 	p29 := util.BuildPod("ns1", "p29", "n8", corev1.PodRunning, api.BuildResourceList("2", "4Gi"), "pg29", nil, nil)
 	pg29 := util.BuildPodGroup("pg29", "ns1", "queue18", 1, nil, schedulingv1beta1.PodGroupRunning)
 	p30 := util.BuildPod("ns1", "p30", "", corev1.PodPending, api.BuildResourceList("1", "0Gi", []api.ScalarResource{{Name: "nvidia.com/gpu", Value: "1"}}...), "pg30", nil, nil)


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
#### What this PR does / why we need it:
This PR fixes a cyclic eviction issue in the capacity plugin where pods could be repeatedly evicted and rescheduled in a loop, causing scheduling instability.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Notice that do not add `Fixes` if the issue is associated with multiple PRs.
-->
Fixes # https://github.com/volcano-sh/volcano/issues/4947   subBug 1:

The capacity plugin could enter a cyclic eviction loop in the following scenario:
##### Example:
Queue1: deserved=3c, has a running pod1 requesting 4c
Queue2: deserved=5c, has a running pod2 requesting 1c, and a pending pod3 requesting 4c
##### The Cycle:
Reclaim phase: Queue2's pod3 triggers eviction of Queue1's pod1 (since Queue1 is over quota: 4c > 3c)
Post-eviction: Queue1's allocated becomes 0, share = 0/3 = 0
Allocate phase: Queue1 gets higher priority (share=0 < Queue2's share=0.2)
Scheduling: pod1 gets rescheduled to Queue1, allocated = 4c again
Repeat: Queue2's pending pod triggers eviction again → cycle repeats
##### Root Cause
The issue occurs because the ReclaimableFn only checks if the current allocated > deserved, but doesn't verify whether eviction would cause allocated to drop below deserved. This allows over-reclaim, making the queue immediately "starving" and eligible for high-priority scheduling.
##### Solution
Add a check in the capacity plugin's ReclaimableFn to prevent eviction if it would cause the queue's allocated resources to fall below its deserved quota in any resource dimension.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
Recycling is not allowed if it causes the queue's allocated resources to fall below its deserved quota. That is, if evicting a pod from the target queue would result in allocated < deserved for the queue, then the eviction of this pod is denied.
```