### PR TITLE
fix(capacity): avoid double-counting inqueue resources for jobs with tasks in Binding state

### DIFF
--- a/pkg/scheduler/plugins/capacity/capacity.go
+++ b/pkg/scheduler/plugins/capacity/capacity.go
@@ -508,12 +508,12 @@ func (cp *capacityPlugin) buildQueueAttrs(ssn *framework.Session) {
 			}
 		}
 
-		// calculate inqueue resource for inqueue jobs
-		// deduct already-allocated task resources from minResources to avoid double-counting:
-		// tasks in Allocated/Binding state are already tracked in attr.allocated (via AllocatedStatus),
-		// but the PodGroup stays Inqueue until tasks reach Running/Bound (ScheduledStatus).
-		// Without this deduction, the same resources appear in both attr.allocated and attr.inqueue.
 		if job.PodGroup.Status.Phase == scheduling.PodGroupInqueue {
+			// calculate inqueue resource for inqueue jobs
+			// deduct already-allocated task resources from minResources to avoid double-counting:
+			// tasks in Allocated/Binding state are already tracked in attr.allocated (via AllocatedStatus),
+			// but the PodGroup stays Inqueue until tasks reach Running/Bound (ScheduledStatus).
+			// Without this deduction, the same resources appear in both attr.allocated and attr.inqueue.
 			if job.PodGroup.Spec.MinResources != nil {
 				inqueued := util.GetInqueueResource(job, job.Allocated)
 				attr.inqueue.Add(job.DeductSchGatedResources(inqueued))
@@ -646,9 +646,9 @@ func (cp *capacityPlugin) buildHierarchicalQueueAttrs(ssn *framework.Session) bo
 			}
 		}
 
-		// same double-counting fix as buildQueueAttrs: deduct already-allocated resources
-		// so tasks in Allocated/Binding state are not counted in both attr.allocated and attr.inqueue.
 		if job.PodGroup.Status.Phase == scheduling.PodGroupInqueue {
+			// same double-counting fix as buildQueueAttrs: deduct already-allocated resources
+			// so tasks in Allocated/Binding state are not counted in both attr.allocated and attr.inqueue.
 			if job.PodGroup.Spec.MinResources != nil {
 				inqueued := util.GetInqueueResource(job, job.Allocated)
 				attr.inqueue.Add(job.DeductSchGatedResources(inqueued))

--- a/pkg/scheduler/plugins/capacity/capacity.go
+++ b/pkg/scheduler/plugins/capacity/capacity.go
@@ -508,10 +508,16 @@ func (cp *capacityPlugin) buildQueueAttrs(ssn *framework.Session) {
 			}
 		}
 
+		// calculate inqueue resource for inqueue jobs
+		// deduct already-allocated task resources from minResources to avoid double-counting:
+		// tasks in Allocated/Binding state are already tracked in attr.allocated (via AllocatedStatus),
+		// but the PodGroup stays Inqueue until tasks reach Running/Bound (ScheduledStatus).
+		// Without this deduction, the same resources appear in both attr.allocated and attr.inqueue.
 		if job.PodGroup.Status.Phase == scheduling.PodGroupInqueue {
-			// deduct the resources of scheduling gated tasks in a job when calculating inqueued resources
-			// so that it will not block other jobs from being inqueued.
-			attr.inqueue.Add(job.DeductSchGatedResources(job.GetMinResources()))
+			if job.PodGroup.Spec.MinResources != nil {
+				inqueued := util.GetInqueueResource(job, job.Allocated)
+				attr.inqueue.Add(job.DeductSchGatedResources(inqueued))
+			}
 		}
 
 		// calculate inqueue resource for running jobs
@@ -640,8 +646,13 @@ func (cp *capacityPlugin) buildHierarchicalQueueAttrs(ssn *framework.Session) bo
 			}
 		}
 
