### PR TITLE
Fix shared mutable objects in scheduler snapshot clones

### DIFF
--- a/pkg/scheduler/api/job_info.go
+++ b/pkg/scheduler/api/job_info.go
@@ -287,7 +287,7 @@ func (ti *TaskInfo) Clone() *TaskInfo {
 		Namespace:                   ti.Namespace,
 		TaskRole:                    ti.TaskRole,
 		Priority:                    ti.Priority,
-		Pod:                         ti.Pod,
+		Pod:                         ti.Pod.DeepCopy(),
 		Resreq:                      ti.Resreq.Clone(),
 		InitResreq:                  ti.InitResreq.Clone(),
 		VolumeReady:                 ti.VolumeReady,

--- a/pkg/scheduler/api/namespace_info.go
+++ b/pkg/scheduler/api/namespace_info.go
@@ -58,8 +58,12 @@ func (n *NamespaceCollection) Delete(quota *v1.ResourceQuota) {
 
 // Snapshot will clone a NamespaceInfo without Heap according NamespaceCollection
 func (n *NamespaceCollection) Snapshot() *NamespaceInfo {
+	copiedQuotaStatus := make(map[string]v1.ResourceQuotaStatus, len(n.QuotaStatus))
+	for k, v := range n.QuotaStatus {
+		copiedQuotaStatus[k] = *v.DeepCopy()
+	}
 	return &NamespaceInfo{
 		Name:        NamespaceName(n.Name),
-		QuotaStatus: n.QuotaStatus,
+		QuotaStatus: copiedQuotaStatus,
 	}
 }

--- a/pkg/scheduler/api/node_info.go
+++ b/pkg/scheduler/api/node_info.go
@@ -214,7 +214,7 @@ func (ni *NodeInfo) RefreshNumaSchedulerInfoByCrd() {
 
 // Clone used to clone nodeInfo Object
 func (ni *NodeInfo) Clone() *NodeInfo {
-	res := NewNodeInfo(ni.Node)
+	res := NewNodeInfo(ni.Node.DeepCopy())
 
 	for _, p := range ni.Tasks {
 		res.AddTask(p)

--- a/pkg/scheduler/api/queue_info.go
+++ b/pkg/scheduler/api/queue_info.go
@@ -72,7 +72,7 @@ func (q *QueueInfo) Clone() *QueueInfo {
 		Weight:    q.Weight,
 		Hierarchy: q.Hierarchy,
 		Weights:   q.Weights,
-		Queue:     q.Queue,
+		Queue:     q.Queue.DeepCopy(),
 	}
 }
 


### PR DESCRIPTION
#### What type of PR is this?

#### What this PR does / why we need it:
**Today the scheduler’s cache snapshot is not fully isolated from the live cache:**

- `TaskInfo.Clone()` used to assign Pod: `ti.Pod` directly without `DeepCopy()`.

  - Any in‑memory mutation to the Pod in the scheduling path (annotations, labels, etc.) can accidentally modify the cache’s Pod object.
- `NodeInfo.Clone()` used `NewNodeInfo(ni.Node)` and reused the same `*v1.Node`.
  - The cloned NodeInfo and the cache share the same Node, so code that relies on a “cloned node” can still mutate the original.
- `NamespaceCollection.Snapshot()` returned QuotaStatus: `n.QuotaStatus` by reference.
  - The Cluster snapshot and the live cache share the same `map[string]v1.ResourceQuotaStatus`, so updating quota status on either side is not isolated.
- `QueueInfo.Clone()` used Queue: `q.Queue` directly.
  - The cloned QueueInfo and the cache share the same `*scheduling.Queue`, so `status/annotations` changes in one place affect the other.

Because the scheduler snapshot is supposed to represent a point‑in‑time, read‑only view of the cluster state, sharing these mutable objects breaks that contract.
#### Why is it necessary to fix this?
- Correctness / data isolation:
The scheduler frequently mutates objects during scheduling decisions (e.g. annotations, internal bookkeeping). If the snapshot and cache share pointers, those mutations can:
  - leak back into the cache and affect subsequent scheduling cycles, or
  - be affected by `informer/cache` updates while a scheduling cycle is still using the snapshot.
This can lead to non‑deterministic behaviour and very hard‑to‑debug race conditions.


- Consistent semantics for `Clone() / Snapshot()`:
By definition, `Clone() / Snapshot()` should return independent copies. Most fields already follow this (e.g. `Resreq.Clone()`, `NumaInfo.Clone()`, `CSINodeStatusInfo.Clone()`, `HyperNodesInfo.HyperNodes()` doing deep copies), but Pod, Node, Queue and Namespace quota were exceptions. Fixing them makes the API consistent and less surprising for contributors.

#### What happened in our scenario?
We utilize Ascend NPUs, where the Ascend plugin allocates NPU cards based on Pod annotations. We encountered a critical bug in preemption scenarios (`evict/unevict`) where the Ascend annotations were not released and recycled in matching pairs. This led to severe issues, such as duplicate NPU card allocations.

If the Pods within the scheduler snapshot were DeepCopyed, even if the Ascend annotations fail to be released and recycled in pairs during the current cycle, it would not result in duplicate card allocations when the next scheduling session begins. The isolation provided by deep copying ensures that any residual or incorrect annotation states from the previous cycle do not persist or corrupt the state for subsequent scheduling rounds.
#### 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Notice that do not add `Fixes` if the issue is associated with multiple PRs.
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
None
```