### PR TITLE
release-1.14: Update KUBE_VERSION to 1.34.1 in webhook-manager Dockerfile

### DIFF
--- a/installer/dockerfile/webhook-manager/Dockerfile
+++ b/installer/dockerfile/webhook-manager/Dockerfile
@@ -22,7 +22,7 @@ ADD . volcano
 RUN cd volcano && make vc-webhook-manager
 
 FROM alpine:latest
-ARG KUBE_VERSION="1.32.0"
+ARG KUBE_VERSION="1.34.1"
 ARG TARGETARCH
 ARG APK_MIRROR
 RUN if [[ -n "$APK_MIRROR" ]]; then sed -i "s@https://dl-cdn.alpinelinux.org@${APK_MIRROR}@g" /etc/apk/repositories ; fi && \


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Updates the `KUBE_VERSION` ARG in the webhook-manager Dockerfile from `1.32.0` to `1.34.1`. This ARG controls which version of `kubectl` is downloaded into the webhook-manager image. It was missed during the Kubernetes 1.34 adaptation in volcano-sh/volcano#4704, leaving the image with a stale kubectl binary two major versions behind.

The corresponding fix for master (`1.35.0`) has been filed as volcano-sh/volcano#5062.

#### Which issue(s) this PR fixes:

Fixes an oversight in volcano-sh/volcano#4704.

#### Special notes for your reviewer:

The webhook-manager Dockerfile downloads `kubectl` at build time using `KUBE_VERSION`. This was last updated during the k8s 1.32 adaptation and was not bumped in either the 1.34 or 1.35 adaptation PRs.

#### Does this PR introduce a user-facing change?

```release-note
Update kubectl version bundled in webhook-manager image to match the supported Kubernetes version.
```