### PR TITLE
fix: panic and restart of volcano scheduler pods on install

### DIFF
--- a/pkg/scheduler/cache/cache.go
+++ b/pkg/scheduler/cache/cache.go
@@ -476,17 +476,21 @@ func newDefaultAndRootQueue(vcClient vcclient.Interface, defaultQueue string) {
 			Factor:   1,
 			Jitter:   0.1,
 		}, func(err error) bool {
-			return !apierrors.IsAlreadyExists(err)
+			return true
 		}, func() error {
 			klog.V(2).Infof("Start to create queue %s", name)
 			_, err := vcClient.SchedulingV1beta1().Queues().Create(context.TODO(), &newQueue, metav1.CreateOptions{})
-			if err != nil {
-				klog.V(2).Infof("Failed to create queue %s: %v, will retry", name, err)
-				return err
+			if err == nil {
+				klog.V(2).Infof("Successfully created queue %s", name)
+				return nil
 			}
-
-			klog.V(2).Infof("Successfully created queue %s", name)
-			return nil
+			// If this queue has just been created by others and already exists, skip creating it.
+			if apierrors.IsAlreadyExists(err) {
+				klog.V(2).Infof("Queue %s already exists, skip creating.", name)
+				return nil
+			}
+			klog.Errorf("Failed to create queue %s: %v, will retry", name, err)
+			return err
 		})
 	}
 

--- a/pkg/scheduler/cache/cache_test.go
+++ b/pkg/scheduler/cache/cache_test.go
@@ -24,15 +24,20 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"sync"
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 
+	vcv1beta1 "volcano.sh/apis/pkg/apis/scheduling/v1beta1"
+	vcclient "volcano.sh/apis/pkg/client/clientset/versioned"
+	vcclientfake "volcano.sh/apis/pkg/client/clientset/versioned/fake"
 	"volcano.sh/volcano/pkg/scheduler/api"
 	"volcano.sh/volcano/pkg/scheduler/util"
 )
@@ -426,4 +431,51 @@ func (m *mockPreBinder) PreBind(ctx context.Context, bindCtx *BindContext) error
 
 func (m *mockPreBinder) PreBindRollBack(ctx context.Context, bindCtx *BindContext) {
 	// do nothing
+}
+
+func TestNewDefaultAndRootQueue(t *testing.T) {
+	rootQueue := "root"
+	defaultQueue := "default"
+
+	tests := []struct {
+		name             string
+		vcClient         vcclient.Interface
+		concurrentNumber int
+	}{
+		{
+			name:             "successfully create the both queues",
+			vcClient:         vcclientfake.NewSimpleClientset(),
+			concurrentNumber: 2,
+		}, {
+			name:             "successfully create the default queue, skip the root queue",
+			vcClient:         vcclientfake.NewSimpleClientset(&vcv1beta1.Queue{ObjectMeta: metav1.ObjectMeta{Name: rootQueue}}),
+			concurrentNumber: 2,
+		}, {
+			name:             "successfully create the root queue, skip the default queue",
+			vcClient:         vcclientfake.NewSimpleClientset(&vcv1beta1.Queue{ObjectMeta: metav1.ObjectMeta{Name: defaultQueue}}),
+			concurrentNumber: 2,
+		}, {
+			name: "skip the both queues",
+			vcClient: vcclientfake.NewSimpleClientset(&vcv1beta1.Queue{ObjectMeta: metav1.ObjectMeta{Name: rootQueue}},
+				&vcv1beta1.Queue{ObjectMeta: metav1.ObjectMeta{Name: defaultQueue}}),
+			concurrentNumber: 2,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var wg sync.WaitGroup
+			wg.Add(tt.concurrentNumber)
+			for i := 0; i < tt.concurrentNumber; i++ {
+				go func() {
+					defer wg.Done()
+					newDefaultAndRootQueue(tt.vcClient, defaultQueue)
+				}()
+			}
+			wg.Wait()
+			_, rootErr := tt.vcClient.SchedulingV1beta1().Queues().Get(context.TODO(), rootQueue, metav1.GetOptions{})
+			assert.NoError(t, rootErr)
+			_, defaultErr := tt.vcClient.SchedulingV1beta1().Queues().Get(context.TODO(), defaultQueue, metav1.GetOptions{})
+			assert.NoError(t, defaultErr)
+		})
+	}
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
Fix the bug that when installing volcano with two or more volcano scheduler pods, some of these pods may panic and restart.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Notice that do not add `Fixes` if the issue is associated with multiple PRs.
-->
Fixes #5074

#### Special notes for your reviewer:
None

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```