### PR TITLE
Fix flaky test: stop waiting after Restarting phase

### DIFF
--- a/test/e2e/jobseq/job_error_handling.go
+++ b/test/e2e/jobseq/job_error_handling.go
@@ -190,8 +190,8 @@ var _ = Describe("Job Error Handling", func() {
 			},
 		})
 
-		// job phase: pending -> running -> restarting -> running
-		err := e2eutil.WaitJobPhases(testCtx, job, []vcbatch.JobPhase{vcbatch.Pending, vcbatch.Running, vcbatch.Restarting, vcbatch.Running})
+		// job phase: pending -> running -> restarting
+		err := e2eutil.WaitJobPhases(testCtx, job, []vcbatch.JobPhase{vcbatch.Pending, vcbatch.Running, vcbatch.Restarting})
 		Expect(err).NotTo(HaveOccurred())
 	})
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Fixes a flaky e2e test: `job level LifecyclePolicy, Event: PodFailed, Action: RestartPod; Event PodEvicted, Action: TerminateJob, Timeout: 5m`

The test was waiting for the job to transition through `Pending → Running → Restarting → Running`, but the job gets stuck in `Restarting` because the pod command (`sleep 10s && xxx`) keeps failing and restarting indefinitely.

This PR stops waiting after the `Restarting` phase since that correctly validates the `RestartPodAction` behavior.

#### Which issue(s) this PR fixes:

Fixes #5015

#### Special notes for your reviewer:

**Testing:**
- Without fix: Test times out after ~625s with error "expected Running, got Restarting"
- With fix: Test passes in ~24s

The test correctly validates that `RestartPodAction` triggers the `Restarting` phase. Waiting for `Running` is not meaningful since the pod will keep failing forever.

#### Does this PR introduce a user-facing change?

```release-note
NONE
