### PR TITLE
Fix within-job preemption committing evictions when preemptor scheduling fails

### DIFF
--- a/pkg/scheduler/actions/preempt/preempt.go
+++ b/pkg/scheduler/actions/preempt/preempt.go
@@ -268,12 +268,14 @@ func (pmpt *Action) Execute(ssn *framework.Session) {
 				if err != nil {
 					klog.V(3).Infof("Preemptor <%s/%s> failed to preempt Task , err: %s", preemptor.Namespace, preemptor.Name, err)
 				}
-				stmt.Commit()
 
-				// If no preemption, next job.
+				// Only commit if preemption was successful, otherwise discard to rollback evictions.
+				// This is consistent with between-job preemption which checks JobPipelined before committing.
 				if !assigned {
+					stmt.Discard()
 					break
 				}
+				stmt.Commit()
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

Fixes a correctness issue in Volcano’s within-job preemption where victim pods were evicted even when the preemptor task could not be scheduled.

## Problem

The within-job preemption path committed eviction statements unconditionally.  
When the preemptor failed scheduling due to queue capacity or resource constraints, evictions were still applied, causing irreversible pod deletion.

## Root Cause

Evictions were staged via `stmt.Evict()` before scheduling feasibility checks.  
When assignment failed, the statement was still committed instead of being discarded.

## Fix

Commit the preemption statement only when the preemptor is successfully assigned.  
Otherwise, discard the statement to rollback all eviction operations.

## Impact

- Prevents unnecessary victim pod eviction  
- Preserves gang scheduling (`MinAvailable`) guarantees  
- Avoids silent workload disruption and cluster churn  

## Scope

Minimal, targeted fix scoped to within-job preemption logic.  
No API changes and no behavior change for successful preemption cases.