### PR TITLE
fix(reclaim): isolate evictions per node to prevent ghost evictions

### DIFF
--- a/pkg/scheduler/actions/reclaim/reclaim.go
+++ b/pkg/scheduler/actions/reclaim/reclaim.go
@@ -212,6 +212,12 @@ func (ra *Action) reclaimForTask(ssn *framework.Session, stmt *framework.Stateme
 			continue
 		}
 
+		// Use a temporary statement per node attempt so that eviction operations
+		// are isolated. On success the operations are merged into the caller's
+		// statement; on failure they are discarded, so evictions are only committed
+		// when reclaim succeeds on this node.
+		nodeStmt := framework.NewStatement(ssn)
+
 		victimsQueue := ssn.BuildVictimsPriorityQueue(victims, task)
 		resreq := task.InitResreq.Clone()
 		reclaimed := api.EmptyResource()
@@ -224,7 +230,7 @@ func (ra *Action) reclaimForTask(ssn *framework.Session, stmt *framework.Stateme
 			reclaimee := victimsQueue.Pop().(*api.TaskInfo)
 			klog.V(3).Infof("Try to reclaim Task <%s/%s> for Tasks <%s/%s>",
 				reclaimee.Namespace, reclaimee.Name, task.Namespace, task.Name)
-			stmt.Evict(reclaimee, "reclaim")
+			nodeStmt.Evict(reclaimee, "reclaim")
 			reclaimed.Add(reclaimee.Resreq)
 			availableResources.Add(reclaimee.Resreq)
 			evictionOccurred = true
@@ -236,16 +242,24 @@ func (ra *Action) reclaimForTask(ssn *framework.Session, stmt *framework.Stateme
 		klog.V(3).Infof("Reclaimed <%v> for task <%s/%s> requested <%v>, and Node <%s> availableResources <%v>.", reclaimed, task.Namespace, task.Name, task.InitResreq, n.Name, availableResources)
 
 		if task.InitResreq.LessEqual(availableResources, api.Zero) {
-			if err := stmt.Pipeline(task, n.Name, evictionOccurred); err != nil {
+			if err := nodeStmt.Pipeline(task, n.Name, evictionOccurred); err != nil {
 				klog.Errorf("Failed to pipeline Task <%s/%s> on Node <%s>",
 					task.Namespace, task.Name, n.Name)
-				if rollbackErr := stmt.UnPipeline(task); rollbackErr != nil {
+				if rollbackErr := nodeStmt.UnPipeline(task); rollbackErr != nil {
 					klog.Errorf("Failed to unpipeline Task %v on %v in Session %v for %v.",
 						task.UID, n.Name, ssn.UID, rollbackErr)
 				}
+				// Pipeline failed: discard all evictions for this node and try the next one.
+				nodeStmt.Discard()
+				continue
 			}
+			// Pipeline succeeded: merge this node's operations into the caller's statement.
+			stmt.Merge(nodeStmt)
 			break
 		}
+
+		// Not enough resources on this node even after evictions: discard and try next node.
+		nodeStmt.Discard()
 	}
 }
 

--- a/pkg/scheduler/actions/reclaim/reclaim_test.go
+++ b/pkg/scheduler/actions/reclaim/reclaim_test.go
@@ -259,6 +259,56 @@ func TestReclaim(t *testing.T) {
 			ExpectEvicted: []string{"c1/preemptee1-1"},
 		},
 		{
+			// Regression test for the per-node nodeStmt isolation introduced to fix
+			// ghost evictions in reclaimForTask.
+			//
+			// Setup: two nodes; preemptor (q2) needs 2 CPU.
+			//   Cluster total = 4 CPU → each queue deserves 2 CPU (equal weight).
+			//   q1 allocated = 3 CPU (overusing by 1 CPU); q2 allocated = 0 CPU.
+			//   Proportion Preemptive check: 0 + 2 = 2 ≤ 2 (q2.deserved) → passes.
+			//
+			//   n1: 1 CPU total, fully used by victim-n1 (1 CPU, q1, preemptable).
+			//       FutureIdle=0; 0+1=1 < 2 → ValidateVictims fails → n1 skipped entirely.
+			//   n2: 3 CPU total, 1 CPU idle + victim-n2 (2 CPU, q1, preemptable).
+			//       FutureIdle=1; 1+2=3 ≥ 2 → ValidateVictims passes → reclaim succeeds.
+			//
+			// Expected: only victim-n2 is evicted. victim-n1 must NOT be evicted.
+			//
+			// Before the nodeStmt fix, evictions went directly into the outer Statement
+			// without per-node isolation, so evictions from nodes that are later skipped
+			// or fail could leak into stmt.Commit(). The nodeStmt pattern prevents this.
+			Name: "only evict victims from the node where reclaim actually succeeds",
+			Plugins: map[string]framework.PluginBuilder{
+				conformance.PluginName: conformance.New,
+				gang.PluginName:        gang.New,
+				proportion.PluginName:  proportion.New,
+			},
+			PodGroups: []*schedulingv1beta1.PodGroup{
+				util.BuildPodGroupWithPrio("pg-victim", "c1", "q1", 0, nil, schedulingv1beta1.PodGroupRunning, "low-priority"),
+				util.BuildPodGroupWithPrio("pg-preemptor", "c1", "q2", 1, nil, schedulingv1beta1.PodGroupInqueue, "high-priority"),
+			},
+			Pods: []*v1.Pod{
+				// n1 victim: only 1 CPU freed — insufficient for 2 CPU preemptor;
+				// ValidateVictims (0 idle + 1 CPU = 1 < 2) rejects n1 before any eviction.
+				util.BuildPod("c1", "victim-n1", "n1", v1.PodRunning, api.BuildResourceList("1", "1G"), "pg-victim", map[string]string{schedulingv1beta1.PodPreemptable: "true"}, make(map[string]string)),
+				// n2 victim: 2 CPU freed; n2 has 1 CPU idle, so 1+2=3 ≥ 2; reclaim succeeds.
+				util.BuildPod("c1", "victim-n2", "n2", v1.PodRunning, api.BuildResourceList("2", "2G"), "pg-victim", map[string]string{schedulingv1beta1.PodPreemptable: "true"}, make(map[string]string)),
+				util.BuildPod("c1", "preemptor", "", v1.PodPending, api.BuildResourceList("2", "2G"), "pg-preemptor", make(map[string]string), make(map[string]string)),
+			},
+			Nodes: []*v1.Node{
+				// n1: 1 CPU total, fully used by victim-n1.
+				util.BuildNode("n1", api.BuildResourceList("1", "1G", []api.ScalarResource{{Name: "pods", Value: "10"}}...), make(map[string]string)),
+				// n2: 3 CPU total; victim-n2 uses 2 CPU leaving 1 CPU idle.
+				util.BuildNode("n2", api.BuildResourceList("3", "3G", []api.ScalarResource{{Name: "pods", Value: "10"}}...), make(map[string]string)),
+			},
+			Queues: []*schedulingv1beta1.Queue{
+				util.BuildQueue("q1", 1, nil),
+				util.BuildQueue("q2", 1, nil),
+			},
+			ExpectEvictNum: 1,
+			ExpectEvicted:  []string{"c1/victim-n2"},
+		},
+		{
 			Name: "Reclaim succeeds for second task when first task has PreemptionPolicy=Never",
 			Plugins: map[string]framework.PluginBuilder{
 				conformance.PluginName: conformance.New,


### PR DESCRIPTION
#### What type of PR is this?
Bug fix

#### What this PR does / why we need it:
`reclaimForTask` had the same ghost-eviction bug already fixed in `normalPreempt`.
When reclaim iterates over multiple nodes, evictions were written directly into the
shared statement, so if node A's victims weren't sufficient and we fell through to
node B, both A's and B's evictions would be committed on success, killing pods
unrelated to the final scheduling decision.

The fix mirrors the pattern from `normalPreempt`: allocate a temporary `nodeStmt`
per node attempt, discard it if that node doesn't pan out, and merge it into the
outer statement only when the task is actually pipelined to that node.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Notice that do not add `Fixes` if the issue is associated with multiple PRs.
-->
NONE

#### Special notes for your reviewer:
The fix is intentionally the same pattern used in `normalPreempt` — worth
cross-referencing that code path when reviewing. A regression test is included
that sets up two nodes where only one can satisfy the preemptor, asserting only
that node's victim gets evicted.
-->
```release-note
NONE
```