+		// same double-counting fix as buildQueueAttrs: deduct already-allocated resources
+		// so tasks in Allocated/Binding state are not counted in both attr.allocated and attr.inqueue.
 		if job.PodGroup.Status.Phase == scheduling.PodGroupInqueue {
-			attr.inqueue.Add(job.DeductSchGatedResources(job.GetMinResources()))
+			if job.PodGroup.Spec.MinResources != nil {
+				inqueued := util.GetInqueueResource(job, job.Allocated)
+				attr.inqueue.Add(job.DeductSchGatedResources(inqueued))
+			}
 		}
 
 		// calculate inqueue resource for running jobs

--- a/pkg/scheduler/plugins/capacity/capacity_test.go
+++ b/pkg/scheduler/plugins/capacity/capacity_test.go
@@ -19,6 +19,7 @@ package capacity
 import (
 	"os"
 	"testing"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -30,6 +31,7 @@ import (
 	"volcano.sh/volcano/pkg/scheduler/actions/enqueue"
 	"volcano.sh/volcano/pkg/scheduler/actions/reclaim"
 	"volcano.sh/volcano/pkg/scheduler/api"
+	"volcano.sh/volcano/pkg/scheduler/cache"
 	"volcano.sh/volcano/pkg/scheduler/conf"
 	"volcano.sh/volcano/pkg/scheduler/framework"
 	"volcano.sh/volcano/pkg/scheduler/plugins/gang"
@@ -1069,5 +1071,131 @@ func Test_buildHierarchicalQueueAttrs_nilSafety(t *testing.T) {
 				t.Fatal(err)
 			}
 		})
