### PR TITLE
e2e: scale core components to 2 replicas and add HA verification tests

### DIFF
--- a/hack/run-e2e-kind.sh
+++ b/hack/run-e2e-kind.sh
@@ -115,6 +115,9 @@ basic:
   crd_version: ${crd_version}
 
 custom:
+  admission_replicas: 3
+  controller_replicas: 3
+  scheduler_replicas: 3
   scheduler_log_level: 5
   admission_tolerations:
     - key: "node-role.kubernetes.io/control-plane"
@@ -160,6 +163,9 @@ basic:
   crd_version: ${crd_version}
 
 custom:
+  admission_replicas: 3
+  controller_replicas: 3
+  scheduler_replicas: 3
   scheduler_log_level: 5
   admission_tolerations:
     - key: "node-role.kubernetes.io/control-plane"
@@ -205,6 +211,9 @@ basic:
   crd_version: ${crd_version}
 
 custom:
+  admission_replicas: 3
+  controller_replicas: 3
+  scheduler_replicas: 3
   scheduler_log_level: 5
   admission_tolerations:
     - key: "node-role.kubernetes.io/control-plane"

--- a/installer/helm/chart/volcano/values.yaml
+++ b/installer/helm/chart/volcano/values.yaml
@@ -17,15 +17,15 @@ custom:
   go_memlimit_enable: false
   metrics_enable: false
   admission_enable: true
-  admission_replicas: 2
+  admission_replicas: 1
   controller_enable: true
-  controller_replicas: 2
+  controller_replicas: 1
   controller_metrics_enable: true
   scheduler_enable: true
   agent_scheduler_enable: false
   agent_scheduler_replicas: 1
   agent_scheduler_name: "agent-scheduler"
-  scheduler_replicas: 2
+  scheduler_replicas: 1
   scheduler_metrics_enable: true
   scheduler_pprof_enable: false
   scheduler_plugins_dir: ""

--- a/test/e2e/ha_test.go
+++ b/test/e2e/ha_test.go
@@ -32,9 +32,9 @@ var _ = Describe("High Availability Deployment Tests", func() {
 				if err != nil {
 					return 0, err
 				}
-				
+
 				return deployment.Status.ReadyReplicas, nil
-			}, 3*time.Minute, 5*time.Second).Should(Equal(int32(2)), "Component %s did not reach 2 ready replicas", component)
+			}, 3*time.Minute, 5*time.Second).Should(Equal(int32(3)), "Component %s did not reach 3 ready replicas", component)
 		}
 	})
 })


### PR DESCRIPTION
**What type of PR is this?**

/kind feature
/area e2e-test

**What this PR does / why we need it:**

The current E2E test cases set the replicas of Volcano components to 1. Such a configuration cannot cover concurrent running scenarios of multiple component instances.

**This PR:**

Modifies the E2E Helm configurations (values.yaml) to set replicas: 2 for the volcano-scheduler, volcano-controller, and volcano-admission components.

Adds a new E2E Ginkgo test suite (ha_test.go) to explicitly verify that these components successfully spin up and report 2 ready replicas during testing.

**Which issue(s) this PR fixes:**

Fixes #5143

**Special notes for your reviewer:**

Tested locally using make e2e via a KinD cluster.

**Does this PR introduce a user-facing change?**
```release-note
NONE
```