### PR TITLE
enhance: add detailed logging to gang plugin for debugging

### DIFF
--- a/pkg/scheduler/plugins/gang/gang.go
+++ b/pkg/scheduler/plugins/gang/gang.go
@@ -182,10 +182,14 @@ func (gp *gangPlugin) OnSessionOpen(ssn *framework.Session) {
 
 	ssn.AddJobReadyFn(gp.Name(), func(obj interface{}) bool {
 		ji := obj.(*api.JobInfo)
-		if ji.CheckTaskReady() && ji.CheckSubJobReady() && ji.IsReady() {
-			return true
+		isReady := ji.CheckTaskReady() && ji.CheckSubJobReady() && ji.IsReady()
+		if isReady {
+			klog.V(4).Infof("Gang JobReadyFn: job <%s/%s> is ready", ji.Namespace, ji.Name)
+		} else {
+			klog.V(4).Infof("Gang JobReadyFn: job <%s/%s> is NOT ready, taskReady=%v, subJobReady=%v, isReady=%v",
+				ji.Namespace, ji.Name, ji.CheckTaskReady(), ji.CheckSubJobReady(), ji.IsReady())
 		}
-		return false
+		return isReady
 	})
 
 	ssn.AddSubJobReadyFn(gp.Name(), func(obj interface{}) bool {
@@ -216,6 +220,7 @@ func (gp *gangPlugin) OnSessionOpen(ssn *framework.Session) {
 		return ji.IsStarving()
 	}
 	ssn.AddJobStarvingFns(gp.Name(), jobStarvingFn)
+	klog.V(3).Infof("Gang plugin initialized, total jobs: %d, total queues: %d", len(ssn.Jobs), len(ssn.Queues))
 }
 
 func (gp *gangPlugin) OnSessionClose(ssn *framework.Session) {
@@ -240,8 +245,12 @@ func (gp *gangPlugin) OnSessionClose(ssn *framework.Session) {
 				return num + job.ReadyTaskNum()
 			}
 			unreadyTaskCount = job.MinAvailable - schedulableTaskNum()
-			msg := fmt.Sprintf("%v/%v tasks in gang unschedulable: %v",
-				unreadyTaskCount, len(job.Tasks), job.FitError())
+			pendingTaskNames := make([]string, 0)
+			for _, task := range job.TaskStatusIndex[api.Pending] {
+				pendingTaskNames = append(pendingTaskNames, task.Name)
+			}
+			msg := fmt.Sprintf("%v/%v tasks in gang unschedulable, pending tasks: %v. FitError: %v",
+				unreadyTaskCount, len(job.Tasks), pendingTaskNames, job.FitError())
 
 			unScheduleJobCount++
 			if !ssn.IsJobTerminated(job.UID) {
@@ -286,4 +295,20 @@ func (gp *gangPlugin) OnSessionClose(ssn *framework.Session) {
 	}
 
 	metrics.UpdateUnscheduleJobCount(unScheduleJobCount)
+
+	var readyJobCount, unreadyJobCount, terminatedJobCount int
+	for _, job := range ssn.Jobs {
+		if len(job.Tasks) == 0 {
+			continue
+		}
+		if job.IsReady() {
+			readyJobCount++
+		} else if ssn.IsJobTerminated(job.UID) {
+			terminatedJobCount++
+		} else {
+			unreadyJobCount++
+		}
+	}
+	klog.V(3).Infof("Gang OnSessionClose: total jobs: %d, ready: %d, unready: %d, terminated: %d",
+		len(ssn.Jobs), readyJobCount, unreadyJobCount, terminatedJobCount)
 }

--- a/pkg/scheduler/plugins/gang/gang.go
+++ b/pkg/scheduler/plugins/gang/gang.go
@@ -189,7 +189,7 @@ func (gp *gangPlugin) OnSessionOpen(ssn *framework.Session) {
 		if isReady {
 			klog.V(4).Infof("Gang JobReadyFn: job <%s/%s> is ready", ji.Namespace, ji.Name)
 		} else {
-			klog.V(4).Infof("Gang JobReadyFn: job <%s/%s> is NOT ready, taskReady=%v, subJobReady=%v, isReady=%v",
+			klog.V(4).Infof("Gang JobReadyFn: job <%s/%s> is NOT ready, taskReady=%v, subJobReady=%v, minAvailableReady=%v",
 				ji.Namespace, ji.Name, taskReady, subJobReady, jobIsReady)
 		}
 		return isReady
@@ -252,8 +252,16 @@ func (gp *gangPlugin) OnSessionClose(ssn *framework.Session) {
 			for _, task := range job.TaskStatusIndex[api.Pending] {
 				pendingTaskNames = append(pendingTaskNames, task.Name)
 			}
+
+			const maxPendingTasksInMsg = 5
+			pendingInMsg := pendingTaskNames
+			if len(pendingInMsg) > maxPendingTasksInMsg {
+				pendingInMsg = append(pendingInMsg[:maxPendingTasksInMsg], fmt.Sprintf("and %d more", len(pendingInMsg)-maxPendingTasksInMsg))
+			}
 			msg := fmt.Sprintf("%v/%v tasks in gang unschedulable, pending tasks: %v. FitError: %v",
-				unreadyTaskCount, len(job.Tasks), pendingTaskNames, job.FitError())
+				unreadyTaskCount, len(job.Tasks), pendingInMsg, job.FitError())
+			klog.V(3).Infof("Gang OnSessionClose: job <%s/%s> unschedulable, all pending tasks: %v",
+				job.Namespace, job.Name, pendingTaskNames)
 
 			unScheduleJobCount++
 			if !ssn.IsJobTerminated(job.UID) {
@@ -299,19 +307,21 @@ func (gp *gangPlugin) OnSessionClose(ssn *framework.Session) {
 
 	metrics.UpdateUnscheduleJobCount(unScheduleJobCount)
 
+	var totalJobsWithTasks int
 	var readyJobCount, unreadyJobCount, terminatedJobCount int
 	for _, job := range ssn.Jobs {
 		if len(job.Tasks) == 0 {
 			continue
 		}
-		if job.IsReady() {
-			readyJobCount++
-		} else if ssn.IsJobTerminated(job.UID) {
+		totalJobsWithTasks++
+		if ssn.IsJobTerminated(job.UID) {
 			terminatedJobCount++
+		} else if job.IsReady() {
+			readyJobCount++
 		} else {
 			unreadyJobCount++
 		}
 	}
 	klog.V(3).Infof("Gang OnSessionClose: total jobs: %d, ready: %d, unready: %d, terminated: %d",
-		len(ssn.Jobs), readyJobCount, unreadyJobCount, terminatedJobCount)
+		totalJobsWithTasks, readyJobCount, unreadyJobCount, terminatedJobCount)
 }

--- a/pkg/scheduler/plugins/gang/gang.go
+++ b/pkg/scheduler/plugins/gang/gang.go
@@ -182,12 +182,15 @@ func (gp *gangPlugin) OnSessionOpen(ssn *framework.Session) {
 
 	ssn.AddJobReadyFn(gp.Name(), func(obj interface{}) bool {
 		ji := obj.(*api.JobInfo)
-		isReady := ji.CheckTaskReady() && ji.CheckSubJobReady() && ji.IsReady()
+		taskReady := ji.CheckTaskReady()
+		subJobReady := ji.CheckSubJobReady()
+		jobIsReady := ji.IsReady()
+		isReady := taskReady && subJobReady && jobIsReady
 		if isReady {
 			klog.V(4).Infof("Gang JobReadyFn: job <%s/%s> is ready", ji.Namespace, ji.Name)
 		} else {
 			klog.V(4).Infof("Gang JobReadyFn: job <%s/%s> is NOT ready, taskReady=%v, subJobReady=%v, isReady=%v",
-				ji.Namespace, ji.Name, ji.CheckTaskReady(), ji.CheckSubJobReady(), ji.IsReady())
+				ji.Namespace, ji.Name, taskReady, subJobReady, jobIsReady)
 		}
 		return isReady
 	})
@@ -245,7 +248,7 @@ func (gp *gangPlugin) OnSessionClose(ssn *framework.Session) {
 				return num + job.ReadyTaskNum()
 			}
 			unreadyTaskCount = job.MinAvailable - schedulableTaskNum()
-			pendingTaskNames := make([]string, 0)
+			pendingTaskNames := make([]string, 0, len(job.TaskStatusIndex[api.Pending]))
 			for _, task := range job.TaskStatusIndex[api.Pending] {
 				pendingTaskNames = append(pendingTaskNames, task.Name)
 			}


### PR DESCRIPTION
## Summary

- Add initialization log in `OnSessionOpen` with job and queue counts
- Add state tracking log in `JobReadyFn` showing ready/unready reasons
- Add session close summary log with ready/unready/terminated job counts
- Enhance unschedulable path with pending task names in error message

## Test plan

- [ ] Build passes on Linux
- [ ] Gang scheduling behavior unchanged
- [ ] Logs visible at appropriate verbosity levels (V3, V4)