### PR TITLE
[Colocation Enhancement] Support CPU Throttle

### DIFF
--- a/docs/design/cpu-throttle-design.md
+++ b/docs/design/cpu-throttle-design.md
@@ -1,0 +1,110 @@
+CPU Throttle Feature Design
+===
+
+Design Principles
+---
+
+The CPU Throttle feature dynamically adjusts the BestEffort root cgroup CPU quota based on node allocatable CPU and real-time CPU usage. It follows a "monitor-event-handler" architecture pattern, implementing periodic monitoring with conservative updates to avoid jitter.
+
+Core Design Philosophy
+
+1. **Quota Budgeting**: Computes a BE CPU quota budget from allocatable CPU minus real-time CPU usage.
+
+2. **Jitter Control**: Use a jitter limit percentage to avoid frequent updates for small jitter.
+
+3. **QoS Awareness**: Only applies throttling to BE cgroup; higher-priority workloads are protected by request accounting.
+
+4. **Runtime Configurability**: Supports dynamic configuration updates for flexible adaptation.
+
+Implementation Architecture
+---
+
+### Probe Layer (cpumonitor)
+
+**Responsibility**: Monitor node CPU utilization and trigger throttling events
+
+**Key Components**:
+
+- `detectCPUQuota()`: Core detection logic
+
+- Configuration parameters: `cpuThrottlingThreshold` (allocatable percentage limit), `cpuJitterLimitPercent` (minimum delta before emitting updates), `cpuRecoverLimitPercent` (maximum increase per update)
+
+- State management: `lastCPUQuotaMilli` (last emitted BE quota in millicores)
+
+**Quota Computation Logic**:
+
+```
+allowedMilli = allocatableMilli * cpuThrottlingThreshold / 100
+availableBEMilli = max(allowedMilli - usedMilli, 0)
+cap availableBEMilli increase to lastCPUQuotaMilli * (1 + cpuRecoverLimitPercent/100)
+emit event if first run, or lastCPUQuotaMilli == 0 and availableBEMilli != 0,
+or |availableBEMilli - lastCPUQuotaMilli| >= lastCPUQuotaMilli * cpuJitterLimitPercent / 100
+```
+
+### Event Layer
+
+Event Type: `NodeCPUThrottleEvent`
+
+```go
+type NodeCPUThrottleEvent struct {
+    TimeStamp time.Time
+    Resource  v1.ResourceName
+    CPUQuotaMilli int64 // BE quota in millicores
+}
+```
+
+### Handler Layer (cputhrottle)
+
+**Responsibility**: Execute actual CPU throttling operations
+
+**Core Algorithm**:
+
+- **Quota Application**: Converts millicores to CFS quota and writes to the BE root cgroup
+
+- **cgroup Operations**: Directly manipulates `cpu.cfs_quota_us` files
+
+**Key Methods**:
+
+```go
+applyBEQuota()             // Apply BE root quota
+quotaFromMilliCPU()        // Convert millicores to quota
+writeBEQuota()             // Update cgroup quota file
+```
+
+Technical Implementation Details
+---
+
+**CPU Quota Calculation**
+
+```
+quota = milliCPU * 100000 / 1000
+quota <= 0 means unlimited (-1)
+```
+
+**cgroup File Operations**
+
+- Read: cgroup path from QoS BE root
+- Write: Update quota value to corresponding cgroup file
+
+**Configuration Hot Updates**
+Supports dynamic updates via `ColocationConfig`:
+
+- `cpuThrottlingThreshold`
+
+- `cpuJitterLimitPercent`
+
+- `cpuRecoverLimitPercent`
+
+- Feature enable/disable
+
+## Configuration
+
+Example Configuration
+
+```yaml
+cpuThrottlingConfig:
+  enable: true
+  cpuThrottlingThreshold: 80    # Allow BE quota up to 80% of allocatable CPU
+  cpuJitterLimitPercent: 1      # Emit updates when quota changes by >=1%
+  cpuRecoverLimitPercent: 10    # Cap quota increases to 10% per update
+```

