### PR TITLE
revert(cache): podInformer sync change

### DIFF
--- a/pkg/scheduler/cache/event_handlers.go
+++ b/pkg/scheduler/cache/event_handlers.go
@@ -264,7 +264,7 @@ func (sc *SchedulerCache) addPod(pod *v1.Pod) error {
 }
 
 func (sc *SchedulerCache) syncTask(oldTask *schedulingapi.TaskInfo) error {
-	newPod, err := sc.podInformer.Lister().Pods(oldTask.Namespace).Get(oldTask.Name)
+	newPod, err := sc.kubeClient.CoreV1().Pods(oldTask.Namespace).Get(context.TODO(), oldTask.Name, metav1.GetOptions{})
 	if err != nil {
 		if errors.IsNotFound(err) {
 			sc.Mutex.Lock()


### PR DESCRIPTION
In https://github.com/volcano-sh/volcano/pull/4938 we changed the syncTask communication to use the podInformer. It looks like we can't do this as dra tests starting to fail. This means that our current way of the syncTask cache handling needs be rethought, or our eventHandlers on the podInformer are not good enough and our podInformer cache is not working properly.
Let's track this problem in https://github.com/volcano-sh/volcano/issues/4946 and figure out the reason why this is happening, and revert this part of the change now.

#### What type of PR is this?
/kind bug
/kind failing-test

#### What this PR does / why we need it:
The commit reverts the direct API call -> podInformer call change in https://github.com/volcano-sh/volcano/pull/4938  so the DRA test can pass again.

The failing test was _single node supports sharing concurrently_:
Action Run:
https://github.com/volcano-sh/volcano/actions/runs/20941605477/job/60176132151
Plain logs:
[link](https://productionresultssa8.blob.core.windows.net/actions-results/4f4829bf-25f9-4a3b-8cfc-ff974add5afc/workflow-job-run-4d17fd34-a892-510c-8e22-b071a8c3eecf/logs/job/job-logs.txt?rsct=text%2Fplain&se=2026-01-13T08%3A45%3A14Z&sig=aSAp3DWJDPzPpf2o8D1y14o5ke0mPhmuCHDzgMN1YOY%3D&ske=2026-01-13T17%3A46%3A43Z&skoid=ca7593d4-ee42-46cd-af88-8b886a2f84eb&sks=b&skt=2026-01-13T05%3A46%3A43Z&sktid=398a6654-997b-47e9-b12b-9515b896b4de&skv=2025-11-05&sp=r&spr=https&sr=b&st=2026-01-13T08%3A35%3A09Z&sv=2025-11-05).

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Notice that do not add `Fixes` if the issue is associated with multiple PRs.
-->
Fixes #4946
