### PR TITLE
fix(job): handle nil pod when AlreadyExists error on create

### DIFF
--- a/pkg/controllers/job/job_controller_actions.go
+++ b/pkg/controllers/job/job_controller_actions.go
@@ -526,7 +526,7 @@ func (cc *jobcontroller) syncJob(jobInfo *apis.JobInfo, updateStatus state.Updat
 							klog.V(4).Infof("Pod %s for Job %s already exists, skipping", pod.Name, job.Name)
 						} else {
 							// Failed to create Pod. The error will be collected and the sync will be retried.
-							//This is to ensure all pods for the same Job are created
+							// This is to ensure all pods for the same Job are created
 							// so that gang-scheduling can schedule the Job successfully.
 							klog.Errorf("Failed to create pod %s for Job %s, err %#v",
 								pod.Name, job.Name, err)


### PR DESCRIPTION
# Job Controller Panic on Pod Create AlreadyExists

## Issue

In `syncJob` (`pkg/controllers/job/job_controller_actions.go`), the controller treats `AlreadyExists` from `Pods().Create()` as success and dereferences `newPod`, which is **nil** on 409 errors.

Result: **nil pointer dereference panic**.

---

## Impact

- Controller-manager crash
- Broken job reconciliation
- Affects normal restarts and multi-pod jobs

---

## Repro

Restart controller during pod creation → `AlreadyExists` → panic.

---

## Root Cause

Kubernetes `Create` returns `(nil, err)` on `AlreadyExists`.  
Code assumes success and uses `newPod`.

---

## Fix

Only use `newPod` when `err == nil`.  
Skip on `AlreadyExists` and reconcile via informer.
<img width="485" height="47" alt="Test1" src="https://github.com/user-attachments/assets/2466c016-e3e7-4941-b918-0e591e720d93" />
