### PR TITLE
fix(event): fix FailedScheduling message might inaccurate when podgroup is ready

### DIFF
--- a/pkg/scheduler/api/job_info.go
+++ b/pkg/scheduler/api/job_info.go
@@ -772,7 +772,12 @@ func (ji *JobInfo) FitError() string {
 		reasons[status.String()] += len(taskMap)
 	}
 	reasons["minAvailable"] = int(ji.MinAvailable)
-	reasonMsg := fmt.Sprintf("%v, %v", scheduling.PodGroupNotReady, strings.Join(sortReasonsHistogram(reasons), ", "))
+
+	podGroupStatus := scheduling.PodGroupNotReady
+	if ji.IsReady() {
+		podGroupStatus = scheduling.PodGroupReady
+	}
+	reasonMsg := fmt.Sprintf("%v, %v", podGroupStatus, strings.Join(sortReasonsHistogram(reasons), ", "))
 
 	// Stat histogram for pending tasks only
 	reasons = make(map[string]int)


### PR DESCRIPTION
#### What type of PR is this?
bug fix
#### What this PR does / why we need it:

Fix the message print pod group is not ready when podgorup is already running.
```
Events:
  Type     Reason                  Age   From                  Message
  ----     ------                  ----  ----                  -------
  Warning  FailedScheduling        13m   volcano               pod group is ready, 1 minAvailable, 8 Running, 83 Pending; Pending: 83 Unschedulable
  Normal   AddEkletNodeToleration  13m   admission-controller  Successfully add eklet node toleration
  Warning  FailedScheduling        103s  volcano               pod group is ready, 1 minAvailable, 52 Pending, 8 Running; Pending: 52 Unschedulable
  Warning  FailedScheduling        82s   volcano               pod group is ready, 1 minAvailable, 51 Pending, 8 Running; Pending: 51 Unschedulable
  Warning  FailedScheduling        75s   volcano               pod group is ready, 1 minAvailable, 50 Pending, 8 Running; Pending: 50 Unschedulable
  Warning  FailedScheduling        40s   volcano               pod group is ready, 1 minAvailable, 49 Pending, 8 Running; Pending: 49 Unschedulable
  Warning  FailedScheduling        22s   volcano               pod group is ready, 1 minAvailable, 47 Pending, 8 Running; Pending: 47 Unschedulable
  Warning  FailedScheduling        14s   volcano               pod group is ready, 1 minAvailable, 46 Pending, 8 Running; Pending: 46 Unschedulable
```

#### Which issue(s) this PR fixes:
Fixes #4971

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```