### PR TITLE
add UT tests about no sharing|soft|hard modes in scheduler

### DIFF
--- a/pkg/agentscheduler/actions/allocate/allocate_shard_test.go
+++ b/pkg/agentscheduler/actions/allocate/allocate_shard_test.go
@@ -1,0 +1,176 @@
+/*
+Copyright 2025 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package allocate
+
+import (
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	"volcano.sh/volcano/cmd/agent-scheduler/app/options"
+	scheduleroptions "volcano.sh/volcano/cmd/scheduler/app/options"
+	agentapi "volcano.sh/volcano/pkg/agentscheduler/api"
+	"volcano.sh/volcano/pkg/agentscheduler/framework"
+	"volcano.sh/volcano/pkg/agentscheduler/plugins/nodeorder"
+	"volcano.sh/volcano/pkg/agentscheduler/plugins/predicates"
+	agentuthelper "volcano.sh/volcano/pkg/agentscheduler/uthelper"
+	"volcano.sh/volcano/pkg/scheduler/api"
+	"volcano.sh/volcano/pkg/scheduler/conf"
+	"volcano.sh/volcano/pkg/scheduler/util"
+	commonutil "volcano.sh/volcano/pkg/util"
+)
+
+// TestAllocateWithShard tests agent scheduler allocate action behavior with shard configuration
+func TestAllocateWithShard(t *testing.T) {
+	// Register plugins
+	framework.RegisterPluginBuilder(predicates.PluginName, predicates.New)
+	framework.RegisterPluginBuilder(nodeorder.PluginName, nodeorder.New)
+
+	// Initialize ServerOpts if nil (for agent scheduler)
+	if options.ServerOpts == nil {
+		options.ServerOpts = options.NewServerOption()
+	}
+	// Initialize scheduler ServerOpts if nil (for volume binding plugin)
+	// predicate_helper.go uses scheduler's options, so we need to set it
+	if scheduleroptions.ServerOpts == nil {
+		scheduleroptions.ServerOpts = scheduleroptions.NewServerOption()
+	}
+	// Save original options to restore after test
+	originalShardingMode := options.ServerOpts.ShardingMode
+	originalShardName := options.ServerOpts.ShardName
+	originalSchedulerShardingMode := scheduleroptions.ServerOpts.ShardingMode
+	originalSchedulerShardName := scheduleroptions.ServerOpts.ShardName
+	defer func() {
+		if options.ServerOpts != nil {
+			options.ServerOpts.ShardingMode = originalShardingMode
+			options.ServerOpts.ShardName = originalShardName
+		}
+		if scheduleroptions.ServerOpts != nil {
+			scheduleroptions.ServerOpts.ShardingMode = originalSchedulerShardingMode
+			scheduleroptions.ServerOpts.ShardName = originalSchedulerShardName
+		}
+	}()
+
+	scheduleroptions.ServerOpts.PercentageOfNodesToFind = 100
+
+	// Common setup shared across all test cases
+	trueValue := true
+	tiers := []conf.Tier{
+		{
+			Plugins: []conf.PluginOption{
+				{
+					Name:             predicates.PluginName,
+					EnabledPredicate: &trueValue,
+				},
+				{
+					Name:             nodeorder.PluginName,
+					EnabledNodeOrder: &trueValue,
+					Arguments: map[string]interface{}{
+						"leastrequested.weight": 1,
+						"mostrequested.weight":  0,
+					},
+				},
+			},
+		},
+	}
+
+	// Create test framework (shared setup)
+	testFwk, err := agentuthelper.NewTestFramework("test-scheduler", []framework.Action{New()}, tiers, []conf.Configuration{})
+	if err != nil {
+		t.Fatalf("Failed to create test framework: %v", err)
+	}
+	defer testFwk.Close()
+
+	// Add nodes to cache (shared setup)
+	// n1: in shard, medium resources.
+	// n2: out of shard, fewer resources.
+	// n3: out of shard, more resources than n1 (to highlight soft shard preference).
+	// n4: in shard, fewer resources than n1.
+	n1 := util.BuildNode("n1", api.BuildResourceList("10", "20Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), make(map[string]string))
+	n2 := util.BuildNode("n2", api.BuildResourceList("2", "4Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), make(map[string]string))
+	n3 := util.BuildNode("n3", api.BuildResourceList("20", "40Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), make(map[string]string))
+	n4 := util.BuildNode("n4", api.BuildResourceList("5", "10Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), make(map[string]string))
+	testFwk.MockCache.AddOrUpdateNode(n1)
+	testFwk.MockCache.AddOrUpdateNode(n2)
+	testFwk.MockCache.AddOrUpdateNode(n3)
+	testFwk.MockCache.AddOrUpdateNode(n4)
+
+	// Update snapshot after adding nodes.
+	snapshot := testFwk.Framework.GetSnapshot()
+	if err := testFwk.MockCache.UpdateSnapshot(snapshot); err != nil {
+		t.Fatalf("Failed to update snapshot: %v", err)
+	}
+
+	// Create common pod and task (shared setup)
+	pod := util.BuildPod("c1", "p1", "", v1.PodPending, api.BuildResourceList("1", "1G"), "", make(map[string]string), make(map[string]string))
+	task := api.NewTaskInfo(pod)
+
+	shardTests := []struct {
+		shardingMode string
+		shardName    string
+		nodesInShard []string
+		expectedNode string
+		testName     string
+	}{
+		{
+			shardingMode: commonutil.HardShardingMode,
+			shardName:    "test-shard",
+			nodesInShard: []string{"n1", "n4"},
+			expectedNode: "n1", // within shard, n1 has more resources than n4.
+			testName:     "hard sharding mode - allocate to node in shard",
+		},
+		{
+			shardingMode: commonutil.SoftShardingMode,
+			shardName:    "test-shard",
+			nodesInShard: []string{"n1", "n4"},
+			expectedNode: "n1", // prefer shard node n1 over n3 even though n3 has more resources.
+			testName:     "soft sharding mode - prefer node in shard",
+		},
+	}
+
+	for _, tt := range shardTests {
+		t.Run(tt.testName, func(t *testing.T) {
+			// Set sharding options for both agent scheduler and scheduler.
+			options.ServerOpts.ShardingMode = tt.shardingMode
+			options.ServerOpts.ShardName = tt.shardName
+			scheduleroptions.ServerOpts.ShardingMode = tt.shardingMode
+			scheduleroptions.ServerOpts.ShardName = tt.shardName
+
+			// Create scheduling context (per-test setup)
+			nodesInShardSet := sets.New(tt.nodesInShard...)
+			queuedPodInfo, err := agentuthelper.CreateSchedulingContext(pod, nodesInShardSet)
+			if err != nil {
+				t.Fatalf("Failed to create QueuedPodInfo: %v", err)
+			}
+			schedCtx := &agentapi.SchedulingContext{
+				Task:          task,
+				QueuedPodInfo: queuedPodInfo,
+				NodesInShard:  nodesInShardSet,
+			}
+
+			// Execute scheduling
+			testFwk.Framework.ClearCycleState()
+			testFwk.Framework.OnCycleStart()
+			testFwk.Action.Execute(testFwk.Framework, schedCtx)
+			testFwk.Framework.OnCycleEnd()
+
+			// Verify result
+			agentuthelper.VerifySchedulingResult(t, testFwk.MockCache, tt.expectedNode)
+		})
+	}
+}

--- a/pkg/agentscheduler/uthelper/helper.go
+++ b/pkg/agentscheduler/uthelper/helper.go
@@ -1,0 +1,148 @@
+/*
+Copyright 2025 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package uthelper
+
+import (
+	"context"
+	"reflect"
+	"time"
+	"unsafe"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/klog/v2"
+	fwk "k8s.io/kube-scheduler/framework"
+	k8sframework "k8s.io/kubernetes/pkg/scheduler/framework"
+	k8smetrics "k8s.io/kubernetes/pkg/scheduler/metrics"
+
+	k8sschedulingqueue "volcano.sh/volcano/third_party/kubernetes/pkg/scheduler/backend/queue"
+
+	"volcano.sh/volcano/pkg/agentscheduler/cache"
+	"volcano.sh/volcano/pkg/agentscheduler/framework"
+	"volcano.sh/volcano/pkg/agentscheduler/metrics"
+	"volcano.sh/volcano/pkg/scheduler/conf"
+)
+
+// TestFramework wraps common test setup for agent scheduler tests.
+type TestFramework struct {
+	MockCache       *cache.SchedulerCache
+	Framework       *framework.Framework
+	Action          framework.Action
+	Cancel          context.CancelFunc
+	SchedulingQueue k8sschedulingqueue.SchedulingQueue
+}
+
+// NewTestFramework creates a new test framework with mock cache and scheduling queue.
+func NewTestFramework(schedulerName string, actions []framework.Action, tiers []conf.Tier, configurations []conf.Configuration) (*TestFramework, error) {
+	// Initialize metrics.
+	metrics.InitKubeSchedulerRelatedMetrics()
+
+	// Create mock cache.
+	mockCache := cache.NewDefaultMockSchedulerCache(schedulerName)
+
+	// Initialize scheduling queue.
+	ctx, cancel := context.WithCancel(context.Background())
+	metricsRecorder := k8smetrics.NewMetricsAsyncRecorder(1000, time.Second, ctx.Done())
+	queueingHintMapPerProfile := make(k8sschedulingqueue.QueueingHintMapPerProfile)
+	queueingHintMap := make(k8sschedulingqueue.QueueingHintMap)
+	defaultQueueingHintFn := func(_ klog.Logger, _ *v1.Pod, _, _ interface{}) (fwk.QueueingHint, error) {
+		return fwk.Queue, nil
+	}
+	wildCardEvent := fwk.ClusterEvent{Resource: fwk.WildCard, ActionType: fwk.All}
+	queueingHintMap[wildCardEvent] = append(queueingHintMap[wildCardEvent], &k8sschedulingqueue.QueueingHintFunction{
+		QueueingHintFn: defaultQueueingHintFn,
+	})
+	queueingHintMapPerProfile[schedulerName] = queueingHintMap
+	schedulingQueue := k8sschedulingqueue.NewSchedulingQueue(
+		cache.Less,
+		mockCache.SharedInformerFactory(),
+		k8sschedulingqueue.WithMetricsRecorder(metricsRecorder),
+		k8sschedulingqueue.WithQueueingHintMapPerProfile(queueingHintMapPerProfile),
+	)
+
+	// Set schedulingQueue using unsafe pointer since it's unexported.
+	rv := reflect.ValueOf(mockCache).Elem()
+	schedulingQueueField := rv.FieldByName("schedulingQueue")
+	if !schedulingQueueField.IsValid() {
+		cancel()
+		return nil, &reflect.ValueError{Method: "schedulingQueue", Kind: reflect.Invalid}
+	}
+	fieldAddr := unsafe.Pointer(schedulingQueueField.UnsafeAddr())
+	*(*k8sschedulingqueue.SchedulingQueue)(fieldAddr) = schedulingQueue
+	mockCache.ConflictAwareBinder = cache.NewConflictAwareBinder(mockCache, schedulingQueue)
+
+	// Create framework.
+	var action framework.Action
+	if len(actions) > 0 {
+		action = actions[0]
+		action.OnActionInit(configurations)
+	}
+	fwk := framework.NewFramework(actions, tiers, mockCache, configurations)
+
+	// Update snapshot.
+	snapshot := fwk.GetSnapshot()
+	if err := mockCache.UpdateSnapshot(snapshot); err != nil {
+		cancel()
+		return nil, err
+	}
+
+	return &TestFramework{
+		MockCache:       mockCache,
+		Framework:       fwk,
+		Action:          action,
+		Cancel:          cancel,
+		SchedulingQueue: schedulingQueue,
+	}, nil
+}
+
+// Close cleans up the test framework.
+func (tf *TestFramework) Close() {
+	if tf.Cancel != nil {
+		tf.Cancel()
+	}
+}
+
+// VerifySchedulingResult verifies the scheduling result from BindCheckChannel.
+func VerifySchedulingResult(t interface {
+	Fatalf(format string, args ...interface{})
+}, mockCache *cache.SchedulerCache, expectedNode string) {
+	select {
+	case result := <-mockCache.ConflictAwareBinder.BindCheckChannel:
+		if result == nil {
+			t.Fatalf("Expected schedule result, got nil")
+			return
+		}
+		if len(result.SuggestedNodes) == 0 {
+			t.Fatalf("Expected at least one suggested node, got 0")
+			return
+		}
+		if result.SuggestedNodes[0].Name != expectedNode {
+			t.Fatalf("Expected node %s, got %s", expectedNode, result.SuggestedNodes[0].Name)
+		}
+	case <-time.After(1 * time.Second):
+		t.Fatalf("Timeout waiting for schedule result in BindCheckChannel")
+	}
+}
+
+// CreateSchedulingContext creates a QueuedPodInfo for testing.
+func CreateSchedulingContext(pod *v1.Pod, nodesInShard sets.Set[string]) (*k8sframework.QueuedPodInfo, error) {
+	podInfo, err := k8sframework.NewPodInfo(pod)
+	if err != nil {
+		return nil, err
+	}
+	return &k8sframework.QueuedPodInfo{PodInfo: podInfo}, nil
+}

--- a/pkg/scheduler/actions/backfill/backfill_shard_test.go
+++ b/pkg/scheduler/actions/backfill/backfill_shard_test.go
@@ -1,0 +1,177 @@
+/*
+Copyright 2025 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package backfill
+
+import (
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	schedulingv1 "volcano.sh/apis/pkg/apis/scheduling/v1beta1"
+	"volcano.sh/volcano/cmd/scheduler/app/options"
+	"volcano.sh/volcano/pkg/scheduler/api"
+	"volcano.sh/volcano/pkg/scheduler/conf"
+	"volcano.sh/volcano/pkg/scheduler/framework"
+	"volcano.sh/volcano/pkg/scheduler/plugins/gang"
+	"volcano.sh/volcano/pkg/scheduler/plugins/predicates"
+	"volcano.sh/volcano/pkg/scheduler/uthelper"
+	"volcano.sh/volcano/pkg/scheduler/util"
+	commonutil "volcano.sh/volcano/pkg/util"
+)
+
+// TestBackfillWithShard tests backfill action behavior with shard configuration
+func TestBackfillWithShard(t *testing.T) {
+	plugins := map[string]framework.PluginBuilder{
+		gang.PluginName:       gang.New,
+		predicates.PluginName: predicates.New,
+	}
+
+	// Initialize ServerOpts if nil
+	if options.ServerOpts == nil {
+		options.ServerOpts = options.NewServerOption()
+	}
+	// Save original options
+	originalShardingMode := options.ServerOpts.ShardingMode
+	originalShardName := options.ServerOpts.ShardName
+	defer func() {
+		if options.ServerOpts != nil {
+			options.ServerOpts.ShardingMode = originalShardingMode
+			options.ServerOpts.ShardName = originalShardName
+		}
+	}()
+
+	trueValue := true
+	tiers := []conf.Tier{
+		{
+			Plugins: []conf.PluginOption{
+				{
+					Name:            gang.PluginName,
+					EnabledJobReady: &trueValue,
+				},
+				{
+					Name:             predicates.PluginName,
+					EnabledPredicate: &trueValue,
+				},
+			},
+		},
+	}
+
+	tests := []uthelper.TestCommonStruct{
+		{
+			Name: "hard sharding mode - backfill to node in shard",
+			PodGroups: []*schedulingv1.PodGroup{
+				util.BuildPodGroup("pg1", "c1", "c1", 0, nil, schedulingv1.PodGroupInqueue),
+			},
+			Pods: []*v1.Pod{
+				// BestEffort pod for backfill
+				util.BuildPod("c1", "p1", "", v1.PodPending, api.BuildResourceList("0", "0"), "pg1", make(map[string]string), make(map[string]string)),
+			},
+			// n1 in shard, n2/n3/n4 are out of shard. n3 has more resources but is out of shard.
+			Nodes: []*v1.Node{
+				util.BuildNode("n1", api.BuildResourceList("10", "20Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), make(map[string]string)),
+				util.BuildNode("n2", api.BuildResourceList("2", "4Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), make(map[string]string)),
+				util.BuildNode("n3", api.BuildResourceList("20", "40Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), make(map[string]string)),
+				util.BuildNode("n4", api.BuildResourceList("5", "10Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), make(map[string]string)),
+			},
+			Queues: []*schedulingv1.Queue{
+				util.BuildQueue("c1", 1, nil),
+			},
+			ExpectBindsNum: 1,
+			ExpectBindMap: map[string]string{
+				"c1/p1": "n1",
+			},
+			ShardingMode: commonutil.HardShardingMode,
+			ShardName:    "test-shard",
+			NodesInShard: []string{"n1"},
+		},
+		{
+			Name: "soft sharding mode - prefer node in shard",
+			PodGroups: []*schedulingv1.PodGroup{
+				util.BuildPodGroup("pg1", "c1", "c1", 0, nil, schedulingv1.PodGroupInqueue),
+			},
+			Pods: []*v1.Pod{
+				// BestEffort pod for backfill
+				util.BuildPod("c1", "p1", "", v1.PodPending, api.BuildResourceList("0", "0"), "pg1", make(map[string]string), make(map[string]string)),
+			},
+			// n1 in shard, n2/n3/n4 are out of shard. Soft mode still prefers shard nodes,
+			// even though n3 (out of shard) has the most resources.
+			Nodes: []*v1.Node{
+				util.BuildNode("n1", api.BuildResourceList("10", "20Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), make(map[string]string)),
+				util.BuildNode("n2", api.BuildResourceList("2", "4Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), make(map[string]string)),
+				util.BuildNode("n3", api.BuildResourceList("20", "40Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), make(map[string]string)),
+				util.BuildNode("n4", api.BuildResourceList("5", "10Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), make(map[string]string)),
+			},
+			Queues: []*schedulingv1.Queue{
+				util.BuildQueue("c1", 1, nil),
+			},
+			ExpectBindsNum: 1,
+			ExpectBindMap: map[string]string{
+				"c1/p1": "n1",
+			},
+			ShardingMode: commonutil.SoftShardingMode,
+			ShardName:    "test-shard",
+			NodesInShard: []string{"n1"},
+		},
+		{
+			// Identical nodes, only one is in shard: soft sharding should still prefer the shard node.
+			Name: "soft sharding mode - identical nodes prefer shard node",
+			PodGroups: []*schedulingv1.PodGroup{
+				util.BuildPodGroup("pg1", "c1", "c1", 0, nil, schedulingv1.PodGroupInqueue),
+			},
+			Pods: []*v1.Pod{
+				// BestEffort pod for backfill
+				util.BuildPod("c1", "p1", "", v1.PodPending, api.BuildResourceList("0", "0"), "pg1", make(map[string]string), make(map[string]string)),
+			},
+			Nodes: []*v1.Node{
+				// n1 and n2 are identical in capacity and labels.
+				util.BuildNode("n1", api.BuildResourceList("10", "20Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), make(map[string]string)),
+				util.BuildNode("n2", api.BuildResourceList("10", "20Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), make(map[string]string)),
+			},
+			Queues: []*schedulingv1.Queue{
+				util.BuildQueue("c1", 1, nil),
+			},
+			ExpectBindsNum: 1,
+			ExpectBindMap: map[string]string{
+				"c1/p1": "n1",
+			},
+			ShardingMode: commonutil.SoftShardingMode,
+			ShardName:    "test-shard",
+			NodesInShard: []string{"n1"},
+		},
+	}
+
+	for i, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			test.Plugins = plugins
+			ssn := test.RegisterSession(tiers, nil)
+			if len(test.NodesInShard) > 0 {
+				ssn.NodesInShard = sets.New(test.NodesInShard...)
+				options.ServerOpts.ShardingMode = test.ShardingMode
+				options.ServerOpts.ShardName = test.ShardName
+			}
+			defer test.Close()
+
+			action := New()
+			test.Run([]framework.Action{action})
+
+			if err := test.CheckAll(i); err != nil {
+				t.Fatalf("Test %s failed: %v", test.Name, err)
+			}
+		})
+	}
+}

--- a/pkg/scheduler/actions/preempt/preempt_shard_test.go
+++ b/pkg/scheduler/actions/preempt/preempt_shard_test.go
@@ -1,0 +1,160 @@
+/*
+Copyright 2025 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package preempt
+
+import (
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	schedulingv1 "k8s.io/api/scheduling/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	schedulingv1beta1 "volcano.sh/apis/pkg/apis/scheduling/v1beta1"
+	"volcano.sh/volcano/cmd/scheduler/app/options"
+	"volcano.sh/volcano/pkg/scheduler/api"
+	"volcano.sh/volcano/pkg/scheduler/conf"
+	"volcano.sh/volcano/pkg/scheduler/framework"
+	"volcano.sh/volcano/pkg/scheduler/plugins/conformance"
+	"volcano.sh/volcano/pkg/scheduler/plugins/gang"
+	"volcano.sh/volcano/pkg/scheduler/plugins/predicates"
+	"volcano.sh/volcano/pkg/scheduler/plugins/priority"
+	"volcano.sh/volcano/pkg/scheduler/plugins/proportion"
+	"volcano.sh/volcano/pkg/scheduler/uthelper"
+	"volcano.sh/volcano/pkg/scheduler/util"
+	commonutil "volcano.sh/volcano/pkg/util"
+)
+
+// TestPreemptWithShard tests preempt action behavior with shard configuration
+func TestPreemptWithShard(t *testing.T) {
+	plugins := map[string]framework.PluginBuilder{
+		conformance.PluginName: conformance.New,
+		gang.PluginName:        gang.New,
+		priority.PluginName:    priority.New,
+		proportion.PluginName:  proportion.New,
+		predicates.PluginName:  predicates.New,
+	}
+
+	// Save original options
+	originalShardingMode := options.ServerOpts.ShardingMode
+	originalShardName := options.ServerOpts.ShardName
+	defer func() {
+		options.ServerOpts.ShardingMode = originalShardingMode
+		options.ServerOpts.ShardName = originalShardName
+	}()
+
+	highPrio := util.BuildPriorityClass("high-priority", 100000)
+	lowPrio := util.BuildPriorityClass("low-priority", 10)
+
+	trueValue := true
+	tiers := []conf.Tier{
+		{
+			Plugins: []conf.PluginOption{
+				{
+					Name:               conformance.PluginName,
+					EnabledPreemptable: &trueValue,
+				},
+				{
+					Name:               gang.PluginName,
+					EnabledPreemptable: &trueValue,
+					EnabledJobStarving: &trueValue,
+				},
+				{
+					Name:               priority.PluginName,
+					EnabledPreemptable: &trueValue,
+					EnabledJobStarving: &trueValue,
+				},
+				{
+					Name:             predicates.PluginName,
+					EnabledPredicate: &trueValue,
+				},
+			},
+		},
+	}
+
+	tests := []uthelper.TestCommonStruct{
+		{
+			Name: "hard sharding mode - preempt from node in shard",
+			PodGroups: []*schedulingv1beta1.PodGroup{
+				util.BuildPodGroupWithPrio("pg1", "c1", "q1", 1, nil, schedulingv1beta1.PodGroupInqueue, lowPrio.Name),
+				util.BuildPodGroupWithPrio("pg2", "c1", "q1", 1, nil, schedulingv1beta1.PodGroupInqueue, highPrio.Name),
+			},
+			Pods: []*v1.Pod{
+				util.BuildPod("c1", "preemptee1", "n1", v1.PodRunning, api.BuildResourceList("1", "1G"), "pg1", map[string]string{schedulingv1beta1.PodPreemptable: "true"}, make(map[string]string)),
+				util.BuildPod("c1", "preemptee2", "n2", v1.PodRunning, api.BuildResourceList("1", "1G"), "pg1", map[string]string{schedulingv1beta1.PodPreemptable: "true"}, make(map[string]string)),
+				util.BuildPod("c1", "preemptor1", "", v1.PodPending, api.BuildResourceList("1", "1G"), "pg2", make(map[string]string), make(map[string]string)),
+			},
+			Nodes: []*v1.Node{
+				util.BuildNode("n1", api.BuildResourceList("1", "1G", []api.ScalarResource{{Name: "pods", Value: "10"}}...), make(map[string]string)),
+				util.BuildNode("n2", api.BuildResourceList("1", "1G", []api.ScalarResource{{Name: "pods", Value: "10"}}...), make(map[string]string)),
+			},
+			Queues: []*schedulingv1beta1.Queue{
+				util.BuildQueue("q1", 1, nil),
+			},
+			PriClass:       []*schedulingv1.PriorityClass{highPrio, lowPrio},
+			ExpectEvictNum: 1,
+			ExpectEvicted:  []string{"c1/preemptee1"},
+			ShardingMode:   commonutil.HardShardingMode,
+			ShardName:      "test-shard",
+			NodesInShard:   []string{"n1"},
+		},
+		{
+			Name: "soft sharding mode - prefer preempting from node in shard",
+			PodGroups: []*schedulingv1beta1.PodGroup{
+				util.BuildPodGroupWithPrio("pg1", "c1", "q1", 1, nil, schedulingv1beta1.PodGroupInqueue, lowPrio.Name),
+				util.BuildPodGroupWithPrio("pg2", "c1", "q1", 1, nil, schedulingv1beta1.PodGroupInqueue, highPrio.Name),
+			},
+			Pods: []*v1.Pod{
+				util.BuildPod("c1", "preemptee1", "n1", v1.PodRunning, api.BuildResourceList("1", "1G"), "pg1", map[string]string{schedulingv1beta1.PodPreemptable: "true"}, make(map[string]string)),
+				util.BuildPod("c1", "preemptee2", "n2", v1.PodRunning, api.BuildResourceList("1", "1G"), "pg1", map[string]string{schedulingv1beta1.PodPreemptable: "true"}, make(map[string]string)),
+				util.BuildPod("c1", "preemptor1", "", v1.PodPending, api.BuildResourceList("1", "1G"), "pg2", make(map[string]string), make(map[string]string)),
+			},
+			Nodes: []*v1.Node{
+				util.BuildNode("n1", api.BuildResourceList("1", "1G", []api.ScalarResource{{Name: "pods", Value: "10"}}...), make(map[string]string)),
+				util.BuildNode("n2", api.BuildResourceList("1", "1G", []api.ScalarResource{{Name: "pods", Value: "10"}}...), make(map[string]string)),
+			},
+			Queues: []*schedulingv1beta1.Queue{
+				util.BuildQueue("q1", 1, nil),
+			},
+			PriClass:       []*schedulingv1.PriorityClass{highPrio, lowPrio},
+			ExpectEvictNum: 1,
+			ExpectEvicted:  []string{"c1/preemptee1"},
+			ShardingMode:   commonutil.SoftShardingMode,
+			ShardName:      "test-shard",
+			NodesInShard:   []string{"n1"},
+		},
+	}
+
+	for i, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			test.Plugins = plugins
+			ssn := test.RegisterSession(tiers, nil)
+			if len(test.NodesInShard) > 0 {
+				ssn.NodesInShard = sets.New(test.NodesInShard...)
+				options.ServerOpts.ShardingMode = test.ShardingMode
+				options.ServerOpts.ShardName = test.ShardName
+			}
+			defer test.Close()
+
+			action := New()
+			test.Run([]framework.Action{action})
+
+			if err := test.CheckAll(i); err != nil {
+				t.Fatalf("Test %s failed: %v", test.Name, err)
+			}
+		})
+	}
+}

--- a/pkg/scheduler/actions/reclaim/reclaim_shard_test.go
+++ b/pkg/scheduler/actions/reclaim/reclaim_shard_test.go
@@ -1,0 +1,180 @@
+/*
+Copyright 2025 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reclaim
+
+import (
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	schedulingv1 "k8s.io/api/scheduling/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	schedulingv1beta1 "volcano.sh/apis/pkg/apis/scheduling/v1beta1"
+	"volcano.sh/volcano/cmd/scheduler/app/options"
+	"volcano.sh/volcano/pkg/scheduler/api"
+	"volcano.sh/volcano/pkg/scheduler/conf"
+	"volcano.sh/volcano/pkg/scheduler/framework"
+	"volcano.sh/volcano/pkg/scheduler/plugins/conformance"
+	"volcano.sh/volcano/pkg/scheduler/plugins/gang"
+	"volcano.sh/volcano/pkg/scheduler/plugins/predicates"
+	"volcano.sh/volcano/pkg/scheduler/plugins/priority"
+	"volcano.sh/volcano/pkg/scheduler/plugins/proportion"
+	"volcano.sh/volcano/pkg/scheduler/uthelper"
+	"volcano.sh/volcano/pkg/scheduler/util"
+	commonutil "volcano.sh/volcano/pkg/util"
+)
+
+// TestReclaimWithShard tests reclaim action behavior with shard configuration
+func TestReclaimWithShard(t *testing.T) {
+	plugins := map[string]framework.PluginBuilder{
+		conformance.PluginName: conformance.New,
+		gang.PluginName:        gang.New,
+		proportion.PluginName:  proportion.New,
+		predicates.PluginName:  predicates.New,
+		priority.PluginName:    priority.New,
+	}
+
+	// Save original options
+	originalShardingMode := options.ServerOpts.ShardingMode
+	originalShardName := options.ServerOpts.ShardName
+	defer func() {
+		options.ServerOpts.ShardingMode = originalShardingMode
+		options.ServerOpts.ShardName = originalShardName
+	}()
+
+	reclaim := New()
+	trueValue := true
+	tiers := []conf.Tier{
+		{
+			Plugins: []conf.PluginOption{
+				{
+					Name:               conformance.PluginName,
+					EnabledReclaimable: &trueValue,
+				},
+				{
+					Name:               gang.PluginName,
+					EnabledReclaimable: &trueValue,
+					EnabledJobStarving: &trueValue,
+				},
+				{
+					Name:               proportion.PluginName,
+					EnabledReclaimable: &trueValue,
+					EnabledQueueOrder:  &trueValue,
+					EnablePreemptive:   &trueValue,
+				},
+				{
+					Name:               priority.PluginName,
+					EnabledReclaimable: &trueValue,
+					EnabledJobOrder:    &trueValue,
+					EnabledTaskOrder:   &trueValue,
+				},
+				{
+					Name:             predicates.PluginName,
+					EnabledPredicate: &trueValue,
+				},
+			},
+		},
+	}
+
+	highPrio := util.BuildPriorityClass("high-priority", 100000)
+	lowPrio := util.BuildPriorityClass("low-priority", 10)
+
+	tests := []uthelper.TestCommonStruct{
+		{
+			Name: "hard sharding mode - only reclaim from nodes in shard",
+			PodGroups: []*schedulingv1beta1.PodGroup{
+				util.BuildPodGroupWithPrio("pg1", "c1", "q1", 1, nil, schedulingv1beta1.PodGroupInqueue, lowPrio.Name),
+				util.BuildPodGroupWithPrio("pg2", "c1", "q2", 1, nil, schedulingv1beta1.PodGroupInqueue, highPrio.Name),
+			},
+			Pods: []*v1.Pod{
+				// Preemptable pod on n1 (in shard) - node is full
+				util.BuildPod("c1", "preemptee1", "n1", v1.PodRunning, api.BuildResourceList("2", "2Gi"), "pg1", map[string]string{schedulingv1beta1.PodPreemptable: "true"}, make(map[string]string)),
+				// Preemptable pod on n2 (out of shard) to highlight hard mode only touches shard nodes
+				util.BuildPod("c1", "preemptee2", "n2", v1.PodRunning, api.BuildResourceList("2", "2Gi"), "pg1", map[string]string{schedulingv1beta1.PodPreemptable: "true"}, make(map[string]string)),
+				// High-priority pending pod.
+				util.BuildPod("c1", "preemptor1", "", v1.PodPending, api.BuildResourceList("1", "1G"), "pg2", make(map[string]string), make(map[string]string)),
+			},
+			Nodes: []*v1.Node{
+				util.BuildNode("n1", api.BuildResourceList("2", "2Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), make(map[string]string)),
+				util.BuildNode("n2", api.BuildResourceList("2", "2Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), make(map[string]string)),
+			},
+			Queues: []*schedulingv1beta1.Queue{
+				util.BuildQueue("q1", 1, nil),
+				util.BuildQueue("q2", 1, nil),
+			},
+			PriClass:       []*schedulingv1.PriorityClass{highPrio, lowPrio},
+			ExpectEvictNum: 1,
+			// In hard mode, reclaim should only evict from nodes in shard (n1),
+			// even though there is another preemptable pod on n2 (out of shard).
+			ExpectEvicted: []string{"c1/preemptee1"},
+			ShardingMode:  commonutil.HardShardingMode,
+			ShardName:     "test-shard",
+			NodesInShard:  []string{"n1"},
+		},
+		{
+			Name: "soft sharding mode - prefer reclaiming from node in shard",
+			PodGroups: []*schedulingv1beta1.PodGroup{
+				util.BuildPodGroupWithPrio("pg1", "c1", "q1", 1, nil, schedulingv1beta1.PodGroupInqueue, lowPrio.Name),
+				util.BuildPodGroupWithPrio("pg2", "c1", "q2", 1, nil, schedulingv1beta1.PodGroupInqueue, highPrio.Name),
+			},
+			Pods: []*v1.Pod{
+				// Preemptable pod on n1 (in shard) - node is full
+				util.BuildPod("c1", "preemptee1", "n1", v1.PodRunning, api.BuildResourceList("2", "2Gi"), "pg1", map[string]string{schedulingv1beta1.PodPreemptable: "true"}, make(map[string]string)),
+				// Preemptable pod on n2 (out of shard) to highlight soft mode prefers shard nodes
+				util.BuildPod("c1", "preemptee2", "n2", v1.PodRunning, api.BuildResourceList("2", "2Gi"), "pg1", map[string]string{schedulingv1beta1.PodPreemptable: "true"}, make(map[string]string)),
+				// High-priority pending pod.
+				util.BuildPod("c1", "preemptor1", "", v1.PodPending, api.BuildResourceList("1", "1G"), "pg2", make(map[string]string), make(map[string]string)),
+			},
+			Nodes: []*v1.Node{
+				// n1 and n2 are identical in capacity and labels.
+				util.BuildNode("n1", api.BuildResourceList("2", "2Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), make(map[string]string)),
+				util.BuildNode("n2", api.BuildResourceList("2", "2Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), make(map[string]string)),
+			},
+			Queues: []*schedulingv1beta1.Queue{
+				util.BuildQueue("q1", 1, nil),
+				util.BuildQueue("q2", 1, nil),
+			},
+			PriClass:       []*schedulingv1.PriorityClass{highPrio, lowPrio},
+			ExpectEvictNum: 1,
+			// In soft mode, reclaim should prefer evicting from nodes in shard (n1),
+			// even though n1 and n2 are identical and both have preemptable pods.
+			ExpectEvicted: []string{"c1/preemptee1"},
+			ShardingMode:  commonutil.SoftShardingMode,
+			ShardName:     "test-shard",
+			NodesInShard:  []string{"n1"},
+		},
+	}
+
+	for i, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			test.Plugins = plugins
+			ssn := test.RegisterSession(tiers, nil)
+			if len(test.NodesInShard) > 0 {
+				ssn.NodesInShard = sets.New(test.NodesInShard...)
+				options.ServerOpts.ShardingMode = test.ShardingMode
+				options.ServerOpts.ShardName = test.ShardName
+			}
+			defer test.Close()
+
+			test.Run([]framework.Action{reclaim})
+
+			if err := test.CheckAll(i); err != nil {
+				t.Fatalf("Test %s failed: %v", test.Name, err)
+			}
+		})
+	}
+}

--- a/pkg/scheduler/uthelper/helper.go
+++ b/pkg/scheduler/uthelper/helper.go
@@ -107,6 +107,12 @@ type TestCommonStruct struct {
 	// MinimalBindCheck true will only check both bind num, false by default.
 	MinimalBindCheck bool
 
+	// Shard test configuration (optional). When NodesInShard is non-nil/non-empty,
+	// RegisterSession caller should set options.ServerOpts and ssn.NodesInShard after session is created.
+	ShardingMode string
+	ShardName    string
+	NodesInShard []string
+
 	// fake interface instance when check results need
 	stop       chan struct{}
 	binder     cache.Binder


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
Part of https://github.com/volcano-sh/volcano/issues/4957
#### Test what
1.`pkg/agentscheduler/actions/allocate/allocate_shard_test.go `
Test Functionality: Test how the agent scheduler's allocate action handles hard sharding and soft sharding modes.
* Hard Sharding Mode: Distributes tasks only on nodes within the shard.
* Soft Sharding Mode: Prioritizes allocation on nodes within the shard, but can also allocate on nodes outside the shard.
Corresponding PR Feature: Agent scheduler supports sharded scheduling.


2.`pkg/scheduler/actions/allocate/allocate_shard_test.go`
Test Functionality: Test how the scheduler's allocate action handles hard sharding and soft sharding modes.
* Hard sharding mode: Allocates tasks only on nodes within the shard.
* Soft sharding mode: Prioritizes allocation on nodes within the shard.
Corresponding PR Feature: Scheduler allocate action supports sharded scheduling.

3.`pkg/scheduler/actions/backfill/backfill_shard_test.go `
Test Functionality: Test how the backfill action handles hard sharding and soft sharding modes.
* Hard sharding mode: Backfill is only executed on nodes within the shard.
* Soft sharding mode: Backfill is executed on nodes within the shard first.
Corresponding PR Feature: Backfill action supports shard scheduling.

4.`pkg/scheduler/actions/reclaim/reclaim_shard_test.go `
Test Functionality: Test how the reclaim action handles hard sharding and soft sharding modes.
* Hard sharding mode: Reclaims resources only from nodes within the shard.
* Soft sharding mode: Prioritizes reclaiming resources from nodes within the shard.
Corresponding PR Feature: Supports sharding scheduling in the reclaim action.

5.`pkg/scheduler/actions/preempt/preempt_shard_test.go `
Test Functionality: Test how the preempt action handles hard sharding and soft sharding modes.
* Hard sharding mode: Preempts resources only from nodes within the shard.
* Soft sharding mode: Preempts resources from nodes within the shard first.
Corresponding PR Feature: Supports sharding scheduling in the preempt action.

6.`pkg/scheduler/plugins/predicates/predicates_test.go - TestPredicatesWithShard`
Testing Functionality: Test how the predicates plugin filters nodes in sharded mode.
* Hard Shard Mode: Filters out nodes not in the shards.
* Soft Shard Mode: Allows nodes outside the shards to pass through.
* No Shard Mode: Processes all nodes normally.
Corresponding PR Feature: The predicates plugin supports node filtering in hard sharded mode.

7.`pkg/scheduler/plugins/nodeorder/nodeorder_test.go - Sharding Test`
Testing Functionality: Testing how the nodeorder plugin sorts nodes in sharded mode.
* Hard Sharding Mode: Prioritizes nodes within each shard.
* Soft Sharding Mode: Prioritizes nodes within each shard.
Corresponding PR Feature: The nodeorder plugin supports shard priority sorting.