### PR TITLE
feat: Support pod level resource request and limit settings

### DIFF
--- a/cmd/scheduler/app/server.go
+++ b/cmd/scheduler/app/server.go
@@ -39,15 +39,12 @@ import (
 	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/klog/v2"
 
-	utilfeature "k8s.io/apiserver/pkg/util/feature"
-
 	// Register gcp auth
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/leaderelection"
 	"k8s.io/client-go/tools/leaderelection/resourcelock"
 	"k8s.io/client-go/tools/record"
-	basecompatibility "k8s.io/component-base/compatibility"
 
 	// Register rest client metrics
 	_ "k8s.io/component-base/metrics/prometheus/restclient"
@@ -61,7 +58,7 @@ func Run(opt *options.ServerOption) error {
 	}
 
 	// Align default feature-gates with the connected cluster's version.
-	if err := setupComponentGlobals(config); err != nil {
+	if err := commonutil.SetupComponentGlobals(config); err != nil {
 		klog.Errorf("failed to set component globals: %v", err)
 		return err
 	}
@@ -180,36 +177,4 @@ func startMetricsServer(opt *options.ServerOption) {
 	if err := server.ListenAndServe(); err != nil {
 		klog.Errorf("start metrics/pprof http server failed: %v", err)
 	}
-}
-
-// setupComponentGlobals discovers the API server version and sets
-// Volcano's effective version + feature gate defaults to match the cluster.
-// This makes defaults (like DRA) correct on older clusters.
-func setupComponentGlobals(config *restclient.Config) error {
-	client, err := clientset.NewForConfig(config)
-	if err != nil {
-		return err
-	}
-
-	serverVersion, err := client.Discovery().ServerVersion()
-	if err != nil {
-		return err
-	}
-
-	kubeVersion := fmt.Sprintf("%s.%s", serverVersion.Major, serverVersion.Minor)
-	kubeEffectiveVersion := basecompatibility.NewEffectiveVersionFromString(kubeVersion, "", "")
-
-	componentGlobalsRegistry := basecompatibility.NewComponentGlobalsRegistry()
-	if componentGlobalsRegistry.EffectiveVersionFor(basecompatibility.DefaultKubeComponent) == nil {
-		err = componentGlobalsRegistry.Register(
-			basecompatibility.DefaultKubeComponent,
-			kubeEffectiveVersion,
-			utilfeature.DefaultMutableFeatureGate,
-		)
-		if err != nil {
-			return fmt.Errorf("failed to register component globals: %w", err)
-		}
-	}
-
-	return componentGlobalsRegistry.Set()
 }

--- a/cmd/webhook-manager/app/server.go
+++ b/cmd/webhook-manager/app/server.go
@@ -57,6 +57,12 @@ func Run(config *options.Config) error {
 		return fmt.Errorf("unable to build k8s config: %v", err)
 	}
 
+	// Align default feature-gates with the connected cluster's version.
+	if err := commonutil.SetupComponentGlobals(restConfig); err != nil {
+		klog.Errorf("failed to set component globals: %v", err)
+		return err
+	}
+
 	admissionConf := wkconfig.LoadAdmissionConf(config.ConfigPath)
 	if admissionConf == nil {
 		klog.Errorf("loadAdmissionConf failed.")

--- a/pkg/webhooks/admission/jobs/validate/admit_job.go
+++ b/pkg/webhooks/admission/jobs/validate/admit_job.go
@@ -28,11 +28,13 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/klog/v2"
 	k8score "k8s.io/kubernetes/pkg/apis/core"
 	k8scorev1 "k8s.io/kubernetes/pkg/apis/core/v1"
 	k8scorevalid "k8s.io/kubernetes/pkg/apis/core/validation"
 	"k8s.io/kubernetes/pkg/capabilities"
+	kubefeatures "k8s.io/kubernetes/pkg/features"
 
 	"volcano.sh/apis/pkg/apis/batch/v1alpha1"
 	schedulingv1beta1 "volcano.sh/apis/pkg/apis/scheduling/v1beta1"
@@ -347,7 +349,9 @@ func validateTaskTemplate(task v1alpha1.TaskSpec, job *v1alpha1.Job, index int) 
 		Template: coreTemplateSpec,
 	}
 
-	opts := k8scorevalid.PodValidationOptions{}
+	opts := k8scorevalid.PodValidationOptions{
+		PodLevelResourcesEnabled: utilfeature.DefaultFeatureGate.Enabled(kubefeatures.PodLevelResources),
+	}
 	if allErrs := k8scorevalid.ValidatePodTemplate(&corePodTemplate, opts); len(allErrs) > 0 {
 		msg := fmt.Sprintf("spec.task[%d].", index)
 		for index := range allErrs {

--- a/pkg/webhooks/admission/jobs/validate/admit_job_test.go
+++ b/pkg/webhooks/admission/jobs/validate/admit_job_test.go
@@ -22,10 +22,12 @@ import (
 	"testing"
 
 	admissionv1 "k8s.io/api/admission/v1"
-
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
+	"k8s.io/kubernetes/pkg/features"
 
 	"volcano.sh/apis/pkg/apis/batch/v1alpha1"
 	busv1alpha1 "volcano.sh/apis/pkg/apis/bus/v1alpha1"
@@ -42,14 +44,16 @@ func TestValidateJobCreate(t *testing.T) {
 	highestTierAllowed := 1
 
 	testCases := []struct {
-		Name           string
-		Job            v1alpha1.Job
-		ExpectErr      bool
-		reviewResponse admissionv1.AdmissionResponse
-		ret            string
+		Name                     string
+		PodLevelResourcesEnabled bool
+		Job                      v1alpha1.Job
+		ExpectErr                bool
+		reviewResponse           admissionv1.AdmissionResponse
+		ret                      string
 	}{
 		{
-			Name: "simple-valid-job",
+			Name:                     "simple-valid-job",
+			PodLevelResourcesEnabled: false,
 			Job: v1alpha1.Job{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "simple-valid-job",
@@ -121,9 +125,76 @@ func TestValidateJobCreate(t *testing.T) {
 			ret:            "",
 			ExpectErr:      false,
 		},
+		{
+			Name:                     "validate valid-job with pod level resources",
+			PodLevelResourcesEnabled: true,
+			Job: v1alpha1.Job{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "valid-job-with-pod-level-resources",
+					Namespace: namespace,
+				},
+				Spec: v1alpha1.JobSpec{
+					MinAvailable: 1,
+					Queue:        "default",
+					Tasks: []v1alpha1.TaskSpec{
+						{
+							Name:     "task-1",
+							Replicas: 1,
+							Template: v1.PodTemplateSpec{
+								ObjectMeta: metav1.ObjectMeta{
+									Labels: map[string]string{"name": "test"},
+								},
+								Spec: v1.PodSpec{
+									Resources: &v1.ResourceRequirements{
+										Requests: v1.ResourceList{
+											v1.ResourceCPU:                     resource.MustParse("4"),
+											v1.ResourceMemory:                  resource.MustParse("8Gi"),
+											v1.ResourceHugePagesPrefix + "1Mi": resource.MustParse("2Gi"),
+										},
+										Limits: v1.ResourceList{
+											v1.ResourceCPU:                     resource.MustParse("4"),
+											v1.ResourceMemory:                  resource.MustParse("8Gi"),
+											v1.ResourceHugePagesPrefix + "1Mi": resource.MustParse("2Gi"),
+										},
+									},
+									Containers: []v1.Container{
+										{
+											Name:  "fake-name",
+											Image: "busybox:1.24",
+											Resources: v1.ResourceRequirements{
+												Requests: v1.ResourceList{
+													v1.ResourceCPU:                     resource.MustParse("2"),
+													v1.ResourceMemory:                  resource.MustParse("4Gi"),
+													v1.ResourceHugePagesPrefix + "1Mi": resource.MustParse("1Gi"),
+												},
+												Limits: v1.ResourceList{
+													v1.ResourceCPU:                     resource.MustParse("2"),
+													v1.ResourceMemory:                  resource.MustParse("4Gi"),
+													v1.ResourceHugePagesPrefix + "1Mi": resource.MustParse("1Gi"),
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+					Policies: []v1alpha1.LifecyclePolicy{
+						{
+							Event:  busv1alpha1.PodEvictedEvent,
+							Action: busv1alpha1.RestartTaskAction,
+						},
+					},
+				},
+			},
+			reviewResponse: admissionv1.AdmissionResponse{Allowed: true},
+			ret:            "",
+			ExpectErr:      false,
+		},
 		// duplicate task name
 		{
-			Name: "duplicate-task-job",
+			Name:                     "duplicate-task-job",
+			PodLevelResourcesEnabled: false,
 			Job: v1alpha1.Job{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "duplicate-task-job",
@@ -176,7 +247,8 @@ func TestValidateJobCreate(t *testing.T) {
 		},
 		// Duplicated Policy Event
 		{
-			Name: "job-policy-duplicated",
+			Name:                     "job-policy-duplicated",
+			PodLevelResourcesEnabled: false,
 			Job: v1alpha1.Job{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "job-policy-duplicated",
@@ -222,7 +294,8 @@ func TestValidateJobCreate(t *testing.T) {
 		},
 		// Min Available illegal
 		{
-			Name: "Min Available illegal",
+			Name:                     "Min Available illegal",
+			PodLevelResourcesEnabled: false,
 			Job: v1alpha1.Job{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "job-min-illegal",
@@ -258,7 +331,8 @@ func TestValidateJobCreate(t *testing.T) {
 		},
 		// Job Plugin illegal
 		{
-			Name: "Job Plugin illegal",
+			Name:                     "Job Plugin illegal",
+			PodLevelResourcesEnabled: false,
 			Job: v1alpha1.Job{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "job-plugin-illegal",
@@ -305,7 +379,8 @@ func TestValidateJobCreate(t *testing.T) {
 		// These validations are now enforced by CRD schema validation and VAP (ValidatingAdmissionPolicy).
 		// no task specified in the job
 		{
-			Name: "no-task",
+			Name:                     "no-task",
+			PodLevelResourcesEnabled: false,
 			Job: v1alpha1.Job{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "no-task",
@@ -323,7 +398,8 @@ func TestValidateJobCreate(t *testing.T) {
 		},
 		// replica set less than zero
 		{
-			Name: "replica-lessThanZero",
+			Name:                     "replica-lessThanZero",
+			PodLevelResourcesEnabled: false,
 			Job: v1alpha1.Job{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "replica-lessThanZero",
@@ -359,7 +435,8 @@ func TestValidateJobCreate(t *testing.T) {
 		},
 		// Policy Event with exit code
 		{
-			Name: "job-policy-withExitCode",
+			Name:                     "job-policy-withExitCode",
+			PodLevelResourcesEnabled: false,
 			Job: v1alpha1.Job{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "job-policy-withExitCode",
@@ -402,7 +479,8 @@ func TestValidateJobCreate(t *testing.T) {
 		},
 		// Both policy event and exit code are nil
 		{
-			Name: "policy-noEvent-noExCode",
+			Name:                     "policy-noEvent-noExCode",
+			PodLevelResourcesEnabled: false,
 			Job: v1alpha1.Job{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "policy-noEvent-noExCode",
@@ -443,7 +521,8 @@ func TestValidateJobCreate(t *testing.T) {
 		},
 		// invalid policy event
 		{
-			Name: "invalid-policy-event",
+			Name:                     "invalid-policy-event",
+			PodLevelResourcesEnabled: false,
 			Job: v1alpha1.Job{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "invalid-policy-event",
@@ -485,7 +564,8 @@ func TestValidateJobCreate(t *testing.T) {
 		},
 		// invalid policy action
 		{
-			Name: "invalid-policy-action",
+			Name:                     "invalid-policy-action",
+			PodLevelResourcesEnabled: false,
 			Job: v1alpha1.Job{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "invalid-policy-action",
@@ -527,7 +607,8 @@ func TestValidateJobCreate(t *testing.T) {
 		},
 		// policy exit-code zero
 		{
-			Name: "policy-extcode-zero",
+			Name:                     "policy-extcode-zero",
+			PodLevelResourcesEnabled: false,
 			Job: v1alpha1.Job{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "policy-extcode-zero",
@@ -571,7 +652,8 @@ func TestValidateJobCreate(t *testing.T) {
 		},
 		// duplicate policy exit-code
 		{
-			Name: "duplicate-exitcode",
+			Name:                     "duplicate-exitcode",
+			PodLevelResourcesEnabled: false,
 			Job: v1alpha1.Job{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "duplicate-exitcode",
@@ -619,7 +701,8 @@ func TestValidateJobCreate(t *testing.T) {
 		},
 		// Policy with any event and other events
 		{
-			Name: "job-policy-withExitCode",
+			Name:                     "job-policy-withExitCode",
+			PodLevelResourcesEnabled: false,
 			Job: v1alpha1.Job{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "job-policy-withExitCode",
@@ -665,7 +748,8 @@ func TestValidateJobCreate(t *testing.T) {
 		},
 		// invalid mount volume
 		{
-			Name: "invalid-mount-volume",
+			Name:                     "invalid-mount-volume",
+			PodLevelResourcesEnabled: false,
 			Job: v1alpha1.Job{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "invalid-mount-volume",
@@ -712,7 +796,8 @@ func TestValidateJobCreate(t *testing.T) {
 		},
 		// duplicate mount volume
 		{
-			Name: "duplicate-mount-volume",
+			Name:                     "duplicate-mount-volume",
+			PodLevelResourcesEnabled: false,
 			Job: v1alpha1.Job{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "duplicate-mount-volume",
@@ -763,7 +848,8 @@ func TestValidateJobCreate(t *testing.T) {
 			ExpectErr:      true,
 		},
 		{
-			Name: "volume without VolumeClaimName and VolumeClaim",
+			Name:                     "volume without VolumeClaimName and VolumeClaim",
+			PodLevelResourcesEnabled: false,
 			Job: v1alpha1.Job{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "invalid-volume",
@@ -813,7 +899,8 @@ func TestValidateJobCreate(t *testing.T) {
 		},
 		// task Policy with any event and other events
 		{
-			Name: "taskpolicy-withAnyandOthrEvent",
+			Name:                     "taskpolicy-withAnyandOthrEvent",
+			PodLevelResourcesEnabled: false,
 			Job: v1alpha1.Job{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "taskpolicy-withAnyandOthrEvent",
@@ -859,7 +946,8 @@ func TestValidateJobCreate(t *testing.T) {
 		},
 		// job with no queue created
 		{
-			Name: "job-with-noQueue",
+			Name:                     "job-with-noQueue",
+			PodLevelResourcesEnabled: false,
 			Job: v1alpha1.Job{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "job-with-noQueue",
@@ -894,7 +982,8 @@ func TestValidateJobCreate(t *testing.T) {
 			ExpectErr:      true,
 		},
 		{
-			Name: "job with privileged init container",
+			Name:                     "job with privileged init container",
+			PodLevelResourcesEnabled: false,
 			Job: v1alpha1.Job{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "valid-job",
@@ -938,7 +1027,8 @@ func TestValidateJobCreate(t *testing.T) {
 			ExpectErr:      false,
 		},
 		{
-			Name: "job with privileged container",
+			Name:                     "job with privileged container",
+			PodLevelResourcesEnabled: false,
 			Job: v1alpha1.Job{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "valid-job",
@@ -976,7 +1066,8 @@ func TestValidateJobCreate(t *testing.T) {
 			ExpectErr:      false,
 		},
 		{
-			Name: "job with valid task depends on",
+			Name:                     "job with valid task depends on",
+			PodLevelResourcesEnabled: false,
 			Job: v1alpha1.Job{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "job-with-valid-task-depends-on",
@@ -1026,7 +1117,8 @@ func TestValidateJobCreate(t *testing.T) {
 			ExpectErr:      false,
 		},
 		{
-			Name: "job with invalid task depends on",
+			Name:                     "job with invalid task depends on",
+			PodLevelResourcesEnabled: false,
 			Job: v1alpha1.Job{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "job-with-invalid-task-depends-on",
@@ -1077,7 +1169,8 @@ func TestValidateJobCreate(t *testing.T) {
 		},
 		// task PartitionSize set less than zero
 		{
-			Name: "PartitionSize-lessThanZero",
+			Name:                     "PartitionSize-lessThanZero",
+			PodLevelResourcesEnabled: false,
 			Job: v1alpha1.Job{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "PartitionSize-lessThanZero",
@@ -1117,7 +1210,8 @@ func TestValidateJobCreate(t *testing.T) {
 		},
 		// task TotalPartitions set less than zero
 		{
-			Name: "TotalPartitions-lessThanZero",
+			Name:                     "TotalPartitions-lessThanZero",
+			PodLevelResourcesEnabled: false,
 			Job: v1alpha1.Job{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "TotalPartitions-lessThanZero",
@@ -1157,7 +1251,8 @@ func TestValidateJobCreate(t *testing.T) {
 		},
 		// task-with-invalid-PartitionPolicy: replicas not equal to TotalPartitions*PartitionSize
 		{
-			Name: "task-with-invalid-PartitionPolicy",
+			Name:                     "task-with-invalid-PartitionPolicy",
+			PodLevelResourcesEnabled: false,
 			Job: v1alpha1.Job{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "task-with-invalid-PartitionPolicy",
@@ -1197,7 +1292,8 @@ func TestValidateJobCreate(t *testing.T) {
 		},
 		// task-with-valid-PartitionPolicy: replicas equal to TotalPartitions*PartitionSize
 		{
-			Name: "task-with-valid-PartitionPolicy",
+			Name:                     "task-with-valid-PartitionPolicy",
+			PodLevelResourcesEnabled: false,
 			Job: v1alpha1.Job{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "task-with-valid-PartitionPolicy",
@@ -1236,7 +1332,8 @@ func TestValidateJobCreate(t *testing.T) {
 			ExpectErr:      false,
 		},
 		{
-			Name: "task-with-valid-NetworkTopology-and-PartitionPolicy",
+			Name:                     "task-with-valid-NetworkTopology-and-PartitionPolicy",
+			PodLevelResourcesEnabled: false,
 			Job: v1alpha1.Job{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "task-with-valid-NetworkTopology-and-PartitionPolicy",
@@ -1283,7 +1380,8 @@ func TestValidateJobCreate(t *testing.T) {
 			ExpectErr:      false,
 		},
 		{
-			Name: "job-with-invalid-NetworkTopology-and-PartitionPolicy",
+			Name:                     "job-with-invalid-NetworkTopology-and-PartitionPolicy",
+			PodLevelResourcesEnabled: false,
 			Job: v1alpha1.Job{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "job-with-invalid-NetworkTopology-and-PartitionPolicy",
@@ -1332,7 +1430,8 @@ func TestValidateJobCreate(t *testing.T) {
 			ExpectErr:      true,
 		},
 		{
-			Name: "job-with-invalid-NetworkTopology",
+			Name:                     "job-with-invalid-NetworkTopology",
+			PodLevelResourcesEnabled: false,
 			Job: v1alpha1.Job{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "job-with-invalid-NetworkTopology",
@@ -1376,7 +1475,8 @@ func TestValidateJobCreate(t *testing.T) {
 			ExpectErr:      true,
 		},
 		{
-			Name: "task-with-invalid-PartitionPolicy",
+			Name:                     "task-with-invalid-PartitionPolicy",
+			PodLevelResourcesEnabled: false,
 			Job: v1alpha1.Job{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "task-with-invalid-PartitionPolicy",
@@ -1420,7 +1520,8 @@ func TestValidateJobCreate(t *testing.T) {
 			ExpectErr:      true,
 		},
 		{
-			Name: "task-with-valid-PartitionPolicy-MinPartitions",
+			Name:                     "task-with-valid-PartitionPolicy-MinPartitions",
+			PodLevelResourcesEnabled: false,
 			Job: v1alpha1.Job{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "task-with-valid-PartitionPolicy-MinPartitions",
@@ -1460,7 +1561,8 @@ func TestValidateJobCreate(t *testing.T) {
 			ExpectErr:      false,
 		},
 		{
-			Name: "task-with-invalid-PartitionPolicy-MinPartitions-not-equal",
+			Name:                     "task-with-invalid-PartitionPolicy-MinPartitions-not-equal",
+			PodLevelResourcesEnabled: false,
 			Job: v1alpha1.Job{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "task-with-invalid-PartitionPolicy-MinPartitions",
@@ -1501,7 +1603,8 @@ func TestValidateJobCreate(t *testing.T) {
 			ExpectErr:      true,
 		},
 		{
-			Name: "task-with-valid-PartitionPolicy-MinPartitions-equal",
+			Name:                     "task-with-valid-PartitionPolicy-MinPartitions-equal",
+			PodLevelResourcesEnabled: false,
 			Job: v1alpha1.Job{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "task-with-valid-PartitionPolicy-MinPartitions-equal",
@@ -1543,7 +1646,8 @@ func TestValidateJobCreate(t *testing.T) {
 		},
 		// Test MPI plugin validation
 		{
-			Name: "job-with-mpi-plugin-valid-master",
+			Name:                     "job-with-mpi-plugin-valid-master",
+			PodLevelResourcesEnabled: false,
 			Job: v1alpha1.Job{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "job-with-mpi-plugin-valid-master",
@@ -1592,7 +1696,8 @@ func TestValidateJobCreate(t *testing.T) {
 			ExpectErr:      false,
 		},
 		{
-			Name: "job-with-mpi-plugin-valid-master-without-worker",
+			Name:                     "job-with-mpi-plugin-valid-master-without-worker",
+			PodLevelResourcesEnabled: false,
 			Job: v1alpha1.Job{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "job-with-mpi-plugin-valid-master",
@@ -1627,7 +1732,8 @@ func TestValidateJobCreate(t *testing.T) {
 			ExpectErr:      false,
 		},
 		{
-			Name: "job-with-mpi-plugin-invalid-master",
+			Name:                     "job-with-mpi-plugin-invalid-master",
+			PodLevelResourcesEnabled: false,
 			Job: v1alpha1.Job{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "job-with-mpi-plugin-invalid-master",
@@ -1661,6 +1767,216 @@ func TestValidateJobCreate(t *testing.T) {
 			ret:            "The specified mpi master task was not found",
 			ExpectErr:      true,
 		},
+		{
+			Name:                     "validate invalid-job with pod level resources less than aggregate container resources",
+			PodLevelResourcesEnabled: true,
+			Job: v1alpha1.Job{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "invalid-job-with-pod-level-resources",
+					Namespace: namespace,
+				},
+				Spec: v1alpha1.JobSpec{
+					MinAvailable: 1,
+					Queue:        "default",
+					Tasks: []v1alpha1.TaskSpec{
+						{
+							Name:     "task-1",
+							Replicas: 1,
+							Template: v1.PodTemplateSpec{
+								ObjectMeta: metav1.ObjectMeta{
+									Labels: map[string]string{"name": "test"},
+								},
+								Spec: v1.PodSpec{
+									Resources: &v1.ResourceRequirements{
+										Requests: v1.ResourceList{
+											v1.ResourceCPU:                     resource.MustParse("2"),
+											v1.ResourceHugePagesPrefix + "1Mi": resource.MustParse("2Gi"),
+											v1.ResourceHugePagesPrefix + "1Ki": resource.MustParse("2Gi"),
+										},
+										Limits: v1.ResourceList{
+											v1.ResourceCPU:                     resource.MustParse("2"),
+											v1.ResourceHugePagesPrefix + "1Mi": resource.MustParse("2Gi"),
+											v1.ResourceHugePagesPrefix + "1Ki": resource.MustParse("2Gi"),
+										},
+									},
+									InitContainers: []v1.Container{
+										{
+											Name:  "fake-name-0",
+											Image: "busybox:1.24",
+											Resources: v1.ResourceRequirements{
+												Requests: v1.ResourceList{
+													v1.ResourceCPU: resource.MustParse("2"),
+												},
+											},
+										},
+									},
+									Containers: []v1.Container{
+										{
+											Name:  "fake-name-1",
+											Image: "busybox:1.24",
+											Resources: v1.ResourceRequirements{
+												Requests: v1.ResourceList{
+													v1.ResourceCPU: resource.MustParse("2"),
+												},
+											},
+										},
+										{
+											Name:  "fake-name-2",
+											Image: "busybox:1.24",
+											Resources: v1.ResourceRequirements{
+												Requests: v1.ResourceList{
+													v1.ResourceCPU: resource.MustParse("2"),
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			reviewResponse: admissionv1.AdmissionResponse{Allowed: false},
+			ret:            "spec.task[0].template.spec.resources.requests[cpu]: Invalid value: \"2\": must be greater than or equal to aggregate container requests of 4",
+			ExpectErr:      true,
+		},
+		{
+			Name:                     "validate valid-job with pod level resources less than aggregate container resources, but PodLevelResources disabled",
+			PodLevelResourcesEnabled: false,
+			Job: v1alpha1.Job{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "invalid-job-with-pod-level-resources",
+					Namespace: namespace,
+				},
+				Spec: v1alpha1.JobSpec{
+					MinAvailable: 1,
+					Queue:        "default",
+					Tasks: []v1alpha1.TaskSpec{
+						{
+							Name:     "task-1",
+							Replicas: 1,
+							Template: v1.PodTemplateSpec{
+								ObjectMeta: metav1.ObjectMeta{
+									Labels: map[string]string{"name": "test"},
+								},
+								Spec: v1.PodSpec{
+									Resources: &v1.ResourceRequirements{
+										Requests: v1.ResourceList{
+											v1.ResourceCPU:                     resource.MustParse("2"),
+											v1.ResourceHugePagesPrefix + "1Mi": resource.MustParse("2Gi"),
+											v1.ResourceHugePagesPrefix + "1Ki": resource.MustParse("2Gi"),
+										},
+										Limits: v1.ResourceList{
+											v1.ResourceCPU:                     resource.MustParse("2"),
+											v1.ResourceHugePagesPrefix + "1Mi": resource.MustParse("2Gi"),
+											v1.ResourceHugePagesPrefix + "1Ki": resource.MustParse("2Gi"),
+										},
+									},
+									InitContainers: []v1.Container{
+										{
+											Name:  "fake-name-0",
+											Image: "busybox:1.24",
+											Resources: v1.ResourceRequirements{
+												Requests: v1.ResourceList{
+													v1.ResourceCPU: resource.MustParse("2"),
+												},
+											},
+										},
+									},
+									Containers: []v1.Container{
+										{
+											Name:  "fake-name-1",
+											Image: "busybox:1.24",
+											Resources: v1.ResourceRequirements{
+												Requests: v1.ResourceList{
+													v1.ResourceCPU: resource.MustParse("2"),
+												},
+											},
+										},
+										{
+											Name:  "fake-name-2",
+											Image: "busybox:1.24",
+											Resources: v1.ResourceRequirements{
+												Requests: v1.ResourceList{
+													v1.ResourceCPU: resource.MustParse("2"),
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			reviewResponse: admissionv1.AdmissionResponse{Allowed: true},
+			ret:            "",
+			ExpectErr:      false,
+		},
+		{
+			Name:                     "validate invalid-job with pod level resource requests greater than limits",
+			PodLevelResourcesEnabled: true,
+			Job: v1alpha1.Job{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "invalid-job-with-pod-level-resources",
+					Namespace: namespace,
+				},
+				Spec: v1alpha1.JobSpec{
+					MinAvailable: 1,
+					Queue:        "default",
+					Tasks: []v1alpha1.TaskSpec{
+						{
+							Name:     "task-1",
+							Replicas: 1,
+							Template: v1.PodTemplateSpec{
+								ObjectMeta: metav1.ObjectMeta{
+									Labels: map[string]string{"name": "test"},
+								},
+								Spec: v1.PodSpec{
+									Resources: &v1.ResourceRequirements{
+										Requests: v1.ResourceList{
+											v1.ResourceCPU: resource.MustParse("6"),
+										},
+										Limits: v1.ResourceList{
+											v1.ResourceCPU: resource.MustParse("4"),
+										},
+									},
+									Containers: []v1.Container{
+										{
+											Name:  "fake-name-1",
+											Image: "busybox:1.24",
+											Resources: v1.ResourceRequirements{
+												Requests: v1.ResourceList{
+													v1.ResourceCPU: resource.MustParse("2"),
+												},
+												Limits: v1.ResourceList{
+													v1.ResourceCPU: resource.MustParse("2"),
+												},
+											},
+										},
+										{
+											Name:  "fake-name-2",
+											Image: "busybox:1.24",
+											Resources: v1.ResourceRequirements{
+												Requests: v1.ResourceList{
+													v1.ResourceCPU: resource.MustParse("2"),
+												},
+												Limits: v1.ResourceList{
+													v1.ResourceCPU: resource.MustParse("2"),
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			reviewResponse: admissionv1.AdmissionResponse{Allowed: false},
+			ret:            "spec.task[0].template.spec.resources.requests: Invalid value: \"6\": must be less than or equal to cpu limit of 4",
+			ExpectErr:      true,
+		},
 	}
 
 	defaultqueue := &schedulingv1beta2.Queue{
@@ -1692,8 +2008,9 @@ func TestValidateJobCreate(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.Name, func(t *testing.T) {
+			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.PodLevelResources, testCase.PodLevelResourcesEnabled)
 			ret := validateJobCreate(&testCase.Job, &testCase.reviewResponse)
-			//fmt.Printf("test-case name:%s, ret:%v  testCase.reviewResponse:%v \n", testCase.Name, ret,testCase.reviewResponse)
+			//fmt.Printf("test-case name:%s, ret:%v  testCase.reviewResponse:%v \n", testCase.Name, ret, testCase.reviewResponse)
 			if testCase.ExpectErr == true && ret == "" {
 				t.Errorf("Expect error msg :%s, but got nil.", testCase.ret)
 			}


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

In order to make resource sharing among containers within a pod easier and provide users with greater flexibility, Kubernetes has allowed settings of resource requests & limits at the pod level since v1.32, and has released the beta version in v1.34. Unfortunately, Volcano currently does not support this feature and cannot benefit from it.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Notice that do not add `Fixes` if the issue is associated with multiple PRs.
-->
Fixes #5016

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
Pod-level resource requests & limits are now allowed for users to set.
```