### PR TITLE
capacity: compute queue overused metric from final share instead of preemptiveFn

### DIFF
--- a/pkg/scheduler/plugins/capacity/capacity.go
+++ b/pkg/scheduler/plugins/capacity/capacity.go
@@ -191,9 +191,6 @@ func (cp *capacityPlugin) OnSessionOpen(ssn *framework.Session) {
 				queue.Name, futureUsed, attr.deserved, task.Resreq)
 		}
 
-		overused := !isPreemptive
-		metrics.UpdateQueueOverused(attr.name, overused)
-
 		// PreemptiveFn is the opposite of OverusedFn in proportion plugin cause as long as there is a one-dimensional
 		// resource whose deserved is greater than allocated, current task can reclaim by preempt others.
 		return isPreemptive
@@ -396,6 +393,10 @@ func (cp *capacityPlugin) OnSessionOpen(ssn *framework.Session) {
 }
 
 func (cp *capacityPlugin) OnSessionClose(ssn *framework.Session) {
+	for _, attr := range cp.queueOpts {
+		overused := attr.share > 1
+		metrics.UpdateQueueOverused(attr.name, overused)
+	}
 	cp.totalResource = nil
 	cp.totalGuarantee = nil
 	cp.queueOpts = nil


### PR DESCRIPTION
#### What type of PR is this?

bug fix

#### What this PR does / why we need it:

The queue overused metric (UpdateQueueOverused) was previously updated inside AddPreemptiveFn, which runs per-task-per-queue during preemption. This caused the metric to be overwritten multiple times within a single scheduling cycle and reflect task-level preemption eligibility rather than actual queue overuse.

Additionally, the previous logic derived the metric from `!isPreemptive`, which semantically represented "cannot reclaim" instead of whether the queue exceeded its deserved resources.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Notice that do not add `Fixes` if the issue is associated with multiple PRs.
-->
Fixes issue: 5048 - bug2

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```