### PR TITLE
Fixed issue where jobs with subgroups but not hard networkTopology.mode could not be scheduled.

### DIFF
--- a/pkg/scheduler/actions/allocate/allocate.go
+++ b/pkg/scheduler/actions/allocate/allocate.go
@@ -298,10 +298,12 @@ func (alloc *Action) allocateResources(actx *allocateContext) {
 
 		job := jobs.Pop().(*api.JobInfo)
 		updateJobTier(ssn.HyperNodeTierNameMap, job)
-		if job.ContainsHardTopology() {
+		// Currently, both hard-mode network topology scheduling and subjob level scheduling use allocateForJob.
+		// TODO: In the future, we may need to unify the logic of network topology-aware scheduling and normal scheduling.
+		if job.ContainsHardTopology() || job.ContainsSubJobPolicy() {
 			jobWorksheet := actx.jobWorksheet[job.UID]
 
-			klog.V(3).InfoS("Try to allocate resource for job contains hard topology", "queue", queue.Name, "job", job.UID,
+			klog.V(3).InfoS("Try to allocate resource for job contains hard topology or subjob policy", "queue", queue.Name, "job", job.UID,
 				"allocatedHyperNode", job.AllocatedHyperNode, "subJobNum", jobWorksheet.subJobs.Len())
 			stmt := alloc.allocateForJob(job, jobWorksheet, ssn.HyperNodes[framework.ClusterTopHyperNode])
 			if stmt != nil && ssn.JobReady(job) { // do not commit stmt when job is pipelined

--- a/pkg/scheduler/actions/allocate/allocate_test.go
+++ b/pkg/scheduler/actions/allocate/allocate_test.go
@@ -5523,6 +5523,28 @@ func TestAllocateWithPartitionPolicyNetworkTopology(t *testing.T) {
 			ExpectBindsNum:   2,
 			MinimalBindCheck: true,
 		},
+		{
+			Name: "no network topology at job or subgroup level but has SubJobPolicy, can allocate job successfully",
+			PodGroups: []*schedulingv1.PodGroup{
+				util.BuildPodGroupWithSubGroupPolicy("pg1", "c1", "", "q1", 2, nil, schedulingv1.PodGroupInqueue, "", 0,
+					[]schedulingv1.SubGroupPolicySpec{
+						util.BuildSubGroupPolicyWithMinSubGroups("worker", []string{"volcano.sh/task-spec"}, "", 0, 1, 2),
+					}),
+			},
+			Pods: []*v1.Pod{
+				util.BuildPod("c1", "p1", "", v1.PodPending, api.BuildResourceList("2", "4G"), "pg1", map[string]string{"volcano.sh/task-spec": "worker-0"}, nil),
+				util.BuildPod("c1", "p2", "", v1.PodPending, api.BuildResourceList("2", "4G"), "pg1", map[string]string{"volcano.sh/task-spec": "worker-1"}, nil),
+			},
+			Nodes: []*v1.Node{
+				util.BuildNode("n1", api.BuildResourceList("2", "4Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), nil),
+				util.BuildNode("n2", api.BuildResourceList("2", "4Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), nil),
+			},
+			Queues: []*schedulingv1.Queue{
+				util.BuildQueue("q1", 1, nil),
+			},
+			ExpectBindsNum:   2,
+			MinimalBindCheck: true,
+		},
 	}
 
 	trueValue := true

--- a/pkg/scheduler/util/test_utils.go
+++ b/pkg/scheduler/util/test_utils.go
@@ -358,23 +358,34 @@ func BuildSubGroupPolicyWithSubGroupSize(name string, matchLabelKeys []string, m
 	return BuildSubGroupPolicyWithMinSubGroups(name, matchLabelKeys, mode, highestTierAllowed, subGroupSize, 0)
 }
 
+// BuildSubGroupPolicyWithMinSubGroups builds SubGroupPolicy with minSubGroups, if the mode is not empty, it will also set NetworkTopology for the subgroup
 func BuildSubGroupPolicyWithMinSubGroups(name string, matchLabelKeys []string, mode string, highestTierAllowed int, subGroupSize, minSubGroups int32) schedulingv1beta1.SubGroupPolicySpec {
 	subGroupPolicy := schedulingv1beta1.SubGroupPolicySpec{
-		Name: name,
-		NetworkTopology: &schedulingv1beta1.NetworkTopologySpec{
-			Mode:               schedulingv1beta1.NetworkTopologyMode(mode),
-			HighestTierAllowed: &highestTierAllowed,
-		},
+		Name:         name,
 		SubGroupSize: &subGroupSize,
 		MinSubGroups: &minSubGroups,
 	}
 	subGroupPolicy.MatchLabelKeys = matchLabelKeys
+
+	if mode != "" {
+		subGroupPolicy.NetworkTopology = &schedulingv1beta1.NetworkTopologySpec{
+			Mode:               schedulingv1beta1.NetworkTopologyMode(mode),
+			HighestTierAllowed: &highestTierAllowed,
+		}
+	}
+
 	return subGroupPolicy
 }
 
-// BuildPodGroupWithSubGroupPolicy builds podGroup with NetworkTopology and SubGroupPolicy.
+// BuildPodGroupWithSubGroupPolicy builds podGroup with SubGroupPolicy, if the mode is not empty, it will also set NetworkTopology for the podgroup
 func BuildPodGroupWithSubGroupPolicy(name, ns, hyperNodeName, queue string, minMember int32, taskMinMember map[string]int32, status schedulingv1beta1.PodGroupPhase, mode string, highestTierAllowed int, subGroupPolicy []schedulingv1beta1.SubGroupPolicySpec) *schedulingv1beta1.PodGroup {
-	pg := BuildPodGroupWithNetWorkTopologies(name, ns, hyperNodeName, queue, minMember, taskMinMember, status, mode, highestTierAllowed)
+	var pg *schedulingv1beta1.PodGroup
+	if mode != "" {
+		pg = BuildPodGroupWithNetWorkTopologies(name, ns, hyperNodeName, queue, minMember, taskMinMember, status, mode, highestTierAllowed)
+	} else {
+		pg = BuildPodGroup(name, ns, queue, minMember, taskMinMember, status)
+	}
+
 	pg.Spec.SubGroupPolicy = subGroupPolicy
 	return pg
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
When networkTopology.mode is not hard, but subgroups exist, scheduling is not possible, we need to support it. 
This pr is inherited from #4872

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Notice that do not add `Fixes` if the issue is associated with multiple PRs.
-->
Fixes #4871

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```