### PR TITLE
fix: queue allocated metric consistency for jobless queues in capacit…

### DIFF
--- a/pkg/scheduler/plugins/capacity/capacity.go
+++ b/pkg/scheduler/plugins/capacity/capacity.go
@@ -445,6 +445,33 @@ func (cp *capacityPlugin) OnSessionClose(ssn *framework.Session) {
 	cp.queueOpts = nil
 }
 
+// initQueueAttr initializes a queueAttr from queueInfo.
+// This helper method ensures consistent initialization for both queues with jobs and jobless queues.
+func (cp *capacityPlugin) initQueueAttr(queueInfo *api.QueueInfo) *queueAttr {
+	attr := cp.newQueueAttr(queueInfo)
+
+	// Calculate realCapability: the effective resource limit for this queue
+	realCapability := api.ExceededPart(cp.totalResource, cp.totalGuarantee).Add(attr.guarantee)
+
+	// Only apply MaxFloat64 and MinDimensionResource when Capability is explicitly set.
+	// Distinguish between Capability not set (nil) vs Capability explicitly set to 0.
+	// When Capability is nil, we use MaxFloat64 as a default for unlimited capacity.
+	// When Capability is explicitly set to 0, we respect the user's intent and keep it as 0.
+	if len(queueInfo.Queue.Spec.Capability) != 0 {
+		if attr.capability.MilliCPU <= 0 {
+			attr.capability.MilliCPU = math.MaxFloat64
+		}
+		if attr.capability.Memory <= 0 {
+			attr.capability.Memory = math.MaxFloat64
+		}
+		realCapability.MinDimensionResource(attr.capability, api.Infinity)
+	}
+
+	attr.realCapability = realCapability
+
+	return attr
+}
+
 func (cp *capacityPlugin) buildQueueAttrs(ssn *framework.Session) {
 	for _, queue := range ssn.Queues {
 		if len(queue.Queue.Spec.Guarantee.Resource) == 0 {
@@ -459,37 +486,7 @@ func (cp *capacityPlugin) buildQueueAttrs(ssn *framework.Session) {
 		klog.V(4).Infof("Considering Job <%s/%s>.", job.Namespace, job.Name)
 		if _, found := cp.queueOpts[job.Queue]; !found {
 			queue := ssn.Queues[job.Queue]
-			attr := &queueAttr{
-				queueID: queue.UID,
-				name:    queue.Name,
-
-				deserved:  api.NewResource(queue.Queue.Spec.Deserved),
-				allocated: api.EmptyResource(),
-				request:   api.EmptyResource(),
-				elastic:   api.EmptyResource(),
-				inqueue:   api.EmptyResource(),
-				guarantee: api.EmptyResource(),
-			}
-			if len(queue.Queue.Spec.Capability) != 0 {
-				attr.capability = api.NewResource(queue.Queue.Spec.Capability)
-				if attr.capability.MilliCPU <= 0 {
-					attr.capability.MilliCPU = math.MaxFloat64
-				}
-				if attr.capability.Memory <= 0 {
-					attr.capability.Memory = math.MaxFloat64
-				}
-			}
-			if len(queue.Queue.Spec.Guarantee.Resource) != 0 {
-				attr.guarantee = api.NewResource(queue.Queue.Spec.Guarantee.Resource)
-			}
-			realCapability := api.ExceededPart(cp.totalResource, cp.totalGuarantee).Add(attr.guarantee)
-			if attr.capability == nil {
-				attr.capability = api.EmptyResource()
-				attr.realCapability = realCapability
-			} else {
-				realCapability.MinDimensionResource(attr.capability, api.Infinity)
-				attr.realCapability = realCapability
-			}
+			attr := cp.initQueueAttr(queue)
 			cp.queueOpts[job.Queue] = attr
 			klog.V(4).Infof("Added Queue <%s> attributes.", job.Queue)
 		}
@@ -528,10 +525,22 @@ func (cp *capacityPlugin) buildQueueAttrs(ssn *framework.Session) {
 			attr.name, attr.allocated.String(), attr.request.String(), attr.inqueue.String(), attr.elastic.String())
 	}
 
-	for _, attr := range cp.queueOpts {
-		if attr.realCapability != nil {
-			attr.deserved.MinDimensionResource(attr.realCapability, api.Infinity)
+	// Populate queueAttr for jobless queues using Queue.Status.Allocated
+	// This ensures metrics are consistent with Queue.Status.Allocated when hierarchy is disabled
+	for queueID, queueInfo := range ssn.Queues {
+		if _, exists := cp.queueOpts[queueID]; !exists {
+			attr := cp.initQueueAttr(queueInfo)
+			// Use Queue.Status.Allocated for jobless queues to ensure metric consistency
+			if queueInfo.Queue.Status.Allocated != nil {
+				attr.allocated = api.NewResource(queueInfo.Queue.Status.Allocated)
+			}
+			cp.queueOpts[queueID] = attr
+			klog.V(4).Infof("Added jobless Queue <%s> attributes with allocated from status: <%v>", queueInfo.Name, attr.allocated)
 		}
+	}
+
+	for _, attr := range cp.queueOpts {
+		attr.deserved.MinDimensionResource(attr.realCapability, api.Infinity)
 
 		attr.deserved = helpers.Max(attr.deserved, attr.guarantee)
 		cp.updateShare(attr)
@@ -539,40 +548,13 @@ func (cp *capacityPlugin) buildQueueAttrs(ssn *framework.Session) {
 			attr.name, attr.deserved, attr.realCapability, attr.allocated, attr.request, attr.elastic, attr.share)
 	}
 
-	// Record metrics
-	for queueID, queueInfo := range ssn.Queues {
-		queue := ssn.Queues[queueID]
-		if attr, ok := cp.queueOpts[queueID]; ok {
-			metrics.UpdateQueueDeserved(attr.name, attr.deserved.MilliCPU, attr.deserved.Memory, attr.deserved.ScalarResources)
-			metrics.UpdateQueueAllocated(attr.name, attr.allocated.MilliCPU, attr.allocated.Memory, attr.allocated.ScalarResources)
-			metrics.UpdateQueueRequest(attr.name, attr.request.MilliCPU, attr.request.Memory, attr.request.ScalarResources)
-			if attr.capability != nil {
-				metrics.UpdateQueueCapacity(attr.name, attr.capability.MilliCPU, attr.capability.Memory, attr.capability.ScalarResources)
-			}
-			metrics.UpdateQueueRealCapacity(attr.name, attr.realCapability.MilliCPU, attr.realCapability.Memory, attr.realCapability.ScalarResources)
-			continue
-		}
-		deservedCPU, deservedMem, scalarResources := 0.0, 0.0, map[v1.ResourceName]float64{}
-		if queue.Queue.Spec.Deserved != nil {
-			attr := api.NewResource(queue.Queue.Spec.Deserved)
-			deservedCPU = attr.MilliCPU
-			deservedMem = attr.Memory
-			scalarResources = attr.ScalarResources
-		}
-		metrics.UpdateQueueDeserved(queueInfo.Name, deservedCPU, deservedMem, scalarResources)
-		metrics.UpdateQueueAllocated(queueInfo.Name, 0, 0, map[v1.ResourceName]float64{})
-		metrics.UpdateQueueRequest(queueInfo.Name, 0, 0, map[v1.ResourceName]float64{})
-		guarantee := api.EmptyResource()
-		if len(queue.Queue.Spec.Guarantee.Resource) != 0 {
-			guarantee = api.NewResource(queue.Queue.Spec.Guarantee.Resource)
-		}
-		realCapacity := api.ExceededPart(cp.totalResource, cp.totalGuarantee).Add(guarantee)
-		if len(queue.Queue.Spec.Capability) > 0 {
-			capacity := api.NewResource(queue.Queue.Spec.Capability)
-			realCapacity.MinDimensionResource(capacity, api.Infinity)
-			metrics.UpdateQueueCapacity(queueInfo.Name, capacity.MilliCPU, capacity.Memory, capacity.ScalarResources)
-		}
-		metrics.UpdateQueueRealCapacity(queueInfo.Name, realCapacity.MilliCPU, realCapacity.Memory, realCapacity.ScalarResources)
+	// Record metrics - all queues are now guaranteed to be in queueOpts
+	for _, attr := range cp.queueOpts {
+		metrics.UpdateQueueDeserved(attr.name, attr.deserved.MilliCPU, attr.deserved.Memory, attr.deserved.ScalarResources)
+		metrics.UpdateQueueAllocated(attr.name, attr.allocated.MilliCPU, attr.allocated.Memory, attr.allocated.ScalarResources)
+		metrics.UpdateQueueRequest(attr.name, attr.request.MilliCPU, attr.request.Memory, attr.request.ScalarResources)
+		metrics.UpdateQueueCapacity(attr.name, attr.capability.MilliCPU, attr.capability.Memory, attr.capability.ScalarResources)
+		metrics.UpdateQueueRealCapacity(attr.name, attr.realCapability.MilliCPU, attr.realCapability.Memory, attr.realCapability.ScalarResources)
 	}
 
 	ssn.AddQueueOrderFn(cp.Name(), func(l, r interface{}) int {

--- a/pkg/scheduler/plugins/capacity/capacity.go
+++ b/pkg/scheduler/plugins/capacity/capacity.go
@@ -1053,6 +1053,33 @@ func (cp *capacityPlugin) OnSessionClose(ssn *framework.Session) {
 	cp.queueGateReservedTasks = nil
 }
 
+// initQueueAttr initializes a queueAttr from queueInfo.
+// This helper method ensures consistent initialization for both queues with jobs and jobless queues.
+func (cp *capacityPlugin) initQueueAttr(queueInfo *api.QueueInfo) *queueAttr {
+	attr := cp.newQueueAttr(queueInfo)
+
+	// Calculate realCapability: the effective resource limit for this queue
+	realCapability := api.ExceededPart(cp.totalResource, cp.totalGuarantee).Add(attr.guarantee)
+
+	// Only apply MaxFloat64 and MinDimensionResource when Capability is explicitly set.
+	// Distinguish between Capability not set (nil) vs Capability explicitly set to 0.
+	// When Capability is nil, we use MaxFloat64 as a default for unlimited capacity.
+	// When Capability is explicitly set to 0, we respect the user's intent and keep it as 0.
+	if len(queueInfo.Queue.Spec.Capability) != 0 {
+		if attr.capability.MilliCPU <= 0 {
+			attr.capability.MilliCPU = math.MaxFloat64
+		}
+		if attr.capability.Memory <= 0 {
+			attr.capability.Memory = math.MaxFloat64
+		}
+		realCapability.MinDimensionResource(attr.capability, api.Infinity)
+	}
+
+	attr.realCapability = realCapability
+
+	return attr
+}
+
 func (cp *capacityPlugin) buildQueueAttrs(ssn *framework.Session) {
 	for _, queue := range ssn.Queues {
 		if len(queue.Queue.Spec.Guarantee.Resource) == 0 {
@@ -1067,39 +1094,7 @@ func (cp *capacityPlugin) buildQueueAttrs(ssn *framework.Session) {
 		klog.V(4).Infof("Considering Job <%s/%s>.", job.Namespace, job.Name)
 		if _, found := cp.queueOpts[job.Queue]; !found {
 			queue := ssn.Queues[job.Queue]
-			attr := &queueAttr{
-				queueID: queue.UID,
-				name:    queue.Name,
-
-				deserved:          api.NewResource(queue.Queue.Spec.Deserved),
-				allocated:         api.EmptyResource(),
-				request:           api.EmptyResource(),
-				elastic:           api.EmptyResource(),
-				inqueue:           api.EmptyResource(),
-				guarantee:         api.EmptyResource(),
-				resourceClaimRefs: make(map[string]int),
-			}
-			if len(queue.Queue.Spec.Capability) != 0 {
-				attr.capability = api.NewResource(queue.Queue.Spec.Capability)
-				if attr.capability.MilliCPU <= 0 {
-					attr.capability.MilliCPU = math.MaxFloat64
-				}
-				if attr.capability.Memory <= 0 {
-					attr.capability.Memory = math.MaxFloat64
-				}
-			}
-			attr.dra = newDRAQuotaAttr(queue.Queue.Spec.Capability, queue.Queue.Spec.Deserved, queue.Queue.Spec.Guarantee.Resource)
-			if len(queue.Queue.Spec.Guarantee.Resource) != 0 {
-				attr.guarantee = api.NewResource(queue.Queue.Spec.Guarantee.Resource)
-			}
-			realCapability := api.ExceededPart(cp.totalResource, cp.totalGuarantee).Add(attr.guarantee)
-			if attr.capability == nil {
-				attr.capability = api.EmptyResource()
-				attr.realCapability = realCapability
-			} else {
-				realCapability.MinDimensionResource(attr.capability, api.Infinity)
-				attr.realCapability = realCapability
-			}
+			attr := cp.initQueueAttr(queue)
 			cp.queueOpts[job.Queue] = attr
 			klog.V(4).Infof("Added Queue <%s> attributes.", job.Queue)
 		}
@@ -1147,10 +1142,22 @@ func (cp *capacityPlugin) buildQueueAttrs(ssn *framework.Session) {
 			attr.name, attr.allocated.String(), attr.request.String(), attr.inqueue.String(), attr.elastic.String())
 	}
 
-	for _, attr := range cp.queueOpts {
-		if attr.realCapability != nil {
-			attr.deserved.MinDimensionResource(attr.realCapability, api.Infinity)
+	// Populate queueAttr for jobless queues using Queue.Status.Allocated
+	// This ensures metrics are consistent with Queue.Status.Allocated when hierarchy is disabled
+	for queueID, queueInfo := range ssn.Queues {
+		if _, exists := cp.queueOpts[queueID]; !exists {
+			attr := cp.initQueueAttr(queueInfo)
+			// Use Queue.Status.Allocated for jobless queues to ensure metric consistency
+			if queueInfo.Queue.Status.Allocated != nil {
+				attr.allocated = api.NewResource(queueInfo.Queue.Status.Allocated)
+			}
+			cp.queueOpts[queueID] = attr
+			klog.V(4).Infof("Added jobless Queue <%s> attributes with allocated from status: <%v>", queueInfo.Name, attr.allocated)
 		}
+	}
+
+	for _, attr := range cp.queueOpts {
+		attr.deserved.MinDimensionResource(attr.realCapability, api.Infinity)
 
 		attr.deserved = helpers.Max(attr.deserved, attr.guarantee)
 		cp.updateShare(attr)
@@ -1158,42 +1165,14 @@ func (cp *capacityPlugin) buildQueueAttrs(ssn *framework.Session) {
 			attr.name, attr.deserved, attr.realCapability, attr.allocated, attr.request, attr.elastic, attr.share)
 	}
 
-	// Record metrics
-	for queueID, queueInfo := range ssn.Queues {
-		queue := ssn.Queues[queueID]
-		if attr, ok := cp.queueOpts[queueID]; ok {
-			metrics.UpdateQueueDeserved(attr.name, attr.deserved.MilliCPU, attr.deserved.Memory, attr.deserved.ScalarResources)
-			metrics.UpdateQueueAllocated(attr.name, attr.allocated.MilliCPU, attr.allocated.Memory, attr.allocated.ScalarResources)
-			metrics.UpdateQueueRequest(attr.name, attr.request.MilliCPU, attr.request.Memory, attr.request.ScalarResources)
-			metrics.UpdateQueueInqueue(attr.name, attr.inqueue.MilliCPU, attr.inqueue.Memory, attr.inqueue.ScalarResources)
-			if attr.capability != nil {
-				metrics.UpdateQueueCapacity(attr.name, attr.capability.MilliCPU, attr.capability.Memory, attr.capability.ScalarResources)
-			}
-			metrics.UpdateQueueRealCapacity(attr.name, attr.realCapability.MilliCPU, attr.realCapability.Memory, attr.realCapability.ScalarResources)
-			continue
-		}
-		deservedCPU, deservedMem, scalarResources := 0.0, 0.0, map[v1.ResourceName]float64{}
-		if queue.Queue.Spec.Deserved != nil {
-			attr := api.NewResource(queue.Queue.Spec.Deserved)
-			deservedCPU = attr.MilliCPU
-			deservedMem = attr.Memory
-			scalarResources = attr.ScalarResources
-		}
-		metrics.UpdateQueueDeserved(queueInfo.Name, deservedCPU, deservedMem, scalarResources)
-		metrics.UpdateQueueAllocated(queueInfo.Name, 0, 0, map[v1.ResourceName]float64{})
-		metrics.UpdateQueueRequest(queueInfo.Name, 0, 0, map[v1.ResourceName]float64{})
-		metrics.UpdateQueueInqueue(queueInfo.Name, 0, 0, map[v1.ResourceName]float64{})
-		guarantee := api.EmptyResource()
-		if len(queue.Queue.Spec.Guarantee.Resource) != 0 {
-			guarantee = api.NewResource(queue.Queue.Spec.Guarantee.Resource)
-		}
-		realCapacity := api.ExceededPart(cp.totalResource, cp.totalGuarantee).Add(guarantee)
-		if len(queue.Queue.Spec.Capability) > 0 {
-			capacity := api.NewResource(queue.Queue.Spec.Capability)
-			realCapacity.MinDimensionResource(capacity, api.Infinity)
-			metrics.UpdateQueueCapacity(queueInfo.Name, capacity.MilliCPU, capacity.Memory, capacity.ScalarResources)
-		}
-		metrics.UpdateQueueRealCapacity(queueInfo.Name, realCapacity.MilliCPU, realCapacity.Memory, realCapacity.ScalarResources)
+	// Record metrics - all queues are now guaranteed to be in queueOpts
+	for _, attr := range cp.queueOpts {
+		metrics.UpdateQueueDeserved(attr.name, attr.deserved.MilliCPU, attr.deserved.Memory, attr.deserved.ScalarResources)
+		metrics.UpdateQueueAllocated(attr.name, attr.allocated.MilliCPU, attr.allocated.Memory, attr.allocated.ScalarResources)
+		metrics.UpdateQueueRequest(attr.name, attr.request.MilliCPU, attr.request.Memory, attr.request.ScalarResources)
+		metrics.UpdateQueueInqueue(attr.name, attr.inqueue.MilliCPU, attr.inqueue.Memory, attr.inqueue.ScalarResources)
+		metrics.UpdateQueueCapacity(attr.name, attr.capability.MilliCPU, attr.capability.Memory, attr.capability.ScalarResources)
+		metrics.UpdateQueueRealCapacity(attr.name, attr.realCapability.MilliCPU, attr.realCapability.Memory, attr.realCapability.ScalarResources)
 	}
 
 	ssn.AddQueueOrderFn(cp.Name(), func(l, r interface{}) int {

--- a/pkg/scheduler/plugins/capacity/capacity_test.go
+++ b/pkg/scheduler/plugins/capacity/capacity_test.go
@@ -994,7 +994,6 @@ func Test_buildHierarchicalQueueAttrs_nilSafety(t *testing.T) {
 	actions := []framework.Action{allocate.New()}
 
 	n1 := util.BuildNode("n1", api.BuildResourceList("4", "4Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), map[string]string{})
-
 	tiers := []conf.Tier{
 		{
 			Plugins: []conf.PluginOption{
@@ -1070,4 +1069,84 @@ func Test_buildHierarchicalQueueAttrs_nilSafety(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestBuildQueueAttrsMetricConsistency tests Bug 1 fix:
+// Queue allocated metric should be consistent with Queue.Status.Allocated
+// when hierarchy is disabled, including for jobless queues (like root queue).
+// Before the fix: jobless queues were not added to queueOpts, causing metrics to report stale values as allocated.
+// After the fix: jobless queues are added to queueOpts with allocated from Queue.Status.Allocated.
+func TestBuildQueueAttrsMetricConsistency(t *testing.T) {
+	plugins := map[string]framework.PluginBuilder{PluginName: New}
+	trueValue := true
+
+	// Create a node
+	n1 := util.BuildNode("n1", api.BuildResourceList("4", "4Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), map[string]string{})
+
+	// Create a pod in q1 (allocated)
+	p1 := util.BuildPod("ns1", "p1", "n1", corev1.PodRunning, api.BuildResourceList("2", "2Gi"), "pg1", make(map[string]string), make(map[string]string))
+	pg1 := util.BuildPodGroup("pg1", "ns1", "q1", 1, nil, schedulingv1beta1.PodGroupRunning)
+
+	// Create queues: root (jobless, has Status.Allocated set) and q1 (has job)
+	root := util.BuildQueueWithResourcesQuantity("root", api.BuildResourceList("4", "4Gi"), nil)
+	// Simulate that root has allocated resources (from previous scheduling cycles)
+	root.Status.Allocated = api.BuildResourceList("2", "2Gi")
+	queue1 := util.BuildQueueWithResourcesQuantity("q1", api.BuildResourceList("2", "2Gi"), api.BuildResourceList("4", "4Gi"))
+
+	test := uthelper.TestCommonStruct{
+		Name:      "Jobless queue gets allocated from Status.Allocated",
+		Plugins:   plugins,
+		Pods:      []*corev1.Pod{p1},
+		Nodes:     []*corev1.Node{n1},
+		PodGroups: []*schedulingv1beta1.PodGroup{pg1},
+		Queues:    []*schedulingv1beta1.Queue{root, queue1},
+	}
+
+	tiers := []conf.Tier{
+		{
+			Plugins: []conf.PluginOption{
+				{
+					Name:               PluginName,
+					EnabledAllocatable: &trueValue,
+					EnablePreemptive:   &trueValue,
+					EnabledReclaimable: &trueValue,
+					EnabledQueueOrder:  &trueValue,
+					// Hierarchy is NOT enabled - this is the key for Bug 1
+					EnabledHierarchy: nil,
+				},
+			},
+		},
+	}
+
+	t.Run(test.Name, func(t *testing.T) {
+		ssn := test.RegisterSession(tiers, nil)
+		defer test.Close()
+
+		// Verify both queues exist in the session
+		if len(ssn.Queues) != 2 {
+			t.Fatalf("Expected 2 queues in session, got %d", len(ssn.Queues))
+		}
+
+		// Verify root queue (jobless) exists in session.Queues
+		rootQueueID := api.QueueID("root")
+		rootQueue, exists := ssn.Queues[rootQueueID]
+		if !exists {
+			t.Fatal("Root queue (jobless) should exist in session.Queues")
+		}
+
+		// Verify root queue has Status.Allocated set
+		if rootQueue.Queue.Status.Allocated == nil {
+			t.Fatal("Root queue should have Status.Allocated set")
+		}
+
+		// The fix ensures the root queue's allocated is read from Status.Allocated
+		expectedAllocated := api.NewResource(api.BuildResourceList("2", "2Gi"))
+		actualAllocated := api.NewResource(rootQueue.Queue.Status.Allocated)
+		if actualAllocated.MilliCPU != expectedAllocated.MilliCPU {
+			t.Errorf("Root queue allocated CPU: got %v, want %v", actualAllocated.MilliCPU, expectedAllocated.MilliCPU)
+		}
+		if actualAllocated.Memory != expectedAllocated.Memory {
+			t.Errorf("Root queue allocated Memory: got %v, want %v", actualAllocated.Memory, expectedAllocated.Memory)
+		}
+	})
 }

--- a/pkg/scheduler/plugins/capacity/capacity_test.go
+++ b/pkg/scheduler/plugins/capacity/capacity_test.go
@@ -1357,7 +1357,6 @@ func Test_buildHierarchicalQueueAttrs_nilSafety(t *testing.T) {
 	actions := []framework.Action{allocate.New()}
 
 	n1 := util.BuildNode("n1", api.BuildResourceList("4", "4Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), map[string]string{})
-
 	tiers := []conf.Tier{
 		{
 			Plugins: []conf.PluginOption{
@@ -2106,5 +2105,89 @@ func TestCheckDRAAllocatable_overflowRejected(t *testing.T) {
 	}
 	if !checkDRAAllocatable(fresh, map[string]*api.DRAResource{dc: {Count: 4}}, false, true) {
 		t.Fatalf("checkDRAAllocatable rejected a valid request (4 <= 8); want admitted")
+	}
+}
+
+// TestBuildQueueAttrsMetricConsistency tests Bug 1 fix:
+// Queue allocated metric should be consistent with Queue.Status.Allocated
+// when hierarchy is disabled, including for jobless queues (like root queue).
+// Before the fix: jobless queues were not added to queueOpts, so their
+// allocated metric was reported as zero instead of Queue.Status.Allocated.
+// After the fix: jobless queues are added to queueOpts with allocated read
+// from Queue.Status.Allocated.
+func TestBuildQueueAttrsMetricConsistency(t *testing.T) {
+	trueValue := true
+
+	n1 := util.BuildNode("n1", api.BuildResourceList("4", "4Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), map[string]string{})
+
+	// A running pod in q1: q1 is a "queue with jobs", so its allocated is
+	// derived from the job (2 CPU / 2Gi).
+	p1 := util.BuildPod("ns1", "p1", "n1", corev1.PodRunning, api.BuildResourceList("2", "2Gi"), "pg1", make(map[string]string), make(map[string]string))
+	pg1 := util.BuildPodGroup("pg1", "ns1", "q1", 1, nil, schedulingv1beta1.PodGroupRunning)
+
+	// root is a jobless queue: it has no pods of its own, but its
+	// Status.Allocated reflects resources allocated by child queues in a
+	// previous cycle. The fix must surface this value in metrics.
+	root := util.BuildQueueWithResourcesQuantity("root", api.BuildResourceList("4", "4Gi"), nil)
+	root.Status.Allocated = api.BuildResourceList("3", "3Gi")
+
+	queue1 := util.BuildQueueWithResourcesQuantity("q1", api.BuildResourceList("2", "2Gi"), api.BuildResourceList("4", "4Gi"))
+
+	binder := util.NewFakeBinder(10)
+	evictor := util.NewFakeEvictor(0)
+	statusUpdater := &util.FakeStatusUpdater{}
+	stop := make(chan struct{})
+	defer close(stop)
+
+	sc := cache.NewCustomMockSchedulerCache("test-capacity", binder, evictor, statusUpdater, nil, nil)
+	sc.Run(stop)
+	sc.AddOrUpdateNode(n1)
+	sc.AddPod(p1)
+	sc.AddPodGroupV1beta1(pg1)
+	sc.AddQueueV1beta1(root)
+	sc.AddQueueV1beta1(queue1)
+
+	tiers := []conf.Tier{
+		{
+			Plugins: []conf.PluginOption{
+				{
+					Name:               PluginName,
+					EnabledAllocatable: &trueValue,
+					EnabledOverused:    &trueValue,
+					EnabledJobEnqueued: &trueValue,
+					// Hierarchy is NOT enabled - this is the key for Bug 1.
+					EnabledHierarchy: nil,
+				},
+			},
+		},
+	}
+
+	ssn := framework.OpenSession(sc, tiers, nil)
+	defer framework.CloseSession(ssn)
+
+	cp := New(nil).(*capacityPlugin)
+	cp.OnSessionOpen(ssn)
+
+	// The jobless root queue MUST be present in queueOpts (this is the fix).
+	rootAttr, ok := cp.queueOpts[api.QueueID("root")]
+	if !ok {
+		t.Fatal("jobless root queue should be present in queueOpts after buildQueueAttrs")
+	}
+
+	// Its allocated must come from Queue.Status.Allocated, not zero.
+	expectedRoot := api.NewResource(api.BuildResourceList("3", "3Gi"))
+	if rootAttr.allocated.MilliCPU != expectedRoot.MilliCPU || rootAttr.allocated.Memory != expectedRoot.Memory {
+		t.Errorf("jobless root queue allocated: got %v, want %v (from Status.Allocated)", rootAttr.allocated, expectedRoot)
+	}
+
+	// Sanity: a queue with a job derives its allocated from the job, proving
+	// the two code paths (job vs jobless) populate queueOpts independently.
+	q1Attr, ok := cp.queueOpts[api.QueueID("q1")]
+	if !ok {
+		t.Fatal("q1 should be present in queueOpts")
+	}
+	expectedQ1 := api.NewResource(api.BuildResourceList("2", "2Gi"))
+	if q1Attr.allocated.MilliCPU != expectedQ1.MilliCPU || q1Attr.allocated.Memory != expectedQ1.Memory {
+		t.Errorf("q1 allocated: got %v, want %v (from job)", q1Attr.allocated, expectedQ1)
 	}
 }


### PR DESCRIPTION
/kind bug

   **What this PR does / why we need it:**
   Fixes a bug where jobless queues (like root) had their allocated metrics incorrectly
   reported as zero when hierarchy was disabled, instead of using the actual
   `Queue.Status.Allocated` value.

   **Which issue(s) this PR fixes:**
   Related to #5048 (Bug 1)

   **Special notes for your reviewer:**
   None

   **Does this PR introduce a user-facing change?**
   ```release-note
   Fixed queue allocated metric consistency for jobless queues in capacity plugin when
   hierarchy is disabled

