### PR TITLE
fix(proportion): avoid double-counting inqueue resources for jobs wit…

### DIFF
--- a/pkg/scheduler/plugins/proportion/proportion.go
+++ b/pkg/scheduler/plugins/proportion/proportion.go
@@ -155,8 +155,16 @@ func (pp *proportionPlugin) OnSessionOpen(ssn *framework.Session) {
 			}
 		}
 
+		// calculate inqueue resource for inqueue jobs
+		// deduct already-allocated task resources from minResources to avoid double-counting:
+		// tasks in Allocated/Binding state are already tracked in attr.allocated (via AllocatedStatus),
+		// but the PodGroup stays Inqueue until tasks reach Running/Bound (ScheduledStatus).
+		// Without this deduction, the same resources appear in both attr.allocated and attr.inqueue.
 		if job.PodGroup.Status.Phase == scheduling.PodGroupInqueue {
-			attr.inqueue.Add(job.DeductSchGatedResources(job.GetMinResources()))
+			if job.PodGroup.Spec.MinResources != nil {
+				inqueued := util.GetInqueueResource(job, job.Allocated)
+				attr.inqueue.Add(job.DeductSchGatedResources(inqueued))
+			}
 		}
 
 		// calculate inqueue resource for running jobs

--- a/pkg/scheduler/plugins/proportion/proportion_test.go
+++ b/pkg/scheduler/plugins/proportion/proportion_test.go
@@ -47,6 +47,24 @@ import (
 	"volcano.sh/volcano/pkg/scheduler/util"
 )
 
+// waitForBinds reads exactly n items from ch within deadline and returns them.
+// It fails the test if fewer than n items arrive within the timeout.
+func waitForBinds(t *testing.T, ch <-chan string, n int, timeout time.Duration) map[string]bool {
+	t.Helper()
+	got := make(map[string]bool, n)
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	for i := 0; i < n; i++ {
+		select {
+		case bind := <-ch:
+			got[bind] = true
+		case <-timer.C:
+			t.Fatalf("timeout waiting for bind #%d/%d (got so far: %v)", i+1, n, got)
+		}
+	}
+	return got
+}
+
 func TestMain(m *testing.M) {
 	options.Default()
 	os.Exit(m.Run())
@@ -505,5 +523,125 @@ func TestAllocate(t *testing.T) {
 				t.Fatal(err)
 			}
 		})
