### PR TITLE
chore(metrics): remove non-existent metrics schedule_attempts_total

### DIFF
--- a/pkg/scheduler/metrics/metrics.go
+++ b/pkg/scheduler/metrics/metrics.go
@@ -109,6 +109,14 @@ var (
 		},
 	)
 
+	scheduleAttempts = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Subsystem: VolcanoSubSystemName,
+			Name:      "schedule_attempts_total",
+			Help:      "Number of attempts to schedule pods, by the result. 'unschedulable' means a pod could not be scheduled, while 'error' means an internal scheduler problem.",
+		}, []string{"result"},
+	)
+
 	preemptionVictims = promauto.NewGauge(
 		prometheus.GaugeOpts{
 			Subsystem: VolcanoSubSystemName,
@@ -189,6 +197,11 @@ func UpdateE2eSchedulingLastTimeByJob(jobName string, queue string, namespace st
 // UpdateTaskScheduleDuration updates single task scheduling latency
 func UpdateTaskScheduleDuration(duration time.Duration) {
 	taskSchedulingLatency.Observe(DurationInMilliseconds(duration))
+}
+
+// UpdatePodScheduleStatus update pod schedule decision, could be Success, Failure, Error
+func UpdatePodScheduleStatus(label string, count int) {
+	scheduleAttempts.WithLabelValues(label).Add(float64(count))
 }
 
 // UpdatePreemptionVictimsCount updates count of preemption victims


### PR DESCRIPTION
#### What type of PR is this?

#### What this PR does / why we need it:
- The metrics `schedule_attempts_total` does not exist

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Notice that do not add `Fixes` if the issue is associated with multiple PRs.
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```