### PR TITLE
  fix(scheduler): guard within-job preemption commit with JobPipeline check

### DIFF
--- a/pkg/scheduler/actions/preempt/preempt.go
+++ b/pkg/scheduler/actions/preempt/preempt.go
@@ -279,7 +279,6 @@ func (pmpt *Action) Execute(ssn *framework.Session) {
 				}
 
 				// Only commit if preemption was successful, otherwise discard to rollback evictions.
-				// This is consistent with between-job preemption which checks JobPipelined before committing.
 				if !assigned {
 					stmt.Discard()
 					break


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Fixes within-job preemption to only commit evictions when the job actually becomes pipelined, preventing unnecessary victim pod churn and API-server load.

Previously, each task preemption created a separate Statement and committed immediately, regardless of whether the overall job could schedule. This caused evicted pods to be recreated by the job controller, leading to thrashing loops when resources were insufficient.

Now, we accumulate all preemptions into one Statement per job and only commit if `ssn.JobPipelined(job)` returns true — matching the existing cross-queue preemption pattern.

#### Which issue(s) this PR fixes:

Fixes #NA

#### Special notes for your reviewer:

The fix mirrors the cross-queue preemption logic at lines 215-221. The redundant `_, found := preemptorTasks[job.UID]` check was also removed (always true after the outer map check).

#### Does this PR introduce a user-facing change?

```release-note
Fixed within-job preemption to prevent unnecessary victim pod evictions when the preemptor job cannot become schedulable. This reduces pod churn and API-server load in preemption-heavy scenarios.
```