### PR TITLE
Proposal: feat(capacity) parent-based reclaim

### DIFF
--- a/docs/design/hierarchical-queue-on-capacity-plugin.md
+++ b/docs/design/hierarchical-queue-on-capacity-plugin.md
@@ -36,6 +36,16 @@ For example, consider the following hierarchical queue structure and jobs:
 
 When job A performs reclaim or preempt actions, the system should first consider job B (belonging to the same parent queue a), and then consider job C (belonging to the same parent queue root).
 
+### Story 5
+
+When `parentBasedReclaimEnabled` is enabled for the capacity plugin and hierarchy is enabled, cross-parent reclaim should respect parent-level deserved resources.
+
+If a child queue is over its own deserved but its parent queue is still below parent deserved, the child's extra usage is treated as intra-parent borrowing and should not be reclaimed by other parent trees.
+
+Reclaim from that child becomes eligible only when both the child queue and the relevant parent queue are over deserved on reclaim-relevant dimensions.
+
+For sibling reclaim under the same direct parent, existing child-level reclaim checks remain in effect.
+
 ## Design detail
 
 ### Webhook
@@ -102,6 +112,28 @@ When job A performs reclaim or preempt actions, the system should first consider
   - For example, in the case of `AddJobEnqueueableFn`, it should directly return `util.Reject`, preventing the job from being enqueued. No scheduling should be performed in situations that do not align with the previously described conditions. Users need to adjust the queues based on the printed error information until normal scheduling can be resumed.
 - `AddQueueOrderFn`: Prioritize leaf queues (queues without child queues) when considering queue ordering. For two leaf queues, the ordering will be determined by considering their parent queues layer by layer, starting from the root queue.
 - `AddAllocatableFn`: Ensure that only leaf queues can schedule jobs/podgroups.