--- a/pkg/agent/config/api/types.go
+++ b/pkg/agent/config/api/types.go
@@ -65,6 +65,9 @@ type ColocationConfig struct {
 
 	// Evicting related config.
 	EvictingConfig *Evicting `json:"evictingConfig,omitempty" configKey:"Evicting"`
+
+	// cpuThrottling related config
+	CPUThrottlingConfig *CPUThrottling `json:"cpuThrottlingConfig,omitempty" configKey:"CPUThrottling"`
 }
 
 type CPUQos struct {
@@ -111,4 +114,15 @@ type Evicting struct {
 	EvictingCPULowWatermark *int `json:"evictingCPULowWatermark,omitempty"`
 	// EvictingMemoryLowWatermark defines the low watermark percent of memory usage when the node could recover schedule pods.
 	EvictingMemoryLowWatermark *int `json:"evictingMemoryLowWatermark,omitempty"`
+}
+
+type CPUThrottling struct {
+	Enable *bool `json:"enable,omitempty"`
+	// CPUThrottlingThreshold defines the threshold percent of CPU usage when CPU throttling should begin.
+	CPUThrottlingThreshold *int `json:"cpuThrottlingThreshold,omitempty"`
+	// CPUJitterLimitPercent defines the percentage range of allowed CPU usage variation.
+	// Within this range, CPU throttle modifications for BestEffort pods will not be triggered.
+	CPUJitterLimitPercent *int `json:"cpuJitterLimitPercent,omitempty"`
+	// CPURecoverLimitPercent defines the maximum percent CPU quota increase allowed per interval.
+	CPURecoverLimitPercent *int `json:"cpuRecoverLimitPercent,omitempty"`
 }

--- a/pkg/agent/config/api/validate.go
+++ b/pkg/agent/config/api/validate.go
@@ -35,6 +35,9 @@ var (
 	EvictingCPULowWatermarkHigherThanHighWatermark               = "cpu evicting low watermark is higher than high watermark"
 	EvictingMemoryLowWatermarkHigherThanHighWatermark            = "memory evicting low watermark is higher than high watermark"
 	IllegalOverSubscriptionTypes                                 = "overSubscriptionType(%s) is not supported, only supports cpu/memory"
+	IllegalCPUThrottlingThreshold                                = "cpuThrottlingThreshold must be a positive number between 1 and 100"
+	IllegalCPUJitterLimitPercent                                 = "cpuJitterLimitPercent must be a non-negative number between 1 and 100"
+	IllegalCPURecoverLimitPercent                                = "cpuRecoverLimitPercent must be a positive number between 1 and 100"
 )
 
 type Validate interface {
@@ -142,5 +145,28 @@ func (c *ColocationConfig) Validate() []error {
 	errs = append(errs, c.NetworkQosConfig.Validate()...)
 	errs = append(errs, c.OverSubscriptionConfig.Validate()...)
 	errs = append(errs, c.EvictingConfig.Validate()...)
+	errs = append(errs, c.CPUThrottlingConfig.Validate()...)
+	return errs
+}
+
+func (c *CPUThrottling) Validate() []error {
+	if c == nil {
+		return nil
+	}
+
+	var errs []error
+	if c.CPUThrottlingThreshold != nil &&
+		(*c.CPUThrottlingThreshold <= 0 || *c.CPUThrottlingThreshold > 100) {
+		errs = append(errs, errors.New(IllegalCPUThrottlingThreshold))
+	}
+
+	if c.CPUJitterLimitPercent != nil && *c.CPUJitterLimitPercent < 0 {
+		errs = append(errs, errors.New(IllegalCPUJitterLimitPercent))
+	}
+
+	if c.CPURecoverLimitPercent != nil && *c.CPURecoverLimitPercent <= 0 {
+		errs = append(errs, errors.New(IllegalCPURecoverLimitPercent))
+	}
+
 	return errs
 }

--- a/pkg/agent/config/utils/utils.go
+++ b/pkg/agent/config/utils/utils.go
@@ -87,6 +87,9 @@ const (
             "evictingMemoryHighWatermark":60,
             "evictingCPULowWatermark":30,
             "evictingMemoryLowWatermark":30
+        },
+		"cpuThrottlingConfig":{
+            "enable":false
         }
     }
 }
