### PR TITLE
fix(scheduler): remove node from cache when node selector no longer matches

### DIFF
--- a/pkg/scheduler/cache/event_handlers.go
+++ b/pkg/scheduler/cache/event_handlers.go
@@ -621,6 +621,15 @@ func (sc *SchedulerCache) SyncNode(nodeName string) error {
 	}
 
 	if !sc.nodeCanAddCache(node) {
+		// If node exists in cache but no longer matches node selector, remove it
+		if _, exists := sc.Nodes[nodeName]; exists {
+			if deleteErr := sc.RemoveNode(nodeName); deleteErr != nil {
+				klog.Errorf("Failed to remove node <%s> from cache that no longer matches node selector: %s",
+					nodeName, deleteErr.Error())
+				return deleteErr
+			}
+			klog.V(3).Infof("Node <%s> no longer matches node selector, removed from cache.", nodeName)
+		}
 		return nil
 	}
 	nodeCopy := node.DeepCopy()


### PR DESCRIPTION
## Problem
When a node's label is removed and it no longer matches the node selector (--node-selector flag), the scheduler cache was not removing the node, causing pods to still be scheduled to that node.

Fixes #5122

## Solution
In `SyncNode` function, when `nodeCanAddCache` returns false, check if the node exists in cache and remove it if necessary.

## Changes
- Modified `pkg/scheduler/cache/event_handlers.go`
- When node no longer matches node selector but exists in cache, remove it from cache
- Added appropriate error handling and logging

## Testing
- [ ] Remove label from a node that was previously matching node selector
- [ ] Verify node is removed from scheduler cache
- [ ] Verify pods are no longer scheduled to that node