### PR TITLE
enhancement(mpi): relax validation to support single-master MPI jobs

### DIFF
--- a/pkg/webhooks/admission/jobs/validate/admit_job.go
+++ b/pkg/webhooks/admission/jobs/validate/admit_job.go
@@ -133,14 +133,9 @@ func validateJobCreate(job *v1alpha1.Job, reviewResponse *admissionv1.AdmissionR
 	if _, ok := job.Spec.Plugins[controllerMpi.MPIPluginName]; ok {
 		mp := controllerMpi.NewInstance(job.Spec.Plugins[controllerMpi.MPIPluginName])
 		masterIndex := jobhelpers.GetTaskIndexUnderJob(mp.GetMasterName(), job)
-		workerIndex := jobhelpers.GetTaskIndexUnderJob(mp.GetWorkerName(), job)
 		if masterIndex == -1 {
 			reviewResponse.Allowed = false
 			return "The specified mpi master task was not found"
-		}
-		if workerIndex == -1 {
-			reviewResponse.Allowed = false
-			return "The specified mpi worker task was not found"
 		}
 	}
 


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This PR removes the validation requirement that enforces MPI jobs to define worker replicas.

In practice, MPI jobs can be valid with only a master replica, such as single-node or standalone MPI workloads.
Several customer scenarios rely on this behavior.

Previously, users had to remove the MPI plugin entirely to bypass this validation, which significantly increases the operational and usability cost.

By relaxing this validation:

* MPI jobs with only a master replica are supported
* Existing multi-worker MPI jobs continue to work as before
* User experience and flexibility are improved without breaking compatibility


#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Notice that do not add `Fixes` if the issue is associated with multiple PRs.
-->

Fixes https://github.com/volcano-sh/volcano/issues/4955

#### Special notes for your reviewer:

* This change only affects **validation logic**
* No changes are made to MPI runtime behavior
* Backward-compatible for existing MPI workloads with worker replicas
* Please verify that other plugins or scheduling assumptions do not rely on the presence of workers


#### Does this PR introduce a user-facing change?

```release-note
MPI jobs can now be submitted with only a master replica. Worker replicas are no longer mandatory.
```
