### PR TITLE
fix(scheduler): handle concurrent queue creation in multi-scheduler scenario

### DIFF
--- a/pkg/scheduler/cache/cache.go
+++ b/pkg/scheduler/cache/cache.go
@@ -470,7 +470,7 @@ func newDefaultAndRootQueue(vcClient vcclient.Interface, defaultQueue string) {
 			},
 		}
 
-		return retry.OnError(wait.Backoff{
+		err = retry.OnError(wait.Backoff{
 			Steps:    60,
 			Duration: time.Second,
 			Factor:   1,
@@ -488,6 +488,14 @@ func newDefaultAndRootQueue(vcClient vcclient.Interface, defaultQueue string) {
 			klog.V(2).Infof("Successfully created queue %s", name)
 			return nil
 		})
+
+		// If the queue was created by another scheduler pod concurrently, treat it as success
+		if err != nil && apierrors.IsAlreadyExists(err) {
+			klog.V(2).Infof("Queue %s was created by another scheduler, skip.", name)
+			return nil
+		}
+
+		return err
 	}
 
 	if err := createIfNotExists("root", false); err != nil {


### PR DESCRIPTION
## Problem

When installing Volcano with two or more scheduler pods (master-slave/leader election mode), they will concurrently try to create the default and root queues in the `newDefaultAndRootQueue` function before the leader election process.

Such concurrency causes some pods to:
1. Try to create the queue
2. Fail with `AlreadyExists` error (because another pod created it)
3. Return the error from `retry.OnError`
4. Call `klog.Fatalf` and panic
5. Restart repeatedly

## Solution

Handle the `AlreadyExists` error gracefully after `retry.OnError` completes:

```go
// If the queue was created by another scheduler pod concurrently, treat it as success
if err != nil && apierrors.IsAlreadyExists(err) {
    klog.V(2).Infof("Queue %s was created by another scheduler, skip.", name)
    return nil
}
```

This treats the `AlreadyExists` error as a success case since the queue now exists (created by another scheduler), preventing the scheduler pod from panicking.

## Changes

- Added check for `AlreadyExists` error after `retry.OnError` in `newDefaultAndRootQueue`
- If queue already exists, treat as success instead of returning error
- Added appropriate log message

## Testing

- [ ] Deploy multiple scheduler pods simultaneously
- [ ] Verify no scheduler pods panic due to queue creation conflict
- [ ] Verify both root and default queues are created successfully

## Related Issue

Fixes #5074

/cc @JesseStutler
