### PR TITLE
Add predicate helper unit tests

### DIFF
--- a/pkg/scheduler/util/predicate_helper_test.go
+++ b/pkg/scheduler/util/predicate_helper_test.go
@@ -155,6 +155,8 @@ func TestPredicateNodes(t *testing.T) {
 			},
 			nodes: []*api.NodeInfo{
 				{Name: "node1"},
+				{Name: "node2"},
+				{Name: "node3"},
 			},
 			nodesInShard:     sets.New[string]("node1"),
 			shardingMode:     commonutil.HardShardingMode,
@@ -162,7 +164,12 @@ func TestPredicateNodes(t *testing.T) {
 			predicateFn:      func(*api.TaskInfo, *api.NodeInfo) error { return nil },
 			expectedNodes:    []string{"node1"},
 			expectedErr:      "",
-			expectedErrCache: map[string]map[string]string{},
+			expectedErrCache: map[string]map[string]string{
+				"job1/worker": {
+					"node2": "node isn't in scheduler node shard",
+					"node3": "node isn't in scheduler node shard",
+				},
+			},
 		},
 	}
 


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
https://github.com/volcano-sh/volcano/pull/4983#discussion_r2726584627, in https://github.com/volcano-sh/volcano/pull/4983, I submit some unit tests to cover predicate_helper and nodeorder, but the suggested tests from @qi-min missed to be added in that PR, so I raised a new PR to cover these two cases in predicate_helper:
1. Nodes will not be excluded (in the node list but not in node shard) in soft mode
2. Nodes in shard will not be excluded when in hard mode ( the node both in node list and node shard)

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Notice that do not add `Fixes` if the issue is associated with multiple PRs.
-->
Fixes https://github.com/volcano-sh/volcano/pull/4983#discussion_r2726584627

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```