### PR TITLE
fix(reclaim): don't commit evictions from nodes we end up not using

### DIFF
--- a/pkg/scheduler/actions/reclaim/reclaim.go
+++ b/pkg/scheduler/actions/reclaim/reclaim.go
@@ -219,33 +219,41 @@ func (ra *Action) reclaimForTask(ssn *framework.Session, stmt *framework.Stateme
 		// The reclaimed resources should be added to the remaining available resources of the nodes to avoid over-reclaiming.
 		availableResources := n.FutureIdle()
 
+		// Use a per-node statement so that evictions are isolated to this node.
+		// Only merge into the caller's stmt if Pipeline succeeds; otherwise discard
+		// so victims on nodes that end up unused are never committed to Kubernetes.
+		nodeStmt := framework.NewStatement(ssn)
 		evictionOccurred := false
 		for !victimsQueue.Empty() {
-			reclaimee := victimsQueue.Pop().(*api.TaskInfo)
-			klog.V(3).Infof("Try to reclaim Task <%s/%s> for Tasks <%s/%s>",
-				reclaimee.Namespace, reclaimee.Name, task.Namespace, task.Name)
-			stmt.Evict(reclaimee, "reclaim")
-			reclaimed.Add(reclaimee.Resreq)
-			availableResources.Add(reclaimee.Resreq)
-			evictionOccurred = true
 			if resreq.LessEqual(availableResources, api.Zero) {
 				break
 			}
+			reclaimee := victimsQueue.Pop().(*api.TaskInfo)
+			klog.V(3).Infof("Try to reclaim Task <%s/%s> for Tasks <%s/%s>",
+				reclaimee.Namespace, reclaimee.Name, task.Namespace, task.Name)
+			nodeStmt.Evict(reclaimee, "reclaim")
+			reclaimed.Add(reclaimee.Resreq)
+			availableResources.Add(reclaimee.Resreq)
+			evictionOccurred = true
 		}
 
 		klog.V(3).Infof("Reclaimed <%v> for task <%s/%s> requested <%v>, and Node <%s> availableResources <%v>.", reclaimed, task.Namespace, task.Name, task.InitResreq, n.Name, availableResources)
 
-		if task.InitResreq.LessEqual(availableResources, api.Zero) {
-			if err := stmt.Pipeline(task, n.Name, evictionOccurred); err != nil {
+		if resreq.LessEqual(availableResources, api.Zero) {
+			if err := nodeStmt.Pipeline(task, n.Name, evictionOccurred); err != nil {
 				klog.Errorf("Failed to pipeline Task <%s/%s> on Node <%s>",
 					task.Namespace, task.Name, n.Name)
-				if rollbackErr := stmt.UnPipeline(task); rollbackErr != nil {
+				if rollbackErr := nodeStmt.UnPipeline(task); rollbackErr != nil {
 					klog.Errorf("Failed to unpipeline Task %v on %v in Session %v for %v.",
 						task.UID, n.Name, ssn.UID, rollbackErr)
 				}
+				nodeStmt.Discard()
+				continue
 			}
+			stmt.Merge(nodeStmt)
 			break
 		}
+		nodeStmt.Discard()
 	}
 }
 

--- a/pkg/scheduler/actions/reclaim/reclaim_test.go
+++ b/pkg/scheduler/actions/reclaim/reclaim_test.go
@@ -291,6 +291,53 @@ func TestReclaim(t *testing.T) {
 			ExpectEvictNum: 1,
 			ExpectEvicted:  []string{"c1/victim-pod"},
 		},
+		{
+			// Regression: the original victim loop placed the "resources satisfied"
+			// check AFTER each eviction rather than before it.  This caused at least
+			// one victim to be spuriously evicted even when the node's FutureIdle was
+			// already sufficient to host the preemptor — a classic "evict on node1,
+			// then succeed on node2" side-effect where evictions from a node that ends
+			// up unused are committed alongside the winning node's evictions.
+			//
+			// Setup:
+			//   • q1 (weight=1) is overused: victim-n1 (2 CPU) exceeds q1's 1-CPU
+			//     deserved share, so the victim is eligible for reclaim.
+			//   • q2 (weight=9) is starving: preemptor1 requests 3 CPU.
+			//   • n1 has 8 CPU idle (10 CPU – 2 CPU victim), which already satisfies
+			//     the 3-CPU request before any eviction is attempted.
+			//
+			// Without the guard-at-top fix the victim is evicted unnecessarily and
+			// committed to Kubernetes.  With the fix the loop exits immediately and
+			// 0 evictions are committed to the winning node's statement.
+			Name: "only commit evictions on the node where reclaim succeeds",
+			Plugins: map[string]framework.PluginBuilder{
+				conformance.PluginName: conformance.New,
+				gang.PluginName:        gang.New,
+				proportion.PluginName:  proportion.New,
+			},
+			PodGroups: []*schedulingv1beta1.PodGroup{
+				util.BuildPodGroupWithPrio("pg-victim", "c1", "q1", 0, nil, schedulingv1beta1.PodGroupRunning, "low-priority"),
+				util.BuildPodGroupWithPrio("pg-preemptor", "c1", "q2", 1, nil, schedulingv1beta1.PodGroupInqueue, "low-priority"),
+			},
+			Pods: []*v1.Pod{
+				// victim-n1 uses 2 CPU; n1 still has 8 CPU idle — already enough for the
+				// 3-CPU preemptor, so no eviction should be committed.
+				util.BuildPod("c1", "victim-n1", "n1", v1.PodRunning, api.BuildResourceList("2", "2G"), "pg-victim", map[string]string{schedulingv1beta1.PodPreemptable: "true"}, make(map[string]string)),
+				util.BuildPod("c1", "preemptor1", "", v1.PodPending, api.BuildResourceList("3", "3G"), "pg-preemptor", make(map[string]string), make(map[string]string)),
+			},
+			Nodes: []*v1.Node{
+				// 10 CPU / 10G node; after the 2-CPU victim, idle = 8 CPU ≥ preemptor request (3 CPU).
+				util.BuildNode("n1", api.BuildResourceList("10", "10G", []api.ScalarResource{{Name: "pods", Value: "10"}}...), make(map[string]string)),
+			},
+			Queues: []*schedulingv1beta1.Queue{
+				// q1 deserves 1 CPU (weight 1 of 10 total), uses 2 CPU → overused → victim is reclaimable.
+				util.BuildQueue("q1", 1, nil),
+				// q2 deserves 9 CPU (weight 9 of 10 total), uses 0 → starving → preemptor can reclaim.
+				util.BuildQueue("q2", 9, nil),
+			},
+			ExpectEvictNum: 0,
+			ExpectEvicted:  []string{},
+		},
 	}
 
 	reclaim := New()


### PR DESCRIPTION
### What's the bug

`reclaim.go` has the same atomicity issue that was fixed in `preempt.go` via #5010 — victim evictions are written into the shared statement before we know if the candidate node will actually be used. If we move on to the next node, those evictions still commit. Pods get killed for nothing.

### Fix

Same pattern as #5010 — use a per-node `nodeStmt`, merge into the shared statement only if the node wins, discard otherwise. `Statement.Merge()` already exists from #5010 so no new APIs needed.

### Related
- #5010 — fixed the same bug in `preempt.go`, introduced `Statement.Merge()`
- #5043 — also triggered by #5010; this takes the `nodeStmt`/`Merge` approach