### PR TITLE
Proposal: feat(capacity) ancestor-based reclaim with level

### DIFF
--- a/docs/design/hierarchical-queue-on-capacity-plugin.md
+++ b/docs/design/hierarchical-queue-on-capacity-plugin.md
@@ -127,6 +127,254 @@ When job A performs reclaim or preempt actions, the system should first consider
 
 - `updateParentQueue`: Update the resource status of parent queues whenever the `updateShare` function is executed. It will traverse the queue hierarchy from the bottom up and update the resource information of parent queues accordingly.
 
+### Reclaim scope control
+
+When hierarchical queue mode is enabled in the capacity plugin, reclaim scope can be controlled with plugin argument `ancestorReclaimLevel`:
+
+- `0`: no ancestor restriction (existing behavior).
+- `1`: parent-level deserved checks are added for cross-parent reclaim.
+- `2`: grandparent-level deserved checks are also added when queues diverge at that level.
+- `N`: deeper ancestor levels are checked in the same way.
+
+An example configuration:
+```yaml
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: volcano-scheduler-configmap
+  namespace: volcano-system
+data:
+  volcano-scheduler.conf: |
+    actions: "enqueue, allocate, backfill, reclaim" # add reclaim action.
+    tiers:
+    - plugins:
+      - name: priority
+      - name: gang
+        enablePreemptable: false
+      - name: conformance
+    - plugins:
+      - name: drf
+        enablePreemptable: false
+      - name: predicates
+      - name: capacity # add this field and remove proportion plugin.
+        enableHierarchy: true
+        arguments:
+          # Controls how far reclaim can cross queue hierarchy boundaries.
+          # 0: no ancestor restriction (default behavior)
+          # 1: adds parent-level deserved checks for cross-parent reclaim
+          # 2: adds grandparent-level deserved checks (and so on for larger levels)
+          ancestorReclaimLevel: 1
+      - name: nodeorder
+      - name: binpack
+```
+
+When hierarchy is enabled for the capacity plugin, `ancestorReclaimLevel` controls reclaim scope:
+
+- `0` keeps the default unrestricted cross-hierarchy reclaim behavior. A reclaimer queue can reclaim from leaf queues that are over deserved.
+- `1` adds parent-level deserved checks for cross-parent reclaim. If a child queue is over its deserved but its parent is not over deserved, reclaim from that queue is blocked.
+- `2` adds grandparent-level deserved checks when queues diverge at grandparent level.
+- `N` extends this to deeper ancestors by adding the corresponding ancestor-level checks.
+
+In reclaim when hierarchy is enabled, victims are processed by `BuildVictimsPriorityQueue`, so reclaim follows the scheduler victim-ordering semantics. Between candidates from the same ordering class, queue share (`max(allocated/deserved)`) still drives reclaim pressure toward more overused queues.
+
+#### Interaction examples in a hierarchy:
+
+- Siblings (same direct parent): reclaim is decided solely by leaf-queue checks. Even when `ancestorReclaimLevel >= 1`, no additional parent-level deserved checks are applied because the reclaimer and reclaimee already share the same parent ancestor at that level.
+- Cousins (different parents, same grandparent): with `ancestorReclaimLevel=1`, reclaim requires both leaf-level and parent-level deserved exceedance; with `ancestorReclaimLevel=2`, grandparent-level checks are also enforced when applicable.
+- Second cousins (different grandparents, same higher ancestor): higher `ancestorReclaimLevel` values add the corresponding ancestor-level deserved checks before reclaim is allowed.
+
+This allows operators to tighten reclaim boundaries in larger queue trees while preserving default behavior when no restriction is required.
+
+#### Unit test scenarios and behavior map
+
+The table-driven test `Test_capacityPlugin_AncestorReclaimScenarios` covers case1-case11 with explicit topologies and reclaim outcomes.
+
+**case1: Can reclaim based on parent deserved when ancestorReclaimLevel is 1**
+
+```mermaid
+graph TD
+  R[root]
+  Q1[case1_queue1<br/>deserved: a100=1<br/>capability: unset]
+  Q11[case1_queue11<br/>deserved: unset<br/>capability: unset]
+  Q2[case1_queue2<br/>deserved: unset<br/>capability: unset]
+  R --> Q1
+  Q1 --> Q11
+  R --> Q2
+```
+
+- Workloads: `p1` running on `n1` in `case1_queue2` requests `a100=4`; `p2` pending in `case1_queue11` requests `a100=1`.
+- Level: `ancestorReclaimLevel=1`.
+- Expected: `p1` is evicted and `p2` (podgroup `pg2`) is pipelined to `n1`.
+
+**case2: Cross-parent reclaim pipelines project1 pending job when project2 child and parent are both over deserved**
+
+```mermaid
+graph TD
+  R[root]
+  P1[project1_root<br/>deserved: a100=1<br/>capability: a100=2]
+  P1NP[project1_non-preemptable<br/>deserved: a100=1<br/>capability: a100=1]
+  P1P[project1_preemptable<br/>deserved: unset<br/>capability: unset]
+  P2[project2_root<br/>deserved: a100=3<br/>capability: a100=4]
+  P2NP[project2_non-preemptable<br/>deserved: a100=3<br/>capability: a100=3]
+  P2P[project2_preemptable<br/>deserved: unset<br/>capability: unset]
+  R --> P1
+  P1 --> P1NP
+  P1 --> P1P
+  R --> P2
+  P2 --> P2NP
+  P2 --> P2P
+```
+
+- Workloads: `p1..p4` running on `n1` in `project2_preemptable` (`a100=1` each), `p5` pending in `project1_preemptable` (`a100=1`).
+- Level: `ancestorReclaimLevel=1`.
+- Expected: lower-priority `p4` is evicted and `p5` (podgroup `pg5`) is pipelined to `n1`.
+
+**case3: Cross-parent reclaim can evict sibling-queue victim first**
+
+Queue topology is identical to case2.
+
+- Workloads: continuation-style state with `p1..p3` running on `n1` in `project2_preemptable` (`a100=1` each), `p4` pending as reclaimed (`a100=1`), `p5` already running in `project1_preemptable` (`a100=1`), and `p6` pending in `project2_non-preemptable` (`a100=1`).
+- Level: `ancestorReclaimLevel=1`.
+- Expected: `p3` is evicted and `p6` (podgroup `pg6`) is pipelined to `n1`.
+
+**case4: Cross-parent reclaim is blocked when victim child is not over deserved**
+
+```mermaid
+graph TD
+  R[root]
+  P1[case4_parent1<br/>deserved: a100=1<br/>capability: unset]
+  C1[case4_child1<br/>deserved: a100=1<br/>capability: unset]
+  C1S[case4_child1_sibling<br/>deserved: unset<br/>capability: unset]
+  P2[case4_parent2<br/>deserved: a100=1<br/>capability: unset]
+  C2[case4_child2<br/>deserved: a100=1<br/>capability: unset]
+  R --> P1
+  P1 --> C1
+  P1 --> C1S
+  R --> P2
+  P2 --> C2
+```
+
+- Workloads: `p1` running on `n1` in `case4_child1` (`a100=1`), `p3` running in sibling queue (non-preemptable, `a100=1`), `p2` pending in `case4_child2` (`a100=1`).
+- Level: `ancestorReclaimLevel=1`.
+- Expected: no eviction and no pipeline.
+
+**case5: level 0 allows reclaim based on leaf-level deserved checks**
+
+```mermaid
+graph TD
+  R[root]
+  GA[grand-a<br/>deserved: cpu=2, mem=2Gi<br/>capability: cpu=4, mem=4Gi]
+  PA[parent-a<br/>deserved: cpu=2, mem=2Gi<br/>capability: cpu=2, mem=2Gi]
+  QA[queue-a<br/>deserved: cpu=2, mem=2Gi<br/>capability: cpu=2, mem=2Gi]
+  GB[grand-b<br/>deserved: cpu=3, mem=3Gi<br/>capability: cpu=4, mem=4Gi]
+  PB[parent-b<br/>deserved: cpu=1, mem=1Gi<br/>capability: cpu=2, mem=2Gi]
+  QB[queue-b<br/>deserved: cpu=1, mem=1Gi<br/>capability: cpu=2, mem=2Gi]
+  R --> GA
+  GA --> PA
+  PA --> QA
+  R --> GB
+  GB --> PB
+  PB --> QB
+```
+
+- Workloads: `p-victim` running in `queue-b` (`cpu=2, mem=2Gi`), `p-reclaimer` pending in `queue-a` (`cpu=2, mem=2Gi`).
+- Level: `ancestorReclaimLevel=0`.
+- Expected: `p-victim` is evicted and `p-reclaimer` is pipelined.
+
+**case6: level 1 allows reclaim when parent-level check passes**
+
+Queue topology is identical to case5.
+
+- Workloads: same as case5.
+- Level: `ancestorReclaimLevel=1`.
+- Expected: parent-level check passes, so eviction/pipeline still happens.
+
+**case7: level 2 blocks reclaim when grandparent-level check fails**
+
+Queue topology is identical to case5.
+
+- Workloads: same as case5.
+- Level: `ancestorReclaimLevel=2`.
+- Expected: grandparent-level gate fails; no eviction and no pipeline.
+
+**case8: level 1 blocks sibling reclaim when leaf deserved is unset and no ancestor gate applies**
+
+```mermaid
+graph TD
+  R[root]
+  P[parent<br/>deserved: cpu=4, mem=4Gi<br/>capability: cpu=4, mem=4Gi]
+  QA[queue-a<br/>deserved: unset<br/>capability: unset]
+  QB[queue-b<br/>deserved: unset<br/>capability: unset]
+  R --> P
+  P --> QA
+  P --> QB
+```
+
+- Workloads: `p-victim` running in `queue-b` (`cpu=2, mem=2Gi`), `p-reclaimer` pending in `queue-a` (`cpu=2, mem=2Gi`).
+- Level: `ancestorReclaimLevel=1`.
+- Expected: no eviction and no pipeline.
+
+**case9: level 2 blocks reclaim when leaf deserved is unset and queues share grandparent**
+
+```mermaid
+graph TD
+  R[root]
+  G[grand<br/>deserved: cpu=2, mem=2Gi<br/>capability: cpu=2, mem=2Gi]
+  PA[parent-a<br/>deserved: unset<br/>capability: unset]
+  QA[queue-a<br/>deserved: unset<br/>capability: unset]
+  PB[parent-b<br/>deserved: unset<br/>capability: unset]
+  QB[queue-b<br/>deserved: unset<br/>capability: unset]
+  R --> G
+  G --> PA
+  PA --> QA
+  G --> PB
+  PB --> QB
+```
+
+- Workloads: `p-victim` running in `queue-b` (`cpu=2, mem=2Gi`), `p-reclaimer` pending in `queue-a` (`cpu=2, mem=2Gi`).
+- Level: `ancestorReclaimLevel=2`.
+- Expected: no eviction and no pipeline.
+
+**case10: level 2 blocks reclaim in unbalanced shared-grandparent tree when leaf deserved is unset**
+
+```mermaid
+graph TD
+  R[root]
+  G[grand<br/>deserved: cpu=1, mem=1Gi<br/>capability: cpu=2, mem=2Gi]
+  PD[parent-deep<br/>deserved: cpu=1, mem=1Gi<br/>capability: cpu=2, mem=2Gi]
+  QD[queue-deep<br/>deserved: unset<br/>capability: unset]
+  QS[queue-shallow<br/>deserved: unset<br/>capability: unset]
+  R --> G
+  G --> PD
+  PD --> QD
+  G --> QS
+```
+
+- Workloads: `p-victim` running in `queue-deep` (`cpu=2, mem=2Gi`), `p-reclaimer` pending in `queue-shallow` (`cpu=2, mem=2Gi`).
+- Level: `ancestorReclaimLevel=2`.
+- Expected: no eviction and no pipeline.
+
+**case11: unbalanced level2 blocks reclaim when depth-2 ancestor is not over deserved**
+
+```mermaid
+graph TD
+  R[root]
+  SP[shallow-parent<br/>deserved: a100=1<br/>capability: unset]
+  QS[queue-shallow<br/>deserved: a100=1<br/>capability: unset]
+  DG[deep-grand<br/>deserved: a100=2<br/>capability: unset]
+  DP[deep-parent<br/>deserved: a100=1<br/>capability: unset]
+  QD[queue-deep<br/>deserved: a100=1<br/>capability: unset]
+  R --> SP
+  SP --> QS
+  R --> DG
+  DG --> DP
+  DP --> QD
+```
+
+- Workloads: `p-victim` running in `queue-deep` requests `a100=2`; `p-reclaimer` pending in `queue-shallow` requests `a100=1`.
+- Level: `ancestorReclaimLevel=2`.
+- Expected: depth-2 ancestor gate fails; no eviction and no pipeline.
+
 **Note:** The above modifications are primarily applicable when `EnabledHierarchy` is set to true. If the capacity plugin does not require hierarchical queue management, the existing implementations of these functions will be retained.
 
 ### Vcctl