+	}
+}
+
+// TestNoDoubleCountingForInqueueJobWithBindingTasks is a regression test for the bug where
+// the proportion plugin double-counts queue resources for jobs whose tasks are in Allocated/Binding
+// state while their PodGroup is still in Inqueue phase.
+//
+// Root cause: tasks in Allocated/Binding state are counted in attr.allocated (via AllocatedStatus),
+// but ScheduledStatus excludes Allocated/Binding, so getPodGroupPhase keeps the PodGroup as
+// Inqueue. The Inqueue branch then adds the full minResources to attr.inqueue unconditionally,
+// causing the same CPU to appear in both attr.allocated and attr.inqueue.
+//
+// Fix: use GetInqueueResource(job, job.Allocated) for the Inqueue branch, matching the Running
+// branch's deduction logic, so already-allocated resources are not double-counted.
+func TestNoDoubleCountingForInqueueJobWithBindingTasks(t *testing.T) {
+	options.Default()
+
+	// Tell the allocate action that the enqueue action is active, so it will
+	// not bypass the queue-capacity check by promoting Pending→Inqueue itself.
+	prevEnabledActionMap := conf.EnabledActionMap
+	conf.EnabledActionMap = map[string]bool{"enqueue": true}
+	defer func() { conf.EnabledActionMap = prevEnabledActionMap }()
+
+	trueValue := true
+	plugins := map[string]framework.PluginBuilder{PluginName: New}
+	uthelper.RegisterPlugins(plugins)
+	defer framework.CleanupPluginBuilders()
+
+	tiers := []conf.Tier{
+		{
+			Plugins: []conf.PluginOption{
+				{
+					Name:               PluginName,
+					EnabledAllocatable: &trueValue,
+					EnabledOverused:    &trueValue,
+					EnabledJobEnqueued: &trueValue,
+				},
+			},
+		},
+	}
+
+	// Node with 4 CPU — enough for jobA (3 CPU) + jobB (1 CPU).
+	n1 := util.BuildNode("n1", api.BuildResourceList("4", "8Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), nil)
+
+	res1cpu := api.BuildResourceList("1", "1Gi")
+	minRes3cpu := api.BuildResourceList("3", "3Gi")
+	minRes1cpu := api.BuildResourceList("1", "1Gi")
+
+	// jobA: 3 tasks × 1 CPU, PodGroup already Inqueue with minResources=3CPU.
+	// After cycle 1 allocates these, they move to Binding in the cache while the
+	// PodGroup stays Inqueue (Binding ∉ ScheduledStatus).
+	pgA := util.BuildPodGroup("pgA", "ns1", "q1", 3, nil, schedulingv1beta1.PodGroupInqueue)
+	pgA.Spec.MinResources = &minRes3cpu
+	pA1 := util.BuildPod("ns1", "pA1", "", apiv1.PodPending, res1cpu, "pgA", nil, nil)
+	pA2 := util.BuildPod("ns1", "pA2", "", apiv1.PodPending, res1cpu, "pgA", nil, nil)
+	pA3 := util.BuildPod("ns1", "pA3", "", apiv1.PodPending, res1cpu, "pgA", nil, nil)
+
+	// jobB: 1 task × 1 CPU, PodGroup Pending.
+	// With correct accounting (queue used=3CPU, cap=4CPU) this should be enqueued and bound.
+	// With the double-counting bug (queue appears used=6CPU > cap=4CPU) it is rejected.
+	pgB := util.BuildPodGroup("pgB", "ns1", "q1", 1, nil, schedulingv1beta1.PodGroupPending)
+	pgB.Spec.MinResources = &minRes1cpu
+	pB1 := util.BuildPod("ns1", "pB1", "", apiv1.PodPending, res1cpu, "pgB", nil, nil)
+
+	// Queue with 4 CPU capacity.
+	q1 := util.BuildQueue("q1", 1, api.BuildResourceList("4", "8Gi"))
+
+	binder := util.NewFakeBinder(10)
+	evictor := util.NewFakeEvictor(0)
+	statusUpdater := &util.FakeStatusUpdater{}
+	stop := make(chan struct{})
+	defer close(stop)
+
+	sc := cache.NewCustomMockSchedulerCache("test-proportion", binder, evictor, statusUpdater, nil, nil)
+	sc.Run(stop)
+	sc.AddOrUpdateNode(n1)
+	// Only add jobA to the cache for cycle 1. jobB is intentionally omitted so the
+	// allocate action (which auto-promotes Pending→Inqueue when no enqueue action is
+	// configured) cannot accidentally schedule pB1 in cycle 1.
+	sc.AddPod(pA1)
+	sc.AddPod(pA2)
+	sc.AddPod(pA3)
+	sc.AddPodGroupV1beta1(pgA)
+	sc.AddQueueV1beta1(q1)
+
+	// Cycle 1: allocate jobA's tasks.
+	// After this cycle, pA1/pA2/pA3 are in Binding state in the scheduler cache.
+	// pgA remains Inqueue because Binding ∉ ScheduledStatus.
+	ssn1 := framework.OpenSession(sc, tiers, nil)
+	allocate.New().Execute(ssn1)
+	framework.CloseSession(ssn1)
+
+	// Wait for all 3 cycle-1 bind notifications and verify they are for jobA.
+	cycle1 := waitForBinds(t, binder.Channel, 3, 5*time.Second)
+	for _, pod := range []string{"ns1/pA1", "ns1/pA2", "ns1/pA3"} {
+		if !cycle1[pod] {
+			t.Errorf("expected %s to be bound in cycle 1, got %v", pod, cycle1)
+		}
+	}
+
+	// Add jobB to the cache now that cycle 1 is complete.
+	// The cache now has: pA1/pA2/pA3 in Binding + pgA Inqueue + n1 with 1 CPU free.
+	sc.AddPod(pB1)
+	sc.AddPodGroupV1beta1(pgB)
+
+	// Cycle 2: enqueue + allocate for jobB.
+	// The scheduler cache now has jobA's tasks as Binding + pgA still Inqueue.
+	// Correct behaviour (fix applied): attr.allocated=3CPU, attr.inqueue=max(0,3-3)=0CPU
+	//   → jobB.minReq(1CPU) + 3CPU + 0CPU = 4CPU ≤ capacity(4CPU) → jobB enqueued & bound.
+	// Buggy behaviour (pre-fix): attr.allocated=3CPU, attr.inqueue=3CPU (full minResources)
+	//   → jobB.minReq(1CPU) + 3CPU + 3CPU = 7CPU > capacity(4CPU) → jobB rejected.
+	ssn2 := framework.OpenSession(sc, tiers, nil)
+	enqueue.New().Execute(ssn2)
+	allocate.New().Execute(ssn2)
+	framework.CloseSession(ssn2)
+
+	cycle2 := waitForBinds(t, binder.Channel, 1, 5*time.Second)
+	if !cycle2["ns1/pB1"] {
+		t.Errorf("regression: pB1 was not bound in cycle 2 (got %v) — proportion plugin "+
+			"is double-counting inqueue resources for pgA whose tasks are in Binding state", cycle2)
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?

bug fix

#### What this PR does / why we need it:

While investigating some scheduling issues I noticed that jobs can get stuck in Pending even when there's clearly enough queue capacity available. Tracked it down to a double-counting bug in the proportion plugin.

When a gang-scheduled job's tasks get allocated, they move to `Binding` state in the scheduler cache. The problem is that `Binding` is part of `AllocatedStatus` but not `ScheduledStatus`, so the PodGroup stays `Inqueue` until the tasks actually reach `Running`. During this window, the proportion plugin counts those task resources in both `attr.allocated` and `attr.inqueue` — the full `minResources` gets added to `attr.inqueue` without deducting what's already allocated.

So if job-a uses 3 CPU on a 4 CPU queue, while its tasks are binding the queue looks like it's using 6 CPU, and any new job gets rejected even though there's 1 CPU free.

The `PodGroupRunning` branch already handles this correctly using `GetInqueueResource(job, job.Allocated)` which returns `max(0, minResources - already_allocated)`. Applied the same logic to the `PodGroupInqueue` branch.

#### Which issue(s) this PR fixes:

Fixes #5099 

#### Special notes for your reviewer:

Added a regression test that runs two scheduler cycles against a shared cache, cycle 1 allocates job-a (3×1CPU) leaving its tasks in `Binding`, cycle 2 tries to enqueue job-b (1×1CPU) on a 4 CPU queue. Without the fix the test times out waiting for job-b to be bound. With the fix it passes.

#### Does this PR introduce a user-facing change?

```release-note
Fix proportion plugin double-counting inqueue resources for jobs with tasks in Binding state, which could cause queues to appear over-capacity and block schedulable jobs.
```