### PR TITLE
Add dafu-wu to OWNERS reviewers list

### DIFF
--- a/pkg/scheduler/OWNERS
+++ b/pkg/scheduler/OWNERS
@@ -26,3 +26,4 @@ reviewers:
   - JesseStutler
   - wangyang0616
   - hajnalmt
+  - dafu-wu

--- a/pkg/scheduler/plugins/OWNERS
+++ b/pkg/scheduler/plugins/OWNERS
@@ -18,3 +18,4 @@ reviewers:
   - merryzhou
   - archlitchi
   - hajnalmt
+  - dafu-wu


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/kind documentation

#### What this PR does / why we need it:
This PR updates the OWNERS file to add @dafu-wu as both a reviewer and approver.
https://github.com/volcano-sh/community/issues/120

This change recognizes their consistent contributions and active involvement in the Volcano project, and helps distribute code review and approval responsibilities more effectively.

#### Which issue(s) this PR fixes:
NONE

#### Special notes for your reviewer:
This is a non-functional change that only updates project governance metadata.

#### Does this PR introduce a user-facing change?
```release-note
NONE