+	}
+}
+
+// waitForBinds reads n bind notifications from ch within timeout, failing the
+// test if fewer arrive in time. Returns the set of bound pod keys (namespace/name).
+func waitForBinds(t *testing.T, ch <-chan string, n int, timeout time.Duration) map[string]bool {
+	t.Helper()
+	got := make(map[string]bool, n)
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	for i := 0; i < n; i++ {
+		select {
+		case bind := <-ch:
+			got[bind] = true
+		case <-timer.C:
+			t.Fatalf("timeout waiting for bind %d/%d (got so far: %v)", i+1, n, got)
+		}
+	}
+	return got
+}
+
+// TestNoDoubleCountingForInqueueJobWithBindingTasks is a regression test for the
+// double-counting bug in the capacity plugin, mirroring what was fixed for the
+// proportion plugin in #5100. @hajnalmt flagged this in the review of that PR.
+//
+// The bug: when jobA's tasks move to Binding after an allocate cycle, they are
+// tracked in attr.allocated (Binding ∈ AllocatedStatus). But the PodGroup stays
+// Inqueue because Binding ∉ ScheduledStatus, so buildQueueAttrs adds the full
+// minResources to attr.inqueue on top of what's already in attr.allocated.
+// Queue looks over-capacity, jobB gets rejected even though there's room.
+//
+// This test exercises the real Binding window by running two scheduler cycles:
+// cycle 1 allocates jobA's tasks (leaving them in Binding), then cycle 2
+// enqueues + allocates jobB. With the fix, jobB binds correctly.
+func TestNoDoubleCountingForInqueueJobWithBindingTasks(t *testing.T) {
+	options.Default()
+
+	prevEnabledActionMap := conf.EnabledActionMap
+	conf.EnabledActionMap = map[string]bool{"enqueue": true}
+	defer func() { conf.EnabledActionMap = prevEnabledActionMap }()
+
+	trueValue := true
+	plugins := map[string]framework.PluginBuilder{PluginName: New}
+	uthelper.RegisterPlugins(plugins)
+	defer framework.CleanupPluginBuilders()
+
+	tiers := []conf.Tier{
+		{
+			Plugins: []conf.PluginOption{
+				{
+					Name:               PluginName,
+					EnabledAllocatable: &trueValue,
+					EnabledOverused:    &trueValue,
+					EnabledJobEnqueued: &trueValue,
+				},
+			},
+		},
+	}
+
+	n1 := util.BuildNode("n1", api.BuildResourceList("4", "8Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), nil)
+
+	res1cpu := api.BuildResourceList("1", "1Gi")
+	minRes3cpu := api.BuildResourceList("3", "3Gi")
+	minRes1cpu := api.BuildResourceList("1", "1Gi")
+
+	// jobA: 3 pending tasks, PodGroup already Inqueue. Cycle 1 will allocate these,
+	// moving them to Binding in the cache while pgA stays Inqueue.
+	pgA := util.BuildPodGroup("pgA", "ns1", "q1", 3, nil, schedulingv1beta1.PodGroupInqueue)
+	pgA.Spec.MinResources = &minRes3cpu
+	pA1 := util.BuildPod("ns1", "pA1", "", corev1.PodPending, res1cpu, "pgA", nil, nil)
+	pA2 := util.BuildPod("ns1", "pA2", "", corev1.PodPending, res1cpu, "pgA", nil, nil)
+	pA3 := util.BuildPod("ns1", "pA3", "", corev1.PodPending, res1cpu, "pgA", nil, nil)
+
+	// jobB: 1 pending task. 1 CPU is free after jobA takes 3, so it should be
+	// enqueued and bound in cycle 2. The double-counting bug makes the queue appear
+	// at 6/4 CPU and rejects it.
+	pgB := util.BuildPodGroup("pgB", "ns1", "q1", 1, nil, schedulingv1beta1.PodGroupPending)
+	pgB.Spec.MinResources = &minRes1cpu
+	pB1 := util.BuildPod("ns1", "pB1", "", corev1.PodPending, res1cpu, "pgB", nil, nil)
+
+	q1 := util.BuildQueueWithResourcesQuantity("q1", nil, api.BuildResourceList("4", "8Gi"))
+
+	binder := util.NewFakeBinder(10)
+	evictor := util.NewFakeEvictor(0)
+	statusUpdater := &util.FakeStatusUpdater{}
+	stop := make(chan struct{})
+	defer close(stop)
+
+	sc := cache.NewCustomMockSchedulerCache("test-capacity", binder, evictor, statusUpdater, nil, nil)
+	sc.Run(stop)
+	sc.AddOrUpdateNode(n1)
+	// Only jobA in cache for cycle 1 so jobB can't accidentally get scheduled early.
+	sc.AddPod(pA1)
+	sc.AddPod(pA2)
+	sc.AddPod(pA3)
+	sc.AddPodGroupV1beta1(pgA)
+	sc.AddQueueV1beta1(q1)
+
+	// Cycle 1: allocate jobA. After this pA1/pA2/pA3 are Binding in cache,
+	// pgA stays Inqueue (Binding ∉ ScheduledStatus).
+	ssn1 := framework.OpenSession(sc, tiers, nil)
+	allocate.New().Execute(ssn1)
+	framework.CloseSession(ssn1)
+
+	cycle1 := waitForBinds(t, binder.Channel, 3, 5*time.Second)
+	for _, pod := range []string{"ns1/pA1", "ns1/pA2", "ns1/pA3"} {
+		if !cycle1[pod] {
+			t.Errorf("expected %s bound in cycle 1, got %v", pod, cycle1)
+		}
+	}
+
+	// Now add jobB. Cache state: pA1/pA2/pA3 Binding, pgA Inqueue, 1 CPU free.
+	sc.AddPod(pB1)
+	sc.AddPodGroupV1beta1(pgB)
+
+	// Cycle 2: enqueue + allocate.
+	// Correct (fix applied):  allocated=3CPU, inqueue=max(0,3-3)=0 → 1+3+0=4 ≤ 4 → jobB bound.
+	// Buggy (pre-fix):        allocated=3CPU, inqueue=3CPU         → 1+3+3=7 > 4 → jobB rejected.
+	ssn2 := framework.OpenSession(sc, tiers, nil)
+	enqueue.New().Execute(ssn2)
+	allocate.New().Execute(ssn2)
+	framework.CloseSession(ssn2)
+
+	cycle2 := waitForBinds(t, binder.Channel, 1, 5*time.Second)
+	if !cycle2["ns1/pB1"] {
+		t.Errorf("regression: pB1 not bound in cycle 2 (got %v) — capacity plugin double-counting inqueue resources for pgA with tasks in Binding", cycle2)
 	}
 }

--- a/pkg/scheduler/plugins/capacity/capacity_test.go
+++ b/pkg/scheduler/plugins/capacity/capacity_test.go
@@ -1074,27 +1074,8 @@ func Test_buildHierarchicalQueueAttrs_nilSafety(t *testing.T) {
 	}
 }
 
-// waitForBinds reads n bind notifications from ch within timeout, failing the
-// test if fewer arrive in time. Returns the set of bound pod keys (namespace/name).
-func waitForBinds(t *testing.T, ch <-chan string, n int, timeout time.Duration) map[string]bool {
-	t.Helper()
-	got := make(map[string]bool, n)
-	timer := time.NewTimer(timeout)
-	defer timer.Stop()
-	for i := 0; i < n; i++ {
-		select {
-		case bind := <-ch:
-			got[bind] = true
-		case <-timer.C:
-			t.Fatalf("timeout waiting for bind %d/%d (got so far: %v)", i+1, n, got)
-		}
-	}
-	return got
-}
-
-// TestNoDoubleCountingForInqueueJobWithBindingTasks is a regression test for the
-// double-counting bug in the capacity plugin, mirroring what was fixed for the
-// proportion plugin in #5100. @hajnalmt flagged this in the review of that PR.
+// TestNoDoubleCountingForInqueueJobWithBindingTasks is a regression test for a
+// double-counting bug in the capacity plugin.
 //
 // The bug: when jobA's tasks move to Binding after an allocate cycle, they are
 // tracked in attr.allocated (Binding ∈ AllocatedStatus). But the PodGroup stays
@@ -1175,7 +1156,7 @@ func TestNoDoubleCountingForInqueueJobWithBindingTasks(t *testing.T) {
 	allocate.New().Execute(ssn1)
 	framework.CloseSession(ssn1)
 
-	cycle1 := waitForBinds(t, binder.Channel, 3, 5*time.Second)
+	cycle1 := uthelper.WaitForBinds(t, binder.Channel, 3, 5*time.Second)
 	for _, pod := range []string{"ns1/pA1", "ns1/pA2", "ns1/pA3"} {
 		if !cycle1[pod] {
 			t.Errorf("expected %s bound in cycle 1, got %v", pod, cycle1)
@@ -1194,7 +1175,7 @@ func TestNoDoubleCountingForInqueueJobWithBindingTasks(t *testing.T) {
 	allocate.New().Execute(ssn2)
 	framework.CloseSession(ssn2)
 
-	cycle2 := waitForBinds(t, binder.Channel, 1, 5*time.Second)
+	cycle2 := uthelper.WaitForBinds(t, binder.Channel, 1, 5*time.Second)
 	if !cycle2["ns1/pB1"] {
 		t.Errorf("regression: pB1 not bound in cycle 2 (got %v) — capacity plugin double-counting inqueue resources for pgA with tasks in Binding", cycle2)
 	}

--- a/pkg/scheduler/plugins/proportion/proportion_test.go
+++ b/pkg/scheduler/plugins/proportion/proportion_test.go
@@ -47,24 +47,6 @@ import (
 	"volcano.sh/volcano/pkg/scheduler/util"
 )
 
-// waitForBinds reads exactly n items from ch within deadline and returns them.
-// It fails the test if fewer than n items arrive within the timeout.
-func waitForBinds(t *testing.T, ch <-chan string, n int, timeout time.Duration) map[string]bool {
-	t.Helper()
-	got := make(map[string]bool, n)
-	timer := time.NewTimer(timeout)
-	defer timer.Stop()
-	for i := 0; i < n; i++ {
-		select {
-		case bind := <-ch:
-			got[bind] = true
-		case <-timer.C:
-			t.Fatalf("timeout waiting for bind #%d/%d (got so far: %v)", i+1, n, got)
-		}
-	}
-	return got
-}
-
 func TestMain(m *testing.M) {
 	options.Default()
 	os.Exit(m.Run())
@@ -616,7 +598,7 @@ func TestNoDoubleCountingForInqueueJobWithBindingTasks(t *testing.T) {
 	framework.CloseSession(ssn1)
 
 	// Wait for all 3 cycle-1 bind notifications and verify they are for jobA.
-	cycle1 := waitForBinds(t, binder.Channel, 3, 5*time.Second)
+	cycle1 := uthelper.WaitForBinds(t, binder.Channel, 3, 5*time.Second)
 	for _, pod := range []string{"ns1/pA1", "ns1/pA2", "ns1/pA3"} {
 		if !cycle1[pod] {
 			t.Errorf("expected %s to be bound in cycle 1, got %v", pod, cycle1)
@@ -639,7 +621,7 @@ func TestNoDoubleCountingForInqueueJobWithBindingTasks(t *testing.T) {
 	allocate.New().Execute(ssn2)
 	framework.CloseSession(ssn2)
 
-	cycle2 := waitForBinds(t, binder.Channel, 1, 5*time.Second)
+	cycle2 := uthelper.WaitForBinds(t, binder.Channel, 1, 5*time.Second)
 	if !cycle2["ns1/pB1"] {
 		t.Errorf("regression: pB1 was not bound in cycle 2 (got %v) — proportion plugin "+
 			"is double-counting inqueue resources for pgA whose tasks are in Binding state", cycle2)

--- a/pkg/scheduler/uthelper/util.go
+++ b/pkg/scheduler/uthelper/util.go
@@ -16,6 +16,11 @@ limitations under the License.
 
 package uthelper
 
+import (
+	"testing"
+	"time"
+)
+
 // Contains compares a key in a slice and returns true if exist in it
 func Contains[T comparable](elements []T, key T) bool {
 	for _, v := range elements {
@@ -24,4 +29,22 @@ func Contains[T comparable](elements []T, key T) bool {
 		}
 	}
 	return false
+}
+
+// WaitForBinds reads exactly n items from ch within timeout and returns them.
+// It fails the test if fewer than n items arrive within the timeout.
+func WaitForBinds(t *testing.T, ch <-chan string, n int, timeout time.Duration) map[string]bool {
+	t.Helper()
+	got := make(map[string]bool, n)
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	for i := 0; i < n; i++ {
+		select {
+		case bind := <-ch:
+			got[bind] = true
+		case <-timer.C:
+			t.Fatalf("timeout waiting for bind #%d/%d (got so far: %v)", i+1, n, got)
+		}
+	}
+	return got
 }


### PR DESCRIPTION
**What type of PR is this?**
Bug fix

**What this PR does / why we need it:**

Follow-up to #5100, same double-counting bug, same fix, but in the capacity plugin. @hajnalmt flagged this during review of that PR.

When a job's tasks land in `Binding`, they show up in `attr.allocated` (because `Binding` is part of `AllocatedStatus`). But the `PodGroup` stays `Inqueue` until those tasks actually reach `Running`, so the `PodGroupInqueue` branch was also adding the full `minResources` to `attr.inqueue`. Same resources counted twice, queue looks over-capacity, other jobs pile up in `Pending` for no reason.

The `PodGroupRunning` branch already does this right, it calls `util.GetInqueueResource(job, job.Allocated)` which subtracts what's already allocated before adding to inqueue. Just needed to do the same for `PodGroupInqueue`. The capacity plugin has this pattern in two places (`buildQueueAttrs` and `buildHierarchicalQueueAttrs`), both fixed here.

**Which issue(s) this PR fixes:**
Fixes #5099

**Special notes for your reviewer:**
Both spots in the capacity plugin are fixed, `buildQueueAttrs` and `buildHierarchicalQueueAttrs`. Logic is identical to what landed in #5100 for proportion, just applied here.

**Does this PR introduce a user-facing change?**

Fix capacity plugin double-counting inqueue resources for jobs with tasks in `Binding` state, which could cause queues to appear over-capacity and block schedulable jobs.