### PR TITLE
feat(metrics): Optimize the metrics to monitor task operation performance/e2e task scheduling latecy

### DIFF
--- a/docs/design/metrics.md
+++ b/docs/design/metrics.md
@@ -21,7 +21,7 @@ This metrics track execution of plugins and actions of volcano loop.
 | `e2e_job_scheduling_start_time`           | Gauge           | `job_name`=&lt;job_name&gt;, `queue`=&lt;queue&gt;, `job_namespace`=&lt;job_namespace&gt; | End-to-end job scheduling start time                                           |
 | `plugin_scheduling_latency_milliseconds`  | Histogram       | `plugin`=&lt;plugin_name&gt;, `OnSession`=&lt;OnSession&gt;                               | Plugin scheduling latency in milliseconds                                      |
 | `action_scheduling_latency_milliseconds`  | Histogram       | `action`=&lt;action_name&gt;                                                              | Action scheduling latency in milliseconds                                      |
-| `task_scheduling_latency_milliseconds`    | Histogram       | None                                                                                      | Task scheduling latency in milliseconds                                        |
+| `task_scheduling_latency_milliseconds`    | Histogram       | None                                                                                      | Task scheduling latency in milliseconds (task create to task bound to a node)  |
 
 
 ### volcano operations
@@ -61,6 +61,17 @@ This metrics describe internal state of volcano.
 | `job_retry_counts`                     | Counter         | `job_id`=&lt;job_id&gt;                                           | The number of retry counts for one job        |
 | `job_completed_phase_count`            | Counter         | `job_name`=&lt;job_name&gt; `queue_name`=&lt;queue_name&gt;       | The number of job completed phase             |
 | `job_failed_phase_count`               | Counter         | `job_name`=&lt;job_name&gt; `queue_name`=&lt;queue_name&gt;       | The number of job failed phase                |
+| `task_pending_count`                   | Gauge           | None                                                              | The number of pending task in scheduler       |
+| `task_allocated_count`                 | Gauge           | None                                                              | The number of allocated task in scheduler     |
+| `task_pipelined_count`                 | Gauge           | None                                                              | The number of pipelined task in scheduler     |
+| `task_binding_count`                   | Gauge           | None                                                              | The number of binding task in scheduler       |
+| `task_bound_count`                     | Gauge           | None                                                              | The number of bound task in scheduler         |
+| `task_running_count`                   | Gauge           | None                                                              | The number of running task in scheduler       |
+| `task_releasing_count`                 | Gauge           | None                                                              | The number of releasing task in scheduler     |
+| `task_succeeded_count`                 | Gauge           | None                                                              | The number of succeeded task in scheduler     |
+| `task_failed_count`                    | Gauge           | None                                                              | The number of failed task in scheduler        |
+| `task_unknown_count`                   | Gauge           | None                                                              | The number of unknown task in scheduler       |
+| `task_operation_latency_milliseconds`  | Histogram       | `operation`=&lt;operation_name&gt; `result`=&lt;result&gt;        | Task task operation latency in milliseconds   |
 
 ### volcano Liveness
 Healthcheck last time of volcano activity and timeout

--- a/pkg/agentscheduler/cache/binder.go
+++ b/pkg/agentscheduler/cache/binder.go
@@ -24,7 +24,6 @@ import (
 
 	agentapi "volcano.sh/volcano/pkg/agentscheduler/api"
 	"volcano.sh/volcano/pkg/scheduler/api"
-	"volcano.sh/volcano/pkg/scheduler/metrics"
 	k8sschedulingqueue "volcano.sh/volcano/third_party/kubernetes/pkg/scheduler/backend/queue"
 )
 
@@ -118,7 +117,6 @@ func (binder *ConflictAwareBinder) CheckAndBindPod(scheduleResult *agentapi.PodS
 	binder.recordsMutex.Lock()
 	defer binder.recordsMutex.Unlock()
 	binder.nodeBindRecords[node.Name] = nodeBindGeneration
-	metrics.UpdateTaskScheduleDuration(metrics.Duration(task.Pod.CreationTimestamp.Time))
 }
 
 // FindNonConflictingNode return node if version of candidate node is newer than the version of node used in last bind