@@ -123,6 +126,9 @@ func DefaultColocationConfig() *api.ColocationConfig {
 			EvictingMemoryHighWatermark: utilpointer.Int(DefaultEvictingMemoryHighWatermark),
 			EvictingCPULowWatermark:     utilpointer.Int(DefaultEvictingCPULowWatermark),
 			EvictingMemoryLowWatermark:  utilpointer.Int(DefaultEvictingMemoryLowWatermark),
+		},
+		CPUThrottlingConfig: &api.CPUThrottling{
+			Enable: utilpointer.Bool(false),
 		},
 	}
 }

--- a/pkg/agent/events/eventsmgr.go
+++ b/pkg/agent/events/eventsmgr.go
@@ -18,6 +18,7 @@ package events
 
 import (
 	"context"
+	"reflect"
 
 	"k8s.io/klog/v2"
 
@@ -31,6 +32,7 @@ import (
 
 	_ "volcano.sh/volcano/pkg/agent/events/handlers/cpuburst"
 	_ "volcano.sh/volcano/pkg/agent/events/handlers/cpuqos"
+	_ "volcano.sh/volcano/pkg/agent/events/handlers/cputhrottle"
 	_ "volcano.sh/volcano/pkg/agent/events/handlers/eviction"
 	_ "volcano.sh/volcano/pkg/agent/events/handlers/memoryqos"
 	_ "volcano.sh/volcano/pkg/agent/events/handlers/networkqos"
@@ -58,10 +60,15 @@ func NewEventManager(config *config.Configuration, metricCollectManager *metricc
 		configMgr:            coloconfig.NewManager(config, []coloconfig.Listener{factory}),
 	}
 
+	probeInstances := make(map[uintptr]framework.Probe)
 	for eventName, newProbeFuncs := range probes.GetEventProbeFuncs() {
-		eventQueue := mgr.eventQueueFactory.EventQueue(eventName)
 		for _, newProbeFunc := range newProbeFuncs {
-			prob := newProbeFunc(config, metricCollectManager, eventQueue.GetQueue())
+			funcKey := reflect.ValueOf(newProbeFunc).Pointer()
+			prob, ok := probeInstances[funcKey]
+			if !ok {
+				prob = newProbeFunc(config, metricCollectManager, mgr.eventQueueFactory)
+				probeInstances[funcKey] = prob
+			}
 			klog.InfoS("Registering event probe", "eventName", eventName, "probeName", prob.ProbeName())
 			mgr.eventQueueFactory.RegistryEventProbe(eventName, prob)
 		}

--- a/pkg/agent/events/framework/types.go
+++ b/pkg/agent/events/framework/types.go
@@ -31,6 +31,8 @@ const (
 	NodeResourcesEventName EventName = "NodeResourcesSync"
 
 	NodeMonitorEventName EventName = "NodeUtilizationSync"
+
+	NodeCPUThrottleEventName EventName = "NodeCPUThrottleSync"
 )
 
 type PodEvent struct {
@@ -52,4 +54,10 @@ type NodeMonitorEvent struct {
 	TimeStamp time.Time
 	// Resource represents which resource is under pressure.
 	Resource corev1.ResourceName
+}
+
+type NodeCPUThrottleEvent struct {
+	TimeStamp     time.Time
+	Resource      corev1.ResourceName
+	CPUQuotaMilli int64
 }

--- a/pkg/agent/events/handlers/cputhrottle/cpu_throttling.go
+++ b/pkg/agent/events/handlers/cputhrottle/cpu_throttling.go
@@ -1,0 +1,159 @@
+/*
+Copyright 2026 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cputhrottle
+
+import (
+	"fmt"
+	"os"
+	"path"
+	"strconv"
+	"sync"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/klog/v2"
+
+	"volcano.sh/volcano/pkg/agent/config/api"
+	"volcano.sh/volcano/pkg/agent/events/framework"
+	"volcano.sh/volcano/pkg/agent/events/handlers"
+	"volcano.sh/volcano/pkg/agent/events/handlers/base"
+	"volcano.sh/volcano/pkg/agent/features"
+	"volcano.sh/volcano/pkg/agent/utils"
+	"volcano.sh/volcano/pkg/agent/utils/cgroup"
+	"volcano.sh/volcano/pkg/config"
+	"volcano.sh/volcano/pkg/metriccollect"
+)
+
+const (
+	unlimitedQuota = -1
+	CPUPeriod      = 100000
+)
+
+func init() {
+	handlers.RegisterEventHandleFunc(string(framework.NodeCPUThrottleEventName), NewCPUThrottleHandler)
+}
+
+type CPUThrottleHandler struct {
+	*base.BaseHandle
+	cgroupMgr cgroup.CgroupManager
+
+	// Record Pod throttled status
+	mutex sync.Mutex
+}
+
+func NewCPUThrottleHandler(config *config.Configuration, mgr *metriccollect.MetricCollectorManager,
+	cgroupMgr cgroup.CgroupManager) framework.Handle {
+	return &CPUThrottleHandler{
+		BaseHandle: &base.BaseHandle{
+			Name:   string(features.CPUThrottleFeature),
+			Config: config,
+		},
+		cgroupMgr: cgroupMgr,
+	}
+}
+
+func (h *CPUThrottleHandler) Handle(event interface{}) error {
+	cpuEvent, ok := event.(framework.NodeCPUThrottleEvent)
+	if !ok {
+		return fmt.Errorf("invalid event type for CPU Throttle handler")
+	}
+
+	if cpuEvent.Resource != v1.ResourceCPU {
+		return nil
+	}
+
+	quota := h.quotaFromMilliCPU(cpuEvent.CPUQuotaMilli)
+
+	klog.InfoS("Handling CPU throttling event",
+		"cpuQuotaMilli", cpuEvent.CPUQuotaMilli,
+		"quota", quota)
+
+	return h.applyBEQuota(quota)
+}
+
+func (h *CPUThrottleHandler) applyBEQuota(quota int64) error {
+	h.mutex.Lock()
+	defer h.mutex.Unlock()
+
+	filePath, err := h.writeBEQuota(quota)
+	if err != nil {
+		if os.IsNotExist(err) {
+			klog.InfoS("Cgroup file not existed", "cgroupFile", filePath)
+		}
+		return fmt.Errorf("failed to apply BE root cpu quota: %w", err)
+	}
+
+	klog.InfoS("Applied BE root CPU quota", "quota", quota, "cgroupFile", filePath)
+	return nil
+}
+
+func (h *CPUThrottleHandler) quotaFromMilliCPU(milliCPU int64) int64 {
+	if milliCPU < 0 {
+		return -1
+	}
+
+	return milliCPU * CPUPeriod / 1000
+}
+
+func (h *CPUThrottleHandler) writeBEQuota(quota int64) (string, error) {
+	cgroupPath, err := h.cgroupMgr.GetQoSCgroupPath(v1.PodQOSBestEffort, cgroup.CgroupCpuSubsystem)
+	if err != nil {
+		return "", err
+	}
+
+	quotaFile := cgroup.CPUQuotaTotalFile
+	if quota != unlimitedQuota && quota < cgroup.CPUQuotaMin {
+		quota = cgroup.CPUQuotaMin
+	}
+	quotaValue := strconv.FormatInt(quota, 10)
+	if h.cgroupMgr.GetCgroupVersion() == cgroup.CgroupV2 {
+		quotaFile = cgroup.CPUQuotaTotalFileV2
+		if quota == unlimitedQuota {
+			quotaValue = "max"
+		} else {
+			quotaValue = fmt.Sprintf("%d %d", quota, CPUPeriod)
+		}
+	}
+
+	filePath := path.Join(cgroupPath, quotaFile)
+	if err := utils.UpdateFile(filePath, []byte(quotaValue)); err != nil {
+		return filePath, err
+	}
+
+	return filePath, nil
+}
+
+func (h *CPUThrottleHandler) RefreshCfg(cfg *api.ColocationConfig) error {
+	if err := h.BaseHandle.RefreshCfg(cfg); err != nil {
+		return err
+	}
+
+	h.mutex.Lock()
+	defer h.mutex.Unlock()
+
+	if !h.Active {
+		klog.InfoS("CPU throttle feature disabled, recovering all throttled pods")
+		filePath, err := h.writeBEQuota(unlimitedQuota)
+		if err != nil {
+			if os.IsNotExist(err) {
+				klog.InfoS("Cgroup file not existed", "cgroupFile", filePath)
+			}
+			return fmt.Errorf("failed to apply BE root cpu quota: %w", err)
+		}
+		klog.InfoS("Recovered all throttled pods")
+	}
+	return nil
+}

--- a/pkg/agent/events/probes/registry.go
+++ b/pkg/agent/events/probes/registry.go
@@ -19,8 +19,6 @@ package probes
 import (
 	"sync"
 
-	"k8s.io/client-go/util/workqueue"
-
 	"volcano.sh/volcano/pkg/agent/events/framework"
 	"volcano.sh/volcano/pkg/config"
 	"volcano.sh/volcano/pkg/metriccollect"
@@ -29,7 +27,7 @@ import (
 var probeFuncs = map[string][]NewEventProbeFunc{}
 var mutex sync.Mutex
 
-type NewEventProbeFunc = func(config *config.Configuration, mgr *metriccollect.MetricCollectorManager, queue workqueue.RateLimitingInterface) framework.Probe
+type NewEventProbeFunc = func(config *config.Configuration, mgr *metriccollect.MetricCollectorManager, eventQueueFactory *framework.EventQueueFactory) framework.Probe
 
 func RegisterEventProbeFunc(eventName string, f NewEventProbeFunc) {
 	mutex.Lock()

--- a/pkg/agent/features/feature.go
+++ b/pkg/agent/features/feature.go
@@ -26,4 +26,5 @@ const (
 	OverSubscriptionFeature Feature = "OverSubscription"
 	EvictionFeature         Feature = "Eviction"
 	ResourcesFeature        Feature = "Resources"
+	CPUThrottleFeature      Feature = "CPUThrottle"
 )

--- a/pkg/agent/features/feature_gate.go
+++ b/pkg/agent/features/feature_gate.go
@@ -85,6 +85,11 @@ func (f *featureGate) Enabled(key Feature, c *api.ColocationConfig) (bool, error
 	case EvictionFeature, ResourcesFeature:
 		// Always return true because eviction manager need take care of all nodes.
 		return true, nil
+	case CPUThrottleFeature:
+		if c.CPUThrottlingConfig == nil || c.CPUThrottlingConfig.Enable == nil {
+			return false, fmt.Errorf("nil cpuThrottling config")
+		}
+		return nodeOverSubscriptionEnabled && *c.CPUThrottlingConfig.Enable, nil
 	default:
 		return false, fmt.Errorf("unsupported feature %s", string(key))
 	}

--- a/pkg/agent/oversubscription/policy/extend/extend.go
+++ b/pkg/agent/oversubscription/policy/extend/extend.go
@@ -126,7 +126,7 @@ func (e *extendResource) CalOverSubscriptionResources() {
 	}
 
 	includeGuaranteedPods := utilpod.IncludeGuaranteedPods()
-	currentUsage := e.usageGetter.UsagesByValue(includeGuaranteedPods)
+	currentUsage := e.usageGetter.UsagesByValue(includeGuaranteedPods, true)
 	overSubscriptionRes := make(apis.Resource)
 
 	for _, resType := range apis.OverSubscriptionResourceTypes {

--- a/pkg/agent/utils/cgroup/cgroup.go
+++ b/pkg/agent/utils/cgroup/cgroup.go
@@ -74,6 +74,7 @@ const (
 	CPUQuotaBurstFileV2 string = "cpu.max.burst"
 	CPUQuotaTotalFileV2 string = "cpu.max"
 	CPUIdleFileV2       string = "cpu.idle"
+	CPUQuotaMin         int64  = 1000
 
 	MemoryUsageFileV2 string = "memory.stat"
 	MemoryHighFileV2  string = "memory.high"

--- a/pkg/metriccollect/local/local_collector.go
+++ b/pkg/metriccollect/local/local_collector.go
@@ -35,6 +35,7 @@ type LocalMetricInfo struct {
 	ResourceType          string
 	IncludeGuaranteedPods bool
 	IncludeSystemUsed     bool
+	IncludeBestEffortPods bool
 }
 
 type SubCollector interface {

--- a/pkg/resourceusage/fake_resource_usage_getter.go
+++ b/pkg/resourceusage/fake_resource_usage_getter.go
@@ -34,7 +34,7 @@ func NewFakeResourceGetter(cpuUsageByValue, memoryUsageByValue, cpuUsageByPercen
 	}
 }
 
-func (f *fakeResourceGetter) UsagesByValue(_ bool) Resource {
+func (f *fakeResourceGetter) UsagesByValue(_ bool, _ bool) Resource {
 	return map[v1.ResourceName]int64{
 		v1.ResourceCPU:    f.cpuUsageByValue,
 		v1.ResourceMemory: f.memoryUsageByValue,

--- a/pkg/resourceusage/resource_usage_getter_test.go
+++ b/pkg/resourceusage/resource_usage_getter_test.go
@@ -39,11 +39,13 @@ func Test_getter_UsagesByValue(t *testing.T) {
 		name                  string
 		collector             *metriccollect.MetricCollectorManager
 		includeGuaranteedPods bool
+		includeBestEffortPods bool
 		want                  Resource
 	}{
 		{
 			name:                  "include guaranteed pods",
 			includeGuaranteedPods: true,
+			includeBestEffortPods: true,
 			collector:             collector,
 			want: map[v1.ResourceName]int64{
 				v1.ResourceCPU:    int64(1000),
@@ -53,6 +55,17 @@ func Test_getter_UsagesByValue(t *testing.T) {
 		{
 			name:                  "not include guaranteed pods",
 			includeGuaranteedPods: false,
+			includeBestEffortPods: true,
+			collector:             collector,
+			want: map[v1.ResourceName]int64{
+				v1.ResourceCPU:    int64(1000),
+				v1.ResourceMemory: int64(2000),
+			},
+		},
+		{
+			name:                  "not include best effort pods",
+			includeGuaranteedPods: true,
+			includeBestEffortPods: false,
 			collector:             collector,
 			want: map[v1.ResourceName]int64{
 				v1.ResourceCPU:    int64(1000),
@@ -67,7 +80,7 @@ func Test_getter_UsagesByValue(t *testing.T) {
 				collectorName: fakecollector.CollectorName,
 				collector:     tt.collector,
 			}
-			if got := g.UsagesByValue(tt.includeGuaranteedPods); !reflect.DeepEqual(got, tt.want) {
+			if got := g.UsagesByValue(tt.includeGuaranteedPods, tt.includeBestEffortPods); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("UsagesByValue() = %v, want %v", got, tt.want)
 			}
 		})


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
This PR introduces a CPU Throttle feature to Volcano Agent that dynamically limit CPU usage of BestEffort Pods.

The probe calculates a BestEffort CPU quota budget from node allocatable CPU and online Pod requests, emits throttle events when the quota changes beyond a jitter threshold, and the handler applies the updated quota to the BE root cgroup.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Notice that do not add `Fixes` if the issue is associated with multiple PRs.
-->
Fixes #4468

#### Special notes for your reviewer:
This PR includes unit tests for both cpu throttle handler and monitor, and the tests have passed.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
Operators can configure cpuThrottlingConfig with cpuThrottlingThreshold and cpuJitterLimitPercent to control BE CPU throttling behavior.
```