### PR TITLE
feat: improve golangci-lint version check with interactive upgrade prompt

### DIFF
--- a/hack/verify-golangci-lint.sh
+++ b/hack/verify-golangci-lint.sh
@@ -28,15 +28,21 @@ GOLANGCI_LINT_PKG="github.com/golangci/golangci-lint/v2/cmd/golangci-lint"
 # -----------------------------------
 
 # install_golangci_lint installs the required version of golangci-lint via
-# 'go install' and ensures $GOPATH/bin is on PATH.
+# 'go install' and ensures the Go binary directory ($GOBIN or $GOPATH/bin) is on PATH.
 install_golangci_lint() {
   echo "Installing golangci-lint ${REQUIRED_VERSION} ..."
-  GOOS="${OS:-$(go env GOOS)}" go install "${GOLANGCI_LINT_PKG}@${REQUIRED_VERSION}"
-  if [[ $? -ne 0 ]]; then
+  local ret=0
+  GOOS="${OS:-$(go env GOOS)}" go install "${GOLANGCI_LINT_PKG}@${REQUIRED_VERSION}" || ret=$?
+  if [[ ${ret} -ne 0 ]]; then
     echo "ERROR: golangci-lint installation failed."
     exit 1
   fi
-  export PATH="${GOPATH}/bin:${PATH}"
+  local go_install_path="${GOBIN:-${GOPATH}/bin}"
+  if [[ -z "${go_install_path}" ]]; then
+    echo "ERROR: GOPATH and GOBIN are not set. Cannot determine Go binary install path." >&2
+    exit 1
+  fi
+  export PATH="${go_install_path}:${PATH}"
   echo "golangci-lint ${REQUIRED_VERSION} installed successfully."
 }
 
@@ -57,10 +63,19 @@ check_golangci_lint() {
   # while v1 prints e.g.
   #   golangci-lint has version 1.64.8 built with ...
   local raw_version
-  raw_version="$(golangci-lint --version 2>/dev/null | head -1)"
+  if ! raw_version="$(golangci-lint --version 2>/dev/null | head -1)"; then
+    # If version detection fails (e.g., corrupted binary), treat as unknown
+    # so that the mismatch/reinstall logic below is triggered.
+    raw_version=""
+  fi
   # Grab the semver token right after "version".
   local installed_version
-  installed_version="$(echo "${raw_version}" | grep -oP 'version\s+\Kv?\d+\.\d+\.\d+')"
+  installed_version="$(echo "${raw_version}" | sed -n -E 's/.*version[[:space:]]+(v?[0-9]+\.[0-9]+\.[0-9]+).*/\1/p')"
+  if [[ -z "${installed_version}" ]]; then
+    echo "WARNING: Could not parse golangci-lint version from: ${raw_version}"
+    install_golangci_lint
+    return
+  fi
   # Normalise: ensure leading 'v'
   installed_version="v${installed_version#v}"
 
@@ -83,6 +98,7 @@ check_golangci_lint() {
   fi
 
   # Interactive: ask the user.
+  local answer
   read -r -p "Install golangci-lint ${REQUIRED_VERSION} now? [Y/n] " answer
   case "${answer}" in
     [nN][oO]|[nN])


### PR DESCRIPTION
#### What type of PR is this?
/kind rfe

#### What this PR does / why we need it:
The lint script previously only checked whether golangci-lint was installed, but not whether it was the correct version. When an older or incompatible version was present (e.g. v1.x vs required v2.x), the linter would fail with a confusing Go version mismatch error.

Add version detection and comparison against a **REQUIRED_VERSION** constant. When a mismatch is found, the script now:
- Prints a clear diagnostic showing installed vs required version
- In CI or non-interactive shells, auto-installs the correct version
- In interactive terminals, prompts the user to install (Y/n)

Also improves shell hygiene: proper quoting, BASH_SOURCE array syntax, local variables, GOOS fallback, and removes set +e/set -e toggles.

#### Which issue(s) this PR fixes:
I haven't created one (it's not a big issue, but a valid improvement).

#### Special notes for your reviewer:
The new kubernetes version:
https://github.com/volcano-sh/volcano/pull/5000
Introduced a significant version bump in this:
https://github.com/volcano-sh/volcano/pull/5000/changes#diff-e5b79dee569c7bfc32112f03efded380e74f7241d6b74e3a7fbd2c00090e643dL30

If someone has the old version installed like me, it will face with the following error.
```
make lint
```

```
hack/verify-golangci-lint.sh
checking whether golangci-lint has been installed
found golangci-lint
begin run golangci-lint
INFO golangci-lint has version 1.64.8 built with go1.24.1 from 8b37f141 on 2025-03-17T20:41:53Z
INFO [config_reader] Config search paths: [./ /home/uih20178/Github/hajnalmt-volcano /home/uih20178/Github /home/uih20178 /home /]
INFO [config_reader] Used config file .golangci.yml
WARN [config_reader] The configuration option `output.uniq-by-line` is deprecated, please use `issues.uniq-by-line`
Error: can't load config: the Go language version (go1.24) used to build golangci-lint is lower than the targeted Go version (1.25.0)
Failed executing command with error: can't load config: the Go language version (go1.24) used to build golangci-lint is lower than the targeted Go version (1.25.0)
FAILED: golangci-lint stale.

Please review the above warnings. You can test via './hack/verify-golangci-lint.sh' or 'make lint'.
If the above warnings do not make sense, you can exempt this warning with a comment
 (if your reviewer is okay with it).
In general please prefer to fix the error, we have already disabled specific lints
 that the project chooses to ignore.
See: https://golangci-lint.run/usage/false-positives/

make: *** [Makefile:237: lint] Error 1
```

Let's go ahead of the problem, being future proof and help the users to upgrade to the right version with a prompt from now on. 😊 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```