### PR TITLE
fix(capacity): prevent nil panic in hierarchical queue mode

### DIFF
--- a/pkg/scheduler/plugins/capacity/capacity.go
+++ b/pkg/scheduler/plugins/capacity/capacity.go
@@ -612,6 +612,11 @@ func (cp *capacityPlugin) buildHierarchicalQueueAttrs(ssn *framework.Session) bo
 	for _, job := range ssn.Jobs {
 		klog.V(4).Infof("Considering Job <%s/%s>.", job.Namespace, job.Name)
 		attr := cp.queueOpts[job.Queue]
+		if attr == nil {
+			klog.Warningf("Job <%s/%s> references queue %s which is not found in session queues, skipping",
+				job.Namespace, job.Name, job.Queue)
+			continue
+		}
 		if len(attr.children) > 0 {
 			klog.Errorf("The Queue <%s> of Job <%s/%s> is not leaf queue", attr.name, job.Namespace, job.Name)
 			return false
@@ -670,6 +675,10 @@ func (cp *capacityPlugin) buildHierarchicalQueueAttrs(ssn *framework.Session) bo
 	// root queue is default queue and users are not aware of it. User is allowed to sumbit jobs which exceed current cluster total resources,
 	// so root queue should not restrict by current total resources. User need to restrict resource through creating queue manually
 	rootQueueAttr := cp.queueOpts[api.QueueID(cp.rootQueue)]
+	if rootQueueAttr == nil {
+		klog.Warningf("Root queue %q not found in session queues, skipping hierarchy initialization", cp.rootQueue)
+		return false
+	}
 	infinityResource := api.InfiniteResource()
 	if cp.totalResource.ScalarResources != nil {
 		for k := range cp.totalResource.ScalarResources {

--- a/pkg/scheduler/plugins/capacity/capacity_test.go
+++ b/pkg/scheduler/plugins/capacity/capacity_test.go
@@ -984,3 +984,90 @@ func Test_updateQueueAttrShare(t *testing.T) {
 		})
 	}
 }
+
+// Test_buildHierarchicalQueueAttrs_nilSafety is a regression test for nil pointer
+// dereferences in buildHierarchicalQueueAttrs when the root queue or a job's queue
+// is absent from the session snapshot.
+func Test_buildHierarchicalQueueAttrs_nilSafety(t *testing.T) {
+	plugins := map[string]framework.PluginBuilder{PluginName: New, predicates.PluginName: predicates.New, gang.PluginName: gang.New}
+	trueValue := true
+	actions := []framework.Action{allocate.New()}
+
+	n1 := util.BuildNode("n1", api.BuildResourceList("4", "4Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), map[string]string{})
+
+	tiers := []conf.Tier{
+		{
+			Plugins: []conf.PluginOption{
+				{
+					Name:               PluginName,
+					EnabledAllocatable: &trueValue,
+					EnabledReclaimable: &trueValue,
+					EnabledQueueOrder:  &trueValue,
+					EnabledHierarchy:   &trueValue,
+					EnabledJobEnqueued: &trueValue,
+				},
+				{
+					Name:             predicates.PluginName,
+					EnabledPredicate: &trueValue,
+				},
+				{
+					Name:               gang.PluginName,
+					EnabledJobStarving: &trueValue,
+				},
+			},
+		},
+	}
+
+	tests := []uthelper.TestCommonStruct{
+		{
+			// Regression: root queue absent from ssn.Queues caused nil pointer dereference
+			// at buildHierarchicalQueueAttrs:679 (rootQueueAttr.capability.IsEmpty()).
+			// With the fix, buildHierarchicalQueueAttrs returns false and the session
+			// completes gracefully without scheduling any pods.
+			Name:           "no-panic when root queue is absent (empty ssn.Queues)",
+			Plugins:        plugins,
+			Pods:           []*corev1.Pod{},
+			Nodes:          []*corev1.Node{n1},
+			PodGroups:      []*schedulingv1beta1.PodGroup{},
+			Queues:         []*schedulingv1beta1.Queue{}, // no Queue CRs at all
+			ExpectBindMap:  map[string]string{},
+			ExpectBindsNum: 0,
+		},
+		{
+			// Regression: a job whose queue was deleted between scheduling sessions caused
+			// nil pointer dereference at buildHierarchicalQueueAttrs:615 (attr.children).
+			// The root queue IS present so the queues loop succeeds, but the job's queue
+			// is missing from ssn.Queues. With the fix the job is skipped with a warning
+			// and scheduling continues for all other work.
+			Name:    "no-panic when job references a deleted queue",
+			Plugins: plugins,
+			Pods: []*corev1.Pod{
+				util.BuildPod("ns1", "orphan", "", corev1.PodPending,
+					api.BuildResourceList("1", "1Gi"), "pg-orphan",
+					make(map[string]string), make(map[string]string)),
+			},
+			Nodes: []*corev1.Node{n1},
+			PodGroups: []*schedulingv1beta1.PodGroup{
+				// pg-orphan belongs to "deleted-queue" which is NOT in Queues below
+				util.BuildPodGroup("pg-orphan", "ns1", "deleted-queue", 1, nil,
+					schedulingv1beta1.PodGroupInqueue),
+			},
+			// Only the root queue exists; "deleted-queue" has been removed
+			Queues:         []*schedulingv1beta1.Queue{buildQueueWithParents("root", "", nil, nil)},
+			ExpectBindMap:  map[string]string{},
+			ExpectBindsNum: 0,
+		},
+	}
+
+	for i, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			test.RegisterSession(tiers, nil)
+			defer test.Close()
+			// Must not panic; any panic will surface as a test failure via t.Fatal.
+			test.Run(actions)
+			if err := test.CheckAll(i); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?
fix

#### What this PR does / why we need it:
If you delete a queue while jobs are still running, or if the scheduler starts before any Queue CRs exist, `buildHierarchicalQueueAttrs` will silently get a nil pointer back from the map and immediately crash the scheduler, taking down scheduling for every workload in the cluster.

This adds two nil checks: one before touching the root queue attr, one before iterating a job's queue attr. Instead of panicking, the function now returns `false` (which already means "skip this session") and logs a warning. The scheduler recovers on its own next cycle.

#### Which issue(s) this PR fixes:
Fixes #NA

#### Special notes for your reviewer:
None

#### Does this PR introduce a user-facing change?
```release-note
Fix scheduler panic in capacity plugin when a queue is deleted while jobs are still running, or when the scheduler starts before Queue CRs are created in hierarchical mode.
```