### PR TITLE
feat: support inheriting pod annotations and labels when creating PodGroup

### DIFF
--- a/cmd/controller-manager/app/options/options.go
+++ b/cmd/controller-manager/app/options/options.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/component-base/config"
 	componentbaseconfigvalidation "k8s.io/component-base/config/validation"
 
+	podgroup "volcano.sh/volcano/pkg/controllers/podgroup/options"
 	"volcano.sh/volcano/pkg/kube"
 )
 
@@ -77,8 +78,10 @@ type ServerOption struct {
 	EnableHealthz      bool
 	EnableMetrics      bool
 	ListenAddress      string
-	// To determine whether inherit owner's annotations for pods when create podgroup
-	InheritOwnerAnnotations bool
+
+	// PodGroupOptions holds podgroup controller specific options.
+	PodGroupOptions podgroup.Options
+
 	// WorkerThreadsForPG is the number of threads syncing podgroup operations
 	// The larger the number, the faster the podgroup processing, but requires more CPU load.
 	WorkerThreadsForPG uint32
@@ -127,12 +130,15 @@ func (s *ServerOption) AddFlags(fs *pflag.FlagSet, knownControllers []string) {
 	fs.BoolVar(&s.EnableHealthz, "enable-healthz", false, "Enable the health check; it is false by default")
 	fs.BoolVar(&s.EnableMetrics, "enable-metrics", false, "Enable the metrics function; it is false by default")
 	fs.StringVar(&s.ListenAddress, "listen-address", defaultListenAddress, "The address to listen on for HTTP requests.")
-	fs.BoolVar(&s.InheritOwnerAnnotations, "inherit-owner-annotations", true, "Enable inherit owner annotations for pods when create podgroup; it is enabled by default")
+
 	fs.Uint32Var(&s.WorkerThreadsForPG, "worker-threads-for-podgroup", defaultPodGroupWorkers, "The number of threads syncing podgroup operations. The larger the number, the faster the podgroup processing, but requires more CPU load.")
 	fs.Uint32Var(&s.WorkerThreadsForGC, "worker-threads-for-gc", defaultGCWorkers, "The number of threads for recycling jobs. The larger the number, the faster the job recycling, but requires more CPU load.")
 	fs.Uint32Var(&s.WorkerThreadsForQueue, "worker-threads-for-queue", defaultQueueWorkers, "The number of threads syncing queue operations. The larger the number, the faster the queue processing, but requires more CPU load.")
 	fs.StringSliceVar(&s.Controllers, "controllers", strings.Split(defaultControllers, ","), fmt.Sprintf("Specify controller gates. Use '*' for all controllers, all knownController: %s ,and we can use "+
 		"'-' to disable controllers, e.g. \"-job-controller,-queue-controller\" to disable job and queue controllers.", knownControllers))
+
+	// PodGroup controller flags (inherit annotations/labels behavior) are defined and maintained in pkg/controllers/podgroup/options.
+	podgroup.AddFlags(fs, &s.PodGroupOptions)
 }
 
 // CheckOptionOrDie checks all options and returns all errors if they are invalid.

--- a/cmd/controller-manager/app/options/options_test.go
+++ b/cmd/controller-manager/app/options/options_test.go
@@ -39,6 +39,7 @@ import (
 	_ "volcano.sh/volcano/pkg/controllers/jobflow"
 	_ "volcano.sh/volcano/pkg/controllers/jobtemplate"
 	_ "volcano.sh/volcano/pkg/controllers/podgroup"
+	podgroup "volcano.sh/volcano/pkg/controllers/podgroup/options"
 	_ "volcano.sh/volcano/pkg/controllers/queue"
 	"volcano.sh/volcano/pkg/features"
 	"volcano.sh/volcano/pkg/kube"
@@ -74,6 +75,12 @@ func TestAddFlags(t *testing.T) {
 		"--leader-elect-renew-deadline=20s",
 		"--leader-elect-retry-period=10s",
 		"--feature-gates=ResourceTopology=false",
+		"--inherit-owner-annotation-prefixes=volcano.sh/",
+		"--inherit-owner-annotation-prefixes=test.group.annotation/",
+		"--inherit-owner-label-prefixes=test.group.label/",
+		"--inherit-pod-annotation-prefixes=volcano.sh/",
+		"--inherit-pod-annotation-prefixes=test.group.annotation/",
+		"--inherit-pod-label-prefixes=test.group.label/",
 	}
 	fs.Parse(args)
 
@@ -92,7 +99,27 @@ func TestAddFlags(t *testing.T) {
 		MaxRequeueNum:           defaultMaxRequeueNum,
 		HealthzBindAddress:      ":11251",
 		ListenAddress:           defaultListenAddress,
-		InheritOwnerAnnotations: true,
+
+		PodGroupOptions: podgroup.Options{
+			InheritOwnerAnnotations: true,
+			InheritOwnerLabels:      false,
+			InheritPodAnnotations:   true,
+			InheritPodLabels:        true,
+			InheritOwnerAnnotationPrefixes: []string{
+				"volcano.sh/",
+				"test.group.annotation/",
+			},
+			InheritOwnerLabelPrefixes: []string{
+				"test.group.label/",
+			},
+			InheritPodAnnotationPrefixes: []string{
+				"volcano.sh/",
+				"test.group.annotation/",
+			},
+			InheritPodLabelPrefixes: []string{
+				"test.group.label/",
+			},
+		},
 		LeaderElection: config.LeaderElectionConfiguration{
 			LeaderElect:       true,
 			LeaseDuration:     metav1.Duration{Duration: 60 * time.Second},

--- a/cmd/controller-manager/app/server.go
+++ b/cmd/controller-manager/app/server.go
@@ -144,7 +144,7 @@ func startControllers(config *rest.Config, opt *options.ServerOption) func(ctx c
 	controllerOpt.VolcanoClient = vcclientset.NewForConfigOrDie(config)
 	controllerOpt.SharedInformerFactory = informers.NewSharedInformerFactory(controllerOpt.KubeClient, 0)
 	controllerOpt.VCSharedInformerFactory = informerfactory.NewSharedInformerFactory(controllerOpt.VolcanoClient, 0)
-	controllerOpt.InheritOwnerAnnotations = opt.InheritOwnerAnnotations
+	controllerOpt.PodGroupControllerOptions = opt.PodGroupOptions
 	controllerOpt.WorkerThreadsForPG = opt.WorkerThreadsForPG
 	controllerOpt.WorkerThreadsForQueue = opt.WorkerThreadsForQueue
 	controllerOpt.WorkerThreadsForGC = opt.WorkerThreadsForGC

--- a/pkg/controllers/framework/interface.go
+++ b/pkg/controllers/framework/interface.go
@@ -23,6 +23,8 @@ import (
 
 	vcclientset "volcano.sh/apis/pkg/client/clientset/versioned"
 	vcinformer "volcano.sh/apis/pkg/client/informers/externalversions"
+
+	podgroup "volcano.sh/volcano/pkg/controllers/podgroup/options"
 )
 
 // ControllerOption is the main context object for the controllers.
@@ -36,10 +38,11 @@ type ControllerOption struct {
 	CronJobWorkerNum        uint32
 	MaxRequeueNum           int
 
-	InheritOwnerAnnotations bool
-	WorkerThreadsForPG      uint32
-	WorkerThreadsForQueue   uint32
-	WorkerThreadsForGC      uint32
+	PodGroupControllerOptions podgroup.Options
+
+	WorkerThreadsForPG    uint32
+	WorkerThreadsForQueue uint32
+	WorkerThreadsForGC    uint32
 
 	// Config holds the common attributes that can be passed to a Kubernetes client
 	// and controllers registered by the users can use it.

--- a/pkg/controllers/podgroup/options/options.go
+++ b/pkg/controllers/podgroup/options/options.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2026 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package options
+
+import (
+	"github.com/spf13/pflag"
+
+	scheduling "volcano.sh/apis/pkg/apis/scheduling/v1beta1"
+)
+
+// Options holds configuration for podgroup controller inherit behavior.
+type Options struct {
+	// InheritOwnerAnnotations enables inheriting owner's annotations for pods when creating podgroup.
+	InheritOwnerAnnotations bool
+	// InheritOwnerAnnotationPrefixes defines owner's annotation prefixes to inherit to PodGroup.
+	InheritOwnerAnnotationPrefixes []string
+
+	// InheritPodAnnotations enables inheriting pod annotations when creating podgroup.
+	InheritPodAnnotations bool
+	// InheritPodAnnotationPrefixes defines pod's annotation prefixes to inherit to PodGroup.
+	InheritPodAnnotationPrefixes []string
+
+	// InheritOwnerLabels enables inheriting owner's labels when creating podgroup.
+	InheritOwnerLabels bool
+	// InheritOwnerLabelPrefixes defines owner's label prefixes to inherit to PodGroup.
+	InheritOwnerLabelPrefixes []string
+
+	// InheritPodLabels enables inheriting pod labels when creating podgroup.
+	InheritPodLabels bool
+	// InheritPodLabelPrefixes defines pod's label prefixes to inherit to PodGroup.
+	InheritPodLabelPrefixes []string
+}
+
+// AddFlags adds podgroup controller flags to the specified FlagSet.
+func AddFlags(fs *pflag.FlagSet, o *Options) {
+	fs.BoolVar(&o.InheritOwnerAnnotations, "inherit-owner-annotations", true, "Enable inherit owner annotations for pods when create podgroup; it is enabled by default")
+	fs.StringArrayVar(&o.InheritOwnerAnnotationPrefixes, "inherit-owner-annotation-prefixes", []string{"volcano.sh/"}, "Owner's annotations prefixes which will be inherited to PodGroup; by default, with 'volcano.sh/' prefix will be inherited to PodGroup")
+	fs.BoolVar(&o.InheritOwnerLabels, "inherit-owner-labels", false, "Enable inherit labels of owner when create podgroup; it is disabled by default")
+	fs.StringArrayVar(&o.InheritOwnerLabelPrefixes, "inherit-owner-label-prefixes", []string{"volcano.sh/"}, "Owner's labels prefixes which will be inherited to PodGroup; by default, with 'volcano.sh/' prefix will be inherited to PodGroup")
+
+	fs.BoolVar(&o.InheritPodAnnotations, "inherit-pod-annotations", true, "Enable inherit annotations of pods when create podgroup; it is enabled by default")
+	fs.StringArrayVar(&o.InheritPodAnnotationPrefixes, "inherit-pod-annotation-prefixes", []string{scheduling.PodPreemptable, scheduling.CooldownTime, scheduling.RevocableZone, scheduling.JDBMinAvailable, scheduling.JDBMaxUnavailable}, "Pod's annotation prefixes which will be inherited to PodGroup; by default, selected volcano.sh/* annotation keys (e.g. pod-preemptable, cooldown-time, revocable-zone, jdb-min-available, jdb-max-unavailable) are inherited")
+	fs.BoolVar(&o.InheritPodLabels, "inherit-pod-labels", true, "Enable inherit labels of pods when create podgroup; it is enabled by default")
+	fs.StringArrayVar(&o.InheritPodLabelPrefixes, "inherit-pod-label-prefixes", []string{scheduling.PodPreemptable, scheduling.CooldownTime}, "Pod's label prefixes which will be inherited to PodGroup; by default, selected volcano.sh/* label keys (e.g. pod-preemptable, cooldown-time) are inherited")
+}

--- a/pkg/controllers/podgroup/pg_controller.go
+++ b/pkg/controllers/podgroup/pg_controller.go
@@ -36,6 +36,7 @@ import (
 	schedulinginformer "volcano.sh/apis/pkg/client/informers/externalversions/scheduling/v1beta1"
 	schedulinglister "volcano.sh/apis/pkg/client/listers/scheduling/v1beta1"
 	"volcano.sh/volcano/pkg/controllers/framework"
+	"volcano.sh/volcano/pkg/controllers/podgroup/options"
 	"volcano.sh/volcano/pkg/features"
 )
 
@@ -67,8 +68,7 @@ type pgcontroller struct {
 	schedulerNames []string
 	workers        uint32
 
-	// To determine whether inherit owner's annotations for pods when create podgroup
-	inheritOwnerAnnotations bool
+	options.Options
 }
 
 func (pg *pgcontroller) Name() string {
@@ -85,7 +85,10 @@ func (pg *pgcontroller) Initialize(opt *framework.ControllerOption) error {
 
 	pg.schedulerNames = make([]string, len(opt.SchedulerNames))
 	copy(pg.schedulerNames, opt.SchedulerNames)
-	pg.inheritOwnerAnnotations = opt.InheritOwnerAnnotations
+
+	pg.Options = opt.PodGroupControllerOptions
+
+	klog.Infof("Podgroup Controller Options %+v", pg.Options)
 
 	pg.informerFactory = opt.SharedInformerFactory
 	pg.podInformer = opt.SharedInformerFactory.Core().V1().Pods()


### PR DESCRIPTION

#### What type of PR is this?

/kind feature


#### What this PR does / why we need it:

This PR enhances the behavior of **pg-controller** when creating a PodGroup for a Pod.

Previously, pg-controller only inherited annotations from the Pod’s owner (e.g. Job, Deployment).
With this change, pg-controller can additionally:

* Inherit **annotations and labels directly from the Pod itself**
* Support **fine-grained configuration** to explicitly specify **which annotations and labels should be inherited**

This makes PodGroup metadata propagation more flexible and controllable, which is especially useful for:

* Scheduling-related annotations/labels
* User-defined metadata that should not be placed on the owner object
* Avoiding over-inheriting unnecessary fields


#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Notice that do not add `Fixes` if the issue is associated with multiple PRs.
-->

Fixes # https://github.com/volcano-sh/volcano/issues/4953


#### Special notes for your reviewer:

* This change is **backward-compatible**: existing behavior of inheriting annotations from the Pod owner remains unchanged by default.
* Inheritance from Pod annotations/labels is **opt-in** and configurable.
* Please pay special attention to:

  * The inheritance filtering logic
  * Precedence rules between owner metadata and Pod metadata (if applicable)
  * Any potential impact on existing PodGroup creation flows


#### Does this PR introduce a user-facing change?

```release-note
pg-controller now supports inheriting annotations and labels from the Pod itself when creating a PodGroup, with the ability to explicitly configure which fields are propagated.
```

