### PR TITLE
fix: remove duplicated session close call

### DIFF
--- a/pkg/scheduler/framework/framework.go
+++ b/pkg/scheduler/framework/framework.go
@@ -66,5 +66,4 @@ func CloseSession(ssn *Session) {
 	}
 
 	closeSession(ssn)
-	ssn.cache.OnSessionClose()
 }


### PR DESCRIPTION
#### What type of PR is this?
fix
#### What this PR does / why we need it:
cache.OnSessionClose method is called twice when session closed

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Notice that do not add `Fixes` if the issue is associated with multiple PRs.
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```