### PR TITLE
scheduler: call Initialize() and UnInitialize() in action lifecycle

### DIFF
--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -86,10 +86,39 @@ func NewScheduler(config *rest.Config, opt *options.ServerOption) (*Scheduler, e
 	return scheduler, nil
 }
 
+// Initialize all configured actions once.
+func (pc *Scheduler) initActions() {
+	pc.mutex.Lock()
+	actions := pc.actions
+	pc.mutex.Unlock()
+	for _, action := range actions {
+		action.Initialize()
+	}
+}
+
+// Uninitialize all configured actions.
+func (pc *Scheduler) cleanupActions() {
+	pc.mutex.Lock()
+	actions := pc.actions
+	pc.mutex.Unlock()
+	for _, action := range actions {
+		action.UnInitialize()
+	}
+}
+
 // Run initializes and starts the Scheduler. It loads the configuration,
 // initializes the cache, and begins the scheduling process.
 func (pc *Scheduler) Run(stopCh <-chan struct{}) {
 	pc.loadSchedulerConf()
+
+	pc.initActions()
+
+	// Cleanup on scheduler shutdown.
+	go func() {
+		<-stopCh
+		pc.cleanupActions()
+	}()
+
 	go pc.watchSchedulerConf(stopCh)
 	// Start cache for policy.
 	pc.cache.SetMetricsConf(pc.metricsConf)

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -52,11 +52,17 @@ type Scheduler struct {
 	schedulePeriod time.Duration
 	once           sync.Once
 
-	mutex              sync.Mutex
-	actions            []framework.Action
-	plugins            []conf.Tier
-	configurations     []conf.Configuration
-	metricsConf        map[string]string
+	mutex          sync.Mutex
+	actions        []framework.Action
+	plugins        []conf.Tier
+	configurations []conf.Configuration
+	metricsConf    map[string]string
+
+	defaultActions        []framework.Action
+	defaultPlugins        []conf.Tier
+	defaultConfigurations []conf.Configuration
+	defaultMetricsConf    map[string]string
+
 	dumper             schedcache.Dumper
 	disableDefaultConf bool
 }
@@ -86,35 +92,34 @@ func NewScheduler(config *rest.Config, opt *options.ServerOption) (*Scheduler, e
 	return scheduler, nil
 }
 
-// Initialize all configured actions once.
-func (pc *Scheduler) initActions() {
-	pc.mutex.Lock()
-	actions := pc.actions
-	pc.mutex.Unlock()
+// Run initializes and starts the Scheduler. It parses the scheduler configuration, initializes actions,
+// applies the configuration and starts the scheduling loop, cache and configuration watcher.
+func (pc *Scheduler) Run(stopCh <-chan struct{}) {
+	actions, plugins, configurations, metricsConf, err := pc.loadSchedulerConf()
+	if err != nil {
+		klog.Fatalf("Failed to load scheduler configuration: %v", err)
+	}
+
 	for _, action := range actions {
 		action.Initialize()
 	}
-}
 
-// Uninitialize all configured actions.
-func (pc *Scheduler) cleanupActions() {
 	pc.mutex.Lock()
-	actions := pc.actions
+	pc.actions = actions
+	pc.plugins = plugins
+	pc.configurations = configurations
+	pc.metricsConf = metricsConf
 	pc.mutex.Unlock()
-	for _, action := range actions {
-		action.UnInitialize()
-	}
-}
-
-// Run initializes and starts the Scheduler. It loads the configuration,
-// initializes the cache, and begins the scheduling process.
-func (pc *Scheduler) Run(stopCh <-chan struct{}) {
-	pc.loadSchedulerConf()
 
 	// Cleanup on scheduler shutdown.
 	go func() {
 		<-stopCh
-		pc.cleanupActions()
+		pc.mutex.Lock()
+		oldActions := append([]framework.Action(nil), pc.actions...)
+		pc.mutex.Unlock()
+		for _, action := range oldActions {
+			action.UnInitialize()
+		}
 	}()
 
 	go pc.watchSchedulerConf(stopCh)
@@ -161,12 +166,8 @@ func (pc *Scheduler) runOnce() {
 	}
 }
 
-func (pc *Scheduler) loadSchedulerConf() {
+func (pc *Scheduler) loadSchedulerConf() ([]framework.Action, []conf.Tier, []conf.Configuration, map[string]string, error) {
 	klog.V(4).Infof("Start loadSchedulerConf ...")
-	defer func() {
-		actions, plugins := pc.getSchedulerConf()
-		klog.V(2).Infof("Finished loading scheduler config. Final state: actions=%v, plugins=%v", actions, plugins)
-	}()
 
 	if pc.disableDefaultConf && len(pc.schedulerConf) == 0 {
 		klog.Fatalf("No --scheduler-conf path provided and default configuration fallback is disabled")
@@ -175,7 +176,7 @@ func (pc *Scheduler) loadSchedulerConf() {
 	var err error
 	if !pc.disableDefaultConf {
 		pc.once.Do(func() {
-			pc.actions, pc.plugins, pc.configurations, pc.metricsConf, err = UnmarshalSchedulerConf(DefaultSchedulerConf)
+			pc.defaultActions, pc.defaultPlugins, pc.defaultConfigurations, pc.defaultMetricsConf, err = UnmarshalSchedulerConf(DefaultSchedulerConf)
 			if err != nil {
 				klog.Fatalf("Invalid default configuration: unmarshal Scheduler config %s failed: %v", DefaultSchedulerConf, err)
 			}
@@ -189,51 +190,27 @@ func (pc *Scheduler) loadSchedulerConf() {
 			if pc.disableDefaultConf {
 				klog.Fatalf("Failed to read scheduler config and default configuration fallback is disabled")
 			}
-			klog.Errorf("Failed to read the Scheduler config in '%s', using previous configuration: %v",
+			klog.Errorf("Failed to read the Scheduler config in '%s', falling back to default: %v",
 				pc.schedulerConf, err)
-			return
+			return pc.defaultActions, pc.defaultPlugins, pc.defaultConfigurations, pc.defaultMetricsConf, nil
 		}
 		config = strings.TrimSpace(string(confData))
 	}
 
-	actions, plugins, configurations, metricsConf, err := UnmarshalSchedulerConf(config)
-	if err != nil {
-		if pc.disableDefaultConf {
-			klog.Fatalf("Invalid scheduler configuration and default configuration fallback is disabled")
+	if len(config) != 0 {
+		actions, plugins, configurations, metricsConf, err := UnmarshalSchedulerConf(config)
+		if err != nil {
+			if pc.disableDefaultConf {
+				klog.Fatalf("Invalid scheduler configuration and default configuration fallback is disabled")
+			}
+			klog.Errorf("Scheduler config %s is invalid, falling back to default: %v", config, err)
+			return pc.defaultActions, pc.defaultPlugins, pc.defaultConfigurations, pc.defaultMetricsConf, nil
 		}
-		klog.Errorf("Scheduler config %s is invalid: %v", config, err)
-		return
+		klog.V(2).Infof("Loaded scheduler configuration from file")
+		return actions, plugins, configurations, metricsConf, nil
 	}
-
-	pc.mutex.Lock()
-	oldActions := pc.actions
-	pc.actions = actions
-	pc.plugins = plugins
-	pc.configurations = configurations
-	pc.metricsConf = metricsConf
-	pc.mutex.Unlock()
-
-	// Cleanup old actions
-	for _, action := range oldActions {
-		action.UnInitialize()
-	}
-
-	// Initialize new actions
-	for _, action := range actions {
-		action.Initialize()
-	}
-}
-
-func (pc *Scheduler) getSchedulerConf() (actions []string, plugins []string) {
-	for _, action := range pc.actions {
-		actions = append(actions, action.Name())
-	}
-	for _, tier := range pc.plugins {
-		for _, plugin := range tier.Plugins {
-			plugins = append(plugins, plugin.Name)
-		}
-	}
-	return
+	klog.V(2).Infof("Using default scheduler configuration")
+	return pc.defaultActions, pc.defaultPlugins, pc.defaultConfigurations, pc.defaultMetricsConf, nil
 }
 
 func (pc *Scheduler) watchSchedulerConf(stopCh <-chan struct{}) {
@@ -250,7 +227,24 @@ func (pc *Scheduler) watchSchedulerConf(stopCh <-chan struct{}) {
 			}
 			klog.V(4).Infof("watch %s event: %v", pc.schedulerConf, event)
 			if event.Op&fsnotify.Write == fsnotify.Write || event.Op&fsnotify.Create == fsnotify.Create {
-				pc.loadSchedulerConf()
+				actions, plugins, configurations, metricsConf, err := pc.loadSchedulerConf()
+				if err != nil {
+					klog.Errorf("Failed to reload scheduler config: %v", err)
+					continue
+				}
+				for _, action := range actions {
+					action.Initialize()
+				}
+				pc.mutex.Lock()
+				oldActions := append([]framework.Action(nil), pc.actions...)
+				pc.actions = actions
+				pc.plugins = plugins
+				pc.configurations = configurations
+				pc.metricsConf = metricsConf
+				pc.mutex.Unlock()
+				for _, action := range oldActions {
+					action.UnInitialize()
+				}
 				pc.cache.SetMetricsConf(pc.metricsConf)
 			}
 		case err, ok := <-errCh:

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -111,8 +111,6 @@ func (pc *Scheduler) cleanupActions() {
 func (pc *Scheduler) Run(stopCh <-chan struct{}) {
 	pc.loadSchedulerConf()
 
-	pc.initActions()
-
 	// Cleanup on scheduler shutdown.
 	go func() {
 		<-stopCh
@@ -208,11 +206,22 @@ func (pc *Scheduler) loadSchedulerConf() {
 	}
 
 	pc.mutex.Lock()
+	oldActions := pc.actions
 	pc.actions = actions
 	pc.plugins = plugins
 	pc.configurations = configurations
 	pc.metricsConf = metricsConf
 	pc.mutex.Unlock()
+
+	// Cleanup old actions
+	for _, action := range oldActions {
+		action.UnInitialize()
+	}
+
+	// Initialize new actions
+	for _, action := range actions {
+		action.Initialize()
+	}
 }
 
 func (pc *Scheduler) getSchedulerConf() (actions []string, plugins []string) {

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -25,7 +25,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -51,18 +50,12 @@ type Scheduler struct {
 	schedulerConf  string
 	fileWatcher    filewatcher.FileWatcher
 	schedulePeriod time.Duration
-	once           sync.Once
 
-	mutex          sync.Mutex
+	mutex          sync.RWMutex
 	actions        []framework.Action
 	plugins        []conf.Tier
 	configurations []conf.Configuration
 	metricsConf    map[string]string
-
-	defaultActions        []framework.Action
-	defaultPlugins        []conf.Tier
-	defaultConfigurations []conf.Configuration
-	defaultMetricsConf    map[string]string
 
 	dumper             schedcache.Dumper
 	disableDefaultConf bool
@@ -132,9 +125,8 @@ func (pc *Scheduler) Run(stopCh <-chan struct{}) {
 	go func() {
 		<-stopCh
 		pc.mutex.Lock()
-		oldActions := slices.Clone(pc.actions)
-		pc.mutex.Unlock()
-		for _, action := range oldActions {
+		defer pc.mutex.Unlock()
+		for _, action := range pc.actions {
 			action.UnInitialize()
 		}
 	}()
@@ -156,11 +148,11 @@ func (pc *Scheduler) runOnce() {
 	scheduleStartTime := time.Now()
 	defer klog.V(4).Infof("End scheduling ...")
 
-	pc.mutex.Lock()
+	pc.mutex.RLock()
+	defer pc.mutex.RUnlock()
 	actions := pc.actions
 	plugins := pc.plugins
 	configurations := pc.configurations
-	pc.mutex.Unlock()
 
 	// Load ConfigMap to check which action is enabled.
 	conf.EnabledActionMap = make(map[string]bool)
@@ -196,44 +188,49 @@ func (pc *Scheduler) loadSchedulerConf() ([]framework.Action, []conf.Tier, []con
 		klog.Fatalf("No --scheduler-conf path provided and default configuration fallback is disabled")
 	}
 
-	var err error
-	if !pc.disableDefaultConf {
-		pc.once.Do(func() {
-			pc.defaultActions, pc.defaultPlugins, pc.defaultConfigurations, pc.defaultMetricsConf, err = UnmarshalSchedulerConf(DefaultSchedulerConf)
-			if err != nil {
-				klog.Fatalf("Invalid default configuration: unmarshal Scheduler config %s failed: %v", DefaultSchedulerConf, err)
-			}
-		})
-	}
-
-	var config string
-	if len(pc.schedulerConf) != 0 {
-		confData, err := os.ReadFile(pc.schedulerConf)
+	// If config file path is not given, only parse and return DefaultSchedulerConf
+	if len(pc.schedulerConf) == 0 {
+		actions, plugins, configurations, metricsConf, err := UnmarshalSchedulerConf(DefaultSchedulerConf)
 		if err != nil {
-			if pc.disableDefaultConf {
-				klog.Fatalf("Failed to read scheduler config and default configuration fallback is disabled")
-			}
-			klog.Errorf("Failed to read the Scheduler config in '%s', falling back to default: %v",
-				pc.schedulerConf, err)
-			return pc.defaultActions, pc.defaultPlugins, pc.defaultConfigurations, pc.defaultMetricsConf, nil
+			klog.Fatalf("Invalid builtin default configuration: %v", err)
 		}
-		config = strings.TrimSpace(string(confData))
-	}
-
-	if len(config) != 0 {
-		actions, plugins, configurations, metricsConf, err := UnmarshalSchedulerConf(config)
-		if err != nil {
-			if pc.disableDefaultConf {
-				klog.Fatalf("Invalid scheduler configuration and default configuration fallback is disabled")
-			}
-			klog.Errorf("Scheduler config %s is invalid, falling back to default: %v", config, err)
-			return pc.defaultActions, pc.defaultPlugins, pc.defaultConfigurations, pc.defaultMetricsConf, nil
-		}
-		klog.V(2).Infof("Loaded scheduler configuration from file")
+		klog.V(2).Infof("No scheduler config file provided, using builtin default configuration")
 		return actions, plugins, configurations, metricsConf, nil
 	}
-	klog.V(2).Infof("Using default scheduler configuration")
-	return pc.defaultActions, pc.defaultPlugins, pc.defaultConfigurations, pc.defaultMetricsConf, nil
+
+	// If config file path is given, read the file
+	confData, err := os.ReadFile(pc.schedulerConf)
+	if err != nil {
+		if pc.disableDefaultConf {
+			klog.Fatalf("Failed to read scheduler config and default configuration fallback is disabled")
+		}
+
+		return nil, nil, nil, nil, fmt.Errorf("Failed to read scheduler config '%s': %w", pc.schedulerConf, err)
+	}
+
+	config := strings.TrimSpace(string(confData))
+
+	// If file exists but is empty, treat it as config not provided
+	if len(config) == 0 {
+		klog.V(2).Infof("Scheduler config file '%s' is empty, using builtin default configuration", pc.schedulerConf)
+		actions, plugins, configurations, metricsConf, err := UnmarshalSchedulerConf(DefaultSchedulerConf)
+		if err != nil {
+			klog.Fatalf("Invalid builtin default configuration: %v", err)
+		}
+		return actions, plugins, configurations, metricsConf, nil
+	}
+
+	// Parse the file content
+	actions, plugins, configurations, metricsConf, err := UnmarshalSchedulerConf(config)
+	if err != nil {
+		if pc.disableDefaultConf {
+			klog.Fatalf("Invalid scheduler configuration and default configuration fallback is disabled")
+		}
+		return nil, nil, nil, nil, fmt.Errorf("Failed to parse scheduler config '%s': %w", pc.schedulerConf, err)
+	}
+
+	klog.V(2).Infof("Loaded scheduler configuration from file '%s'", pc.schedulerConf)
+	return actions, plugins, configurations, metricsConf, nil
 }
 
 func (pc *Scheduler) getSchedulerConf() (actions []string, plugins []string) {
@@ -264,26 +261,32 @@ func (pc *Scheduler) watchSchedulerConf(stopCh <-chan struct{}) {
 			if event.Op&fsnotify.Write == fsnotify.Write || event.Op&fsnotify.Create == fsnotify.Create {
 				actions, plugins, configurations, metricsConf, err := pc.loadSchedulerConf()
 				if err != nil {
-					klog.Errorf("Failed to reload scheduler config: %v", err)
+					klog.Errorf("Skipping config reload, keeping current active configuration: %v", err)
 					continue
 				}
 				pc.mutex.Lock()
-				oldActions := slices.Clone(pc.actions)
-				pc.mutex.Unlock()
-
-				oldMap := actionMap(oldActions)
+				oldMap := actionMap(pc.actions)
 				newMap := actionMap(actions)
 				for name, action := range newMap {
 					if _, exists := oldMap[name]; !exists {
 						action.Initialize()
 					}
 				}
-				pc.applySchedulerConf(actions, plugins, configurations, metricsConf)
+				pc.actions = actions
+				pc.plugins = plugins
+				pc.configurations = configurations
+				pc.metricsConf = metricsConf
 				for name, action := range oldMap {
 					if _, exists := newMap[name]; !exists {
 						action.UnInitialize()
 					}
 				}
+				pc.mutex.Unlock()
+				if pc.cache != nil {
+					pc.cache.SetMetricsConf(metricsConf)
+				}
+				actionNames, pluginNames := pc.getSchedulerConf()
+				klog.V(2).Infof("Scheduler configuration reloaded: actions=%v, plugins=%v", actionNames, pluginNames)
 			}
 		case err, ok := <-errCh:
 			if !ok {

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -25,6 +25,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -92,6 +93,27 @@ func NewScheduler(config *rest.Config, opt *options.ServerOption) (*Scheduler, e
 	return scheduler, nil
 }
 
+func (pc *Scheduler) applySchedulerConf(
+	actions []framework.Action,
+	plugins []conf.Tier,
+	configurations []conf.Configuration,
+	metricsConf map[string]string,
+) {
+	pc.mutex.Lock()
+	pc.actions = actions
+	pc.plugins = plugins
+	pc.configurations = configurations
+	pc.metricsConf = metricsConf
+	pc.mutex.Unlock()
+
+	if pc.cache != nil {
+		pc.cache.SetMetricsConf(pc.metricsConf)
+	}
+
+	actionNames, pluginNames := pc.getSchedulerConf()
+	klog.V(2).Infof("Scheduler configuration applied: actions=%v, plugins=%v", actionNames, pluginNames)
+}
+
 // Run initializes and starts the Scheduler. It parses the scheduler configuration, initializes actions,
 // applies the configuration and starts the scheduling loop, cache and configuration watcher.
 func (pc *Scheduler) Run(stopCh <-chan struct{}) {
@@ -104,18 +126,13 @@ func (pc *Scheduler) Run(stopCh <-chan struct{}) {
 		action.Initialize()
 	}
 
-	pc.mutex.Lock()
-	pc.actions = actions
-	pc.plugins = plugins
-	pc.configurations = configurations
-	pc.metricsConf = metricsConf
-	pc.mutex.Unlock()
+	pc.applySchedulerConf(actions, plugins, configurations, metricsConf)
 
 	// Cleanup on scheduler shutdown.
 	go func() {
 		<-stopCh
 		pc.mutex.Lock()
-		oldActions := append([]framework.Action(nil), pc.actions...)
+		oldActions := slices.Clone(pc.actions)
 		pc.mutex.Unlock()
 		for _, action := range oldActions {
 			action.UnInitialize()
@@ -123,8 +140,6 @@ func (pc *Scheduler) Run(stopCh <-chan struct{}) {
 	}()
 
 	go pc.watchSchedulerConf(stopCh)
-	// Start cache for policy.
-	pc.cache.SetMetricsConf(pc.metricsConf)
 	pc.cache.Run(stopCh)
 	klog.V(2).Infof("Scheduler completes Initialization and start to run")
 	go wait.Until(pc.runOnce, pc.schedulePeriod, stopCh)
@@ -164,6 +179,14 @@ func (pc *Scheduler) runOnce() {
 		action.Execute(ssn)
 		metrics.UpdateActionDuration(action.Name(), metrics.Duration(actionStartTime))
 	}
+}
+
+func actionMap(actions []framework.Action) map[string]framework.Action {
+	m := make(map[string]framework.Action)
+	for _, a := range actions {
+		m[a.Name()] = a
+	}
+	return m
 }
 
 func (pc *Scheduler) loadSchedulerConf() ([]framework.Action, []conf.Tier, []conf.Configuration, map[string]string, error) {
@@ -213,6 +236,18 @@ func (pc *Scheduler) loadSchedulerConf() ([]framework.Action, []conf.Tier, []con
 	return pc.defaultActions, pc.defaultPlugins, pc.defaultConfigurations, pc.defaultMetricsConf, nil
 }
 
+func (pc *Scheduler) getSchedulerConf() (actions []string, plugins []string) {
+	for _, action := range pc.actions {
+		actions = append(actions, action.Name())
+	}
+	for _, tier := range pc.plugins {
+		for _, plugin := range tier.Plugins {
+			plugins = append(plugins, plugin.Name)
+		}
+	}
+	return
+}
+
 func (pc *Scheduler) watchSchedulerConf(stopCh <-chan struct{}) {
 	if pc.fileWatcher == nil {
 		return
@@ -232,20 +267,23 @@ func (pc *Scheduler) watchSchedulerConf(stopCh <-chan struct{}) {
 					klog.Errorf("Failed to reload scheduler config: %v", err)
 					continue
 				}
-				for _, action := range actions {
-					action.Initialize()
-				}
 				pc.mutex.Lock()
-				oldActions := append([]framework.Action(nil), pc.actions...)
-				pc.actions = actions
-				pc.plugins = plugins
-				pc.configurations = configurations
-				pc.metricsConf = metricsConf
+				oldActions := slices.Clone(pc.actions)
 				pc.mutex.Unlock()
-				for _, action := range oldActions {
-					action.UnInitialize()
+
+				oldMap := actionMap(oldActions)
+				newMap := actionMap(actions)
+				for name, action := range newMap {
+					if _, exists := oldMap[name]; !exists {
+						action.Initialize()
+					}
 				}
-				pc.cache.SetMetricsConf(pc.metricsConf)
+				pc.applySchedulerConf(actions, plugins, configurations, metricsConf)
+				for name, action := range oldMap {
+					if _, exists := newMap[name]; !exists {
+						action.UnInitialize()
+					}
+				}
 			}
 		case err, ok := <-errCh:
 			if !ok {

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -27,13 +27,23 @@ func (f *lifecycleTestAction) UnInitialize() {
 	f.callOrder = append(f.callOrder, "uninitialize")
 }
 
+func initActions(actions []framework.Action) {
+	for _, action := range actions {
+		action.Initialize()
+	}
+}
+
+func cleanupActions(actions []framework.Action) {
+	for _, action := range actions {
+		action.UnInitialize()
+	}
+}
+
 func TestScheduler_ActionLifecycle(t *testing.T) {
 	testAction := &lifecycleTestAction{}
-	scheduler := &Scheduler{
-		actions: []framework.Action{testAction},
-	}
-	scheduler.initActions()
-	scheduler.cleanupActions()
+	actions := []framework.Action{testAction}
+	initActions(actions)
+	cleanupActions(actions)
 	expected := []string{"initialize", "uninitialize"}
 	if !reflect.DeepEqual(testAction.callOrder, expected) {
 		t.Fatalf("unexpected lifecycle order: got %v, want %v",

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -1,0 +1,42 @@
+package scheduler
+
+import (
+	"reflect"
+	"testing"
+
+	"volcano.sh/volcano/pkg/scheduler/framework"
+)
+
+type lifecycleTestAction struct {
+	callOrder []string
+}
+
+func (f *lifecycleTestAction) Name() string {
+	return "lifecycle-test"
+}
+
+func (f *lifecycleTestAction) Initialize() {
+	f.callOrder = append(f.callOrder, "initialize")
+}
+
+func (f *lifecycleTestAction) Execute(ssn *framework.Session) {
+	// not relevant for this test
+}
+
+func (f *lifecycleTestAction) UnInitialize() {
+	f.callOrder = append(f.callOrder, "uninitialize")
+}
+
+func TestScheduler_ActionLifecycle(t *testing.T) {
+	testAction := &lifecycleTestAction{}
+	scheduler := &Scheduler{
+		actions: []framework.Action{testAction},
+	}
+	scheduler.initActions()
+	scheduler.cleanupActions()
+	expected := []string{"initialize", "uninitialize"}
+	if !reflect.DeepEqual(testAction.callOrder, expected) {
+		t.Fatalf("unexpected lifecycle order: got %v, want %v",
+			testAction.callOrder, expected)
+	}
+}

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -1,30 +1,77 @@
+/*
+Copyright 2026 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package scheduler
 
 import (
+	"os"
 	"reflect"
 	"testing"
+	"time"
 
+	"github.com/fsnotify/fsnotify"
 	"volcano.sh/volcano/pkg/scheduler/framework"
 )
 
 type lifecycleTestAction struct {
+	name      string
 	callOrder []string
 }
 
 func (f *lifecycleTestAction) Name() string {
-	return "lifecycle-test"
+	return f.name
 }
 
 func (f *lifecycleTestAction) Initialize() {
 	f.callOrder = append(f.callOrder, "initialize")
 }
 
-func (f *lifecycleTestAction) Execute(ssn *framework.Session) {
-	// not relevant for this test
-}
+func (f *lifecycleTestAction) Execute(ssn *framework.Session) {}
 
 func (f *lifecycleTestAction) UnInitialize() {
 	f.callOrder = append(f.callOrder, "uninitialize")
+}
+
+type mockWatcher struct {
+	eventCh chan fsnotify.Event
+	errCh   chan error
+}
+
+func (m *mockWatcher) Events() chan fsnotify.Event {
+	return m.eventCh
+}
+
+func (m *mockWatcher) Errors() chan error {
+	return m.errCh
+}
+
+func (m *mockWatcher) Close() {}
+
+func writeTempConfig(t *testing.T, content string) string {
+	file, err := os.CreateTemp("", "scheduler-conf-*.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := file.WriteString(content); err != nil {
+		t.Fatal(err)
+	}
+	file.Close()
+
+	return file.Name()
 }
 
 func initActions(actions []framework.Action) {
@@ -40,13 +87,75 @@ func cleanupActions(actions []framework.Action) {
 }
 
 func TestScheduler_ActionLifecycle(t *testing.T) {
-	testAction := &lifecycleTestAction{}
+	testAction := &lifecycleTestAction{name: "test"}
+
 	actions := []framework.Action{testAction}
+
 	initActions(actions)
 	cleanupActions(actions)
+
 	expected := []string{"initialize", "uninitialize"}
+
 	if !reflect.DeepEqual(testAction.callOrder, expected) {
 		t.Fatalf("unexpected lifecycle order: got %v, want %v",
 			testAction.callOrder, expected)
 	}
+}
+
+func TestLoadSchedulerConf_Basic(t *testing.T) {
+	config := `
+actions: "enqueue"
+`
+
+	path := writeTempConfig(t, config)
+	defer os.Remove(path)
+
+	s := &Scheduler{
+		schedulerConf: path,
+	}
+
+	actions, _, _, _, err := s.loadSchedulerConf()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(actions) == 0 {
+		t.Fatalf("expected actions to be loaded")
+	}
+}
+
+func TestWatchSchedulerConf_Reload(t *testing.T) {
+	initialConfig := `
+actions: "enqueue"
+`
+
+	path := writeTempConfig(t, initialConfig)
+	defer os.Remove(path)
+
+	s := &Scheduler{
+		schedulerConf: path,
+	}
+
+	watcher := &mockWatcher{
+		eventCh: make(chan fsnotify.Event, 1),
+		errCh:   make(chan error),
+	}
+	s.fileWatcher = watcher
+
+	stopCh := make(chan struct{})
+
+	go s.watchSchedulerConf(stopCh)
+
+	watcher.eventCh <- fsnotify.Event{Op: fsnotify.Write}
+
+	time.Sleep(100 * time.Millisecond)
+
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	if len(s.actions) == 0 {
+		t.Fatalf("expected actions to be loaded after reload")
+	}
+
+	close(stopCh)
 }


### PR DESCRIPTION
#### What type of PR is this?

bugfix

#### What this PR does / why we need it:

- Currently, scheduler actions only invoke Execute() during a scheduling cycle.
- Initialize() and UnInitialize() are defined in the Action interface but are called only in unit tests and never in production code.
- This change ensures every scheduler follows its full lifecycle - Initialize(), Execute(), UnInitialize().

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Notice that do not add `Fixes` if the issue is associated with multiple PRs.
-->
Fixes #5052 

#### Special notes for your reviewer:
NONE

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```