### PR TITLE
enhancement(victim selection): improve same job-priority victim selection

### DIFF
--- a/pkg/scheduler/framework/session_plugins.go
+++ b/pkg/scheduler/framework/session_plugins.go
@@ -656,6 +656,9 @@ func (ssn *Session) SubJobOrderFn(l, r interface{}) bool {
 	return lv.UID < rv.UID
 }
 
+// JobOrderCompareFn compares l and r by running enabled JobOrder plugins in
+// order and returning the first non-zero comparison result. It returns 0 if
+// all plugins consider l and r equal.
 func (ssn *Session) JobOrderCompareFn(l, r interface{}) int {
 	for _, tier := range ssn.Tiers {
 		for _, plugin := range tier.Plugins {
@@ -1095,8 +1098,13 @@ func (ssn *Session) HyperNodeGradientForSubJobFn(subJob *api.SubJobInfo, hyperNo
 }
 
 // BuildVictimsPriorityQueue returns a priority queue with victims sorted by:
-// if victims has same job id, sorted by !ssn.TaskOrderFn
-// if victims has different job id, sorted by !ssn.JobOrderFn
+//  1. If victims belong to the same job, use !ssn.TaskOrderFn.
+//  2. If either victim's job is missing, evict orphaned tasks first; if both
+//     are orphaned, use !ssn.TaskOrderFn.
+//  3. If the preemptor job is missing or victims are in the same queue, compare
+//     jobs with JobOrderCompareFn and use !ssn.TaskOrderFn as a tie-break.
+//  4. If victims are in different queues and preemptor job exists, use
+//     ssn.VictimQueueOrderFn.
 func (ssn *Session) BuildVictimsPriorityQueue(victims []*api.TaskInfo, preemptor *api.TaskInfo) *util.PriorityQueue {
 	jobThenTaskOrder := func(lvJob, rvJob *api.JobInfo, l, r interface{}) bool {
 		if cmp := ssn.JobOrderCompareFn(lvJob, rvJob); cmp != 0 {

--- a/pkg/scheduler/framework/session_plugins.go
+++ b/pkg/scheduler/framework/session_plugins.go
@@ -656,8 +656,7 @@ func (ssn *Session) SubJobOrderFn(l, r interface{}) bool {
 	return lv.UID < rv.UID
 }
 
-// JobOrderFn invoke joborder function of the plugins
-func (ssn *Session) JobOrderFn(l, r interface{}) bool {
+func (ssn *Session) JobOrderCompareFn(l, r interface{}) int {
 	for _, tier := range ssn.Tiers {
 		for _, plugin := range tier.Plugins {
 			if !isEnabled(plugin.EnabledJobOrder) {
@@ -668,9 +667,18 @@ func (ssn *Session) JobOrderFn(l, r interface{}) bool {
 				continue
 			}
 			if j := jof(l, r); j != 0 {
-				return j < 0
+				return j
 			}
 		}
+	}
+
+	return 0
+}
+
+// JobOrderFn invoke joborder function of the plugins
+func (ssn *Session) JobOrderFn(l, r interface{}) bool {
+	if res := ssn.JobOrderCompareFn(l, r); res != 0 {
+		return res < 0
 	}
 
 	// If no job order funcs, order job by CreationTimestamp first, then by UID.
@@ -1090,6 +1098,13 @@ func (ssn *Session) HyperNodeGradientForSubJobFn(subJob *api.SubJobInfo, hyperNo
 // if victims has same job id, sorted by !ssn.TaskOrderFn
 // if victims has different job id, sorted by !ssn.JobOrderFn
 func (ssn *Session) BuildVictimsPriorityQueue(victims []*api.TaskInfo, preemptor *api.TaskInfo) *util.PriorityQueue {
+	jobThenTaskOrder := func(lvJob, rvJob *api.JobInfo, l, r interface{}) bool {
+		if cmp := ssn.JobOrderCompareFn(lvJob, rvJob); cmp != 0 {
+			return cmp > 0
+		}
+		return !ssn.TaskOrderFn(l, r)
+	}
+
 	victimsQueue := util.NewPriorityQueue(func(l, r interface{}) bool {
 		lv := l.(*api.TaskInfo)
 		rv := r.(*api.TaskInfo)
@@ -1121,14 +1136,14 @@ func (ssn *Session) BuildVictimsPriorityQueue(victims []*api.TaskInfo, preemptor
 		}
 
 		if !preemptorJobFound {
-			return !ssn.JobOrderFn(lvJob, rvJob)
+			return jobThenTaskOrder(lvJob, rvJob, l, r)
 		}
 
 		if lvJob.Queue != rvJob.Queue {
 			return ssn.VictimQueueOrderFn(ssn.Queues[lvJob.Queue], ssn.Queues[rvJob.Queue], ssn.Queues[preemptorJob.Queue])
 		}
 
-		return !ssn.JobOrderFn(lvJob, rvJob)
+		return jobThenTaskOrder(lvJob, rvJob, l, r)
 	})
 	for _, victim := range victims {
 		victimsQueue.Push(victim)

--- a/pkg/scheduler/framework/session_plugins_victim_order_test.go
+++ b/pkg/scheduler/framework/session_plugins_victim_order_test.go
@@ -1,0 +1,117 @@
+/*
+Copyright 2026 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package framework_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+
+	schedulingv1 "volcano.sh/apis/pkg/apis/scheduling/v1beta1"
+	"volcano.sh/volcano/pkg/scheduler/api"
+	"volcano.sh/volcano/pkg/scheduler/conf"
+	"volcano.sh/volcano/pkg/scheduler/framework"
+	"volcano.sh/volcano/pkg/scheduler/plugins/priority"
+	"volcano.sh/volcano/pkg/scheduler/uthelper"
+	"volcano.sh/volcano/pkg/scheduler/util"
+)
+
+func TestBuildVictimsPriorityQueueJobTieBreaksWithTaskOrder(t *testing.T) {
+	trueValue := true
+	plugins := map[string]framework.PluginBuilder{priority.PluginName: priority.New}
+	highPri, lowPri := int32(100), int32(1)
+	queueQ1 := util.BuildQueue("q1", 1, nil)
+	nodeN1 := util.BuildNode("n1", api.BuildResourceList("10", "10Gi", []api.ScalarResource{{Name: "pods", Value: "20"}}...), nil)
+	pgHigh := util.BuildPodGroup("pg-high", "ns1", "q1", 1, nil, schedulingv1.PodGroupRunning)
+	pgLow := util.BuildPodGroup("pg-low", "ns1", "q1", 1, nil, schedulingv1.PodGroupRunning)
+	pgPreemptor := util.BuildPodGroup("pg-preemptor", "ns1", "q1", 1, nil, schedulingv1.PodGroupPending)
+	pHigh := util.BuildPodWithPriority("ns1", "p-high", "n1", v1.PodRunning, api.BuildResourceList("1", "1Gi"), "pg-high", nil, nil, &highPri)
+	pLow := util.BuildPodWithPriority("ns1", "p-low", "n1", v1.PodRunning, api.BuildResourceList("1", "1Gi"), "pg-low", nil, nil, &lowPri)
+	pPreemptor := util.BuildPodWithPriority("ns1", "p-preemptor", "", v1.PodPending, api.BuildResourceList("1", "1Gi"), "pg-preemptor", nil, nil, &highPri)
+
+	tiers := []conf.Tier{{
+		Plugins: []conf.PluginOption{{
+			Name:             priority.PluginName,
+			EnabledJobOrder:  &trueValue,
+			EnabledTaskOrder: &trueValue,
+		}},
+	}}
+
+	findTask := func(ssn *framework.Session, podName string) *api.TaskInfo {
+		for _, job := range ssn.Jobs {
+			for _, task := range job.Tasks {
+				if task.Name == podName {
+					return task
+				}
+			}
+		}
+		return nil
+	}
+
+	baseTestStruct := func() uthelper.TestCommonStruct {
+		return uthelper.TestCommonStruct{
+			Plugins: plugins,
+			Queues:  []*schedulingv1.Queue{queueQ1.DeepCopy()},
+			Nodes:   []*v1.Node{nodeN1.DeepCopy()},
+			PodGroups: []*schedulingv1.PodGroup{
+				pgHigh.DeepCopy(),
+				pgLow.DeepCopy(),
+			},
+			Pods: []*v1.Pod{
+				pHigh.DeepCopy(),
+				pLow.DeepCopy(),
+			},
+		}
+	}
+
+	t.Run("preemptor job found", func(t *testing.T) {
+		tc := baseTestStruct()
+		tc.PodGroups = append(tc.PodGroups, pgPreemptor.DeepCopy())
+		tc.Pods = append(tc.Pods, pPreemptor.DeepCopy())
+		ssn := tc.RegisterSession(tiers, nil)
+		defer tc.Close()
+
+		high := findTask(ssn, "p-high")
+		low := findTask(ssn, "p-low")
+		preemptor := findTask(ssn, "p-preemptor")
+		assert.NotNil(t, high)
+		assert.NotNil(t, low)
+		assert.NotNil(t, preemptor)
+
+		victims := []*api.TaskInfo{high, low}
+		pq := ssn.BuildVictimsPriorityQueue(victims, preemptor)
+		first := pq.Pop().(*api.TaskInfo)
+		assert.Equal(t, "p-low", first.Name)
+	})
+
+	t.Run("preemptor job missing", func(t *testing.T) {
+		tc := baseTestStruct()
+		ssn := tc.RegisterSession(tiers, nil)
+		defer tc.Close()
+
+		high := findTask(ssn, "p-high")
+		low := findTask(ssn, "p-low")
+		assert.NotNil(t, high)
+		assert.NotNil(t, low)
+
+		victims := []*api.TaskInfo{high, low}
+		pq := ssn.BuildVictimsPriorityQueue(victims, &api.TaskInfo{Job: api.JobID("missing")})
+		first := pq.Pop().(*api.TaskInfo)
+		assert.Equal(t, "p-low", first.Name)
+	})
+}

--- a/pkg/scheduler/framework/session_plugins_victim_order_test.go
+++ b/pkg/scheduler/framework/session_plugins_victim_order_test.go
@@ -18,9 +18,11 @@ package framework_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	schedulingv1 "volcano.sh/apis/pkg/apis/scheduling/v1beta1"
 	"volcano.sh/volcano/pkg/scheduler/api"
@@ -39,6 +41,8 @@ func TestBuildVictimsPriorityQueueJobTieBreaksWithTaskOrder(t *testing.T) {
 	nodeN1 := util.BuildNode("n1", api.BuildResourceList("10", "10Gi", []api.ScalarResource{{Name: "pods", Value: "20"}}...), nil)
 	pgHigh := util.BuildPodGroup("pg-high", "ns1", "q1", 1, nil, schedulingv1.PodGroupRunning)
 	pgLow := util.BuildPodGroup("pg-low", "ns1", "q1", 1, nil, schedulingv1.PodGroupRunning)
+	pgHigh.CreationTimestamp = metav1.NewTime(time.Unix(20, 0))
+	pgLow.CreationTimestamp = metav1.NewTime(time.Unix(10, 0))
 	pgPreemptor := util.BuildPodGroup("pg-preemptor", "ns1", "q1", 1, nil, schedulingv1.PodGroupPending)
 	pHigh := util.BuildPodWithPriority("ns1", "p-high", "n1", v1.PodRunning, api.BuildResourceList("1", "1Gi"), "pg-high", nil, nil, &highPri)
 	pLow := util.BuildPodWithPriority("ns1", "p-low", "n1", v1.PodRunning, api.BuildResourceList("1", "1Gi"), "pg-low", nil, nil, &lowPri)
@@ -92,6 +96,9 @@ func TestBuildVictimsPriorityQueueJobTieBreaksWithTaskOrder(t *testing.T) {
 		assert.NotNil(t, high)
 		assert.NotNil(t, low)
 		assert.NotNil(t, preemptor)
+		highJob := ssn.Jobs[high.Job]
+		lowJob := ssn.Jobs[low.Job]
+		assert.Equal(t, 0, ssn.JobOrderCompareFn(highJob, lowJob))
 
 		victims := []*api.TaskInfo{high, low}
 		pq := ssn.BuildVictimsPriorityQueue(victims, preemptor)
@@ -108,6 +115,9 @@ func TestBuildVictimsPriorityQueueJobTieBreaksWithTaskOrder(t *testing.T) {
 		low := findTask(ssn, "p-low")
 		assert.NotNil(t, high)
 		assert.NotNil(t, low)
+		highJob := ssn.Jobs[high.Job]
+		lowJob := ssn.Jobs[low.Job]
+		assert.Equal(t, 0, ssn.JobOrderCompareFn(highJob, lowJob))
 
 		victims := []*api.TaskInfo{high, low}
 		pq := ssn.BuildVictimsPriorityQueue(victims, &api.TaskInfo{Job: api.JobID("missing")})


### PR DESCRIPTION
#### What type of PR is this?
/kind rfe
/kind feature

#### What this PR does / why we need it:
This PR improves same job-priority victim selection in `BuildVictimsPriorityQueue` by applying plugin job compare first and using `TaskOrderFn` as tie-break when job ordering is equal.
The behavior is applied in both the preemptor-missing path and the same-queue path so creation timestamp is not the implicit final decision maker.

#### Which issue(s) this PR fixes:
Fixes #5112

#### Special notes for your reviewer:
- Key logic change is in `pkg/scheduler/framework/session_plugins.go`.
- Focused unit coverage is in `pkg/scheduler/framework/session_plugins_victim_order_test.go`.
- The unit test is intentionally in `framework_test` package to avoid import cycle with real plugin wiring.
- Commits are split by scope:
  - code: `ebbab911d`
  - tests: `2474cfcc9`
  - docs/test clarification: `f5e049e43`
- The victim selection process was quite controversial for these tie-break scenarios as:
`return lv.CreationTimestamp.Before(&rv.CreationTimestamp)` means `return true` when `lv` is older than `rv`, so if two jobs have the same priority the order is ascending by timestamp, for the `jobOrder` resulting in oldest first job ordering. For the victims we have negated this via `!ssn.JobOrderFn(...)` resulting in youngest first victim selection, so we evicted younger jobs on the cluster instead of the older jobs in the reclaim and preempt actions.
- AI usage disclosure: A little AI assistance was used in the creation of this PR, but the author thoroughly guided the implementation process and rewrote a good chunk of the generated parts.
- AI rhyme:
  In volcano's queue where victims flow,
  when job ranks tie, task rules shall show;
  no timestamp shall decide the fight,
  task-order keeps the choice set right.

#### Does this PR introduce a user-facing change?
```release-note
Improve scheduler victim selection tie-break behavior for same job-priority scenarios by using task-order when job-order ties in BuildVictimsPriorityQueue.
```