### PR TITLE
perf(nta) NTA scheduling performance improvement by optimizing hyperNodeGradientFn

### DIFF
--- a/pkg/scheduler/api/sub_job_info.go
+++ b/pkg/scheduler/api/sub_job_info.go
@@ -261,3 +261,15 @@ func (sji *SubJobInfo) AllocatedTaskNum() int32 {
 func (sji *SubJobInfo) CloneStatusFrom(source *SubJobInfo) {
 	sji.AllocatedHyperNode = source.AllocatedHyperNode
 }
+
+// GetMinResources The current sub job is constrained to gang scheduling,
+// where the MinAvailable of a sub job equals the size of itself.
+// so the minimum required resource to run a sub job can be considered as
+// the total initResReq of each pending task in the sub job.
+func (sji *SubJobInfo) GetMinResources() *Resource {
+	totalResource := EmptyResource()
+	for _, task := range sji.TaskStatusIndex[Pending] {
+		totalResource.Add(task.InitResreq)
+	}
+	return totalResource
+}


### PR DESCRIPTION
#### What type of PR is this?

area/performance kind/feature

#### What this PR does / why we need it:

Currently, the network topology-aware plugin iterates from bottom to top in a hypernode tree and caused inefficiency. For detailed description please review issue [#4899](https://github.com/volcano-sh/volcano/issues/4899#event-21805727490) . This PR introduces HyperNode pre-filtering logic within hyperNodeGradientFn. Specifically, we only keep a hypernode to eligibleHyperNodes when minResource is less than or equal to the idle resource of a hypernode, or the future idle resource of a hypernode.

Note that here minResource can refer to both the minimum required resource of a job or a sub job.

The PR also modifies sub_job_info.go for sub job minReource calculation purposes. Right now a sub job is constrained to gang scheduling, so the minimum required resource of a sub job can be considered as the total initResReq of each pending task in the sub job.

```go
func (sji *SubJobInfo) GetMinResources() *Resource {
	totalResource := EmptyResource()
	for _, task := range sji.TaskStatusIndex[Pending] {
		totalResource.Add(task.InitResreq)
	}
	return totalResource
}
``` 

Improvement: Under the setup as in issue 4899, when we have a subgroup for each pod, resulting in 1000 subgroups, the total scheduling duration can last about 1 minute. This number is optimized to a few seconds in this PR. When we build 100 subgroups, each containing 10 pods, scheduling duration is optimized by about 0.5 seconds, from about 6.3 seconds to 5.9 seconds. By observation, I believe the differences in the number of subgroups mainly contribute to scheduling duration before optimization. The main reason is that the scheduler will have to perform more dry run operations.

#### Which issue(s) this PR fixes:

#4899 issue 1

#### Special notes for your reviewer:

This PR is based on [#4889](https://github.com/volcano-sh/volcano/pull/4889) so it should be merged after #4889 is merged.

Feel free to modify TestHyperNodeGradientPreFiltering for correctness checks and BenchmarkHyperNodeGradientFnPerformance for performance benchmarks. 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```