### PR TITLE
Feature: Implement pluggable shard policies for NodeShard controller

### DIFF
--- a/docs/user-guide/how_to_configure_sharding_configmap.md
+++ b/docs/user-guide/how_to_configure_sharding_configmap.md
@@ -27,8 +27,20 @@ The controller is told which ConfigMap to watch via two flags:
 
 ## ConfigMap Format
 
-The configuration is stored under the `sharding.yaml` key inside the
-ConfigMap. The format is:
+Each scheduler declares an ordered list of policies. The framework runs
+`filter → sort → select` per scheduler, dispatching to whichever interface
+each policy implements:
+
+1. **filter** — every Filterer runs; a node passes only when *every* Filterer accepts it (AND-intersection).
+2. **sort** — every Scorer runs; the framework combines scores via
+   `final = Σ (policy.weight × policy.Score(node))` and stable-sorts
+   descending.
+3. **select** — every Selector runs in config order; each receives the
+   previous's output. The built-in `node-limit` Selector truncates to
+   `maxNodes`. `minNodes` is informational only (the framework cannot
+   synthesize nodes that don't exist). Deprecated scheduler-level
+   `minNodes` / `maxNodes` still synthesize `node-limit` for compatibility
+   and emit a warning; new configuration should add `node-limit` explicitly.
 
 ```yaml
 apiVersion: v1
@@ -39,23 +51,65 @@ metadata:
 data:
   sharding.yaml: |
     schedulerConfigs:
-      - name: agent-scheduler
-        type: agent
-        cpuUtilizationMin: 0.7
-        cpuUtilizationMax: 1.0
-        preferWarmupNodes: true
-        minNodes: 1
-        maxNodes: 100
       - name: volcano
         type: volcano
-        cpuUtilizationMin: 0.0
-        cpuUtilizationMax: 0.69
-        preferWarmupNodes: false
-        minNodes: 1
-        maxNodes: 100
+        policies:
+          - name: allocation-rate
+            weight: 1
+            arguments:
+              minCPUUtil: 0.0
+              maxCPUUtil: 0.6
+          - name: warmup
+            weight: 2          # higher weight, prefer warmup nodes first
+            arguments:
+              warmupLabel: "node.volcano.sh/warmup"
+              warmupLabelValue: "true"
+          - name: node-limit
+            arguments:
+              minNodes: 2
+              maxNodes: 100
+
+      - name: agent-scheduler
+        type: agent
+        policies:
+          - name: allocation-rate
+            weight: 1
+            arguments:
+              minCPUUtil: 0.7
+              maxCPUUtil: 1.0
+          - name: warmup
+            weight: 5          # very strong warmup preference for agent shard
+          - name: node-limit
+            arguments:
+              minNodes: 2
+              maxNodes: 50
     shardSyncPeriod: "60s"
     enableNodeEventTrigger: true
 ```
+
+### policies entry reference
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `name` | string | yes | Registered policy name (`allocation-rate`, `warmup`, `node-limit`). |
+| `weight` | int | no (default 1) | Scales the policy's `Score` contribution. Only meaningful for policies that implement Scorer. |
+| `arguments` | map | no | Policy-specific arguments. Use the `node-limit` policy for `minNodes`/`maxNodes`. |
+
+### Built-in policies
+
+- **`allocation-rate`** — implements Filterer + Scorer. Filter rejects nodes
+  outside `[minCPUUtil, maxCPUUtil]` or with missing metrics. Score normalizes
+  CPU utilization within the configured range to `[0, 1]`, so workloads pack
+  onto already-busy nodes.
+- **`warmup`** — implements Scorer only. Returns `1.0` if the node carries
+  the configured warmup label/value, else `0.0`. Combined with `weight: N`,
+  warmup-labeled nodes get a `+N` boost in the weighted sort.
+- **`node-limit`** — implements Selector only. Applies `minNodes` /
+  `maxNodes` from its `arguments`; `maxNodes` truncates the selected nodes,
+  while `minNodes` is informational only.
+
+See `pkg/controllers/sharding/policy/README.md` for the full policy
+framework reference and how to add a custom policy.
 
 ## Parameter Reference
 
@@ -68,11 +122,9 @@ that participates in node sharding. At least one entry is required.
 |-----------|------|----------|-------------|
 | `name` | string | yes | Scheduler name. Must match the `schedulerName` field in NodeShard CRDs. |
 | `type` | string | yes | Scheduler type, e.g. `"volcano"` or `"agent"`. |
-| `cpuUtilizationMin` | float | yes | Lower bound (inclusive) of the CPU utilisation range `[0.0, 1.0]` that makes a node eligible for this scheduler's shard. |
-| `cpuUtilizationMax` | float | yes | Upper bound (inclusive) of the CPU utilisation range. Must be >= `cpuUtilizationMin`. |
-| `preferWarmupNodes` | bool | yes | When `true`, warmup nodes (label: `node.volcano.sh/warmup=true`) are sorted first when selecting shard members. |
-| `minNodes` | int | yes | Minimum number of nodes the shard must contain. Must be >= 0. |
-| `maxNodes` | int | yes | Maximum number of nodes the shard may contain. Must be >= `minNodes`. |
+| `policies` | list | yes | Ordered policy chain. See the ConfigMap Format section above. |
+| `minNodes` | int | no | Deprecated. Still synthesizes `node-limit` for compatibility and logs a warning; use `policies[].arguments.minNodes` on the `node-limit` policy instead. |
+| `maxNodes` | int | no | Deprecated. Still synthesizes `node-limit` for compatibility and logs a warning; use `policies[].arguments.maxNodes` on the `node-limit` policy instead. |
 
 ### Top-level Options
 
@@ -100,20 +152,32 @@ custom:
   sharding_configmap_enable: true
   sharding_configmap_data: |
     schedulerConfigs:
-      - name: agent-scheduler
-        type: agent
-        cpuUtilizationMin: 0.7
-        cpuUtilizationMax: 1.0
-        preferWarmupNodes: true
-        minNodes: 1
-        maxNodes: 100
       - name: volcano
         type: volcano
-        cpuUtilizationMin: 0.0
-        cpuUtilizationMax: 0.69
-        preferWarmupNodes: false
-        minNodes: 1
-        maxNodes: 100
+        policies:
+          - name: allocation-rate
+            weight: 1
+            arguments:
+              minCPUUtil: 0.0
+              maxCPUUtil: 0.6
+          - name: node-limit
+            arguments:
+              minNodes: 1
+              maxNodes: 100
+      - name: agent-scheduler
+        type: agent
+        policies:
+          - name: allocation-rate
+            weight: 1
+            arguments:
+              minCPUUtil: 0.7
+              maxCPUUtil: 1.0
+          - name: warmup
+            weight: 2
+          - name: node-limit
+            arguments:
+              minNodes: 1
+              maxNodes: 100
     shardSyncPeriod: "60s"
     enableNodeEventTrigger: true
 ```
@@ -124,10 +188,12 @@ The controller validates the ConfigMap contents on every load/reload:
 
 1. `schedulerConfigs` must contain at least one entry.
 2. Each entry must have a non-empty `name`.
-3. `cpuUtilizationMin` and `cpuUtilizationMax` must be in `[0.0, 1.0]`.
-4. `cpuUtilizationMin` must be <= `cpuUtilizationMax`.
-5. `minNodes` must be >= 0.
-6. `maxNodes` must be >= `minNodes`.
+3. Deprecated scheduler-level `minNodes` must be >= 0 and `maxNodes` must be
+   >= `minNodes` when present.
+4. Each `policies[].name` must be a registered policy.
+5. `policies[].weight` must be >= 0 (omit for default of 1).
+6. `policies[].arguments` may contain `minNodes` / `maxNodes` only for the
+   `node-limit` policy.
 
 If validation fails, the previous valid configuration is preserved and an
 error is logged.

--- a/pkg/controllers/sharding/config.go
+++ b/pkg/controllers/sharding/config.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The Volcano Authors.
+Copyright 2026 The Volcano Authors.
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -22,6 +22,8 @@ import (
 	"github.com/spf13/pflag"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/yaml"
+
+	"volcano.sh/volcano/pkg/controllers/sharding/policy/allocationrate"
 )
 
 const (
@@ -31,7 +33,33 @@ const (
 	DefaultConfigMapName = "volcano-sharding-configmap"
 	// DefaultConfigMapNamespace is the default namespace of the sharding ConfigMap.
 	DefaultConfigMapNamespace = "volcano-system"
+	// DefaultPolicyName is the policy used when none is specified (backward compatibility).
+	DefaultPolicyName = "allocation-rate"
 )
+
+// preferWarmupNodesDeprecatedMsg is logged when a config sets the deprecated
+// top-level preferWarmupNodes field. The flag is no longer honored by the
+// allocation-rate policy after the pluggable-policy refactor; users who want
+// warmup-aware ordering should switch to policy=warmup.
+const preferWarmupNodesDeprecatedMsg = "scheduler %q: preferWarmupNodes is no longer honored by the allocation-rate policy; " +
+	"use policy=warmup to prioritize warmup nodes"
+
+const nodeLimitScalarsDeprecatedMsg = "scheduler %q: scheduler-level minNodes/maxNodes are deprecated; " +
+	"configure the node-limit policy with minNodes/maxNodes arguments instead"
+
+// PolicySpec is one policy entry in a scheduler's policy chain. Mirrors
+// the user-facing YAML shape; converted to the internal PolicyRef at
+// controller setup.
+type PolicySpec struct {
+	// Name is the registered policy name (e.g. "allocation-rate", "warmup").
+	Name string `json:"name"`
+	// Weight scales the policy's Score contribution; default 1. Only
+	// meaningful for policies that implement the Scorer interface.
+	Weight int `json:"weight,omitempty"`
+	// Arguments holds policy-specific arguments. minNodes/maxNodes are only
+	// valid on the node-limit policy.
+	Arguments map[string]interface{} `json:"arguments,omitempty"`
+}
 
 // SchedulerConfigSpec defines the per-scheduler sharding parameters.
 // It is used both as the internal representation and as the YAML-serialisable
@@ -41,17 +69,39 @@ type SchedulerConfigSpec struct {
 	Name string `json:"name"`
 	// Type describes the workload class (e.g. "volcano", "agent").
 	Type string `json:"type"`
+
+	// Policies is the per-scheduler policy chain. When empty,
+	// applyPolicyDefaults synthesizes a default chain from legacy fields.
+	Policies []PolicySpec `json:"policies,omitempty"`
+	// Arguments holds legacy single-policy arguments. Deprecated: use Policies.
+	Arguments map[string]interface{} `json:"arguments,omitempty"`
 	// CPUUtilizationMin is the lower bound (inclusive) of the CPU utilisation range
 	// [0.0, 1.0] that makes a node eligible for this scheduler's shard.
+	//
+	// Deprecated: use Policies instead.
 	CPUUtilizationMin float64 `json:"cpuUtilizationMin"`
 	// CPUUtilizationMax is the upper bound (inclusive) of the CPU utilisation range.
+	//
+	// Deprecated: use Policies instead.
 	CPUUtilizationMax float64 `json:"cpuUtilizationMax"`
 	// PreferWarmupNodes indicates whether warmup nodes should be sorted before
 	// regular nodes when selecting shard members.
+	//
+	// Deprecated: use Policies (add a "warmup" entry) instead.
 	PreferWarmupNodes bool `json:"preferWarmupNodes"`
-	// MinNodes is the minimum number of nodes the shard must contain.
+
+	// MinNodes is informational only: the framework cannot synthesize nodes
+	// that don't exist. If the policy chain returns fewer than MinNodes, the
+	// shortfall is logged but the result is not padded. Scheduler-level
+	// scalar; not a per-policy setting.
+	//
+	// Deprecated: use Policies (add a "node-limit" entry) instead.
 	MinNodes int `json:"minNodes"`
-	// MaxNodes is the maximum number of nodes the shard may contain.
+	// MaxNodes is a hard cap. The policy-selected node list is truncated to
+	// at most MaxNodes by the framework. Scheduler-level scalar; not a
+	// per-policy setting. MaxNodes <= 0 means "no upper bound".
+	//
+	// Deprecated: use Policies (add a "node-limit" entry) instead.
 	MaxNodes int `json:"maxNodes"`
 }
 
@@ -98,8 +148,38 @@ func ParseShardingConfig(data []byte) (*ShardingConfig, error) {
 		if sc.MaxNodes < sc.MinNodes {
 			return nil, fmt.Errorf("schedulerConfigs[%d] (%s): maxNodes (%d) must be >= minNodes (%d)", i, sc.Name, sc.MaxNodes, sc.MinNodes)
 		}
+		if err := validatePolicies(i, sc.Name, sc.Policies); err != nil {
+			return nil, err
+		}
 	}
 	return cfg, nil
+}
+
+// validatePolicies checks per-policy constraints that apply regardless of
+// whether the spec arrived via ConfigMap or CLI flags. Callable from any
+// entry point that builds a SchedulerConfigSpec.
+//
+// node-limit is the one policy that legitimately consumes minNodes /
+// maxNodes in its Arguments; the rejection rule below explicitly allows it.
+func validatePolicies(specIdx int, schedName string, policies []PolicySpec) error {
+	for j, p := range policies {
+		if p.Name == "" {
+			return fmt.Errorf("schedulerConfigs[%d] (%s): policies[%d].name must not be empty", specIdx, schedName, j)
+		}
+		if p.Weight < 0 {
+			return fmt.Errorf("schedulerConfigs[%d] (%s): policies[%d] (%s): weight must be >= 0 (omit for default of 1)", specIdx, schedName, j, p.Name)
+		}
+		if p.Name == "node-limit" {
+			continue
+		}
+		if _, ok := p.Arguments["minNodes"]; ok {
+			return fmt.Errorf("schedulerConfigs[%d] (%s): policies[%d] (%s): minNodes is only supported by the node-limit policy", specIdx, schedName, j, p.Name)
+		}
+		if _, ok := p.Arguments["maxNodes"]; ok {
+			return fmt.Errorf("schedulerConfigs[%d] (%s): policies[%d] (%s): maxNodes is only supported by the node-limit policy", specIdx, schedName, j, p.Name)
+		}
+	}
+	return nil
 }
 
 // ShardingControllerOptions holds all runtime-configurable options for the
@@ -152,7 +232,7 @@ func (opts *ShardingControllerOptions) AddFlags(fs *pflag.FlagSet) {
 
 	fs.StringSliceVar(&opts.SchedulerConfigsRaw, "scheduler-configs", defaultConfigs,
 		"Deprecated: use a sharding ConfigMap (--sharding-configmap) instead. "+
-			"Scheduler configurations in format: name:type:min_util:max_util:prefer_warmup:min_nodes:max_nodes. "+
+			"Format: name:type:min_util:max_util:prefer_warmup:min_nodes:max_nodes. "+
 			"Used only when no valid sharding ConfigMap is available.")
 
 	fs.DurationVar(&opts.ShardSyncPeriod, "shard-sync-period", 60*time.Second,
@@ -172,58 +252,130 @@ func (opts *ShardingControllerOptions) AddFlags(fs *pflag.FlagSet) {
 
 // ParseConfig parses the raw colon-separated config strings into SchedulerConfigs.
 // This is used only when ConfigMap-based configuration is not available.
+// Warning: configuring sharding via command line is deprecated and will be
+// removed in a future release; use the sharding ConfigMap instead.
 func (opts *ShardingControllerOptions) ParseConfig() error {
 	configs := make([]SchedulerConfigSpec, 0, len(opts.SchedulerConfigsRaw))
 
 	for _, configStr := range opts.SchedulerConfigsRaw {
 		parts := strings.Split(configStr, ":")
+
 		if len(parts) != 7 {
-			return fmt.Errorf("invalid scheduler config format: %s, expected 7 parts separated by ':'", configStr)
+			return fmt.Errorf("invalid scheduler config format: %s, expected 7 colon-separated parts", configStr)
 		}
 
-		// Parse CPU utilization min
-		minUtil, err := parseUtilization(parts[2])
+		config, err := parseOldFormat(parts)
 		if err != nil {
-			return fmt.Errorf("invalid min utilization in %s: %v", configStr, err)
+			return fmt.Errorf("failed to parse scheduler config %s: %v", configStr, err)
 		}
-
-		// Parse CPU utilization max
-		maxUtil, err := parseUtilization(parts[3])
-		if err != nil {
-			return fmt.Errorf("invalid max utilization in %s: %v", configStr, err)
-		}
-
-		// Parse prefer warmup
-		preferWarmup, err := strconv.ParseBool(parts[4])
-		if err != nil {
-			return fmt.Errorf("invalid prefer warmup flag in %s: %v", configStr, err)
-		}
-
-		// Parse min nodes
-		minNodes, err := strconv.Atoi(parts[5])
-		if err != nil {
-			return fmt.Errorf("invalid min nodes in %s: %v", configStr, err)
-		}
-
-		// Parse max nodes
-		maxNodes, err := strconv.Atoi(parts[6])
-		if err != nil {
-			return fmt.Errorf("invalid max nodes in %s: %v", configStr, err)
-		}
-
-		configs = append(configs, SchedulerConfigSpec{
-			Name:              parts[0],
-			Type:              parts[1],
-			CPUUtilizationMin: minUtil,
-			CPUUtilizationMax: maxUtil,
-			PreferWarmupNodes: preferWarmup,
-			MinNodes:          minNodes,
-			MaxNodes:          maxNodes,
-		})
+		klog.V(3).Infof("Parsed old format config for scheduler %s, converting to %s policy", config.Name, DefaultPolicyName)
+		configs = append(configs, config)
 	}
-
+	klog.Warningf("--scheduler-configs is deprecated and will be removed in a future release; migrate to the sharding ConfigMap")
 	opts.SchedulerConfigs = configs
 	return nil
+}
+
+// parseOldFormat parses old format config: name:type:minUtil:maxUtil:preferWarmup:minNodes:maxNodes
+func parseOldFormat(parts []string) (SchedulerConfigSpec, error) {
+	minUtil, err := parseUtilization(parts[2])
+	if err != nil {
+		return SchedulerConfigSpec{}, fmt.Errorf("invalid min utilization: %v", err)
+	}
+	maxUtil, err := parseUtilization(parts[3])
+	if err != nil {
+		return SchedulerConfigSpec{}, fmt.Errorf("invalid max utilization: %v", err)
+	}
+	preferWarmup, err := strconv.ParseBool(parts[4])
+	if err != nil {
+		return SchedulerConfigSpec{}, fmt.Errorf("invalid prefer warmup flag: %v", err)
+	}
+	minNodes, err := strconv.Atoi(parts[5])
+	if err != nil {
+		return SchedulerConfigSpec{}, fmt.Errorf("invalid min nodes: %v", err)
+	}
+	maxNodes, err := strconv.Atoi(parts[6])
+	if err != nil {
+		return SchedulerConfigSpec{}, fmt.Errorf("invalid max nodes: %v", err)
+	}
+
+	if preferWarmup {
+		klog.Warningf(preferWarmupNodesDeprecatedMsg, parts[0])
+	}
+
+	return SchedulerConfigSpec{
+		Name: parts[0],
+		Type: parts[1],
+		Arguments: map[string]interface{}{
+			allocationrate.ArgMinCPUUtil: minUtil,
+			allocationrate.ArgMaxCPUUtil: maxUtil,
+		},
+		Policies: []PolicySpec{{
+			Name:   DefaultPolicyName,
+			Weight: 1,
+			Arguments: map[string]interface{}{
+				allocationrate.ArgMinCPUUtil: minUtil,
+				allocationrate.ArgMaxCPUUtil: maxUtil,
+			},
+		}},
+		// Keep deprecated fields for backwards compatibility
+		CPUUtilizationMin: minUtil,
+		CPUUtilizationMax: maxUtil,
+		PreferWarmupNodes: preferWarmup,
+		MinNodes:          minNodes,
+		MaxNodes:          maxNodes,
+	}, nil
+}
+
+// applyPolicyDefaults populates spec.Policies from deprecated scalar fields
+// for compatibility. Synthesis rules:
+//
+//   - spec.Policies empty: synthesize an allocation-rate entry from
+//     spec.Arguments (or CPUUtilizationMin/Max when Arguments is empty).
+//   - PreferWarmupNodes set: append a warmup entry.
+//   - MinNodes/MaxNodes > 0 and node-limit not in chain: append a node-limit
+//     entry and warn users to configure node-limit directly.
+func applyPolicyDefaults(spec *SchedulerConfigSpec) {
+	if len(spec.Policies) == 0 {
+		if len(spec.Arguments) == 0 {
+			spec.Arguments = map[string]interface{}{
+				allocationrate.ArgMinCPUUtil: spec.CPUUtilizationMin,
+				allocationrate.ArgMaxCPUUtil: spec.CPUUtilizationMax,
+			}
+		}
+		spec.Policies = []PolicySpec{{
+			Name:      DefaultPolicyName,
+			Weight:    1,
+			Arguments: spec.Arguments,
+		}}
+		if spec.PreferWarmupNodes {
+			klog.Warningf(preferWarmupNodesDeprecatedMsg, spec.Name)
+			spec.Policies = append(spec.Policies, PolicySpec{
+				Name:   "warmup",
+				Weight: 1,
+			})
+		}
+	}
+
+	if (spec.MinNodes > 0 || spec.MaxNodes > 0) && !hasPolicy(spec.Policies, "node-limit") {
+		klog.Warningf(nodeLimitScalarsDeprecatedMsg, spec.Name)
+		spec.Policies = append(spec.Policies, PolicySpec{
+			Name: "node-limit",
+			Arguments: map[string]interface{}{
+				"minNodes": spec.MinNodes,
+				"maxNodes": spec.MaxNodes,
+			},
+		})
+	}
+}
+
+func hasPolicy(policies []PolicySpec, name string) bool {
+	for _, p := range policies {
+		if p.Name == name {
+			return true
+		}
+	}
+	return false
 }
 
 // parseUtilization parses a utilization string to float64.

--- a/pkg/controllers/sharding/config_test.go
+++ b/pkg/controllers/sharding/config_test.go
@@ -193,3 +193,141 @@ func TestNewShardingControllerOptions_Defaults(t *testing.T) {
 	assert.InDelta(t, 1.0, agent.CPUUtilizationMax, 1e-9)
 	assert.True(t, agent.PreferWarmupNodes)
 }
+
+func TestParseConfigOldFormat(t *testing.T) {
+	opts := &ShardingControllerOptions{
+		SchedulerConfigsRaw: []string{
+			"volcano:volcano:0.0:0.6:false:2:100",
+			"agent-scheduler:agent:0.7:1.0:true:2:100",
+		},
+	}
+
+	err := opts.ParseConfig()
+	if err != nil {
+		t.Fatalf("ParseConfig() error = %v", err)
+	}
+
+	if len(opts.SchedulerConfigs) != 2 {
+		t.Fatalf("ParseConfig() parsed %d configs, want 2", len(opts.SchedulerConfigs))
+	}
+
+	// Check first config
+	config1 := opts.SchedulerConfigs[0]
+	if config1.Name != "volcano" {
+		t.Errorf("config1.Name = %v, want volcano", config1.Name)
+	}
+	if config1.Type != "volcano" {
+		t.Errorf("config1.Type = %v, want volcano", config1.Type)
+	}
+	if len(config1.Policies) != 1 || config1.Policies[0].Name != "allocation-rate" {
+		t.Errorf("config1.Policies = %#v, want [allocation-rate]", config1.Policies)
+	}
+	if config1.Arguments["minCPUUtil"] != 0.0 {
+		t.Errorf("config1.Arguments[minCPUUtil] = %v, want 0.0", config1.Arguments["minCPUUtil"])
+	}
+	if config1.Arguments["maxCPUUtil"] != 0.6 {
+		t.Errorf("config1.Arguments[maxCPUUtil] = %v, want 0.6", config1.Arguments["maxCPUUtil"])
+	}
+	if _, ok := config1.Arguments["preferWarmupNodes"]; ok {
+		t.Errorf("config1.Arguments[preferWarmupNodes] should be absent for allocation-rate; "+
+			"got %v", config1.Arguments["preferWarmupNodes"])
+	}
+	if config1.MinNodes != 2 {
+		t.Errorf("config1.MinNodes = %v, want 2", config1.MinNodes)
+	}
+	if config1.MaxNodes != 100 {
+		t.Errorf("config1.MaxNodes = %v, want 100", config1.MaxNodes)
+	}
+
+	// Check second config
+	config2 := opts.SchedulerConfigs[1]
+	if config2.Name != "agent-scheduler" {
+		t.Errorf("config2.Name = %v, want agent-scheduler", config2.Name)
+	}
+	if len(config2.Policies) != 1 || config2.Policies[0].Name != "allocation-rate" {
+		t.Errorf("config2.Policies = %#v, want [allocation-rate]", config2.Policies)
+	}
+	if config2.Arguments["minCPUUtil"] != 0.7 {
+		t.Errorf("config2.Arguments[minCPUUtil] = %v, want 0.7", config2.Arguments["minCPUUtil"])
+	}
+	if _, ok := config2.Arguments["preferWarmupNodes"]; ok {
+		t.Errorf("config2.Arguments[preferWarmupNodes] should be absent for allocation-rate; "+
+			"got %v", config2.Arguments["preferWarmupNodes"])
+	}
+}
+
+func TestParseConfigRejectsNewFormat(t *testing.T) {
+	opts := &ShardingControllerOptions{
+		SchedulerConfigsRaw: []string{
+			"volcano:volcano:allocation-rate:2:100:minCPUUtil=0.0,maxCPUUtil=0.6,preferWarmupNodes=false",
+			"agent:agent:capability:2:50:maxCapacityPercent=0.30",
+			"warmup-sched:warmup:warmup:5:100:allowNonWarmup=true",
+		},
+	}
+
+	err := opts.ParseConfig()
+	if err == nil {
+		t.Fatalf("ParseConfig() expected error for new format, got nil")
+	}
+	assert.ErrorContains(t, err, "expected 7 colon-separated parts")
+}
+
+func TestParseConfigMixedFormatsRejected(t *testing.T) {
+	opts := &ShardingControllerOptions{
+		SchedulerConfigsRaw: []string{
+			"volcano:volcano:0.0:0.6:false:2:100",                 // Old format
+			"agent:agent:capability:2:50:maxCapacityPercent=0.30", // New format
+		},
+	}
+
+	err := opts.ParseConfig()
+	if err == nil {
+		t.Fatalf("ParseConfig() expected error for mixed formats, got nil")
+	}
+	assert.ErrorContains(t, err, "expected 7 colon-separated parts")
+}
+
+func TestParseConfigInvalidFormat(t *testing.T) {
+	tests := []struct {
+		name   string
+		config string
+	}{
+		{
+			name:   "too few parts",
+			config: "volcano:volcano:0.0:0.6",
+		},
+		{
+			name:   "invalid min util",
+			config: "volcano:volcano:invalid:0.6:false:2:100",
+		},
+		{
+			name:   "invalid max util",
+			config: "volcano:volcano:0.0:invalid:false:2:100",
+		},
+		{
+			name:   "invalid prefer warmup",
+			config: "volcano:volcano:0.0:0.6:invalid:2:100",
+		},
+		{
+			name:   "invalid min nodes",
+			config: "volcano:volcano:0.0:0.6:false:invalid:100",
+		},
+		{
+			name:   "invalid max nodes",
+			config: "volcano:volcano:0.0:0.6:false:2:invalid",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opts := &ShardingControllerOptions{
+				SchedulerConfigsRaw: []string{tt.config},
+			}
+
+			err := opts.ParseConfig()
+			if err == nil {
+				t.Errorf("ParseConfig() expected error for %s, got nil", tt.name)
+			}
+		})
+	}
+}

--- a/pkg/controllers/sharding/configmap_reload_test.go
+++ b/pkg/controllers/sharding/configmap_reload_test.go
@@ -91,9 +91,9 @@ schedulerConfigs:
 
 	require.Len(t, configs, 3, "should have 3 scheduler configs after reload")
 	assert.Equal(t, "volcano", configs[0].Name)
-	assert.InDelta(t, 0.5, configs[0].ShardStrategy.CPUUtilizationRange.Max, 1e-9)
+	assert.InDelta(t, 0.5, configs[0].Policies[0].Arguments["maxCPUUtil"], 1e-9)
 	assert.Equal(t, "agent-scheduler", configs[1].Name)
-	assert.InDelta(t, 0.6, configs[1].ShardStrategy.CPUUtilizationRange.Min, 1e-9)
+	assert.InDelta(t, 0.6, configs[1].Policies[0].Arguments["minCPUUtil"], 1e-9)
 	assert.Equal(t, "batch-scheduler", configs[2].Name)
 	assert.Equal(t, "batch", configs[2].Type)
 }
@@ -563,11 +563,11 @@ func TestRun_FallsBackToFlagDefaultsWhenConfigMapAbsent(t *testing.T) {
 		assert.Equal(t, expected.Name, configs[i].Name,
 			"scheduler config[%d] name should match flag default", i)
 		assert.InDelta(t, expected.CPUUtilizationMin,
-			configs[i].ShardStrategy.CPUUtilizationRange.Min, 1e-9,
-			"scheduler config[%d] CPUUtilizationMin should match flag default", i)
+			configs[i].Policies[0].Arguments["minCPUUtil"], 1e-9,
+			"scheduler config[%d] minCPUUtil should match flag default", i)
 		assert.InDelta(t, expected.CPUUtilizationMax,
-			configs[i].ShardStrategy.CPUUtilizationRange.Max, 1e-9,
-			"scheduler config[%d] CPUUtilizationMax should match flag default", i)
+			configs[i].Policies[0].Arguments["maxCPUUtil"], 1e-9,
+			"scheduler config[%d] maxCPUUtil should match flag default", i)
 	}
 
 	// The controller should still be functional: syncShards should create

--- a/pkg/controllers/sharding/policy/README.md
+++ b/pkg/controllers/sharding/policy/README.md
@@ -1,0 +1,246 @@
+# Volcano Shard Policy Framework
+
+This package implements the pluggable policy framework used by the NodeShard
+controller to assign nodes to schedulers. Each policy implements the
+`ShardPolicy` interface (see `interface.go`) and is configured via the
+sharding ConfigMap.
+
+## Package layout
+
+```
+policy/
+├── interface.go      // ShardPolicy / Filterer / Scorer / Selector, PolicyContext
+├── registry.go       // Thread-safe RegisterPolicy / GetPolicy
+├── arguments.go      // Type-safe argument parsing helpers
+├── types.go          // Shared types
+├── builtin/          // init() that registers all built-in policies
+├── allocationrate/   // CPU-utilization range filter + score
+├── nodelimit/        // Node-count Selector (truncate to maxNodes)
+└── warmup/           // Warmup-label score
+```
+
+## Configuration
+
+Policies are configured per-scheduler via the sharding ConfigMap (key
+`sharding.yaml`). The full ConfigMap schema and reload behaviour are
+documented in
+[`docs/user-guide/how_to_configure_sharding_configmap.md`](../../../../docs/user-guide/how_to_configure_sharding_configmap.md);
+this section covers only the `policies` and `arguments` fields.
+
+### Policy chain
+
+A scheduler declares an ordered list of policies. Each policy
+contributes to the pipeline phases its struct implements: a `Filterer`
+contributes to filter, a `Scorer` contributes to sort. The framework
+runs `filter → sort → select` per scheduler:
+
+1. **filter** — AND-intersection: a node passes only when every configured
+   `Filterer` accepts it. When no policy implements `Filterer`, all
+   candidates advance.
+2. **sort** — weighted sum: `final[node] = Σ (policy.weight × policy.Score(node))`,
+   stable-sorted descending.
+3. **select** — every `Selector` runs in config order; each receives the previous's output. The built-in `node-limit` Selector truncates to `maxNodes`. `minNodes` is informational only: the framework cannot synthesize nodes, so a shorter result is logged but not padded.
+
+```yaml
+schedulerConfigs:
+  - name: volcano
+    type: volcano
+    policies:
+      - name: allocation-rate
+        weight: 1
+        arguments:
+          minCPUUtil: 0.0
+          maxCPUUtil: 0.6
+      - name: warmup
+        weight: 2                # higher weight = prefer warmup nodes first
+        arguments:
+          warmupLabel: "node.volcano.sh/warmup"
+          warmupLabelValue: "true"
+      - name: node-limit
+        arguments:
+          minNodes: 2
+          maxNodes: 100
+
+  - name: agent-scheduler
+    type: agent
+    policies:
+      - name: allocation-rate
+        weight: 1
+        arguments:
+          minCPUUtil: 0.7
+          maxCPUUtil: 1.0
+      - name: warmup
+        weight: 5                # very strong warmup preference for agent shard
+      - name: node-limit
+        arguments:
+          minNodes: 2
+          maxNodes: 50
+```
+
+How the volcano scheduler config above behaves:
+
+- **Filter:** `allocation-rate` rejects nodes outside `[0.0, 0.6]` CPU
+  util or with missing metrics. `warmup` is `Scorer`-only, so it does
+  not contribute to filter.
+- **Sort:** combined score is `1 × normalized_util + 2 × warmup_signal`,
+  where `normalized_util` rescales CPU utilization within `[0.0, 0.6]` to
+  `[0, 1]`. A 0.05-util warmup node scores `1 × 0.083 + 2 × 1 ≈ 2.08`; a
+  0.55-util non-warmup node scores `1 × 0.917 + 2 × 0 ≈ 0.92`. Warmup
+  nodes rank first within the surviving filter cohort.
+- **Select:** `node-limit` trims to `[2, 100]` (best-effort min, hard max).
+
+Field reference for a policies entry:
+
+| Field | Type | Notes |
+|---|---|---|
+| `name` | string, required | registered policy name (`allocation-rate`, `warmup`, `node-limit`) |
+| `weight` | int ≥ 0 | default `1`. Only meaningful for `Scorer` policies. |
+| `arguments` | map | policy-specific. Use the `node-limit` policy for `minNodes`/`maxNodes`. |
+
+Scheduler-level `minNodes` / `maxNodes` are deprecated. They still synthesize
+a `node-limit` policy for compatibility and emit a warning, but new
+configuration should add `node-limit` explicitly.
+
+## Built-in policies
+
+### `allocation-rate`
+
+Implements `Filterer` + `Scorer`. Filter rejects nodes outside
+`[minCPUUtil, maxCPUUtil]` (or with missing metrics). Score normalizes
+CPU utilization within the configured range to `[0, 1]`, so higher util
+ranks higher — workloads pack onto already-busy nodes, leaving
+lightly-loaded nodes available for other schedulers. This is the
+default policy.
+
+| Argument | Type | Description |
+|---|---|---|
+| `minCPUUtil` | float | Lower bound of the CPU utilization range, `[0.0, 1.0]`. |
+| `maxCPUUtil` | float | Upper bound of the CPU utilization range, `[0.0, 1.0]`. |
+
+### `warmup`
+
+Implements `Scorer` only. Score returns `1.0` if the node carries the
+configured warmup label/value, else `0.0`. Combined with `weight: N` in
+config, warmup-labeled nodes receive a `+N` boost in the framework's
+weighted-sum sort — pulled ahead of non-warmup candidates without
+filtering non-warmup nodes out entirely.
+
+| Argument | Type | Description |
+|---|---|---|
+| `warmupLabel` | string | Label key identifying warmup nodes. Default: `node.volcano.sh/warmup`. |
+| `warmupLabelValue` | string | Label value identifying warmup nodes. Default: `"true"`. |
+
+### `node-limit`
+
+Implements `Selector` only. Truncates the sorted candidate list to at most
+`maxNodes`. Add `node-limit` explicitly when a scheduler needs node-count
+selection. Deprecated scheduler-level `minNodes` / `maxNodes` still synthesize
+this policy for compatibility, but that path logs a warning.
+
+| Argument | Type | Description |
+|---|---|---|
+| `minNodes` | int | Informational lower bound; the framework cannot synthesize nodes. |
+| `maxNodes` | int | Hard upper cap. `<= 0` means no upper bound. |
+
+## Adding a custom policy
+
+### 1. Implement `ShardPolicy` plus `Filterer`, `Scorer`, and/or `Selector`
+
+Every policy implements `ShardPolicy` for lifecycle (`Name`,
+`Initialize`, `Cleanup`). Pipeline participation is opt-in: a policy
+that filters implements `Filterer`, a policy that ranks implements
+`Scorer`. Both is fine. The framework type-asserts at runtime to
+discover which phases the policy contributes to.
+
+```go
+package mypolicy
+
+import (
+    "fmt"
+
+    corev1 "k8s.io/api/core/v1"
+
+    "volcano.sh/volcano/pkg/controllers/sharding/policy"
+)
+
+const PolicyName = "my-policy"
+
+type myPolicy struct {
+    param1 float64
+}
+
+func New() policy.ShardPolicy {
+    return &myPolicy{param1: 0.5}
+}
+
+func (p *myPolicy) Name() string { return PolicyName }
+
+func (p *myPolicy) Initialize(args policy.Arguments) error {
+    args.GetFloat64(&p.param1, "param1")
+    if p.param1 < 0 || p.param1 > 1 {
+        return fmt.Errorf("invalid param1: must be in [0, 1]")
+    }
+    return nil
+}
+
+func (p *myPolicy) Cleanup() {}
+
+// Filter implements policy.Filterer. The framework excludes already-assigned
+// nodes before this is called; the predicate only needs to express the
+// per-policy eligibility rule.
+func (p *myPolicy) Filter(ctx *policy.PolicyContext, node *corev1.Node) bool {
+    metrics := ctx.NodeMetrics[node.Name]
+    if metrics == nil {
+        return false
+    }
+    return metrics.CPUUtilization <= p.param1
+}
+
+// Score implements policy.Scorer. Return a value in [0, 1]; the framework
+// does not clamp.
+func (p *myPolicy) Score(ctx *policy.PolicyContext, node *corev1.Node) float64 {
+    metrics := ctx.NodeMetrics[node.Name]
+    if metrics == nil {
+        return 0
+    }
+    return 1.0 - metrics.CPUUtilization // prefer idle nodes
+}
+```
+
+### 2. Register the policy
+
+Add an entry to `policy/builtin/builtin.go` (importing your subpackage from
+the parent `policy` package would create an import cycle):
+
+```go
+// in pkg/controllers/sharding/policy/builtin/builtin.go
+import "volcano.sh/volcano/pkg/controllers/sharding/policy/mypolicy"
+
+func init() {
+    // ...existing registrations...
+    policy.RegisterPolicy(mypolicy.PolicyName, mypolicy.New)
+}
+```
+
+### 3. Reference it from the sharding ConfigMap
+
+```yaml
+schedulerConfigs:
+  - name: my-scheduler
+    type: volcano
+    policies:
+      - name: my-policy
+        weight: 1
+        arguments:
+          param1: 0.7
+      - name: node-limit
+        arguments:
+          minNodes: 2
+          maxNodes: 100
+```
+
+## Tests
+
+```bash
+go test ./pkg/controllers/sharding/policy/...
+```

--- a/pkg/controllers/sharding/policy/allocationrate/allocationrate.go
+++ b/pkg/controllers/sharding/policy/allocationrate/allocationrate.go
@@ -1,0 +1,121 @@
+/*
+Copyright 2026 The Volcano Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+	http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package allocationrate
+
+import (
+	"fmt"
+	"math"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/klog/v2"
+
+	"volcano.sh/volcano/pkg/controllers/sharding/policy"
+)
+
+// PolicyName is the user-visible name of this policy.
+const PolicyName = "allocation-rate"
+
+// Argument keys recognized by Initialize. Exported so config-synthesis
+// callers can reference the same names without re-stating string literals.
+const (
+	ArgMinCPUUtil = "minCPUUtil"
+	ArgMaxCPUUtil = "maxCPUUtil"
+)
+
+// utilQuant is the quantization step for CPU-utilization rounding (2 decimal
+// places). Filter and Score both round through roundUtil so they cannot drift.
+const utilQuant = 100
+
+func roundUtil(u float64) float64 {
+	return math.Round(u*utilQuant) / utilQuant
+}
+
+type allocationRatePolicy struct {
+	minCPURounded   float64
+	maxCPURounded   float64
+	cpuRangeRounded float64
+}
+
+// New creates a new allocation-rate policy instance.
+func New() policy.ShardPolicy {
+	return &allocationRatePolicy{
+		maxCPURounded:   1.0,
+		cpuRangeRounded: 1.0,
+	}
+}
+
+func (p *allocationRatePolicy) Name() string { return PolicyName }
+
+func (p *allocationRatePolicy) Initialize(args policy.Arguments) error {
+	var minCPU, maxCPU float64
+	args.GetFloat64(&minCPU, ArgMinCPUUtil)
+	args.GetFloat64(&maxCPU, ArgMaxCPUUtil)
+
+	if minCPU < 0 || maxCPU > 1 || minCPU > maxCPU {
+		return fmt.Errorf("invalid CPU utilization range [%.2f, %.2f]: must be within [0.0, 1.0] and min <= max",
+			minCPU, maxCPU)
+	}
+
+	p.minCPURounded = roundUtil(minCPU)
+	p.maxCPURounded = roundUtil(maxCPU)
+	p.cpuRangeRounded = p.maxCPURounded - p.minCPURounded
+
+	klog.V(3).Infof("Initialized allocation-rate policy: CPU range [%.2f, %.2f]",
+		p.minCPURounded, p.maxCPURounded)
+	return nil
+}
+
+func (p *allocationRatePolicy) Cleanup() {}
+
+// Filter rejects nodes outside [minCPUUtil, maxCPUUtil] or with missing
+// metrics. The framework excludes already-assigned nodes before Filter runs.
+func (p *allocationRatePolicy) Filter(ctx *policy.PolicyContext, node *corev1.Node) bool {
+	metrics := ctx.NodeMetrics[node.Name]
+	if metrics == nil {
+		return false
+	}
+	if metrics.CPUUtilization < 0 {
+		return false
+	}
+	util := roundUtil(metrics.CPUUtilization)
+	return util >= p.minCPURounded && util <= p.maxCPURounded
+}
+
+// Score normalizes CPUUtilization within the configured [minCPUUtil,
+// maxCPUUtil] range so the output spans [0, 1] regardless of how narrow the
+// range is. Higher util pulls the node forward in the sort so workloads pack
+// onto already-busy nodes, leaving lightly-loaded nodes available for other
+// schedulers.
+func (p *allocationRatePolicy) Score(ctx *policy.PolicyContext, node *corev1.Node) float64 {
+	metrics := ctx.NodeMetrics[node.Name]
+	if metrics == nil {
+		return 0
+	}
+	if metrics.CPUUtilization < 0 {
+		return 0
+	}
+	if p.cpuRangeRounded == 0 {
+		return 1
+	}
+	util := roundUtil(metrics.CPUUtilization)
+	score := (util - p.minCPURounded) / p.cpuRangeRounded
+	// Clamp to [0, 1] in case Score is invoked on a node Filter would reject.
+	if score < 0 {
+		return 0
+	}
+	if score > 1 {
+		return 1
+	}
+	return score
+}

--- a/pkg/controllers/sharding/policy/allocationrate/allocationrate_test.go
+++ b/pkg/controllers/sharding/policy/allocationrate/allocationrate_test.go
@@ -1,0 +1,224 @@
+/*
+Copyright 2026 The Volcano Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+	http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package allocationrate
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"volcano.sh/volcano/pkg/controllers/sharding/policy"
+)
+
+func TestAllocationRatePolicyInitialize(t *testing.T) {
+	tests := []struct {
+		name      string
+		args      policy.Arguments
+		expectErr bool
+	}{
+		{
+			name:      "valid configuration",
+			args:      policy.Arguments{ArgMinCPUUtil: 0.0, ArgMaxCPUUtil: 0.6},
+			expectErr: false,
+		},
+		{
+			name:      "invalid CPU range - min > max",
+			args:      policy.Arguments{ArgMinCPUUtil: 0.7, ArgMaxCPUUtil: 0.5},
+			expectErr: true,
+		},
+		{
+			name:      "invalid CPU range - negative min",
+			args:      policy.Arguments{ArgMinCPUUtil: -0.1, ArgMaxCPUUtil: 0.5},
+			expectErr: true,
+		},
+		{
+			name:      "invalid CPU range - max > 1",
+			args:      policy.Arguments{ArgMinCPUUtil: 0.0, ArgMaxCPUUtil: 1.5},
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := New()
+			err := p.Initialize(tt.args)
+			if (err != nil) != tt.expectErr {
+				t.Errorf("Initialize() error = %v, expectErr %v", err, tt.expectErr)
+			}
+		})
+	}
+}
+
+// newPolicy constructs and Initialize-s a policy with the given args.
+func newPolicy(t *testing.T, args policy.Arguments) (policy.Filterer, policy.Scorer) {
+	t.Helper()
+	p := New()
+	if err := p.Initialize(args); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+	f, ok := p.(policy.Filterer)
+	if !ok {
+		t.Fatalf("policy does not implement Filterer")
+	}
+	s, ok := p.(policy.Scorer)
+	if !ok {
+		t.Fatalf("policy does not implement Scorer")
+	}
+	return f, s
+}
+
+func node(name string) *corev1.Node {
+	return &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: name}}
+}
+
+func TestAllocationRatePolicyFilter(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    policy.Arguments
+		metrics *policy.NodeMetrics
+		want    bool
+	}{
+		{
+			name:    "in-range util passes",
+			args:    policy.Arguments{ArgMinCPUUtil: 0.3, ArgMaxCPUUtil: 0.7},
+			metrics: &policy.NodeMetrics{CPUUtilization: 0.5},
+			want:    true,
+		},
+		{
+			name:    "below-range util rejected",
+			args:    policy.Arguments{ArgMinCPUUtil: 0.3, ArgMaxCPUUtil: 0.7},
+			metrics: &policy.NodeMetrics{CPUUtilization: 0.2},
+			want:    false,
+		},
+		{
+			name:    "above-range util rejected",
+			args:    policy.Arguments{ArgMinCPUUtil: 0.3, ArgMaxCPUUtil: 0.7},
+			metrics: &policy.NodeMetrics{CPUUtilization: 0.8},
+			want:    false,
+		},
+		{
+			name:    "boundary inclusive",
+			args:    policy.Arguments{ArgMinCPUUtil: 0.3, ArgMaxCPUUtil: 0.7},
+			metrics: &policy.NodeMetrics{CPUUtilization: 0.30},
+			want:    true,
+		},
+		{
+			name:    "missing metrics rejected",
+			args:    policy.Arguments{ArgMinCPUUtil: 0.0, ArgMaxCPUUtil: 1.0},
+			metrics: nil,
+			want:    false,
+		},
+		{
+			name:    "negative util rejected",
+			args:    policy.Arguments{ArgMinCPUUtil: 0.0, ArgMaxCPUUtil: 1.0},
+			metrics: &policy.NodeMetrics{CPUUtilization: -1.0},
+			want:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f, _ := newPolicy(t, tt.args)
+			ctx := &policy.PolicyContext{
+				NodeMetrics: map[string]*policy.NodeMetrics{"n": tt.metrics},
+			}
+			if got := f.Filter(ctx, node("n")); got != tt.want {
+				t.Errorf("Filter = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAllocationRatePolicyScore(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    policy.Arguments
+		metrics *policy.NodeMetrics
+		want    float64
+	}{
+		{
+			name:    "full range: util passes through",
+			args:    policy.Arguments{ArgMinCPUUtil: 0.0, ArgMaxCPUUtil: 1.0},
+			metrics: &policy.NodeMetrics{CPUUtilization: 0.5},
+			want:    0.5,
+		},
+		{
+			name:    "full range: max maps to 1.0",
+			args:    policy.Arguments{ArgMinCPUUtil: 0.0, ArgMaxCPUUtil: 1.0},
+			metrics: &policy.NodeMetrics{CPUUtilization: 1.0},
+			want:    1.0,
+		},
+		{
+			name:    "narrow range normalizes to [0,1]",
+			args:    policy.Arguments{ArgMinCPUUtil: 0.4, ArgMaxCPUUtil: 0.6},
+			metrics: &policy.NodeMetrics{CPUUtilization: 0.5},
+			want:    0.5,
+		},
+		{
+			name:    "narrow range: min maps to 0",
+			args:    policy.Arguments{ArgMinCPUUtil: 0.4, ArgMaxCPUUtil: 0.6},
+			metrics: &policy.NodeMetrics{CPUUtilization: 0.4},
+			want:    0.0,
+		},
+		{
+			name:    "narrow range: max maps to 1",
+			args:    policy.Arguments{ArgMinCPUUtil: 0.4, ArgMaxCPUUtil: 0.6},
+			metrics: &policy.NodeMetrics{CPUUtilization: 0.6},
+			want:    1.0,
+		},
+		{
+			name:    "collapsed range returns 1",
+			args:    policy.Arguments{ArgMinCPUUtil: 0.5, ArgMaxCPUUtil: 0.5},
+			metrics: &policy.NodeMetrics{CPUUtilization: 0.5},
+			want:    1.0,
+		},
+		{
+			name:    "util above max clamps to 1",
+			args:    policy.Arguments{ArgMinCPUUtil: 0.4, ArgMaxCPUUtil: 0.6},
+			metrics: &policy.NodeMetrics{CPUUtilization: 0.7},
+			want:    1.0,
+		},
+		{
+			name:    "util below min clamps to 0",
+			args:    policy.Arguments{ArgMinCPUUtil: 0.4, ArgMaxCPUUtil: 0.6},
+			metrics: &policy.NodeMetrics{CPUUtilization: 0.3},
+			want:    0.0,
+		},
+		{
+			name:    "missing metrics returns 0",
+			args:    policy.Arguments{ArgMinCPUUtil: 0.0, ArgMaxCPUUtil: 1.0},
+			metrics: nil,
+			want:    0.0,
+		},
+		{
+			name:    "negative util returns 0",
+			args:    policy.Arguments{ArgMinCPUUtil: 0.0, ArgMaxCPUUtil: 1.0},
+			metrics: &policy.NodeMetrics{CPUUtilization: -0.5},
+			want:    0.0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, s := newPolicy(t, tt.args)
+			ctx := &policy.PolicyContext{
+				NodeMetrics: map[string]*policy.NodeMetrics{"n": tt.metrics},
+			}
+			if got := s.Score(ctx, node("n")); got != tt.want {
+				t.Errorf("Score = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/controllers/sharding/policy/arguments.go
+++ b/pkg/controllers/sharding/policy/arguments.go
@@ -1,0 +1,81 @@
+/*
+Copyright 2026 The Volcano Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+	http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package policy
+
+import "k8s.io/klog/v2"
+
+// GetInt retrieves an integer value from arguments.
+func (a Arguments) GetInt(ptr *int, key string) {
+	if ptr == nil {
+		return
+	}
+
+	argv, ok := a[key]
+	if !ok {
+		return
+	}
+
+	value, ok := argv.(int)
+	if !ok {
+		klog.Warningf("Could not parse argument: %v for key %s to int", argv, key)
+		return
+	}
+
+	*ptr = value
+}
+
+// GetFloat64 retrieves a float64 value from arguments
+func (a Arguments) GetFloat64(ptr *float64, key string) {
+	if ptr == nil {
+		return
+	}
+
+	argv, ok := a[key]
+	if !ok {
+		return
+	}
+
+	value, ok := argv.(float64)
+	if !ok {
+		// Try to convert from int
+		if intVal, ok := argv.(int); ok {
+			*ptr = float64(intVal)
+			return
+		}
+		klog.Warningf("Could not parse argument: %v for key %s to float64", argv, key)
+		return
+	}
+
+	*ptr = value
+}
+
+// GetString retrieves a string value from arguments
+func (a Arguments) GetString(ptr *string, key string) {
+	if ptr == nil {
+		return
+	}
+
+	argv, ok := a[key]
+	if !ok {
+		return
+	}
+
+	value, ok := argv.(string)
+	if !ok {
+		klog.Warningf("Could not parse argument: %v for key %s to string", argv, key)
+		return
+	}
+
+	*ptr = value
+}

--- a/pkg/controllers/sharding/policy/builtin/builtin.go
+++ b/pkg/controllers/sharding/policy/builtin/builtin.go
@@ -1,0 +1,41 @@
+/*
+Copyright 2026 The Volcano Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+	http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package builtin registers all built-in shard policies with the policy
+// registry. It lives in its own package (sibling to policy/allocationrate,
+// policy/nodelimit, policy/warmup) so that the parent `policy` package has
+// no inbound imports from its subpackages, which would create an import
+// cycle (each subpackage imports `policy` for the ShardPolicy interface).
+//
+// Importers should blank-import this package once, before any policy is
+// looked up via policy.GetPolicy:
+//
+//	import _ "volcano.sh/volcano/pkg/controllers/sharding/policy/builtin"
+package builtin
+
+import (
+	"k8s.io/klog/v2"
+
+	"volcano.sh/volcano/pkg/controllers/sharding/policy"
+	"volcano.sh/volcano/pkg/controllers/sharding/policy/allocationrate"
+	"volcano.sh/volcano/pkg/controllers/sharding/policy/nodelimit"
+	"volcano.sh/volcano/pkg/controllers/sharding/policy/warmup"
+)
+
+func init() {
+	policy.RegisterPolicy(allocationrate.PolicyName, allocationrate.New)
+	policy.RegisterPolicy(nodelimit.PolicyName, nodelimit.New)
+	policy.RegisterPolicy(warmup.PolicyName, warmup.New)
+
+	klog.V(2).Infof("Registered %d shard policies: %v", len(policy.ListPolicies()), policy.ListPolicies())
+}

--- a/pkg/controllers/sharding/policy/interface.go
+++ b/pkg/controllers/sharding/policy/interface.go
@@ -1,0 +1,78 @@
+/*
+Copyright 2026 The Volcano Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+	http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package policy
+
+import (
+	corev1 "k8s.io/api/core/v1"
+
+	shardv1alpha1 "volcano.sh/apis/pkg/apis/shard/v1alpha1"
+)
+
+// ShardPolicy is the lifecycle contract every policy implements. A policy
+// participates in pipeline phases by additionally implementing Filterer
+// and/or Scorer; the framework uses type assertions to dispatch.
+type ShardPolicy interface {
+	Name() string
+	Initialize(args Arguments) error
+	Cleanup()
+}
+
+// Filterer participates in the filter phase. A node is eligible only when
+// every configured Filterer accepts it (AND-intersection). Implementations
+// must be deterministic and side-effect free. Nodes already assigned to
+// another scheduler are excluded by the framework before Filter is called.
+type Filterer interface {
+	Filter(ctx *PolicyContext, node *corev1.Node) bool
+}
+
+// Scorer participates in the score phase. Score returns a value in [0, 1];
+// higher is better. The framework combines Scorers via weighted sum:
+//
+//	final[node] = Σ (policy.weight × policy.Score(node))
+//
+// Implementations must clamp/normalize their output to [0, 1]; the framework
+// does not enforce.
+type Scorer interface {
+	Score(ctx *PolicyContext, node *corev1.Node) float64
+}
+
+// Selector participates in the select phase (clamp). It receives candidates
+// that have already been Filtered and ordered by Score, and returns the
+// final shard membership. Selectors enforce collection-level constraints
+// such as max node count or resource budgets.
+//
+// Multiple Selectors run in config order; each receives the previous one's
+// output. Returning an empty slice stops the chain. A Selector must not
+// reorder candidates — it returns the input slice unchanged or a prefix
+// thereof.
+type Selector interface {
+	Select(ctx *PolicyContext, candidates []*corev1.Node) []*corev1.Node
+}
+
+// PolicyContext provides input for policy execution.
+type PolicyContext struct {
+	SchedulerName string
+	SchedulerType string
+
+	AllNodes      []*corev1.Node
+	NodeMetrics   map[string]*NodeMetrics
+	AssignedNodes map[string]string // node name → scheduler name
+	CurrentShard  *shardv1alpha1.NodeShard
+}
+
+// Arguments holds configuration parameters for policies.
+type Arguments map[string]interface{}
+
+// PolicyBuilder is a factory function that creates policy instances.
+type PolicyBuilder func() ShardPolicy

--- a/pkg/controllers/sharding/policy/nodelimit/nodelimit.go
+++ b/pkg/controllers/sharding/policy/nodelimit/nodelimit.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2026 The Volcano Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+	http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nodelimit
+
+import (
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/klog/v2"
+
+	"volcano.sh/volcano/pkg/controllers/sharding/policy"
+)
+
+// PolicyName is the user-visible name of this policy.
+const PolicyName = "node-limit"
+
+type nodeLimitPolicy struct {
+	minNodes int
+	maxNodes int
+}
+
+// New creates a new node-limit policy instance.
+func New() policy.ShardPolicy {
+	return &nodeLimitPolicy{}
+}
+
+func (p *nodeLimitPolicy) Name() string { return PolicyName }
+
+func (p *nodeLimitPolicy) Initialize(args policy.Arguments) error {
+	args.GetInt(&p.minNodes, "minNodes")
+	args.GetInt(&p.maxNodes, "maxNodes")
+
+	if p.minNodes < 0 {
+		return fmt.Errorf("invalid minNodes %d: must be >= 0", p.minNodes)
+	}
+	if p.maxNodes > 0 && p.maxNodes < p.minNodes {
+		return fmt.Errorf("invalid bounds [%d, %d]: maxNodes must be >= minNodes",
+			p.minNodes, p.maxNodes)
+	}
+
+	klog.V(3).Infof("Initialized node-limit policy: bounds [%d, %d]",
+		p.minNodes, p.maxNodes)
+	return nil
+}
+
+func (p *nodeLimitPolicy) Cleanup() {}
+
+// Select truncates the sorted candidate list to at most maxNodes. minNodes
+// is informational: the framework cannot synthesize nodes that don't
+// exist. A shortfall is logged but the result is not padded.
+//
+// maxNodes <= 0 means "no upper bound".
+func (p *nodeLimitPolicy) Select(ctx *policy.PolicyContext, candidates []*corev1.Node) []*corev1.Node {
+	if p.maxNodes > 0 && len(candidates) > p.maxNodes {
+		candidates = candidates[:p.maxNodes]
+	}
+	if p.minNodes > 0 && len(candidates) < p.minNodes {
+		klog.V(4).Infof("Pipeline returned %d nodes for scheduler %s, below minNodes=%d",
+			len(candidates), ctx.SchedulerName, p.minNodes)
+	}
+	return candidates
+}

--- a/pkg/controllers/sharding/policy/nodelimit/nodelimit_test.go
+++ b/pkg/controllers/sharding/policy/nodelimit/nodelimit_test.go
@@ -1,0 +1,166 @@
+/*
+Copyright 2026 The Volcano Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+	http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nodelimit
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"volcano.sh/volcano/pkg/controllers/sharding/policy"
+)
+
+func TestNodeLimitInitialize(t *testing.T) {
+	tests := []struct {
+		name      string
+		args      policy.Arguments
+		expectErr bool
+	}{
+		{
+			name:      "valid bounds",
+			args:      policy.Arguments{"minNodes": 2, "maxNodes": 10},
+			expectErr: false,
+		},
+		{
+			name:      "max only",
+			args:      policy.Arguments{"maxNodes": 5},
+			expectErr: false,
+		},
+		{
+			name:      "no bounds (no-op selector)",
+			args:      policy.Arguments{},
+			expectErr: false,
+		},
+		{
+			name:      "negative minNodes rejected",
+			args:      policy.Arguments{"minNodes": -1, "maxNodes": 5},
+			expectErr: true,
+		},
+		{
+			name:      "max < min rejected",
+			args:      policy.Arguments{"minNodes": 10, "maxNodes": 5},
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := New()
+			if err := p.Initialize(tt.args); (err != nil) != tt.expectErr {
+				t.Errorf("Initialize() error = %v, expectErr %v", err, tt.expectErr)
+			}
+		})
+	}
+}
+
+func node(name string) *corev1.Node {
+	return &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: name}}
+}
+
+func newSelector(t *testing.T, args policy.Arguments) policy.Selector {
+	t.Helper()
+	p := New()
+	if err := p.Initialize(args); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+	s, ok := p.(policy.Selector)
+	if !ok {
+		t.Fatalf("policy does not implement Selector")
+	}
+	return s
+}
+
+func names(nodes []*corev1.Node) []string {
+	out := make([]string, len(nodes))
+	for i, n := range nodes {
+		out[i] = n.Name
+	}
+	return out
+}
+
+func TestNodeLimitSelect(t *testing.T) {
+	tests := []struct {
+		name       string
+		args       policy.Arguments
+		input      []*corev1.Node
+		expectKeep int
+	}{
+		{
+			name:       "len < max keeps all",
+			args:       policy.Arguments{"maxNodes": 5},
+			input:      []*corev1.Node{node("a"), node("b"), node("c")},
+			expectKeep: 3,
+		},
+		{
+			name:       "len == max keeps all",
+			args:       policy.Arguments{"maxNodes": 3},
+			input:      []*corev1.Node{node("a"), node("b"), node("c")},
+			expectKeep: 3,
+		},
+		{
+			name:       "len > max truncates",
+			args:       policy.Arguments{"maxNodes": 2},
+			input:      []*corev1.Node{node("a"), node("b"), node("c"), node("d")},
+			expectKeep: 2,
+		},
+		{
+			name:       "max=0 means no upper bound",
+			args:       policy.Arguments{},
+			input:      []*corev1.Node{node("a"), node("b"), node("c")},
+			expectKeep: 3,
+		},
+		{
+			name:       "len < min logs but does not pad",
+			args:       policy.Arguments{"minNodes": 5, "maxNodes": 10},
+			input:      []*corev1.Node{node("a"), node("b")},
+			expectKeep: 2,
+		},
+		{
+			name:       "empty input stays empty",
+			args:       policy.Arguments{"maxNodes": 5},
+			input:      nil,
+			expectKeep: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := newSelector(t, tt.args)
+			got := s.Select(&policy.PolicyContext{SchedulerName: "test"}, tt.input)
+			if len(got) != tt.expectKeep {
+				t.Errorf("Select kept %d nodes, want %d. Got: %v", len(got), tt.expectKeep, names(got))
+			}
+		})
+	}
+}
+
+func TestNodeLimitTruncatesPrefix(t *testing.T) {
+	// Confirm Select returns the *prefix* of the input (preserves order),
+	// not some random subset.
+	s := newSelector(t, policy.Arguments{"maxNodes": 3})
+	in := []*corev1.Node{node("a"), node("b"), node("c"), node("d"), node("e")}
+	got := s.Select(&policy.PolicyContext{SchedulerName: "test"}, in)
+
+	want := []string{"a", "b", "c"}
+	gotNames := names(got)
+	if len(gotNames) != len(want) {
+		t.Fatalf("expected %d nodes, got %d: %v", len(want), len(gotNames), gotNames)
+	}
+	for i := range want {
+		if gotNames[i] != want[i] {
+			t.Errorf("position %d: got %q, want %q", i, gotNames[i], want[i])
+		}
+	}
+}

--- a/pkg/controllers/sharding/policy/registry.go
+++ b/pkg/controllers/sharding/policy/registry.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2026 The Volcano Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+	http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package policy
+
+import (
+	"fmt"
+	"sync"
+
+	"k8s.io/klog/v2"
+)
+
+var (
+	registry      = make(map[string]PolicyBuilder)
+	registryMutex sync.RWMutex
+)
+
+// RegisterPolicy registers a policy builder with the given name
+func RegisterPolicy(name string, builder PolicyBuilder) {
+	registryMutex.Lock()
+	defer registryMutex.Unlock()
+
+	if _, exists := registry[name]; exists {
+		klog.Fatalf("policy %s already registered", name)
+	}
+
+	registry[name] = builder
+}
+
+// GetPolicy retrieves a policy builder by name
+func GetPolicy(name string) (PolicyBuilder, error) {
+	registryMutex.RLock()
+	defer registryMutex.RUnlock()
+
+	builder, exists := registry[name]
+	if !exists {
+		return nil, fmt.Errorf("policy %s not found", name)
+	}
+
+	return builder, nil
+}
+
+// ListPolicies returns a list of all registered policy names
+func ListPolicies() []string {
+	registryMutex.RLock()
+	defer registryMutex.RUnlock()
+
+	names := make([]string, 0, len(registry))
+	for name := range registry {
+		names = append(names, name)
+	}
+
+	return names
+}

--- a/pkg/controllers/sharding/policy/registry_test.go
+++ b/pkg/controllers/sharding/policy/registry_test.go
@@ -1,0 +1,92 @@
+/*
+Copyright 2026 The Volcano Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+	http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package policy
+
+import (
+	"testing"
+)
+
+// mockPolicy is a minimal ShardPolicy used only to exercise the registry.
+type mockPolicy struct {
+	name string
+}
+
+func (m *mockPolicy) Name() string                    { return m.name }
+func (m *mockPolicy) Initialize(args Arguments) error { return nil }
+func (m *mockPolicy) Cleanup()                        {}
+
+func TestRegisterAndGetPolicy(t *testing.T) {
+	// Register a test policy
+	testPolicyName := "test-policy"
+	builder := func() ShardPolicy {
+		return &mockPolicy{name: testPolicyName}
+	}
+
+	RegisterPolicy(testPolicyName, builder)
+
+	// Try to get the policy
+	retrievedBuilder, err := GetPolicy(testPolicyName)
+	if err != nil {
+		t.Fatalf("GetPolicy() error = %v", err)
+	}
+
+	if retrievedBuilder == nil {
+		t.Fatal("GetPolicy() returned nil builder")
+	}
+
+	// Create a policy instance and verify it
+	policy := retrievedBuilder()
+	if policy.Name() != testPolicyName {
+		t.Errorf("policy.Name() = %v, want %v", policy.Name(), testPolicyName)
+	}
+}
+
+func TestGetPolicyNotFound(t *testing.T) {
+	_, err := GetPolicy("non-existent-policy")
+	if err == nil {
+		t.Error("GetPolicy() expected error for non-existent policy, got nil")
+	}
+}
+
+func TestListPolicies(t *testing.T) {
+	// This test deliberately registers a couple of locally-named test
+	// policies rather than asserting on the production set. The production
+	// policies are registered by the sibling `builtin` package, which
+	// cannot be imported from here without re-introducing the cycle this
+	// package was split to avoid. Verification that all built-in policies
+	// register correctly belongs in pkg/controllers/sharding/policy/builtin.
+	testNames := []string{"list-test-alpha", "list-test-beta"}
+	builder := func() ShardPolicy { return &mockPolicy{name: "test"} }
+	for _, n := range testNames {
+		RegisterPolicy(n, builder)
+	}
+
+	policies := ListPolicies()
+	if len(policies) == 0 {
+		t.Error("ListPolicies() returned empty list")
+	}
+
+	for _, expected := range testNames {
+		found := false
+		for _, registered := range policies {
+			if registered == expected {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("Expected policy %s not found in registered policies: %v", expected, policies)
+		}
+	}
+}

--- a/pkg/controllers/sharding/policy/types.go
+++ b/pkg/controllers/sharding/policy/types.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2026 The Volcano Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+	http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package policy
+
+import (
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+// NodeMetrics contains comprehensive metrics for a node
+// This is duplicated here to avoid circular imports between policy and sharding packages
+type NodeMetrics struct {
+	NodeName        string
+	ResourceVersion string
+	LastUpdated     time.Time
+
+	// Resource capacity and allocatable
+	CPUCapacity       resource.Quantity
+	CPUAllocatable    resource.Quantity
+	MemoryCapacity    resource.Quantity
+	MemoryAllocatable resource.Quantity
+
+	// Resource utilization
+	CPUUtilization    float64 // 0.0 to 1.0
+	MemoryUtilization float64 // 0.0 to 1.0
+
+	// Node characteristics
+	IsWarmupNode bool
+	PodCount     int
+	Labels       map[string]string
+	Annotations  map[string]string
+}

--- a/pkg/controllers/sharding/policy/warmup/warmup.go
+++ b/pkg/controllers/sharding/policy/warmup/warmup.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2026 The Volcano Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+	http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package warmup
+
+import (
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/klog/v2"
+
+	"volcano.sh/volcano/pkg/controllers/sharding/policy"
+)
+
+const PolicyName = "warmup"
+
+type warmupPolicy struct {
+	warmupLabel      string
+	warmupLabelValue string
+}
+
+// New creates a new warmup policy instance.
+func New() policy.ShardPolicy {
+	return &warmupPolicy{
+		warmupLabel:      "node.volcano.sh/warmup",
+		warmupLabelValue: "true",
+	}
+}
+
+func (p *warmupPolicy) Name() string { return PolicyName }
+
+func (p *warmupPolicy) Initialize(args policy.Arguments) error {
+	args.GetString(&p.warmupLabel, "warmupLabel")
+	args.GetString(&p.warmupLabelValue, "warmupLabelValue")
+
+	if p.warmupLabel == "" {
+		return fmt.Errorf("warmupLabel cannot be empty")
+	}
+
+	klog.V(3).Infof("Initialized warmup policy: label %s=%s",
+		p.warmupLabel, p.warmupLabelValue)
+	return nil
+}
+
+func (p *warmupPolicy) Cleanup() {}
+
+// Score returns 1.0 if the node carries the configured warmup label/value,
+// else 0.0. Combined with weight: N in config, warmup-labeled nodes receive
+// a +N boost in the framework's weighted-sum sort — pulled ahead of
+// non-warmup candidates without filtering non-warmup out entirely.
+func (p *warmupPolicy) Score(ctx *policy.PolicyContext, node *corev1.Node) float64 {
+	if node == nil || node.Labels[p.warmupLabel] != p.warmupLabelValue {
+		return 0.0
+	}
+	return 1.0
+}

--- a/pkg/controllers/sharding/policy/warmup/warmup_test.go
+++ b/pkg/controllers/sharding/policy/warmup/warmup_test.go
@@ -1,0 +1,119 @@
+/*
+Copyright 2026 The Volcano Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+	http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package warmup
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"volcano.sh/volcano/pkg/controllers/sharding/policy"
+)
+
+func TestWarmupPolicyInitialize(t *testing.T) {
+	tests := []struct {
+		name      string
+		args      policy.Arguments
+		expectErr bool
+	}{
+		{
+			name: "valid configuration",
+			args: policy.Arguments{
+				"warmupLabel":      "node.volcano.sh/warmup",
+				"warmupLabelValue": "true",
+			},
+			expectErr: false,
+		},
+		{
+			name:      "empty warmup label rejected",
+			args:      policy.Arguments{"warmupLabel": ""},
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := New()
+			if err := p.Initialize(tt.args); (err != nil) != tt.expectErr {
+				t.Errorf("Initialize() error = %v, expectErr %v", err, tt.expectErr)
+			}
+		})
+	}
+}
+
+func TestWarmupPolicyScore(t *testing.T) {
+	tests := []struct {
+		name   string
+		args   policy.Arguments
+		labels map[string]string
+		want   float64
+	}{
+		{
+			name:   "default label, present",
+			args:   policy.Arguments{},
+			labels: map[string]string{"node.volcano.sh/warmup": "true"},
+			want:   1.0,
+		},
+		{
+			name:   "default label, absent",
+			args:   policy.Arguments{},
+			labels: map[string]string{},
+			want:   0.0,
+		},
+		{
+			name:   "default label, wrong value",
+			args:   policy.Arguments{},
+			labels: map[string]string{"node.volcano.sh/warmup": "false"},
+			want:   0.0,
+		},
+		{
+			name: "custom label and value, match",
+			args: policy.Arguments{
+				"warmupLabel":      "node.example.com/pool",
+				"warmupLabelValue": "warm",
+			},
+			labels: map[string]string{"node.example.com/pool": "warm"},
+			want:   1.0,
+		},
+		{
+			name: "custom label and value, mismatch",
+			args: policy.Arguments{
+				"warmupLabel":      "node.example.com/pool",
+				"warmupLabelValue": "warm",
+			},
+			labels: map[string]string{"node.example.com/pool": "cold"},
+			want:   0.0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := New()
+			if err := p.Initialize(tt.args); err != nil {
+				t.Fatalf("Initialize() error = %v", err)
+			}
+			s, ok := p.(policy.Scorer)
+			if !ok {
+				t.Fatalf("policy does not implement Scorer")
+			}
+			node := &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{Name: "n", Labels: tt.labels},
+			}
+			if got := s.Score(&policy.PolicyContext{}, node); got != tt.want {
+				t.Errorf("Score = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/controllers/sharding/sharding_controller.go
+++ b/pkg/controllers/sharding/sharding_controller.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The Volcano Authors.
+Copyright 2026 The Volcano Authors.
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -16,6 +16,7 @@ package sharding
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -332,37 +333,34 @@ func (sc *ShardingController) refreshNodeMetrics() {
 func (sc *ShardingController) parseSchedulerConfigsFromOptions() {
 	sc.schedulerConfigs = make([]SchedulerConfig, 0, len(sc.controllerOptions.SchedulerConfigs))
 
-	for _, configSpec := range sc.controllerOptions.SchedulerConfigs {
-		config := SchedulerConfig{
-			Name: configSpec.Name,
-			Type: configSpec.Type,
-			ShardStrategy: ShardStrategy{
-				CPUUtilizationRange: struct {
-					Min float64
-					Max float64
-				}{
-					Min: configSpec.CPUUtilizationMin,
-					Max: configSpec.CPUUtilizationMax,
-				},
-				PreferWarmupNodes: configSpec.PreferWarmupNodes,
-				MinNodes:          configSpec.MinNodes,
-				MaxNodes:          configSpec.MaxNodes,
-			},
+	for i, configSpec := range sc.controllerOptions.SchedulerConfigs {
+		applyPolicyDefaults(&configSpec)
+		if err := validatePolicies(i, configSpec.Name, configSpec.Policies); err != nil {
+			klog.Errorf("Invalid scheduler config: %v", err)
+			continue
 		}
 
-		sc.schedulerConfigs = append(sc.schedulerConfigs, config)
-		klog.Infof("Added scheduler config: %s", config.Name)
+		sc.schedulerConfigs = append(sc.schedulerConfigs, schedulerConfigFromSpec(configSpec))
+		klog.Infof("Added scheduler config: %s with %d policies", configSpec.Name, len(configSpec.Policies))
 	}
 
 	klog.Infof("Initialized with %d scheduler configurations", len(sc.schedulerConfigs))
 	for _, config := range sc.schedulerConfigs {
-		klog.Infof("  Scheduler %s (%s): CPU range [%.2f, %.2f], warmup=%v, nodes=[%d,%d]",
-			config.Name, config.Type,
-			config.ShardStrategy.CPUUtilizationRange.Min,
-			config.ShardStrategy.CPUUtilizationRange.Max,
-			config.ShardStrategy.PreferWarmupNodes,
-			config.ShardStrategy.MinNodes,
-			config.ShardStrategy.MaxNodes)
+		klog.Infof("  Scheduler %s (%s): policies=%v",
+			config.Name, config.Type, summarizePolicies(config.Policies))
+	}
+}
+
+// schedulerConfigFromSpec converts the user-facing SchedulerConfigSpec into
+// the internal SchedulerConfig. Both code paths (CLI options and ConfigMap)
+// funnel through here so the conversion stays consistent.
+func schedulerConfigFromSpec(spec SchedulerConfigSpec) SchedulerConfig {
+	return SchedulerConfig{
+		Name:     spec.Name,
+		Type:     spec.Type,
+		Policies: toPolicyRefs(spec.Policies),
+		MinNodes: spec.MinNodes,
+		MaxNodes: spec.MaxNodes,
 	}
 }
 
@@ -866,22 +864,8 @@ func (sc *ShardingController) loadConfigFromConfigMap() (bool, error) {
 func (sc *ShardingController) applyShardingConfig(cfg *ShardingConfig) {
 	newConfigs := make([]SchedulerConfig, 0, len(cfg.SchedulerConfigs))
 	for _, spec := range cfg.SchedulerConfigs {
-		newConfigs = append(newConfigs, SchedulerConfig{
-			Name: spec.Name,
-			Type: spec.Type,
-			ShardStrategy: ShardStrategy{
-				CPUUtilizationRange: struct {
-					Min float64
-					Max float64
-				}{
-					Min: spec.CPUUtilizationMin,
-					Max: spec.CPUUtilizationMax,
-				},
-				PreferWarmupNodes: spec.PreferWarmupNodes,
-				MinNodes:          spec.MinNodes,
-				MaxNodes:          spec.MaxNodes,
-			},
-		})
+		applyPolicyDefaults(&spec)
+		newConfigs = append(newConfigs, schedulerConfigFromSpec(spec))
 	}
 
 	periodChanged := false
@@ -914,14 +898,42 @@ func (sc *ShardingController) applyShardingConfig(cfg *ShardingConfig) {
 
 	klog.Infof("ShardingController: applied %d scheduler configs from ConfigMap:", len(newConfigs))
 	for _, c := range newConfigs {
-		klog.Infof("  %s (%s): CPU [%.2f, %.2f], warmup=%v, nodes=[%d,%d]",
-			c.Name, c.Type,
-			c.ShardStrategy.CPUUtilizationRange.Min,
-			c.ShardStrategy.CPUUtilizationRange.Max,
-			c.ShardStrategy.PreferWarmupNodes,
-			c.ShardStrategy.MinNodes,
-			c.ShardStrategy.MaxNodes)
+		klog.Infof("  %s (%s): policies=%v, nodes=[%d,%d]",
+			c.Name, c.Type, summarizePolicies(c.Policies), c.MinNodes, c.MaxNodes)
 	}
+}
+
+// toPolicyRefs converts the YAML-shaped PolicySpec list into the internal
+// PolicyRef list. Defaults Weight to 1 when omitted.
+func toPolicyRefs(specs []PolicySpec) []PolicyRef {
+	if len(specs) == 0 {
+		return nil
+	}
+	refs := make([]PolicyRef, 0, len(specs))
+	for _, s := range specs {
+		w := s.Weight
+		if w == 0 {
+			w = 1
+		}
+		refs = append(refs, PolicyRef{
+			Name:      s.Name,
+			Weight:    w,
+			Arguments: s.Arguments,
+		})
+	}
+	return refs
+}
+
+// summarizePolicies renders a one-line list for log messages.
+func summarizePolicies(refs []PolicyRef) string {
+	if len(refs) == 0 {
+		return "[]"
+	}
+	parts := make([]string, 0, len(refs))
+	for _, r := range refs {
+		parts = append(parts, fmt.Sprintf("%s(w=%d)", r.Name, r.Weight))
+	}
+	return "[" + strings.Join(parts, ", ") + "]"
 }
 
 func (sc *ShardingController) getShardSyncPeriod() time.Duration {

--- a/pkg/controllers/sharding/sharding_function_test.go
+++ b/pkg/controllers/sharding/sharding_function_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The Volcano Authors.
+Copyright 2026 The Volcano Authors.
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -155,17 +155,23 @@ func TestSchedulerConfigParsing(t *testing.T) {
 
 	agentConfig := controller.getSchedulerConfigByName("custom-agent")
 	assert.NotNil(t, agentConfig, "agent config should exist")
-	assert.Equal(t, 0.8, agentConfig.ShardStrategy.CPUUtilizationRange.Min, "agent min CPU should be 0.8")
-	assert.Equal(t, 1.0, agentConfig.ShardStrategy.CPUUtilizationRange.Max, "agent max CPU should be 1.0")
-	assert.True(t, agentConfig.ShardStrategy.PreferWarmupNodes, "agent should prefer warmup nodes")
-	assert.Equal(t, 2, agentConfig.ShardStrategy.MinNodes, "agent min nodes should be 2")
-	assert.Equal(t, 5, agentConfig.ShardStrategy.MaxNodes, "agent max nodes should be 5")
+	assert.Equal(t, 2, agentConfig.MinNodes, "agent min nodes should be 2")
+	assert.Equal(t, 5, agentConfig.MaxNodes, "agent max nodes should be 5")
+	// Deprecated scalar fields synthesize a Policies chain for compatibility.
+	assert.Equal(t, 3, len(agentConfig.Policies), "agent should have allocation-rate + warmup + node-limit")
+	assert.Equal(t, "allocation-rate", agentConfig.Policies[0].Name)
+	assert.Equal(t, 0.8, agentConfig.Policies[0].Arguments["minCPUUtil"])
+	assert.Equal(t, 1.0, agentConfig.Policies[0].Arguments["maxCPUUtil"])
+	assert.Equal(t, "warmup", agentConfig.Policies[1].Name)
+	assert.Equal(t, "node-limit", agentConfig.Policies[2].Name)
 
 	volcanoConfig := controller.getSchedulerConfigByName("custom-volcano")
 	assert.NotNil(t, volcanoConfig, "volcano config should exist")
-	assert.Equal(t, 0.0, volcanoConfig.ShardStrategy.CPUUtilizationRange.Min, "volcano min CPU should be 0.0")
-	assert.Equal(t, 0.4, volcanoConfig.ShardStrategy.CPUUtilizationRange.Max, "volcano max CPU should be 0.4")
-	assert.False(t, volcanoConfig.ShardStrategy.PreferWarmupNodes, "volcano should not prefer warmup nodes")
-	assert.Equal(t, 1, volcanoConfig.ShardStrategy.MinNodes, "volcano min nodes should be 1")
-	assert.Equal(t, 10, volcanoConfig.ShardStrategy.MaxNodes, "volcano max nodes should be 10")
+	assert.Equal(t, 1, volcanoConfig.MinNodes, "volcano min nodes should be 1")
+	assert.Equal(t, 10, volcanoConfig.MaxNodes, "volcano max nodes should be 10")
+	assert.Equal(t, 2, len(volcanoConfig.Policies), "volcano should have allocation-rate + node-limit")
+	assert.Equal(t, "allocation-rate", volcanoConfig.Policies[0].Name)
+	assert.Equal(t, 0.0, volcanoConfig.Policies[0].Arguments["minCPUUtil"])
+	assert.Equal(t, 0.4, volcanoConfig.Policies[0].Arguments["maxCPUUtil"])
+	assert.Equal(t, "node-limit", volcanoConfig.Policies[1].Name)
 }

--- a/pkg/controllers/sharding/sharding_manager.go
+++ b/pkg/controllers/sharding/sharding_manager.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The Volcano Authors.
+Copyright 2026 The Volcano Authors.
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -15,7 +15,6 @@ package sharding
 
 import (
 	"fmt"
-	"math"
 	"sort"
 	"time"
 
@@ -23,16 +22,36 @@ import (
 	"k8s.io/klog/v2"
 
 	shardv1alpha1 "volcano.sh/apis/pkg/apis/shard/v1alpha1"
+	"volcano.sh/volcano/pkg/controllers/sharding/policy"
+
+	// Blank-import registers all built-in shard policies (allocation-rate,
+	// warmup) with the policy registry at process init. Removing this import
+	// will leave the registry empty and break policy lookup.
+	_ "volcano.sh/volcano/pkg/controllers/sharding/policy/builtin"
 )
 
 const (
 	defaultBatchSize = 50
 )
 
+// resolvedPolicy pairs a configured PolicyRef with its constructed instance
+// and pre-resolved interface views. The Filter/Score/Select nil checks let
+// the hot path skip type assertions on every reconcile.
+type resolvedPolicy struct {
+	Ref      PolicyRef
+	Instance policy.ShardPolicy
+	Filter   policy.Filterer // nil if Instance does not implement Filterer
+	Score    policy.Scorer   // nil if Instance does not implement Scorer
+	Select   policy.Selector // nil if Instance does not implement Selector
+}
+
 // ShardingManager calculates shard assignments
 type ShardingManager struct {
 	schedulerConfigs []SchedulerConfig
 	metricsProvider  NodeMetricsProvider
+	// policyCache holds, for each scheduler, the ordered list of resolved
+	// policies that participate in its pipeline. Keyed by SchedulerConfig.Name.
+	policyCache map[string][]resolvedPolicy
 }
 
 // NewShardingManager creates a new sharding manager
@@ -40,9 +59,50 @@ func NewShardingManager(schedulerConfigs []SchedulerConfig, nodeMetricsProvider 
 	manager := &ShardingManager{
 		schedulerConfigs: schedulerConfigs,
 		metricsProvider:  nodeMetricsProvider,
+		policyCache:      make(map[string][]resolvedPolicy),
+	}
+
+	if err := manager.initializePolicies(); err != nil {
+		klog.Errorf("Failed to initialize policies: %v", err)
 	}
 
 	return manager
+}
+
+// initializePolicies constructs and Initializes one policy instance per
+// PolicyRef in each scheduler's chain. Policies are constructed once at
+// startup and reused across reconciles.
+func (sm *ShardingManager) initializePolicies() error {
+	for _, config := range sm.schedulerConfigs {
+		resolved := make([]resolvedPolicy, 0, len(config.Policies))
+		for _, ref := range config.Policies {
+			builder, err := policy.GetPolicy(ref.Name)
+			if err != nil {
+				return fmt.Errorf("policy %s not found for scheduler %s: %v",
+					ref.Name, config.Name, err)
+			}
+			instance := builder()
+			if err := instance.Initialize(policy.Arguments(ref.Arguments)); err != nil {
+				return fmt.Errorf("failed to initialize policy %s for scheduler %s: %v",
+					ref.Name, config.Name, err)
+			}
+			rp := resolvedPolicy{Ref: ref, Instance: instance}
+			if f, ok := instance.(policy.Filterer); ok {
+				rp.Filter = f
+			}
+			if s, ok := instance.(policy.Scorer); ok {
+				rp.Score = s
+			}
+			if sel, ok := instance.(policy.Selector); ok {
+				rp.Select = sel
+			}
+			resolved = append(resolved, rp)
+			klog.V(3).Infof("Initialized policy %s (weight=%d) for scheduler %s with args: %v",
+				instance.Name(), ref.Weight, config.Name, ref.Arguments)
+		}
+		sm.policyCache[config.Name] = resolved
+	}
+	return nil
 }
 
 // CalculateShardAssignments calculates shard assignments for all schedulers
@@ -55,69 +115,54 @@ func (sm *ShardingManager) CalculateShardAssignments(
 	defer func() {
 		duration := time.Since(startTime)
 		klog.V(4).Infof("Calculated shard assignments in %v for %d nodes", duration, len(nodes))
-
 		if duration > 1*time.Second {
 			klog.Warningf("Slow shard assignment calculation: %v for %d nodes", duration, len(nodes))
 		}
 	}()
 
-	// Batch processing for large clusters
 	if len(nodes) > defaultBatchSize {
 		return sm.calculateShardAssignmentsBatched(nodes, currentShards)
 	}
 
-	// Prepare node resources info
-	nodeResources := sm.prepareNodeResourcesInfo(nodes)
-	nodeMap := make(map[string]*corev1.Node)
-	for i := range nodes {
-		node := nodes[i]
-		nodeMap[node.Name] = node
-	}
+	allMetrics := sm.metricsProvider.GetAllNodeMetrics()
+	policyMetrics := sm.convertNodeMetrics(allMetrics)
 
-	// Track assigned nodes to ensure mutual exclusivity
 	assignedNodes := make(map[string]string) // node name -> scheduler name
 
-	// Prepare current shards map
 	currentShardsMap := make(map[string]*shardv1alpha1.NodeShard)
 	for i := range currentShards {
 		currentShardsMap[currentShards[i].Name] = currentShards[i]
 	}
 
-	// Calculate assignments for each scheduler
 	assignments := make(map[string]*ShardAssignment)
 
 	for _, config := range sm.schedulerConfigs {
-		klog.V(4).Infof("Calculating assignment for scheduler: %s", config.Name)
+		klog.V(4).Infof("Calculating assignment for scheduler %s with %d policies",
+			config.Name, len(sm.policyCache[config.Name]))
 
-		// Apply hard filtering to get eligible nodes
-		eligibleNodes := sm.filterEligibleNodes(config, nodeResources, nodeMap, assignedNodes)
-
-		// Prioritize nodes based on warmup preference and utilization
-		prioritizedNodes := sm.prioritizeNodes(config, eligibleNodes, nodeResources)
-
-		// Select nodes within constraints
-		selectedNodes := sm.selectNodesWithinConstraints(config, prioritizedNodes)
-
-		// Mark nodes as assigned
-		for _, node := range selectedNodes {
-			assignedNodes[node] = config.Name
-		}
-
-		// Create assignment
-		assignment := &ShardAssignment{
+		ctx := &policy.PolicyContext{
 			SchedulerName: config.Name,
-			NodesDesired:  selectedNodes,
-			StrategyUsed:  "hard-filtering",
-			Version:       fmt.Sprintf("%d", time.Now().UnixNano()),
-			Reason: fmt.Sprintf("Selected %d nodes within CPU range [%.2f, %.2f]",
-				len(selectedNodes), config.ShardStrategy.CPUUtilizationRange.Min,
-				config.ShardStrategy.CPUUtilizationRange.Max),
+			SchedulerType: config.Type,
+			AllNodes:      nodes,
+			NodeMetrics:   policyMetrics,
+			AssignedNodes: assignedNodes,
+			CurrentShard:  currentShardsMap[config.Name],
 		}
 
-		assignments[config.Name] = assignment
+		selected := sm.runPipeline(config, ctx)
 
-		klog.Infof("Scheduler %s assigned %d nodes: %v",
-			config.Name, len(selectedNodes), selectedNodes)
+		for _, nodeName := range selected {
+			assignedNodes[nodeName] = config.Name
+		}
+
+		assignments[config.Name] = &ShardAssignment{
+			SchedulerName: config.Name,
+			NodesDesired:  selected,
+			Version:       fmt.Sprintf("%d", time.Now().UnixNano()),
+		}
+
+		klog.Infof("Scheduler %s assigned %d nodes via %s: %v",
+			config.Name, len(selected), summarizePolicies(config.Policies), selected)
 	}
 
 	klog.Infof("Completed shard assignments: %d nodes assigned to %d schedulers",
@@ -126,7 +171,112 @@ func (sm *ShardingManager) CalculateShardAssignments(
 	return assignments, nil
 }
 
-// calculateShardAssignmentsBatched processes nodes in batches for large clusters
+// runPipeline executes Filter → Score → Select for one scheduler.
+//
+// Filter is AND-intersection: a node passes only when every configured
+// Filterer accepts it. When no policy implements Filterer, every candidate
+// advances.
+//
+// Score is the weighted sum Σ (policy.Weight × Score(node)). Weight defaults
+// to 1 when omitted (see toPolicyRefs). To disable a Scorer's contribution,
+// remove it from the chain rather than relying on weight = 0.
+//
+// Select runs every Selector in config order; each receives the previous's
+// output. An empty result stops the chain. The framework synthesizes a
+// node-limit Selector from SchedulerConfigSpec.MinNodes/MaxNodes via
+// applyPolicyDefaults so MaxNodes is honored without an inline clamp.
+func (sm *ShardingManager) runPipeline(config SchedulerConfig, ctx *policy.PolicyContext) []string {
+	resolved := sm.policyCache[config.Name]
+	candidates := dropAssigned(ctx.AllNodes, ctx.AssignedNodes)
+
+	filterers := make([]policy.Filterer, 0, len(resolved))
+	for _, rp := range resolved {
+		if rp.Filter != nil {
+			filterers = append(filterers, rp.Filter)
+		}
+	}
+	if len(filterers) > 0 {
+		kept := candidates[:0]
+		for _, n := range candidates {
+			pass := true
+			for _, f := range filterers {
+				if !f.Filter(ctx, n) {
+					pass = false
+					break
+				}
+			}
+			if pass {
+				kept = append(kept, n)
+			}
+		}
+		candidates = kept
+	}
+
+	// Parallel slice indexed by candidate position avoids per-node string
+	// hashing in the sort comparator.
+	if len(candidates) > 1 {
+		scores := make([]float64, len(candidates))
+		anyScorer := false
+		for _, rp := range resolved {
+			if rp.Score == nil {
+				continue
+			}
+			anyScorer = true
+			w := float64(rp.Ref.Weight)
+			for i, n := range candidates {
+				scores[i] += w * rp.Score.Score(ctx, n)
+			}
+		}
+		if anyScorer {
+			indices := make([]int, len(candidates))
+			for i := range indices {
+				indices[i] = i
+			}
+			sort.SliceStable(indices, func(i, j int) bool {
+				return scores[indices[i]] > scores[indices[j]]
+			})
+			sorted := make([]*corev1.Node, len(candidates))
+			for i, idx := range indices {
+				sorted[i] = candidates[idx]
+			}
+			candidates = sorted
+		}
+	}
+
+	// Phase 3: Select. Every Selector runs in config order; an empty
+	// return stops the chain.
+	for _, rp := range resolved {
+		if rp.Select == nil {
+			continue
+		}
+		candidates = rp.Select.Select(ctx, candidates)
+		if len(candidates) == 0 {
+			klog.V(4).Infof("Selector %s returned 0 nodes for scheduler %s; stopping chain",
+				rp.Ref.Name, config.Name)
+			break
+		}
+	}
+
+	names := make([]string, len(candidates))
+	for i, n := range candidates {
+		names[i] = n.Name
+	}
+	return names
+}
+
+// dropAssigned returns nodes not already claimed by another scheduler. The
+// returned slice is freshly allocated so phase loops can reslice it freely.
+func dropAssigned(nodes []*corev1.Node, assigned map[string]string) []*corev1.Node {
+	out := make([]*corev1.Node, 0, len(nodes))
+	for _, n := range nodes {
+		if _, taken := assigned[n.Name]; taken {
+			continue
+		}
+		out = append(out, n)
+	}
+	return out
+}
+
 func (sm *ShardingManager) calculateShardAssignmentsBatched(
 	nodes []*corev1.Node,
 	currentShards []*shardv1alpha1.NodeShard,
@@ -134,7 +284,6 @@ func (sm *ShardingManager) calculateShardAssignmentsBatched(
 	batchSize := defaultBatchSize
 	assignments := make(map[string]*ShardAssignment)
 
-	// Process nodes in batches
 	for i := 0; i < len(nodes); i += batchSize {
 		end := i + batchSize
 		if end > len(nodes) {
@@ -147,7 +296,6 @@ func (sm *ShardingManager) calculateShardAssignmentsBatched(
 			return nil, err
 		}
 
-		// Merge assignments
 		for scheduler, assignment := range batchAssignments {
 			if existing, exists := assignments[scheduler]; exists {
 				existing.NodesDesired = append(existing.NodesDesired, assignment.NodesDesired...)
@@ -156,214 +304,37 @@ func (sm *ShardingManager) calculateShardAssignmentsBatched(
 			}
 		}
 
-		// Small delay between batches to prevent resource starvation
 		time.Sleep(10 * time.Millisecond)
 	}
 
 	return assignments, nil
 }
 
-// filterEligibleNodes applies hard filtering based on strategy
-func (sm *ShardingManager) filterEligibleNodes(
-	config SchedulerConfig,
-	nodeResources map[string]*NodeResourceInfo,
-	nodeMap map[string]*corev1.Node,
-	assignedNodes map[string]string,
-) []*corev1.Node {
-	var eligibleNodes []*corev1.Node
-
-	minCPU := config.ShardStrategy.CPUUtilizationRange.Min
-	maxCPU := config.ShardStrategy.CPUUtilizationRange.Max
-
-	for nodeName, resourceInfo := range nodeResources {
-		// Skip already assigned nodes
-		if _, exists := assignedNodes[nodeName]; exists {
+func (sm *ShardingManager) convertNodeMetrics(metrics map[string]*NodeMetrics) map[string]*policy.NodeMetrics {
+	policyMetrics := make(map[string]*policy.NodeMetrics, len(metrics))
+	for nodeName, m := range metrics {
+		if m == nil {
 			continue
 		}
-
-		// Skip nodes with invalid utilization data
-		if resourceInfo.CPUUtilization < 0 {
-			continue
-		}
-
-		// round the utilization with 2 floating points
-		cpuUtilRounded := math.Round(resourceInfo.CPUUtilization*100) / 100
-		minCPURounded := math.Round(minCPU*100) / 100
-		maxCPURounded := math.Round(maxCPU*100) / 100
-
-		if cpuUtilRounded < minCPURounded || cpuUtilRounded > maxCPURounded {
-			continue
-		}
-
-		// Node is eligible
-		if node, exists := nodeMap[nodeName]; exists {
-			eligibleNodes = append(eligibleNodes, node)
+		policyMetrics[nodeName] = &policy.NodeMetrics{
+			NodeName:          m.NodeName,
+			ResourceVersion:   m.ResourceVersion,
+			LastUpdated:       m.LastUpdated,
+			CPUCapacity:       m.CPUCapacity,
+			CPUAllocatable:    m.CPUAllocatable,
+			MemoryCapacity:    m.MemoryCapacity,
+			MemoryAllocatable: m.MemoryAllocatable,
+			CPUUtilization:    m.CPUUtilization,
+			MemoryUtilization: m.MemoryUtilization,
+			IsWarmupNode:      m.IsWarmupNode,
+			PodCount:          m.PodCount,
+			Labels:            m.Labels,
+			Annotations:       m.Annotations,
 		}
 	}
-
-	klog.V(4).Infof("Scheduler %s has %d eligible nodes (CPU range: [%.2f, %.2f])",
-		config.Name, len(eligibleNodes), minCPU, maxCPU)
-
-	return eligibleNodes
+	return policyMetrics
 }
 
-// prioritizeNodes orders nodes based on warmup preference and utilization
-func (sm *ShardingManager) prioritizeNodes(
-	config SchedulerConfig,
-	nodes []*corev1.Node,
-	nodeResources map[string]*NodeResourceInfo,
-) []*corev1.Node {
-	if len(nodes) <= 1 {
-		return nodes
-	}
-
-	// create node index
-	nodeIndex := make(map[string]int)
-	for i, node := range nodes {
-		nodeIndex[node.Name] = i
-	}
-
-	// divide nodes into two groups using the warmup label
-	warmupNodes := make([]*corev1.Node, 0)
-	nonWarmupNodes := make([]*corev1.Node, 0)
-
-	for _, node := range nodes {
-		info := nodeResources[node.Name]
-		if info.IsWarmupNode {
-			warmupNodes = append(warmupNodes, node)
-		} else {
-			nonWarmupNodes = append(nonWarmupNodes, node)
-		}
-	}
-
-	// sort nodes by CPU utilization within groups
-	sort.Slice(warmupNodes, func(i, j int) bool {
-		infoI := nodeResources[warmupNodes[i].Name]
-		infoJ := nodeResources[warmupNodes[j].Name]
-		return infoI.CPUUtilization > infoJ.CPUUtilization
-	})
-
-	sort.Slice(nonWarmupNodes, func(i, j int) bool {
-		infoI := nodeResources[nonWarmupNodes[i].Name]
-		infoJ := nodeResources[nonWarmupNodes[j].Name]
-		return infoI.CPUUtilization > infoJ.CPUUtilization
-	})
-
-	// combine results: prefer warmup node
-	prioritized := make([]*corev1.Node, 0, len(nodes))
-
-	if config.ShardStrategy.PreferWarmupNodes {
-		prioritized = append(prioritized, warmupNodes...)
-		prioritized = append(prioritized, nonWarmupNodes...)
-	} else {
-		prioritized = append(prioritized, nonWarmupNodes...)
-		prioritized = append(prioritized, warmupNodes...)
-	}
-
-	return prioritized
-}
-
-// selectNodesWithinConstraints selects nodes within min/max constraints
-func (sm *ShardingManager) selectNodesWithinConstraints(
-	config SchedulerConfig,
-	nodes []*corev1.Node,
-) []string {
-	// compute the number of necessary nodes
-	desiredCount := sm.calculateDesiredNodeCount(config, len(nodes))
-
-	// ensure the desired node count is smaller than the minimum nodes
-	if desiredCount < config.ShardStrategy.MinNodes {
-		desiredCount = config.ShardStrategy.MinNodes
-	}
-
-	// if eligible nodes is smaller than desired, then use all eligible nodes
-	if len(nodes) < desiredCount {
-		desiredCount = len(nodes)
-	}
-
-	// select nodes
-	selected := make([]string, 0, desiredCount)
-
-	// first select nodes according to priority
-	for i := 0; i < desiredCount && i < len(nodes); i++ {
-		selected = append(selected, nodes[i].Name)
-	}
-
-	// check whether it meets the minimum node constraint
-	if len(selected) < config.ShardStrategy.MinNodes && len(nodes) > len(selected) {
-		// add extra nodes until the minimum node constraint is met
-		additionalNeeded := config.ShardStrategy.MinNodes - len(selected)
-		for i := len(selected); i < len(nodes) && additionalNeeded > 0; i++ {
-			selected = append(selected, nodes[i].Name)
-			additionalNeeded--
-		}
-	}
-
-	return selected
-}
-
-// calculateDesiredNodeCount calculates desired node count based on strategy constraints
-func (sm *ShardingManager) calculateDesiredNodeCount(config SchedulerConfig, eligibleNodeCount int) int {
-	// select all eligible nodes
-	desired := eligibleNodeCount
-
-	// apply max constraint
-	if desired > config.ShardStrategy.MaxNodes {
-		desired = config.ShardStrategy.MaxNodes
-	}
-
-	// apply min constraint
-	if desired < config.ShardStrategy.MinNodes {
-		desired = config.ShardStrategy.MinNodes
-	}
-
-	return desired
-}
-
-// prepareNodeResourcesInfo prepares resource information for nodes
-func (sm *ShardingManager) prepareNodeResourcesInfo(nodes []*corev1.Node) map[string]*NodeResourceInfo {
-	// Get all metrics from provider
-	allMetrics := sm.metricsProvider.GetAllNodeMetrics()
-
-	resources := make(map[string]*NodeResourceInfo)
-
-	for _, node := range nodes {
-		metrics := allMetrics[node.Name]
-		if metrics == nil {
-			// Create default metrics if not available
-			klog.Warningf("Metrics not found for node %s, assuming zero utilization for sharding calculation.", node.Name)
-			metrics = &NodeMetrics{
-				CPUUtilization:    0.0,
-				MemoryUtilization: 0.0,
-				IsWarmupNode:      node.Labels["node.volcano.sh/warmup"] == "true",
-				Labels:            node.Labels,
-				Annotations:       node.Annotations,
-				LastUpdated:       time.Now(),
-			}
-		}
-
-		info := &NodeResourceInfo{
-			NodeName:          node.Name,
-			CPUAllocatable:    metrics.CPUAllocatable,
-			CPUCapacity:       metrics.CPUCapacity,
-			MemoryAllocatable: metrics.MemoryAllocatable,
-			MemoryCapacity:    metrics.MemoryCapacity,
-			CPUUtilization:    metrics.CPUUtilization,
-			MemoryUtilization: metrics.MemoryUtilization,
-			IsWarmupNode:      metrics.IsWarmupNode,
-			PodCount:          metrics.PodCount,
-			Labels:            metrics.Labels,
-			Annotations:       metrics.Annotations,
-		}
-
-		resources[node.Name] = info
-	}
-
-	return resources
-}
-
-// calculateSingleSchedulerAssignment calculates assignment for a single scheduler
-// This implementation uses hard filtering instead of complex scoring
 func (sm *ShardingManager) calculateSingleSchedulerAssignment(
 	config SchedulerConfig,
 	ctx *AssignmentContext,
@@ -374,52 +345,30 @@ func (sm *ShardingManager) calculateSingleSchedulerAssignment(
 		klog.V(4).Infof("Calculated single scheduler assignment for %s in %v", config.Name, duration)
 	}()
 
-	nodeResources := sm.prepareNodeResourcesInfo(ctx.AllNodes)
+	allMetrics := sm.metricsProvider.GetAllNodeMetrics()
+	policyMetrics := sm.convertNodeMetrics(allMetrics)
 
-	// Create node map for quick lookup
-	nodeMap := make(map[string]*corev1.Node)
-	for _, node := range ctx.AllNodes {
-		nodeMap[node.Name] = node
+	policyCtx := &policy.PolicyContext{
+		SchedulerName: config.Name,
+		SchedulerType: config.Type,
+		AllNodes:      ctx.AllNodes,
+		NodeMetrics:   policyMetrics,
+		AssignedNodes: ctx.AssignedNodes,
+		CurrentShard:  ctx.CurrentShards[config.Name],
 	}
 
-	// Apply hard filtering to get eligible nodes
-	eligibleNodes := sm.filterEligibleNodes(config, nodeResources, nodeMap, ctx.AssignedNodes)
+	selected := sm.runPipeline(config, policyCtx)
 
-	// Prioritize nodes based on warmup preference and utilization
-	prioritizedNodes := sm.prioritizeNodes(config, eligibleNodes, nodeResources)
-
-	// Select nodes within constraints
-	selectedNodes := sm.selectNodesWithinConstraints(config, prioritizedNodes)
-
-	// Mark nodes as assigned in context
-	for _, nodeName := range selectedNodes {
+	for _, nodeName := range selected {
 		ctx.AssignedNodes[nodeName] = config.Name
 	}
 
-	// Create assignment
-	assignment := &ShardAssignment{
+	klog.Infof("Scheduler %s single assignment: %d nodes selected via %s",
+		config.Name, len(selected), summarizePolicies(config.Policies))
+
+	return &ShardAssignment{
 		SchedulerName: config.Name,
-		NodesDesired:  selectedNodes,
-		StrategyUsed:  "hard-filtering",
+		NodesDesired:  selected,
 		Version:       fmt.Sprintf("%d", time.Now().UnixNano()),
-		Reason:        sm.generateAssignmentReason(config, len(selectedNodes), len(eligibleNodes)),
-	}
-
-	klog.Infof("Scheduler %s single assignment completed: %d nodes selected from %d eligible",
-		config.Name, len(selectedNodes), len(eligibleNodes))
-
-	return assignment, nil
-}
-
-// generateAssignmentReason creates a human-readable reason for the assignment
-func (sm *ShardingManager) generateAssignmentReason(config SchedulerConfig, selectedCount, eligibleCount int) string {
-	minCPU := config.ShardStrategy.CPUUtilizationRange.Min
-	maxCPU := config.ShardStrategy.CPUUtilizationRange.Max
-	warmupPref := "with warmup preference"
-	if !config.ShardStrategy.PreferWarmupNodes {
-		warmupPref = "without warmup preference"
-	}
-
-	return fmt.Sprintf("Selected %d nodes from %d eligible nodes in CPU range [%.2f, %.2f] %s",
-		selectedCount, eligibleCount, minCPU, maxCPU, warmupPref)
+	}, nil
 }

--- a/pkg/controllers/sharding/sharding_manager_pipeline_test.go
+++ b/pkg/controllers/sharding/sharding_manager_pipeline_test.go
@@ -1,0 +1,440 @@
+/*
+Copyright 2026 The Volcano Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+	http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sharding
+
+import (
+	"reflect"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// stubMetricsProvider satisfies NodeMetricsProvider for pipeline tests. The
+// metric map is supplied by the caller; the pipeline reads it via
+// GetAllNodeMetrics.
+type stubMetricsProvider struct {
+	metrics map[string]*NodeMetrics
+}
+
+func (s *stubMetricsProvider) GetNodeMetrics(name string) *NodeMetrics { return s.metrics[name] }
+func (s *stubMetricsProvider) GetAllNodeMetrics() map[string]*NodeMetrics {
+	return s.metrics
+}
+func (s *stubMetricsProvider) UpdateNodeMetrics(string, *NodeMetrics) {}
+
+func nodeWithLabels(name string, labels map[string]string) *corev1.Node {
+	return &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Labels: labels},
+	}
+}
+
+// TestPipelineFilterScoreClamp exercises the full Filter → Score → Clamp
+// pipeline through ShardingManager.runPipeline.
+func TestPipelineFilterScoreClamp(t *testing.T) {
+	// Jesse's Apr 15 example: allocation-rate weight 1, warmup weight 2.
+	// Filter (allocation-rate only) keeps util ∈ [0, 0.6].
+	// Score combines: alloc.Score (= util) × 1 + warmup.Score (= 0/1) × 2.
+	cfg := SchedulerConfig{
+		Name:     "vol",
+		Type:     "volcano",
+		MinNodes: 0,
+		MaxNodes: 5,
+		Policies: []PolicyRef{
+			{Name: "allocation-rate", Weight: 1, Arguments: map[string]interface{}{
+				"minCPUUtil": 0.0,
+				"maxCPUUtil": 0.6,
+			}},
+			{Name: "warmup", Weight: 2, Arguments: map[string]interface{}{
+				"warmupLabel":      "warmup",
+				"warmupLabelValue": "true",
+			}},
+		},
+	}
+
+	warmupYes := map[string]string{"warmup": "true"}
+	warmupNo := map[string]string{"warmup": "false"}
+
+	nodes := []*corev1.Node{
+		nodeWithLabels("n1", warmupYes),
+		nodeWithLabels("n2", warmupNo),
+		nodeWithLabels("n3", warmupYes),
+		nodeWithLabels("n4", warmupNo),
+		nodeWithLabels("n5", warmupYes), // util 0.65 → filtered out
+		nodeWithLabels("n6", warmupNo),  // util 0.90 → filtered out
+		nodeWithLabels("n7", warmupYes),
+		nodeWithLabels("n8", warmupNo), // missing metrics → filtered out
+	}
+
+	metrics := map[string]*NodeMetrics{
+		"n1": {NodeName: "n1", CPUUtilization: 0.10},
+		"n2": {NodeName: "n2", CPUUtilization: 0.55},
+		"n3": {NodeName: "n3", CPUUtilization: 0.05},
+		"n4": {NodeName: "n4", CPUUtilization: 0.40},
+		"n5": {NodeName: "n5", CPUUtilization: 0.65},
+		"n6": {NodeName: "n6", CPUUtilization: 0.90},
+		"n7": {NodeName: "n7", CPUUtilization: 0.30},
+		// n8 has no metrics
+	}
+
+	mgr := NewShardingManager([]SchedulerConfig{cfg}, &stubMetricsProvider{metrics: metrics})
+	assignments, err := mgr.CalculateShardAssignments(nodes, nil)
+	if err != nil {
+		t.Fatalf("CalculateShardAssignments error: %v", err)
+	}
+
+	got := assignments["vol"].NodesDesired
+
+	// Expected weighted scores for survivors:
+	//   n1: 0.10 + 2.0 = 2.10
+	//   n2: 0.55 + 0.0 = 0.55
+	//   n3: 0.05 + 2.0 = 2.05
+	//   n4: 0.40 + 0.0 = 0.40
+	//   n7: 0.30 + 2.0 = 2.30
+	// Sort desc: n7, n1, n3, n2, n4. Clamp to maxNodes=5 → unchanged.
+	want := []string{"n7", "n1", "n3", "n2", "n4"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("pipeline output\n  got:  %v\n  want: %v", got, want)
+	}
+}
+
+// TestPipelineFilterAndIntersection confirms multiple Filterers AND-combine.
+// Two allocation-rate policies with overlapping but distinct CPU ranges:
+//   - policy A accepts util ∈ [0.0, 0.5]
+//   - policy B accepts util ∈ [0.3, 1.0]
+//
+// Only nodes accepted by *both* (i.e. util ∈ [0.3, 0.5]) survive filter.
+func TestPipelineFilterAndIntersection(t *testing.T) {
+	cfg := SchedulerConfig{
+		Name:     "vol",
+		MaxNodes: 10,
+		Policies: []PolicyRef{
+			{Name: "allocation-rate", Weight: 1, Arguments: map[string]interface{}{
+				"minCPUUtil": 0.0, "maxCPUUtil": 0.5,
+			}},
+			{Name: "allocation-rate", Weight: 1, Arguments: map[string]interface{}{
+				"minCPUUtil": 0.3, "maxCPUUtil": 1.0,
+			}},
+		},
+	}
+	nodes := []*corev1.Node{
+		nodeWithLabels("low", nil),  // 0.2 — passes A, fails B
+		nodeWithLabels("mid", nil),  // 0.4 — passes both
+		nodeWithLabels("high", nil), // 0.7 — fails A, passes B
+	}
+	metrics := map[string]*NodeMetrics{
+		"low":  {NodeName: "low", CPUUtilization: 0.2},
+		"mid":  {NodeName: "mid", CPUUtilization: 0.4},
+		"high": {NodeName: "high", CPUUtilization: 0.7},
+	}
+
+	mgr := NewShardingManager([]SchedulerConfig{cfg}, &stubMetricsProvider{metrics: metrics})
+	assignments, err := mgr.CalculateShardAssignments(nodes, nil)
+	if err != nil {
+		t.Fatalf("CalculateShardAssignments error: %v", err)
+	}
+
+	got := assignments["vol"].NodesDesired
+	want := []string{"mid"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("AND-intersection should keep only nodes accepted by every Filterer\n  got:  %v\n  want: %v", got, want)
+	}
+}
+
+// TestPipelineNoFiltererSkipsFilterPhase confirms Q7 — when zero policies
+// implement Filterer, the filter phase is a pass-through.
+func TestPipelineNoFiltererSkipsFilterPhase(t *testing.T) {
+	cfg := SchedulerConfig{
+		Name:     "vol",
+		Type:     "volcano",
+		MaxNodes: 10,
+		Policies: []PolicyRef{
+			// warmup is Scorer-only; no Filterer in this chain.
+			{Name: "warmup", Weight: 1},
+		},
+	}
+
+	nodes := []*corev1.Node{
+		nodeWithLabels("a", map[string]string{"node.volcano.sh/warmup": "true"}),
+		nodeWithLabels("b", map[string]string{"node.volcano.sh/warmup": "false"}),
+		nodeWithLabels("c", nil), // no labels — should still pass filter
+	}
+	metrics := map[string]*NodeMetrics{
+		"a": {NodeName: "a", CPUUtilization: 0.5},
+		"b": {NodeName: "b", CPUUtilization: 0.5},
+		"c": {NodeName: "c", CPUUtilization: 0.5},
+	}
+
+	mgr := NewShardingManager([]SchedulerConfig{cfg}, &stubMetricsProvider{metrics: metrics})
+	assignments, err := mgr.CalculateShardAssignments(nodes, nil)
+	if err != nil {
+		t.Fatalf("CalculateShardAssignments error: %v", err)
+	}
+
+	got := assignments["vol"].NodesDesired
+	if len(got) != 3 {
+		t.Errorf("expected all 3 nodes to survive (no filterer), got %v", got)
+	}
+	// warmup-only sort: 'a' should be first (score 1.0), b/c after (score 0).
+	if got[0] != "a" {
+		t.Errorf("expected 'a' first via warmup score, got %v", got)
+	}
+}
+
+// TestPipelineWeightedSum confirms Q1 — Σ (weight × score), not tier ordering.
+// A high-util non-warmup node should outrank a low-util warmup node when
+// allocation-rate's weight is high enough relative to warmup's.
+func TestPipelineWeightedSum(t *testing.T) {
+	// allocation-rate weight=10 dominates warmup weight=1. A non-warmup
+	// node with util 0.6 (score 6.0) beats a warmup node with util 0.0
+	// (score 0.0 + 1.0 = 1.0).
+	cfg := SchedulerConfig{
+		Name:     "vol",
+		Type:     "volcano",
+		MaxNodes: 10,
+		Policies: []PolicyRef{
+			{Name: "allocation-rate", Weight: 10, Arguments: map[string]interface{}{
+				"minCPUUtil": 0.0, "maxCPUUtil": 1.0,
+			}},
+			{Name: "warmup", Weight: 1, Arguments: map[string]interface{}{
+				"warmupLabel": "warmup", "warmupLabelValue": "true",
+			}},
+		},
+	}
+
+	nodes := []*corev1.Node{
+		nodeWithLabels("warmlow", map[string]string{"warmup": "true"}),
+		nodeWithLabels("regulhi", map[string]string{"warmup": "false"}),
+	}
+	metrics := map[string]*NodeMetrics{
+		"warmlow": {NodeName: "warmlow", CPUUtilization: 0.0},
+		"regulhi": {NodeName: "regulhi", CPUUtilization: 0.6},
+	}
+
+	mgr := NewShardingManager([]SchedulerConfig{cfg}, &stubMetricsProvider{metrics: metrics})
+	assignments, err := mgr.CalculateShardAssignments(nodes, nil)
+	if err != nil {
+		t.Fatalf("CalculateShardAssignments error: %v", err)
+	}
+
+	got := assignments["vol"].NodesDesired
+	want := []string{"regulhi", "warmlow"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("weighted sum should let high-weight policy dominate\n  got:  %v\n  want: %v", got, want)
+	}
+}
+
+// TestPipelineClampHonored confirms maxNodes truncation runs only when a
+// node-limit Selector is present in the policy chain.
+func TestPipelineClampHonored(t *testing.T) {
+	cfg := SchedulerConfig{
+		Name:     "vol",
+		MaxNodes: 2, // for documentation; the node-limit policy below enforces it
+		Policies: []PolicyRef{
+			{Name: "allocation-rate", Weight: 1, Arguments: map[string]interface{}{
+				"minCPUUtil": 0.0, "maxCPUUtil": 1.0,
+			}},
+			{Name: "node-limit", Arguments: map[string]interface{}{
+				"maxNodes": 2,
+			}},
+		},
+	}
+
+	nodes := []*corev1.Node{
+		nodeWithLabels("a", nil),
+		nodeWithLabels("b", nil),
+		nodeWithLabels("c", nil),
+		nodeWithLabels("d", nil),
+	}
+	metrics := map[string]*NodeMetrics{
+		"a": {NodeName: "a", CPUUtilization: 0.4},
+		"b": {NodeName: "b", CPUUtilization: 0.8},
+		"c": {NodeName: "c", CPUUtilization: 0.2},
+		"d": {NodeName: "d", CPUUtilization: 0.6},
+	}
+
+	mgr := NewShardingManager([]SchedulerConfig{cfg}, &stubMetricsProvider{metrics: metrics})
+	assignments, err := mgr.CalculateShardAssignments(nodes, nil)
+	if err != nil {
+		t.Fatalf("CalculateShardAssignments error: %v", err)
+	}
+
+	got := assignments["vol"].NodesDesired
+	if len(got) != 2 {
+		t.Errorf("clamp should trim to maxNodes=2, got %d nodes: %v", len(got), got)
+	}
+	// Sorted by util desc: b(0.8), d(0.6), a(0.4), c(0.2). After clamp: [b, d].
+	want := []string{"b", "d"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("expected top-2 by score after clamp\n  got:  %v\n  want: %v", got, want)
+	}
+}
+
+// TestPipelineNodeLimitSynthesizedFromScalars verifies deprecated
+// MinNodes/MaxNodes still synthesize node-limit for compatibility.
+func TestPipelineNodeLimitSynthesizedFromScalars(t *testing.T) {
+	spec := SchedulerConfigSpec{
+		Name:     "vol",
+		Type:     "volcano",
+		MinNodes: 1,
+		MaxNodes: 2,
+		Policies: []PolicySpec{
+			{Name: "allocation-rate", Weight: 1, Arguments: map[string]interface{}{
+				"minCPUUtil": 0.0, "maxCPUUtil": 1.0,
+			}},
+		},
+	}
+	applyPolicyDefaults(&spec)
+
+	if !hasPolicy(spec.Policies, "node-limit") {
+		t.Fatalf("expected node-limit to be synthesized; got policies: %v", spec.Policies)
+	}
+
+	cfg := schedulerConfigFromSpec(spec)
+	nodes := []*corev1.Node{
+		nodeWithLabels("a", nil),
+		nodeWithLabels("b", nil),
+		nodeWithLabels("c", nil),
+		nodeWithLabels("d", nil),
+	}
+	metrics := map[string]*NodeMetrics{
+		"a": {NodeName: "a", CPUUtilization: 0.4},
+		"b": {NodeName: "b", CPUUtilization: 0.8},
+		"c": {NodeName: "c", CPUUtilization: 0.2},
+		"d": {NodeName: "d", CPUUtilization: 0.6},
+	}
+
+	mgr := NewShardingManager([]SchedulerConfig{cfg}, &stubMetricsProvider{metrics: metrics})
+	assignments, err := mgr.CalculateShardAssignments(nodes, nil)
+	if err != nil {
+		t.Fatalf("CalculateShardAssignments error: %v", err)
+	}
+
+	got := assignments["vol"].NodesDesired
+	want := []string{"b", "d"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("synthesized node-limit should clamp to top-2 by score\n  got:  %v\n  want: %v", got, want)
+	}
+}
+
+// TestPipelineDropAssigned confirms cross-scheduler exclusivity — the
+// hoisted dropAssigned step removes nodes already claimed by an earlier
+// scheduler in the iteration.
+func TestPipelineDropAssigned(t *testing.T) {
+	cfgs := []SchedulerConfig{
+		{
+			Name:     "first",
+			MaxNodes: 10,
+			Policies: []PolicyRef{
+				{Name: "allocation-rate", Weight: 1, Arguments: map[string]interface{}{
+					"minCPUUtil": 0.0, "maxCPUUtil": 1.0,
+				}},
+			},
+		},
+		{
+			Name:     "second",
+			MaxNodes: 10,
+			Policies: []PolicyRef{
+				{Name: "allocation-rate", Weight: 1, Arguments: map[string]interface{}{
+					"minCPUUtil": 0.0, "maxCPUUtil": 1.0,
+				}},
+			},
+		},
+	}
+
+	nodes := []*corev1.Node{
+		nodeWithLabels("x", nil),
+		nodeWithLabels("y", nil),
+	}
+	metrics := map[string]*NodeMetrics{
+		"x": {NodeName: "x", CPUUtilization: 0.9},
+		"y": {NodeName: "y", CPUUtilization: 0.1},
+	}
+
+	mgr := NewShardingManager(cfgs, &stubMetricsProvider{metrics: metrics})
+	assignments, err := mgr.CalculateShardAssignments(nodes, nil)
+	if err != nil {
+		t.Fatalf("CalculateShardAssignments error: %v", err)
+	}
+
+	first := assignments["first"].NodesDesired
+	second := assignments["second"].NodesDesired
+
+	// First scheduler claims both (no max). Second sees zero candidates.
+	if len(first) != 2 {
+		t.Errorf("first scheduler expected 2 nodes, got %v", first)
+	}
+	if len(second) != 0 {
+		t.Errorf("second scheduler expected 0 nodes (all assigned), got %v", second)
+	}
+}
+
+// TestApplyPolicyDefaultsSynthesisLegacy checks back-compat synthesis: when
+// Policies is empty and only legacy fields are set, applyPolicyDefaults
+// produces an equivalent Policies entry.
+func TestApplyPolicyDefaultsSynthesisLegacy(t *testing.T) {
+	tests := []struct {
+		name   string
+		spec   SchedulerConfigSpec
+		expect []PolicySpec
+	}{
+		{
+			name: "explicit Policies untouched",
+			spec: SchedulerConfigSpec{
+				Policies: []PolicySpec{{Name: "allocation-rate", Weight: 1}},
+			},
+			expect: []PolicySpec{{Name: "allocation-rate", Weight: 1}},
+		},
+		{
+			name: "empty Policies, default policy synthesized",
+			spec: SchedulerConfigSpec{
+				CPUUtilizationMin: 0.2,
+				CPUUtilizationMax: 0.7,
+			},
+			expect: []PolicySpec{
+				{
+					Name:   "allocation-rate",
+					Weight: 1,
+					Arguments: map[string]interface{}{
+						"minCPUUtil": 0.2,
+						"maxCPUUtil": 0.7,
+					},
+				},
+			},
+		},
+		{
+			name: "preferWarmupNodes appends warmup entry",
+			spec: SchedulerConfigSpec{
+				Arguments:         map[string]interface{}{"minCPUUtil": 0.0, "maxCPUUtil": 1.0},
+				PreferWarmupNodes: true,
+			},
+			expect: []PolicySpec{
+				{Name: "allocation-rate", Weight: 1, Arguments: map[string]interface{}{
+					"minCPUUtil": 0.0, "maxCPUUtil": 1.0,
+				}},
+				{Name: "warmup", Weight: 1},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			spec := tt.spec
+			applyPolicyDefaults(&spec)
+			if !reflect.DeepEqual(spec.Policies, tt.expect) {
+				t.Errorf("\n  got:  %#v\n  want: %#v", spec.Policies, tt.expect)
+			}
+		})
+	}
+}

--- a/pkg/controllers/sharding/sharding_types.go
+++ b/pkg/controllers/sharding/sharding_types.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The Volcano Authors.
+Copyright 2026 The Volcano Authors.
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -22,27 +22,30 @@ import (
 	shardv1alpha1 "volcano.sh/apis/pkg/apis/shard/v1alpha1"
 )
 
-// ShardStrategy defines hard boundaries for node assignment
-type ShardStrategy struct {
-	// CPUUtilizationRange specifies inclusive range [min, max] for CPU utilization
-	CPUUtilizationRange struct {
-		Min float64
-		Max float64
-	}
-
-	// PreferWarmupNodes indicates preference for warmup nodes
-	PreferWarmupNodes bool
-
-	// MinNodes and MaxNodes define node count constraints
-	MinNodes int
-	MaxNodes int
+// PolicyRef is one entry in a scheduler's policy chain. Multiple PolicyRefs
+// drive the multi-policy pipeline: each Filterer contributes to the filter
+// phase (OR-union) and each Scorer to the score phase (weighted sum).
+type PolicyRef struct {
+	Name      string                 // registered policy name (e.g. "allocation-rate")
+	Weight    int                    // applied to Score output; default 1; only meaningful for Scorers
+	Arguments map[string]interface{} // policy-specific arguments
 }
 
-// SchedulerConfig defines the configuration for a scheduler
+// SchedulerConfig defines the configuration for a scheduler.
 type SchedulerConfig struct {
-	Name          string
-	Type          string // "volcano" or "agent"
-	ShardStrategy ShardStrategy
+	Name string
+	Type string // "volcano" or "agent"
+
+	// Policies is the per-scheduler policy chain. Filterers contribute to
+	// filter (OR-union); Scorers to score (weighted sum). Empty means no
+	// policy participation in those phases.
+	Policies []PolicyRef
+
+	// MinNodes and MaxNodes are common (non-policy-specific) bounds on the
+	// number of nodes assigned to this scheduler. The sharding controller
+	// clamps the policy output to this range; policies do not see them.
+	MinNodes int
+	MaxNodes int
 }
 
 // AssignmentCache stores the result of shard assignments with version control
@@ -97,13 +100,11 @@ type NodeResourceInfo struct {
 	Annotations       map[string]string
 }
 
-// ShardAssignment represents assignment for a single scheduler
+// ShardAssignment represents assignment for a single scheduler.
 type ShardAssignment struct {
 	SchedulerName string
 	NodesDesired  []string
-	StrategyUsed  string
 	Version       string
-	Reason        string
 }
 
 // AssignmentChangeEvent represents a change in assignment


### PR DESCRIPTION
#### What type of PR is this?
This PR transforms the NodeShard controller from a monolithic, hard-coded sharding implementation to a flexible plugin architecture, addressing issue #4944 and enabling fast Agent scheduling capabilities from #4722.

#### What this PR does / why we need it:
The original NodeShard implementation (from PR #4777) had two critical limitations:
1. **Single Strategy**: Only supported allocation-rate based sharding (pod request / node allocatable)
2. **Tight Coupling**: Sharding logic hard-coded in `ShardingManager`, making it difficult to extend

This prevented supporting new use cases like:
- Fast Agent scheduling requiring capacity headroom
- Warmup pool prioritization for minimal latency
- Custom sharding strategies for different workload types

### Solution Architecture

```
┌─────────────────────────────────────────────────────────┐
│               ShardingController                         │
│  (Parses config, manages lifecycle)                      │
└───────────────────────┬─────────────────────────────────┘
                        │
                        ▼
┌─────────────────────────────────────────────────────────┐
│               ShardingManager                            │
│  (Orchestrates policies, manages cache)                  │
└───────────────────────┬─────────────────────────────────┘
                        │
          ┌─────────────┼─────────────┐
          │             │             │
          ▼             ▼             ▼
    ┌──────────┐  ┌──────────┐  ┌──────────┐
    │Allocation│  │Capability│  │ Warmup   │
    │  Rate    │  │ Policy   │  │ Policy   │
    │ Policy   │  │          │  │          │
    └──────────┘  └──────────┘  └──────────┘
          │             │             │
          └─────────────┴─────────────┘
                        │
                        ▼
              ┌──────────────────┐
              │ Policy Registry  │
              │ (Thread-safe)    │
              └──────────────────┘
```

Key Changes:
- Created policy framework with ShardPolicy interface
- Implemented allocation-rate policy (extracted existing logic)
- Implemented capability policy (30% capacity headroom for agents)
- Implemented warmup policy (prioritize pre-warmed nodes)
- Added dual-format config parsing (backwards compatible)
- Refactored ShardingManager to delegate to policies
- Added comprehensive unit tests for all policies

New Directory Structure:
- pkg/controllers/sharding/policy/          # Policy framework
- pkg/controllers/sharding/policy/allocationrate/  # Allocation-rate policy
- pkg/controllers/sharding/policy/capability/      # Capability policy
- pkg/controllers/sharding/policy/warmup/          # Warmup policy

Configuration Examples:
- Old format: "volcano:volcano:0.0:0.6:false:2:100" (still works)
- New format: "volcano:volcano:allocation-rate:2:100:minCPUUtil=0.0,maxCPUUtil=0.6"


#### Which issue(s) this PR fixes:

Fixes #4944

#### Special notes for your reviewer:


#### Does this PR introduce a user-facing change?
```release-note
Yes.

New configuration format:
  - allocation-rate: CPU utilization-based (default, backwards compatible)
  - capability: Capacity headroom for fast Agent scheduling
  - warmup: Pre-warmed node prioritization
```