--- a/docs/design/hierarchical-queue-on-capacity-plugin.md
+++ b/docs/design/hierarchical-queue-on-capacity-plugin.md
@@ -129,44 +129,14 @@ When job A performs reclaim or preempt actions, the system should first consider
 
 ### Reclaim scope control
 
-When hierarchical queue mode is enabled in the capacity plugin, reclaim scope can be controlled with plugin argument `ancestorReclaimLevel`:
+When hierarchical queue mode is enabled in the capacity plugin, reclaim scope can be controlled with plugin argument `ancestorReclaimLevel`. See [Capacity Plugin User Guide](../user-guide/how_to_use_capacity_plugin.md#configure-ancestor-reclaim-level) for the user-facing configuration guide.
 
 - `0`: no ancestor restriction (existing behavior).
 - `1`: parent-level deserved checks are added for cross-parent reclaim.
 - `2`: grandparent-level deserved checks are also added when queues diverge at that level.
 - `N`: deeper ancestor levels are checked in the same way.
 
-An example configuration:
-```yaml
-kind: ConfigMap
-apiVersion: v1
-metadata:
-  name: volcano-scheduler-configmap
-  namespace: volcano-system
-data:
-  volcano-scheduler.conf: |
-    actions: "enqueue, allocate, backfill, reclaim" # add reclaim action.
-    tiers:
-    - plugins:
-      - name: priority
-      - name: gang
-        enablePreemptable: false
-      - name: conformance
-    - plugins:
-      - name: drf
-        enablePreemptable: false
-      - name: predicates
-      - name: capacity # add this field and remove proportion plugin.
-        enableHierarchy: true
-        arguments:
-          # Controls how far reclaim can cross queue hierarchy boundaries.
-          # 0: no ancestor restriction (default behavior)
-          # 1: adds parent-level deserved checks for cross-parent reclaim
-          # 2: adds grandparent-level deserved checks (and so on for larger levels)
-          ancestorReclaimLevel: 1
-      - name: nodeorder
-      - name: binpack
-```
+For example, setting `ancestorReclaimLevel: 1` adds parent-level deserved checks for cross-parent reclaim, while `ancestorReclaimLevel: 2` also considers the grandparent level when queues diverge there.
 
 When hierarchy is enabled for the capacity plugin, `ancestorReclaimLevel` controls reclaim scope:
 
@@ -179,7 +149,7 @@ In reclaim when hierarchy is enabled, victims are processed by `BuildVictimsPrio
 
 #### Interaction examples in a hierarchy:
 
-- Siblings (same direct parent): reclaim is decided solely by leaf-queue checks. Even when `ancestorReclaimLevel >= 1`, no additional parent-level deserved checks are applied because the reclaimer and reclaimee already share the same parent ancestor at that level.
+- Siblings (same direct parent): ancestor-level checks are skipped for the shared parent because the reclaimer and reclaimee already share that ancestor. Reclaim can still be blocked by the leaf-level contention-avoidance gate when both leaf queues have no relevant deserved signal for the requested resources.
 - Cousins (different parents, same grandparent): with `ancestorReclaimLevel=1`, reclaim requires both leaf-level and parent-level deserved exceedance; with `ancestorReclaimLevel=2`, grandparent-level checks are also enforced when applicable.
 - Second cousins (different grandparents, same higher ancestor): higher `ancestorReclaimLevel` values add the corresponding ancestor-level deserved checks before reclaim is allowed.
 
@@ -352,7 +322,7 @@ graph TD
 
 - Workloads: `p-victim` running in `queue-deep` (`cpu=2, mem=2Gi`), `p-reclaimer` pending in `queue-shallow` (`cpu=2, mem=2Gi`).
 - Level: `ancestorReclaimLevel=2`.
-- Expected: no eviction and no pipeline.
+- Expected: no eviction and no pipeline. Although `grand` is over deserved, the victim leaf and reclaimer leaf both have no relevant deserved resources for the requested `cpu`/`memory`. Because the queues share `grand` within `ancestorReclaimLevel=2`, the leaf-level contention-avoidance gate skips reclaim before the grandparent deserved check can make the victim eligible.
 
 **case11: unbalanced level2 blocks reclaim when depth-2 ancestor is not over deserved**
 

--- a/docs/user-guide/how_to_use_capacity_plugin.md
+++ b/docs/user-guide/how_to_use_capacity_plugin.md
@@ -191,4 +191,3 @@ demo-2-6dfb86c49b-k9b9v   1/1     Running   0          37s
 demo-2-6dfb86c49b-rpzvg   0/1     Pending   0          37s
 demo-2-6dfb86c49b-zch7w   1/1     Running   0          37s
 ```
-

--- a/docs/user-guide/how_to_use_capacity_plugin.md
+++ b/docs/user-guide/how_to_use_capacity_plugin.md
@@ -49,6 +49,48 @@ data:
       - name: binpack
 ```
 
+## Configure ancestor reclaim level
+
+When hierarchical queue mode is enabled in the capacity plugin, reclaim scope can be controlled with plugin argument `ancestorReclaimLevel`:
+
+- `0`: no ancestor restriction. This is the default behavior.
+- `1`: add parent-level deserved checks for cross-parent reclaim.
+- `2`: also add grandparent-level deserved checks when queues diverge at that level.
+- `N`: check deeper ancestor levels in the same way.
+
+Example configuration:
+
+```yaml
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: volcano-scheduler-configmap
+  namespace: volcano-system
+data:
+  volcano-scheduler.conf: |
+    actions: "enqueue, allocate, backfill, reclaim" # add reclaim action.
+    tiers:
+    - plugins:
+      - name: priority
+      - name: gang
+        enablePreemptable: false
+      - name: conformance
+    - plugins:
+      - name: drf
+        enablePreemptable: false
+      - name: predicates
+      - name: capacity # add this field and remove proportion plugin.
+        enableHierarchy: true
+        arguments:
+          # Controls how far reclaim can cross queue hierarchy boundaries.
+          # 0: no ancestor restriction (default behavior)
+          # 1: adds parent-level deserved checks for cross-parent reclaim
+          # 2: adds grandparent-level deserved checks, and so on for larger levels
+          ancestorReclaimLevel: 1
+      - name: nodeorder
+      - name: binpack
+```
+
 ## Config queue's deserved resources
 
 Assume there are two nodes and two queues named queue1 and queue2 in your kubernetes cluster, and each node has 4 CPU and 16Gi memory, then there will be total 8 CPU and 32Gi memory in your cluster.

--- a/pkg/scheduler/framework/session_plugins.go
+++ b/pkg/scheduler/framework/session_plugins.go
@@ -656,6 +656,9 @@ func (ssn *Session) SubJobOrderFn(l, r interface{}) bool {
 	return lv.UID < rv.UID
 }
 
+// JobOrderCompareFn compares l and r by running enabled JobOrder plugins in
+// order and returning the first non-zero comparison result. It returns 0 if
+// all plugins consider l and r equal.
 func (ssn *Session) JobOrderCompareFn(l, r interface{}) int {
 	for _, tier := range ssn.Tiers {
 		for _, plugin := range tier.Plugins {
@@ -1095,8 +1098,13 @@ func (ssn *Session) HyperNodeGradientForSubJobFn(subJob *api.SubJobInfo, hyperNo
 }
 
 // BuildVictimsPriorityQueue returns a priority queue with victims sorted by:
-// if victims has same job id, sorted by !ssn.TaskOrderFn
-// if victims has different job id, sorted by !ssn.JobOrderFn
+//  1. If victims belong to the same job, use !ssn.TaskOrderFn.
+//  2. If either victim's job is missing, evict orphaned tasks first; if both
+//     are orphaned, use !ssn.TaskOrderFn.
+//  3. If the preemptor job is missing or victims are in the same queue, compare
+//     jobs with JobOrderCompareFn and use !ssn.TaskOrderFn as a tie-break.
+//  4. If victims are in different queues and preemptor job exists, use
+//     ssn.VictimQueueOrderFn.
 func (ssn *Session) BuildVictimsPriorityQueue(victims []*api.TaskInfo, preemptor *api.TaskInfo) *util.PriorityQueue {
 	jobThenTaskOrder := func(lvJob, rvJob *api.JobInfo, l, r interface{}) bool {
 		if cmp := ssn.JobOrderCompareFn(lvJob, rvJob); cmp != 0 {

--- a/pkg/scheduler/framework/session_plugins.go
+++ b/pkg/scheduler/framework/session_plugins.go
@@ -656,8 +656,7 @@ func (ssn *Session) SubJobOrderFn(l, r interface{}) bool {
 	return lv.UID < rv.UID
 }
 
-// JobOrderFn invoke joborder function of the plugins
-func (ssn *Session) JobOrderFn(l, r interface{}) bool {
+func (ssn *Session) JobOrderCompareFn(l, r interface{}) int {
 	for _, tier := range ssn.Tiers {
 		for _, plugin := range tier.Plugins {
 			if !isEnabled(plugin.EnabledJobOrder) {
@@ -668,9 +667,18 @@ func (ssn *Session) JobOrderFn(l, r interface{}) bool {
 				continue
 			}
 			if j := jof(l, r); j != 0 {
-				return j < 0
+				return j
 			}
 		}
+	}
+
+	return 0
+}
+
+// JobOrderFn invoke joborder function of the plugins
+func (ssn *Session) JobOrderFn(l, r interface{}) bool {
+	if res := ssn.JobOrderCompareFn(l, r); res != 0 {
+		return res < 0
 	}
 
 	// If no job order funcs, order job by CreationTimestamp first, then by UID.
@@ -1090,6 +1098,13 @@ func (ssn *Session) HyperNodeGradientForSubJobFn(subJob *api.SubJobInfo, hyperNo
 // if victims has same job id, sorted by !ssn.TaskOrderFn
 // if victims has different job id, sorted by !ssn.JobOrderFn
 func (ssn *Session) BuildVictimsPriorityQueue(victims []*api.TaskInfo, preemptor *api.TaskInfo) *util.PriorityQueue {
+	jobThenTaskOrder := func(lvJob, rvJob *api.JobInfo, l, r interface{}) bool {
+		if cmp := ssn.JobOrderCompareFn(lvJob, rvJob); cmp != 0 {
+			return cmp > 0
+		}
+		return !ssn.TaskOrderFn(l, r)
+	}
+
 	victimsQueue := util.NewPriorityQueue(func(l, r interface{}) bool {
 		lv := l.(*api.TaskInfo)
 		rv := r.(*api.TaskInfo)
@@ -1121,14 +1136,14 @@ func (ssn *Session) BuildVictimsPriorityQueue(victims []*api.TaskInfo, preemptor
 		}
 
 		if !preemptorJobFound {
-			return !ssn.JobOrderFn(lvJob, rvJob)
+			return jobThenTaskOrder(lvJob, rvJob, l, r)
 		}
 
 		if lvJob.Queue != rvJob.Queue {
 			return ssn.VictimQueueOrderFn(ssn.Queues[lvJob.Queue], ssn.Queues[rvJob.Queue], ssn.Queues[preemptorJob.Queue])
 		}
 
-		return !ssn.JobOrderFn(lvJob, rvJob)
+		return jobThenTaskOrder(lvJob, rvJob, l, r)
 	})
 	for _, victim := range victims {
 		victimsQueue.Push(victim)

--- a/pkg/scheduler/framework/session_plugins_victim_order_test.go
+++ b/pkg/scheduler/framework/session_plugins_victim_order_test.go
@@ -1,0 +1,117 @@
+/*
+Copyright 2026 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package framework_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+
+	schedulingv1 "volcano.sh/apis/pkg/apis/scheduling/v1beta1"
+	"volcano.sh/volcano/pkg/scheduler/api"
+	"volcano.sh/volcano/pkg/scheduler/conf"
+	"volcano.sh/volcano/pkg/scheduler/framework"
+	"volcano.sh/volcano/pkg/scheduler/plugins/priority"
+	"volcano.sh/volcano/pkg/scheduler/uthelper"
+	"volcano.sh/volcano/pkg/scheduler/util"
+)
+
+func TestBuildVictimsPriorityQueueJobTieBreaksWithTaskOrder(t *testing.T) {
+	trueValue := true
+	plugins := map[string]framework.PluginBuilder{priority.PluginName: priority.New}
+	highPri, lowPri := int32(100), int32(1)
+	queueQ1 := util.BuildQueue("q1", 1, nil)
+	nodeN1 := util.BuildNode("n1", api.BuildResourceList("10", "10Gi", []api.ScalarResource{{Name: "pods", Value: "20"}}...), nil)
+	pgHigh := util.BuildPodGroup("pg-high", "ns1", "q1", 1, nil, schedulingv1.PodGroupRunning)
+	pgLow := util.BuildPodGroup("pg-low", "ns1", "q1", 1, nil, schedulingv1.PodGroupRunning)
+	pgPreemptor := util.BuildPodGroup("pg-preemptor", "ns1", "q1", 1, nil, schedulingv1.PodGroupPending)
+	pHigh := util.BuildPodWithPriority("ns1", "p-high", "n1", v1.PodRunning, api.BuildResourceList("1", "1Gi"), "pg-high", nil, nil, &highPri)
+	pLow := util.BuildPodWithPriority("ns1", "p-low", "n1", v1.PodRunning, api.BuildResourceList("1", "1Gi"), "pg-low", nil, nil, &lowPri)
+	pPreemptor := util.BuildPodWithPriority("ns1", "p-preemptor", "", v1.PodPending, api.BuildResourceList("1", "1Gi"), "pg-preemptor", nil, nil, &highPri)
+
+	tiers := []conf.Tier{{
+		Plugins: []conf.PluginOption{{
+			Name:             priority.PluginName,
+			EnabledJobOrder:  &trueValue,
+			EnabledTaskOrder: &trueValue,
+		}},
+	}}
+
+	findTask := func(ssn *framework.Session, podName string) *api.TaskInfo {
+		for _, job := range ssn.Jobs {
+			for _, task := range job.Tasks {
+				if task.Name == podName {
+					return task
+				}
+			}
+		}
+		return nil
+	}
+
+	baseTestStruct := func() uthelper.TestCommonStruct {
+		return uthelper.TestCommonStruct{
+			Plugins: plugins,
+			Queues:  []*schedulingv1.Queue{queueQ1.DeepCopy()},
+			Nodes:   []*v1.Node{nodeN1.DeepCopy()},
+			PodGroups: []*schedulingv1.PodGroup{
+				pgHigh.DeepCopy(),
+				pgLow.DeepCopy(),
+			},
+			Pods: []*v1.Pod{
+				pHigh.DeepCopy(),
+				pLow.DeepCopy(),
+			},
+		}
+	}
+
+	t.Run("preemptor job found", func(t *testing.T) {
+		tc := baseTestStruct()
+		tc.PodGroups = append(tc.PodGroups, pgPreemptor.DeepCopy())
+		tc.Pods = append(tc.Pods, pPreemptor.DeepCopy())
+		ssn := tc.RegisterSession(tiers, nil)
+		defer tc.Close()
+
+		high := findTask(ssn, "p-high")
+		low := findTask(ssn, "p-low")
+		preemptor := findTask(ssn, "p-preemptor")
+		assert.NotNil(t, high)
+		assert.NotNil(t, low)
+		assert.NotNil(t, preemptor)
+
+		victims := []*api.TaskInfo{high, low}
+		pq := ssn.BuildVictimsPriorityQueue(victims, preemptor)
+		first := pq.Pop().(*api.TaskInfo)
+		assert.Equal(t, "p-low", first.Name)
+	})
+
+	t.Run("preemptor job missing", func(t *testing.T) {
+		tc := baseTestStruct()
+		ssn := tc.RegisterSession(tiers, nil)
+		defer tc.Close()
+
+		high := findTask(ssn, "p-high")
+		low := findTask(ssn, "p-low")
+		assert.NotNil(t, high)
+		assert.NotNil(t, low)
+
+		victims := []*api.TaskInfo{high, low}
+		pq := ssn.BuildVictimsPriorityQueue(victims, &api.TaskInfo{Job: api.JobID("missing")})
+		first := pq.Pop().(*api.TaskInfo)
+		assert.Equal(t, "p-low", first.Name)
+	})
+}

--- a/pkg/scheduler/framework/session_plugins_victim_order_test.go
+++ b/pkg/scheduler/framework/session_plugins_victim_order_test.go
@@ -18,9 +18,11 @@ package framework_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	schedulingv1 "volcano.sh/apis/pkg/apis/scheduling/v1beta1"
 	"volcano.sh/volcano/pkg/scheduler/api"
@@ -39,6 +41,8 @@ func TestBuildVictimsPriorityQueueJobTieBreaksWithTaskOrder(t *testing.T) {
 	nodeN1 := util.BuildNode("n1", api.BuildResourceList("10", "10Gi", []api.ScalarResource{{Name: "pods", Value: "20"}}...), nil)
 	pgHigh := util.BuildPodGroup("pg-high", "ns1", "q1", 1, nil, schedulingv1.PodGroupRunning)
 	pgLow := util.BuildPodGroup("pg-low", "ns1", "q1", 1, nil, schedulingv1.PodGroupRunning)
+	pgHigh.CreationTimestamp = metav1.NewTime(time.Unix(20, 0))
+	pgLow.CreationTimestamp = metav1.NewTime(time.Unix(10, 0))
 	pgPreemptor := util.BuildPodGroup("pg-preemptor", "ns1", "q1", 1, nil, schedulingv1.PodGroupPending)
 	pHigh := util.BuildPodWithPriority("ns1", "p-high", "n1", v1.PodRunning, api.BuildResourceList("1", "1Gi"), "pg-high", nil, nil, &highPri)
 	pLow := util.BuildPodWithPriority("ns1", "p-low", "n1", v1.PodRunning, api.BuildResourceList("1", "1Gi"), "pg-low", nil, nil, &lowPri)
@@ -92,6 +96,9 @@ func TestBuildVictimsPriorityQueueJobTieBreaksWithTaskOrder(t *testing.T) {
 		assert.NotNil(t, high)
 		assert.NotNil(t, low)
 		assert.NotNil(t, preemptor)
+		highJob := ssn.Jobs[high.Job]
+		lowJob := ssn.Jobs[low.Job]
+		assert.Equal(t, 0, ssn.JobOrderCompareFn(highJob, lowJob))
 
 		victims := []*api.TaskInfo{high, low}
 		pq := ssn.BuildVictimsPriorityQueue(victims, preemptor)
@@ -108,6 +115,9 @@ func TestBuildVictimsPriorityQueueJobTieBreaksWithTaskOrder(t *testing.T) {
 		low := findTask(ssn, "p-low")
 		assert.NotNil(t, high)
 		assert.NotNil(t, low)
+		highJob := ssn.Jobs[high.Job]
+		lowJob := ssn.Jobs[low.Job]
+		assert.Equal(t, 0, ssn.JobOrderCompareFn(highJob, lowJob))
 
 		victims := []*api.TaskInfo{high, low}
 		pq := ssn.BuildVictimsPriorityQueue(victims, &api.TaskInfo{Job: api.JobID("missing")})

--- a/pkg/scheduler/plugins/capacity/capacity.go
+++ b/pkg/scheduler/plugins/capacity/capacity.go
@@ -40,7 +40,8 @@ import (
 )
 
 const (
-	PluginName = "capacity"
+	PluginName              = "capacity"
+	ancestorReclaimLevelKey = "ancestorReclaimLevel"
 
 	// preFilterStateKey is the key in CycleState to InterPodAffinity pre-computed data for Filtering.
 	// Using the name of the plugin will likely help us avoid collisions with other plugins.
@@ -58,9 +59,10 @@ const (
 )
 
 type capacityPlugin struct {
-	rootQueue      string
-	totalResource  *api.Resource
-	totalGuarantee *api.Resource
+	rootQueue            string
+	totalResource        *api.Resource
+	totalGuarantee       *api.Resource
+	ancestorReclaimLevel int
 
 	queueOpts map[api.QueueID]*queueAttr
 	// Arguments given for the plugin
@@ -420,6 +422,7 @@ func New(arguments framework.Arguments) framework.Plugin {
 		totalResource:                   api.EmptyResource(),
 		totalGuarantee:                  api.EmptyResource(),
 		queueOpts:                       map[api.QueueID]*queueAttr{},
+		ancestorReclaimLevel:            0,
 		pluginArguments:                 arguments,
 		queueGateReservedTasks:          make(map[api.QueueID]map[api.TaskID]*api.TaskInfo),
 		dynamicResourceAllocationEnable: dynamicResourceAllocationEnable,
@@ -432,6 +435,8 @@ func (cp *capacityPlugin) Name() string {
 }
 
 func (cp *capacityPlugin) OnSessionOpen(ssn *framework.Session) {
+	cp.parseArguments()
+
 	// Prepare scheduling data for this session.
 	cp.totalResource.Add(ssn.TotalResource)
 
@@ -459,7 +464,22 @@ func (cp *capacityPlugin) OnSessionOpen(ssn *framework.Session) {
 			return victims, util.Reject
 		}
 
-		for _, reclaimee := range reclaimees {
+		reclaimerJob := ssn.Jobs[reclaimer.Job]
+		if reclaimerJob == nil {
+			klog.Warningf("[capacity] Skip reclaim for reclaimer <%s/%s>: job <%s> not found in session",
+				reclaimer.Namespace, reclaimer.Name, reclaimer.Job)
+			return victims, util.Reject
+		}
+		reclaimerAttr := cp.queueOpts[reclaimerJob.Queue]
+		if reclaimerAttr == nil {
+			klog.Warningf("[capacity] Skip reclaim for reclaimer <%s/%s>: queue <%s> not found in queueOpts",
+				reclaimer.Namespace, reclaimer.Name, reclaimerJob.Queue)
+			return victims, util.Reject
+		}
+
+		reclaimeesQueue := ssn.BuildVictimsPriorityQueue(reclaimees, reclaimer)
+		for !reclaimeesQueue.Empty() {
+			reclaimee := reclaimeesQueue.Pop().(*api.TaskInfo)
 			job := ssn.Jobs[reclaimee.Job]
 			if job == nil {
 				klog.Warningf("[capacity] Skip reclaimee <%s/%s>: job <%s> not found in session (orphaned task from deleted PodGroup)",
@@ -490,34 +510,93 @@ func (cp *capacityPlugin) OnSessionOpen(ssn *framework.Session) {
 				allocations[job.Queue] = attr.allocated.Clone()
 			}
 			allocated := allocations[job.Queue]
+			ancestorAllocations := make(map[api.QueueID]*api.Resource)
 
 			// Check guarantee
 			if satisfies, _ := cp.checkGuaranteeConstraint(allocated, reclaimee, attr.guarantee); !satisfies {
 				continue
 			}
 
-			// If the reclaimee has no intersecting resource dimensions with deserved, it is a victim.
+			// A reclaimee is eligible as a victim if it is an immediate victim or
+			// if its queue's allocated resources exceed deserved resources on dimensions relevant to the reclaimee.
+			childEligible := false
 			if isVictim, reason := cp.isImmediateVictim(reclaimee, attr.deserved); isVictim {
-				allocated.Sub(reclaimee.Resreq)
-				victims = append(victims, reclaimee)
-				klog.V(5).Infof("%s. It's a victim. Current victims: %+v.", reason, victims)
-				continue
-			}
-
-			// Check deserved
-			if exceeds, dims, reason := cp.checkDeservedExceedance(
-				allocated, attr.deserved, reclaimee, reclaimer, attr.name); !exceeds {
-				klog.V(5).Infof("%s", reason)
-				continue
-			} else {
+				// If hierarchy is enabled and ancestor reclaim is configured, even if the reclaimee is an immediate victim,
+				// we still need to check if it shares any non-root ancestor within the configured level with the reclaimer and
+				// both leaf deserved signals are empty for requested resources under shared ancestor scope.
+				// If so, the reclaimee will not be reclaimed to avoid unnecessary preemption when there is no real contention.
+				if hierarchyEnabled && cp.ancestorReclaimLevel > 0 && cp.sharesAnyNonRootAncestorWithinLevel(reclaimerAttr, attr) &&
+					!hasRelevantDeserved(reclaimer, reclaimerAttr.deserved) {
+					klog.V(5).Infof("[capacity] Skip reclaim for reclaimee <%s/%s> from queue <%s>: both leaf deserved signals are empty for requested resources under shared ancestor scope ancestorReclaimLevel=%d",
+						reclaimee.Namespace, reclaimee.Name, attr.queueID, cp.ancestorReclaimLevel)
+					continue
+				}
+				childEligible = true
+				klog.V(5).Infof("%s. It's a victim for queue <%s>.", reason, attr.name)
+			} else if exceeds, dims, reason := cp.checkDeservedExceedance(
+				allocated, attr.deserved, reclaimee, reclaimer, attr.name); exceeds {
+				childEligible = true
 				klog.V(5).Infof("[capacity] Reclaimee <%s/%s> is a victim from queue <%s> for reclaimer <%s/%s>. "+
 					"Allocated: <%v>, Deserved: <%v>, Reclaimee Resreq: <%v>, Reclaimable on dimensions: %v.",
 					reclaimee.Namespace, reclaimee.Name, attr.queueID, reclaimer.Namespace, reclaimer.Name,
 					allocated, attr.deserved, reclaimee.Resreq, dims)
-				allocated.Sub(reclaimee.Resreq)
-				victims = append(victims, reclaimee)
-				klog.V(5).Infof("[capacity] Current victims: %+v.", victims)
+			} else {
+				klog.V(5).Infof("%s.", reason)
 			}
+
+			if !childEligible {
+				continue
+			}
+
+			// If hierarchy is enabled and ancestor reclaim is configured,
+			// check ancestors up to the configured level to avoid reclaiming a victim when there is no real contention.
+			ancestorEligible := true
+			if hierarchyEnabled && cp.ancestorReclaimLevel > 0 {
+				for level := 1; level <= cp.ancestorReclaimLevel; level++ {
+					ancestorAttr, needCheck := cp.getReclaimeeAncestorToCheck(reclaimerAttr, attr, level)
+					if !needCheck {
+						continue
+					}
+					if ancestorAttr == nil {
+						ancestorEligible = false
+						klog.Warningf("[capacity] Skip reclaimee <%s/%s>: ancestor check target at level %d is nil", reclaimee.Namespace, reclaimee.Name, level)
+						break
+					}
+					if _, found := allocations[ancestorAttr.queueID]; !found {
+						allocations[ancestorAttr.queueID] = ancestorAttr.allocated.Clone()
+					}
+					ancestorAllocated := allocations[ancestorAttr.queueID]
+					ancestorAllocations[ancestorAttr.queueID] = ancestorAllocated
+
+					if isVictim, reason := cp.isImmediateVictim(reclaimee, ancestorAttr.deserved); isVictim {
+						klog.V(5).Infof("%s. It's a victim for ancestor queue <%s>.", reason, ancestorAttr.name)
+						continue
+					}
+
+					exceeds, dims, reason := cp.checkDeservedExceedance(
+						ancestorAllocated, ancestorAttr.deserved, reclaimee, reclaimer, ancestorAttr.name)
+					if !exceeds {
+						ancestorEligible = false
+						klog.V(5).Infof("%s.", reason)
+						break
+					}
+					klog.V(5).Infof("[capacity] Reclaimee <%s/%s> is a victim from ancestor queue <%s> for reclaimer <%s/%s>. "+
+						"Allocated: <%v>, Deserved: <%v>, Reclaimee Resreq: <%v>, Reclaimable on dimensions: %v.",
+						reclaimee.Namespace, reclaimee.Name, ancestorAttr.name, reclaimer.Namespace, reclaimer.Name,
+						ancestorAllocated, ancestorAttr.deserved, reclaimee.Resreq, dims)
+				}
+			}
+
+			if !ancestorEligible {
+				continue
+			}
+
+			allocated.Sub(reclaimee.Resreq)
+			for _, ancestorAllocated := range ancestorAllocations {
+				ancestorAllocated.Sub(reclaimee.Resreq)
+			}
+			victims = append(victims, reclaimee)
+			klog.V(5).Infof("[capacity] Current victims: %+v.", victims)
 		}
 		klog.V(4).Infof("[capacity] Victims from capacity plugin: victims=%+v reclaimer=%s.", victims, reclaimer)
 		return victims, util.Permit
@@ -553,8 +632,33 @@ func (cp *capacityPlugin) OnSessionOpen(ssn *framework.Session) {
 				"The futureUsed: %v, deserved: %v, allocated: %v, task requested: %v",
 				queue.Name, resourceNames, futureUsed, attr.deserved, attr.allocated, task.Resreq)
 		} else {
-			klog.V(3).Infof("Queue <%v> can not reclaim, futureUsed: %v, deserved: %v, requested: %v",
+			klog.V(4).Infof("Queue <%v> itself can not reclaim, futureUsed: %v, deserved: %v, requested: %v",
 				queue.Name, futureUsed, attr.deserved, task.Resreq)
+			if hierarchyEnabled && cp.ancestorReclaimLevel > 0 {
+				for level := 1; level <= cp.ancestorReclaimLevel; level++ {
+					ancestorID, found := queueAncestorAtDepth(attr, level)
+					if !found || ancestorID == rootQueueID {
+						continue
+					}
+					ancestorAttr := cp.queueOpts[ancestorID]
+					if ancestorAttr == nil {
+						continue
+					}
+
+					futureUsedAncestor := ancestorAttr.allocated.Clone().Add(task.Resreq)
+					isPreemptive, resourceNames = futureUsedAncestor.LessEqualPartlyWithDimensionZeroFiltered(ancestorAttr.deserved, task.Resreq)
+					if isPreemptive {
+						klog.V(3).Infof("Queue's ancestor <%v> can reclaim on resource dimensions: %v. "+
+							"The futureUsedAncestor: %v, deserved: %v, allocated: %v, task requested: %v",
+							ancestorAttr.name, resourceNames, futureUsedAncestor, ancestorAttr.deserved, ancestorAttr.allocated, task.Resreq)
+						break
+					}
+				}
+			}
+			if !isPreemptive {
+				klog.V(4).Infof("Queue <%v> and its ancestors can not reclaim. futureUsed: %v, deserved: %v, requested: %v",
+					queue.Name, futureUsed, attr.deserved, task.Resreq)
+			}
 		}
 
 		// PreemptiveFn is the opposite of OverusedFn in proportion plugin cause as long as there is a one-dimensional
@@ -835,6 +939,45 @@ func (cp *capacityPlugin) OnSessionOpen(ssn *framework.Session) {
 			}
 		},
 	})
+}
+
+func (cp *capacityPlugin) parseArguments() {
+	ancestorReclaimLevel := 0
+	cp.pluginArguments.GetInt(&ancestorReclaimLevel, ancestorReclaimLevelKey)
+
+	if ancestorReclaimLevel < 0 {
+		klog.Warningf("%s should be non-negative, got %d. Falling back to 0.", ancestorReclaimLevelKey, ancestorReclaimLevel)
+		ancestorReclaimLevel = 0
+	}
+
+	cp.ancestorReclaimLevel = ancestorReclaimLevel
+	klog.V(4).Infof("[capacity] reclaim ancestor level configured as %d", cp.ancestorReclaimLevel)
+}
+
+func (cp *capacityPlugin) getReclaimeeAncestorToCheck(reclaimerAttr, reclaimeeAttr *queueAttr, level int) (*queueAttr, bool) {
+	if reclaimerAttr == nil || reclaimeeAttr == nil || level <= 0 {
+		return nil, false
+	}
+
+	reclaimerAncestors := ancestorsByLevel(reclaimerAttr, level)
+	reclaimeeAncestors := ancestorsByLevel(reclaimeeAttr, level)
+
+	reclaimeeAncestorID, reclaimeeFound := reclaimeeAncestors[level]
+	if !reclaimeeFound || reclaimeeAncestorID == rootQueueID {
+		return nil, false
+	}
+
+	reclaimerAncestorID, reclaimerFound := reclaimerAncestors[level]
+	if reclaimerFound && reclaimerAncestorID == reclaimeeAncestorID {
+		return nil, false
+	}
+
+	ancestorAttr := cp.queueOpts[reclaimeeAncestorID]
+	if ancestorAttr == nil {
+		return nil, true
+	}
+
+	return ancestorAttr, true
 }
 
 func (cp *capacityPlugin) OnSessionClose(ssn *framework.Session) {
@@ -1535,20 +1678,6 @@ func (cp *capacityPlugin) checkJobEnqueueableHierarchically(ssn *framework.Sessi
 	return true
 }
 
-func getQueueLevel(l *queueAttr, r *queueAttr) int {
-	level := 0
-
-	for i := 0; i < min(len(l.ancestors), len(r.ancestors)); i++ {
-		if l.ancestors[i] == r.ancestors[i] {
-			level = i
-		} else {
-			return level
-		}
-	}
-
-	return level
-}
-
 func getCapacityState(cycleState fwk.CycleState) (*capacityState, error) {
 	c, err := cycleState.Read(capacityStateKey)
 	if err != nil {
@@ -1679,12 +1808,18 @@ func (cp *capacityPlugin) isImmediateVictim(
 	reclaimee *api.TaskInfo,
 	deserved *api.Resource,
 ) (bool, string) {
-	deservedIntersecting := len(api.Intersection(reclaimee.Resreq, deserved)) > 0
-	if !deservedIntersecting {
+	if !hasRelevantDeserved(reclaimee, deserved) {
 		return true, fmt.Sprintf("[capacity] No intersection between deserved: <%v> and reclaimee <%s/%s>: <%v>",
 			deserved, reclaimee.Namespace, reclaimee.Name, reclaimee.Resreq)
 	}
 	return false, ""
+}
+
+func hasRelevantDeserved(task *api.TaskInfo, deserved *api.Resource) bool {
+	if task == nil || deserved == nil {
+		return false
+	}
+	return len(api.Intersection(task.Resreq, deserved)) > 0
 }
 
 // checkDeservedExceedance checks if the queue's allocated resources exceed its deserved resources
@@ -1708,4 +1843,71 @@ func (cp *capacityPlugin) checkDeservedExceedance(
 		return false, nil, reason
 	}
 	return true, dims, ""
+}
+
+func (cp *capacityPlugin) sharesAnyNonRootAncestorWithinLevel(a, b *queueAttr) bool {
+	if cp == nil || a == nil || b == nil || cp.ancestorReclaimLevel <= 0 {
+		return false
+	}
+
+	aAncestors := ancestorIDSet(ancestorsByLevel(a, cp.ancestorReclaimLevel))
+	bAncestors := ancestorIDSet(ancestorsByLevel(b, cp.ancestorReclaimLevel))
+
+	for ancestor := range aAncestors {
+		if ancestor == rootQueueID {
+			continue
+		}
+		if _, found := bAncestors[ancestor]; found {
+			return true
+		}
+	}
+
+	return false
+}
+
+func getQueueLevel(l *queueAttr, r *queueAttr) int {
+	level := 0
+
+	for i := range min(len(l.ancestors), len(r.ancestors)) {
+		if l.ancestors[i] == r.ancestors[i] {
+			level = i
+		} else {
+			return level
+		}
+	}
+
+	return level
+}
+
+func queueAncestorAtDepth(attr *queueAttr, depth int) (api.QueueID, bool) {
+	if attr == nil || depth <= 0 || len(attr.ancestors) < depth {
+		return "", false
+	}
+
+	return attr.ancestors[len(attr.ancestors)-depth], true
+}
+
+func ancestorsByLevel(attr *queueAttr, maxLevel int) map[int]api.QueueID {
+	ancestors := make(map[int]api.QueueID)
+	if attr == nil || maxLevel <= 0 {
+		return ancestors
+	}
+
+	for level := 1; level <= maxLevel; level++ {
+		ancestorID, found := queueAncestorAtDepth(attr, level)
+		if !found {
+			continue
+		}
+		ancestors[level] = ancestorID
+	}
+
+	return ancestors
+}
+
+func ancestorIDSet(ancestorsByDepth map[int]api.QueueID) map[api.QueueID]struct{} {
+	set := make(map[api.QueueID]struct{}, len(ancestorsByDepth))
+	for _, ancestorID := range ancestorsByDepth {
+		set[ancestorID] = struct{}{}
+	}
+	return set
 }

--- a/pkg/scheduler/plugins/capacity/capacity_test.go
+++ b/pkg/scheduler/plugins/capacity/capacity_test.go
@@ -42,6 +42,7 @@ import (
 	"volcano.sh/volcano/pkg/scheduler/framework"
 	"volcano.sh/volcano/pkg/scheduler/plugins/gang"
 	"volcano.sh/volcano/pkg/scheduler/plugins/predicates"
+	"volcano.sh/volcano/pkg/scheduler/plugins/priority"
 	"volcano.sh/volcano/pkg/scheduler/uthelper"
 	"volcano.sh/volcano/pkg/scheduler/util"
 )
@@ -825,6 +826,359 @@ func Test_capacityPlugin_OnSessionOpenWithHierarchy(t *testing.T) {
 	}
 	for i, test := range tests {
 		t.Run(test.Name, func(t *testing.T) {
+			test.RegisterSession(tiers, nil)
+			defer test.Close()
+			test.Run(actions)
+			if err := test.CheckAll(i); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
+func Test_capacityPlugin_AncestorReclaimScenarios(t *testing.T) {
+	plugins := map[string]framework.PluginBuilder{
+		PluginName:            New,
+		predicates.PluginName: predicates.New,
+		gang.PluginName:       gang.New,
+		priority.PluginName:   priority.New,
+	}
+	actions := []framework.Action{enqueue.New(), reclaim.New(), allocate.New()}
+
+	type scenario struct {
+		name            string
+		level           int
+		includePriority bool
+		build           func(t *testing.T) (nodes []*corev1.Node, pods []*corev1.Pod, pgs []*schedulingv1beta1.PodGroup, queues []*schedulingv1beta1.Queue)
+		expectPipeLined map[string][]string
+		expectEvicted   []string
+		expectEvictNum  int
+		expectBindsNum  int
+		expectBindMap   map[string]string
+	}
+
+	buildTier := func(level int, includePriority bool) []conf.Tier {
+		trueValue := true
+		plugins := []conf.PluginOption{
+			{
+				Name:               PluginName,
+				EnabledAllocatable: &trueValue,
+				EnablePreemptive:   &trueValue,
+				EnabledReclaimable: &trueValue,
+				EnabledQueueOrder:  &trueValue,
+				EnabledHierarchy:   &trueValue,
+				EnabledJobEnqueued: &trueValue,
+				Arguments: framework.Arguments{
+					"ancestorReclaimLevel": level,
+				},
+			},
+			{
+				Name:             predicates.PluginName,
+				EnabledPredicate: &trueValue,
+			},
+			{
+				Name:               gang.PluginName,
+				EnabledJobStarving: &trueValue,
+			},
+		}
+		if includePriority {
+			plugins = append(plugins, conf.PluginOption{
+				Name:             priority.PluginName,
+				EnabledJobOrder:  &trueValue,
+				EnabledTaskOrder: &trueValue,
+			})
+		}
+		return []conf.Tier{{Plugins: plugins}}
+	}
+
+	buildProjectQueueTree := func() (*schedulingv1beta1.Queue, *schedulingv1beta1.Queue, *schedulingv1beta1.Queue, *schedulingv1beta1.Queue, *schedulingv1beta1.Queue, *schedulingv1beta1.Queue, *schedulingv1beta1.Queue) {
+		root := buildQueueWithParents("root", "", api.BuildResourceList("16", "16Gi", []api.ScalarResource{{Name: "nvidia.com/a100", Value: "4"}, {Name: "rdma", Value: "1000"}}...), nil)
+		project1RootQueue := buildQueueWithParents("project1_root", "root", api.BuildResourceList("", "", []api.ScalarResource{{Name: "nvidia.com/a100", Value: "1"}}...), api.BuildResourceList("", "", []api.ScalarResource{{Name: "nvidia.com/a100", Value: "2"}}...))
+		project1NonPreemptableQueue := buildQueueWithParents("project1_non-preemptable", "project1_root", api.BuildResourceList("", "", []api.ScalarResource{{Name: "nvidia.com/a100", Value: "1"}}...), api.BuildResourceList("", "", []api.ScalarResource{{Name: "nvidia.com/a100", Value: "1"}}...))
+		project1PreemptableQueue := buildQueueWithParents("project1_preemptable", "project1_root", nil, nil)
+		project2RootQueue := buildQueueWithParents("project2_root", "root", api.BuildResourceList("", "", []api.ScalarResource{{Name: "nvidia.com/a100", Value: "3"}}...), api.BuildResourceList("", "", []api.ScalarResource{{Name: "nvidia.com/a100", Value: "4"}}...))
+		project2NonPreemptableQueue := buildQueueWithParents("project2_non-preemptable", "project2_root", api.BuildResourceList("", "", []api.ScalarResource{{Name: "nvidia.com/a100", Value: "3"}}...), api.BuildResourceList("", "", []api.ScalarResource{{Name: "nvidia.com/a100", Value: "3"}}...))
+		project2PreemptableQueue := buildQueueWithParents("project2_preemptable", "project2_root", nil, nil)
+		return root, project1RootQueue, project1NonPreemptableQueue, project1PreemptableQueue, project2RootQueue, project2NonPreemptableQueue, project2PreemptableQueue
+	}
+
+	buildLevelSemanticsTree := func() (*schedulingv1beta1.Queue, *schedulingv1beta1.Queue, *schedulingv1beta1.Queue, *schedulingv1beta1.Queue, *schedulingv1beta1.Queue, *schedulingv1beta1.Queue, *schedulingv1beta1.Queue) {
+		root := buildQueueWithParents("root", "", nil, nil)
+		grandA := buildQueueWithParents("grand-a", "root", api.BuildResourceList("2", "2Gi"), api.BuildResourceList("4", "4Gi"))
+		parentA := buildQueueWithParents("parent-a", "grand-a", api.BuildResourceList("2", "2Gi"), api.BuildResourceList("2", "2Gi"))
+		queueA := buildQueueWithParents("queue-a", "parent-a", api.BuildResourceList("2", "2Gi"), api.BuildResourceList("2", "2Gi"))
+		grandB := buildQueueWithParents("grand-b", "root", api.BuildResourceList("3", "3Gi"), api.BuildResourceList("4", "4Gi"))
+		parentB := buildQueueWithParents("parent-b", "grand-b", api.BuildResourceList("1", "1Gi"), api.BuildResourceList("2", "2Gi"))
+		queueB := buildQueueWithParents("queue-b", "parent-b", api.BuildResourceList("1", "1Gi"), api.BuildResourceList("2", "2Gi"))
+		return root, grandA, parentA, queueA, grandB, parentB, queueB
+	}
+
+	scenarios := []scenario{
+		{
+			name:            "case1: Can reclaim based on parent deserved when ancestorReclaimLevel is 1",
+			level:           1,
+			includePriority: true,
+			build: func(t *testing.T) (nodes []*corev1.Node, pods []*corev1.Pod, pgs []*schedulingv1beta1.PodGroup, queues []*schedulingv1beta1.Queue) {
+				n1 := util.BuildNode("n1", api.BuildResourceList("16", "16Gi", []api.ScalarResource{{Name: "nvidia.com/a100", Value: "4"}, {Name: "rdma/hca", Value: "1001"}, {Name: "pods", Value: "11"}}...), map[string]string{})
+
+				root := buildQueueWithParents("root", "", api.BuildResourceList("16", "16Gi", []api.ScalarResource{{Name: "nvidia.com/a100", Value: "4"}, {Name: "rdma", Value: "1000"}}...), nil)
+				case1Queue1 := buildQueueWithParents("case1_queue1", "root", api.BuildResourceList("", "", []api.ScalarResource{{Name: "nvidia.com/a100", Value: "1"}}...), nil)
+				case1Queue11 := buildQueueWithParents("case1_queue11", "case1_queue1", nil, nil)
+				case1Queue2 := buildQueueWithParents("case1_queue2", "root", nil, nil)
+
+				pg1 := util.BuildPodGroup("pg1", "ns1", "case1_queue2", 1, nil, schedulingv1beta1.PodGroupRunning)
+				pg2 := util.BuildPodGroup("pg2", "ns1", "case1_queue11", 1, nil, schedulingv1beta1.PodGroupInqueue)
+
+				p1 := util.BuildPod("ns1", "p1", "n1", corev1.PodRunning, api.BuildResourceList("1", "1Gi", []api.ScalarResource{{Name: "nvidia.com/a100", Value: "4"}, {Name: "rdma/hca", Value: "1"}}...), "pg1", map[string]string{}, map[string]string{})
+				p2 := util.BuildPod("ns1", "p2", "", corev1.PodPending, api.BuildResourceList("1", "1Gi", []api.ScalarResource{{Name: "nvidia.com/a100", Value: "1"}, {Name: "rdma/hca", Value: "1"}}...), "pg2", map[string]string{}, map[string]string{})
+
+				return []*corev1.Node{n1}, []*corev1.Pod{p1, p2}, []*schedulingv1beta1.PodGroup{pg1, pg2}, []*schedulingv1beta1.Queue{root, case1Queue1, case1Queue11, case1Queue2}
+			},
+			expectPipeLined: map[string][]string{"ns1/pg2": {"n1"}},
+			expectEvicted:   []string{"ns1/p1"},
+			expectEvictNum:  1,
+		},
+		{
+			name:            "case2: Cross-parent reclaim pipelines project1 pending job when project2 child and parent are both over deserved",
+			level:           1,
+			includePriority: true,
+			build: func(t *testing.T) (nodes []*corev1.Node, pods []*corev1.Pod, pgs []*schedulingv1beta1.PodGroup, queues []*schedulingv1beta1.Queue) {
+				n1 := util.BuildNode("n1", api.BuildResourceList("16", "16Gi", []api.ScalarResource{{Name: "nvidia.com/a100", Value: "4"}, {Name: "rdma/hca", Value: "1001"}, {Name: "pods", Value: "11"}}...), map[string]string{})
+
+				root, project1RootQueue, project1NonPreemptableQueue, project1PreemptableQueue, project2RootQueue, project2NonPreemptableQueue, project2PreemptableQueue := buildProjectQueueTree()
+
+				pg1 := util.BuildPodGroup("pg1", "ns1", "project2_preemptable", 1, nil, schedulingv1beta1.PodGroupRunning)
+				pg2 := util.BuildPodGroup("pg2", "ns1", "project2_preemptable", 1, nil, schedulingv1beta1.PodGroupRunning)
+				pg3 := util.BuildPodGroup("pg3", "ns1", "project2_preemptable", 1, nil, schedulingv1beta1.PodGroupRunning)
+				pg4 := util.BuildPodGroup("pg4", "ns1", "project2_preemptable", 1, nil, schedulingv1beta1.PodGroupRunning)
+				pg5 := util.BuildPodGroup("pg5", "ns1", "project1_preemptable", 1, nil, schedulingv1beta1.PodGroupPending)
+
+				priority1, priority2 := int32(1), int32(2)
+				p1 := util.BuildPodWithPriority("ns1", "p1", "n1", corev1.PodRunning, api.BuildResourceList("1", "1Gi", []api.ScalarResource{{Name: "nvidia.com/a100", Value: "1"}, {Name: "rdma/hca", Value: "1"}}...), "pg1", map[string]string{}, map[string]string{}, &priority2)
+				p2 := util.BuildPodWithPriority("ns1", "p2", "n1", corev1.PodRunning, api.BuildResourceList("1", "1Gi", []api.ScalarResource{{Name: "nvidia.com/a100", Value: "1"}, {Name: "rdma/hca", Value: "1"}}...), "pg2", map[string]string{}, map[string]string{}, &priority2)
+				p3 := util.BuildPodWithPriority("ns1", "p3", "n1", corev1.PodRunning, api.BuildResourceList("1", "1Gi", []api.ScalarResource{{Name: "nvidia.com/a100", Value: "1"}, {Name: "rdma/hca", Value: "1"}}...), "pg3", map[string]string{}, map[string]string{}, &priority2)
+				p4 := util.BuildPodWithPriority("ns1", "p4", "n1", corev1.PodRunning, api.BuildResourceList("1", "1Gi", []api.ScalarResource{{Name: "nvidia.com/a100", Value: "1"}, {Name: "rdma/hca", Value: "1"}}...), "pg4", map[string]string{}, map[string]string{}, &priority1)
+				p5 := util.BuildPod("ns1", "p5", "", corev1.PodPending, api.BuildResourceList("1", "1Gi", []api.ScalarResource{{Name: "nvidia.com/a100", Value: "1"}, {Name: "rdma/hca", Value: "1"}}...), "pg5", map[string]string{}, map[string]string{})
+
+				return []*corev1.Node{n1}, []*corev1.Pod{p1, p2, p3, p4, p5}, []*schedulingv1beta1.PodGroup{pg1, pg2, pg3, pg4, pg5}, []*schedulingv1beta1.Queue{root, project1RootQueue, project1NonPreemptableQueue, project1PreemptableQueue, project2RootQueue, project2NonPreemptableQueue, project2PreemptableQueue}
+			},
+			expectPipeLined: map[string][]string{"ns1/pg5": {"n1"}},
+			expectEvicted:   []string{"ns1/p4"},
+			expectEvictNum:  1,
+		},
+		{
+			name:            "case3: Cross-parent reclaim can evict sibling-queue victim first",
+			level:           1,
+			includePriority: true,
+			build: func(t *testing.T) (nodes []*corev1.Node, pods []*corev1.Pod, pgs []*schedulingv1beta1.PodGroup, queues []*schedulingv1beta1.Queue) {
+				n1 := util.BuildNode("n1", api.BuildResourceList("16", "16Gi", []api.ScalarResource{{Name: "nvidia.com/a100", Value: "4"}, {Name: "rdma/hca", Value: "1001"}, {Name: "pods", Value: "11"}}...), map[string]string{})
+
+				root, project1RootQueue, project1NonPreemptableQueue, project1PreemptableQueue, project2RootQueue, project2NonPreemptableQueue, project2PreemptableQueue := buildProjectQueueTree()
+
+				pg1 := util.BuildPodGroup("pg1", "ns1", "project2_preemptable", 1, nil, schedulingv1beta1.PodGroupRunning)
+				pg2 := util.BuildPodGroup("pg2", "ns1", "project2_preemptable", 1, nil, schedulingv1beta1.PodGroupRunning)
+				pg3 := util.BuildPodGroup("pg3", "ns1", "project2_preemptable", 1, nil, schedulingv1beta1.PodGroupRunning)
+				pg4Reclaimed := util.BuildPodGroup("pg4_reclaimed", "ns1", "project2_preemptable", 1, nil, schedulingv1beta1.PodGroupInqueue)
+				pg5Pipelined := util.BuildPodGroup("pg5_pipelined", "ns1", "project1_preemptable", 1, nil, schedulingv1beta1.PodGroupRunning)
+				pg6 := util.BuildPodGroup("pg6", "ns1", "project2_non-preemptable", 1, nil, schedulingv1beta1.PodGroupPending)
+
+				priority2 := int32(2)
+				p1 := util.BuildPodWithPriority("ns1", "p1", "n1", corev1.PodRunning, api.BuildResourceList("1", "1Gi", []api.ScalarResource{{Name: "nvidia.com/a100", Value: "1"}, {Name: "rdma/hca", Value: "1"}}...), "pg1", map[string]string{}, map[string]string{}, &priority2)
+				p2 := util.BuildPodWithPriority("ns1", "p2", "n1", corev1.PodRunning, api.BuildResourceList("1", "1Gi", []api.ScalarResource{{Name: "nvidia.com/a100", Value: "1"}, {Name: "rdma/hca", Value: "1"}}...), "pg2", map[string]string{}, map[string]string{}, &priority2)
+				p3 := util.BuildPodWithPriority("ns1", "p3", "n1", corev1.PodRunning, api.BuildResourceList("1", "1Gi", []api.ScalarResource{{Name: "nvidia.com/a100", Value: "1"}, {Name: "rdma/hca", Value: "1"}}...), "pg3", map[string]string{}, map[string]string{}, &priority2)
+				p4Reclaimed := util.BuildPod("ns1", "p4", "", corev1.PodPending, api.BuildResourceList("1", "1Gi", []api.ScalarResource{{Name: "nvidia.com/a100", Value: "1"}, {Name: "rdma/hca", Value: "1"}}...), "pg4_reclaimed", map[string]string{}, map[string]string{})
+				p5Pipelined := util.BuildPod("ns1", "p5", "n1", corev1.PodRunning, api.BuildResourceList("1", "1Gi", []api.ScalarResource{{Name: "nvidia.com/a100", Value: "1"}, {Name: "rdma/hca", Value: "1"}}...), "pg5_pipelined", map[string]string{}, map[string]string{})
+				p6 := util.BuildPod("ns1", "p6", "", corev1.PodPending, api.BuildResourceList("1", "1Gi", []api.ScalarResource{{Name: "nvidia.com/a100", Value: "1"}, {Name: "rdma/hca", Value: "1"}}...), "pg6", map[string]string{}, map[string]string{})
+
+				return []*corev1.Node{n1}, []*corev1.Pod{p1, p2, p3, p4Reclaimed, p5Pipelined, p6}, []*schedulingv1beta1.PodGroup{pg1, pg2, pg3, pg4Reclaimed, pg5Pipelined, pg6}, []*schedulingv1beta1.Queue{root, project1RootQueue, project1NonPreemptableQueue, project1PreemptableQueue, project2RootQueue, project2NonPreemptableQueue, project2PreemptableQueue}
+			},
+			expectPipeLined: map[string][]string{"ns1/pg6": {"n1"}},
+			expectEvicted:   []string{"ns1/p3"},
+			expectEvictNum:  1,
+		},
+		{
+			name:            "case4: Cross-parent reclaim is blocked when victim child is not over deserved",
+			level:           1,
+			includePriority: true,
+			build: func(t *testing.T) (nodes []*corev1.Node, pods []*corev1.Pod, pgs []*schedulingv1beta1.PodGroup, queues []*schedulingv1beta1.Queue) {
+				n1 := util.BuildNode("n1", api.BuildResourceList("8", "8Gi", []api.ScalarResource{{Name: "nvidia.com/a100", Value: "1"}, {Name: "rdma/hca", Value: "1001"}, {Name: "pods", Value: "11"}}...), map[string]string{})
+
+				root := buildQueueWithParents("root", "", api.BuildResourceList("16", "16Gi", []api.ScalarResource{{Name: "nvidia.com/a100", Value: "4"}, {Name: "rdma", Value: "1000"}}...), nil)
+				case4Parent1 := buildQueueWithParents("case4_parent1", "root", api.BuildResourceList("", "", []api.ScalarResource{{Name: "nvidia.com/a100", Value: "1"}}...), nil)
+				case4Child1 := buildQueueWithParents("case4_child1", "case4_parent1", api.BuildResourceList("", "", []api.ScalarResource{{Name: "nvidia.com/a100", Value: "1"}}...), nil)
+				case4Child1Sibling := buildQueueWithParents("case4_child1_sibling", "case4_parent1", nil, nil)
+				case4Parent2 := buildQueueWithParents("case4_parent2", "root", api.BuildResourceList("", "", []api.ScalarResource{{Name: "nvidia.com/a100", Value: "1"}}...), nil)
+				case4Child2 := buildQueueWithParents("case4_child2", "case4_parent2", api.BuildResourceList("", "", []api.ScalarResource{{Name: "nvidia.com/a100", Value: "1"}}...), nil)
+
+				pg1 := util.BuildPodGroup("pg1", "ns1", "case4_child1", 1, nil, schedulingv1beta1.PodGroupRunning)
+				pg2 := util.BuildPodGroup("pg2", "ns1", "case4_child2", 1, nil, schedulingv1beta1.PodGroupPending)
+				pg3 := util.BuildPodGroup("pg3", "ns1", "case4_child1_sibling", 1, nil, schedulingv1beta1.PodGroupRunning)
+
+				p1 := util.BuildPod("ns1", "p1", "n1", corev1.PodRunning, api.BuildResourceList("1", "1Gi", []api.ScalarResource{{Name: "nvidia.com/a100", Value: "1"}, {Name: "rdma/hca", Value: "1"}}...), "pg1", map[string]string{}, map[string]string{})
+				p2 := util.BuildPod("ns1", "p2", "", corev1.PodPending, api.BuildResourceList("1", "1Gi", []api.ScalarResource{{Name: "nvidia.com/a100", Value: "1"}, {Name: "rdma/hca", Value: "1"}}...), "pg2", map[string]string{}, map[string]string{})
+				p3 := util.BuildPod("ns1", "p3", "n1", corev1.PodRunning, api.BuildResourceList("1", "1Gi", []api.ScalarResource{{Name: "nvidia.com/a100", Value: "1"}, {Name: "rdma/hca", Value: "1"}}...), "pg3", map[string]string{schedulingv1beta1.PodPreemptable: "false"}, map[string]string{})
+
+				return []*corev1.Node{n1}, []*corev1.Pod{p1, p2, p3}, []*schedulingv1beta1.PodGroup{pg1, pg2, pg3}, []*schedulingv1beta1.Queue{root, case4Parent1, case4Child1, case4Child1Sibling, case4Parent2, case4Child2}
+			},
+			expectPipeLined: map[string][]string{},
+			expectEvicted:   []string{},
+			expectEvictNum:  0,
+		},
+		{
+			name:            "case5: level 0 allows reclaim based on leaf-level deserved checks",
+			level:           0,
+			includePriority: false,
+			build: func(t *testing.T) (nodes []*corev1.Node, pods []*corev1.Pod, pgs []*schedulingv1beta1.PodGroup, queues []*schedulingv1beta1.Queue) {
+				n1 := util.BuildNode("n1", api.BuildResourceList("2", "2Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), map[string]string{})
+				root, grandA, parentA, queueA, grandB, parentB, queueB := buildLevelSemanticsTree()
+				pVictim := util.BuildPod("ns1", "p-victim", "n1", corev1.PodRunning, api.BuildResourceList("2", "2Gi"), "pg-victim", nil, nil)
+				pReclaimer := util.BuildPod("ns1", "p-reclaimer", "", corev1.PodPending, api.BuildResourceList("2", "2Gi"), "pg-reclaimer", nil, nil)
+				pgVictim := util.BuildPodGroup("pg-victim", "ns1", "queue-b", 1, nil, schedulingv1beta1.PodGroupRunning)
+				pgReclaimer := util.BuildPodGroup("pg-reclaimer", "ns1", "queue-a", 1, nil, schedulingv1beta1.PodGroupInqueue)
+				return []*corev1.Node{n1}, []*corev1.Pod{pVictim, pReclaimer}, []*schedulingv1beta1.PodGroup{pgVictim, pgReclaimer}, []*schedulingv1beta1.Queue{root, grandA, parentA, queueA, grandB, parentB, queueB}
+			},
+			expectPipeLined: map[string][]string{"ns1/pg-reclaimer": {"n1"}},
+			expectEvicted:   []string{"ns1/p-victim"},
+			expectEvictNum:  1,
+		},
+		{
+			name:            "case6: level 1 allows reclaim when parent-level check passes",
+			level:           1,
+			includePriority: false,
+			build: func(t *testing.T) (nodes []*corev1.Node, pods []*corev1.Pod, pgs []*schedulingv1beta1.PodGroup, queues []*schedulingv1beta1.Queue) {
+				n1 := util.BuildNode("n1", api.BuildResourceList("2", "2Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), map[string]string{})
+				root, grandA, parentA, queueA, grandB, parentB, queueB := buildLevelSemanticsTree()
+				pVictim := util.BuildPod("ns1", "p-victim", "n1", corev1.PodRunning, api.BuildResourceList("2", "2Gi"), "pg-victim", nil, nil)
+				pReclaimer := util.BuildPod("ns1", "p-reclaimer", "", corev1.PodPending, api.BuildResourceList("2", "2Gi"), "pg-reclaimer", nil, nil)
+				pgVictim := util.BuildPodGroup("pg-victim", "ns1", "queue-b", 1, nil, schedulingv1beta1.PodGroupRunning)
+				pgReclaimer := util.BuildPodGroup("pg-reclaimer", "ns1", "queue-a", 1, nil, schedulingv1beta1.PodGroupInqueue)
+				return []*corev1.Node{n1}, []*corev1.Pod{pVictim, pReclaimer}, []*schedulingv1beta1.PodGroup{pgVictim, pgReclaimer}, []*schedulingv1beta1.Queue{root, grandA, parentA, queueA, grandB, parentB, queueB}
+			},
+			expectPipeLined: map[string][]string{"ns1/pg-reclaimer": {"n1"}},
+			expectEvicted:   []string{"ns1/p-victim"},
+			expectEvictNum:  1,
+		},
+		{
+			name:            "case7: level 2 blocks reclaim when grandparent-level check fails",
+			level:           2,
+			includePriority: false,
+			build: func(t *testing.T) (nodes []*corev1.Node, pods []*corev1.Pod, pgs []*schedulingv1beta1.PodGroup, queues []*schedulingv1beta1.Queue) {
+				n1 := util.BuildNode("n1", api.BuildResourceList("2", "2Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), map[string]string{})
+				root, grandA, parentA, queueA, grandB, parentB, queueB := buildLevelSemanticsTree()
+				pVictim := util.BuildPod("ns1", "p-victim", "n1", corev1.PodRunning, api.BuildResourceList("2", "2Gi"), "pg-victim", nil, nil)
+				pReclaimer := util.BuildPod("ns1", "p-reclaimer", "", corev1.PodPending, api.BuildResourceList("2", "2Gi"), "pg-reclaimer", nil, nil)
+				pgVictim := util.BuildPodGroup("pg-victim", "ns1", "queue-b", 1, nil, schedulingv1beta1.PodGroupRunning)
+				pgReclaimer := util.BuildPodGroup("pg-reclaimer", "ns1", "queue-a", 1, nil, schedulingv1beta1.PodGroupInqueue)
+				return []*corev1.Node{n1}, []*corev1.Pod{pVictim, pReclaimer}, []*schedulingv1beta1.PodGroup{pgVictim, pgReclaimer}, []*schedulingv1beta1.Queue{root, grandA, parentA, queueA, grandB, parentB, queueB}
+			},
+			expectPipeLined: map[string][]string{},
+			expectEvicted:   []string{},
+			expectEvictNum:  0,
+		},
+		{
+			name:            "case8: level 1 blocks sibling reclaim when leaf deserved is unset and no ancestor gate applies",
+			level:           1,
+			includePriority: false,
+			build: func(t *testing.T) (nodes []*corev1.Node, pods []*corev1.Pod, pgs []*schedulingv1beta1.PodGroup, queues []*schedulingv1beta1.Queue) {
+				n1 := util.BuildNode("n1", api.BuildResourceList("2", "2Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), map[string]string{})
+				root := buildQueueWithParents("root", "", nil, nil)
+				parent := buildQueueWithParents("parent", "root", api.BuildResourceList("4", "4Gi"), api.BuildResourceList("4", "4Gi"))
+				queueA := buildQueueWithParents("queue-a", "parent", nil, nil)
+				queueB := buildQueueWithParents("queue-b", "parent", nil, nil)
+				pVictim := util.BuildPod("ns1", "p-victim", "n1", corev1.PodRunning, api.BuildResourceList("2", "2Gi"), "pg-victim", nil, nil)
+				pReclaimer := util.BuildPod("ns1", "p-reclaimer", "", corev1.PodPending, api.BuildResourceList("2", "2Gi"), "pg-reclaimer", nil, nil)
+				pgVictim := util.BuildPodGroup("pg-victim", "ns1", "queue-b", 1, nil, schedulingv1beta1.PodGroupRunning)
+				pgReclaimer := util.BuildPodGroup("pg-reclaimer", "ns1", "queue-a", 1, nil, schedulingv1beta1.PodGroupInqueue)
+				return []*corev1.Node{n1}, []*corev1.Pod{pVictim, pReclaimer}, []*schedulingv1beta1.PodGroup{pgVictim, pgReclaimer}, []*schedulingv1beta1.Queue{root, parent, queueA, queueB}
+			},
+			expectPipeLined: map[string][]string{},
+			expectEvicted:   []string{},
+			expectEvictNum:  0,
+		},
+		{
+			name:            "case9: level 2 blocks reclaim when leaf deserved is unset and queues share grandparent",
+			level:           2,
+			includePriority: false,
+			build: func(t *testing.T) (nodes []*corev1.Node, pods []*corev1.Pod, pgs []*schedulingv1beta1.PodGroup, queues []*schedulingv1beta1.Queue) {
+				n1 := util.BuildNode("n1", api.BuildResourceList("2", "2Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), map[string]string{})
+				root := buildQueueWithParents("root", "", nil, nil)
+				grand := buildQueueWithParents("grand", "root", api.BuildResourceList("2", "2Gi"), api.BuildResourceList("2", "2Gi"))
+				parentA := buildQueueWithParents("parent-a", "grand", nil, nil)
+				queueA := buildQueueWithParents("queue-a", "parent-a", nil, nil)
+				parentB := buildQueueWithParents("parent-b", "grand", nil, nil)
+				queueB := buildQueueWithParents("queue-b", "parent-b", nil, nil)
+				pVictim := util.BuildPod("ns1", "p-victim", "n1", corev1.PodRunning, api.BuildResourceList("2", "2Gi"), "pg-victim", nil, nil)
+				pReclaimer := util.BuildPod("ns1", "p-reclaimer", "", corev1.PodPending, api.BuildResourceList("2", "2Gi"), "pg-reclaimer", nil, nil)
+				pgVictim := util.BuildPodGroup("pg-victim", "ns1", "queue-b", 1, nil, schedulingv1beta1.PodGroupRunning)
+				pgReclaimer := util.BuildPodGroup("pg-reclaimer", "ns1", "queue-a", 1, nil, schedulingv1beta1.PodGroupInqueue)
+				return []*corev1.Node{n1}, []*corev1.Pod{pVictim, pReclaimer}, []*schedulingv1beta1.PodGroup{pgVictim, pgReclaimer}, []*schedulingv1beta1.Queue{root, grand, parentA, queueA, parentB, queueB}
+			},
+			expectPipeLined: map[string][]string{},
+			expectEvicted:   []string{},
+			expectEvictNum:  0,
+		},
+		{
+			name:            "case10: level 2 blocks reclaim in unbalanced shared-grandparent tree when leaf deserved is unset",
+			level:           2,
+			includePriority: false,
+			build: func(t *testing.T) (nodes []*corev1.Node, pods []*corev1.Pod, pgs []*schedulingv1beta1.PodGroup, queues []*schedulingv1beta1.Queue) {
+				n1 := util.BuildNode("n1", api.BuildResourceList("2", "2Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), map[string]string{})
+				root := buildQueueWithParents("root", "", nil, nil)
+				grand := buildQueueWithParents("grand", "root", api.BuildResourceList("1", "1Gi"), api.BuildResourceList("2", "2Gi"))
+				parentDeep := buildQueueWithParents("parent-deep", "grand", api.BuildResourceList("1", "1Gi"), api.BuildResourceList("2", "2Gi"))
+				queueDeep := buildQueueWithParents("queue-deep", "parent-deep", nil, nil)
+				queueShallow := buildQueueWithParents("queue-shallow", "grand", nil, nil)
+				pVictim := util.BuildPod("ns1", "p-victim", "n1", corev1.PodRunning, api.BuildResourceList("2", "2Gi"), "pg-victim", nil, nil)
+				pReclaimer := util.BuildPod("ns1", "p-reclaimer", "", corev1.PodPending, api.BuildResourceList("2", "2Gi"), "pg-reclaimer", nil, nil)
+				pgVictim := util.BuildPodGroup("pg-victim", "ns1", "queue-deep", 1, nil, schedulingv1beta1.PodGroupRunning)
+				pgReclaimer := util.BuildPodGroup("pg-reclaimer", "ns1", "queue-shallow", 1, nil, schedulingv1beta1.PodGroupInqueue)
+				return []*corev1.Node{n1}, []*corev1.Pod{pVictim, pReclaimer}, []*schedulingv1beta1.PodGroup{pgVictim, pgReclaimer}, []*schedulingv1beta1.Queue{root, grand, parentDeep, queueDeep, queueShallow}
+			},
+			expectPipeLined: map[string][]string{},
+			expectEvicted:   []string{},
+			expectEvictNum:  0,
+		},
+		{
+			name:            "case11: unbalanced level2 blocks reclaim when depth-2 ancestor is not over deserved",
+			level:           2,
+			includePriority: false,
+			build: func(t *testing.T) (nodes []*corev1.Node, pods []*corev1.Pod, pgs []*schedulingv1beta1.PodGroup, queues []*schedulingv1beta1.Queue) {
+				n1 := util.BuildNode("n1", api.BuildResourceList("4", "4Gi", []api.ScalarResource{{Name: "pods", Value: "10"}, {Name: "nvidia.com/a100", Value: "2"}}...), map[string]string{})
+				root := buildQueueWithParents("root", "", nil, nil)
+				shallowParent := buildQueueWithParents("shallow-parent", "root", api.BuildResourceList("", "", []api.ScalarResource{{Name: "nvidia.com/a100", Value: "1"}}...), nil)
+				queueShallow := buildQueueWithParents("queue-shallow", "shallow-parent", api.BuildResourceList("", "", []api.ScalarResource{{Name: "nvidia.com/a100", Value: "1"}}...), nil)
+				deepGrand := buildQueueWithParents("deep-grand", "root", api.BuildResourceList("", "", []api.ScalarResource{{Name: "nvidia.com/a100", Value: "2"}}...), nil)
+				deepParent := buildQueueWithParents("deep-parent", "deep-grand", api.BuildResourceList("", "", []api.ScalarResource{{Name: "nvidia.com/a100", Value: "1"}}...), nil)
+				queueDeep := buildQueueWithParents("queue-deep", "deep-parent", api.BuildResourceList("", "", []api.ScalarResource{{Name: "nvidia.com/a100", Value: "1"}}...), nil)
+				pVictim := util.BuildPod("ns1", "p-victim", "n1", corev1.PodRunning, api.BuildResourceList("1", "1Gi", []api.ScalarResource{{Name: "nvidia.com/a100", Value: "2"}}...), "pg-victim", nil, nil)
+				pReclaimer := util.BuildPod("ns1", "p-reclaimer", "", corev1.PodPending, api.BuildResourceList("1", "1Gi", []api.ScalarResource{{Name: "nvidia.com/a100", Value: "1"}}...), "pg-reclaimer", nil, nil)
+				pgVictim := util.BuildPodGroup("pg-victim", "ns1", "queue-deep", 1, nil, schedulingv1beta1.PodGroupRunning)
+				pgReclaimer := util.BuildPodGroup("pg-reclaimer", "ns1", "queue-shallow", 1, nil, schedulingv1beta1.PodGroupInqueue)
+				return []*corev1.Node{n1}, []*corev1.Pod{pVictim, pReclaimer}, []*schedulingv1beta1.PodGroup{pgVictim, pgReclaimer}, []*schedulingv1beta1.Queue{root, shallowParent, queueShallow, deepGrand, deepParent, queueDeep}
+			},
+			expectPipeLined: map[string][]string{},
+			expectEvicted:   []string{},
+			expectEvictNum:  0,
+		},
+	}
+
+	for i, sc := range scenarios {
+		t.Run(sc.name, func(t *testing.T) {
+			nodes, pods, pgs, queues := sc.build(t)
+			test := uthelper.TestCommonStruct{
+				Name:            sc.name,
+				Plugins:         plugins,
+				Nodes:           nodes,
+				Pods:            pods,
+				PodGroups:       pgs,
+				Queues:          queues,
+				ExpectPipeLined: sc.expectPipeLined,
+				ExpectEvicted:   sc.expectEvicted,
+				ExpectEvictNum:  sc.expectEvictNum,
+				ExpectBindsNum:  sc.expectBindsNum,
+				ExpectBindMap:   sc.expectBindMap,
+			}
+			tiers := buildTier(sc.level, sc.includePriority)
 			test.RegisterSession(tiers, nil)
 			defer test.Close()
 			test.Run(actions)


### PR DESCRIPTION
#### What type of PR is this?
/kind feature
/area scheduling

#### What this PR does / why we need it:
This PR mainly ports and adapts https://github.com/volcano-sh/volcano/pull/5111 from parent-based reclaim semantics to `ancestorReclaimLevel` in the capacity plugin.

From design perspective only **one** shall be merged from:
- https://github.com/volcano-sh/volcano/pull/5111
- https://github.com/volcano-sh/volcano/pull/5115

The capacity plugin now has an `ancestorReclaimLevel` configuration to support ancestor-based reclaim behavior in hierarchical queues, so child queues can reclaim borrowed resources through configured parent/grandparent ancestor constraints.

It also updates `ReclaimableFn` victim processing to use `BuildVictimsPriorityQueue`, aligning reclaim victim selection with scheduler victim-ordering semantics.

The PR has a comprehensive test plan, but `Test_capacityPlugin_OnSessionOpenWithHierarchy` remains baseline (`case0`-`case12`), and ancestor-specific reclaim coverage is centralized in `Test_capacityPlugin_AncestorReclaimScenarios`.

#### Which issue(s) this PR fixes:
Fixes #5107

#### Special notes for your reviewer:
- Prerequisite victim-selection commits (from https://github.com/volcano-sh/volcano/pull/5113) are required here for reliable test pass (reclaimee selection will be consistent with it):
  - `ebbab911d` — enhancement(victim selection): add job ordering tie-break with task order
  - `2474cfcc9` — test(victim selection): add tie-break coverage in framework_test package
  - `f5e049e43` — test(victim selection): strengthen tie-break proof and update docs
- Commits are split by scope:
  - code: `d046371ff`
  - tests: `05e48f9c7`
  - docs: `00e8d36ae`
  - review docs clarification: `717aeace6`
- AI usage disclosure:
  - This PR is heavily AI-written, then thoroughly hammered and refined for correctness and quality.
  - Rhyme:
    Volcano wakes where hot clouds swirl,
    Queues reclaim in a steady curl;
    Ancestors guide the fairness flow,
    So borrowed sparks return and glow.

#### Does this PR introduce a user-facing change?
```release-note
feat(capacity): add ancestorReclaimLevel to control ancestor-based reclaim behavior in hierarchical queues
```