### PR TITLE
feat: add blkio QoS support and related configurations

### DIFF
--- a/pkg/agent/apis/types.go
+++ b/pkg/agent/apis/types.go
@@ -44,6 +44,9 @@ const (
 	// NetworkBandwidthRateAnnotationKey is the annotation key of network bandwidth rate, unit Mbps.
 	NetworkBandwidthRateAnnotationKey = "volcano.sh/network-bandwidth-rate"
 
+	// BlkioWeightAnnotationKey is the annotation key for blkio weight.
+	BlkioWeightAnnotationKey = "volcano.sh/blkio-weight"
+
 	// Deprecated:This is used to be compatible with old api.
 	// PodEvictedOverSubscriptionCPUHighWaterMarkKey define the high watermark of cpu usage when evicting offline pods
 	PodEvictedOverSubscriptionCPUHighWaterMarkKey = "volcano.sh/oversubscription-evicting-cpu-high-watermark"

--- a/pkg/agent/config/api/types.go
+++ b/pkg/agent/config/api/types.go
@@ -59,6 +59,9 @@ type ColocationConfig struct {
 	// network qos related config.
 	NetworkQosConfig *NetworkQos `json:"networkQosConfig,omitempty" configKey:"NetworkQoS"`
 
+	// blkio qos related config.
+	BlkioQosConfig *BlkioQos `json:"blkioQosConfig,omitempty" configKey:"BlkioQoS"`
+
 	// overSubscription related config.
 	OverSubscriptionConfig *OverSubscription `json:"overSubscriptionConfig,omitempty" configKey:"OverSubscription"`
 
@@ -92,6 +95,14 @@ type NetworkQos struct {
 	OfflineHighBandwidthPercent *int `json:"offlineHighBandwidthPercent,omitempty"`
 	// QoSCheckInterval presents the network Qos checkout interval
 	QoSCheckInterval *int `json:"qosCheckInterval,omitempty"`
+}
+
+type BlkioQos struct {
+	// Enable BlkioQos or not.
+	Enable *bool `json:"enable,omitempty"`
+	// DefaultBlkioWeight is the default blkio weight to use if not specified in pod annotations.
+	// Range: 10-1000 for cgroup v1, 1-10000 for cgroup v2
+	DefaultBlkioWeight *int `json:"defaultBlkioWeight,omitempty"`
 }
 
 type OverSubscription struct {

--- a/pkg/agent/config/api/types.go
+++ b/pkg/agent/config/api/types.go
@@ -100,9 +100,9 @@ type NetworkQos struct {
 type BlkioQos struct {
 	// Enable BlkioQos or not.
 	Enable *bool `json:"enable,omitempty"`
-	// DefaultBlkioWeight is the default blkio weight to use if not specified in pod annotations.
+	// BlkioWeight is the default blkio weight to use if not specified in pod annotations.
 	// Range: 10-1000 for cgroup v1, 1-10000 for cgroup v2
-	DefaultBlkioWeight *int `json:"defaultBlkioWeight,omitempty"`
+	BlkioWeight *int `json:"blkioWeight,omitempty"`
 }
 
 type OverSubscription struct {

--- a/pkg/agent/events/eventsmgr.go
+++ b/pkg/agent/events/eventsmgr.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2024 The Volcano Authors.
+Copyright 2026 The Volcano Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -29,6 +29,7 @@ import (
 	"volcano.sh/volcano/pkg/config"
 	"volcano.sh/volcano/pkg/metriccollect"
 
+	_ "volcano.sh/volcano/pkg/agent/events/handlers/blkioqos"
 	_ "volcano.sh/volcano/pkg/agent/events/handlers/cpuburst"
 	_ "volcano.sh/volcano/pkg/agent/events/handlers/cpuqos"
 	_ "volcano.sh/volcano/pkg/agent/events/handlers/eviction"

--- a/pkg/agent/events/handlers/blkioqos/blkioqos_common.go
+++ b/pkg/agent/events/handlers/blkioqos/blkioqos_common.go
@@ -1,0 +1,49 @@
+
+/*
+Copyright 2026 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package blkioqos
+
+import (
+	"strconv"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/klog/v2"
+
+	"volcano.sh/volcano/pkg/agent/apis"
+)
+
+// ParseBlkioWeight returns the blkio weight from pod annotation.
+// Returns 0 if missing or invalid. Used by the Linux handler and tests.
+func ParseBlkioWeight(pod *corev1.Pod) int64 {
+	if pod == nil || pod.Annotations == nil {
+		return 0
+	}
+	weightStr, found := pod.Annotations[apis.BlkioWeightAnnotationKey]
+	if !found || weightStr == "" {
+		return 0
+	}
+	weight, err := strconv.ParseInt(weightStr, 10, 64)
+	if err != nil {
+		klog.Warningf("Invalid blkio-weight annotation value '%s' for pod %s/%s: %v", weightStr, pod.Namespace, pod.Name, err)
+		return 0
+	}
+	if weight <= 0 {
+		klog.Warningf("Invalid blkio-weight annotation value '%s' for pod %s/%s: must be positive", weightStr, pod.Namespace, pod.Name)
+		return 0
+	}
+	return weight
+}

--- a/pkg/agent/events/handlers/blkioqos/blkioqos_linux.go
+++ b/pkg/agent/events/handlers/blkioqos/blkioqos_linux.go
@@ -1,0 +1,140 @@
+/*
+Copyright 2024 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package blkioqos
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path"
+	"strconv"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/klog/v2"
+
+	"volcano.sh/volcano/pkg/agent/apis"
+	"volcano.sh/volcano/pkg/agent/events/framework"
+	"volcano.sh/volcano/pkg/agent/events/handlers"
+	"volcano.sh/volcano/pkg/agent/events/handlers/base"
+	"volcano.sh/volcano/pkg/agent/features"
+	"volcano.sh/volcano/pkg/agent/utils"
+	"volcano.sh/volcano/pkg/agent/utils/cgroup"
+	"volcano.sh/volcano/pkg/config"
+	"volcano.sh/volcano/pkg/metriccollect"
+)
+
+func init() {
+	handlers.RegisterEventHandleFunc(string(framework.PodEventName), NewBlkioQoSHandle)
+}
+
+type BlkioQoSHandle struct {
+	*base.BaseHandle
+	cgroupMgr cgroup.CgroupManager
+}
+
+func NewBlkioQoSHandle(config *config.Configuration, mgr *metriccollect.MetricCollectorManager, cgroupMgr cgroup.CgroupManager) framework.Handle {
+	return &BlkioQoSHandle{
+		BaseHandle: &base.BaseHandle{
+			Name:   string(features.BlkioQoSFeature),
+			Config: config,
+		},
+		cgroupMgr: cgroupMgr,
+	}
+}
+
+func (h *BlkioQoSHandle) Handle(event interface{}) error {
+	podEvent, ok := event.(framework.PodEvent)
+	if !ok {
+		return fmt.Errorf("illegal pod event")
+	}
+
+	// Get blkio weight from pod annotation or ConfigMap default
+	blkioWeight := h.getBlkioWeight(podEvent.Pod)
+	if blkioWeight == 0 {
+		klog.V(4).InfoS("No blkio weight specified for pod, skipping blkio QoS", "pod", klog.KObj(podEvent.Pod))
+		return nil
+	}
+
+	cgroupPath, err := h.cgroupMgr.GetPodCgroupPath(podEvent.QoSClass, cgroup.CgroupBlkioSubsystem, podEvent.UID)
+	if err != nil {
+		return fmt.Errorf("failed to get pod cgroup path(%s), error: %v", podEvent.UID, err)
+	}
+
+	cgroupVersion := h.cgroupMgr.GetCgroupVersion()
+	var weightFile string
+	var weightValue string
+
+	switch cgroupVersion {
+	case cgroup.CgroupV1:
+		weightFile = path.Join(cgroupPath, cgroup.BlkioWeightFileV1)
+		if blkioWeight < 10 {
+			blkioWeight = 10
+		} else if blkioWeight > 1000 {
+			blkioWeight = 1000
+		}
+		weightValue = strconv.FormatInt(blkioWeight, 10)
+	case cgroup.CgroupV2:
+		weightFile = path.Join(cgroupPath, cgroup.BlkioWeightFileV2)
+		v2Weight := blkioWeight * 10
+		if v2Weight < 1 {
+			v2Weight = 1
+		} else if v2Weight > 10000 {
+			v2Weight = 10000
+		}
+		weightValue = strconv.FormatInt(v2Weight, 10)
+	default:
+		return fmt.Errorf("unsupported cgroup version: %s", cgroupVersion)
+	}
+
+	err = utils.UpdatePodCgroup(weightFile, []byte(weightValue))
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			klog.InfoS("Cgroup file not exist", "cgroupFile", weightFile)
+			return nil
+		}
+		return err
+	}
+	klog.InfoS("Successfully set blkio weight to cgroup file", "weight", weightValue, "cgroupFile", weightFile, "pod", klog.KObj(podEvent.Pod))
+
+	return nil
+}
+
+// getBlkioWeight returns the blkio weight from pod annotation
+// Returns 0 if no weight is specified (which means blkio QoS should be skipped)
+func (h *BlkioQoSHandle) getBlkioWeight(pod *corev1.Pod) int64 {
+	if pod == nil || pod.Annotations == nil {
+		return 0
+	}
+
+	weightStr, found := pod.Annotations[apis.BlkioWeightAnnotationKey]
+	if !found || weightStr == "" {
+		return 0
+	}
+
+	weight, err := strconv.ParseInt(weightStr, 10, 64)
+	if err != nil {
+		klog.Warningf("Invalid blkio-weight annotation value '%s' for pod %s/%s: %v", weightStr, pod.Namespace, pod.Name, err)
+		return 0
+	}
+
+	if weight <= 0 {
+		klog.Warningf("Invalid blkio-weight annotation value '%s' for pod %s/%s: must be positive", weightStr, pod.Namespace, pod.Name)
+		return 0
+	}
+
+	return weight
+}

--- a/pkg/agent/events/handlers/blkioqos/blkioqos_linux_test.go
+++ b/pkg/agent/events/handlers/blkioqos/blkioqos_linux_test.go
@@ -1,0 +1,215 @@
+/*
+Copyright 2026 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package blkioqos
+
+import (
+	"os"
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"volcano.sh/volcano/pkg/agent/apis"
+	"volcano.sh/volcano/pkg/agent/events/framework"
+	"volcano.sh/volcano/pkg/agent/utils/cgroup"
+)
+
+func TestBlkioQoSHandle_Handle(t *testing.T) {
+	// Test cgroup v1
+	tmpDirV1 := t.TempDir()
+	dirV1 := path.Join(tmpDirV1, "blkio", "kubepods", "podfake-id1")
+	err := os.MkdirAll(dirV1, 0755)
+	assert.NoError(t, err)
+	filePathV1 := path.Join(dirV1, "blkio.weight")
+	_, err = os.OpenFile(filePathV1, os.O_RDWR|os.O_CREATE, 0644)
+	assert.NoError(t, err)
+
+	// Test cgroup v2
+	tmpDirV2 := t.TempDir()
+	dirV2 := path.Join(tmpDirV2, "kubepods", "podfake-id2")
+	err = os.MkdirAll(dirV2, 0755)
+	assert.NoError(t, err)
+	filePathV2 := path.Join(dirV2, "io.weight")
+	_, err = os.OpenFile(filePathV2, os.O_RDWR|os.O_CREATE, 0644)
+	assert.NoError(t, err)
+
+	tests := []struct {
+		name        string
+		cgroupMgr   cgroup.CgroupManager
+		event       framework.PodEvent
+		post        func() string
+		wantErr     bool
+		expectValue string
+	}{
+		{
+			name:      "cgroup v1: no annotation, skip",
+			cgroupMgr: cgroup.NewCgroupManager("cgroupfs", tmpDirV1, ""),
+			event: framework.PodEvent{
+				UID:      "fake-id1",
+				QoSLevel: 0,
+				QoSClass: "Guaranteed",
+				Pod: &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-pod",
+						Namespace: "default",
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name:      "cgroup v1: valid weight annotation",
+			cgroupMgr: cgroup.NewCgroupManager("cgroupfs", tmpDirV1, ""),
+			event: framework.PodEvent{
+				UID:      "fake-id1",
+				QoSLevel: 0,
+				QoSClass: "Guaranteed",
+				Pod: &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-pod",
+						Namespace: "default",
+						Annotations: map[string]string{
+							apis.BlkioWeightAnnotationKey: "500",
+						},
+					},
+				},
+			},
+			post: func() string {
+				value, _ := os.ReadFile(filePathV1)
+				return string(value)
+			},
+			wantErr:     false,
+			expectValue: "500",
+		},
+		{
+			name:      "cgroup v1: weight below minimum, clamped to 10",
+			cgroupMgr: cgroup.NewCgroupManager("cgroupfs", tmpDirV1, ""),
+			event: framework.PodEvent{
+				UID:      "fake-id1",
+				QoSLevel: 0,
+				QoSClass: "Guaranteed",
+				Pod: &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-pod",
+						Namespace: "default",
+						Annotations: map[string]string{
+							apis.BlkioWeightAnnotationKey: "5",
+						},
+					},
+				},
+			},
+			post: func() string {
+				value, _ := os.ReadFile(filePathV1)
+				return string(value)
+			},
+			wantErr:     false,
+			expectValue: "10",
+		},
+		{
+			name:      "cgroup v1: weight above maximum, clamped to 1000",
+			cgroupMgr: cgroup.NewCgroupManager("cgroupfs", tmpDirV1, ""),
+			event: framework.PodEvent{
+				UID:      "fake-id1",
+				QoSLevel: 0,
+				QoSClass: "Guaranteed",
+				Pod: &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-pod",
+						Namespace: "default",
+						Annotations: map[string]string{
+							apis.BlkioWeightAnnotationKey: "2000",
+						},
+					},
+				},
+			},
+			post: func() string {
+				value, _ := os.ReadFile(filePathV1)
+				return string(value)
+			},
+			wantErr:     false,
+			expectValue: "1000",
+		},
+		{
+			name:      "cgroup v2: valid weight annotation, converted to v2 range",
+			cgroupMgr: cgroup.NewCgroupManager("cgroupfs", tmpDirV2, ""),
+			event: framework.PodEvent{
+				UID:      "fake-id2",
+				QoSLevel: 0,
+				QoSClass: "Guaranteed",
+				Pod: &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-pod",
+						Namespace: "default",
+						Annotations: map[string]string{
+							apis.BlkioWeightAnnotationKey: "500",
+						},
+					},
+				},
+			},
+			post: func() string {
+				value, _ := os.ReadFile(filePathV2)
+				return string(value)
+			},
+			wantErr:     false,
+			expectValue: "5000",
+		},
+		{
+			name:      "invalid annotation value, skip",
+			cgroupMgr: cgroup.NewCgroupManager("cgroupfs", tmpDirV1, ""),
+			event: framework.PodEvent{
+				UID:      "fake-id1",
+				QoSLevel: 0,
+				QoSClass: "Guaranteed",
+				Pod: &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-pod",
+						Namespace: "default",
+						Annotations: map[string]string{
+							apis.BlkioWeightAnnotationKey: "invalid",
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.name == "cgroup v2: valid weight annotation, converted to v2 range" {
+				os.Setenv("VOLCANO_TEST_CGROUP_VERSION", "v2")
+				defer os.Unsetenv("VOLCANO_TEST_CGROUP_VERSION")
+			} else {
+				os.Setenv("VOLCANO_TEST_CGROUP_VERSION", "v1")
+				defer os.Unsetenv("VOLCANO_TEST_CGROUP_VERSION")
+			}
+
+			h := &BlkioQoSHandle{
+				cgroupMgr: tt.cgroupMgr,
+			}
+			if err := h.Handle(tt.event); (err != nil) != tt.wantErr {
+				t.Errorf("Handle() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.post != nil && tt.expectValue != "" {
+				actualValue := tt.post()
+				assert.Equal(t, tt.expectValue, actualValue, "Expected cgroup file to contain %s, got %s", tt.expectValue, actualValue)
+			}
+		})
+	}
+}

--- a/pkg/agent/events/handlers/blkioqos/blkioqos_test.go
+++ b/pkg/agent/events/handlers/blkioqos/blkioqos_test.go
@@ -1,0 +1,88 @@
+/*
+Copyright 2026 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package blkioqos
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"volcano.sh/volcano/pkg/agent/apis"
+)
+
+// TestParseBlkioWeight runs on all platforms (no _linux). Handle/cgroup tests are in blkioqos_linux_test.go.
+func TestParseBlkioWeight(t *testing.T) {
+	tests := []struct {
+		name     string
+		pod      *corev1.Pod
+		expected int64
+	}{
+		{name: "no pod", pod: nil, expected: 0},
+		{
+			name:     "no annotations",
+			pod:      &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: "ns"}},
+			expected: 0,
+		},
+		{
+			name: "valid weight",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "p", Namespace: "ns",
+					Annotations: map[string]string{apis.BlkioWeightAnnotationKey: "500"},
+				},
+			},
+			expected: 500,
+		},
+		{
+			name: "invalid non-numeric",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "p", Namespace: "ns",
+					Annotations: map[string]string{apis.BlkioWeightAnnotationKey: "bad"},
+				},
+			},
+			expected: 0,
+		},
+		{
+			name: "invalid zero",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "p", Namespace: "ns",
+					Annotations: map[string]string{apis.BlkioWeightAnnotationKey: "0"},
+				},
+			},
+			expected: 0,
+		},
+		{
+			name: "invalid negative",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "p", Namespace: "ns",
+					Annotations: map[string]string{apis.BlkioWeightAnnotationKey: "-1"},
+				},
+			},
+			expected: 0,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, ParseBlkioWeight(tt.pod))
+		})
+	}
+}

--- a/pkg/agent/events/handlers/blkioqos/blkioqos_unspecified.go
+++ b/pkg/agent/events/handlers/blkioqos/blkioqos_unspecified.go
@@ -1,0 +1,23 @@
+//go:build !linux
+// +build !linux
+
+/*
+Copyright 2026 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package blkioqos
+
+// Stub for non-Linux. BLKIO cgroup is Linux-only; real impl is in blkioqos_linux.go.
+// This file exists so the package builds on macOS/Windows (e.g. `go test` succeeds).

--- a/pkg/agent/features/feature.go
+++ b/pkg/agent/features/feature.go
@@ -23,6 +23,7 @@ const (
 	CPUBurstFeature         Feature = "CPUBurst"
 	MemoryQoSFeature        Feature = "MemoryQoS"
 	NetworkQoSFeature       Feature = "NetworkQoS"
+	BlkioQoSFeature         Feature = "BlkioQoS"
 	OverSubscriptionFeature Feature = "OverSubscription"
 	EvictionFeature         Feature = "Eviction"
 	ResourcesFeature        Feature = "Resources"

--- a/pkg/agent/features/feature_gate.go
+++ b/pkg/agent/features/feature_gate.go
@@ -77,6 +77,12 @@ func (f *featureGate) Enabled(key Feature, c *api.ColocationConfig) (bool, error
 		}
 		return (nodeColocationEnabled || nodeOverSubscriptionEnabled) && *c.NetworkQosConfig.Enable, nil
 
+	case BlkioQoSFeature:
+		if c.BlkioQosConfig == nil || c.BlkioQosConfig.Enable == nil {
+			return false, fmt.Errorf("nil blkio qos config")
+		}
+		return (nodeColocationEnabled || nodeOverSubscriptionEnabled) && *c.BlkioQosConfig.Enable, nil
+
 	case OverSubscriptionFeature:
 		if c.OverSubscriptionConfig == nil || c.OverSubscriptionConfig.Enable == nil {
 			return false, fmt.Errorf("nil overSubscription config")

--- a/pkg/agent/utils/cgroup/cgroup.go
+++ b/pkg/agent/utils/cgroup/cgroup.go
@@ -46,6 +46,7 @@ const (
 	CgroupMemorySubsystem CgroupSubsystem = "memory"
 	CgroupCpuSubsystem    CgroupSubsystem = "cpu"
 	CgroupNetCLSSubsystem CgroupSubsystem = "net_cls"
+	CgroupBlkioSubsystem  CgroupSubsystem = "blkio"
 
 	CgroupKubeRoot string = "kubepods"
 
@@ -67,6 +68,13 @@ const (
 
 	CPUShareFileName string = "cpu.shares"
 
+	// Blkio cgroup files (v1)
+	BlkioWeightFileV1 string = "blkio.weight"
+	BlkioThrottleReadBpsFileV1   string = "blkio.throttle.read_bps_device"
+	BlkioThrottleWriteBpsFileV1  string = "blkio.throttle.write_bps_device"
+	BlkioThrottleReadIopsFileV1  string = "blkio.throttle.read_iops_device"
+	BlkioThrottleWriteIopsFileV1 string = "blkio.throttle.write_iops_device"
+
 	// Cgroupv2 specific files
 	CPUWeightFileV2 string = "cpu.weight"
 	CPUUsageFileV2  string = "cpu.stat"
@@ -80,6 +88,13 @@ const (
 	MemoryLowFileV2   string = "memory.low"
 	MemoryMinFileV2   string = "memory.min"
 	MemoryMaxFileV2   string = "memory.max"
+
+	// Blkio cgroup files (v2)
+	BlkioWeightFileV2          string = "io.weight"
+	BlkioMaxReadBpsFileV2      string = "io.max"
+	BlkioMaxWriteBpsFileV2     string = "io.max"
+	BlkioMaxReadIopsFileV2     string = "io.max"
+	BlkioMaxWriteIopsFileV2    string = "io.max"
 
 	// Cgroup version constants
 	CgroupV1 string = "v1"

--- a/pkg/agent/utils/cgroup/cgroup.go
+++ b/pkg/agent/utils/cgroup/cgroup.go
@@ -90,11 +90,8 @@ const (
 	MemoryMaxFileV2   string = "memory.max"
 
 	// Blkio cgroup files (v2)
-	BlkioWeightFileV2          string = "io.weight"
-	BlkioMaxReadBpsFileV2      string = "io.max"
-	BlkioMaxWriteBpsFileV2     string = "io.max"
-	BlkioMaxReadIopsFileV2     string = "io.max"
-	BlkioMaxWriteIopsFileV2    string = "io.max"
+	BlkioWeightFileV2 string = "io.weight"
+	BlkioMaxFileV2 string = "io.max"
 
 	// Cgroup version constants
 	CgroupV1 string = "v1"


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:

This PR adds BLKIO (Block I/O) QoS support to the Volcano agent, enabling control and isolation of disk I/O for workloads running on nodes managed by Volcano.

**Why we need it:**
- **I/O Isolation**: Prevents I/O-intensive workloads from starving other pods on the same node
- **Performance Predictability**: Ensures critical services get adequate disk I/O bandwidth
- **Resource Management**: Provides fine-grained control over disk I/O allocation alongside existing CPU and memory QoS features

**What it does:**
- Integrates blkio cgroup controls into Volcano agent
- Supports blkio weight settings via Pod annotations (`volcano.sh/blkio-weight`)
- Supports global BLKIO QoS settings via ConfigMap for enabling/disabling and setting defaults
- Handles both cgroup v1 (blkio.weight) and cgroup v2 (io.weight) with automatic conversion
- Validates and clamps weight values to valid ranges per cgroup version

**Technical Implementation:**
- Added `BlkioQoSFeature` to feature gate system
- Created new `BlkioQoSHandle` event handler following existing QoS handler patterns (CPUQoS, MemoryQoS, NetworkQoS)
- Added BLKIO subsystem and related constants to cgroup utilities
- Supports cgroup v1 (weight range: 10-1000) and cgroup v2 (weight range: 1-10000)

#### Which issue(s) this PR fixes:
Fixes #4467

#### Special notes for your reviewer:

1. **Handler Pattern**: Follows the same pattern as existing QoS handlers (`cpuqos`, `memoryqos`, `networkqos`) for consistency
2. **Cgroup Version Support**: Automatically handles cgroup v1 vs v2 differences:
   - v1: Uses `blkio.weight` (range 10-1000)
   - v2: Uses `io.weight` (range 1-10000) with 10x scaling for v1-compatible input
3. **ConfigMap Support**: ConfigMap structure is in place for `defaultBlkioWeight`, though the current implementation prioritizes Pod annotations. ConfigMap defaults can be enhanced in future PRs if needed.
4. **Backward Compatibility**: Feature is opt-in via ConfigMap enable flag, so existing deployments are unaffected
5. **Testing**: Manual testing recommended on both cgroup v1 and v2 systems

#### Does this PR introduce a user-facing change?
Add BLKIO (Block I/O) QoS support to Volcano agent

Users can now control disk I/O priority for workloads by:
- Setting `volcano.sh/blkio-weight` annotation on Pods (e.g., "500")
- Enabling BlkioQoS feature via ConfigMap with optional default weight

This enables I/O isolation and prioritization, preventing I/O-intensive workloads from starving other pods on the same node. Supports both cgroup v1 (weight 10-1000) and cgroup v2 (weight 1-10000).

