### PR TITLE
feat: make `candidateNodeCount` configurable in agent allocate action

### DIFF
--- a/pkg/agentscheduler/actions/allocate/allocate.go
+++ b/pkg/agentscheduler/actions/allocate/allocate.go
@@ -35,6 +35,7 @@ import (
 
 const (
 	DefaultCandidateNodeCount = 3
+	CandidateNodeCountKey     = "candidateNodeCount"
 )
 
 type Action struct {
@@ -65,6 +66,7 @@ func (alloc *Action) Initialize() {}
 func (alloc *Action) parseArguments(configurations []conf.Configuration) {
 	arguments := vfwk.GetArgOfActionFromConf(configurations, alloc.Name())
 	arguments.GetBool(&alloc.enablePredicateErrorCache, conf.EnablePredicateErrCacheKey)
+	arguments.GetInt(&alloc.candidateNodeCount, CandidateNodeCountKey)
 }
 
 func (alloc *Action) Execute(fwk *framework.Framework, schedCtx *agentapi.SchedulingContext) {


### PR DESCRIPTION
#### What type of PR is this?

#### What this PR does / why we need it:
The allocate action in the Agent Scheduler uses `candidateNodeCount` to determine how many node suggestions are sent to the optimistic binder. Previously, this was hardcoded to `3`. This PR updates `parseArguments` to read `candidateNodeCount` from the scheduler configuration, allowing users to tune it as per their liking.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Notice that do not add `Fixes` if the issue is associated with multiple PRs.
-->
None

#### Special notes for your reviewer:
- Does this need extra validation like `candidateNodeCount >= 2`  or similar?

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
The number of candidate nodes in a scheduling decision (candidateNodeCount) is now configurable.
```