--- a/pkg/scheduler/api/types.go
+++ b/pkg/scheduler/api/types.go
@@ -67,6 +67,21 @@ const (
 	Unknown
 )
 
+func AllTaskStatus() []TaskStatus {
+	return []TaskStatus{
+		Pending,
+		Allocated,
+		Pipelined,
+		Binding,
+		Bound,
+		Running,
+		Releasing,
+		Succeeded,
+		Failed,
+		Unknown,
+	}
+}
+
 func (ts TaskStatus) String() string {
 	switch ts {
 	case Pending:

--- a/pkg/scheduler/framework/session.go
+++ b/pkg/scheduler/framework/session.go
@@ -52,7 +52,6 @@ import (
 	"volcano.sh/volcano/pkg/scheduler/api"
 	"volcano.sh/volcano/pkg/scheduler/cache"
 	"volcano.sh/volcano/pkg/scheduler/conf"
-	"volcano.sh/volcano/pkg/scheduler/metrics"
 	"volcano.sh/volcano/pkg/scheduler/util"
 )
 
@@ -862,7 +861,6 @@ func (ssn *Session) dispatch(task *api.TaskInfo) error {
 		return fmt.Errorf("failed to find job %s", task.Job)
 	}
 
-	metrics.UpdateTaskScheduleDuration(metrics.Duration(task.Pod.CreationTimestamp.Time))
 	return nil
 }
 

--- a/pkg/scheduler/framework/statement.go
+++ b/pkg/scheduler/framework/statement.go
@@ -25,6 +25,7 @@ package framework
 import (
 	"errors"
 	"fmt"
+	"time"
 
 	"k8s.io/klog/v2"
 
@@ -43,6 +44,19 @@ const (
 	// Allocate op
 	Allocate
 )
+
+func (o Operation) String() string {
+	switch o {
+	case Evict:
+		return "evict"
+	case Pipeline:
+		return "pipeline"
+	case Allocate:
+		return "allocate"
+	default:
+		return "Unknown"
+	}
+}
 
 type operation struct {
 	name   Operation
@@ -349,7 +363,6 @@ func (s *Statement) allocate(task *api.TaskInfo) error {
 		return fmt.Errorf("failed to find job %s", task.Job)
 	}
 
-	metrics.UpdateTaskScheduleDuration(metrics.Duration(task.Pod.CreationTimestamp.Time))
 	return nil
 }
 
@@ -418,23 +431,28 @@ func (s *Statement) Discard() {
 func (s *Statement) Commit() {
 	klog.V(3).Info("Committing operations ...")
 	for _, op := range s.operations {
+		now := time.Now()
 		op.task.ClearLastTxContext()
+		var err error
 		switch op.name {
 		case Evict:
-			err := s.evict(op.task, op.reason)
-			if err != nil {
+			if err = s.evict(op.task, op.reason); err != nil {
 				klog.Errorf("Failed to evict task: %s", err.Error())
 			}
 		case Pipeline:
 			s.pipeline(op.task)
 		case Allocate:
-			err := s.allocate(op.task)
-			if err != nil {
+			if err = s.allocate(op.task); err != nil {
 				if e := s.unallocate(op.task); e != nil {
 					klog.Errorf("Failed to unallocate task <%v/%v>: %v.", op.task.Namespace, op.task.Name, e)
 				}
 				klog.Errorf("Failed to allocate task <%v/%v>: %v.", op.task.Namespace, op.task.Name, err)
 			}
+		}
+		if err != nil {
+			metrics.UpdateTaskOperationErrLatency(op.name.String(), metrics.Duration(now))
+		} else {
+			metrics.UpdateTaskOperationSuccessLatency(op.name.String(), metrics.Duration(now))
 		}
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?
feature
#### What this PR does / why we need it:
 1. Add new metrics task_xx_count to record the task count cached by the scheduler
 2. Add new metrics task_operation_latency_milliseconds to record the cost of task operation
 3. Update task_scheduling_latency_milliseconds to record the real cost from task create to task bound to node

#### Which issue(s) this PR fixes:

Fixes #4930, #4972

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```