### PR TITLE
fix(cache): resyncTask, retryResyncTask and syncTask changes 

### DIFF
--- a/pkg/scheduler/cache/cache.go
+++ b/pkg/scheduler/cache/cache.go
@@ -1152,6 +1152,12 @@ func (sc *SchedulerCache) parseDeletedJobsKey(key string) (jobUID string, jobPgU
 
 func (sc *SchedulerCache) resyncTask(task *schedulingapi.TaskInfo) {
 	key := sc.generateErrTaskKey(task)
+	sc.errTasks.Add(key)
+}
+
+func (sc *SchedulerCache) retryResyncTask(task *schedulingapi.TaskInfo) {
+	klog.V(3).Infof("Retry to resync task <%v:%v/%v>", task.UID, task.Namespace, task.Name)
+	key := sc.generateErrTaskKey(task)
 	sc.errTasks.AddRateLimited(key)
 }
 
@@ -1207,7 +1213,7 @@ func (sc *SchedulerCache) processResyncTask() {
 	reSynced := false
 	if err := sc.syncTask(task); err != nil {
 		klog.ErrorS(err, "Failed to sync task, retry it", "namespace", task.Namespace, "name", task.Name)
-		sc.resyncTask(task)
+		sc.retryResyncTask(task)
 		reSynced = true
 	} else {
 		klog.V(4).Infof("Successfully synced task <%s/%s>", task.Namespace, task.Name)

--- a/pkg/scheduler/cache/cache.go
+++ b/pkg/scheduler/cache/cache.go
@@ -1156,7 +1156,7 @@ func (sc *SchedulerCache) resyncTask(task *schedulingapi.TaskInfo) {
 }
 
 func (sc *SchedulerCache) retryResyncTask(task *schedulingapi.TaskInfo) {
-	klog.V(3).Infof("Retry to resync task <%v:%v/%v>", task.UID, task.Namespace, task.Name)
+	klog.V(5).Infof("Retry to resync task <%s:%s/%s>", task.UID, task.Namespace, task.Name)
 	key := sc.generateErrTaskKey(task)
 	sc.errTasks.AddRateLimited(key)
 }

--- a/pkg/scheduler/cache/event_handlers.go
+++ b/pkg/scheduler/cache/event_handlers.go
@@ -264,7 +264,7 @@ func (sc *SchedulerCache) addPod(pod *v1.Pod) error {
 }
 
 func (sc *SchedulerCache) syncTask(oldTask *schedulingapi.TaskInfo) error {
-	newPod, err := sc.kubeClient.CoreV1().Pods(oldTask.Namespace).Get(context.TODO(), oldTask.Name, metav1.GetOptions{})
+	newPod, err := sc.podInformer.Lister().Pods(oldTask.Namespace).Get(oldTask.Name)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			sc.Mutex.Lock()


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

Continutation of the work in https://github.com/volcano-sh/volcano/pull/4754. I kept @fengruotj's commit and added the two needed changes.

#### What this PR does / why we need it:
Right now resyncTask is used in many places and if multiple calls happen in parallel for unrelated reasons, we artificially increase the backoff even though no communication has failed. That means we slow down processing without a real need.
See: https://github.com/volcano-sh/volcano/pull/4754#pullrequestreview-3626874944 

This is one part of the problem, but we should remove the direct API call too and use the podInformer instead.
https://github.com/volcano-sh/volcano/pull/4754#issuecomment-3738245112

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Notice that do not add `Fixes` if the issue is associated with multiple PRs.
-->
Fixes https://github.com/volcano-sh/volcano/issues/4745

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
fix(cache): errTasks proper rate limitation with retryResyncTask @fengruotj
fix(cache): syncTask podInformer usage, retryResyncTask log update @hajnalmt 
```