### PR TITLE
scheduler: fix taskEligibleToPreempt blocking gang job tasks with stale NominatedNodeName

### DIFF
--- a/pkg/scheduler/actions/preempt/preempt.go
+++ b/pkg/scheduler/actions/preempt/preempt.go
@@ -440,7 +440,9 @@ func (pmpt *Action) taskEligibleToPreempt(preemptor *api.TaskInfo) error {
 
 		err := pmpt.ssn.PredicateFn(preemptor, nodeInfo)
 		if err == nil {
-			return fmt.Errorf("not eligible due to the pod's nominated node is already schedulable, which should not happen as preemption means no node is schedulable")
+			klog.V(4).Infof("Task <%s/%s> nominated node <%s> is already schedulable, continue to preempt flow",
+				preemptor.Namespace, preemptor.Name, nomNodeName)
+			return nil
 		}
 
 		fitError, ok := err.(*api.FitError)

--- a/pkg/scheduler/actions/preempt/preempt_test.go
+++ b/pkg/scheduler/actions/preempt/preempt_test.go
@@ -674,6 +674,102 @@ func TestTopologyAwarePreempt(t *testing.T) {
 	}
 }
 
+// TestPreemptWithNominatedNode verifies that a task with a stale NominatedNodeName
+// is not blocked from entering the preempt flow when its nominated node is schedulable.
+// This is a regression test for https://github.com/volcano-sh/volcano/issues/5131.
+func TestPreemptWithNominatedNode(t *testing.T) {
+	plugins := map[string]framework.PluginBuilder{
+		conformance.PluginName: conformance.New,
+		gang.PluginName:        gang.New,
+		priority.PluginName:    priority.New,
+		proportion.PluginName:  proportion.New,
+		predicates.PluginName:  predicates.New,
+	}
+	highPrio := util.BuildPriorityClass("high-priority", 100000)
+	lowPrio := util.BuildPriorityClass("low-priority", 10)
+
+	// Build a pending preemptor pod with a stale NominatedNodeName.
+	// The node has enough idle resources, so PredicateFn will return nil.
+	// Before the fix, taskEligibleToPreempt would incorrectly block this task.
+	preemptorPod := util.BuildPod("c1", "preemptor1", "", v1.PodPending, api.BuildResourceList("1", "1G"), "pg2", make(map[string]string), make(map[string]string))
+	preemptorPod.Status.NominatedNodeName = "n1"
+
+	tests := []uthelper.TestCommonStruct{
+		{
+			Name: "task with stale NominatedNodeName on schedulable node should not be blocked from preempt",
+			PodGroups: []*schedulingv1beta1.PodGroup{
+				util.BuildPodGroupWithPrio("pg1", "c1", "q1", 0, map[string]int32{}, schedulingv1beta1.PodGroupInqueue, "low-priority"),
+				util.BuildPodGroupWithPrio("pg2", "c1", "q1", 1, map[string]int32{"": 1}, schedulingv1beta1.PodGroupInqueue, "high-priority"),
+			},
+			Pods: []*v1.Pod{
+				util.BuildPod("c1", "preemptee1", "n1", v1.PodRunning, api.BuildResourceList("1", "1G"), "pg1", map[string]string{schedulingv1beta1.PodPreemptable: "true"}, make(map[string]string)),
+				preemptorPod,
+			},
+			Nodes: []*v1.Node{
+				util.BuildNode("n1", api.BuildResourceList("10", "10G", []api.ScalarResource{{Name: "pods", Value: "10"}}...), make(map[string]string)),
+			},
+			Queues: []*schedulingv1beta1.Queue{
+				util.BuildQueue("q1", 1, nil),
+			},
+			// The node has plenty of idle resources, so the preemptor should be pipelined
+			// via the 0-victim path without evicting anyone.
+			ExpectEvictNum: 0,
+		},
+	}
+
+	trueValue := true
+	tiers := []conf.Tier{
+		{
+			Plugins: []conf.PluginOption{
+				{
+					Name:               conformance.PluginName,
+					EnabledPreemptable: &trueValue,
+				},
+				{
+					Name:                gang.PluginName,
+					EnabledPreemptable:  &trueValue,
+					EnabledJobPipelined: &trueValue,
+					EnabledJobStarving:  &trueValue,
+				},
+				{
+					Name:                priority.PluginName,
+					EnabledTaskOrder:    &trueValue,
+					EnabledJobOrder:     &trueValue,
+					EnabledPreemptable:  &trueValue,
+					EnabledJobPipelined: &trueValue,
+					EnabledJobStarving:  &trueValue,
+				},
+				{
+					Name:               proportion.PluginName,
+					EnabledOverused:    &trueValue,
+					EnabledAllocatable: &trueValue,
+					EnabledQueueOrder:  &trueValue,
+					EnabledPredicate:   &trueValue,
+				},
+				{
+					Name:               predicates.PluginName,
+					EnabledPreemptable: &trueValue,
+					EnabledPredicate:   &trueValue,
+				},
+			},
+		}}
+
+	actions := []framework.Action{New()}
+	for i, test := range tests {
+		test.Plugins = plugins
+		test.PriClass = []*schedulingv1.PriorityClass{highPrio, lowPrio}
+		t.Run(test.Name, func(t *testing.T) {
+			test.RegisterSession(tiers, []conf.Configuration{{Name: actions[0].Name(),
+				Arguments: map[string]interface{}{EnableTopologyAwarePreemptionKey: false}}})
+			defer test.Close()
+			test.Run(actions)
+			if err := test.CheckAll(i); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
 func buildPodWithPodAntiAffinity(name, namespace, node string, phase v1.PodPhase, req v1.ResourceList, groupName string, labels map[string]string, selector map[string]string, topologyKey string) *v1.Pod {
 	pod := util.BuildPod(name, namespace, node, phase, req, groupName, labels, selector)
 


### PR DESCRIPTION
## What type of PR is this?

/kind bug

## What this PR does / why we need it

When a gang job's allocate attempt fails and rolls back, the `NominatedNodeName` on the pod is not cleared. In the subsequent preempt action, `taskEligibleToPreempt` finds the nominated node is schedulable and incorrectly returns an error, blocking the task from entering the preempt flow entirely.

This prevents the task from reaching the 0-victim pipeline path in `normalPreempt()`, causing the gang to fail `minAvailable` and get discarded in an infinite schedule-rollback loop.

## How does this fix it?

When `PredicateFn` returns nil (node is schedulable), instead of returning an error that blocks the task, we now return nil with a V(4) log message. This allows the task to proceed through the normal preempt flow, which already correctly handles the 0-victim case at lines 383-404 of `preempt.go`.

## Which issue(s) this PR fixes

Fixes #5131

## Does this PR introduce a user-facing change?

```release-note
Fixed a bug where gang job tasks with stale NominatedNodeName were incorrectly blocked from the preempt action when the nominated node had sufficient resources, causing the gang to fail minAvailable in an infinite loop.
```

## Testing

- Added `TestPreemptWithNominatedNode` test that creates a pending task with `NominatedNodeName` set to a schedulable node and verifies it proceeds through the 0-victim pipeline path without being blocked.
- All existing preempt tests continue to pass.