### PR TITLE
fix: Update KUBE_VERSION to 1.35.0 in webhook-manager Dockerfile

### DIFF
--- a/installer/dockerfile/webhook-manager/Dockerfile
+++ b/installer/dockerfile/webhook-manager/Dockerfile
@@ -22,7 +22,7 @@ ADD . volcano
 RUN cd volcano && make vc-webhook-manager
 
 FROM alpine:latest
-ARG KUBE_VERSION="1.32.0"
+ARG KUBE_VERSION="1.35.0"
 ARG TARGETARCH
 ARG APK_MIRROR
 RUN if [[ -n "$APK_MIRROR" ]]; then sed -i "s@https://dl-cdn.alpinelinux.org@${APK_MIRROR}@g" /etc/apk/repositories ; fi && \


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Updates the `KUBE_VERSION` ARG in the webhook-manager Dockerfile from `1.32.0` to `1.35.0`. This ARG controls which version of `kubectl` is downloaded into the webhook-manager image. It was missed during the Kubernetes 1.35 adaptation in volcano-sh/volcano#5000, leaving the image with a stale kubectl binary two major versions behind.

A corresponding change for `release-1.14` (updating `KUBE_VERSION` to `1.34.0`) should also be cherry-picked/submitted separately, as it was similarly missed in volcano-sh/volcano#4704.

#### Which issue(s) this PR fixes:

Fixes an oversight in volcano-sh/volcano#5000 (master) and volcano-sh/volcano#4704 (release-1.14).

#### Special notes for your reviewer:

The webhook-manager Dockerfile downloads `kubectl` at build time using `KUBE_VERSION`. This was last updated during the k8s 1.32 adaptation and was not bumped in either the 1.34 or 1.35 adaptation PRs.

#### Does this PR introduce a user-facing change?

```release-note
Update kubectl version bundled in webhook-manager image to match the supported Kubernetes version.
```