### PR TITLE
scheduler: refactor resource comparison API

### DIFF
--- a/pkg/agentscheduler/actions/allocate/allocate.go
+++ b/pkg/agentscheduler/actions/allocate/allocate.go
@@ -162,7 +162,7 @@ func (alloc *Action) prioritizeNodes(task *api.TaskInfo, predicateNodes []*api.N
 	var candidateNodesInOtherShards []*api.NodeInfo
 	shardingMode := options.ServerOpts.ShardingMode
 	for _, n := range predicateNodes {
-		if task.InitResreq.LessEqual(n.Idle, api.Zero) {
+		if ok, _ := task.InitResreq.LessEqual(n.Idle, api.Zero); ok {
 			switch shardingMode {
 			case commonutil.NoneShardingMode, commonutil.HardShardingMode:
 				candidateNodesInShard = append(candidateNodesInShard, n) //in hardmode, all predicates nodes are in shard
@@ -263,7 +263,7 @@ func (alloc *Action) failureHandler(schedCtx *agentapi.SchedulingContext) {
 func (alloc *Action) predicate(task *api.TaskInfo, node *api.NodeInfo) error {
 	// Check for Resource Predicate
 	var statusSets api.StatusSets
-	if ok, resources := task.InitResreq.LessEqualWithResourcesName(node.Idle, api.Zero); !ok {
+	if ok, resources := task.InitResreq.LessEqual(node.Idle, api.Zero); !ok {
 		statusSets = append(statusSets, &api.Status{Code: api.Unschedulable, Reason: api.WrapInsufficientResourceReason(resources)})
 		return api.NewFitErrWithStatus(task, node, statusSets...)
 	}

--- a/pkg/agentscheduler/actions/allocate/allocate.go
+++ b/pkg/agentscheduler/actions/allocate/allocate.go
@@ -166,7 +166,7 @@ func (alloc *Action) prioritizeNodes(fwk *framework.Framework, task *api.TaskInf
 	var candidateNodesInOtherShards []*api.NodeInfo
 	shardingMode := options.ServerOpts.ShardingMode
 	for _, n := range predicateNodes {
-		if task.InitResreq.LessEqual(n.Idle, api.Zero) {
+		if ok, _ := task.InitResreq.LessEqual(n.Idle, api.Zero); ok {
 			switch shardingMode {
 			case commonutil.NoneShardingMode, commonutil.HardShardingMode:
 				candidateNodesInShard = append(candidateNodesInShard, n) //in hardmode, all predicates nodes are in shard
@@ -267,7 +267,7 @@ func (alloc *Action) failureHandler(fwk *framework.Framework, schedCtx *agentapi
 func (alloc *Action) predicate(fwk *framework.Framework, task *api.TaskInfo, node *api.NodeInfo) error {
 	// Check for Resource Predicate
 	var statusSets api.StatusSets
-	if ok, resources := task.InitResreq.LessEqualWithResourcesName(node.Idle, api.Zero); !ok {
+	if ok, resources := task.InitResreq.LessEqual(node.Idle, api.Zero); !ok {
 		statusSets = append(statusSets, &api.Status{Code: api.Unschedulable, Reason: api.WrapInsufficientResourceReason(resources)})
 		return api.NewFitErrWithStatus(task, node, statusSets...)
 	}

--- a/pkg/scheduler/actions/allocate/allocate.go
+++ b/pkg/scheduler/actions/allocate/allocate.go
@@ -600,8 +600,8 @@ func (alloc *Action) allocateResourcesForTasks(subJob *api.SubJobInfo, tasks *ut
 
 		// "NominatedNodeName" can potentially be set in a previous scheduling cycle as a result of preemption.
 		// This node is likely the only candidate that will fit the pod, and hence we try it first before iterating over all nodes.
-		if len(task.Pod.Status.NominatedNodeName) > 0 {
-			if nominatedNodeInfo, ok := ssn.Nodes[task.Pod.Status.NominatedNodeName]; ok && task.InitResreq.LessEqual(nominatedNodeInfo.FutureIdle(), api.Zero) {
+		if nominatedNodeInfo, ok := ssn.Nodes[task.Pod.Status.NominatedNodeName]; ok {
+			if fit, _ := task.InitResreq.LessEqual(nominatedNodeInfo.FutureIdle(), api.Zero); fit {
 				predicateNodes, fitErrors = ph.PredicateNodes(task, []*api.NodeInfo{nominatedNodeInfo}, alloc.predicate, alloc.enablePredicateErrorCache, ssn.NodesInShard)
 			}
 		}
@@ -720,13 +720,13 @@ func (alloc *Action) prioritizeNodes(ssn *framework.Session, task *api.TaskInfo,
 	var idleCandidateNodesInOtherShards []*api.NodeInfo
 	var futureIdleCandidateNodesInOtherShards []*api.NodeInfo
 	for _, n := range predicateNodes {
-		if task.InitResreq.LessEqual(n.Idle, api.Zero) {
+		if ok, _ := task.InitResreq.LessEqual(n.Idle, api.Zero); ok {
 			if shardingMode == commonutil.SoftShardingMode && !ssn.NodesInShard.Has(n.Name) {
 				idleCandidateNodesInOtherShards = append(idleCandidateNodesInOtherShards, n)
 			} else {
 				idleCandidateNodes = append(idleCandidateNodes, n)
 			}
-		} else if task.InitResreq.LessEqual(n.FutureIdle(), api.Zero) {
+		} else if ok, _ := task.InitResreq.LessEqual(n.FutureIdle(), api.Zero); ok {
 			if shardingMode == commonutil.SoftShardingMode && !ssn.NodesInShard.Has(n.Name) {
 				futureIdleCandidateNodesInOtherShards = append(futureIdleCandidateNodesInOtherShards, n)
 			} else {
@@ -780,7 +780,7 @@ func (alloc *Action) prioritizeNodes(ssn *framework.Session, task *api.TaskInfo,
 
 func (alloc *Action) allocateResourcesForTask(stmt *framework.Statement, task *api.TaskInfo, node *api.NodeInfo, job *api.JobInfo) (err error) {
 	// Allocate idle resource to the task.
-	if task.InitResreq.LessEqual(node.Idle, api.Zero) {
+	if ok, _ := task.InitResreq.LessEqual(node.Idle, api.Zero); ok {
 		klog.V(3).Infof("Binding Task <%v/%v> to node <%v>", task.Namespace, task.Name, node.Name)
 		if err = stmt.Allocate(task, node); err != nil {
 			klog.Errorf("Failed to bind Task %v on %v in Session %v, err: %v",
@@ -800,7 +800,7 @@ func (alloc *Action) allocateResourcesForTask(stmt *framework.Statement, task *a
 		task.Namespace, task.Name, node.Name)
 
 	// Allocate releasing resource to the task if any.
-	if task.InitResreq.LessEqual(node.FutureIdle(), api.Zero) {
+	if ok, _ := task.InitResreq.LessEqual(node.FutureIdle(), api.Zero); ok {
 		klog.V(3).Infof("Pipelining Task <%v/%v> to node <%v> for <%v> on <%v>",
 			task.Namespace, task.Name, node.Name, task.InitResreq, node.Releasing)
 		if err = stmt.Pipeline(task, node.Name, false); err != nil {
@@ -817,7 +817,7 @@ func (alloc *Action) allocateResourcesForTask(stmt *framework.Statement, task *a
 func (alloc *Action) predicate(task *api.TaskInfo, node *api.NodeInfo) error {
 	// Check for Resource Predicate
 	var statusSets api.StatusSets
-	if ok, resources := task.InitResreq.LessEqualWithResourcesName(node.FutureIdle(), api.Zero); !ok {
+	if ok, resources := task.InitResreq.LessEqual(node.FutureIdle(), api.Zero); !ok {
 		statusSets = append(statusSets, &api.Status{Code: api.Unschedulable, Reason: api.WrapInsufficientResourceReason(resources)})
 		return api.NewFitErrWithStatus(task, node, statusSets...)
 	}

--- a/pkg/scheduler/actions/allocate/allocate.go
+++ b/pkg/scheduler/actions/allocate/allocate.go
@@ -794,8 +794,10 @@ func (alloc *Action) allocateResourcesForTasks(subJob *api.SubJobInfo, tasks *ut
 		// Only honor it when the nominated node belongs to this iteration's leaf set (defense in depth against cross-domain leaks).
 		if nominated := task.Pod.Status.NominatedNodeName; len(nominated) > 0 {
 			if _, inLeafSet := nodeNameSet[nominated]; inLeafSet {
-				if nominatedNodeInfo, ok := ssn.Nodes[nominated]; ok && task.InitResreq.LessEqual(nominatedNodeInfo.FutureIdle(), api.Zero) {
-					predicateNodes, fitErrors = ph.PredicateNodes(task, []*api.NodeInfo{nominatedNodeInfo}, alloc.predicate, alloc.enablePredicateErrorCache, ssn.NodesInShard)
+				if nominatedNodeInfo, ok := ssn.Nodes[nominated]; ok {
+					if fit, _ := task.InitResreq.LessEqual(nominatedNodeInfo.FutureIdle(), api.Zero); fit {
+						predicateNodes, fitErrors = ph.PredicateNodes(task, []*api.NodeInfo{nominatedNodeInfo}, alloc.predicate, alloc.enablePredicateErrorCache, ssn.NodesInShard)
+					}
 				}
 			}
 		}
@@ -890,13 +892,13 @@ func (alloc *Action) prioritizeNodes(ssn *framework.Session, task *api.TaskInfo,
 	var idleCandidateNodesInOtherShards []*api.NodeInfo
 	var futureIdleCandidateNodesInOtherShards []*api.NodeInfo
 	for _, n := range predicateNodes {
-		if task.InitResreq.LessEqual(n.Idle, api.Zero) {
+		if ok, _ := task.InitResreq.LessEqual(n.Idle, api.Zero); ok {
 			if shardingMode == commonutil.SoftShardingMode && !ssn.NodesInShard.Has(n.Name) {
 				idleCandidateNodesInOtherShards = append(idleCandidateNodesInOtherShards, n)
 			} else {
 				idleCandidateNodes = append(idleCandidateNodes, n)
 			}
-		} else if task.InitResreq.LessEqual(n.FutureIdle(), api.Zero) {
+		} else if ok, _ := task.InitResreq.LessEqual(n.FutureIdle(), api.Zero); ok {
 			if shardingMode == commonutil.SoftShardingMode && !ssn.NodesInShard.Has(n.Name) {
 				futureIdleCandidateNodesInOtherShards = append(futureIdleCandidateNodesInOtherShards, n)
 			} else {
@@ -950,7 +952,7 @@ func (alloc *Action) prioritizeNodes(ssn *framework.Session, task *api.TaskInfo,
 
 func (alloc *Action) allocateResourcesForTask(stmt *framework.Statement, task *api.TaskInfo, node *api.NodeInfo, job *api.JobInfo) (err error) {
 	// Allocate idle resource to the task.
-	if task.InitResreq.LessEqual(node.Idle, api.Zero) {
+	if ok, _ := task.InitResreq.LessEqual(node.Idle, api.Zero); ok {
 		klog.V(3).Infof("Binding Task <%v/%v> to node <%v>", task.Namespace, task.Name, node.Name)
 		if err = stmt.Allocate(task, node); err != nil {
 			klog.Errorf("Failed to bind Task %v on %v in Session %v, err: %v",
@@ -966,7 +968,7 @@ func (alloc *Action) allocateResourcesForTask(stmt *framework.Statement, task *a
 		task.Namespace, task.Name, node.Name)
 
 	// Allocate releasing resource to the task if any.
-	if task.InitResreq.LessEqual(node.FutureIdle(), api.Zero) {
+	if ok, _ := task.InitResreq.LessEqual(node.FutureIdle(), api.Zero); ok {
 		klog.V(3).Infof("Pipelining Task <%v/%v> to node <%v> for <%v> on <%v>",
 			task.Namespace, task.Name, node.Name, task.InitResreq, node.Releasing)
 		if err = stmt.Pipeline(task, node.Name, false); err != nil {
@@ -983,7 +985,7 @@ func (alloc *Action) allocateResourcesForTask(stmt *framework.Statement, task *a
 func (alloc *Action) predicate(task *api.TaskInfo, node *api.NodeInfo) error {
 	// Check for Resource Predicate
 	var statusSets api.StatusSets
-	if ok, resources := task.InitResreq.LessEqualWithResourcesName(node.FutureIdle(), api.Zero); !ok {
+	if ok, resources := task.InitResreq.LessEqual(node.FutureIdle(), api.Zero); !ok {
 		statusSets = append(statusSets, &api.Status{Code: api.Unschedulable, Reason: api.WrapInsufficientResourceReason(resources)})
 		return api.NewFitErrWithStatus(task, node, statusSets...)
 	}

--- a/pkg/scheduler/actions/gangpreempt/gangpreempt.go
+++ b/pkg/scheduler/actions/gangpreempt/gangpreempt.go
@@ -158,7 +158,7 @@ func (gp *Action) preemptJobInDomains(ssn *framework.Session, stmt *framework.St
 			selectedVictims = append(selectedVictims, bundle.Tasks...)
 			available := domainIdle.Clone()
 			available.Add(utils.SumResreq(selectedVictims))
-			if !jobNeed.LessEqual(available, api.Zero) {
+			if ok, _ := jobNeed.LessEqual(available, api.Zero); !ok {
 				continue
 			}
 

--- a/pkg/scheduler/actions/gangreclaim/gangreclaim.go
+++ b/pkg/scheduler/actions/gangreclaim/gangreclaim.go
@@ -163,7 +163,7 @@ func (gr *Action) reclaimJobInDomains(ssn *framework.Session, stmt *framework.St
 			selectedVictims = append(selectedVictims, bundle.Tasks...)
 			available := domainIdle.Clone()
 			available.Add(utils.SumResreq(selectedVictims))
-			if !jobNeed.LessEqual(available, api.Zero) {
+			if ok, _ := jobNeed.LessEqual(available, api.Zero); !ok {
 				continue
 			}
 

--- a/pkg/scheduler/actions/preempt/preempt.go
+++ b/pkg/scheduler/actions/preempt/preempt.go
@@ -380,7 +380,8 @@ func (pmpt *Action) normalPreempt(
 			// so if current queue is not allocatable(the queue will be overused when consider current preemptor's requests)
 			// or current idle resource is not enough for preemptor, it need to continue preempting
 			// otherwise, break out
-			if ssn.Allocatable(currentQueue, preemptor) && preemptor.InitResreq.LessEqual(node.FutureIdle(), api.Zero) {
+			fit, _ := preemptor.InitResreq.LessEqual(node.FutureIdle(), api.Zero)
+			if ssn.Allocatable(currentQueue, preemptor) && fit {
 				break
 			}
 			preemptee := victimsQueue.Pop().(*api.TaskInfo)
@@ -400,7 +401,8 @@ func (pmpt *Action) normalPreempt(
 			preempted, preemptor.Namespace, preemptor.Name, preemptor.InitResreq)
 
 		// If preemptor's queue is not allocatable, it means preemptor cannot be allocated. So no need care about the node idle resource
-		if ssn.Allocatable(currentQueue, preemptor) && preemptor.InitResreq.LessEqual(node.FutureIdle(), api.Zero) {
+		fit, _ := preemptor.InitResreq.LessEqual(node.FutureIdle(), api.Zero)
+		if ssn.Allocatable(currentQueue, preemptor) && fit {
 			if err := nodeStmt.Pipeline(preemptor, node.Name, evictionOccurred); err != nil {
 				klog.Errorf("Failed to pipeline Task <%s/%s> on Node <%s>",
 					preemptor.Namespace, preemptor.Name, node.Name)
@@ -765,7 +767,8 @@ func SelectVictimsOnNode(
 			return nil, api.AsStatus(err)
 		}
 
-		if ssn.SimulateAllocatableFn(ctx, state, currentQueue, preemptor) && preemptor.InitResreq.LessEqual(nodeInfo.FutureIdle(), api.Zero) {
+		fit, _ := preemptor.InitResreq.LessEqual(nodeInfo.FutureIdle(), api.Zero)
+		if ssn.SimulateAllocatableFn(ctx, state, currentQueue, preemptor) && fit {
 			if err := ssn.SimulatePredicateFn(ctx, state, preemptor, nodeInfo); err == nil {
 				klog.V(3).Infof("Pod %v/%v can be scheduled on node %v after preempt %v/%v, stop evicting more pods", preemptor.Namespace, preemptor.Name, nodeInfo.Name, task.Namespace, task.Name)
 				break
@@ -801,7 +804,8 @@ func SelectVictimsOnNode(
 		}
 
 		var fits bool
-		if ssn.SimulateAllocatableFn(ctx, state, currentQueue, preemptor) && preemptor.InitResreq.LessEqual(nodeInfo.FutureIdle(), api.Zero) {
+		fit, _ := preemptor.InitResreq.LessEqual(nodeInfo.FutureIdle(), api.Zero)
+		if ssn.SimulateAllocatableFn(ctx, state, currentQueue, preemptor) && fit {
 			err := ssn.SimulatePredicateFn(ctx, state, preemptor, nodeInfo)
 			fits = err == nil
 		}

--- a/pkg/scheduler/actions/preempt/preempt.go
+++ b/pkg/scheduler/actions/preempt/preempt.go
@@ -387,7 +387,8 @@ func (pmpt *Action) normalPreempt(
 			// so if current queue is not allocatable(the queue will be overused when consider current preemptor's requests)
 			// or current idle resource is not enough for preemptor, it need to continue preempting
 			// otherwise, break out
-			if ssn.Allocatable(currentQueue, preemptor) && preemptor.InitResreq.LessEqual(node.FutureIdle(), api.Zero) {
+			fit, _ := preemptor.InitResreq.LessEqual(node.FutureIdle(), api.Zero)
+			if ssn.Allocatable(currentQueue, preemptor) && fit {
 				break
 			}
 			preemptee := victimsQueue.Pop().(*api.TaskInfo)
@@ -407,7 +408,8 @@ func (pmpt *Action) normalPreempt(
 			preempted, preemptor.Namespace, preemptor.Name, preemptor.InitResreq)
 
 		// If preemptor's queue is not allocatable, it means preemptor cannot be allocated. So no need care about the node idle resource
-		if ssn.Allocatable(currentQueue, preemptor) && preemptor.InitResreq.LessEqual(node.FutureIdle(), api.Zero) {
+		fit, _ := preemptor.InitResreq.LessEqual(node.FutureIdle(), api.Zero)
+		if ssn.Allocatable(currentQueue, preemptor) && fit {
 			if err := nodeStmt.Pipeline(preemptor, node.Name, evictionOccurred); err != nil {
 				klog.Errorf("Failed to pipeline Task <%s/%s> on Node <%s>",
 					preemptor.Namespace, preemptor.Name, node.Name)
@@ -772,7 +774,8 @@ func SelectVictimsOnNode(
 			return nil, api.AsStatus(err)
 		}
 
-		if ssn.SimulateAllocatableFn(ctx, state, currentQueue, preemptor) && preemptor.InitResreq.LessEqual(nodeInfo.FutureIdle(), api.Zero) {
+		fit, _ := preemptor.InitResreq.LessEqual(nodeInfo.FutureIdle(), api.Zero)
+		if ssn.SimulateAllocatableFn(ctx, state, currentQueue, preemptor) && fit {
 			if err := ssn.SimulatePredicateFn(ctx, state, preemptor, nodeInfo); err == nil {
 				klog.V(3).Infof("Pod %v/%v can be scheduled on node %v after preempt %v/%v, stop evicting more pods", preemptor.Namespace, preemptor.Name, nodeInfo.Name, task.Namespace, task.Name)
 				break
@@ -808,7 +811,8 @@ func SelectVictimsOnNode(
 		}
 
 		var fits bool
-		if ssn.SimulateAllocatableFn(ctx, state, currentQueue, preemptor) && preemptor.InitResreq.LessEqual(nodeInfo.FutureIdle(), api.Zero) {
+		fit, _ := preemptor.InitResreq.LessEqual(nodeInfo.FutureIdle(), api.Zero)
+		if ssn.SimulateAllocatableFn(ctx, state, currentQueue, preemptor) && fit {
 			err := ssn.SimulatePredicateFn(ctx, state, preemptor, nodeInfo)
 			fits = err == nil
 		}

--- a/pkg/scheduler/actions/reclaim/reclaim.go
+++ b/pkg/scheduler/actions/reclaim/reclaim.go
@@ -225,7 +225,7 @@ func (ra *Action) reclaimForTask(ssn *framework.Session, stmt *framework.Stateme
 		nodeStmt := framework.NewStatement(ssn)
 		evictionOccurred := false
 		for !victimsQueue.Empty() {
-			if resreq.LessEqual(availableResources, api.Zero) {
+			if ok, _ := resreq.LessEqual(availableResources, api.Zero); ok {
 				break
 			}
 			reclaimee := victimsQueue.Pop().(*api.TaskInfo)
@@ -239,7 +239,7 @@ func (ra *Action) reclaimForTask(ssn *framework.Session, stmt *framework.Stateme
 
 		klog.V(3).Infof("Reclaimed <%v> for task <%s/%s> requested <%v>, and Node <%s> availableResources <%v>.", reclaimed, task.Namespace, task.Name, task.InitResreq, n.Name, availableResources)
 
-		if resreq.LessEqual(availableResources, api.Zero) {
+		if ok, _ := resreq.LessEqual(availableResources, api.Zero); ok {
 			if err := nodeStmt.Pipeline(task, n.Name, evictionOccurred); err != nil {
 				klog.Errorf("Failed to pipeline Task <%s/%s> on Node <%s>",
 					task.Namespace, task.Name, n.Name)

--- a/pkg/scheduler/actions/reclaim/reclaim.go
+++ b/pkg/scheduler/actions/reclaim/reclaim.go
@@ -225,7 +225,7 @@ func (ra *Action) reclaimForTask(ssn *framework.Session, stmt *framework.Stateme
 		nodeStmt := framework.NewStatement(ssn)
 		evictionOccurred := false
 		for !victimsQueue.Empty() {
-			if resreq.LessEqual(availableResources, api.Zero) {
+			if ok, _ := resreq.LessEqual(availableResources, api.Zero); ok {
 				break
 			}
 			reclaimee := victimsQueue.Pop().(*api.TaskInfo)
@@ -239,7 +239,7 @@ func (ra *Action) reclaimForTask(ssn *framework.Session, stmt *framework.Stateme
 
 		klog.V(3).Infof("Reclaimed <%v> for task <%s/%s> requested <%v>, and Node <%s> availableResources <%v>.", reclaimed, task.Namespace, task.Name, task.InitResreq, n.Name, availableResources)
 
-		if !resreq.LessEqual(availableResources, api.Zero) {
+		if ok, _ := resreq.LessEqual(availableResources, api.Zero); !ok {
 			nodeStmt.Discard()
 			continue
 		}

--- a/pkg/scheduler/actions/utils/bundle.go
+++ b/pkg/scheduler/actions/utils/bundle.go
@@ -238,7 +238,7 @@ func SelectBundles(bundles []*Bundle, need *api.Resource, allowWhole bool) []*Bu
 		}
 		selected = append(selected, b)
 		freed.Add(b.LocalRes)
-		if need.LessEqual(freed, api.Zero) {
+		if ok, _ := need.LessEqual(freed, api.Zero); ok {
 			break
 		}
 	}

--- a/pkg/scheduler/actions/utils/simulate.go
+++ b/pkg/scheduler/actions/utils/simulate.go
@@ -262,7 +262,7 @@ func runSimulateTrialAtHyperNode(
 		if bestNode == nil {
 			return nil, false
 		}
-		if !task.InitResreq.LessEqual(bestNode.FutureIdle(), api.Zero) {
+		if ok, _ := task.InitResreq.LessEqual(bestNode.FutureIdle(), api.Zero); !ok {
 			return nil, false
 		}
 		if err := trial.Pipeline(task, bestNode.Name, victimsPresent); err != nil {
@@ -283,7 +283,7 @@ func runSimulateTrialAtHyperNode(
 }
 
 func simulatePredicate(ssn *framework.Session, task *api.TaskInfo, node *api.NodeInfo) error {
-	if ok, resources := task.InitResreq.LessEqualWithResourcesName(node.FutureIdle(), api.Zero); !ok {
+	if ok, resources := task.InitResreq.LessEqual(node.FutureIdle(), api.Zero); !ok {
 		var statusSets api.StatusSets
 		statusSets = append(statusSets, &api.Status{Code: api.Unschedulable, Reason: api.WrapInsufficientResourceReason(resources)})
 		return api.NewFitErrWithStatus(task, node, statusSets...)
@@ -326,13 +326,13 @@ func prioritizeNodesForSimulate(ssn *framework.Session, task *api.TaskInfo, pred
 	var idleCandidateNodesInOtherShards []*api.NodeInfo
 	var futureIdleCandidateNodesInOtherShards []*api.NodeInfo
 	for _, n := range predicateNodes {
-		if task.InitResreq.LessEqual(n.Idle, api.Zero) {
+		if ok, _ := task.InitResreq.LessEqual(n.Idle, api.Zero); ok {
 			if shardingMode == commonutil.SoftShardingMode && !ssn.NodesInShard.Has(n.Name) {
 				idleCandidateNodesInOtherShards = append(idleCandidateNodesInOtherShards, n)
 			} else {
 				idleCandidateNodes = append(idleCandidateNodes, n)
 			}
-		} else if task.InitResreq.LessEqual(n.FutureIdle(), api.Zero) {
+		} else if ok, _ := task.InitResreq.LessEqual(n.FutureIdle(), api.Zero); ok {
 			if shardingMode == commonutil.SoftShardingMode && !ssn.NodesInShard.Has(n.Name) {
 				futureIdleCandidateNodesInOtherShards = append(futureIdleCandidateNodesInOtherShards, n)
 			} else {

--- a/pkg/scheduler/api/node_info.go
+++ b/pkg/scheduler/api/node_info.go
@@ -317,7 +317,7 @@ func (ni *NodeInfo) setNodeState(node *v1.Node) {
 	}
 
 	// set NodeState according to resources
-	if ok, resources := ni.Used.LessEqualWithResourcesName(ni.Allocatable, Zero); !ok {
+	if ok, resources := ni.Used.LessEqual(ni.Allocatable, Zero); !ok {
 		klog.ErrorS(nil, "Node out of sync", "name", ni.Name, "resources", resources)
 	}
 
@@ -419,7 +419,7 @@ func (ni *NodeInfo) setNode(node *v1.Node) {
 }
 
 func (ni *NodeInfo) allocateIdleResource(ti *TaskInfo) {
-	ok, resources := ti.Resreq.LessEqualWithResourcesName(ni.Idle, Zero)
+	ok, resources := ti.Resreq.LessEqual(ni.Idle, Zero)
 	if ok {
 		ni.Idle.sub(ti.Resreq)
 		return
@@ -460,7 +460,7 @@ func (ni *NodeInfo) AddTask(task *TaskInfo) error {
 			ni.Pipelined.Add(ti.Resreq)
 		case Binding:
 			// When task in Binding status, it will bind to node, we should double-check whether idle resources are enough to put task before bind to apiserver.
-			if ok, resNames := ti.Resreq.LessEqualWithResourcesName(ni.Idle, Zero); !ok {
+			if ok, resNames := ti.Resreq.LessEqual(ni.Idle, Zero); !ok {
 				return fmt.Errorf("node %s resources %v are not enough to put task <%s/%s>, idle: %s, req: %s", ni.Name, resNames, ti.Namespace, ti.Name, ni.Idle.String(), ti.Resreq.String())
 			}
 			ni.allocateIdleResource(ti)

--- a/pkg/scheduler/api/node_info.go
+++ b/pkg/scheduler/api/node_info.go
@@ -318,7 +318,7 @@ func (ni *NodeInfo) setNodeState(node *v1.Node) {
 	}
 
 	// set NodeState according to resources
-	if ok, resources := ni.Used.LessEqualWithResourcesName(ni.Allocatable, Zero); !ok {
+	if ok, resources := ni.Used.LessEqual(ni.Allocatable, Zero); !ok {
 		klog.ErrorS(nil, "Node out of sync", "name", ni.Name, "resources", resources)
 	}
 
@@ -429,7 +429,7 @@ func (ni *NodeInfo) setNode(node *v1.Node) {
 }
 
 func (ni *NodeInfo) allocateIdleResource(ti *TaskInfo) {
-	ok, resources := ti.Resreq.LessEqualWithResourcesName(ni.Idle, Zero)
+	ok, resources := ti.Resreq.LessEqual(ni.Idle, Zero)
 	if ok {
 		ni.Idle.sub(ti.Resreq)
 		return
@@ -469,7 +469,7 @@ func (ni *NodeInfo) AddTask(task *TaskInfo) error {
 			ni.Pipelined.Add(ti.Resreq)
 		case Binding:
 			// When task in Binding status, it will bind to node, we should double-check whether idle resources are enough to put task before bind to apiserver.
-			if ok, resNames := ti.Resreq.LessEqualWithResourcesName(ni.Idle, Zero); !ok {
+			if ok, resNames := ti.Resreq.LessEqual(ni.Idle, Zero); !ok {
 				return fmt.Errorf("node %s resources %v are not enough to put task <%s/%s>, idle: %s, req: %s", ni.Name, resNames, ti.Namespace, ti.Name, ni.Idle.String(), ti.Resreq.String())
 			}
 			ni.allocateIdleResource(ti)

--- a/pkg/scheduler/api/resource_info.go
+++ b/pkg/scheduler/api/resource_info.go
@@ -290,14 +290,15 @@ func (r *Resource) Add(rr *Resource) *Resource {
 
 // Sub subtracts two Resource objects with assertion.
 func (r *Resource) Sub(rr *Resource) *Resource {
-	assert.Assertf(rr.LessEqual(r, Zero), "resource is not sufficient to do operation: <%v> sub <%v>", r, rr)
+	ok, _ := rr.LessEqual(r, Zero)
+	assert.Assertf(ok, "resource is not sufficient to do operation: <%v> sub <%v>", r, rr)
 	return r.sub(rr)
 }
 
 // SubWithoutAssert subtracts two Resource objects without assertion,
 // this function is added because some resource subtraction allows negative results, while others do not.
 func (r *Resource) SubWithoutAssert(rr *Resource) *Resource {
-	ok, resources := rr.LessEqualWithResourcesName(r, Zero)
+	ok, resources := rr.LessEqual(r, Zero)
 	if !ok {
 		klog.Errorf("resources <%v> are not sufficient to do operation: <%v> sub <%v>", resources, r, rr)
 	}
@@ -423,10 +424,11 @@ func (r *Resource) Less(rr *Resource, defaultValue DimensionDefaultValue) bool {
 	return true
 }
 
-// LessEqual returns true only on condition that all dimensions of resources in r are less than or equal with that of rr,
-// Otherwise returns false.
+// LessEqual returns true and an empty slice if all dimensions of resources in r are less than or equal to those of rr,
+// otherwise it returns false and a slice of dimension names where r exceeds rr.
 // @param defaultValue "default value for resource dimension not defined in ScalarResources. Its value can only be one of 'Zero' and 'Infinity'"
-func (r *Resource) LessEqual(rr *Resource, defaultValue DimensionDefaultValue) bool {
+func (r *Resource) LessEqual(rr *Resource, defaultValue DimensionDefaultValue) (bool, []string) {
+	resources := []string{}
 	lessEqualFunc := func(l, r, diff float64) bool {
 		if l < r || math.Abs(l-r) < diff {
 			return true
@@ -434,103 +436,25 @@ func (r *Resource) LessEqual(rr *Resource, defaultValue DimensionDefaultValue) b
 		return false
 	}
 
-	if !lessEqualFunc(r.MilliCPU, rr.MilliCPU, minResource) {
-		return false
+	if r == nil {
+		return true, resources
 	}
-	if !lessEqualFunc(r.Memory, rr.Memory, minResource) {
-		return false
+	if rr == nil {
+		rr = EmptyResource()
 	}
 
+	if !lessEqualFunc(r.MilliCPU, rr.MilliCPU, minResource) {
+		resources = append(resources, "cpu")
+	}
+	if !lessEqualFunc(r.Memory, rr.Memory, minResource) {
+		resources = append(resources, "memory")
+	}
 	if defaultValue == Infinity {
 		for name := range rr.ScalarResources {
 			if _, ok := r.ScalarResources[name]; !ok {
-				return false
+				resources = append(resources, string(name))
 			}
 		}
-	}
-
-	for resourceName, leftValue := range r.ScalarResources {
-		rightValue, ok := rr.ScalarResources[resourceName]
-		if !ok && defaultValue == Infinity {
-			continue
-		}
-
-		if !lessEqualFunc(leftValue, rightValue, minResource) {
-			return false
-		}
-	}
-	return true
-}
-
-// LessEqualWithDimensionAndResourcesName only compare the resource items in req param
-// Will return false and a slice of resource names showing the ones that are insufficient
-// @param req define the resource item to be compared
-// if req is nil, equals r.LessEqualWithResourcesName(rr, Zero)
-func (r *Resource) LessEqualWithDimensionAndResourcesName(rr *Resource, req *Resource) (bool, []string) {
-	resources := []string{}
-	if r == nil {
-		return true, []string{}
-	}
-	if rr == nil {
-		for _, name := range r.ResourceNames() {
-			resources = append(resources, string(name))
-		}
-		return false, resources
-	}
-	if req == nil {
-		return r.LessEqualWithResourcesName(rr, Zero)
-	}
-
-	if req.MilliCPU > 0 && r.MilliCPU > rr.MilliCPU {
-		resources = append(resources, "cpu")
-	}
-	if req.Memory > 0 && r.Memory > rr.Memory {
-		resources = append(resources, "memory")
-	}
-
-	// if r.scalar is nil, whatever rr.scalar is, r is less or equal to rr
-	if r.ScalarResources == nil {
-		if len(resources) > 0 {
-			return false, resources
-		}
-		return true, resources
-	}
-
-	for name, quant := range req.ScalarResources {
-		if IsIgnoredScalarResource(name) {
-			continue
-		}
-		rQuant := r.ScalarResources[name]
-		rrQuant := rr.ScalarResources[name]
-		if quant > 0 && rQuant > rrQuant {
-			resources = append(resources, string(name))
-		}
-	}
-
-	if len(resources) > 0 {
-		return false, resources
-	}
-	return true, resources
-}
-
-// LessEqualWithResourcesName returns true, []string{} only on condition that all dimensions of resources in r are less than or equal with that of rr,
-// Otherwise returns false and a slice of string, which shows what resources are insufficient.
-// @param defaultValue "default value for resource dimension not defined in ScalarResources. Its value can only be one of 'Zero' and 'Infinity'"
-// this function is the same as LessEqual, and it will be merged to LessEqual in the future
-func (r *Resource) LessEqualWithResourcesName(rr *Resource, defaultValue DimensionDefaultValue) (bool, []string) {
-	resources := []string{}
-	lessEqualFunc := func(l, r, diff float64) bool {
-		if l < r || math.Abs(l-r) < diff {
-			return true
-		}
-		return false
-	}
-
-	if !lessEqualFunc(r.MilliCPU, rr.MilliCPU, minResource) {
-		resources = append(resources, "cpu")
-	}
-	if !lessEqualFunc(r.Memory, rr.Memory, minResource) {
-		resources = append(resources, "memory")
 	}
 
 	for resourceName, leftValue := range r.ScalarResources {
@@ -543,10 +467,46 @@ func (r *Resource) LessEqualWithResourcesName(rr *Resource, defaultValue Dimensi
 			resources = append(resources, string(resourceName))
 		}
 	}
+
 	if len(resources) > 0 {
 		return false, resources
 	}
 	return true, resources
+}
+
+// LessEqualWithDimension compares only the dimensions listed in dims.
+// Returns true if r <= rr on all listed dimensions, along with a slice of dimensions where r exceeds rr.
+// If dims is nil or empty, returns true and an empty slice (vacuously true).
+func (r *Resource) LessEqualWithDimension(rr *Resource, dims ResourceNameList) (bool, []string) {
+	if len(dims) == 0 {
+		return true, []string{}
+	}
+	if rr == nil {
+		rr = EmptyResource()
+	}
+
+	resources := []string{}
+	for _, name := range dims {
+		if !r.lessEqualDimension(rr, name) {
+			resources = append(resources, string(name))
+		}
+	}
+
+	return len(resources) == 0, resources
+}
+
+func (r *Resource) lessEqualDimension(rr *Resource, name v1.ResourceName) bool {
+	lessEqualFunc := func(l, r, diff float64) bool {
+		return l < r || math.Abs(l-r) < diff
+	}
+	switch name {
+	case v1.ResourceCPU:
+		return lessEqualFunc(r.MilliCPU, rr.MilliCPU, minResource)
+	case v1.ResourceMemory:
+		return lessEqualFunc(r.Memory, rr.Memory, minResource)
+	default:
+		return lessEqualFunc(r.Get(name), rr.Get(name), minResource)
+	}
 }
 
 // LessPartly returns true if there exists any dimension whose resource amount in r is less than that in rr.
@@ -582,10 +542,12 @@ func (r *Resource) LessPartly(rr *Resource, defaultValue DimensionDefaultValue) 
 	return false
 }
 
-// LessEqualPartly returns true if there exists any dimension whose resource amount in r is less than or equal with that in rr.
-// Otherwise returns false.
+// LessEqualPartly returns true and a slice of sufficient resource names if there exists any dimension
+// whose resource amount in r is less than or equal to that in rr.
+// Otherwise returns false and an empty slice.
 // @param defaultValue "default value for resource dimension not defined in ScalarResources. Its value can only be one of 'Zero' and 'Infinity'"
-func (r *Resource) LessEqualPartly(rr *Resource, defaultValue DimensionDefaultValue) bool {
+func (r *Resource) LessEqualPartly(rr *Resource, defaultValue DimensionDefaultValue) (bool, []string) {
+	resources := []string{}
 	lessEqualFunc := func(l, r, diff float64) bool {
 		if l < r || math.Abs(l-r) < diff {
 			return true
@@ -593,14 +555,24 @@ func (r *Resource) LessEqualPartly(rr *Resource, defaultValue DimensionDefaultVa
 		return false
 	}
 
-	if lessEqualFunc(r.MilliCPU, rr.MilliCPU, minResource) || lessEqualFunc(r.Memory, rr.Memory, minResource) {
-		return true
+	if r == nil {
+		return true, resources
+	}
+	if rr == nil {
+		rr = EmptyResource()
+	}
+
+	if lessEqualFunc(r.MilliCPU, rr.MilliCPU, minResource) {
+		resources = append(resources, "cpu")
+	}
+	if lessEqualFunc(r.Memory, rr.Memory, minResource) {
+		resources = append(resources, "memory")
 	}
 
 	if defaultValue == Zero {
 		for name := range rr.ScalarResources {
 			if _, ok := r.ScalarResources[name]; !ok {
-				return true
+				resources = append(resources, string(name))
 			}
 		}
 	}
@@ -608,93 +580,74 @@ func (r *Resource) LessEqualPartly(rr *Resource, defaultValue DimensionDefaultVa
 	for resourceName, leftValue := range r.ScalarResources {
 		rightValue, ok := rr.ScalarResources[resourceName]
 		if !ok && defaultValue == Infinity {
-			return true
+			resources = append(resources, string(resourceName))
+			continue
 		}
 
 		if lessEqualFunc(leftValue, rightValue, minResource) {
-			return true
+			resources = append(resources, string(resourceName))
 		}
 	}
-	return false
+
+	if len(resources) > 0 {
+		return true, resources
+	}
+	return false, resources
 }
 
-// LessEqualPartlyWithDimension returns true if there exists any dimension
-// whose resource amount in r is less than or equal with that in rr along the requested dimensions in req.
-// Will return true and a slice of resource names that are sufficient
-// @param req define the resource item with the dimensions to be compared
-// if req is nil then return is false and an empty slice
-func (r *Resource) LessEqualPartlyWithDimension(rr *Resource, req *Resource) (bool, []string) {
-	lessEqualFunc := func(l, r, diff float64) bool {
-		return l < r || math.Abs(l-r) < diff
+// LessEqualPartlyWithDimension returns true if any dimension in dims satisfies r <= rr.
+// Returns the matching dimension names. If dims is nil or empty, returns false and an empty slice.
+func (r *Resource) LessEqualPartlyWithDimension(rr *Resource, dims ResourceNameList) (bool, []string) {
+	if len(dims) == 0 {
+		return false, []string{}
+	}
+	if rr == nil {
+		rr = EmptyResource()
 	}
 
 	resources := []string{}
-	found := false
-
-	if req == nil {
-		return false, resources
-	}
-	// CPU
-	if req.MilliCPU > 0 {
-		if lessEqualFunc(r.MilliCPU, rr.MilliCPU, minResource) {
-			resources = append(resources, "cpu")
-			found = true
-		}
-	}
-	// Memory
-	if req.Memory > 0 {
-		if lessEqualFunc(r.Memory, rr.Memory, minResource) {
-			resources = append(resources, "memory")
-			found = true
-		}
-	}
-	// Scalar resources
-	for name, quant := range req.ScalarResources {
-		if IsIgnoredScalarResource(name) {
-			continue
-		}
-		if quant > 0 && lessEqualFunc(r.Get(name), rr.Get(name), minResource) {
+	for _, name := range dims {
+		if r.lessEqualDimension(rr, name) {
 			resources = append(resources, string(name))
-			found = true
 		}
 	}
-	return found, resources
+	return len(resources) > 0, resources
 }
 
-// LessEqualPartlyWithDimensionZeroFiltered filters out dimensions present in req that are both zero (or nil) in r and rr,
-// then calls LessEqualPartlyWithDimension to compare only the relevant dimensions.
-// This is needed for preemption cases, where we want to ignore dimensions that are not being used by either the current resource
-// or the compared resource but are present in the requested resource.
-// Returns true and a slice of resource names that are sufficient along the filtered dimensions.
-// @param req define the resource item with the dimensions to be compared
-// If req is nil, returns false and an empty slice.
-func (r *Resource) LessEqualPartlyWithDimensionZeroFiltered(rr *Resource, req *Resource) (bool, []string) {
-	if req == nil {
+// LessEqualPartlyWithRelevantDimensions filters out dimensions where both r and rr are zero,
+// then compares only the remaining dimensions via LessEqualPartlyWithDimension.
+// In preemption cases, dimensions unused by both resources should be ignored.
+// @param dims define the resource names with the dimensions to be compared
+// If dims is nil or empty, returns false and an empty slice.
+func (r *Resource) LessEqualPartlyWithRelevantDimensions(rr *Resource, dims ResourceNameList) (bool, []string) {
+	if len(dims) == 0 {
 		return false, []string{}
 	}
-	filteredReq := &Resource{}
+	if rr == nil {
+		rr = EmptyResource()
+	}
 
-	// CPU
-	if req.MilliCPU > 0 && !(r.MilliCPU < minResource && rr.MilliCPU < minResource) {
-		filteredReq.MilliCPU = req.MilliCPU
-	}
-	// Memory
-	if req.Memory > 0 && !(r.Memory < minResource && rr.Memory < minResource) {
-		filteredReq.Memory = req.Memory
-	}
-	// Scalar resources
-	if req.ScalarResources != nil {
-		filteredReq.ScalarResources = make(map[v1.ResourceName]float64)
-		for name, quant := range req.ScalarResources {
-			rQuant := r.Get(name)
-			rrQuant := rr.Get(name)
-			if quant > 0 && !(rQuant < minResource && rrQuant < minResource) {
-				filteredReq.ScalarResources[name] = quant
-			}
+	filteredDims := ResourceNameList{}
+	for _, name := range dims {
+		rVal := r.getResourceValue(name)
+		rrVal := rr.getResourceValue(name)
+		if !(rVal < minResource && rrVal < minResource) {
+			filteredDims = append(filteredDims, name)
 		}
 	}
 
-	return r.LessEqualPartlyWithDimension(rr, filteredReq)
+	return r.LessEqualPartlyWithDimension(rr, filteredDims)
+}
+
+func (r *Resource) getResourceValue(name v1.ResourceName) float64 {
+	switch name {
+	case v1.ResourceCPU:
+		return r.MilliCPU
+	case v1.ResourceMemory:
+		return r.Memory
+	default:
+		return r.Get(name)
+	}
 }
 
 // Equal returns true only on condition that values in all dimension are equal with each other for r and rr
@@ -723,155 +676,127 @@ func (r *Resource) Equal(rr *Resource, defaultValue DimensionDefaultValue) bool 
 // @param defaultValue "default value for resource dimension not defined in ScalarResources. Its value can only be one of 'Zero' and 'Infinity'"
 // @returns true and a slice of resource names that are exceeding else false and an empty slice.
 func (r *Resource) GreaterPartly(rr *Resource, defaultValue DimensionDefaultValue) (bool, []string) {
-	ok, resources := r.LessEqualWithResourcesName(rr, defaultValue)
+	ok, resources := r.LessEqual(rr, defaultValue)
 	return !ok, resources
 }
 
 // GreaterPartlyWithDimension returns true if there exists any dimension
-// whose resource amount in r is greater than that in rr along the requested dimensions in req.
+// whose resource amount in r is greater than that in rr along the requested dimensions in dims.
 // Will return true and a slice of resource names that are exceeding
 //
 // The main difference between GreaterPartlyWithDimension and GreaterPartlyWithRelevantDimensions is that the latter
 // will filter out standard dimensions (MilliCPU, Memory) where rr is zero or less than minResource and
-// only considers scalar dimensions greater than 0 in req and present in rr.
+// only considers scalar dimensions greater than 0 in dims and present in rr.
 //
 // For example:
 //
-//	r: <gpu 2> rr: <> req: <gpu 1>
-//	  r.GreaterPartlyWithDimension(rr, req) => (true, [gpu])
-//	  r.GreaterPartlyWithRelevantDimensions(rr, req) => (false, []) since rr does not have gpu resource
-//	r: <cpu 4> rr: <cpu 0> req: <cpu 2>
-//	  r.GreaterPartlyWithDimension(rr, req) => (true, [cpu])
-//	  r.GreaterPartlyWithRelevantDimensions(rr, req) => (false, []) since rr has zero cpu resource
+//	r: <gpu 2> rr: <> dims: [gpu]
+//	  r.GreaterPartlyWithDimension(rr, dims) => (true, [gpu])
+//	  r.GreaterPartlyWithRelevantDimensions(rr, dims) => (false, []) since rr does not have gpu resource
+//	r: <cpu 4> rr: <cpu 0> dims: [cpu]
+//	  r.GreaterPartlyWithDimension(rr, dims) => (true, [cpu])
+//	  r.GreaterPartlyWithRelevantDimensions(rr, dims) => (false, []) since rr has zero cpu resource
 //
 // But these cases are the same:
 //
-//	r: <gpu 2> rr: <gpu 0> req: <gpu 1>
-//	  r.GreaterPartlyWithDimension(rr, req) => (true, [gpu])
-//	  r.GreaterPartlyWithRelevantDimensions(rr, req) => (true, [gpu]) since rr has gpu resource defined (even if zero)
-//	r: <cpu 4> rr: <cpu 0.1> req: <cpu 2>
-//	  r.GreaterPartlyWithDimension(rr, req) => (true, [cpu])
-//	  r.GreaterPartlyWithRelevantDimensions(rr, req) => (true, [cpu]) since rr has cpu resource greater than minResource
+//	r: <gpu 2> rr: <gpu 0> dims: [gpu]
+//	  r.GreaterPartlyWithDimension(rr, dims) => (true, [gpu])
+//	  r.GreaterPartlyWithRelevantDimensions(rr, dims) => (true, [gpu]) since rr has gpu resource defined (even if zero)
+//	r: <cpu 4> rr: <cpu 0.1> dims: [cpu]
+//	  r.GreaterPartlyWithDimension(rr, dims) => (true, [cpu])
+//	  r.GreaterPartlyWithRelevantDimensions(rr, dims) => (true, [cpu]) since rr has cpu resource greater than minResource
 //	r: <cpu 4, memory 8192, gpu 2> rr: <cpu 2, memory 8192, gpu 1>
-//	  req: <cpu 0, memory 0, gpu 1> => return (true, [gpu])
-//	  req: <cpu 2, memory 0, gpu 1> => return (true, [cpu, gpu])
-//	  req: <cpu 0, memory 4096, gpu 0> => return (false, [])
+//	  dims: [gpu]              => return (true, [gpu])
+//	  dims: [cpu, gpu]         => return (true, [cpu, gpu])
+//	  dims: [memory]           => return (false, [])
 //
 // The functions are not interchangeable and should be used based on specific comparison needs.
-// As a remark they don't differ in the handling of r and req, only in the handling of rr.
+// As a remark they don't differ in the handling of r and dims, only in the handling of rr.
 //
 // @param rr is the Resource to compare against. If nil, treated as EmptyResource().
-// @param req is the Resource item with the dimensions to be compared on.
+// @param dims define the resource names with the dimensions to be compared on.
 // @returns true and a slice of resource names that are exceeding else false and an empty slice.
-// If req is nil then return is false and an empty slice.
-func (r *Resource) GreaterPartlyWithDimension(rr *Resource, req *Resource) (bool, []string) {
-	greaterFunc := func(l, r float64) bool {
-		return l > r
-	}
-
-	resources := []string{}
-
-	if req == nil {
-		return false, resources
-	}
-	if rr == nil {
-		rr = EmptyResource()
-	}
-
-	// CPU
-	if req.MilliCPU > 0 {
-		if greaterFunc(r.MilliCPU, rr.MilliCPU) {
-			resources = append(resources, "cpu")
-		}
-	}
-	// Memory
-	if req.Memory > 0 {
-		if greaterFunc(r.Memory, rr.Memory) {
-			resources = append(resources, "memory")
-		}
-	}
-	// Scalar resources
-	for name, quant := range req.ScalarResources {
-		if IsIgnoredScalarResource(name) {
-			continue
-		}
-		if quant > 0 && greaterFunc(r.Get(name), rr.Get(name)) {
-			resources = append(resources, string(name))
-		}
-	}
-	return len(resources) > 0, resources
-}
-
-// GreaterPartlyWithRelevantDimensions compares resource dimensions in req between r and rr,
-// but ignores any standard dimensions (MilliCPU, Memory) where rr is zero or less than minResource.
-// For scalar resources, only dimensions present in both req and rr are considered.
-// This is useful for reclaim scenarios, where you want to check if r exceeds rr
-// only in dimensions that rr actually possesses (i.e., "infinity-type" comparison).
-//
-// The main difference between GreaterPartlyWithDimension and GreaterPartlyWithRelevantDimensions is that the latter
-// will filter out standard dimensions (MilliCPU, Memory) where rr is zero or less than minResource and
-// only considers scalar dimensions greater than 0 in req and present in rr.
-//
-// For example:
-//
-//	r: <gpu 2> rr: <> req: <gpu 1>
-//	  r.GreaterPartlyWithDimension(rr, req) => (true, [gpu])
-//	  r.GreaterPartlyWithRelevantDimensions(rr, req) => (false, []) since rr does not have gpu resource
-//	r: <cpu 4> rr: <cpu 0> req: <cpu 2>
-//	  r.GreaterPartlyWithDimension(rr, req) => (true, [cpu])
-//	  r.GreaterPartlyWithRelevantDimensions(rr, req) => (false, []) since rr has zero cpu resource
-//
-// But these cases are the same:
-//
-//	r: <gpu 2> rr: <gpu 0> req: <gpu 1>
-//	  r.GreaterPartlyWithDimension(rr, req) => (true, [gpu])
-//	  r.GreaterPartlyWithRelevantDimensions(rr, req) => (true, [gpu]) since rr has gpu resource defined (even if zero)
-//	r: <cpu 4> rr: <cpu 0.1> req: <cpu 2>
-//	  r.GreaterPartlyWithDimension(rr, req) => (true, [cpu])
-//	  r.GreaterPartlyWithRelevantDimensions(rr, req) => (true, [cpu]) since rr has cpu resource greater than minResource
-//	r: <cpu 4, memory 8192, gpu 2> rr: <cpu 2, memory 8192, gpu 1>
-//	  req: <cpu 0, memory 0, gpu 1> => return (true, [gpu])
-//	  req: <cpu 2, memory 0, gpu 1> => return (true, [cpu, gpu])
-//	  req: <cpu 0, memory 4096, gpu 0> => return (false, [])
-//
-// The functions are not interchangeable and should be used based on specific comparison needs.
-// As a remark they don't differ in the handling of r and req, only in the handling of rr.
-//
-// @param rr is the Resource to compare against. If nil, treated as EmptyResource().
-// @param req is the Resource item with the dimensions to be compared on.
-// @returns true and a slice of resource names that are exceeding else false and an empty slice.
-// If req is nil then return is false and an empty slice.
-func (r *Resource) GreaterPartlyWithRelevantDimensions(rr *Resource, req *Resource) (bool, []string) {
-	if req == nil {
+// If dims is nil or empty, returns false and an empty slice.
+func (r *Resource) GreaterPartlyWithDimension(rr *Resource, dims ResourceNameList) (bool, []string) {
+	if len(dims) == 0 {
 		return false, []string{}
 	}
 	if rr == nil {
 		rr = EmptyResource()
 	}
-	filteredReq := &Resource{}
 
-	// CPU
-	if req.MilliCPU > 0 && !(rr.MilliCPU < minResource) {
-		filteredReq.MilliCPU = req.MilliCPU
+	resources := []string{}
+	for _, name := range dims {
+		if r.getResourceValue(name) > rr.getResourceValue(name) {
+			resources = append(resources, string(name))
+		}
 	}
 
-	// Memory
-	if req.Memory > 0 && !(rr.Memory < minResource) {
-		filteredReq.Memory = req.Memory
+	return len(resources) > 0, resources
+}
+
+// GreaterPartlyWithRelevantDimensions compares resource dimensions in dims between r and rr,
+// but ignores any standard dimensions (MilliCPU, Memory) where rr is zero or less than minResource.
+// For scalar resources, only dimensions present in both dims and rr are considered.
+// This is useful for reclaim scenarios, where you want to check if r exceeds rr
+// only in dimensions that rr actually possesses (i.e., "infinity-type" comparison).
+//
+// The main difference between GreaterPartlyWithDimension and GreaterPartlyWithRelevantDimensions is that the latter
+// will filter out standard dimensions (MilliCPU, Memory) where rr is zero or less than minResource and
+// only considers scalar dimensions greater than 0 in dims and present in rr.
+//
+// For example:
+//
+//	r: <gpu 2> rr: <> dims: [gpu]
+//	  r.GreaterPartlyWithDimension(rr, dims) => (true, [gpu])
+//	  r.GreaterPartlyWithRelevantDimensions(rr, dims) => (false, []) since rr does not have gpu resource
+//	r: <cpu 4> rr: <cpu 0> dims: [cpu]
+//	  r.GreaterPartlyWithDimension(rr, dims) => (true, [cpu])
+//	  r.GreaterPartlyWithRelevantDimensions(rr, dims) => (false, []) since rr has zero cpu resource
+//
+// But these cases are the same:
+//
+//	r: <gpu 2> rr: <gpu 0> dims: [gpu]
+//	  r.GreaterPartlyWithDimension(rr, dims) => (true, [gpu])
+//	  r.GreaterPartlyWithRelevantDimensions(rr, dims) => (true, [gpu]) since rr has gpu resource defined (even if zero)
+//	r: <cpu 4> rr: <cpu 0.1> dims: [cpu]
+//	  r.GreaterPartlyWithDimension(rr, dims) => (true, [cpu])
+//	  r.GreaterPartlyWithRelevantDimensions(rr, dims) => (true, [cpu]) since rr has cpu resource greater than minResource
+//	r: <cpu 4, memory 8192, gpu 2> rr: <cpu 2, memory 8192, gpu 1>
+//	  dims: [gpu]              => return (true, [gpu])
+//	  dims: [cpu, gpu]         => return (true, [cpu, gpu])
+//	  dims: [memory]           => return (false, [])
+//
+// The functions are not interchangeable and should be used based on specific comparison needs.
+// As a remark they don't differ in the handling of r and dims, only in the handling of rr.
+//
+// @param rr is the Resource to compare against. If nil, treated as EmptyResource().
+// @param dims define the resource names with the dimensions to be compared on.
+// @returns true and a slice of resource names that are exceeding else false and an empty slice.
+// If dims is nil or empty, returns false and an empty slice.
+func (r *Resource) GreaterPartlyWithRelevantDimensions(rr *Resource, dims ResourceNameList) (bool, []string) {
+	if len(dims) == 0 {
+		return false, []string{}
+	}
+	if rr == nil {
+		rr = EmptyResource()
 	}
 
-	// Scalar resources
-	if req.ScalarResources != nil {
-		filteredReq.ScalarResources = make(map[v1.ResourceName]float64)
-		for name, quant := range req.ScalarResources {
-			_, ok := rr.ScalarResources[name]
-			if quant > 0 && ok {
-				filteredReq.ScalarResources[name] = quant
+	filteredDims := ResourceNameList{}
+	for _, name := range dims {
+		rrVal := rr.getResourceValue(name)
+		if name == v1.ResourceCPU || name == v1.ResourceMemory {
+			if !(rrVal < minResource) {
+				filteredDims = append(filteredDims, name)
+			}
+		} else {
+			if _, ok := rr.ScalarResources[name]; ok {
+				filteredDims = append(filteredDims, name)
 			}
 		}
 	}
 
-	return r.GreaterPartlyWithDimension(rr, filteredReq)
+	return r.GreaterPartlyWithDimension(rr, filteredDims)
 }
 
 // Diff calculate the difference between two resource object

--- a/pkg/scheduler/api/resource_info.go
+++ b/pkg/scheduler/api/resource_info.go
@@ -300,14 +300,15 @@ func (r *Resource) Add(rr *Resource) *Resource {
 
 // Sub subtracts two Resource objects with assertion.
 func (r *Resource) Sub(rr *Resource) *Resource {
-	assert.Assertf(rr.LessEqual(r, Zero), "resource is not sufficient to do operation: <%v> sub <%v>", r, rr)
+	ok, _ := rr.LessEqual(r, Zero)
+	assert.Assertf(ok, "resource is not sufficient to do operation: <%v> sub <%v>", r, rr)
 	return r.sub(rr)
 }
 
 // SubWithoutAssert subtracts two Resource objects without assertion,
 // this function is added because some resource subtraction allows negative results, while others do not.
 func (r *Resource) SubWithoutAssert(rr *Resource) *Resource {
-	ok, resources := rr.LessEqualWithResourcesName(r, Zero)
+	ok, resources := rr.LessEqual(r, Zero)
 	if !ok {
 		klog.Errorf("resources <%v> are not sufficient to do operation: <%v> sub <%v>", resources, r, rr)
 	}
@@ -433,10 +434,11 @@ func (r *Resource) Less(rr *Resource, defaultValue DimensionDefaultValue) bool {
 	return true
 }
 
-// LessEqual returns true only on condition that all dimensions of resources in r are less than or equal with that of rr,
-// Otherwise returns false.
+// LessEqual returns true and an empty slice if all dimensions of resources in r are less than or equal to those of rr,
+// otherwise it returns false and a slice of dimension names where r exceeds rr.
 // @param defaultValue "default value for resource dimension not defined in ScalarResources. Its value can only be one of 'Zero' and 'Infinity'"
-func (r *Resource) LessEqual(rr *Resource, defaultValue DimensionDefaultValue) bool {
+func (r *Resource) LessEqual(rr *Resource, defaultValue DimensionDefaultValue) (bool, []string) {
+	resources := []string{}
 	lessEqualFunc := func(l, r, diff float64) bool {
 		if l < r || math.Abs(l-r) < diff {
 			return true
@@ -444,103 +446,25 @@ func (r *Resource) LessEqual(rr *Resource, defaultValue DimensionDefaultValue) b
 		return false
 	}
 
-	if !lessEqualFunc(r.MilliCPU, rr.MilliCPU, minResource) {
-		return false
+	if r == nil {
+		return true, resources
 	}
-	if !lessEqualFunc(r.Memory, rr.Memory, minResource) {
-		return false
+	if rr == nil {
+		rr = EmptyResource()
 	}
 
+	if !lessEqualFunc(r.MilliCPU, rr.MilliCPU, minResource) {
+		resources = append(resources, "cpu")
+	}
+	if !lessEqualFunc(r.Memory, rr.Memory, minResource) {
+		resources = append(resources, "memory")
+	}
 	if defaultValue == Infinity {
 		for name := range rr.ScalarResources {
 			if _, ok := r.ScalarResources[name]; !ok {
-				return false
+				resources = append(resources, string(name))
 			}
 		}
-	}
-
-	for resourceName, leftValue := range r.ScalarResources {
-		rightValue, ok := rr.ScalarResources[resourceName]
-		if !ok && defaultValue == Infinity {
-			continue
-		}
-
-		if !lessEqualFunc(leftValue, rightValue, minResource) {
-			return false
-		}
-	}
-	return true
-}
-
-// LessEqualWithDimensionAndResourcesName only compare the resource items in req param
-// Will return false and a slice of resource names showing the ones that are insufficient
-// @param req define the resource item to be compared
-// if req is nil, equals r.LessEqualWithResourcesName(rr, Zero)
-func (r *Resource) LessEqualWithDimensionAndResourcesName(rr *Resource, req *Resource) (bool, []string) {
-	resources := []string{}
-	if r == nil {
-		return true, []string{}
-	}
-	if rr == nil {
-		for _, name := range r.ResourceNames() {
-			resources = append(resources, string(name))
-		}
-		return false, resources
-	}
-	if req == nil {
-		return r.LessEqualWithResourcesName(rr, Zero)
-	}
-
-	if req.MilliCPU > 0 && r.MilliCPU > rr.MilliCPU {
-		resources = append(resources, "cpu")
-	}
-	if req.Memory > 0 && r.Memory > rr.Memory {
-		resources = append(resources, "memory")
-	}
-
-	// if r.scalar is nil, whatever rr.scalar is, r is less or equal to rr
-	if r.ScalarResources == nil {
-		if len(resources) > 0 {
-			return false, resources
-		}
-		return true, resources
-	}
-
-	for name, quant := range req.ScalarResources {
-		if IsIgnoredScalarResource(name) {
-			continue
-		}
-		rQuant := r.ScalarResources[name]
-		rrQuant := rr.ScalarResources[name]
-		if quant > 0 && rQuant > rrQuant {
-			resources = append(resources, string(name))
-		}
-	}
-
-	if len(resources) > 0 {
-		return false, resources
-	}
-	return true, resources
-}
-
-// LessEqualWithResourcesName returns true, []string{} only on condition that all dimensions of resources in r are less than or equal with that of rr,
-// Otherwise returns false and a slice of string, which shows what resources are insufficient.
-// @param defaultValue "default value for resource dimension not defined in ScalarResources. Its value can only be one of 'Zero' and 'Infinity'"
-// this function is the same as LessEqual, and it will be merged to LessEqual in the future
-func (r *Resource) LessEqualWithResourcesName(rr *Resource, defaultValue DimensionDefaultValue) (bool, []string) {
-	resources := []string{}
-	lessEqualFunc := func(l, r, diff float64) bool {
-		if l < r || math.Abs(l-r) < diff {
-			return true
-		}
-		return false
-	}
-
-	if !lessEqualFunc(r.MilliCPU, rr.MilliCPU, minResource) {
-		resources = append(resources, "cpu")
-	}
-	if !lessEqualFunc(r.Memory, rr.Memory, minResource) {
-		resources = append(resources, "memory")
 	}
 
 	for resourceName, leftValue := range r.ScalarResources {
@@ -553,10 +477,43 @@ func (r *Resource) LessEqualWithResourcesName(rr *Resource, defaultValue Dimensi
 			resources = append(resources, string(resourceName))
 		}
 	}
+
 	if len(resources) > 0 {
 		return false, resources
 	}
 	return true, resources
+}
+
+// LessEqualWithDimension compares only the dimensions listed in dims.
+// Returns true if r <= rr on all listed dimensions, along with a slice of dimensions where r exceeds rr.
+// If dims is nil or empty, returns true and an empty slice (vacuously true).
+func (r *Resource) LessEqualWithDimension(rr *Resource, dims ResourceNameList) (bool, []string) {
+	if len(dims) == 0 {
+		return true, []string{}
+	}
+	if r == nil {
+		return true, []string{}
+	}
+	if rr == nil {
+		rr = EmptyResource()
+	}
+
+	resources := []string{}
+	for _, name := range dims {
+		if IsIgnoredScalarResource(name) {
+			continue
+		}
+		if !r.lessEqualDimension(rr, name) {
+			resources = append(resources, string(name))
+		}
+	}
+
+	return len(resources) == 0, resources
+}
+
+func (r *Resource) lessEqualDimension(rr *Resource, name v1.ResourceName) bool {
+	lVal, rVal := r.Get(name), rr.Get(name)
+	return lVal < rVal || math.Abs(lVal-rVal) < minResource
 }
 
 // LessPartly returns true if there exists any dimension whose resource amount in r is less than that in rr.
@@ -592,10 +549,12 @@ func (r *Resource) LessPartly(rr *Resource, defaultValue DimensionDefaultValue) 
 	return false
 }
 
-// LessEqualPartly returns true if there exists any dimension whose resource amount in r is less than or equal with that in rr.
-// Otherwise returns false.
+// LessEqualPartly returns true and a slice of sufficient resource names if there exists any dimension
+// whose resource amount in r is less than or equal to that in rr.
+// Otherwise returns false and an empty slice.
 // @param defaultValue "default value for resource dimension not defined in ScalarResources. Its value can only be one of 'Zero' and 'Infinity'"
-func (r *Resource) LessEqualPartly(rr *Resource, defaultValue DimensionDefaultValue) bool {
+func (r *Resource) LessEqualPartly(rr *Resource, defaultValue DimensionDefaultValue) (bool, []string) {
+	resources := []string{}
 	lessEqualFunc := func(l, r, diff float64) bool {
 		if l < r || math.Abs(l-r) < diff {
 			return true
@@ -603,14 +562,24 @@ func (r *Resource) LessEqualPartly(rr *Resource, defaultValue DimensionDefaultVa
 		return false
 	}
 
-	if lessEqualFunc(r.MilliCPU, rr.MilliCPU, minResource) || lessEqualFunc(r.Memory, rr.Memory, minResource) {
-		return true
+	if r == nil {
+		return true, resources
+	}
+	if rr == nil {
+		rr = EmptyResource()
+	}
+
+	if lessEqualFunc(r.MilliCPU, rr.MilliCPU, minResource) {
+		resources = append(resources, "cpu")
+	}
+	if lessEqualFunc(r.Memory, rr.Memory, minResource) {
+		resources = append(resources, "memory")
 	}
 
 	if defaultValue == Zero {
 		for name := range rr.ScalarResources {
 			if _, ok := r.ScalarResources[name]; !ok {
-				return true
+				resources = append(resources, string(name))
 			}
 		}
 	}
@@ -618,93 +587,66 @@ func (r *Resource) LessEqualPartly(rr *Resource, defaultValue DimensionDefaultVa
 	for resourceName, leftValue := range r.ScalarResources {
 		rightValue, ok := rr.ScalarResources[resourceName]
 		if !ok && defaultValue == Infinity {
-			return true
+			resources = append(resources, string(resourceName))
+			continue
 		}
 
 		if lessEqualFunc(leftValue, rightValue, minResource) {
-			return true
+			resources = append(resources, string(resourceName))
 		}
 	}
-	return false
+
+	if len(resources) > 0 {
+		return true, resources
+	}
+	return false, resources
 }
 
-// LessEqualPartlyWithDimension returns true if there exists any dimension
-// whose resource amount in r is less than or equal with that in rr along the requested dimensions in req.
-// Will return true and a slice of resource names that are sufficient
-// @param req define the resource item with the dimensions to be compared
-// if req is nil then return is false and an empty slice
-func (r *Resource) LessEqualPartlyWithDimension(rr *Resource, req *Resource) (bool, []string) {
-	lessEqualFunc := func(l, r, diff float64) bool {
-		return l < r || math.Abs(l-r) < diff
+// LessEqualPartlyWithDimension returns true if any dimension in dims satisfies r <= rr.
+// Returns the matching dimension names. If dims is nil or empty, returns false and an empty slice.
+func (r *Resource) LessEqualPartlyWithDimension(rr *Resource, dims ResourceNameList) (bool, []string) {
+	if len(dims) == 0 {
+		return false, []string{}
+	}
+	if rr == nil {
+		rr = EmptyResource()
 	}
 
 	resources := []string{}
-	found := false
-
-	if req == nil {
-		return false, resources
-	}
-	// CPU
-	if req.MilliCPU > 0 {
-		if lessEqualFunc(r.MilliCPU, rr.MilliCPU, minResource) {
-			resources = append(resources, "cpu")
-			found = true
-		}
-	}
-	// Memory
-	if req.Memory > 0 {
-		if lessEqualFunc(r.Memory, rr.Memory, minResource) {
-			resources = append(resources, "memory")
-			found = true
-		}
-	}
-	// Scalar resources
-	for name, quant := range req.ScalarResources {
+	for _, name := range dims {
 		if IsIgnoredScalarResource(name) {
 			continue
 		}
-		if quant > 0 && lessEqualFunc(r.Get(name), rr.Get(name), minResource) {
+		if r.lessEqualDimension(rr, name) {
 			resources = append(resources, string(name))
-			found = true
 		}
 	}
-	return found, resources
+	return len(resources) > 0, resources
 }
 
-// LessEqualPartlyWithDimensionZeroFiltered filters out dimensions present in req that are both zero (or nil) in r and rr,
-// then calls LessEqualPartlyWithDimension to compare only the relevant dimensions.
-// This is needed for preemption cases, where we want to ignore dimensions that are not being used by either the current resource
-// or the compared resource but are present in the requested resource.
-// Returns true and a slice of resource names that are sufficient along the filtered dimensions.
-// @param req define the resource item with the dimensions to be compared
-// If req is nil, returns false and an empty slice.
-func (r *Resource) LessEqualPartlyWithDimensionZeroFiltered(rr *Resource, req *Resource) (bool, []string) {
-	if req == nil {
+// LessEqualPartlyWithRelevantDimensions filters out dimensions where both r and rr are zero,
+// then compares only the remaining dimensions via LessEqualPartlyWithDimension.
+// In preemption cases, dimensions unused by both resources should be ignored.
+// @param dims define the resource names with the dimensions to be compared
+// If dims is nil or empty, returns false and an empty slice.
+func (r *Resource) LessEqualPartlyWithRelevantDimensions(rr *Resource, dims ResourceNameList) (bool, []string) {
+	if len(dims) == 0 {
 		return false, []string{}
 	}
-	filteredReq := &Resource{}
+	if rr == nil {
+		rr = EmptyResource()
+	}
 
-	// CPU
-	if req.MilliCPU > 0 && !(r.MilliCPU < minResource && rr.MilliCPU < minResource) {
-		filteredReq.MilliCPU = req.MilliCPU
-	}
-	// Memory
-	if req.Memory > 0 && !(r.Memory < minResource && rr.Memory < minResource) {
-		filteredReq.Memory = req.Memory
-	}
-	// Scalar resources
-	if req.ScalarResources != nil {
-		filteredReq.ScalarResources = make(map[v1.ResourceName]float64)
-		for name, quant := range req.ScalarResources {
-			rQuant := r.Get(name)
-			rrQuant := rr.Get(name)
-			if quant > 0 && !(rQuant < minResource && rrQuant < minResource) {
-				filteredReq.ScalarResources[name] = quant
-			}
+	filteredDims := ResourceNameList{}
+	for _, name := range dims {
+		rVal := r.Get(name)
+		rrVal := rr.Get(name)
+		if !(rVal < minResource && rrVal < minResource) {
+			filteredDims = append(filteredDims, name)
 		}
 	}
 
-	return r.LessEqualPartlyWithDimension(rr, filteredReq)
+	return r.LessEqualPartlyWithDimension(rr, filteredDims)
 }
 
 // Equal returns true only on condition that values in all dimension are equal with each other for r and rr
@@ -733,155 +675,130 @@ func (r *Resource) Equal(rr *Resource, defaultValue DimensionDefaultValue) bool 
 // @param defaultValue "default value for resource dimension not defined in ScalarResources. Its value can only be one of 'Zero' and 'Infinity'"
 // @returns true and a slice of resource names that are exceeding else false and an empty slice.
 func (r *Resource) GreaterPartly(rr *Resource, defaultValue DimensionDefaultValue) (bool, []string) {
-	ok, resources := r.LessEqualWithResourcesName(rr, defaultValue)
+	ok, resources := r.LessEqual(rr, defaultValue)
 	return !ok, resources
 }
 
 // GreaterPartlyWithDimension returns true if there exists any dimension
-// whose resource amount in r is greater than that in rr along the requested dimensions in req.
+// whose resource amount in r is greater than that in rr along the requested dimensions in dims.
 // Will return true and a slice of resource names that are exceeding
 //
 // The main difference between GreaterPartlyWithDimension and GreaterPartlyWithRelevantDimensions is that the latter
 // will filter out standard dimensions (MilliCPU, Memory) where rr is zero or less than minResource and
-// only considers scalar dimensions greater than 0 in req and present in rr.
+// only considers scalar dimensions greater than 0 in dims and present in rr.
 //
 // For example:
 //
-//	r: <gpu 2> rr: <> req: <gpu 1>
-//	  r.GreaterPartlyWithDimension(rr, req) => (true, [gpu])
-//	  r.GreaterPartlyWithRelevantDimensions(rr, req) => (false, []) since rr does not have gpu resource
-//	r: <cpu 4> rr: <cpu 0> req: <cpu 2>
-//	  r.GreaterPartlyWithDimension(rr, req) => (true, [cpu])
-//	  r.GreaterPartlyWithRelevantDimensions(rr, req) => (false, []) since rr has zero cpu resource
+//	r: <gpu 2> rr: <> dims: [gpu]
+//	  r.GreaterPartlyWithDimension(rr, dims) => (true, [gpu])
+//	  r.GreaterPartlyWithRelevantDimensions(rr, dims) => (false, []) since rr does not have gpu resource
+//	r: <cpu 4> rr: <cpu 0> dims: [cpu]
+//	  r.GreaterPartlyWithDimension(rr, dims) => (true, [cpu])
+//	  r.GreaterPartlyWithRelevantDimensions(rr, dims) => (false, []) since rr has zero cpu resource
 //
 // But these cases are the same:
 //
-//	r: <gpu 2> rr: <gpu 0> req: <gpu 1>
-//	  r.GreaterPartlyWithDimension(rr, req) => (true, [gpu])
-//	  r.GreaterPartlyWithRelevantDimensions(rr, req) => (true, [gpu]) since rr has gpu resource defined (even if zero)
-//	r: <cpu 4> rr: <cpu 0.1> req: <cpu 2>
-//	  r.GreaterPartlyWithDimension(rr, req) => (true, [cpu])
-//	  r.GreaterPartlyWithRelevantDimensions(rr, req) => (true, [cpu]) since rr has cpu resource greater than minResource
+//	r: <gpu 2> rr: <gpu 0> dims: [gpu]
+//	  r.GreaterPartlyWithDimension(rr, dims) => (true, [gpu])
+//	  r.GreaterPartlyWithRelevantDimensions(rr, dims) => (true, [gpu]) since rr has gpu resource defined (even if zero)
+//	r: <cpu 4> rr: <cpu 0.1> dims: [cpu]
+//	  r.GreaterPartlyWithDimension(rr, dims) => (true, [cpu])
+//	  r.GreaterPartlyWithRelevantDimensions(rr, dims) => (true, [cpu]) since rr has cpu resource greater than minResource
 //	r: <cpu 4, memory 8192, gpu 2> rr: <cpu 2, memory 8192, gpu 1>
-//	  req: <cpu 0, memory 0, gpu 1> => return (true, [gpu])
-//	  req: <cpu 2, memory 0, gpu 1> => return (true, [cpu, gpu])
-//	  req: <cpu 0, memory 4096, gpu 0> => return (false, [])
+//	  dims: [gpu]              => return (true, [gpu])
+//	  dims: [cpu, gpu]         => return (true, [cpu, gpu])
+//	  dims: [memory]           => return (false, [])
 //
 // The functions are not interchangeable and should be used based on specific comparison needs.
-// As a remark they don't differ in the handling of r and req, only in the handling of rr.
+// As a remark they don't differ in the handling of r and dims, only in the handling of rr.
 //
 // @param rr is the Resource to compare against. If nil, treated as EmptyResource().
-// @param req is the Resource item with the dimensions to be compared on.
+// @param dims define the resource names with the dimensions to be compared on.
 // @returns true and a slice of resource names that are exceeding else false and an empty slice.
-// If req is nil then return is false and an empty slice.
-func (r *Resource) GreaterPartlyWithDimension(rr *Resource, req *Resource) (bool, []string) {
-	greaterFunc := func(l, r float64) bool {
-		return l > r
-	}
-
-	resources := []string{}
-
-	if req == nil {
-		return false, resources
-	}
-	if rr == nil {
-		rr = EmptyResource()
-	}
-
-	// CPU
-	if req.MilliCPU > 0 {
-		if greaterFunc(r.MilliCPU, rr.MilliCPU) {
-			resources = append(resources, "cpu")
-		}
-	}
-	// Memory
-	if req.Memory > 0 {
-		if greaterFunc(r.Memory, rr.Memory) {
-			resources = append(resources, "memory")
-		}
-	}
-	// Scalar resources
-	for name, quant := range req.ScalarResources {
-		if IsIgnoredScalarResource(name) {
-			continue
-		}
-		if quant > 0 && greaterFunc(r.Get(name), rr.Get(name)) {
-			resources = append(resources, string(name))
-		}
-	}
-	return len(resources) > 0, resources
-}
-
-// GreaterPartlyWithRelevantDimensions compares resource dimensions in req between r and rr,
-// but ignores any standard dimensions (MilliCPU, Memory) where rr is zero or less than minResource.
-// For scalar resources, only dimensions present in both req and rr are considered.
-// This is useful for reclaim scenarios, where you want to check if r exceeds rr
-// only in dimensions that rr actually possesses (i.e., "infinity-type" comparison).
-//
-// The main difference between GreaterPartlyWithDimension and GreaterPartlyWithRelevantDimensions is that the latter
-// will filter out standard dimensions (MilliCPU, Memory) where rr is zero or less than minResource and
-// only considers scalar dimensions greater than 0 in req and present in rr.
-//
-// For example:
-//
-//	r: <gpu 2> rr: <> req: <gpu 1>
-//	  r.GreaterPartlyWithDimension(rr, req) => (true, [gpu])
-//	  r.GreaterPartlyWithRelevantDimensions(rr, req) => (false, []) since rr does not have gpu resource
-//	r: <cpu 4> rr: <cpu 0> req: <cpu 2>
-//	  r.GreaterPartlyWithDimension(rr, req) => (true, [cpu])
-//	  r.GreaterPartlyWithRelevantDimensions(rr, req) => (false, []) since rr has zero cpu resource
-//
-// But these cases are the same:
-//
-//	r: <gpu 2> rr: <gpu 0> req: <gpu 1>
-//	  r.GreaterPartlyWithDimension(rr, req) => (true, [gpu])
-//	  r.GreaterPartlyWithRelevantDimensions(rr, req) => (true, [gpu]) since rr has gpu resource defined (even if zero)
-//	r: <cpu 4> rr: <cpu 0.1> req: <cpu 2>
-//	  r.GreaterPartlyWithDimension(rr, req) => (true, [cpu])
-//	  r.GreaterPartlyWithRelevantDimensions(rr, req) => (true, [cpu]) since rr has cpu resource greater than minResource
-//	r: <cpu 4, memory 8192, gpu 2> rr: <cpu 2, memory 8192, gpu 1>
-//	  req: <cpu 0, memory 0, gpu 1> => return (true, [gpu])
-//	  req: <cpu 2, memory 0, gpu 1> => return (true, [cpu, gpu])
-//	  req: <cpu 0, memory 4096, gpu 0> => return (false, [])
-//
-// The functions are not interchangeable and should be used based on specific comparison needs.
-// As a remark they don't differ in the handling of r and req, only in the handling of rr.
-//
-// @param rr is the Resource to compare against. If nil, treated as EmptyResource().
-// @param req is the Resource item with the dimensions to be compared on.
-// @returns true and a slice of resource names that are exceeding else false and an empty slice.
-// If req is nil then return is false and an empty slice.
-func (r *Resource) GreaterPartlyWithRelevantDimensions(rr *Resource, req *Resource) (bool, []string) {
-	if req == nil {
+// If dims is nil or empty, returns false and an empty slice.
+func (r *Resource) GreaterPartlyWithDimension(rr *Resource, dims ResourceNameList) (bool, []string) {
+	if len(dims) == 0 {
 		return false, []string{}
 	}
 	if rr == nil {
 		rr = EmptyResource()
 	}
-	filteredReq := &Resource{}
 
-	// CPU
-	if req.MilliCPU > 0 && !(rr.MilliCPU < minResource) {
-		filteredReq.MilliCPU = req.MilliCPU
+	resources := []string{}
+	for _, name := range dims {
+		if IsIgnoredScalarResource(name) {
+			continue
+		}
+		if r.Get(name) > rr.Get(name) {
+			resources = append(resources, string(name))
+		}
 	}
 
-	// Memory
-	if req.Memory > 0 && !(rr.Memory < minResource) {
-		filteredReq.Memory = req.Memory
+	return len(resources) > 0, resources
+}
+
+// GreaterPartlyWithRelevantDimensions compares resource dimensions in dims between r and rr,
+// but ignores any standard dimensions (MilliCPU, Memory) where rr is zero or less than minResource.
+// For scalar resources, only dimensions present in both dims and rr are considered.
+// This is useful for reclaim scenarios, where you want to check if r exceeds rr
+// only in dimensions that rr actually possesses (i.e., "infinity-type" comparison).
+//
+// The main difference between GreaterPartlyWithDimension and GreaterPartlyWithRelevantDimensions is that the latter
+// will filter out standard dimensions (MilliCPU, Memory) where rr is zero or less than minResource and
+// only considers scalar dimensions greater than 0 in dims and present in rr.
+//
+// For example:
+//
+//	r: <gpu 2> rr: <> dims: [gpu]
+//	  r.GreaterPartlyWithDimension(rr, dims) => (true, [gpu])
+//	  r.GreaterPartlyWithRelevantDimensions(rr, dims) => (false, []) since rr does not have gpu resource
+//	r: <cpu 4> rr: <cpu 0> dims: [cpu]
+//	  r.GreaterPartlyWithDimension(rr, dims) => (true, [cpu])
+//	  r.GreaterPartlyWithRelevantDimensions(rr, dims) => (false, []) since rr has zero cpu resource
+//
+// But these cases are the same:
+//
+//	r: <gpu 2> rr: <gpu 0> dims: [gpu]
+//	  r.GreaterPartlyWithDimension(rr, dims) => (true, [gpu])
+//	  r.GreaterPartlyWithRelevantDimensions(rr, dims) => (true, [gpu]) since rr has gpu resource defined (even if zero)
+//	r: <cpu 4> rr: <cpu 0.1> dims: [cpu]
+//	  r.GreaterPartlyWithDimension(rr, dims) => (true, [cpu])
+//	  r.GreaterPartlyWithRelevantDimensions(rr, dims) => (true, [cpu]) since rr has cpu resource greater than minResource
+//	r: <cpu 4, memory 8192, gpu 2> rr: <cpu 2, memory 8192, gpu 1>
+//	  dims: [gpu]              => return (true, [gpu])
+//	  dims: [cpu, gpu]         => return (true, [cpu, gpu])
+//	  dims: [memory]           => return (false, [])
+//
+// The functions are not interchangeable and should be used based on specific comparison needs.
+// As a remark they don't differ in the handling of r and dims, only in the handling of rr.
+//
+// @param rr is the Resource to compare against. If nil, treated as EmptyResource().
+// @param dims define the resource names with the dimensions to be compared on.
+// @returns true and a slice of resource names that are exceeding else false and an empty slice.
+// If dims is nil or empty, returns false and an empty slice.
+func (r *Resource) GreaterPartlyWithRelevantDimensions(rr *Resource, dims ResourceNameList) (bool, []string) {
+	if len(dims) == 0 {
+		return false, []string{}
+	}
+	if rr == nil {
+		rr = EmptyResource()
 	}
 
-	// Scalar resources
-	if req.ScalarResources != nil {
-		filteredReq.ScalarResources = make(map[v1.ResourceName]float64)
-		for name, quant := range req.ScalarResources {
-			_, ok := rr.ScalarResources[name]
-			if quant > 0 && ok {
-				filteredReq.ScalarResources[name] = quant
+	filteredDims := ResourceNameList{}
+	for _, name := range dims {
+		rrVal := rr.Get(name)
+		if name == v1.ResourceCPU || name == v1.ResourceMemory {
+			if !(rrVal < minResource) {
+				filteredDims = append(filteredDims, name)
+			}
+		} else {
+			if _, ok := rr.ScalarResources[name]; ok {
+				filteredDims = append(filteredDims, name)
 			}
 		}
 	}
 
-	return r.GreaterPartlyWithDimension(rr, filteredReq)
+	return r.GreaterPartlyWithDimension(rr, filteredDims)
 }
 
 // Diff calculate the difference between two resource object

--- a/pkg/scheduler/api/resource_info_test.go
+++ b/pkg/scheduler/api/resource_info_test.go
@@ -756,32 +756,32 @@ func TestLessEqual(t *testing.T) {
 		},
 	}
 
-	for _, test := range testsForDefaultZero {
-		flag := test.resource1.LessEqual(test.resource2, Zero)
+	for i, test := range testsForDefaultZero {
+		flag, _ := test.resource1.LessEqual(test.resource2, Zero)
 		if !equality.Semantic.DeepEqual(test.expected, flag) {
-			t.Errorf("expected: %#v, got: %#v", test.expected, flag)
+			t.Errorf("Case %v expected: %#v, got: %#v", i, test.expected, flag)
 		}
 	}
 	for caseID, test := range testsForDefaultInfinity {
-		flag := test.resource1.LessEqual(test.resource2, Infinity)
+		flag, _ := test.resource1.LessEqual(test.resource2, Infinity)
 		if !equality.Semantic.DeepEqual(test.expected, flag) {
 			t.Errorf("caseID %d expected: %#v, got: %#v", caseID, test.expected, flag)
 		}
 	}
 }
 
-func TestLessEqualWithDimensionAndResourcesName(t *testing.T) {
+func TestLessEqualWithDimension(t *testing.T) {
 	tests := []struct {
 		resource1             *Resource
 		resource2             *Resource
-		req                   *Resource
+		dims                  ResourceNameList
 		expectedFlag          bool
 		expectedResourceNames []string
 	}{
 		{
 			resource1:             &Resource{},
 			resource2:             &Resource{},
-			req:                   nil,
+			dims:                  nil,
 			expectedFlag:          true,
 			expectedResourceNames: []string{},
 		},
@@ -791,9 +791,9 @@ func TestLessEqualWithDimensionAndResourcesName(t *testing.T) {
 				Memory:   4000,
 			},
 			resource2:             &Resource{},
-			req:                   nil,
-			expectedFlag:          false,
-			expectedResourceNames: []string{"cpu", "memory"},
+			dims:                  nil,
+			expectedFlag:          true,
+			expectedResourceNames: []string{},
 		},
 		{
 			resource1: &Resource{MilliCPU: 5000},
@@ -802,14 +802,14 @@ func TestLessEqualWithDimensionAndResourcesName(t *testing.T) {
 				Memory:          2000,
 				ScalarResources: map[v1.ResourceName]float64{"scalar.test/scalar1": 1000},
 			},
-			req:                   &Resource{MilliCPU: 1000},
+			dims:                  ResourceNameList{v1.ResourceCPU},
 			expectedFlag:          false,
 			expectedResourceNames: []string{"cpu"},
 		},
 		{
 			resource1:             &Resource{MilliCPU: 3000, Memory: 3000},
 			resource2:             &Resource{MilliCPU: 4000, Memory: 2000},
-			req:                   &Resource{Memory: 1000},
+			dims:                  ResourceNameList{v1.ResourceMemory},
 			expectedFlag:          false,
 			expectedResourceNames: []string{"memory"},
 		},
@@ -819,7 +819,7 @@ func TestLessEqualWithDimensionAndResourcesName(t *testing.T) {
 				Memory:   4000,
 			},
 			resource2:             &Resource{},
-			req:                   &Resource{},
+			dims:                  ResourceNameList{},
 			expectedFlag:          true,
 			expectedResourceNames: []string{},
 		},
@@ -829,10 +829,7 @@ func TestLessEqualWithDimensionAndResourcesName(t *testing.T) {
 				ScalarResources: map[v1.ResourceName]float64{"nvidia.com/gpu": 1},
 			},
 			resource2: &Resource{MilliCPU: 8, Memory: 8000},
-			req: &Resource{
-				MilliCPU: 4, Memory: 2000,
-				ScalarResources: map[v1.ResourceName]float64{"nvidia.com/gpu": 1},
-			},
+			dims:                  ResourceNameList{"nvidia.com/gpu"},
 			expectedFlag:          false,
 			expectedResourceNames: []string{"nvidia.com/gpu"},
 		},
@@ -845,12 +842,9 @@ func TestLessEqualWithDimensionAndResourcesName(t *testing.T) {
 				MilliCPU: 100, Memory: 8000,
 				ScalarResources: map[v1.ResourceName]float64{"nvidia.com/A100": 1},
 			},
-			req: &Resource{
-				MilliCPU: 10, Memory: 4000,
-				ScalarResources: map[v1.ResourceName]float64{"nvidia.com/gpu": 0, "nvidia.com/A100": 1, "scalar": 1},
-			},
-			expectedFlag:          true,
-			expectedResourceNames: []string{},
+			dims:                  ResourceNameList{"nvidia.com/gpu", "nvidia.com/A100", "scalar"},
+			expectedFlag:          false,
+			expectedResourceNames: []string{"nvidia.com/gpu"},
 		},
 		{
 			resource1: &Resource{
@@ -861,17 +855,14 @@ func TestLessEqualWithDimensionAndResourcesName(t *testing.T) {
 				MilliCPU: 100, Memory: 8000,
 				ScalarResources: map[v1.ResourceName]float64{"nvidia.com/A100": 1, "scalar": 1},
 			},
-			req: &Resource{
-				Memory:          4000,
-				ScalarResources: map[v1.ResourceName]float64{"nvidia.com/gpu": 0, "nvidia.com/A100": 1, "scalar": 1},
-			},
-			expectedFlag:          true,
-			expectedResourceNames: []string{},
+			dims:                  ResourceNameList{v1.ResourceMemory, "nvidia.com/gpu", "nvidia.com/A100", "scalar"},
+			expectedFlag:          false,
+			expectedResourceNames: []string{"nvidia.com/gpu"},
 		},
 	}
 
 	for i, test := range tests {
-		flag, resourceNames := test.resource1.LessEqualWithDimensionAndResourcesName(test.resource2, test.req)
+		flag, resourceNames := test.resource1.LessEqualWithDimension(test.resource2, test.dims)
 		if !equality.Semantic.DeepEqual(test.expectedFlag, flag) {
 			t.Errorf("Case %v: expected: %#v, got: %#v", i, test.expectedFlag, flag)
 		}
@@ -1180,13 +1171,13 @@ func TestLessEqualPartly(t *testing.T) {
 	}
 
 	for _, test := range testsForDefaultZero {
-		flag := test.resource1.LessEqualPartly(test.resource2, Zero)
+		flag, _ := test.resource1.LessEqualPartly(test.resource2, Zero)
 		if !equality.Semantic.DeepEqual(test.expected, flag) {
 			t.Errorf("expected: %#v, got: %#v", test.expected, flag)
 		}
 	}
 	for _, test := range testsForDefaultInfinity {
-		flag := test.resource1.LessEqualPartly(test.resource2, Infinity)
+		flag, _ := test.resource1.LessEqualPartly(test.resource2, Infinity)
 		if !equality.Semantic.DeepEqual(test.expected, flag) {
 			t.Errorf("expected: %#v, got: %#v", test.expected, flag)
 		}
@@ -1197,77 +1188,77 @@ func TestLessEqualPartlyWithDimension(t *testing.T) {
 	tests := []struct {
 		r         *Resource
 		rr        *Resource
-		req       *Resource
+		dims      ResourceNameList
 		wantBool  bool
 		wantNames []string
 	}{
 		{
 			r:         &Resource{MilliCPU: 1000},
 			rr:        &Resource{MilliCPU: 2000},
-			req:       nil,
+			dims:      nil,
 			wantBool:  false,
 			wantNames: []string{},
 		},
 		{
 			r:         &Resource{MilliCPU: 3000},
 			rr:        &Resource{MilliCPU: 2000},
-			req:       &Resource{MilliCPU: 4000},
+			dims:      ResourceNameList{v1.ResourceCPU},
 			wantBool:  false,
 			wantNames: []string{},
 		},
 		{
 			r:         &Resource{MilliCPU: 1000},
 			rr:        &Resource{MilliCPU: 2000},
-			req:       &Resource{MilliCPU: 500},
+			dims:      ResourceNameList{v1.ResourceCPU},
 			wantBool:  true,
 			wantNames: []string{"cpu"},
 		},
 		{
 			r:         &Resource{Memory: 1024},
 			rr:        &Resource{Memory: 1024},
-			req:       &Resource{Memory: 512},
+			dims:      ResourceNameList{v1.ResourceMemory},
 			wantBool:  true,
 			wantNames: []string{"memory"},
 		},
 		{
 			r:         &Resource{ScalarResources: map[v1.ResourceName]float64{"nvidia.com/gpu": 2}},
 			rr:        &Resource{ScalarResources: map[v1.ResourceName]float64{"nvidia.com/gpu": 4}},
-			req:       &Resource{ScalarResources: map[v1.ResourceName]float64{"nvidia.com/gpu": 1}},
+			dims:      ResourceNameList{"nvidia.com/gpu"},
 			wantBool:  true,
 			wantNames: []string{"nvidia.com/gpu"},
 		},
 		{
 			r:         &Resource{ScalarResources: map[v1.ResourceName]float64{"nvidia.com/gpu": 4}},
 			rr:        &Resource{ScalarResources: map[v1.ResourceName]float64{"nvidia.com/gpu": 4}},
-			req:       &Resource{ScalarResources: map[v1.ResourceName]float64{"nvidia.com/gpu": 2}},
+			dims:      ResourceNameList{"nvidia.com/gpu"},
 			wantBool:  true,
 			wantNames: []string{"nvidia.com/gpu"},
 		},
 		{
 			r:         &Resource{MilliCPU: 3000, Memory: 2048, ScalarResources: map[v1.ResourceName]float64{"nvidia.com/gpu": 5}},
 			rr:        &Resource{MilliCPU: 2000, Memory: 1024, ScalarResources: map[v1.ResourceName]float64{"nvidia.com/gpu": 4}},
-			req:       &Resource{MilliCPU: 1000, Memory: 512, ScalarResources: map[v1.ResourceName]float64{"nvidia.com/gpu": 1}},
+			dims:      ResourceNameList{v1.ResourceCPU, v1.ResourceMemory, "nvidia.com/gpu"},
 			wantBool:  false,
 			wantNames: []string{},
 		},
 		{
 			r:         &Resource{ScalarResources: map[v1.ResourceName]float64{"rdma": 2, "fpga": 2}},
 			rr:        &Resource{ScalarResources: map[v1.ResourceName]float64{"rdma": 2}},
-			req:       &Resource{MilliCPU: 1000, Memory: 512, ScalarResources: map[v1.ResourceName]float64{"rdma": 1, "fpga": 1, "nvidia.com/gpu": 2}},
+			dims:      ResourceNameList{v1.ResourceCPU, v1.ResourceMemory, "rdma", "fpga", "nvidia.com/gpu"},
 			wantBool:  true,
 			wantNames: []string{"cpu", "memory", "rdma", "nvidia.com/gpu"},
 		},
 		{
 			r:         &Resource{ScalarResources: map[v1.ResourceName]float64{"rdma": 1, "fpga": 2, "nvidia.com/gpu": 2}},
 			rr:        &Resource{ScalarResources: map[v1.ResourceName]float64{"rdma": 2, "fpga": 2}},
-			req:       &Resource{MilliCPU: 1000, Memory: 512, ScalarResources: map[v1.ResourceName]float64{"nvidia.com/gpu": 2, "rdma": 1, "fpga": 1}},
+			dims:      ResourceNameList{v1.ResourceCPU, v1.ResourceMemory, "nvidia.com/gpu", "rdma", "fpga"},
 			wantBool:  true,
 			wantNames: []string{"cpu", "memory", "rdma", "fpga"},
 		},
 	}
 
 	for _, tt := range tests {
-		gotBool, gotNames := tt.r.LessEqualPartlyWithDimension(tt.rr, tt.req)
+		gotBool, gotNames := tt.r.LessEqualPartlyWithDimension(tt.rr, tt.dims)
 		if gotBool != tt.wantBool {
 			t.Errorf("got bool %v, want %v", gotBool, tt.wantBool)
 		}
@@ -1279,67 +1270,67 @@ func TestLessEqualPartlyWithDimension(t *testing.T) {
 	}
 }
 
-func TestLessEqualPartlyWithDimensionZeroFiltered(t *testing.T) {
+func TestLessEqualPartlyWithRelevantDimensions(t *testing.T) {
 	tests := []struct {
 		r         *Resource
 		rr        *Resource
-		req       *Resource
+		dims      ResourceNameList
 		wantBool  bool
 		wantNames []string
 	}{
 		{
 			r:         &Resource{MilliCPU: 0, Memory: 0},
 			rr:        &Resource{MilliCPU: 0, Memory: 0},
-			req:       &Resource{MilliCPU: 1000, Memory: 512},
+			dims:      ResourceNameList{v1.ResourceCPU, v1.ResourceMemory},
 			wantBool:  false,
 			wantNames: []string{},
 		},
 		{
 			r:         &Resource{MilliCPU: 1000, Memory: 0},
 			rr:        &Resource{MilliCPU: 2000, Memory: 0},
-			req:       &Resource{MilliCPU: 1000, Memory: 512},
+			dims:      ResourceNameList{v1.ResourceCPU, v1.ResourceMemory},
 			wantBool:  true,
 			wantNames: []string{"cpu"},
 		},
 		{
 			r:         &Resource{MilliCPU: 0, Memory: 0},
 			rr:        &Resource{MilliCPU: 0, Memory: 2048},
-			req:       &Resource{MilliCPU: 1000, Memory: 512},
+			dims:      ResourceNameList{v1.ResourceCPU, v1.ResourceMemory},
 			wantBool:  true,
 			wantNames: []string{"memory"},
 		},
 		{
 			r:         &Resource{MilliCPU: 1000, Memory: 1024},
 			rr:        &Resource{MilliCPU: 2000, Memory: 2048},
-			req:       &Resource{MilliCPU: 1000, Memory: 512},
+			dims:      ResourceNameList{v1.ResourceCPU, v1.ResourceMemory},
 			wantBool:  true,
 			wantNames: []string{"cpu", "memory"},
 		},
 		{
 			r:         &Resource{MilliCPU: 0, Memory: 1024},
 			rr:        &Resource{MilliCPU: 2000, Memory: 0, ScalarResources: map[v1.ResourceName]float64{"nvidia.com/gpu": 4}},
-			req:       &Resource{MilliCPU: 1000, Memory: 512, ScalarResources: map[v1.ResourceName]float64{"nvidia.com/gpu": 2}},
+			dims:      ResourceNameList{v1.ResourceCPU, v1.ResourceMemory, "nvidia.com/gpu"},
 			wantBool:  true,
 			wantNames: []string{"cpu", "nvidia.com/gpu"},
 		},
 		{
 			r:         &Resource{ScalarResources: map[v1.ResourceName]float64{"rdma": 2, "fpga": 2}},
 			rr:        &Resource{ScalarResources: map[v1.ResourceName]float64{"rdma": 2}},
-			req:       &Resource{MilliCPU: 1000, Memory: 512, ScalarResources: map[v1.ResourceName]float64{"nvidia.com/gpu": 2, "rdma": 1, "fpga": 1}},
+			dims:      ResourceNameList{"nvidia.com/gpu", "rdma", "fpga"},
 			wantBool:  true,
 			wantNames: []string{"rdma"},
 		},
 		{
 			r:         &Resource{ScalarResources: map[v1.ResourceName]float64{"rdma": 1, "fpga": 2, "nvidia.com/gpu": 2}},
 			rr:        &Resource{ScalarResources: map[v1.ResourceName]float64{"rdma": 2, "fpga": 2}},
-			req:       &Resource{MilliCPU: 1000, Memory: 512, ScalarResources: map[v1.ResourceName]float64{"nvidia.com/gpu": 2, "rdma": 1, "fpga": 1}},
+			dims:      ResourceNameList{"nvidia.com/gpu", "rdma", "fpga"},
 			wantBool:  true,
 			wantNames: []string{"rdma", "fpga"},
 		},
 	}
 
 	for _, tt := range tests {
-		gotBool, gotNames := tt.r.LessEqualPartlyWithDimensionZeroFiltered(tt.rr, tt.req)
+		gotBool, gotNames := tt.r.LessEqualPartlyWithRelevantDimensions(tt.rr, tt.dims)
 		if gotBool != tt.wantBool {
 			t.Errorf("got bool %v, want %v", gotBool, tt.wantBool)
 		}
@@ -1356,15 +1347,15 @@ func TestGreaterPartlyWithDimension(t *testing.T) {
 		name      string
 		r         *Resource
 		rr        *Resource
-		req       *Resource
+		dims      ResourceNameList
 		wantBool  bool
 		wantNames []string
 	}{
 		{
-			name:      "nil req returns false",
+			name:      "nil dims returns false",
 			r:         &Resource{MilliCPU: 1000},
 			rr:        &Resource{MilliCPU: 500},
-			req:       nil,
+			dims:      nil,
 			wantBool:  false,
 			wantNames: []string{},
 		},
@@ -1372,7 +1363,7 @@ func TestGreaterPartlyWithDimension(t *testing.T) {
 			name:      "cpu greater",
 			r:         &Resource{MilliCPU: 2000},
 			rr:        &Resource{MilliCPU: 1000},
-			req:       &Resource{MilliCPU: 1000},
+			dims:      ResourceNameList{v1.ResourceCPU},
 			wantBool:  true,
 			wantNames: []string{"cpu"},
 		},
@@ -1380,7 +1371,7 @@ func TestGreaterPartlyWithDimension(t *testing.T) {
 			name:      "scalar resource greater",
 			r:         &Resource{ScalarResources: map[v1.ResourceName]float64{"nvidia.com/gpu": 2}},
 			rr:        &Resource{ScalarResources: map[v1.ResourceName]float64{"nvidia.com/gpu": 1}},
-			req:       &Resource{ScalarResources: map[v1.ResourceName]float64{"nvidia.com/gpu": 1}},
+			dims:      ResourceNameList{"nvidia.com/gpu"},
 			wantBool:  true,
 			wantNames: []string{"nvidia.com/gpu"},
 		},
@@ -1388,7 +1379,7 @@ func TestGreaterPartlyWithDimension(t *testing.T) {
 			name:      "cpu and memory, both greater",
 			r:         &Resource{MilliCPU: 2000, Memory: 2048},
 			rr:        &Resource{MilliCPU: 1000, Memory: 1024},
-			req:       &Resource{MilliCPU: 1000, Memory: 1024},
+			dims:      ResourceNameList{v1.ResourceCPU, v1.ResourceMemory},
 			wantBool:  true,
 			wantNames: []string{"cpu", "memory"},
 		},
@@ -1396,7 +1387,7 @@ func TestGreaterPartlyWithDimension(t *testing.T) {
 			name:      "memory greater but not requested",
 			r:         &Resource{MilliCPU: 1000, Memory: 2048},
 			rr:        &Resource{MilliCPU: 1000, Memory: 1024},
-			req:       &Resource{MilliCPU: 1000},
+			dims:      ResourceNameList{v1.ResourceCPU},
 			wantBool:  false,
 			wantNames: []string{},
 		},
@@ -1404,14 +1395,14 @@ func TestGreaterPartlyWithDimension(t *testing.T) {
 			name:      "nothing greater",
 			r:         &Resource{MilliCPU: 1000, Memory: 1024},
 			rr:        &Resource{MilliCPU: 2000, Memory: 2048},
-			req:       &Resource{MilliCPU: 1000, Memory: 1024},
+			dims:      ResourceNameList{v1.ResourceCPU, v1.ResourceMemory},
 			wantBool:  false,
 			wantNames: []string{},
 		},
 	}
 
 	for _, tt := range tests {
-		gotBool, gotNames := tt.r.GreaterPartlyWithDimension(tt.rr, tt.req)
+		gotBool, gotNames := tt.r.GreaterPartlyWithDimension(tt.rr, tt.dims)
 		if gotBool != tt.wantBool {
 			t.Errorf("%s: got bool %v, want %v", tt.name, gotBool, tt.wantBool)
 		}
@@ -1428,15 +1419,15 @@ func TestGreaterPartlyWithRelevantDimensions(t *testing.T) {
 		name      string
 		r         *Resource
 		rr        *Resource
-		req       *Resource
+		dims      ResourceNameList
 		wantBool  bool
 		wantNames []string
 	}{
 		{
-			name:      "nil req returns false",
+			name:      "nil dims returns false",
 			r:         &Resource{MilliCPU: 1000},
 			rr:        &Resource{MilliCPU: 500},
-			req:       nil,
+			dims:      nil,
 			wantBool:  false,
 			wantNames: []string{},
 		},
@@ -1444,7 +1435,7 @@ func TestGreaterPartlyWithRelevantDimensions(t *testing.T) {
 			name:      "cpu greater, rr has cpu",
 			r:         &Resource{MilliCPU: 2000},
 			rr:        &Resource{MilliCPU: 1000},
-			req:       &Resource{MilliCPU: 1000},
+			dims:      ResourceNameList{v1.ResourceCPU},
 			wantBool:  true,
 			wantNames: []string{"cpu"},
 		},
@@ -1452,7 +1443,7 @@ func TestGreaterPartlyWithRelevantDimensions(t *testing.T) {
 			name:      "cpu greater, rr has no cpu (should be ignored)",
 			r:         &Resource{MilliCPU: 2000},
 			rr:        &Resource{},
-			req:       &Resource{MilliCPU: 1000},
+			dims:      ResourceNameList{v1.ResourceCPU},
 			wantBool:  false,
 			wantNames: []string{},
 		},
@@ -1460,7 +1451,7 @@ func TestGreaterPartlyWithRelevantDimensions(t *testing.T) {
 			name:      "scalar resource greater, rr has scalar",
 			r:         &Resource{ScalarResources: map[v1.ResourceName]float64{"nvidia.com/gpu": 2}},
 			rr:        &Resource{ScalarResources: map[v1.ResourceName]float64{"nvidia.com/gpu": 1}},
-			req:       &Resource{ScalarResources: map[v1.ResourceName]float64{"nvidia.com/gpu": 1}},
+			dims:      ResourceNameList{"nvidia.com/gpu"},
 			wantBool:  true,
 			wantNames: []string{"nvidia.com/gpu"},
 		},
@@ -1468,7 +1459,7 @@ func TestGreaterPartlyWithRelevantDimensions(t *testing.T) {
 			name:      "scalar resource greater, rr does not have scalar (should be ignored)",
 			r:         &Resource{ScalarResources: map[v1.ResourceName]float64{"nvidia.com/gpu": 2}},
 			rr:        &Resource{},
-			req:       &Resource{ScalarResources: map[v1.ResourceName]float64{"nvidia.com/gpu": 1}},
+			dims:      ResourceNameList{"nvidia.com/gpu"},
 			wantBool:  false,
 			wantNames: []string{},
 		},
@@ -1476,7 +1467,7 @@ func TestGreaterPartlyWithRelevantDimensions(t *testing.T) {
 			name:      "cpu and memory, only memory greater and present in rr",
 			r:         &Resource{MilliCPU: 1000, Memory: 2048},
 			rr:        &Resource{MilliCPU: 1000, Memory: 1024},
-			req:       &Resource{MilliCPU: 1000, Memory: 1024},
+			dims:      ResourceNameList{v1.ResourceCPU, v1.ResourceMemory},
 			wantBool:  true,
 			wantNames: []string{"memory"},
 		},
@@ -1484,14 +1475,14 @@ func TestGreaterPartlyWithRelevantDimensions(t *testing.T) {
 			name:      "nothing greater",
 			r:         &Resource{MilliCPU: 1000, Memory: 1024},
 			rr:        &Resource{MilliCPU: 2000, Memory: 2048},
-			req:       &Resource{MilliCPU: 1000, Memory: 1024},
+			dims:      ResourceNameList{v1.ResourceCPU, v1.ResourceMemory},
 			wantBool:  false,
 			wantNames: []string{},
 		},
 	}
 
 	for _, tt := range tests {
-		gotBool, gotNames := tt.r.GreaterPartlyWithRelevantDimensions(tt.rr, tt.req)
+		gotBool, gotNames := tt.r.GreaterPartlyWithRelevantDimensions(tt.rr, tt.dims)
 		if gotBool != tt.wantBool {
 			t.Errorf("%s: got bool %v, want %v", tt.name, gotBool, tt.wantBool)
 		}
@@ -1804,7 +1795,7 @@ func TestResource_LessEqualResource(t *testing.T) {
 				Memory:          2000,
 				ScalarResources: map[v1.ResourceName]float64{"scalar.test/scalar1": 1000, "hugepages-test": 2000},
 			},
-			expected: []string{},
+			expected: []string{"hugepages-test", "scalar.test/scalar1"},
 		},
 		{
 			resource1: &Resource{
@@ -1817,16 +1808,18 @@ func TestResource_LessEqualResource(t *testing.T) {
 		},
 	}
 
-	for _, test := range testsForDefaultZero {
-		_, reason := test.resource1.LessEqualWithResourcesName(test.resource2, Zero)
+	for i := range testsForDefaultZero {
+		test := &testsForDefaultZero[i]
+		_, reason := test.resource1.LessEqual(test.resource2, Zero)
 		sort.Strings(test.expected)
 		sort.Strings(reason)
 		if !equality.Semantic.DeepEqual(test.expected, reason) {
 			t.Errorf("expected: %#v, got: %#v", test.expected, reason)
 		}
 	}
-	for caseID, test := range testsForDefaultInfinity {
-		_, reason := test.resource1.LessEqualWithResourcesName(test.resource2, Infinity)
+	for i := range testsForDefaultInfinity {
+		caseID, test := i, &testsForDefaultInfinity[i]
+		_, reason := test.resource1.LessEqual(test.resource2, Infinity)
 		sort.Strings(test.expected)
 		sort.Strings(reason)
 		if !equality.Semantic.DeepEqual(test.expected, reason) {

--- a/pkg/scheduler/api/resource_info_test.go
+++ b/pkg/scheduler/api/resource_info_test.go
@@ -756,32 +756,32 @@ func TestLessEqual(t *testing.T) {
 		},
 	}
 
-	for _, test := range testsForDefaultZero {
-		flag := test.resource1.LessEqual(test.resource2, Zero)
+	for i, test := range testsForDefaultZero {
+		flag, _ := test.resource1.LessEqual(test.resource2, Zero)
 		if !equality.Semantic.DeepEqual(test.expected, flag) {
-			t.Errorf("expected: %#v, got: %#v", test.expected, flag)
+			t.Errorf("Case %v expected: %#v, got: %#v", i, test.expected, flag)
 		}
 	}
 	for caseID, test := range testsForDefaultInfinity {
-		flag := test.resource1.LessEqual(test.resource2, Infinity)
+		flag, _ := test.resource1.LessEqual(test.resource2, Infinity)
 		if !equality.Semantic.DeepEqual(test.expected, flag) {
 			t.Errorf("caseID %d expected: %#v, got: %#v", caseID, test.expected, flag)
 		}
 	}
 }
 
-func TestLessEqualWithDimensionAndResourcesName(t *testing.T) {
+func TestLessEqualWithDimension(t *testing.T) {
 	tests := []struct {
 		resource1             *Resource
 		resource2             *Resource
-		req                   *Resource
+		dims                  ResourceNameList
 		expectedFlag          bool
 		expectedResourceNames []string
 	}{
 		{
 			resource1:             &Resource{},
 			resource2:             &Resource{},
-			req:                   nil,
+			dims:                  nil,
 			expectedFlag:          true,
 			expectedResourceNames: []string{},
 		},
@@ -791,9 +791,9 @@ func TestLessEqualWithDimensionAndResourcesName(t *testing.T) {
 				Memory:   4000,
 			},
 			resource2:             &Resource{},
-			req:                   nil,
-			expectedFlag:          false,
-			expectedResourceNames: []string{"cpu", "memory"},
+			dims:                  nil,
+			expectedFlag:          true,
+			expectedResourceNames: []string{},
 		},
 		{
 			resource1: &Resource{MilliCPU: 5000},
@@ -802,14 +802,14 @@ func TestLessEqualWithDimensionAndResourcesName(t *testing.T) {
 				Memory:          2000,
 				ScalarResources: map[v1.ResourceName]float64{"scalar.test/scalar1": 1000},
 			},
-			req:                   &Resource{MilliCPU: 1000},
+			dims:                  ResourceNameList{v1.ResourceCPU},
 			expectedFlag:          false,
 			expectedResourceNames: []string{"cpu"},
 		},
 		{
 			resource1:             &Resource{MilliCPU: 3000, Memory: 3000},
 			resource2:             &Resource{MilliCPU: 4000, Memory: 2000},
-			req:                   &Resource{Memory: 1000},
+			dims:                  ResourceNameList{v1.ResourceMemory},
 			expectedFlag:          false,
 			expectedResourceNames: []string{"memory"},
 		},
@@ -819,7 +819,7 @@ func TestLessEqualWithDimensionAndResourcesName(t *testing.T) {
 				Memory:   4000,
 			},
 			resource2:             &Resource{},
-			req:                   &Resource{},
+			dims:                  ResourceNameList{},
 			expectedFlag:          true,
 			expectedResourceNames: []string{},
 		},
@@ -828,11 +828,8 @@ func TestLessEqualWithDimensionAndResourcesName(t *testing.T) {
 				MilliCPU: 4, Memory: 4000,
 				ScalarResources: map[v1.ResourceName]float64{"nvidia.com/gpu": 1},
 			},
-			resource2: &Resource{MilliCPU: 8, Memory: 8000},
-			req: &Resource{
-				MilliCPU: 4, Memory: 2000,
-				ScalarResources: map[v1.ResourceName]float64{"nvidia.com/gpu": 1},
-			},
+			resource2:             &Resource{MilliCPU: 8, Memory: 8000},
+			dims:                  ResourceNameList{"nvidia.com/gpu"},
 			expectedFlag:          false,
 			expectedResourceNames: []string{"nvidia.com/gpu"},
 		},
@@ -845,12 +842,9 @@ func TestLessEqualWithDimensionAndResourcesName(t *testing.T) {
 				MilliCPU: 100, Memory: 8000,
 				ScalarResources: map[v1.ResourceName]float64{"nvidia.com/A100": 1},
 			},
-			req: &Resource{
-				MilliCPU: 10, Memory: 4000,
-				ScalarResources: map[v1.ResourceName]float64{"nvidia.com/gpu": 0, "nvidia.com/A100": 1, "scalar": 1},
-			},
-			expectedFlag:          true,
-			expectedResourceNames: []string{},
+			dims:                  ResourceNameList{"nvidia.com/gpu", "nvidia.com/A100", "scalar"},
+			expectedFlag:          false,
+			expectedResourceNames: []string{"nvidia.com/gpu"},
 		},
 		{
 			resource1: &Resource{
@@ -861,17 +855,23 @@ func TestLessEqualWithDimensionAndResourcesName(t *testing.T) {
 				MilliCPU: 100, Memory: 8000,
 				ScalarResources: map[v1.ResourceName]float64{"nvidia.com/A100": 1, "scalar": 1},
 			},
-			req: &Resource{
-				Memory:          4000,
-				ScalarResources: map[v1.ResourceName]float64{"nvidia.com/gpu": 0, "nvidia.com/A100": 1, "scalar": 1},
+			dims:                  ResourceNameList{v1.ResourceMemory, "nvidia.com/gpu", "nvidia.com/A100", "scalar"},
+			expectedFlag:          false,
+			expectedResourceNames: []string{"nvidia.com/gpu"},
+		},
+		{
+			resource1: &Resource{
+				ScalarResources: map[v1.ResourceName]float64{v1.ResourcePods: 1},
 			},
+			resource2:             &Resource{},
+			dims:                  ResourceNameList{v1.ResourcePods},
 			expectedFlag:          true,
 			expectedResourceNames: []string{},
 		},
 	}
 
 	for i, test := range tests {
-		flag, resourceNames := test.resource1.LessEqualWithDimensionAndResourcesName(test.resource2, test.req)
+		flag, resourceNames := test.resource1.LessEqualWithDimension(test.resource2, test.dims)
 		if !equality.Semantic.DeepEqual(test.expectedFlag, flag) {
 			t.Errorf("Case %v: expected: %#v, got: %#v", i, test.expectedFlag, flag)
 		}
@@ -1180,13 +1180,13 @@ func TestLessEqualPartly(t *testing.T) {
 	}
 
 	for _, test := range testsForDefaultZero {
-		flag := test.resource1.LessEqualPartly(test.resource2, Zero)
+		flag, _ := test.resource1.LessEqualPartly(test.resource2, Zero)
 		if !equality.Semantic.DeepEqual(test.expected, flag) {
 			t.Errorf("expected: %#v, got: %#v", test.expected, flag)
 		}
 	}
 	for _, test := range testsForDefaultInfinity {
-		flag := test.resource1.LessEqualPartly(test.resource2, Infinity)
+		flag, _ := test.resource1.LessEqualPartly(test.resource2, Infinity)
 		if !equality.Semantic.DeepEqual(test.expected, flag) {
 			t.Errorf("expected: %#v, got: %#v", test.expected, flag)
 		}
@@ -1197,77 +1197,84 @@ func TestLessEqualPartlyWithDimension(t *testing.T) {
 	tests := []struct {
 		r         *Resource
 		rr        *Resource
-		req       *Resource
+		dims      ResourceNameList
 		wantBool  bool
 		wantNames []string
 	}{
 		{
 			r:         &Resource{MilliCPU: 1000},
 			rr:        &Resource{MilliCPU: 2000},
-			req:       nil,
+			dims:      nil,
 			wantBool:  false,
 			wantNames: []string{},
 		},
 		{
 			r:         &Resource{MilliCPU: 3000},
 			rr:        &Resource{MilliCPU: 2000},
-			req:       &Resource{MilliCPU: 4000},
+			dims:      ResourceNameList{v1.ResourceCPU},
 			wantBool:  false,
 			wantNames: []string{},
 		},
 		{
 			r:         &Resource{MilliCPU: 1000},
 			rr:        &Resource{MilliCPU: 2000},
-			req:       &Resource{MilliCPU: 500},
+			dims:      ResourceNameList{v1.ResourceCPU},
 			wantBool:  true,
 			wantNames: []string{"cpu"},
 		},
 		{
 			r:         &Resource{Memory: 1024},
 			rr:        &Resource{Memory: 1024},
-			req:       &Resource{Memory: 512},
+			dims:      ResourceNameList{v1.ResourceMemory},
 			wantBool:  true,
 			wantNames: []string{"memory"},
 		},
 		{
 			r:         &Resource{ScalarResources: map[v1.ResourceName]float64{"nvidia.com/gpu": 2}},
 			rr:        &Resource{ScalarResources: map[v1.ResourceName]float64{"nvidia.com/gpu": 4}},
-			req:       &Resource{ScalarResources: map[v1.ResourceName]float64{"nvidia.com/gpu": 1}},
+			dims:      ResourceNameList{"nvidia.com/gpu"},
 			wantBool:  true,
 			wantNames: []string{"nvidia.com/gpu"},
 		},
 		{
 			r:         &Resource{ScalarResources: map[v1.ResourceName]float64{"nvidia.com/gpu": 4}},
 			rr:        &Resource{ScalarResources: map[v1.ResourceName]float64{"nvidia.com/gpu": 4}},
-			req:       &Resource{ScalarResources: map[v1.ResourceName]float64{"nvidia.com/gpu": 2}},
+			dims:      ResourceNameList{"nvidia.com/gpu"},
 			wantBool:  true,
 			wantNames: []string{"nvidia.com/gpu"},
 		},
 		{
 			r:         &Resource{MilliCPU: 3000, Memory: 2048, ScalarResources: map[v1.ResourceName]float64{"nvidia.com/gpu": 5}},
 			rr:        &Resource{MilliCPU: 2000, Memory: 1024, ScalarResources: map[v1.ResourceName]float64{"nvidia.com/gpu": 4}},
-			req:       &Resource{MilliCPU: 1000, Memory: 512, ScalarResources: map[v1.ResourceName]float64{"nvidia.com/gpu": 1}},
+			dims:      ResourceNameList{v1.ResourceCPU, v1.ResourceMemory, "nvidia.com/gpu"},
 			wantBool:  false,
 			wantNames: []string{},
 		},
 		{
 			r:         &Resource{ScalarResources: map[v1.ResourceName]float64{"rdma": 2, "fpga": 2}},
 			rr:        &Resource{ScalarResources: map[v1.ResourceName]float64{"rdma": 2}},
-			req:       &Resource{MilliCPU: 1000, Memory: 512, ScalarResources: map[v1.ResourceName]float64{"rdma": 1, "fpga": 1, "nvidia.com/gpu": 2}},
+			dims:      ResourceNameList{v1.ResourceCPU, v1.ResourceMemory, "rdma", "fpga", "nvidia.com/gpu"},
 			wantBool:  true,
 			wantNames: []string{"cpu", "memory", "rdma", "nvidia.com/gpu"},
 		},
 		{
 			r:         &Resource{ScalarResources: map[v1.ResourceName]float64{"rdma": 1, "fpga": 2, "nvidia.com/gpu": 2}},
 			rr:        &Resource{ScalarResources: map[v1.ResourceName]float64{"rdma": 2, "fpga": 2}},
-			req:       &Resource{MilliCPU: 1000, Memory: 512, ScalarResources: map[v1.ResourceName]float64{"nvidia.com/gpu": 2, "rdma": 1, "fpga": 1}},
+			dims:      ResourceNameList{v1.ResourceCPU, v1.ResourceMemory, "nvidia.com/gpu", "rdma", "fpga"},
 			wantBool:  true,
 			wantNames: []string{"cpu", "memory", "rdma", "fpga"},
+		},
+		{
+			r:         &Resource{ScalarResources: map[v1.ResourceName]float64{v1.ResourcePods: 0}},
+			rr:        &Resource{ScalarResources: map[v1.ResourceName]float64{v1.ResourcePods: 1}},
+			dims:      ResourceNameList{v1.ResourcePods},
+			wantBool:  false,
+			wantNames: []string{},
 		},
 	}
 
 	for _, tt := range tests {
-		gotBool, gotNames := tt.r.LessEqualPartlyWithDimension(tt.rr, tt.req)
+		gotBool, gotNames := tt.r.LessEqualPartlyWithDimension(tt.rr, tt.dims)
 		if gotBool != tt.wantBool {
 			t.Errorf("got bool %v, want %v", gotBool, tt.wantBool)
 		}
@@ -1279,67 +1286,74 @@ func TestLessEqualPartlyWithDimension(t *testing.T) {
 	}
 }
 
-func TestLessEqualPartlyWithDimensionZeroFiltered(t *testing.T) {
+func TestLessEqualPartlyWithRelevantDimensions(t *testing.T) {
 	tests := []struct {
 		r         *Resource
 		rr        *Resource
-		req       *Resource
+		dims      ResourceNameList
 		wantBool  bool
 		wantNames []string
 	}{
 		{
 			r:         &Resource{MilliCPU: 0, Memory: 0},
 			rr:        &Resource{MilliCPU: 0, Memory: 0},
-			req:       &Resource{MilliCPU: 1000, Memory: 512},
+			dims:      ResourceNameList{v1.ResourceCPU, v1.ResourceMemory},
 			wantBool:  false,
 			wantNames: []string{},
 		},
 		{
 			r:         &Resource{MilliCPU: 1000, Memory: 0},
 			rr:        &Resource{MilliCPU: 2000, Memory: 0},
-			req:       &Resource{MilliCPU: 1000, Memory: 512},
+			dims:      ResourceNameList{v1.ResourceCPU, v1.ResourceMemory},
 			wantBool:  true,
 			wantNames: []string{"cpu"},
 		},
 		{
 			r:         &Resource{MilliCPU: 0, Memory: 0},
 			rr:        &Resource{MilliCPU: 0, Memory: 2048},
-			req:       &Resource{MilliCPU: 1000, Memory: 512},
+			dims:      ResourceNameList{v1.ResourceCPU, v1.ResourceMemory},
 			wantBool:  true,
 			wantNames: []string{"memory"},
 		},
 		{
 			r:         &Resource{MilliCPU: 1000, Memory: 1024},
 			rr:        &Resource{MilliCPU: 2000, Memory: 2048},
-			req:       &Resource{MilliCPU: 1000, Memory: 512},
+			dims:      ResourceNameList{v1.ResourceCPU, v1.ResourceMemory},
 			wantBool:  true,
 			wantNames: []string{"cpu", "memory"},
 		},
 		{
 			r:         &Resource{MilliCPU: 0, Memory: 1024},
 			rr:        &Resource{MilliCPU: 2000, Memory: 0, ScalarResources: map[v1.ResourceName]float64{"nvidia.com/gpu": 4}},
-			req:       &Resource{MilliCPU: 1000, Memory: 512, ScalarResources: map[v1.ResourceName]float64{"nvidia.com/gpu": 2}},
+			dims:      ResourceNameList{v1.ResourceCPU, v1.ResourceMemory, "nvidia.com/gpu"},
 			wantBool:  true,
 			wantNames: []string{"cpu", "nvidia.com/gpu"},
 		},
 		{
 			r:         &Resource{ScalarResources: map[v1.ResourceName]float64{"rdma": 2, "fpga": 2}},
 			rr:        &Resource{ScalarResources: map[v1.ResourceName]float64{"rdma": 2}},
-			req:       &Resource{MilliCPU: 1000, Memory: 512, ScalarResources: map[v1.ResourceName]float64{"nvidia.com/gpu": 2, "rdma": 1, "fpga": 1}},
+			dims:      ResourceNameList{"nvidia.com/gpu", "rdma", "fpga"},
 			wantBool:  true,
 			wantNames: []string{"rdma"},
 		},
 		{
 			r:         &Resource{ScalarResources: map[v1.ResourceName]float64{"rdma": 1, "fpga": 2, "nvidia.com/gpu": 2}},
 			rr:        &Resource{ScalarResources: map[v1.ResourceName]float64{"rdma": 2, "fpga": 2}},
-			req:       &Resource{MilliCPU: 1000, Memory: 512, ScalarResources: map[v1.ResourceName]float64{"nvidia.com/gpu": 2, "rdma": 1, "fpga": 1}},
+			dims:      ResourceNameList{"nvidia.com/gpu", "rdma", "fpga"},
 			wantBool:  true,
 			wantNames: []string{"rdma", "fpga"},
+		},
+		{
+			r:         &Resource{ScalarResources: map[v1.ResourceName]float64{v1.ResourcePods: 0}},
+			rr:        &Resource{ScalarResources: map[v1.ResourceName]float64{v1.ResourcePods: 1}},
+			dims:      ResourceNameList{v1.ResourcePods},
+			wantBool:  false,
+			wantNames: []string{},
 		},
 	}
 
 	for _, tt := range tests {
-		gotBool, gotNames := tt.r.LessEqualPartlyWithDimensionZeroFiltered(tt.rr, tt.req)
+		gotBool, gotNames := tt.r.LessEqualPartlyWithRelevantDimensions(tt.rr, tt.dims)
 		if gotBool != tt.wantBool {
 			t.Errorf("got bool %v, want %v", gotBool, tt.wantBool)
 		}
@@ -1356,15 +1370,15 @@ func TestGreaterPartlyWithDimension(t *testing.T) {
 		name      string
 		r         *Resource
 		rr        *Resource
-		req       *Resource
+		dims      ResourceNameList
 		wantBool  bool
 		wantNames []string
 	}{
 		{
-			name:      "nil req returns false",
+			name:      "nil dims returns false",
 			r:         &Resource{MilliCPU: 1000},
 			rr:        &Resource{MilliCPU: 500},
-			req:       nil,
+			dims:      nil,
 			wantBool:  false,
 			wantNames: []string{},
 		},
@@ -1372,7 +1386,7 @@ func TestGreaterPartlyWithDimension(t *testing.T) {
 			name:      "cpu greater",
 			r:         &Resource{MilliCPU: 2000},
 			rr:        &Resource{MilliCPU: 1000},
-			req:       &Resource{MilliCPU: 1000},
+			dims:      ResourceNameList{v1.ResourceCPU},
 			wantBool:  true,
 			wantNames: []string{"cpu"},
 		},
@@ -1380,7 +1394,7 @@ func TestGreaterPartlyWithDimension(t *testing.T) {
 			name:      "scalar resource greater",
 			r:         &Resource{ScalarResources: map[v1.ResourceName]float64{"nvidia.com/gpu": 2}},
 			rr:        &Resource{ScalarResources: map[v1.ResourceName]float64{"nvidia.com/gpu": 1}},
-			req:       &Resource{ScalarResources: map[v1.ResourceName]float64{"nvidia.com/gpu": 1}},
+			dims:      ResourceNameList{"nvidia.com/gpu"},
 			wantBool:  true,
 			wantNames: []string{"nvidia.com/gpu"},
 		},
@@ -1388,7 +1402,7 @@ func TestGreaterPartlyWithDimension(t *testing.T) {
 			name:      "cpu and memory, both greater",
 			r:         &Resource{MilliCPU: 2000, Memory: 2048},
 			rr:        &Resource{MilliCPU: 1000, Memory: 1024},
-			req:       &Resource{MilliCPU: 1000, Memory: 1024},
+			dims:      ResourceNameList{v1.ResourceCPU, v1.ResourceMemory},
 			wantBool:  true,
 			wantNames: []string{"cpu", "memory"},
 		},
@@ -1396,7 +1410,7 @@ func TestGreaterPartlyWithDimension(t *testing.T) {
 			name:      "memory greater but not requested",
 			r:         &Resource{MilliCPU: 1000, Memory: 2048},
 			rr:        &Resource{MilliCPU: 1000, Memory: 1024},
-			req:       &Resource{MilliCPU: 1000},
+			dims:      ResourceNameList{v1.ResourceCPU},
 			wantBool:  false,
 			wantNames: []string{},
 		},
@@ -1404,14 +1418,22 @@ func TestGreaterPartlyWithDimension(t *testing.T) {
 			name:      "nothing greater",
 			r:         &Resource{MilliCPU: 1000, Memory: 1024},
 			rr:        &Resource{MilliCPU: 2000, Memory: 2048},
-			req:       &Resource{MilliCPU: 1000, Memory: 1024},
+			dims:      ResourceNameList{v1.ResourceCPU, v1.ResourceMemory},
+			wantBool:  false,
+			wantNames: []string{},
+		},
+		{
+			name:      "ignored scalar resource is skipped",
+			r:         &Resource{ScalarResources: map[v1.ResourceName]float64{v1.ResourcePods: 2}},
+			rr:        &Resource{ScalarResources: map[v1.ResourceName]float64{v1.ResourcePods: 1}},
+			dims:      ResourceNameList{v1.ResourcePods},
 			wantBool:  false,
 			wantNames: []string{},
 		},
 	}
 
 	for _, tt := range tests {
-		gotBool, gotNames := tt.r.GreaterPartlyWithDimension(tt.rr, tt.req)
+		gotBool, gotNames := tt.r.GreaterPartlyWithDimension(tt.rr, tt.dims)
 		if gotBool != tt.wantBool {
 			t.Errorf("%s: got bool %v, want %v", tt.name, gotBool, tt.wantBool)
 		}
@@ -1428,15 +1450,15 @@ func TestGreaterPartlyWithRelevantDimensions(t *testing.T) {
 		name      string
 		r         *Resource
 		rr        *Resource
-		req       *Resource
+		dims      ResourceNameList
 		wantBool  bool
 		wantNames []string
 	}{
 		{
-			name:      "nil req returns false",
+			name:      "nil dims returns false",
 			r:         &Resource{MilliCPU: 1000},
 			rr:        &Resource{MilliCPU: 500},
-			req:       nil,
+			dims:      nil,
 			wantBool:  false,
 			wantNames: []string{},
 		},
@@ -1444,7 +1466,7 @@ func TestGreaterPartlyWithRelevantDimensions(t *testing.T) {
 			name:      "cpu greater, rr has cpu",
 			r:         &Resource{MilliCPU: 2000},
 			rr:        &Resource{MilliCPU: 1000},
-			req:       &Resource{MilliCPU: 1000},
+			dims:      ResourceNameList{v1.ResourceCPU},
 			wantBool:  true,
 			wantNames: []string{"cpu"},
 		},
@@ -1452,7 +1474,7 @@ func TestGreaterPartlyWithRelevantDimensions(t *testing.T) {
 			name:      "cpu greater, rr has no cpu (should be ignored)",
 			r:         &Resource{MilliCPU: 2000},
 			rr:        &Resource{},
-			req:       &Resource{MilliCPU: 1000},
+			dims:      ResourceNameList{v1.ResourceCPU},
 			wantBool:  false,
 			wantNames: []string{},
 		},
@@ -1460,7 +1482,7 @@ func TestGreaterPartlyWithRelevantDimensions(t *testing.T) {
 			name:      "scalar resource greater, rr has scalar",
 			r:         &Resource{ScalarResources: map[v1.ResourceName]float64{"nvidia.com/gpu": 2}},
 			rr:        &Resource{ScalarResources: map[v1.ResourceName]float64{"nvidia.com/gpu": 1}},
-			req:       &Resource{ScalarResources: map[v1.ResourceName]float64{"nvidia.com/gpu": 1}},
+			dims:      ResourceNameList{"nvidia.com/gpu"},
 			wantBool:  true,
 			wantNames: []string{"nvidia.com/gpu"},
 		},
@@ -1468,7 +1490,7 @@ func TestGreaterPartlyWithRelevantDimensions(t *testing.T) {
 			name:      "scalar resource greater, rr does not have scalar (should be ignored)",
 			r:         &Resource{ScalarResources: map[v1.ResourceName]float64{"nvidia.com/gpu": 2}},
 			rr:        &Resource{},
-			req:       &Resource{ScalarResources: map[v1.ResourceName]float64{"nvidia.com/gpu": 1}},
+			dims:      ResourceNameList{"nvidia.com/gpu"},
 			wantBool:  false,
 			wantNames: []string{},
 		},
@@ -1476,7 +1498,7 @@ func TestGreaterPartlyWithRelevantDimensions(t *testing.T) {
 			name:      "cpu and memory, only memory greater and present in rr",
 			r:         &Resource{MilliCPU: 1000, Memory: 2048},
 			rr:        &Resource{MilliCPU: 1000, Memory: 1024},
-			req:       &Resource{MilliCPU: 1000, Memory: 1024},
+			dims:      ResourceNameList{v1.ResourceCPU, v1.ResourceMemory},
 			wantBool:  true,
 			wantNames: []string{"memory"},
 		},
@@ -1484,14 +1506,22 @@ func TestGreaterPartlyWithRelevantDimensions(t *testing.T) {
 			name:      "nothing greater",
 			r:         &Resource{MilliCPU: 1000, Memory: 1024},
 			rr:        &Resource{MilliCPU: 2000, Memory: 2048},
-			req:       &Resource{MilliCPU: 1000, Memory: 1024},
+			dims:      ResourceNameList{v1.ResourceCPU, v1.ResourceMemory},
+			wantBool:  false,
+			wantNames: []string{},
+		},
+		{
+			name:      "ignored scalar resource is skipped",
+			r:         &Resource{ScalarResources: map[v1.ResourceName]float64{v1.ResourcePods: 2}},
+			rr:        &Resource{ScalarResources: map[v1.ResourceName]float64{v1.ResourcePods: 1}},
+			dims:      ResourceNameList{v1.ResourcePods},
 			wantBool:  false,
 			wantNames: []string{},
 		},
 	}
 
 	for _, tt := range tests {
-		gotBool, gotNames := tt.r.GreaterPartlyWithRelevantDimensions(tt.rr, tt.req)
+		gotBool, gotNames := tt.r.GreaterPartlyWithRelevantDimensions(tt.rr, tt.dims)
 		if gotBool != tt.wantBool {
 			t.Errorf("%s: got bool %v, want %v", tt.name, gotBool, tt.wantBool)
 		}
@@ -1804,7 +1834,7 @@ func TestResource_LessEqualResource(t *testing.T) {
 				Memory:          2000,
 				ScalarResources: map[v1.ResourceName]float64{"scalar.test/scalar1": 1000, "hugepages-test": 2000},
 			},
-			expected: []string{},
+			expected: []string{"hugepages-test", "scalar.test/scalar1"},
 		},
 		{
 			resource1: &Resource{
@@ -1817,16 +1847,18 @@ func TestResource_LessEqualResource(t *testing.T) {
 		},
 	}
 
-	for _, test := range testsForDefaultZero {
-		_, reason := test.resource1.LessEqualWithResourcesName(test.resource2, Zero)
+	for i := range testsForDefaultZero {
+		test := &testsForDefaultZero[i]
+		_, reason := test.resource1.LessEqual(test.resource2, Zero)
 		sort.Strings(test.expected)
 		sort.Strings(reason)
 		if !equality.Semantic.DeepEqual(test.expected, reason) {
 			t.Errorf("expected: %#v, got: %#v", test.expected, reason)
 		}
 	}
-	for caseID, test := range testsForDefaultInfinity {
-		_, reason := test.resource1.LessEqualWithResourcesName(test.resource2, Infinity)
+	for i := range testsForDefaultInfinity {
+		caseID, test := i, &testsForDefaultInfinity[i]
+		_, reason := test.resource1.LessEqual(test.resource2, Infinity)
 		sort.Strings(test.expected)
 		sort.Strings(reason)
 		if !equality.Semantic.DeepEqual(test.expected, reason) {

--- a/pkg/scheduler/plugins/capacity/capacity.go
+++ b/pkg/scheduler/plugins/capacity/capacity.go
@@ -191,14 +191,14 @@ func (cp *capacityPlugin) OnSessionOpen(ssn *framework.Session) {
 		attr := cp.queueOpts[queue.UID]
 		futureUsed := attr.allocated.Clone().Add(task.Resreq)
 
-		if allocatable, _ := futureUsed.LessEqualWithDimensionAndResourcesName(attr.realCapability, task.Resreq); !allocatable {
+		if allocatable, _ := futureUsed.LessEqualWithDimension(attr.realCapability, task.Resreq.ResourceNames()); !allocatable {
 			klog.V(3).Infof("Queue <%v> cannot reclaim for <%s/%s> because futureUsed <%v> exceeds realCapability <%v>.",
 				queue.Name, task.Namespace, task.Name, futureUsed, attr.realCapability)
 			return false
 		}
 
 		// If there is a single dimension whose deserved is greater than allocated, current task can reclaim by preempt others.
-		isPreemptive, resourceNames := futureUsed.LessEqualPartlyWithDimensionZeroFiltered(attr.deserved, task.Resreq)
+		isPreemptive, resourceNames := futureUsed.LessEqualPartlyWithRelevantDimensions(attr.deserved, task.Resreq.ResourceNames())
 		if isPreemptive {
 			klog.V(3).Infof("Queue <%v> can reclaim on resource dimensions: %v. "+
 				"The futureUsed: %v, deserved: %v, allocated: %v, task requested: %v",
@@ -938,7 +938,7 @@ func (cp *capacityPlugin) queueAllocatable(queue *api.QueueInfo, candidate *api.
 
 func queueAllocatable(attr *queueAttr, candidate *api.TaskInfo, queue *api.QueueInfo) bool {
 	futureUsed := attr.allocated.Clone().Add(candidate.Resreq)
-	allocatable, _ := futureUsed.LessEqualWithDimensionAndResourcesName(attr.realCapability, candidate.Resreq)
+	allocatable, _ := futureUsed.LessEqualWithDimension(attr.realCapability, candidate.Resreq.ResourceNames())
 	if !allocatable {
 		klog.V(3).Infof("Queue <%v>: realCapability <%v>, allocated <%v>; Candidate <%v>: resource request <%v>",
 			queue.Name, attr.realCapability, attr.allocated, candidate.Name, candidate.Resreq)
@@ -974,7 +974,7 @@ func (cp *capacityPlugin) jobEnqueueable(queue *api.QueueInfo, job *api.JobInfo)
 	// The queue resource quota limit has not reached
 	r := minReq.Clone().Add(attr.allocated).Add(attr.inqueue).Sub(attr.elastic)
 
-	return r.LessEqualWithDimensionAndResourcesName(attr.realCapability, minReq)
+	return r.LessEqualWithDimension(attr.realCapability, minReq.ResourceNames())
 }
 
 func (cp *capacityPlugin) checkJobEnqueueableHierarchically(ssn *framework.Session, queue *api.QueueInfo, job *api.JobInfo) bool {
@@ -1126,7 +1126,7 @@ func (cp *capacityPlugin) checkGuaranteeConstraint(
 	guarantee *api.Resource,
 ) (bool, *api.Resource) {
 	exceptReclaimee := allocated.Clone().Sub(reclaimee.Resreq)
-	reclaimable := guarantee.LessEqual(exceptReclaimee, api.Zero)
+	reclaimable, _ := guarantee.LessEqual(exceptReclaimee, api.Zero)
 	return reclaimable, exceptReclaimee
 }
 
@@ -1155,7 +1155,7 @@ func (cp *capacityPlugin) checkDeservedExceedance(
 	reclaimer *api.TaskInfo,
 	queueName string,
 ) (bool, []string, string) {
-	reclaimable, dims := allocated.GreaterPartlyWithRelevantDimensions(deserved, reclaimee.Resreq)
+	reclaimable, dims := allocated.GreaterPartlyWithRelevantDimensions(deserved, reclaimee.Resreq.ResourceNames())
 	if !reclaimable {
 		reason := fmt.Sprintf(
 			"[capacity] Queue <%v> allocated resources are not greater than deserved on any relevant dimension of reclaimee. "+

--- a/pkg/scheduler/plugins/capacity/capacity.go
+++ b/pkg/scheduler/plugins/capacity/capacity.go
@@ -635,7 +635,7 @@ func (cp *capacityPlugin) OnSessionOpen(ssn *framework.Session) {
 				victims = append(victims, reclaimee)
 				continue
 			}
-			reclaimable, _ := allocated.GreaterPartlyWithRelevantDimensions(attr.deserved, reclaimee.Resreq)
+			reclaimable, _ := allocated.GreaterPartlyWithRelevantDimensions(attr.deserved, reclaimee.Resreq.ResourceNames())
 			if reclaimable {
 				allocated.Sub(reclaimee.Resreq)
 				victims = append(victims, reclaimee)
@@ -667,14 +667,14 @@ func (cp *capacityPlugin) OnSessionOpen(ssn *framework.Session) {
 		}
 		futureUsed := attr.allocated.Clone().Add(totalReq)
 
-		if allocatable, _ := futureUsed.LessEqualWithDimensionAndResourcesName(attr.realCapability, totalReq); !allocatable {
+		if allocatable, _ := futureUsed.LessEqualWithDimension(attr.realCapability, totalReq.ResourceNames()); !allocatable {
 			klog.V(3).Infof("Queue <%v> cannot reclaim because futureUsed <%v> exceeds realCapability <%v>.",
 				queue.Name, futureUsed, attr.realCapability)
 			return false
 		}
 
 		// If there is a single dimension whose deserved is greater than allocated, current tasks can reclaim by preempting others.
-		isPreemptive, resourceNames := futureUsed.LessEqualPartlyWithDimensionZeroFiltered(attr.deserved, totalReq)
+		isPreemptive, resourceNames := futureUsed.LessEqualPartlyWithRelevantDimensions(attr.deserved, totalReq.ResourceNames())
 		if isPreemptive {
 			klog.V(3).Infof("Queue <%v> can reclaim on resource dimensions: %v. "+
 				"The futureUsed: %v, deserved: %v, allocated: %v, tasks requested: %v",
@@ -694,7 +694,7 @@ func (cp *capacityPlugin) OnSessionOpen(ssn *framework.Session) {
 					}
 
 					futureUsedAncestor := ancestorAttr.allocated.Clone().Add(totalReq)
-					isPreemptive, resourceNames = futureUsedAncestor.LessEqualPartlyWithDimensionZeroFiltered(ancestorAttr.deserved, totalReq)
+					isPreemptive, resourceNames = futureUsedAncestor.LessEqualPartlyWithRelevantDimensions(ancestorAttr.deserved, totalReq.ResourceNames())
 					if isPreemptive {
 						klog.V(3).Infof("Queue's ancestor <%v> can reclaim on resource dimensions: %v. "+
 							"The futureUsedAncestor: %v, deserved: %v, allocated: %v, task requested: %v",
@@ -1666,8 +1666,7 @@ func (cp *capacityPlugin) queueAllocatableWithReserved(attr *queueAttr, candidat
 
 	// Include reserved resources in capacity check
 	futureUsed := attr.allocated.Clone().Add(reserved).Add(candidate.Resreq)
-	allocatable, _ := futureUsed.LessEqualWithDimensionAndResourcesName(attr.realCapability, candidate.Resreq)
-
+	allocatable, _ := futureUsed.LessEqualWithDimension(attr.realCapability, candidate.Resreq.ResourceNames())
 	if !allocatable {
 		klog.V(3).Infof("Queue <%v>: realCapability <%v>, allocated <%v>, reserved <%v>; Candidate <%v>: resource request <%v>",
 			queue.Name, attr.realCapability, attr.allocated, reserved, candidate.Name, candidate.Resreq)
@@ -1703,7 +1702,7 @@ func (cp *capacityPlugin) jobEnqueueable(queue *api.QueueInfo, job *api.JobInfo)
 	// The queue resource quota limit has not reached
 	r := minReq.Clone().Add(attr.allocated).Add(attr.inqueue).Sub(attr.elastic)
 
-	valid, reasons := r.LessEqualWithDimensionAndResourcesName(attr.realCapability, minReq)
+	valid, reasons := r.LessEqualWithDimension(attr.realCapability, minReq.ResourceNames())
 	if !valid {
 		return valid, reasons
 	}
@@ -1862,7 +1861,7 @@ func (cp *capacityPlugin) checkGuaranteeConstraint(
 	guarantee *api.Resource,
 ) (bool, *api.Resource) {
 	exceptReclaimee := allocated.Clone().Sub(reclaimee.Resreq)
-	reclaimable := guarantee.LessEqual(exceptReclaimee, api.Zero)
+	reclaimable, _ := guarantee.LessEqual(exceptReclaimee, api.Zero)
 	return reclaimable, exceptReclaimee
 }
 
@@ -1897,7 +1896,7 @@ func (cp *capacityPlugin) checkDeservedExceedance(
 	reclaimer *api.TaskInfo,
 	queueName string,
 ) (bool, []string, string) {
-	reclaimable, dims := allocated.GreaterPartlyWithRelevantDimensions(deserved, reclaimee.Resreq)
+	reclaimable, dims := allocated.GreaterPartlyWithRelevantDimensions(deserved, reclaimee.Resreq.ResourceNames())
 	if !reclaimable {
 		reason := fmt.Sprintf(
 			"[capacity] Queue <%v> allocated resources are not greater than deserved on any relevant dimension of reclaimee. "+

--- a/pkg/scheduler/plugins/network-topology-aware/network_topology_aware.go
+++ b/pkg/scheduler/plugins/network-topology-aware/network_topology_aware.go
@@ -641,7 +641,13 @@ func (nta *networkTopologyAwarePlugin) isEligibleHyperNode(hn *api.HyperNodeInfo
 		return true // Resource status for hypernode not found in cache, skipping pre-filtering for it.
 	}
 
-	if minResource.LessEqual(hnResourceStatus.idle, api.Zero) || minResource.LessEqual(hnResourceStatus.futureIdle, api.Zero) {
+	if minResource == nil {
+		return true
+	}
+
+	lessEqualIdle, _ := minResource.LessEqual(hnResourceStatus.idle, api.Zero)
+	lessEqualFutureIdle, _ := minResource.LessEqual(hnResourceStatus.futureIdle, api.Zero)
+	if lessEqualIdle || lessEqualFutureIdle {
 		return true
 	}
 	return false

--- a/pkg/scheduler/plugins/network-topology-aware/network_topology_aware.go
+++ b/pkg/scheduler/plugins/network-topology-aware/network_topology_aware.go
@@ -660,11 +660,18 @@ func (nta *networkTopologyAwarePlugin) isEligibleHyperNode(hn *api.HyperNodeInfo
 		return true // Resource status for hypernode not found in cache, skipping pre-filtering for it.
 	}
 
-	if purpose == api.PurposeEvict {
-		return minResource.LessEqual(hnResourceStatus.allocatable, api.Zero)
+	if minResource == nil {
+		return true
 	}
 
-	if minResource.LessEqual(hnResourceStatus.idle, api.Zero) || minResource.LessEqual(hnResourceStatus.futureIdle, api.Zero) {
+	if purpose == api.PurposeEvict {
+		ok, _ := minResource.LessEqual(hnResourceStatus.allocatable, api.Zero)
+		return ok
+	}
+
+	lessEqualIdle, _ := minResource.LessEqual(hnResourceStatus.idle, api.Zero)
+	lessEqualFutureIdle, _ := minResource.LessEqual(hnResourceStatus.futureIdle, api.Zero)
+	if lessEqualIdle || lessEqualFutureIdle {
 		return true
 	}
 	return false

--- a/pkg/scheduler/plugins/overcommit/overcommit.go
+++ b/pkg/scheduler/plugins/overcommit/overcommit.go
@@ -121,7 +121,7 @@ func (op *overcommitPlugin) OnSessionOpen(ssn *framework.Session) {
 
 		//TODO: if allow 1 more job to be inqueue beyond overcommit-factor, large job may be inqueue and create pods
 		jobMinReq := job.GetMinResources()
-		couldInqueue, resourceNames := inqueue.Add(jobMinReq).LessEqualWithDimensionAndResourcesName(idle, jobMinReq)
+		couldInqueue, resourceNames := inqueue.Add(jobMinReq).LessEqualWithDimension(idle, jobMinReq.ResourceNames())
 		if couldInqueue { // only compare the requested resource
 			klog.V(4).Infof("Sufficient resources, permit job <%s/%s> to be inqueue", job.Namespace, job.Name)
 			return util.Permit

--- a/pkg/scheduler/plugins/proportion/proportion.go
+++ b/pkg/scheduler/plugins/proportion/proportion.go
@@ -236,7 +236,7 @@ func (pp *proportionPlugin) OnSessionOpen(ssn *framework.Session) {
 			pp.updateShare(attr)
 			klog.V(4).Infof("Format queue <%s> deserved resource to <%v>", attr.name, attr.deserved)
 
-			if attr.request.LessEqual(attr.deserved, api.Zero) {
+			if ok, _ := attr.request.LessEqual(attr.deserved, api.Zero); ok {
 				meet[attr.queueID] = struct{}{}
 				klog.V(4).Infof("queue <%s> is meet", attr.name)
 			} else if equality.Semantic.DeepEqual(attr.deserved, oldDeserved) {
@@ -307,7 +307,7 @@ func (pp *proportionPlugin) OnSessionOpen(ssn *framework.Session) {
 			}
 			allocated := allocations[job.Queue]
 
-			if !allocated.LessEqual(attr.deserved, api.Zero) {
+			if ok, _ := allocated.LessEqual(attr.deserved, api.Zero); !ok {
 				allocated.Sub(reclaimee.Resreq)
 				victims = append(victims, reclaimee)
 			}
@@ -320,7 +320,7 @@ func (pp *proportionPlugin) OnSessionOpen(ssn *framework.Session) {
 		queue := obj.(*api.QueueInfo)
 		attr := pp.queueOpts[queue.UID]
 
-		overused := attr.deserved.LessEqual(attr.allocated, api.Zero)
+		overused, _ := attr.deserved.LessEqual(attr.allocated, api.Zero)
 		metrics.UpdateQueueOverused(attr.name, overused)
 		if overused {
 			klog.V(3).Infof("Queue <%v> is overused: deserved <%v>, allocated <%v>, share <%v>",
@@ -338,7 +338,7 @@ func (pp *proportionPlugin) OnSessionOpen(ssn *framework.Session) {
 
 		attr := pp.queueOpts[queue.UID]
 		futureUsed := attr.allocated.Clone().Add(candidate.Resreq)
-		allocatable, _ := futureUsed.LessEqualWithDimensionAndResourcesName(attr.deserved, candidate.Resreq)
+		allocatable, _ := futureUsed.LessEqualWithDimension(attr.deserved, candidate.Resreq.ResourceNames())
 		if !allocatable {
 			klog.V(3).Infof("Queue <%v>: deserved <%v>, allocated <%v>; Candidate <%v>: resource request <%v>",
 				queue.Name, attr.deserved, attr.allocated, candidate.Name, candidate.Resreq)
@@ -364,7 +364,7 @@ func (pp *proportionPlugin) OnSessionOpen(ssn *framework.Session) {
 		}
 
 		futureUsed := attr.allocated.Clone().Add(candidate.Resreq)
-		allocatable, _ := futureUsed.LessEqualWithDimensionAndResourcesName(attr.deserved, candidate.Resreq)
+		allocatable, _ := futureUsed.LessEqualWithDimension(attr.deserved, candidate.Resreq.ResourceNames())
 		if !allocatable {
 			klog.V(3).Infof("Queue <%v>: deserved <%v>, allocated <%v>; Candidate <%v>: resource request <%v>",
 				queue.Name, attr.deserved, attr.allocated, candidate.Name, candidate.Resreq)
@@ -421,7 +421,7 @@ func (pp *proportionPlugin) OnSessionOpen(ssn *framework.Session) {
 		// The queue resource quota limit has not reached
 		r := minReq.Clone().Add(attr.allocated).Add(attr.inqueue).Sub(attr.elastic)
 
-		inqueue, resourceNames := r.LessEqualWithDimensionAndResourcesName(attr.realCapability, minReq)
+		inqueue, resourceNames := r.LessEqualWithDimension(attr.realCapability, minReq.ResourceNames())
 		klog.V(5).Infof("job %s inqueue %v", job.Name, inqueue)
 		if inqueue {
 			// deduct the resources of scheduling gated tasks in a job when calculating inqueued resources

--- a/pkg/scheduler/plugins/proportion/proportion.go
+++ b/pkg/scheduler/plugins/proportion/proportion.go
@@ -238,7 +238,7 @@ func (pp *proportionPlugin) OnSessionOpen(ssn *framework.Session) {
 			pp.updateShare(attr)
 			klog.V(4).Infof("Format queue <%s> deserved resource to <%v>", attr.name, attr.deserved)
 
-			if attr.request.LessEqual(attr.deserved, api.Zero) {
+			if ok, _ := attr.request.LessEqual(attr.deserved, api.Zero); ok {
 				meet[attr.queueID] = struct{}{}
 				klog.V(4).Infof("queue <%s> is meet", attr.name)
 			} else if equality.Semantic.DeepEqual(attr.deserved, oldDeserved) {
@@ -309,7 +309,7 @@ func (pp *proportionPlugin) OnSessionOpen(ssn *framework.Session) {
 			}
 			allocated := allocations[job.Queue]
 
-			if !allocated.LessEqual(attr.deserved, api.Zero) {
+			if ok, _ := allocated.LessEqual(attr.deserved, api.Zero); !ok {
 				allocated.Sub(reclaimee.Resreq)
 				victims = append(victims, reclaimee)
 			}
@@ -322,7 +322,7 @@ func (pp *proportionPlugin) OnSessionOpen(ssn *framework.Session) {
 		queue := obj.(*api.QueueInfo)
 		attr := pp.queueOpts[queue.UID]
 
-		overused := attr.deserved.LessEqual(attr.allocated, api.Zero)
+		overused, _ := attr.deserved.LessEqual(attr.allocated, api.Zero)
 		metrics.UpdateQueueOverused(attr.name, overused)
 		if overused {
 			klog.V(3).Infof("Queue <%v> is overused: deserved <%v>, allocated <%v>, share <%v>",
@@ -347,7 +347,7 @@ func (pp *proportionPlugin) OnSessionOpen(ssn *framework.Session) {
 		}
 
 		futureUsed := attr.allocated.Clone().Add(totalReq)
-		allocatable, _ := futureUsed.LessEqualWithDimensionAndResourcesName(attr.deserved, totalReq)
+		allocatable, _ := futureUsed.LessEqualWithDimension(attr.deserved, totalReq.ResourceNames())
 		if !allocatable {
 			klog.V(3).Infof("Queue <%v>: deserved <%v>, allocated <%v>; Candidates total request <%v>",
 				queue.Name, attr.deserved, attr.allocated, totalReq)
@@ -373,7 +373,7 @@ func (pp *proportionPlugin) OnSessionOpen(ssn *framework.Session) {
 		}
 
 		futureUsed := attr.allocated.Clone().Add(candidate.Resreq)
-		allocatable, _ := futureUsed.LessEqualWithDimensionAndResourcesName(attr.deserved, candidate.Resreq)
+		allocatable, _ := futureUsed.LessEqualWithDimension(attr.deserved, candidate.Resreq.ResourceNames())
 		if !allocatable {
 			klog.V(3).Infof("Queue <%v>: deserved <%v>, allocated <%v>; Candidate <%v>: resource request <%v>",
 				queue.Name, attr.deserved, attr.allocated, candidate.Name, candidate.Resreq)
@@ -429,7 +429,7 @@ func (pp *proportionPlugin) OnSessionOpen(ssn *framework.Session) {
 		// The queue resource quota limit has not reached
 		r := minReq.Clone().Add(attr.allocated).Add(attr.inqueue).Sub(attr.elastic)
 
-		inqueue, resourceNames := r.LessEqualWithDimensionAndResourcesName(attr.realCapability, minReq)
+		inqueue, resourceNames := r.LessEqualWithDimension(attr.realCapability, minReq.ResourceNames())
 		klog.V(5).Infof("job %s inqueue %v", job.Name, inqueue)
 		if inqueue {
 			return util.Permit

--- a/pkg/scheduler/plugins/task-topology/topology.go
+++ b/pkg/scheduler/plugins/task-topology/topology.go
@@ -138,8 +138,10 @@ func (p *taskTopologyPlugin) TaskOrderFn(l interface{}, r interface{}) int {
 func (p *taskTopologyPlugin) calcBucketScore(task *api.TaskInfo, node *api.NodeInfo) (int, *JobManager, error) {
 	// task could never fits the node
 	maxResource := node.Idle.Clone().Add(node.Releasing)
-	if req := task.Resreq; req != nil && maxResource.LessPartly(req, api.Zero) {
-		return 0, nil, nil
+	if req := task.Resreq; req != nil {
+		if maxResource.LessPartly(req, api.Zero) {
+			return 0, nil, nil
+		}
 	}
 
 	jobManager, hasManager := p.managers[task.Job]
@@ -169,7 +171,10 @@ func (p *taskTopologyPlugin) calcBucketScore(task *api.TaskInfo, node *api.NodeI
 
 	// 3. the other tasks in bucket take into considering
 	score += len(bucket.tasks)
-	if bucket.request == nil || bucket.request.LessEqual(maxResource, api.Zero) {
+	if bucket.request == nil {
+		return score, jobManager, nil
+	}
+	if ok, _ := bucket.request.LessEqual(maxResource, api.Zero); ok {
 		return score, jobManager, nil
 	}
 
@@ -182,7 +187,7 @@ func (p *taskTopologyPlugin) calcBucketScore(task *api.TaskInfo, node *api.NodeI
 		}
 		remains.Sub(bucketTask.Resreq)
 		score--
-		if remains.LessEqual(maxResource, api.Zero) {
+		if ok, _ := remains.LessEqual(maxResource, api.Zero); ok {
 			break
 		}
 	}

--- a/pkg/scheduler/util/scheduler_helper.go
+++ b/pkg/scheduler/util/scheduler_helper.go
@@ -295,7 +295,7 @@ func ValidateVictims(preemptor *api.TaskInfo, node *api.NodeInfo, victims []*api
 	}
 	// Every resource of the preemptor needs to be less or equal than corresponding
 	// idle resource after preemption.
-	if !preemptor.InitResreq.LessEqual(futureIdle, api.Zero) {
+	if ok, _ := preemptor.InitResreq.LessEqual(futureIdle, api.Zero); !ok {
 		return fmt.Errorf("not enough resources: requested <%v>, but future idle <%v>",
 			preemptor.InitResreq, futureIdle)
 	}

--- a/pkg/scheduler/util/scheduler_helper.go
+++ b/pkg/scheduler/util/scheduler_helper.go
@@ -325,7 +325,7 @@ func ValidateVictims(preemptor *api.TaskInfo, node *api.NodeInfo, victims []*api
 	}
 	// Every resource of the preemptor needs to be less or equal than corresponding
 	// idle resource after preemption.
-	if !preemptor.InitResreq.LessEqual(futureIdle, api.Zero) {
+	if ok, _ := preemptor.InitResreq.LessEqual(futureIdle, api.Zero); !ok {
 		return fmt.Errorf("not enough resources: requested <%v>, but future idle <%v>",
 			preemptor.InitResreq, futureIdle)
 	}

--- a/test/e2e/schedulingbase/job_scheduling.go
+++ b/test/e2e/schedulingbase/job_scheduling.go
@@ -317,7 +317,7 @@ var _ = Describe("Job E2E Test", func() {
 
 		need := schedulingapi.NewResource(v1.ResourceList{"cpu": resource.MustParse("500m")})
 		var count int32
-		for need.LessEqual(alloc, schedulingapi.Zero) {
+		for ok, _ := need.LessEqual(alloc, schedulingapi.Zero); ok; ok, _ = need.LessEqual(alloc, schedulingapi.Zero) {
 			count++
 			alloc.Sub(need)
 		}

--- a/test/e2e/util/node.go
+++ b/test/e2e/util/node.go
@@ -76,7 +76,7 @@ func ClusterSize(ctx *TestContext, req v1.ResourceList) int32 {
 			alloc.Sub(res)
 		}
 
-		for slot.LessEqual(alloc, schedulerapi.Zero) {
+		for ok, _ := slot.LessEqual(alloc, schedulerapi.Zero); ok; ok, _ = slot.LessEqual(alloc, schedulerapi.Zero) {
 			alloc.Sub(slot)
 			res++
 		}
@@ -146,7 +146,7 @@ func ComputeNode(ctx *TestContext, req v1.ResourceList) (string, int32) {
 			alloc.Sub(res)
 		}
 
-		for slot.LessEqual(alloc, schedulerapi.Zero) {
+		for ok, _ := slot.LessEqual(alloc, schedulerapi.Zero); ok; ok, _ = slot.LessEqual(alloc, schedulerapi.Zero) {
 			alloc.Sub(slot)
 			res++
 		}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
This PR refactors the Volcano scheduler's resource comparison API to standardize return signatures and dimension-aware filtering. 
- Refactored `pkg/scheduler/api/resource_info.go` functions to provide dimension-level failure feedback via `(bool, []string)`.
- Replaced `LessEqualWithDimensionAndResourcesName` and related functions with standard `LessEqualWithDimension` using `ResourceNameList`.
- This fixes inconsistencies and provides easier debugging for resource allocation limits, as suggested in previous maintainer discussions.

#### Which issue(s) this PR fixes:
Fixes #5155

#### Does this PR introduce a user-facing change?
```release-note
NONE