+- `AddReclaimableFn` (capacity):
+  - Keep existing queue-level reclaim eligibility checks.
+  - Keep sibling reclaim behavior under the same direct parent based on child-level reclaim eligibility.
+  - When `parentBasedReclaimEnabled=true` and hierarchy is enabled, add parent-level deserved checks during victim selection for cross-parent reclaim.
+  - For cross-parent reclaim, a reclaimee from a child queue is selected only if both child-level and parent-level reclaim constraints are satisfied.
+  - This prevents reclaiming borrowed capacity that is still within the parent queue's deserved quota.
+
+#### Configuration example
+
+Enable hierarchy and parent-based reclaim in scheduler configuration:
+
+```yaml
+actions: "enqueue, allocate, backfill"
+tiers:
+  - plugins:
+      - name: capacity
+        enableHierarchy: true
+        arguments:
+          parentBasedReclaimEnabled: true
+      - name: gang
+      - name: priority
+```
 - `BuildVictimsPriorityQueue`: The current implementation of this function relies on `TaskOrderFn` and `JobOrderFn` for sorting victims. Two new functions, `VictimTaskOrderFn` and `VictimJobOrderFn`, will be introduced specifically for sorting victims in the context of hierarchical queues. 
   
   ```go

--- a/pkg/scheduler/framework/session_plugins.go
+++ b/pkg/scheduler/framework/session_plugins.go
@@ -656,6 +656,9 @@ func (ssn *Session) SubJobOrderFn(l, r interface{}) bool {
 	return lv.UID < rv.UID
 }
 
+// JobOrderCompareFn compares l and r by running enabled JobOrder plugins in
+// order and returning the first non-zero comparison result. It returns 0 if
+// all plugins consider l and r equal.
 func (ssn *Session) JobOrderCompareFn(l, r interface{}) int {
 	for _, tier := range ssn.Tiers {
 		for _, plugin := range tier.Plugins {
@@ -1095,8 +1098,13 @@ func (ssn *Session) HyperNodeGradientForSubJobFn(subJob *api.SubJobInfo, hyperNo
 }
 
 // BuildVictimsPriorityQueue returns a priority queue with victims sorted by:
-// if victims has same job id, sorted by !ssn.TaskOrderFn
-// if victims has different job id, sorted by !ssn.JobOrderFn
+//  1. If victims belong to the same job, use !ssn.TaskOrderFn.
+//  2. If either victim's job is missing, evict orphaned tasks first; if both
+//     are orphaned, use !ssn.TaskOrderFn.
+//  3. If the preemptor job is missing or victims are in the same queue, compare
+//     jobs with JobOrderCompareFn and use !ssn.TaskOrderFn as a tie-break.
+//  4. If victims are in different queues and preemptor job exists, use
+//     ssn.VictimQueueOrderFn.
 func (ssn *Session) BuildVictimsPriorityQueue(victims []*api.TaskInfo, preemptor *api.TaskInfo) *util.PriorityQueue {
 	jobThenTaskOrder := func(lvJob, rvJob *api.JobInfo, l, r interface{}) bool {
 		if cmp := ssn.JobOrderCompareFn(lvJob, rvJob); cmp != 0 {

--- a/pkg/scheduler/framework/session_plugins.go
+++ b/pkg/scheduler/framework/session_plugins.go
@@ -656,8 +656,7 @@ func (ssn *Session) SubJobOrderFn(l, r interface{}) bool {
 	return lv.UID < rv.UID
 }
 
-// JobOrderFn invoke joborder function of the plugins
-func (ssn *Session) JobOrderFn(l, r interface{}) bool {
+func (ssn *Session) JobOrderCompareFn(l, r interface{}) int {
 	for _, tier := range ssn.Tiers {
 		for _, plugin := range tier.Plugins {
 			if !isEnabled(plugin.EnabledJobOrder) {
@@ -668,9 +667,18 @@ func (ssn *Session) JobOrderFn(l, r interface{}) bool {
 				continue
 			}
 			if j := jof(l, r); j != 0 {
-				return j < 0
+				return j
 			}
 		}
+	}
+
+	return 0
+}
+
+// JobOrderFn invoke joborder function of the plugins
+func (ssn *Session) JobOrderFn(l, r interface{}) bool {
+	if res := ssn.JobOrderCompareFn(l, r); res != 0 {
+		return res < 0
 	}
 
 	// If no job order funcs, order job by CreationTimestamp first, then by UID.
@@ -1090,6 +1098,13 @@ func (ssn *Session) HyperNodeGradientForSubJobFn(subJob *api.SubJobInfo, hyperNo
 // if victims has same job id, sorted by !ssn.TaskOrderFn
 // if victims has different job id, sorted by !ssn.JobOrderFn
 func (ssn *Session) BuildVictimsPriorityQueue(victims []*api.TaskInfo, preemptor *api.TaskInfo) *util.PriorityQueue {
+	jobThenTaskOrder := func(lvJob, rvJob *api.JobInfo, l, r interface{}) bool {
+		if cmp := ssn.JobOrderCompareFn(lvJob, rvJob); cmp != 0 {
+			return cmp > 0
+		}
+		return !ssn.TaskOrderFn(l, r)
+	}
+
 	victimsQueue := util.NewPriorityQueue(func(l, r interface{}) bool {
 		lv := l.(*api.TaskInfo)
 		rv := r.(*api.TaskInfo)
@@ -1121,14 +1136,14 @@ func (ssn *Session) BuildVictimsPriorityQueue(victims []*api.TaskInfo, preemptor
 		}
 
 		if !preemptorJobFound {
-			return !ssn.JobOrderFn(lvJob, rvJob)
+			return jobThenTaskOrder(lvJob, rvJob, l, r)
 		}
 
 		if lvJob.Queue != rvJob.Queue {
 			return ssn.VictimQueueOrderFn(ssn.Queues[lvJob.Queue], ssn.Queues[rvJob.Queue], ssn.Queues[preemptorJob.Queue])
 		}
 
-		return !ssn.JobOrderFn(lvJob, rvJob)
+		return jobThenTaskOrder(lvJob, rvJob, l, r)
 	})
 	for _, victim := range victims {
 		victimsQueue.Push(victim)

--- a/pkg/scheduler/framework/session_plugins_victim_order_test.go
+++ b/pkg/scheduler/framework/session_plugins_victim_order_test.go
@@ -1,0 +1,117 @@
+/*
+Copyright 2026 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package framework_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+
+	schedulingv1 "volcano.sh/apis/pkg/apis/scheduling/v1beta1"
+	"volcano.sh/volcano/pkg/scheduler/api"
+	"volcano.sh/volcano/pkg/scheduler/conf"
+	"volcano.sh/volcano/pkg/scheduler/framework"
+	"volcano.sh/volcano/pkg/scheduler/plugins/priority"
+	"volcano.sh/volcano/pkg/scheduler/uthelper"
+	"volcano.sh/volcano/pkg/scheduler/util"
+)
+
+func TestBuildVictimsPriorityQueueJobTieBreaksWithTaskOrder(t *testing.T) {
+	trueValue := true
+	plugins := map[string]framework.PluginBuilder{priority.PluginName: priority.New}
+	highPri, lowPri := int32(100), int32(1)
+	queueQ1 := util.BuildQueue("q1", 1, nil)
+	nodeN1 := util.BuildNode("n1", api.BuildResourceList("10", "10Gi", []api.ScalarResource{{Name: "pods", Value: "20"}}...), nil)
+	pgHigh := util.BuildPodGroup("pg-high", "ns1", "q1", 1, nil, schedulingv1.PodGroupRunning)
+	pgLow := util.BuildPodGroup("pg-low", "ns1", "q1", 1, nil, schedulingv1.PodGroupRunning)
+	pgPreemptor := util.BuildPodGroup("pg-preemptor", "ns1", "q1", 1, nil, schedulingv1.PodGroupPending)
+	pHigh := util.BuildPodWithPriority("ns1", "p-high", "n1", v1.PodRunning, api.BuildResourceList("1", "1Gi"), "pg-high", nil, nil, &highPri)
+	pLow := util.BuildPodWithPriority("ns1", "p-low", "n1", v1.PodRunning, api.BuildResourceList("1", "1Gi"), "pg-low", nil, nil, &lowPri)
+	pPreemptor := util.BuildPodWithPriority("ns1", "p-preemptor", "", v1.PodPending, api.BuildResourceList("1", "1Gi"), "pg-preemptor", nil, nil, &highPri)
+
+	tiers := []conf.Tier{{
+		Plugins: []conf.PluginOption{{
+			Name:             priority.PluginName,
+			EnabledJobOrder:  &trueValue,
+			EnabledTaskOrder: &trueValue,
+		}},
+	}}
+
+	findTask := func(ssn *framework.Session, podName string) *api.TaskInfo {
+		for _, job := range ssn.Jobs {
+			for _, task := range job.Tasks {
+				if task.Name == podName {
+					return task
+				}
+			}
+		}
+		return nil
+	}
+
+	baseTestStruct := func() uthelper.TestCommonStruct {
+		return uthelper.TestCommonStruct{
+			Plugins: plugins,
+			Queues:  []*schedulingv1.Queue{queueQ1.DeepCopy()},
+			Nodes:   []*v1.Node{nodeN1.DeepCopy()},
+			PodGroups: []*schedulingv1.PodGroup{
+				pgHigh.DeepCopy(),
+				pgLow.DeepCopy(),
+			},
+			Pods: []*v1.Pod{
+				pHigh.DeepCopy(),
+				pLow.DeepCopy(),
+			},
+		}
+	}
+
+	t.Run("preemptor job found", func(t *testing.T) {
+		tc := baseTestStruct()
+		tc.PodGroups = append(tc.PodGroups, pgPreemptor.DeepCopy())
+		tc.Pods = append(tc.Pods, pPreemptor.DeepCopy())
+		ssn := tc.RegisterSession(tiers, nil)
+		defer tc.Close()
+
+		high := findTask(ssn, "p-high")
+		low := findTask(ssn, "p-low")
+		preemptor := findTask(ssn, "p-preemptor")
+		assert.NotNil(t, high)
+		assert.NotNil(t, low)
+		assert.NotNil(t, preemptor)
+
+		victims := []*api.TaskInfo{high, low}
+		pq := ssn.BuildVictimsPriorityQueue(victims, preemptor)
+		first := pq.Pop().(*api.TaskInfo)
+		assert.Equal(t, "p-low", first.Name)
+	})
+
+	t.Run("preemptor job missing", func(t *testing.T) {
+		tc := baseTestStruct()
+		ssn := tc.RegisterSession(tiers, nil)
+		defer tc.Close()
+
+		high := findTask(ssn, "p-high")
+		low := findTask(ssn, "p-low")
+		assert.NotNil(t, high)
+		assert.NotNil(t, low)
+
+		victims := []*api.TaskInfo{high, low}
+		pq := ssn.BuildVictimsPriorityQueue(victims, &api.TaskInfo{Job: api.JobID("missing")})
+		first := pq.Pop().(*api.TaskInfo)
+		assert.Equal(t, "p-low", first.Name)
+	})
+}

--- a/pkg/scheduler/framework/session_plugins_victim_order_test.go
+++ b/pkg/scheduler/framework/session_plugins_victim_order_test.go
@@ -18,9 +18,11 @@ package framework_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	schedulingv1 "volcano.sh/apis/pkg/apis/scheduling/v1beta1"
 	"volcano.sh/volcano/pkg/scheduler/api"
@@ -39,6 +41,8 @@ func TestBuildVictimsPriorityQueueJobTieBreaksWithTaskOrder(t *testing.T) {
 	nodeN1 := util.BuildNode("n1", api.BuildResourceList("10", "10Gi", []api.ScalarResource{{Name: "pods", Value: "20"}}...), nil)
 	pgHigh := util.BuildPodGroup("pg-high", "ns1", "q1", 1, nil, schedulingv1.PodGroupRunning)
 	pgLow := util.BuildPodGroup("pg-low", "ns1", "q1", 1, nil, schedulingv1.PodGroupRunning)
+	pgHigh.CreationTimestamp = metav1.NewTime(time.Unix(20, 0))
+	pgLow.CreationTimestamp = metav1.NewTime(time.Unix(10, 0))
 	pgPreemptor := util.BuildPodGroup("pg-preemptor", "ns1", "q1", 1, nil, schedulingv1.PodGroupPending)
 	pHigh := util.BuildPodWithPriority("ns1", "p-high", "n1", v1.PodRunning, api.BuildResourceList("1", "1Gi"), "pg-high", nil, nil, &highPri)
 	pLow := util.BuildPodWithPriority("ns1", "p-low", "n1", v1.PodRunning, api.BuildResourceList("1", "1Gi"), "pg-low", nil, nil, &lowPri)
@@ -92,6 +96,9 @@ func TestBuildVictimsPriorityQueueJobTieBreaksWithTaskOrder(t *testing.T) {
 		assert.NotNil(t, high)
 		assert.NotNil(t, low)
 		assert.NotNil(t, preemptor)
+		highJob := ssn.Jobs[high.Job]
+		lowJob := ssn.Jobs[low.Job]
+		assert.Equal(t, 0, ssn.JobOrderCompareFn(highJob, lowJob))
 
 		victims := []*api.TaskInfo{high, low}
 		pq := ssn.BuildVictimsPriorityQueue(victims, preemptor)
@@ -108,6 +115,9 @@ func TestBuildVictimsPriorityQueueJobTieBreaksWithTaskOrder(t *testing.T) {
 		low := findTask(ssn, "p-low")
 		assert.NotNil(t, high)
 		assert.NotNil(t, low)
+		highJob := ssn.Jobs[high.Job]
+		lowJob := ssn.Jobs[low.Job]
+		assert.Equal(t, 0, ssn.JobOrderCompareFn(highJob, lowJob))
 
 		victims := []*api.TaskInfo{high, low}
 		pq := ssn.BuildVictimsPriorityQueue(victims, &api.TaskInfo{Job: api.JobID("missing")})

--- a/pkg/scheduler/plugins/capacity/capacity.go
+++ b/pkg/scheduler/plugins/capacity/capacity.go
@@ -47,6 +47,9 @@ const (
 	capacityStateKey = PluginName
 	rootQueueID      = "root"
 
+	// Holds the argument key of parentBasedReclaimEnabled
+	parentBasedReclaimEnabled = "parentBasedReclaimEnabled"
+
 	// DynamicResourceAllocationEnable is the key for enabling DRA quota enforcement in the capacity plugin
 	DynamicResourceAllocationEnable = "capacity.DynamicResourceAllocationEnable"
 
@@ -64,7 +67,8 @@ type capacityPlugin struct {
 
 	queueOpts map[api.QueueID]*queueAttr
 	// Arguments given for the plugin
-	pluginArguments framework.Arguments
+	pluginArguments           framework.Arguments
+	parentBasedReclaimEnabled bool
 	// queueGateReservedTasks tracks tasks that passed capacity checks but cannot be scheduled
 	// These tasks reserve queue capacity to prevent other tasks from consuming it
 	// Rebuilt fresh at the start of each scheduling cycle in OnSessionOpen
@@ -77,11 +81,13 @@ type capacityPlugin struct {
 }
 
 type queueAttr struct {
-	queueID   api.QueueID
-	name      string
-	share     float64
-	ancestors []api.QueueID
-	children  map[api.QueueID]*queueAttr
+	queueID api.QueueID
+	name    string
+	share   float64
+
+	ancestors     []api.QueueID
+	parentQueueID api.QueueID
+	children      map[api.QueueID]*queueAttr
 
 	deserved  *api.Resource
 	allocated *api.Resource
@@ -416,15 +422,18 @@ func New(arguments framework.Arguments) framework.Plugin {
 	arguments.GetBool(&dynamicResourceAllocationEnable, DynamicResourceAllocationEnable)
 	arguments.GetBool(&draConsumableCapacityEnable, DRAConsumableCapacityEnable)
 
-	return &capacityPlugin{
+	capacityPlugin := &capacityPlugin{
 		totalResource:                   api.EmptyResource(),
 		totalGuarantee:                  api.EmptyResource(),
 		queueOpts:                       map[api.QueueID]*queueAttr{},
 		pluginArguments:                 arguments,
+		parentBasedReclaimEnabled:       false,
 		queueGateReservedTasks:          make(map[api.QueueID]map[api.TaskID]*api.TaskInfo),
 		dynamicResourceAllocationEnable: dynamicResourceAllocationEnable,
 		draConsumableCapacityEnable:     draConsumableCapacityEnable,
 	}
+	arguments.GetBool(&capacityPlugin.parentBasedReclaimEnabled, parentBasedReclaimEnabled)
+	return capacityPlugin
 }
 
 func (cp *capacityPlugin) Name() string {
@@ -444,9 +453,12 @@ func (cp *capacityPlugin) OnSessionOpen(ssn *framework.Session) {
 
 	hierarchyEnabled := ssn.HierarchyEnabled(cp.Name())
 	readyToSchedule := true
+	parentBasedReclaimEnabled := false
 	if hierarchyEnabled {
 		readyToSchedule = cp.buildHierarchicalQueueAttrs(ssn)
-		klog.V(4).Infof("Hierarchy is enabled in capacity plugin")
+		// parentBasedReclaimEnabled is true, only when the argument is set to true and hierarchy is enabled.
+		parentBasedReclaimEnabled = cp.parentBasedReclaimEnabled
+		klog.V(4).Infof("Hierarchy is enabled in capacity plugin, with parentBasedReclaim: %v", parentBasedReclaimEnabled)
 	} else {
 		cp.buildQueueAttrs(ssn)
 	}
@@ -458,8 +470,20 @@ func (cp *capacityPlugin) OnSessionOpen(ssn *framework.Session) {
 			klog.V(3).Infof("Capacity plugin failed to check queue's hierarchical structure!")
 			return victims, util.Reject
 		}
+		reclaimerJob := ssn.Jobs[reclaimer.Job]
+		if reclaimerJob == nil {
+			klog.Warningf("[capacity] Skip reclaim: reclaimer <%s/%s> job <%s> not found in session", reclaimer.Namespace, reclaimer.Name, reclaimer.Job)
+			return victims, util.Reject
+		}
+		reclaimerAttr := cp.queueOpts[reclaimerJob.Queue]
+		if reclaimerAttr == nil {
+			klog.Warningf("[capacity] Skip reclaim: reclaimer queue <%s> not found in queueOpts", reclaimerJob.Queue)
+			return victims, util.Reject
+		}
 
-		for _, reclaimee := range reclaimees {
+		reclaimeesQueue := ssn.BuildVictimsPriorityQueue(reclaimees, reclaimer)
+		for !reclaimeesQueue.Empty() {
+			reclaimee := reclaimeesQueue.Pop().(*api.TaskInfo)
 			job := ssn.Jobs[reclaimee.Job]
 			if job == nil {
 				klog.Warningf("[capacity] Skip reclaimee <%s/%s>: job <%s> not found in session (orphaned task from deleted PodGroup)",
@@ -482,6 +506,19 @@ func (cp *capacityPlugin) OnSessionOpen(ssn *framework.Session) {
 				klog.V(5).Infof("%s, skip it.", reason)
 				continue
 			}
+			parentCheckNeeded := parentBasedReclaimEnabled &&
+				attr.parentQueueID != "" &&
+				attr.parentQueueID != rootQueueID &&
+				attr.parentQueueID != reclaimerAttr.parentQueueID
+			var parentAttr *queueAttr
+			if parentCheckNeeded {
+				parentAttr = cp.queueOpts[attr.parentQueueID]
+				if parentAttr == nil {
+					klog.Warningf("[capacity] Skip reclaimee <%s/%s>: parent queue <%s> not found in queueOpts",
+						reclaimee.Namespace, reclaimee.Name, attr.parentQueueID)
+					continue
+				}
+			}
 
 			// allocations maps each queue to its current allocated resources (cloned) and 'allocated' points to this resource object.
 			// As victims (reclaimees) are selected, their resource requests are subtracted from the corresponding queue's allocation via this pointer.
@@ -490,34 +527,63 @@ func (cp *capacityPlugin) OnSessionOpen(ssn *framework.Session) {
 				allocations[job.Queue] = attr.allocated.Clone()
 			}
 			allocated := allocations[job.Queue]
+			var parentAllocated *api.Resource
+			if parentCheckNeeded {
+				if _, found := allocations[attr.parentQueueID]; !found {
+					allocations[attr.parentQueueID] = parentAttr.allocated.Clone()
+				}
+				parentAllocated = allocations[attr.parentQueueID]
+			}
 
 			// Check guarantee
 			if satisfies, _ := cp.checkGuaranteeConstraint(allocated, reclaimee, attr.guarantee); !satisfies {
 				continue
 			}
 
-			// If the reclaimee has no intersecting resource dimensions with deserved, it is a victim.
+			childEligible := false
 			if isVictim, reason := cp.isImmediateVictim(reclaimee, attr.deserved); isVictim {
-				allocated.Sub(reclaimee.Resreq)
-				victims = append(victims, reclaimee)
-				klog.V(5).Infof("%s. It's a victim. Current victims: %+v.", reason, victims)
-				continue
-			}
-
-			// Check deserved
-			if exceeds, dims, reason := cp.checkDeservedExceedance(
-				allocated, attr.deserved, reclaimee, reclaimer, attr.name); !exceeds {
-				klog.V(5).Infof("%s", reason)
-				continue
-			} else {
+				childEligible = true
+				klog.V(5).Infof("%s. It's a victim for queue <%s>.", reason, attr.name)
+			} else if exceeds, dims, reason := cp.checkDeservedExceedance(
+				allocated, attr.deserved, reclaimee, reclaimer, attr.name); exceeds {
+				childEligible = true
 				klog.V(5).Infof("[capacity] Reclaimee <%s/%s> is a victim from queue <%s> for reclaimer <%s/%s>. "+
 					"Allocated: <%v>, Deserved: <%v>, Reclaimee Resreq: <%v>, Reclaimable on dimensions: %v.",
 					reclaimee.Namespace, reclaimee.Name, attr.queueID, reclaimer.Namespace, reclaimer.Name,
 					allocated, attr.deserved, reclaimee.Resreq, dims)
-				allocated.Sub(reclaimee.Resreq)
-				victims = append(victims, reclaimee)
-				klog.V(5).Infof("[capacity] Current victims: %+v.", victims)
+			} else {
+				klog.V(5).Infof("%s.", reason)
 			}
+
+			if !childEligible {
+				continue
+			}
+
+			if parentCheckNeeded {
+				parentEligible := false
+				if isVictim, reasonParent := cp.isImmediateVictim(reclaimee, parentAttr.deserved); isVictim {
+					parentEligible = true
+					klog.V(5).Infof("%s. It's a victim for parent queue <%s>.", reasonParent, parentAttr.name)
+				} else if exceeds, parentDims, parentReason := cp.checkDeservedExceedance(
+					parentAllocated, parentAttr.deserved, reclaimee, reclaimer, parentAttr.name); exceeds {
+					parentEligible = true
+					klog.V(5).Infof("[capacity] Reclaimee <%s/%s> is a victim from parent queue <%s> for reclaimer <%s/%s>. "+
+						"Allocated: <%v>, Deserved: <%v>, Reclaimee Resreq: <%v>, Reclaimable on dimensions: %v.",
+						reclaimee.Namespace, reclaimee.Name, parentAttr.name, reclaimer.Namespace, reclaimer.Name,
+						parentAllocated, parentAttr.deserved, reclaimee.Resreq, parentDims)
+				} else {
+					klog.V(5).Infof("%s.", parentReason)
+				}
+
+				if !parentEligible {
+					continue
+				}
+				parentAllocated.Sub(reclaimee.Resreq)
+			}
+
+			allocated.Sub(reclaimee.Resreq)
+			victims = append(victims, reclaimee)
+			klog.V(5).Infof("[capacity] Current victims: %+v.", victims)
 		}
 		klog.V(4).Infof("[capacity] Victims from capacity plugin: victims=%+v reclaimer=%s.", victims, reclaimer)
 		return victims, util.Permit
@@ -553,8 +619,23 @@ func (cp *capacityPlugin) OnSessionOpen(ssn *framework.Session) {
 				"The futureUsed: %v, deserved: %v, allocated: %v, task requested: %v",
 				queue.Name, resourceNames, futureUsed, attr.deserved, attr.allocated, task.Resreq)
 		} else {
-			klog.V(3).Infof("Queue <%v> can not reclaim, futureUsed: %v, deserved: %v, requested: %v",
+			klog.V(4).Infof("Queue <%v> itself can not reclaim, futureUsed: %v, deserved: %v, requested: %v",
 				queue.Name, futureUsed, attr.deserved, task.Resreq)
+			// If parentBasedReclaimEnabled is true, check whether the direct parent can reclaim.
+			if parentBasedReclaimEnabled && attr.parentQueueID != "" && attr.parentQueueID != rootQueueID {
+				parentAttr := cp.queueOpts[attr.parentQueueID]
+				futureUsedParent := parentAttr.allocated.Clone().Add(task.Resreq)
+				isPreemptive, resourceNames = futureUsedParent.LessEqualPartlyWithDimensionZeroFiltered(parentAttr.deserved, task.Resreq)
+				if isPreemptive {
+					klog.V(3).Infof("Queue's parent <%v> can reclaim on resource dimensions: %v. "+
+						"The futureUsedParent: %v, deserved: %v, allocated: %v, task requested: %v",
+						parentAttr.name, resourceNames, futureUsedParent, parentAttr.deserved, parentAttr.allocated, task.Resreq)
+				} else {
+					klog.V(4).Infof("Queue <%v> and its parent <%v> can not reclaim. "+
+						"The futureUsedParent: %v, parentDeserved: %v, requested: %v",
+						queue.Name, parentAttr.name, futureUsedParent, parentAttr.deserved, task.Resreq)
+				}
+			}
 		}
 
 		// PreemptiveFn is the opposite of OverusedFn in proportion plugin cause as long as there is a one-dimensional
@@ -1213,10 +1294,11 @@ func (cp *capacityPlugin) buildHierarchicalQueueAttrs(ssn *framework.Session) bo
 
 func (cp *capacityPlugin) newQueueAttr(queue *api.QueueInfo) *queueAttr {
 	attr := &queueAttr{
-		queueID:   queue.UID,
-		name:      queue.Name,
-		ancestors: make([]api.QueueID, 0),
-		children:  make(map[api.QueueID]*queueAttr),
+		queueID:       queue.UID,
+		name:          queue.Name,
+		parentQueueID: api.QueueID(queue.Queue.Spec.Parent),
+		ancestors:     make([]api.QueueID, 0),
+		children:      make(map[api.QueueID]*queueAttr),
 
 		deserved:          api.NewResource(queue.Queue.Spec.Deserved),
 		allocated:         api.EmptyResource(),
@@ -1701,9 +1783,9 @@ func (cp *capacityPlugin) checkDeservedExceedance(
 	if !reclaimable {
 		reason := fmt.Sprintf(
 			"[capacity] Queue <%v> allocated resources are not greater than deserved on any relevant dimension of reclaimee. "+
-				"Hence reclaimee <%s/%s> cannot be reclaimed for reclaimer <%s/%s>. "+
+				"Hence reclaimee <%s/%s> cannot be reclaimed for reclaimer <%s/%s> for queue <%s>. "+
 				"Deserved: <%v>, Allocated: <%v>, Reclaimee Resreq: <%v>",
-			queueName, reclaimee.Namespace, reclaimee.Name, reclaimer.Namespace, reclaimer.Name, deserved, allocated, reclaimee.Resreq,
+			queueName, reclaimee.Namespace, reclaimee.Name, reclaimer.Namespace, reclaimer.Name, queueName, deserved, allocated, reclaimee.Resreq,
 		)
 		return false, nil, reason
 	}

--- a/pkg/scheduler/plugins/capacity/capacity_test.go
+++ b/pkg/scheduler/plugins/capacity/capacity_test.go
@@ -31,6 +31,8 @@ import (
 	batchv1alpha1 "volcano.sh/apis/pkg/apis/batch/v1alpha1"
 	schedulingv1beta1 "volcano.sh/apis/pkg/apis/scheduling/v1beta1"
 
+	"maps"
+
 	"volcano.sh/apis/pkg/apis/scheduling"
 	"volcano.sh/volcano/cmd/scheduler/app/options"
 	"volcano.sh/volcano/pkg/scheduler/actions/allocate"
@@ -42,12 +44,14 @@ import (
 	"volcano.sh/volcano/pkg/scheduler/framework"
 	"volcano.sh/volcano/pkg/scheduler/plugins/gang"
 	"volcano.sh/volcano/pkg/scheduler/plugins/predicates"
+	"volcano.sh/volcano/pkg/scheduler/plugins/priority"
 	"volcano.sh/volcano/pkg/scheduler/uthelper"
 	"volcano.sh/volcano/pkg/scheduler/util"
 )
 
 func TestMain(m *testing.M) {
 	options.Default()
+
 	os.Exit(m.Run())
 }
 
@@ -504,7 +508,7 @@ func TestEnqueueAndAllocatable(t *testing.T) {
 }
 
 func Test_capacityPlugin_OnSessionOpenWithHierarchy(t *testing.T) {
-	plugins := map[string]framework.PluginBuilder{PluginName: New, predicates.PluginName: predicates.New, gang.PluginName: gang.New}
+	plugins := map[string]framework.PluginBuilder{PluginName: New, predicates.PluginName: predicates.New, gang.PluginName: gang.New, priority.PluginName: priority.New}
 	trueValue := true
 	actions := []framework.Action{enqueue.New(), reclaim.New(), allocate.New()}
 
@@ -654,6 +658,84 @@ func Test_capacityPlugin_OnSessionOpenWithHierarchy(t *testing.T) {
 	p17 := util.BuildPod("ns1", "p17", "n3", corev1.PodRunning, api.BuildResourceList("1", "1Gi", []api.ScalarResource{{Name: "nvidia.com/a100", Value: "2"}, {Name: "rdma/hca", Value: "1"}}...), "pg17", make(map[string]string), map[string]string{})
 	p18 := util.BuildPod("ns1", "p18", "n3", corev1.PodRunning, api.BuildResourceList("1", "1Gi", []api.ScalarResource{{Name: "nvidia.com/a100", Value: "2"}, {Name: "rdma/hca", Value: "1"}}...), "pg18", map[string]string{schedulingv1beta1.PodPreemptable: "false"}, map[string]string{})
 
+	// resources for test case 13-16
+	arguments := framework.Arguments{
+		"parentBasedReclaimEnabled": true,
+	}
+	pluginsWithParentBasedReclaim := map[string]framework.PluginBuilder{
+		PluginName: func(args framework.Arguments) framework.Plugin {
+			if args == nil {
+				args = framework.Arguments{}
+			}
+			maps.Copy(args, arguments)
+			return New(args)
+		},
+		predicates.PluginName: predicates.New,
+		gang.PluginName:       gang.New,
+		priority.PluginName:   priority.New,
+	}
+	// node
+	n4 := util.BuildNode("n4", api.BuildResourceList("16", "16Gi", []api.ScalarResource{{Name: "nvidia.com/a100", Value: "4"}, {Name: "rdma/hca", Value: "1001"}, {Name: "pods", Value: "11"}}...), map[string]string{})
+
+	// queue
+	case13_queue1 := buildQueueWithParents("case13_queue1", "root", api.BuildResourceList("", "", []api.ScalarResource{{Name: "nvidia.com/a100", Value: "1"}}...), nil)
+	case13_queue11 := buildQueueWithParents("case13_queue11", "case13_queue1", nil, nil)
+	case13_queue2 := buildQueueWithParents("case13_queue2", "root", nil, nil)
+
+	// podgroup
+	pg19 := util.BuildPodGroup("pg19", "ns1", "case13_queue2", 1, nil, schedulingv1beta1.PodGroupRunning)
+	pg20 := util.BuildPodGroup("pg20", "ns1", "case13_queue11", 1, nil, schedulingv1beta1.PodGroupInqueue)
+
+	// pod
+	p19 := util.BuildPod("ns1", "p19", "n4", corev1.PodRunning, api.BuildResourceList("1", "1Gi", []api.ScalarResource{{Name: "nvidia.com/a100", Value: "4"}, {Name: "rdma/hca", Value: "1"}}...), "pg19", make(map[string]string), map[string]string{})
+	p20 := util.BuildPod("ns1", "p20", "", corev1.PodPending, api.BuildResourceList("1", "1Gi", []api.ScalarResource{{Name: "nvidia.com/a100", Value: "1"}, {Name: "rdma/hca", Value: "1"}}...), "pg20", make(map[string]string), map[string]string{})
+
+	// resources for test case 14 preemptable queue reclaim between projects
+	project1_root_queue := buildQueueWithParents("project1_root", "root", api.BuildResourceList("", "", []api.ScalarResource{{Name: "nvidia.com/a100", Value: "1"}}...), api.BuildResourceList("", "", []api.ScalarResource{{Name: "nvidia.com/a100", Value: "2"}}...))
+	project1_non_preemptable_queue := buildQueueWithParents("project1_non-preemptable", "project1_root", api.BuildResourceList("", "", []api.ScalarResource{{Name: "nvidia.com/a100", Value: "1"}}...), api.BuildResourceList("", "", []api.ScalarResource{{Name: "nvidia.com/a100", Value: "1"}}...))
+	project1_preemptable := buildQueueWithParents("project1_preemptable", "project1_root", nil, nil)
+	project2_root_queue := buildQueueWithParents("project2_root", "root", api.BuildResourceList("", "", []api.ScalarResource{{Name: "nvidia.com/a100", Value: "3"}}...), api.BuildResourceList("", "", []api.ScalarResource{{Name: "nvidia.com/a100", Value: "4"}}...))
+	project2_non_preemptable_queue := buildQueueWithParents("project2_non-preemptable", "project2_root", api.BuildResourceList("", "", []api.ScalarResource{{Name: "nvidia.com/a100", Value: "3"}}...), api.BuildResourceList("", "", []api.ScalarResource{{Name: "nvidia.com/a100", Value: "3"}}...))
+	project2_preemptable_queue := buildQueueWithParents("project2_preemptable", "project2_root", nil, nil)
+
+	// podgroup
+	pg21 := util.BuildPodGroup("pg21", "ns1", "project2_preemptable", 1, nil, schedulingv1beta1.PodGroupRunning)
+	pg22 := util.BuildPodGroup("pg22", "ns1", "project2_preemptable", 1, nil, schedulingv1beta1.PodGroupRunning)
+	pg23 := util.BuildPodGroup("pg23", "ns1", "project2_preemptable", 1, nil, schedulingv1beta1.PodGroupRunning)
+	pg24 := util.BuildPodGroup("pg24", "ns1", "project2_preemptable", 1, nil, schedulingv1beta1.PodGroupRunning)
+	pg25 := util.BuildPodGroup("pg25", "ns1", "project1_preemptable", 1, nil, schedulingv1beta1.PodGroupPending)
+
+	// pod
+	priority1, priority2 := int32(1), int32(2)
+	p21 := util.BuildPodWithPriority("ns1", "p21", "n4", corev1.PodRunning, api.BuildResourceList("1", "1Gi", []api.ScalarResource{{Name: "nvidia.com/a100", Value: "1"}, {Name: "rdma/hca", Value: "1"}}...), "pg21", make(map[string]string), map[string]string{}, &priority2)
+	p22 := util.BuildPodWithPriority("ns1", "p22", "n4", corev1.PodRunning, api.BuildResourceList("1", "1Gi", []api.ScalarResource{{Name: "nvidia.com/a100", Value: "1"}, {Name: "rdma/hca", Value: "1"}}...), "pg22", make(map[string]string), map[string]string{}, &priority2)
+	p23 := util.BuildPodWithPriority("ns1", "p23", "n4", corev1.PodRunning, api.BuildResourceList("1", "1Gi", []api.ScalarResource{{Name: "nvidia.com/a100", Value: "1"}, {Name: "rdma/hca", Value: "1"}}...), "pg23", make(map[string]string), map[string]string{}, &priority2)
+	p24 := util.BuildPodWithPriority("ns1", "p24", "n4", corev1.PodRunning, api.BuildResourceList("1", "1Gi", []api.ScalarResource{{Name: "nvidia.com/a100", Value: "1"}, {Name: "rdma/hca", Value: "1"}}...), "pg24", make(map[string]string), map[string]string{}, &priority1)
+	p25 := util.BuildPod("ns1", "p25", "", corev1.PodPending, api.BuildResourceList("1", "1Gi", []api.ScalarResource{{Name: "nvidia.com/a100", Value: "1"}, {Name: "rdma/hca", Value: "1"}}...), "pg25", make(map[string]string), map[string]string{})
+
+	// Test case expectation after parent-based reclaim
+	pg24_reclaimed := util.BuildPodGroup("pg24_reclaimed", "ns1", "project2_preemptable", 1, nil, schedulingv1beta1.PodGroupInqueue)
+	pg25_pipelined := util.BuildPodGroup("pg25_pipelined", "ns1", "project1_preemptable", 1, nil, schedulingv1beta1.PodGroupRunning)
+	p24_reclaimed := util.BuildPod("ns1", "p24", "", corev1.PodPending, api.BuildResourceList("1", "1Gi", []api.ScalarResource{{Name: "nvidia.com/a100", Value: "1"}, {Name: "rdma/hca", Value: "1"}}...), "pg24_reclaimed", make(map[string]string), map[string]string{})
+	p25_pipelined := util.BuildPod("ns1", "p25", "n4", corev1.PodRunning, api.BuildResourceList("1", "1Gi", []api.ScalarResource{{Name: "nvidia.com/a100", Value: "1"}, {Name: "rdma/hca", Value: "1"}}...), "pg25_pipelined", make(map[string]string), map[string]string{})
+	pg26 := util.BuildPodGroup("pg26", "ns1", "project2_non-preemptable", 1, nil, schedulingv1beta1.PodGroupPending)
+	p26 := util.BuildPod("ns1", "p26", "", corev1.PodPending, api.BuildResourceList("1", "1Gi", []api.ScalarResource{{Name: "nvidia.com/a100", Value: "1"}, {Name: "rdma/hca", Value: "1"}}...), "pg26", make(map[string]string), map[string]string{})
+
+	// resources for test case 16, test parent-based reclaim with
+	n5 := util.BuildNode("n5", api.BuildResourceList("8", "8Gi", []api.ScalarResource{{Name: "nvidia.com/a100", Value: "1"}, {Name: "rdma/hca", Value: "1001"}, {Name: "pods", Value: "11"}}...), map[string]string{})
+	case16_parent1 := buildQueueWithParents("case16_parent1", "root", api.BuildResourceList("", "", []api.ScalarResource{{Name: "nvidia.com/a100", Value: "1"}}...), nil)
+	case16_child1 := buildQueueWithParents("case16_child1", "case16_parent1", api.BuildResourceList("", "", []api.ScalarResource{{Name: "nvidia.com/a100", Value: "1"}}...), nil)
+	case16_child1_sibling := buildQueueWithParents("case16_child1_sibling", "case16_parent1", nil, nil)
+	case16_parent2 := buildQueueWithParents("case16_parent2", "root", api.BuildResourceList("", "", []api.ScalarResource{{Name: "nvidia.com/a100", Value: "1"}}...), nil)
+	case16_child2 := buildQueueWithParents("case16_child2", "case16_parent2", api.BuildResourceList("", "", []api.ScalarResource{{Name: "nvidia.com/a100", Value: "1"}}...), nil)
+	pg27 := util.BuildPodGroup("pg27", "ns1", "case16_child1", 1, nil, schedulingv1beta1.PodGroupRunning)
+	pg28 := util.BuildPodGroup("pg28", "ns1", "case16_child2", 1, nil, schedulingv1beta1.PodGroupPending)
+	pg29 := util.BuildPodGroup("pg29", "ns1", "case16_child1_sibling", 1, nil, schedulingv1beta1.PodGroupRunning)
+	p27 := util.BuildPod("ns1", "p27", "n5", corev1.PodRunning, api.BuildResourceList("1", "1Gi", []api.ScalarResource{{Name: "nvidia.com/a100", Value: "1"}, {Name: "rdma/hca", Value: "1"}}...), "pg27", make(map[string]string), map[string]string{})
+	p28 := util.BuildPod("ns1", "p28", "", corev1.PodPending, api.BuildResourceList("1", "1Gi", []api.ScalarResource{{Name: "nvidia.com/a100", Value: "1"}, {Name: "rdma/hca", Value: "1"}}...), "pg28", make(map[string]string), map[string]string{})
+	p29 := util.BuildPod("ns1", "p29", "n5", corev1.PodRunning, api.BuildResourceList("1", "1Gi", []api.ScalarResource{{Name: "nvidia.com/a100", Value: "1"}, {Name: "rdma/hca", Value: "1"}}...), "pg29", map[string]string{schedulingv1beta1.PodPreemptable: "false"}, map[string]string{})
+
+	// Test case
 	tests := []uthelper.TestCommonStruct{
 		{
 			Name:      "case0: Pod allocatable when queue is leaf queue",
@@ -798,6 +880,56 @@ func Test_capacityPlugin_OnSessionOpenWithHierarchy(t *testing.T) {
 			ExpectEvicted:  []string{"ns1/p17"},
 			ExpectEvictNum: 1,
 		},
+		{
+			Name:      "case13: Can reclaim based on parent deserved when parentBasedReclaimEnabled is true",
+			Plugins:   pluginsWithParentBasedReclaim,
+			Pods:      []*corev1.Pod{p19, p20},
+			Nodes:     []*corev1.Node{n4},
+			PodGroups: []*schedulingv1beta1.PodGroup{pg19, pg20},
+			Queues:    []*schedulingv1beta1.Queue{root2, case13_queue1, case13_queue11, case13_queue2},
+			ExpectPipeLined: map[string][]string{
+				"ns1/pg20": {"n4"},
+			},
+			ExpectEvicted:  []string{"ns1/p19"},
+			ExpectEvictNum: 1,
+		},
+		{
+			Name:      "case14: Cross-parent reclaim pipelines project1 pending job when project2 child and parent are both over deserved, evicting lowest-priority eligible victim",
+			Plugins:   pluginsWithParentBasedReclaim,
+			Pods:      []*corev1.Pod{p21, p22, p23, p24, p25},
+			Nodes:     []*corev1.Node{n4},
+			PodGroups: []*schedulingv1beta1.PodGroup{pg21, pg22, pg23, pg24, pg25},
+			Queues:    []*schedulingv1beta1.Queue{root2, project1_root_queue, project1_non_preemptable_queue, project1_preemptable, project2_root_queue, project2_non_preemptable_queue, project2_preemptable_queue},
+			ExpectPipeLined: map[string][]string{
+				"ns1/pg25": {"n4"},
+			},
+			ExpectEvicted:  []string{"ns1/p24"},
+			ExpectEvictNum: 1,
+		},
+		{
+			Name:      "case15: Cross-parent reclaim skips non-preemptable running task and evicts next eligible victim before pipelining pending non-preemptable queue job",
+			Plugins:   pluginsWithParentBasedReclaim,
+			Pods:      []*corev1.Pod{p21, p22, p23, p24_reclaimed, p25_pipelined, p26},
+			Nodes:     []*corev1.Node{n4},
+			PodGroups: []*schedulingv1beta1.PodGroup{pg21, pg22, pg23, pg24_reclaimed, pg25_pipelined, pg26},
+			Queues:    []*schedulingv1beta1.Queue{root2, project1_root_queue, project1_non_preemptable_queue, project1_preemptable, project2_root_queue, project2_non_preemptable_queue, project2_preemptable_queue},
+			ExpectPipeLined: map[string][]string{
+				"ns1/pg26": {"n4"},
+			},
+			ExpectEvicted:  []string{"ns1/p23"},
+			ExpectEvictNum: 1,
+		},
+		{
+			Name:            "case16: Cross-parent reclaim is blocked when victim child is not over deserved, even if victim parent is over deserved due to sibling usage",
+			Plugins:         pluginsWithParentBasedReclaim,
+			Pods:            []*corev1.Pod{p27, p28, p29},
+			Nodes:           []*corev1.Node{n5},
+			PodGroups:       []*schedulingv1beta1.PodGroup{pg27, pg28, pg29},
+			Queues:          []*schedulingv1beta1.Queue{root2, case16_parent1, case16_child1, case16_child1_sibling, case16_parent2, case16_child2},
+			ExpectPipeLined: map[string][]string{},
+			ExpectEvicted:   []string{},
+			ExpectEvictNum:  0,
+		},
 	}
 
 	tiers := []conf.Tier{
@@ -815,6 +947,11 @@ func Test_capacityPlugin_OnSessionOpenWithHierarchy(t *testing.T) {
 				{
 					Name:             predicates.PluginName,
 					EnabledPredicate: &trueValue,
+				},
+				{
+					Name:             priority.PluginName,
+					EnabledJobOrder:  &trueValue,
+					EnabledTaskOrder: &trueValue,
 				},
 				{
 					Name:               gang.PluginName,


### PR DESCRIPTION
#### What type of PR is this?
/kind feature
/area scheduling

#### What this PR does / why we need it:
This PR adds parent-based reclaim configuration in the capacity plugin and keeps reclaim victim selection aligned with scheduler ordering semantics in hierarchical queue scenarios.

From design perspective only **one** shall be merged from:
- https://github.com/volcano-sh/volcano/pull/5111
- https://github.com/volcano-sh/volcano/pull/5115

It carries prerequisite victim-selection foundation commits so related scheduler tests pass reliably on this branch.

It also updates `ReclaimableFn` victim processing to use `BuildVictimsPriorityQueue`, aligning reclaim victim selection with scheduler victim-ordering semantics.

#### Which issue(s) this PR fixes:
Fixes #5107

#### Special notes for your reviewer:
- Prerequisite victim-selection commits (from https://github.com/volcano-sh/volcano/pull/5113) are required here for reliable test pass (reclaimee selection will be consistent with it):
  - `ebbab911d` — enhancement(victim selection): add job ordering tie-break with task order
  - `2474cfcc9` — test(victim selection): add tie-break coverage in framework_test package
  - `f5e049e43` — test(victim selection): strengthen tie-break proof and update docs
- Parent-based reclaim commits are split by scope:
  - code/tests: `c0015f238`
  - docs: `bee7c539c`
- AI usage disclosure: I wrote this with my bare hands except the design doc change, that one is generated. BTW it's quite outdated anyway.

#### Does this PR introduce a user-facing change?
```release-note
feat(capacity): added parent-based reclaim behavior in capacity plugin
```