### PR TITLE
[Proposal] Per-user fair share scheduling plugin with decayed usage tracking

### DIFF
--- a/docs/design/fairshare.md
+++ b/docs/design/fairshare.md
@@ -54,7 +54,7 @@ inactivity. After 24 hours, the penalty is effectively forgotten.
 
 Volcano recreates plugin instances via `New()` every scheduling cycle, so instance-level
 state is lost between cycles. The fairshare plugin uses package-level globals protected
-by a `sync.Mutex` to persist usage history:
+by a `sync.Mutex` to persist usage history across scheduling cycles:
 
 ```go
 var (
@@ -64,9 +64,52 @@ var (
 )
 ```
 
-State survives across cycles within a scheduler process lifetime. On scheduler pod restart,
-all users reset to zero — this is acceptable because restarts are rare and act as a
-"full forgiveness" event.
+#### Durable persistence (ConfigMap)
+
+To survive scheduler restarts, the plugin can optionally persist state to a ConfigMap.
+When `fairshare.persistState` is set to `"true"`:
+
+1. On the **first scheduling cycle**, a `sync.Once` block loads any existing state from
+   the ConfigMap into `globalUsage` / `globalLastCycle`, then starts a background goroutine.
+2. The **background goroutine** periodically flushes the current state to the ConfigMap
+   (default: every 30 seconds). Writes use the ConfigMap's `resourceVersion` for
+   optimistic concurrency.
+3. On restart, the loaded `globalLastCycle` is used to compute the elapsed time and apply
+   the correct decay, so users are not unfairly penalized or forgiven by the downtime.
+
+The ConfigMap is stored in the scheduler's namespace (default: `volcano-system`):
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: fairshare-usage-state
+  namespace: volcano-system
+  labels:
+    app: volcano-scheduler
+    component: fairshare
+data:
+  state.json: |
+    {
+      "lastCycle": "2026-04-07T12:00:00Z",
+      "queues": {
+        "gpu-queue": {
+          "alice": 12345.67,
+          "bob": 8901.23
+        }
+      }
+    }
+```
+
+**Design considerations:**
+
+- **Leader election**: Volcano already elects a single active scheduler. Only the leader writes.
+- **Data loss window**: At most `flushInterval` seconds of usage data is lost on a crash.
+  With the default 30-second interval and a 4-hour half-life, this is negligible.
+- **Size**: Even with 1000 users across 50 queues, the JSON payload is ~50 KB — well within
+  the 1 MB ConfigMap limit.
+- **Backward compatibility**: Persistence is disabled by default. Existing deployments are
+  unaffected.
 
 ## Configuration
 
@@ -83,6 +126,7 @@ tiers:
       fairshare.resourceKey: "nvidia.com/gpu"
       fairshare.halfLifeMinutes: "240"
       fairshare.enableEnqueueGate: "false"
+      fairshare.persistState: "true"
 ```
 
 ### Arguments
@@ -94,6 +138,10 @@ tiers:
 | `fairshare.resourceKey.<queue>` | _(none)_ | Per-queue resource override (e.g., `amd.com/gpu`, `cpu`) |
 | `fairshare.halfLifeMinutes` | `240` | Half-life for usage decay in minutes |
 | `fairshare.enableEnqueueGate` | `false` | When `true`, blocks users at/above their calculated share from entering the scheduling pipeline |
+| `fairshare.persistState` | `false` | When `true`, persists usage state to a ConfigMap so it survives scheduler restarts |
+| `fairshare.stateNamespace` | `volcano-system` | Namespace for the state ConfigMap |
+| `fairshare.stateConfigMap` | `fairshare-usage-state` | Name of the state ConfigMap |
+| `fairshare.flushIntervalSeconds` | `30` | How often to flush state to the ConfigMap (in seconds) |
 
 ## Interaction with existing plugins
 
@@ -137,7 +185,7 @@ handles ordering among eligible jobs.
 
 ## Testing
 
-### Unit tests (25 tests)
+### Unit tests (33 tests)
 
 - Max-min fair share algorithm correctness (single user, equal demand, asymmetric demand, progressive elimination)
 - Decay factor math (one/two half-lives, zero elapsed, zero half-life, small elapsed)
@@ -145,6 +193,9 @@ handles ordering among eligible jobs.
 - Usage ordering (lower usage wins, equal usage falls to running tiebreaker, realistic multi-user scenario)
 - Decay scenario (10-hour job decay over 4h and 24h)
 - Helpers (namespace extraction, resource key defaults/overrides)
+- Persistence: flush creates ConfigMap, flush updates existing, load populates globals,
+  load handles missing ConfigMap, load handles empty data, flush→load round-trip,
+  disabled persistence is no-op, corrupt JSON returns error
 
 ### Integration tests
 
@@ -159,6 +210,6 @@ Validated on a test cluster with 2 GPU nodes and 4 user namespaces:
 
 ## Limitations
 
-- State is in-memory only; lost on scheduler restart (all users reset to zero)
+- Without `persistState`, state is in-memory only and lost on scheduler restart
 - Namespace-based identity only; no support for arbitrary user labels (can be extended)
-- No persistence to external storage (could be added via ConfigMap or CRD in the future)
+- ConfigMap persistence has a small data-loss window equal to the flush interval on crashes

--- a/docs/design/fairshare.md
+++ b/docs/design/fairshare.md
@@ -1,179 +1,164 @@
-# Namespace fair share
+# Per-User Fair Share Scheduling with Decayed Usage Tracking
 
-[@lminzhw](http://github.com/lminzhw); May 8, 2019
+## Background
 
-## Motivation
+Volcano's existing DRF plugin provides dominant resource fairness at the namespace/queue level,
+but it only considers the **current allocation snapshot** — it has no memory of past usage.
+This leads to a well-documented problem in multi-user GPU clusters (see [#4165](https://github.com/volcano-sh/volcano/issues/4165)):
 
-`Queue` was introduced in [kube-batch](http://github.com/kubernetes-sigs/kube-batch) to share resources among users.
+- User A submits hundreds of GPU jobs and fills the cluster
+- User B arrives later with a handful of jobs
+- As User A's jobs complete, User A's new pending jobs immediately regain priority
+  (they have equal or lower current allocation), effectively starving User B
 
-But, the user in the same `Queue` are equivalent during scheduling. For example, we have a `Queue` contains a small amount of resources, and there are 10 pods belong to UserA and 1000 pods belong to UserB. In this case, pods of UserA would have less probability to bind with node.
+This "submission-order bias" means the first user to flood the queue monopolizes resources
+indefinitely, even when other users have legitimate demand. SLURM solves this with its
+fair share algorithm that tracks historical usage with exponential decay.
 
-So, we need a more fine-grained strategy to balance resource usage among users in the same `Queue`.
+## Proposal
 
-In consideration of multi-user model in kubernetes, we use namespace to distinguish different user. Each namespace would have its weight to control resources usage.
+Add a new `fairshare` scheduler plugin that tracks cumulative resource-seconds per user
+(identified by namespace) and applies exponential half-life decay so that past consumption
+is gradually forgiven.
 
-## Function Specification
+### User identity
 
-Weight have these features:
-> 1. `Queue` level
-> 2. an `integer` with default value 1
-> 3. record in namespace `quota`
-> 4. higher value means more resources after balancing
+Users are identified by their job's **namespace**. This follows the namespace-per-user
+pattern common in multi-tenant Kubernetes GPU clusters. No additional labels are required.
 
-### where is the weight
+### Algorithm
+
+Each scheduling cycle (~1 second):
+
+1. **Decay** all historical usage: `usage × 2^(-elapsed / halfLife)`
+2. **Accumulate** running usage: for each allocated task, add `resource_count × elapsed_seconds`
+   to the user's cumulative total
+3. **Order** pending jobs via `JobOrderFn`:
+   - **Primary**: Lower cumulative usage wins (with a 1.0 resource-second epsilon for float comparison)
+   - **Secondary**: Fewer currently-running resources wins (within-cycle tiebreaker)
+
+### Half-life decay
+
+| Time since usage | Remaining weight (4h half-life) |
+|-----------------|--------------------------------|
+| 0 hours         | 100%                           |
+| 4 hours         | 50%                            |
+| 8 hours         | 25%                            |
+| 12 hours        | 12.5%                          |
+| 24 hours        | 1.6%                           |
+
+A user who consumed 10 GPU-hours will see their usage penalty halve every 4 hours of
+inactivity. After 24 hours, the penalty is effectively forgotten.
+
+### State persistence
+
+Volcano recreates plugin instances via `New()` every scheduling cycle, so instance-level
+state is lost between cycles. The fairshare plugin uses package-level globals protected
+by a `sync.Mutex` to persist usage history:
+
+```go
+var (
+    globalMu        sync.Mutex
+    globalUsage     = make(map[string]map[string]float64) // [queue][user] → resource-seconds
+    globalLastCycle time.Time
+)
+```
+
+State survives across cycles within a scheduler process lifetime. On scheduler pod restart,
+all users reset to zero — this is acceptable because restarts are rare and act as a
+"full forgiveness" event.
+
+## Configuration
 
 ```yaml
-apiVersion: v1
-kind: ResourceQuota
-metadata:
-  namespace: default
-spec:
-  hard:
-    limits.memory: 2Gi
-    volcano.sh/namespace.weight: 1  <- this field represent the weight of this namespace
+actions: "enqueue, allocate, backfill"
+tiers:
+- plugins:
+  - name: priority
+  - name: gang
+  - name: conformance
+  - name: fairshare
+    arguments:
+      fairshare.targetQueues: "gpu-queue"
+      fairshare.resourceKey: "nvidia.com/gpu"
+      fairshare.halfLifeMinutes: "240"
+      fairshare.enableEnqueueGate: "false"
 ```
 
-If many `ResourceQuota` in the same namespace have weight, the weight for this namespace is the highest one of them.
+### Arguments
 
-This weight should be positive, any invalid value is treated as default value 1.
+| Argument | Default | Description |
+|----------|---------|-------------|
+| `fairshare.targetQueues` | _(required)_ | Comma-separated queue names to apply fair share to |
+| `fairshare.resourceKey` | `nvidia.com/gpu` | Default resource to track |
+| `fairshare.resourceKey.<queue>` | _(none)_ | Per-queue resource override (e.g., `amd.com/gpu`, `cpu`) |
+| `fairshare.halfLifeMinutes` | `240` | Half-life for usage decay in minutes |
+| `fairshare.enableEnqueueGate` | `false` | When `true`, blocks users at/above their calculated share from entering the scheduling pipeline |
 
-### Scheduler Framework
+## Interaction with existing plugins
 
-Introduce two new fields in SchedulerCache
+### priority plugin
 
-```go
-type NamespaceInfo struct {
-    Weight int
-}
+The `priority` plugin runs before `fairshare` in the same tier. A higher PriorityClass
+always wins. Fair share only breaks ties at equal priority levels.
 
-type SchedulerCache struct {
-    ...
-    quotaInformer    infov1.ResourceQuotaInformer
-    ...
-    NamespaceInfo  map[string]*kbapi.NamespaceInfo
-    ...
-}
-```
-
-The Scheduler will watch the lifecycle of `ResourceQuota` by `quotaInformer`, and refresh the info in `NamespaceInfo`.
-
-In `openSession` function, we should pass the `NamespaceInfo` through function `cache.Snapshot` into `Session` by using a new filed in `Session`/`ClusterInfo` struct.
-
-```go
-type Session struct {
-    ...
-    NamespaceInfo  map[string]*kbapi.NamespaceInfo
-    ...
-}
-type ClusterInfo struct {
-    ...
-    NamespaceInfo  map[string]*kbapi.NamespaceInfo
-    ...
-}
-```
-
-### Allocate Action
-
-#### Scheduling loop
-
-The behavior of `allocate` action is scheduling job in `Queue` one by one.
-
-At the beginning of scheduling loop, it will take a job with highest priority from `Queue`. And try to schedule tasks that belong to it until job is ready (matches the minMember) then go to next round.
-
-The priority of job mentioned above is defined by `JobOrder` functions registered by plugins. Such as job ready order of Gang plugin, priority order of Priority plugin, and also the share order of DRF plugin.
-
-#### JobOrder
-
-Namespace weight `should not` implement with JobOrder func. Because the scheduling of job would affect priority of the others.
-
-> e.g.
->
-> ns1 has job1, job2, ns2 has job3, job4. The original order is job1-job2-job3-job4.
->
-> After the scheduling of job1, right order should be job3-job4-job2. But in priority queue, we have no chance to fix the priority for job2
-
-#### Namespace Order
-
-To add namespace weight, we introduce a new order function named `NamespaceOrder` in `Session`.
-
-```go
-type Session struct {
-    ...
-    NamespaceOrderFns map[string]api.CompareFn
-    ...
-}
-```
-
-The scheduling loop in allocate should change as follows.
-
-In scheduling loop, firstly, choose a namespace having highest priority by calling `NamespaceOrderFn`, and then choose a job having highest priority using `JobOrderFn` in this namespace.
-
-After scheduling of job, push the namespace and job back to priority queue in order to refresh its priority. Because once a job is scheduled, assigned resource may decrease the priority of this namespace, the other jobs in the same namespace may be scheduled later.
-
-Always assigning resources to namespace with highest priority (lower resource usage) in every turn will make the resource balanced.
+When all competing jobs use the same PriorityClass, fair share is fully effective as the
+tiebreaker. This means using a high PriorityClass only helps when others don't — if everyone
+uses it, fair share still distributes resources equitably.
 
 ### DRF plugin
 
-DRF plugin use preemption and order of job to balance resource among jobs. The `share` in this plugin is defined as resource usage, the higher `share` means this job occupies the more resource now.
+The fairshare plugin is complementary to DRF. DRF handles multi-resource dominance
+(which resource is the bottleneck), while fairshare handles temporal fairness (who has
+consumed more historically). They can coexist or be used independently depending on
+cluster needs.
 
-#### Namespace Compare
+### gang plugin
 
-To introduce namespace weight into this plugin, we should define how to compare namespace having weight firstly.
+No interaction — gang scheduling handles minimum member requirements, while fairshare
+handles ordering among eligible jobs.
 
-For namespace n1 having weight w1 and namespace n2 having weight w2, we can compute the `share` of resource and recorded as u1 and u2. Now, the resource usage of n1 less than n2 can be defined as (u1 / w1 < u2 / w2)
+## Scheduler hooks
 
-`e.g.` ns1 having weight w1=2 use 6cpu, ns2 having weight w2=1 use 2cpu. In the scope of cpu, the ns1 use less resource than ns2. (6 / 3 < 3 / 1)
+| Hook | Purpose |
+|------|---------|
+| `JobOrderFn` | Orders jobs by cumulative usage (lower wins), with running-resource tiebreaker |
+| `JobEnqueueableFn` | (Optional) Blocks users at/above their max-min fair share from the scheduling pipeline |
+| `EventHandler` | Tracks allocations/deallocations in real-time during the scheduling cycle |
 
-#### Namespace Order
+## Logging
 
-Register `NamespaceOrder` function using the strategy mentioned above.
+| klog level | What it shows |
+|------------|---------------|
+| V(2) | Plugin config on creation, per-cycle queue summary (user count, running, demand) |
+| V(3) | Decay factor per cycle, fair shares, usage maps, ordering winner decisions |
+| V(4) | Session open/close, individual allocate/deallocate events |
+| V(5) | Every job comparison, every enqueue evaluation |
 
-#### preemption
+## Testing
 
-> The `preempt` action is disabled now. Do this later.
+### Unit tests (25 tests)
 
-In the `preemption` function now, strategy is just simply comparing the resource share among jobs .
+- Max-min fair share algorithm correctness (single user, equal demand, asymmetric demand, progressive elimination)
+- Decay factor math (one/two half-lives, zero elapsed, zero half-life, small elapsed)
+- `decayAllUsage` (halves after one half-life, cleans up negligible entries, multi-queue)
+- Usage ordering (lower usage wins, equal usage falls to running tiebreaker, realistic multi-user scenario)
+- Decay scenario (10-hour job decay over 4h and 24h)
+- Helpers (namespace extraction, resource key defaults/overrides)
 
-After adding namespace weight, we should check namespace of preemptor and preemptee firstly. The job in namespace with less resources can preempt others, or when namespace resource usage are the same, compare share of job instead.
+### Integration tests
 
-### Feature Interaction
+Validated on a test cluster with 2 GPU nodes and 4 user namespaces:
 
-#### preempt action
+1. **Without decay tracking**: FIFO behavior, last user waited ~7 minutes
+2. **With decay tracking**: All users got GPUs within ~2 minutes, scheduling rotated between users
+3. **Burst asymmetry** (1 user = 8 jobs, others = 1 each): Minority users' jobs completed within ~2 minutes
+4. **DAG/workflow simulation**: GPU steps interleaved across users by cumulative usage
+5. **PriorityClass interaction**: High-priority bypassed fair share as expected
+6. **Scheduler restart**: Running jobs survived, new jobs scheduled fairly post-restart
 
-Preempt is a strategy set to choose victims and finally evict it.
+## Limitations
 
-The way to choose victims is a function set named `Preemptable` registered by plugins. Such as job ready protection of Gang plugin, special pod protection of Conformance plugin, job share balance strategy of DRF plugin.
-
-All these plugin would choose some victims respective, and the intersection of them would be the final victim set. So, the choice made by DRF plugin would never break the requirement of others.
-
-### short hand
-
-1. Preempt may cause killing of some running pod.
-
-### Cases:
-
-- cluster have __16 cpu__, queue and namespace have default weight.
-
-    | queue | namespace | requested | queue assigned | namespace assigned |
-    | ----- | --------- | --------- | -------------- | ------------------ |
-    | q1    | ns1       | 5 cpu     | 8 cpu          | 4 cpu              |
-    |       | ns2       | 10 cpu    |                | 4 cpu              |
-    | q2    | ns3       | 10 cpu    | 8 cpu          | 6 cpu              |
-    |       | ns4       | 2 cpu     |                | 2 cpu              |
-
-- cluster have __16 cpu__, q1 with weight 1, q2 with weight 3. ns1 with weight 3, ns2 have weight 1, ns3 have weight 2, ns4 have weight 6.
-
-    | queue | namespace | requested | queue assigned | namespace assigned |
-    | ----- | --------- | --------- | -------------- | ------------------ |
-    | q1 w1 | ns1 w3    | 5 cpu     | 4 cpu          | 3 cpu              |
-    |       | ns2 w1    | 10 cpu    |                | 1 cpu              |
-    | q2 w3 | ns3 w2    | 10 cpu    | 12 cpu         | 10 cpu             |
-    |       | ns4 w6    | 2 cpu     |                | 2 cpu              |
-
-- cluster have __16 cpu__, q1 with weight 1, q2 with weight 3. ns1 have weight 2, ns2 have weight 6.
-
-    | queue | namespace | requested | queue assigned | namespace assigned |
-    | ----- | --------- | --------- | -------------- | ------------------ |
-    | q1 w1 | ns1 w2    |           | 4 cpu          |                    |
-    | q2 w3 | ns1 w2    | 5 cpu     | 12 cpu         | 3 cpu              |
-    |       | ns2 w6    | 20 cpu    |                | 9 cpu              |
+- State is in-memory only; lost on scheduler restart (all users reset to zero)
+- Namespace-based identity only; no support for arbitrary user labels (can be extended)
+- No persistence to external storage (could be added via ConfigMap or CRD in the future)

--- a/docs/design/fairshare.md
+++ b/docs/design/fairshare.md
@@ -375,3 +375,7 @@ Validated on a test cluster with 2 GPU nodes and 4 tenant namespaces:
 - ConfigMap persistence has a small data-loss window equal to the flush interval on crashes
 - Fairness is scoped within a queue (as in the 2019 proposal above); this plugin does not
   change how DRF/proportion balance resources across queues
+- `fairshare` registers no `PreemptableFn`/`ReclaimableFn`; it only reorders the pending
+  queue and (optionally) gates enqueue. It cannot preempt already-running jobs, so a
+  namespace with long-lived running jobs keeps its resources regardless of how stale its
+  usage penalty becomes

--- a/docs/design/fairshare.md
+++ b/docs/design/fairshare.md
@@ -1,8 +1,26 @@
-# Namespace fair share
+# Fair share scheduling
+
+This document covers two related design proposals for fair share scheduling among
+tenants sharing a `Queue`:
+
+1. [Namespace fair share](#namespace-fair-share-2019) (2019, [@lminzhw](http://github.com/lminzhw)) —
+   static per-namespace weights recorded on `ResourceQuota`, compared via a new
+   `NamespaceOrderFn` scheduling-loop stage.
+2. [Per-namespace fair share with decayed usage tracking](#per-namespace-fair-share-with-decayed-usage-tracking-2026)
+   (2026) — a self-contained scheduler plugin that tracks historical resource-seconds per
+   namespace with exponential decay, addressing the same underlying problem without
+   requiring new `Session`/`SchedulerCache` fields or a `NamespaceOrderFn` stage.
+
+For usage instructions (arguments, configuration examples, interaction with other plugins),
+see the [fairshare user guide](../user-guide/how_to_use_fairshare_plugin.md).
+
+---
+
+## Namespace fair share (2019)
 
 [@lminzhw](http://github.com/lminzhw); May 8, 2019
 
-## Motivation
+### Motivation
 
 `Queue` was introduced in [kube-batch](http://github.com/kubernetes-sigs/kube-batch) to share resources among users.
 
@@ -12,7 +30,7 @@ So, we need a more fine-grained strategy to balance resource usage among users i
 
 In consideration of multi-user model in kubernetes, we use namespace to distinguish different user. Each namespace would have its weight to control resources usage.
 
-## Function Specification
+### Function Specification
 
 Weight have these features:
 > 1. `Queue` level
@@ -20,7 +38,7 @@ Weight have these features:
 > 3. record in namespace `quota`
 > 4. higher value means more resources after balancing
 
-### where is the weight
+#### where is the weight
 
 ```yaml
 apiVersion: v1
@@ -177,3 +195,187 @@ All these plugin would choose some victims respective, and the intersection of t
     | q1 w1 | ns1 w2    |           | 4 cpu          |                    |
     | q2 w3 | ns1 w2    | 5 cpu     | 12 cpu         | 3 cpu              |
     |       | ns2 w6    | 20 cpu    |                | 9 cpu              |
+
+---
+
+## Per-namespace fair share with decayed usage tracking (2026)
+
+### Background
+
+Volcano's existing DRF plugin provides dominant resource fairness at the namespace/queue level,
+but it only considers the **current allocation snapshot** — it has no memory of past usage.
+This leads to a well-documented problem in multi-tenant GPU clusters (see [#4165](https://github.com/volcano-sh/volcano/issues/4165)):
+
+- Namespace A submits hundreds of GPU jobs and fills the cluster
+- Namespace B arrives later with a handful of jobs
+- As namespace A's jobs complete, its new pending jobs immediately regain priority
+  (they have equal or lower current allocation), effectively starving namespace B
+
+This "submission-order bias" means the first tenant to flood the queue monopolizes resources
+indefinitely, even when other tenants have legitimate demand. SLURM solves this with its
+fair share algorithm that tracks historical usage with exponential decay.
+
+This is the same underlying gap the 2019 [Namespace fair share](#namespace-fair-share-2019)
+proposal above targeted, but that design requires new `NamespaceOrderFn` scheduling-loop
+stages and `NamespaceInfo` plumbing through `SchedulerCache`/`Session`/`ClusterInfo` that were
+never landed. The proposal below is intentionally scoped to a single self-contained plugin —
+no framework changes — trading the static, admin-configured `ResourceQuota` weight for a
+usage-based measure that adapts automatically as tenants' consumption rises and falls.
+
+It's also worth calling out an assumption both designs share and that's worth being explicit
+about: Volcano already supports fair sharing *across* queues (via DRF/proportion at the queue
+level). Both the 2019 proposal and this one are about fair sharing **within** a single queue,
+for the case — common when tenants map to namespaces rather than to dedicated queues — where
+multiple tenants submit jobs into the same queue and need to be balanced against each other
+there.
+
+### Proposal
+
+Add a new `fairshare` scheduler plugin that tracks cumulative resource-seconds per namespace
+and applies exponential half-life decay so that past consumption is gradually forgiven.
+
+### Namespace identity
+
+Tenants are identified by their job's **namespace** directly — there is no separate "user"
+concept, since not every cluster maps individual users to namespaces one-to-one (a namespace
+may itself represent a team or project shared by several users). No additional labels are
+required.
+
+### Algorithm
+
+Each scheduling cycle (~1 second):
+
+1. **Decay** all historical usage: `usage × 2^(-elapsed / halfLife)`
+2. **Accumulate** running usage: for each allocated task, add `resource_count × elapsed_seconds`
+   to the namespace's cumulative total
+3. **Order** pending jobs via `JobOrderFn`:
+   - **Primary**: Lower cumulative usage wins (with a 1.0 resource-second epsilon for float comparison)
+   - **Secondary**: Fewer currently-running resources wins (within-cycle tiebreaker)
+
+### Half-life decay
+
+| Time since usage | Remaining weight (4h half-life) |
+|-----------------|--------------------------------|
+| 0 hours         | 100%                           |
+| 4 hours         | 50%                            |
+| 8 hours         | 25%                            |
+| 12 hours        | 12.5%                          |
+| 24 hours        | 1.6%                           |
+
+A namespace that consumed 10 GPU-hours will see its usage penalty halve every 4 hours of
+inactivity. After 24 hours, the penalty is effectively forgotten.
+
+### State persistence
+
+Volcano recreates plugin instances via `New()` every scheduling cycle, so instance-level
+state is lost between cycles. The fairshare plugin uses package-level globals protected
+by a `sync.Mutex` to persist usage history across scheduling cycles:
+
+```go
+var (
+    globalMu        sync.Mutex
+    globalUsage     = make(map[string]map[string]float64) // [queue][namespace] → resource-seconds
+    globalLastCycle time.Time
+)
+```
+
+#### Durable persistence (ConfigMap)
+
+To survive scheduler restarts, the plugin can optionally persist state to a ConfigMap.
+When `fairshare.persistState` is set to `"true"`:
+
+1. On the **first scheduling cycle**, a `sync.Once` block loads any existing state from
+   the ConfigMap into `globalUsage` / `globalLastCycle`.
+2. **`OnSessionClose`** (called once per scheduling cycle, ~1s) flushes the current state
+   to the ConfigMap whenever at least `flushIntervalSeconds` has elapsed since the last
+   flush (default: 30 seconds). Writes use the ConfigMap's `resourceVersion` for
+   optimistic concurrency. Tying the flush to the session lifecycle rather than a
+   detached goroutine+ticker means persistence stops the moment the plugin stops being
+   invoked (e.g. removed from the tier list via a config hot-reload) — a ticker would
+   otherwise keep writing stale state forever with no shutdown hook.
+3. On restart, the loaded `globalLastCycle` is used to compute the elapsed time and apply
+   the correct decay, so namespaces are not unfairly penalized or forgiven by the downtime.
+
+The ConfigMap is stored in the scheduler's namespace (default: `volcano-system`):
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: fairshare-usage-state
+  namespace: volcano-system
+  labels:
+    app: volcano-scheduler
+    component: fairshare
+data:
+  state.json: |
+    {
+      "lastCycle": "2026-04-07T12:00:00Z",
+      "queues": {
+        "gpu-queue": {
+          "team-a": 12345.67,
+          "team-b": 8901.23
+        }
+      }
+    }
+```
+
+**Design considerations:**
+
+- **Leader election**: Volcano already elects a single active scheduler. Only the leader writes.
+- **Data loss window**: At most `flushInterval` seconds of usage data is lost on a crash.
+  With the default 30-second interval and a 4-hour half-life, this is negligible.
+- **Size**: Even with 1000 namespaces across 50 queues, the JSON payload is ~50 KB — well
+  within the 1 MB ConfigMap limit.
+- **Backward compatibility**: Persistence is disabled by default. Existing deployments are
+  unaffected.
+
+### Scheduler hooks
+
+| Hook | Purpose |
+|------|---------|
+| `JobOrderFn` | Orders jobs by cumulative usage (lower wins), with running-resource tiebreaker |
+| `JobEnqueueableFn` | (Optional) Blocks namespaces at/above their max-min fair share from the scheduling pipeline |
+| `EventHandler` | Tracks allocations/deallocations in real-time during the scheduling cycle |
+
+### Testing
+
+#### Unit tests (49 tests)
+
+- Max-min fair share algorithm correctness (single namespace, equal demand, asymmetric demand, progressive elimination)
+- Decay factor math (one/two half-lives, zero elapsed, zero half-life, small elapsed)
+- `decayAllUsage` (halves after one half-life, cleans up negligible entries, multi-queue)
+- Usage ordering (lower usage wins, equal usage falls to running tiebreaker, realistic multi-namespace scenario)
+- Decay scenario (10-hour job decay over 4h and 24h)
+- Helpers (namespace extraction, resource key defaults/overrides)
+- `targetQueues` allowlist behavior (defaults to all queues when unset, restricts to the allowlist when set)
+- `shouldAbstainOrdering` (abstains unless both jobs are in the same targeted queue)
+- A failed persistence flush is retried on the next cycle instead of waiting a full `flushIntervalSeconds`
+- Persistence: flush creates ConfigMap, flush updates existing, load populates globals,
+  load handles missing ConfigMap, load handles empty data, flush→load round-trip,
+  disabled persistence is no-op, corrupt JSON returns error
+- `maybeFlush` rate limiting (disabled is a no-op, first call flushes immediately, a second
+  call within the interval is skipped, flushes again once the interval elapses)
+
+#### Integration tests
+
+Validated on a test cluster with 2 GPU nodes and 4 tenant namespaces:
+
+1. **Without decay tracking**: FIFO behavior, last tenant waited ~7 minutes
+2. **With decay tracking**: All tenants got GPUs within ~2 minutes, scheduling rotated between tenants
+3. **Burst asymmetry** (1 tenant = 8 jobs, others = 1 each): Minority tenants' jobs completed within ~2 minutes
+4. **DAG/workflow simulation**: GPU steps interleaved across tenants by cumulative usage
+5. **PriorityClass interaction**: High-priority bypassed fair share as expected
+6. **Scheduler restart**: Running jobs survived, new jobs scheduled fairly post-restart
+
+### Limitations
+
+- Without `persistState`, state is in-memory only and lost on scheduler restart
+- Namespace-based identity only; no support for arbitrary custom labels (can be extended)
+- ConfigMap persistence has a small data-loss window equal to the flush interval on crashes
+- Fairness is scoped within a queue (as in the 2019 proposal above); this plugin does not
+  change how DRF/proportion balance resources across queues
+- `fairshare` registers no `PreemptableFn`/`ReclaimableFn`; it only reorders the pending
+  queue and (optionally) gates enqueue. It cannot preempt already-running jobs, so a
+  namespace with long-lived running jobs keeps its resources regardless of how stale its
+  usage penalty becomes

--- a/docs/design/fairshare.md
+++ b/docs/design/fairshare.md
@@ -340,7 +340,7 @@ data:
 
 ### Testing
 
-#### Unit tests (47 tests)
+#### Unit tests (49 tests)
 
 - Max-min fair share algorithm correctness (single namespace, equal demand, asymmetric demand, progressive elimination)
 - Decay factor math (one/two half-lives, zero elapsed, zero half-life, small elapsed)
@@ -349,6 +349,8 @@ data:
 - Decay scenario (10-hour job decay over 4h and 24h)
 - Helpers (namespace extraction, resource key defaults/overrides)
 - `targetQueues` allowlist behavior (defaults to all queues when unset, restricts to the allowlist when set)
+- `shouldAbstainOrdering` (abstains unless both jobs are in the same targeted queue)
+- A failed persistence flush is retried on the next cycle instead of waiting a full `flushIntervalSeconds`
 - Persistence: flush creates ConfigMap, flush updates existing, load populates globals,
   load handles missing ConfigMap, load handles empty data, flush→load round-trip,
   disabled persistence is no-op, corrupt JSON returns error

--- a/docs/design/fairshare.md
+++ b/docs/design/fairshare.md
@@ -133,7 +133,7 @@ tiers:
 
 | Argument | Default | Description |
 |----------|---------|-------------|
-| `fairshare.targetQueues` | _(required)_ | Comma-separated queue names to apply fair share to |
+| `fairshare.targetQueues` | _(all queues)_ | Comma-separated queue names to apply fair share to; if unset, applies to every queue |
 | `fairshare.resourceKey` | `nvidia.com/gpu` | Default resource to track |
 | `fairshare.resourceKey.<queue>` | _(none)_ | Per-queue resource override (e.g., `amd.com/gpu`, `cpu`) |
 | `fairshare.halfLifeMinutes` | `240` | Half-life for usage decay in minutes |

--- a/docs/design/fairshare.md
+++ b/docs/design/fairshare.md
@@ -268,24 +268,36 @@ inactivity. After 24 hours, the penalty is effectively forgotten.
 ### State persistence
 
 Volcano recreates plugin instances via `New()` every scheduling cycle, so instance-level
-state is lost between cycles. The fairshare plugin uses package-level globals protected
-by a `sync.Mutex` to persist usage history across scheduling cycles:
+state is lost between cycles. The fairshare plugin keeps usage history in a single
+package-level struct that survives across cycles:
 
 ```go
-var (
-    globalMu        sync.Mutex
-    globalUsage     = make(map[string]map[string]float64) // [queue][namespace] → resource-seconds
-    globalLastCycle time.Time
-)
+var state = &fairShareProcessState{
+    usage: make(map[string]map[string]float64), // [queue][namespace] → resource-seconds
+}
+
+type fairShareProcessState struct {
+    usage     map[string]map[string]float64
+    lastCycle time.Time
+
+    persistenceInitialized bool
+    lastFlushAt            time.Time
+}
 ```
+
+`state` is intentionally unguarded by a lock: `OnSessionOpen`/`OnSessionClose` are only
+ever invoked sequentially from the single scheduler goroutine (Volcano's `wait.Until`
+loop never overlaps invocations). If Volcano ever runs sessions concurrently, this needs
+a real redesign, not a reintroduced global lock.
 
 #### Durable persistence (ConfigMap)
 
 To survive scheduler restarts, the plugin can optionally persist state to a ConfigMap.
 When `fairshare.persistState` is set to `"true"`:
 
-1. On the **first scheduling cycle**, a `sync.Once` block loads any existing state from
-   the ConfigMap into `globalUsage` / `globalLastCycle`.
+1. On the **first scheduling cycle**, `initPersistence` loads any existing state from
+   the ConfigMap into `state.usage` / `state.lastCycle`, guarded by
+   `state.persistenceInitialized` so it only runs once.
 2. **`OnSessionClose`** (called once per scheduling cycle, ~1s) flushes the current state
    to the ConfigMap whenever at least `flushIntervalSeconds` has elapsed since the last
    flush (default: 30 seconds). Writes use the ConfigMap's `resourceVersion` for
@@ -293,7 +305,7 @@ When `fairshare.persistState` is set to `"true"`:
    detached goroutine+ticker means persistence stops the moment the plugin stops being
    invoked (e.g. removed from the tier list via a config hot-reload) — a ticker would
    otherwise keep writing stale state forever with no shutdown hook.
-3. On restart, the loaded `globalLastCycle` is used to compute the elapsed time and apply
+3. On restart, the loaded `state.lastCycle` is used to compute the elapsed time and apply
    the correct decay, so namespaces are not unfairly penalized or forgiven by the downtime.
 
 The ConfigMap is stored in the scheduler's namespace (default: `volcano-system`):

--- a/docs/design/fairshare.md
+++ b/docs/design/fairshare.md
@@ -12,7 +12,7 @@ tenants sharing a `Queue`:
    requiring new `Session`/`SchedulerCache` fields or a `NamespaceOrderFn` stage.
 
 For usage instructions (arguments, configuration examples, interaction with other plugins),
-see the [fairshare user guide](../user-guide/fairshare.md).
+see the [fairshare user guide](../user-guide/how_to_use_fairshare_plugin.md).
 
 ---
 

--- a/docs/design/fairshare.md
+++ b/docs/design/fairshare.md
@@ -1,30 +1,245 @@
-# Per-User Fair Share Scheduling with Decayed Usage Tracking
+# Fair share scheduling
 
-## Background
+This document covers two related design proposals for fair share scheduling among
+tenants sharing a `Queue`:
+
+1. [Namespace fair share](#namespace-fair-share-2019) (2019, [@lminzhw](http://github.com/lminzhw)) —
+   static per-namespace weights recorded on `ResourceQuota`, compared via a new
+   `NamespaceOrderFn` scheduling-loop stage.
+2. [Per-namespace fair share with decayed usage tracking](#per-namespace-fair-share-with-decayed-usage-tracking-2026)
+   (2026) — a self-contained scheduler plugin that tracks historical resource-seconds per
+   namespace with exponential decay, addressing the same underlying problem without
+   requiring new `Session`/`SchedulerCache` fields or a `NamespaceOrderFn` stage.
+
+For usage instructions (arguments, configuration examples, interaction with other plugins),
+see the [fairshare user guide](../user-guide/fairshare.md).
+
+---
+
+## Namespace fair share (2019)
+
+[@lminzhw](http://github.com/lminzhw); May 8, 2019
+
+### Motivation
+
+`Queue` was introduced in [kube-batch](http://github.com/kubernetes-sigs/kube-batch) to share resources among users.
+
+But, the user in the same `Queue` are equivalent during scheduling. For example, we have a `Queue` contains a small amount of resources, and there are 10 pods belong to UserA and 1000 pods belong to UserB. In this case, pods of UserA would have less probability to bind with node.
+
+So, we need a more fine-grained strategy to balance resource usage among users in the same `Queue`.
+
+In consideration of multi-user model in kubernetes, we use namespace to distinguish different user. Each namespace would have its weight to control resources usage.
+
+### Function Specification
+
+Weight have these features:
+> 1. `Queue` level
+> 2. an `integer` with default value 1
+> 3. record in namespace `quota`
+> 4. higher value means more resources after balancing
+
+#### where is the weight
+
+```yaml
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  namespace: default
+spec:
+  hard:
+    limits.memory: 2Gi
+    volcano.sh/namespace.weight: 1  <- this field represent the weight of this namespace
+```
+
+If many `ResourceQuota` in the same namespace have weight, the weight for this namespace is the highest one of them.
+
+This weight should be positive, any invalid value is treated as default value 1.
+
+### Scheduler Framework
+
+Introduce two new fields in SchedulerCache
+
+```go
+type NamespaceInfo struct {
+    Weight int
+}
+
+type SchedulerCache struct {
+    ...
+    quotaInformer    infov1.ResourceQuotaInformer
+    ...
+    NamespaceInfo  map[string]*kbapi.NamespaceInfo
+    ...
+}
+```
+
+The Scheduler will watch the lifecycle of `ResourceQuota` by `quotaInformer`, and refresh the info in `NamespaceInfo`.
+
+In `openSession` function, we should pass the `NamespaceInfo` through function `cache.Snapshot` into `Session` by using a new filed in `Session`/`ClusterInfo` struct.
+
+```go
+type Session struct {
+    ...
+    NamespaceInfo  map[string]*kbapi.NamespaceInfo
+    ...
+}
+type ClusterInfo struct {
+    ...
+    NamespaceInfo  map[string]*kbapi.NamespaceInfo
+    ...
+}
+```
+
+### Allocate Action
+
+#### Scheduling loop
+
+The behavior of `allocate` action is scheduling job in `Queue` one by one.
+
+At the beginning of scheduling loop, it will take a job with highest priority from `Queue`. And try to schedule tasks that belong to it until job is ready (matches the minMember) then go to next round.
+
+The priority of job mentioned above is defined by `JobOrder` functions registered by plugins. Such as job ready order of Gang plugin, priority order of Priority plugin, and also the share order of DRF plugin.
+
+#### JobOrder
+
+Namespace weight `should not` implement with JobOrder func. Because the scheduling of job would affect priority of the others.
+
+> e.g.
+>
+> ns1 has job1, job2, ns2 has job3, job4. The original order is job1-job2-job3-job4.
+>
+> After the scheduling of job1, right order should be job3-job4-job2. But in priority queue, we have no chance to fix the priority for job2
+
+#### Namespace Order
+
+To add namespace weight, we introduce a new order function named `NamespaceOrder` in `Session`.
+
+```go
+type Session struct {
+    ...
+    NamespaceOrderFns map[string]api.CompareFn
+    ...
+}
+```
+
+The scheduling loop in allocate should change as follows.
+
+In scheduling loop, firstly, choose a namespace having highest priority by calling `NamespaceOrderFn`, and then choose a job having highest priority using `JobOrderFn` in this namespace.
+
+After scheduling of job, push the namespace and job back to priority queue in order to refresh its priority. Because once a job is scheduled, assigned resource may decrease the priority of this namespace, the other jobs in the same namespace may be scheduled later.
+
+Always assigning resources to namespace with highest priority (lower resource usage) in every turn will make the resource balanced.
+
+### DRF plugin
+
+DRF plugin use preemption and order of job to balance resource among jobs. The `share` in this plugin is defined as resource usage, the higher `share` means this job occupies the more resource now.
+
+#### Namespace Compare
+
+To introduce namespace weight into this plugin, we should define how to compare namespace having weight firstly.
+
+For namespace n1 having weight w1 and namespace n2 having weight w2, we can compute the `share` of resource and recorded as u1 and u2. Now, the resource usage of n1 less than n2 can be defined as (u1 / w1 < u2 / w2)
+
+`e.g.` ns1 having weight w1=2 use 6cpu, ns2 having weight w2=1 use 2cpu. In the scope of cpu, the ns1 use less resource than ns2. (6 / 3 < 3 / 1)
+
+#### Namespace Order
+
+Register `NamespaceOrder` function using the strategy mentioned above.
+
+#### preemption
+
+> The `preempt` action is disabled now. Do this later.
+
+In the `preemption` function now, strategy is just simply comparing the resource share among jobs .
+
+After adding namespace weight, we should check namespace of preemptor and preemptee firstly. The job in namespace with less resources can preempt others, or when namespace resource usage are the same, compare share of job instead.
+
+### Feature Interaction
+
+#### preempt action
+
+Preempt is a strategy set to choose victims and finally evict it.
+
+The way to choose victims is a function set named `Preemptable` registered by plugins. Such as job ready protection of Gang plugin, special pod protection of Conformance plugin, job share balance strategy of DRF plugin.
+
+All these plugin would choose some victims respective, and the intersection of them would be the final victim set. So, the choice made by DRF plugin would never break the requirement of others.
+
+### short hand
+
+1. Preempt may cause killing of some running pod.
+
+### Cases:
+
+- cluster have __16 cpu__, queue and namespace have default weight.
+
+    | queue | namespace | requested | queue assigned | namespace assigned |
+    | ----- | --------- | --------- | -------------- | ------------------ |
+    | q1    | ns1       | 5 cpu     | 8 cpu          | 4 cpu              |
+    |       | ns2       | 10 cpu    |                | 4 cpu              |
+    | q2    | ns3       | 10 cpu    | 8 cpu          | 6 cpu              |
+    |       | ns4       | 2 cpu     |                | 2 cpu              |
+
+- cluster have __16 cpu__, q1 with weight 1, q2 with weight 3. ns1 with weight 3, ns2 have weight 1, ns3 have weight 2, ns4 have weight 6.
+
+    | queue | namespace | requested | queue assigned | namespace assigned |
+    | ----- | --------- | --------- | -------------- | ------------------ |
+    | q1 w1 | ns1 w3    | 5 cpu     | 4 cpu          | 3 cpu              |
+    |       | ns2 w1    | 10 cpu    |                | 1 cpu              |
+    | q2 w3 | ns3 w2    | 10 cpu    | 12 cpu         | 10 cpu             |
+    |       | ns4 w6    | 2 cpu     |                | 2 cpu              |
+
+- cluster have __16 cpu__, q1 with weight 1, q2 with weight 3. ns1 have weight 2, ns2 have weight 6.
+
+    | queue | namespace | requested | queue assigned | namespace assigned |
+    | ----- | --------- | --------- | -------------- | ------------------ |
+    | q1 w1 | ns1 w2    |           | 4 cpu          |                    |
+    | q2 w3 | ns1 w2    | 5 cpu     | 12 cpu         | 3 cpu              |
+    |       | ns2 w6    | 20 cpu    |                | 9 cpu              |
+
+---
+
+## Per-namespace fair share with decayed usage tracking (2026)
+
+### Background
 
 Volcano's existing DRF plugin provides dominant resource fairness at the namespace/queue level,
 but it only considers the **current allocation snapshot** — it has no memory of past usage.
-This leads to a well-documented problem in multi-user GPU clusters (see [#4165](https://github.com/volcano-sh/volcano/issues/4165)):
+This leads to a well-documented problem in multi-tenant GPU clusters (see [#4165](https://github.com/volcano-sh/volcano/issues/4165)):
 
-- User A submits hundreds of GPU jobs and fills the cluster
-- User B arrives later with a handful of jobs
-- As User A's jobs complete, User A's new pending jobs immediately regain priority
-  (they have equal or lower current allocation), effectively starving User B
+- Namespace A submits hundreds of GPU jobs and fills the cluster
+- Namespace B arrives later with a handful of jobs
+- As namespace A's jobs complete, its new pending jobs immediately regain priority
+  (they have equal or lower current allocation), effectively starving namespace B
 
-This "submission-order bias" means the first user to flood the queue monopolizes resources
-indefinitely, even when other users have legitimate demand. SLURM solves this with its
+This "submission-order bias" means the first tenant to flood the queue monopolizes resources
+indefinitely, even when other tenants have legitimate demand. SLURM solves this with its
 fair share algorithm that tracks historical usage with exponential decay.
 
-## Proposal
+This is the same underlying gap the 2019 [Namespace fair share](#namespace-fair-share-2019)
+proposal above targeted, but that design requires new `NamespaceOrderFn` scheduling-loop
+stages and `NamespaceInfo` plumbing through `SchedulerCache`/`Session`/`ClusterInfo` that were
+never landed. The proposal below is intentionally scoped to a single self-contained plugin —
+no framework changes — trading the static, admin-configured `ResourceQuota` weight for a
+usage-based measure that adapts automatically as tenants' consumption rises and falls.
 
-Add a new `fairshare` scheduler plugin that tracks cumulative resource-seconds per user
-(identified by namespace) and applies exponential half-life decay so that past consumption
-is gradually forgiven.
+It's also worth calling out an assumption both designs share and that's worth being explicit
+about: Volcano already supports fair sharing *across* queues (via DRF/proportion at the queue
+level). Both the 2019 proposal and this one are about fair sharing **within** a single queue,
+for the case — common when tenants map to namespaces rather than to dedicated queues — where
+multiple tenants submit jobs into the same queue and need to be balanced against each other
+there.
 
-### User identity
+### Proposal
 
-Users are identified by their job's **namespace**. This follows the namespace-per-user
-pattern common in multi-tenant Kubernetes GPU clusters. No additional labels are required.
+Add a new `fairshare` scheduler plugin that tracks cumulative resource-seconds per namespace
+and applies exponential half-life decay so that past consumption is gradually forgiven.
+
+### Namespace identity
+
+Tenants are identified by their job's **namespace** directly — there is no separate "user"
+concept, since not every cluster maps individual users to namespaces one-to-one (a namespace
+may itself represent a team or project shared by several users). No additional labels are
+required.
 
 ### Algorithm
 
@@ -32,7 +247,7 @@ Each scheduling cycle (~1 second):
 
 1. **Decay** all historical usage: `usage × 2^(-elapsed / halfLife)`
 2. **Accumulate** running usage: for each allocated task, add `resource_count × elapsed_seconds`
-   to the user's cumulative total
+   to the namespace's cumulative total
 3. **Order** pending jobs via `JobOrderFn`:
    - **Primary**: Lower cumulative usage wins (with a 1.0 resource-second epsilon for float comparison)
    - **Secondary**: Fewer currently-running resources wins (within-cycle tiebreaker)
@@ -47,7 +262,7 @@ Each scheduling cycle (~1 second):
 | 12 hours        | 12.5%                          |
 | 24 hours        | 1.6%                           |
 
-A user who consumed 10 GPU-hours will see their usage penalty halve every 4 hours of
+A namespace that consumed 10 GPU-hours will see its usage penalty halve every 4 hours of
 inactivity. After 24 hours, the penalty is effectively forgotten.
 
 ### State persistence
@@ -59,7 +274,7 @@ by a `sync.Mutex` to persist usage history across scheduling cycles:
 ```go
 var (
     globalMu        sync.Mutex
-    globalUsage     = make(map[string]map[string]float64) // [queue][user] → resource-seconds
+    globalUsage     = make(map[string]map[string]float64) // [queue][namespace] → resource-seconds
     globalLastCycle time.Time
 )
 ```
@@ -70,12 +285,16 @@ To survive scheduler restarts, the plugin can optionally persist state to a Conf
 When `fairshare.persistState` is set to `"true"`:
 
 1. On the **first scheduling cycle**, a `sync.Once` block loads any existing state from
-   the ConfigMap into `globalUsage` / `globalLastCycle`, then starts a background goroutine.
-2. The **background goroutine** periodically flushes the current state to the ConfigMap
-   (default: every 30 seconds). Writes use the ConfigMap's `resourceVersion` for
-   optimistic concurrency.
+   the ConfigMap into `globalUsage` / `globalLastCycle`.
+2. **`OnSessionClose`** (called once per scheduling cycle, ~1s) flushes the current state
+   to the ConfigMap whenever at least `flushIntervalSeconds` has elapsed since the last
+   flush (default: 30 seconds). Writes use the ConfigMap's `resourceVersion` for
+   optimistic concurrency. Tying the flush to the session lifecycle rather than a
+   detached goroutine+ticker means persistence stops the moment the plugin stops being
+   invoked (e.g. removed from the tier list via a config hot-reload) — a ticker would
+   otherwise keep writing stale state forever with no shutdown hook.
 3. On restart, the loaded `globalLastCycle` is used to compute the elapsed time and apply
-   the correct decay, so users are not unfairly penalized or forgiven by the downtime.
+   the correct decay, so namespaces are not unfairly penalized or forgiven by the downtime.
 
 The ConfigMap is stored in the scheduler's namespace (default: `volcano-system`):
 
@@ -94,8 +313,8 @@ data:
       "lastCycle": "2026-04-07T12:00:00Z",
       "queues": {
         "gpu-queue": {
-          "alice": 12345.67,
-          "bob": 8901.23
+          "team-a": 12345.67,
+          "team-b": 8901.23
         }
       }
     }
@@ -106,110 +325,51 @@ data:
 - **Leader election**: Volcano already elects a single active scheduler. Only the leader writes.
 - **Data loss window**: At most `flushInterval` seconds of usage data is lost on a crash.
   With the default 30-second interval and a 4-hour half-life, this is negligible.
-- **Size**: Even with 1000 users across 50 queues, the JSON payload is ~50 KB — well within
-  the 1 MB ConfigMap limit.
+- **Size**: Even with 1000 namespaces across 50 queues, the JSON payload is ~50 KB — well
+  within the 1 MB ConfigMap limit.
 - **Backward compatibility**: Persistence is disabled by default. Existing deployments are
   unaffected.
 
-## Configuration
-
-```yaml
-actions: "enqueue, allocate, backfill"
-tiers:
-- plugins:
-  - name: priority
-  - name: gang
-  - name: conformance
-  - name: fairshare
-    arguments:
-      fairshare.targetQueues: "gpu-queue"
-      fairshare.resourceKey: "nvidia.com/gpu"
-      fairshare.halfLifeMinutes: "240"
-      fairshare.enableEnqueueGate: "false"
-      fairshare.persistState: "true"
-```
-
-### Arguments
-
-| Argument | Default | Description |
-|----------|---------|-------------|
-| `fairshare.targetQueues` | _(all queues)_ | Comma-separated queue names to apply fair share to; if unset, applies to every queue |
-| `fairshare.resourceKey` | `nvidia.com/gpu` | Default resource to track |
-| `fairshare.resourceKey.<queue>` | _(none)_ | Per-queue resource override (e.g., `amd.com/gpu`, `cpu`) |
-| `fairshare.halfLifeMinutes` | `240` | Half-life for usage decay in minutes |
-| `fairshare.enableEnqueueGate` | `false` | When `true`, blocks users at/above their calculated share from entering the scheduling pipeline |
-| `fairshare.persistState` | `false` | When `true`, persists usage state to a ConfigMap so it survives scheduler restarts |
-| `fairshare.stateNamespace` | `volcano-system` | Namespace for the state ConfigMap |
-| `fairshare.stateConfigMap` | `fairshare-usage-state` | Name of the state ConfigMap |
-| `fairshare.flushIntervalSeconds` | `30` | How often to flush state to the ConfigMap (in seconds) |
-
-## Interaction with existing plugins
-
-### priority plugin
-
-The `priority` plugin runs before `fairshare` in the same tier. A higher PriorityClass
-always wins. Fair share only breaks ties at equal priority levels.
-
-When all competing jobs use the same PriorityClass, fair share is fully effective as the
-tiebreaker. This means using a high PriorityClass only helps when others don't — if everyone
-uses it, fair share still distributes resources equitably.
-
-### DRF plugin
-
-The fairshare plugin is complementary to DRF. DRF handles multi-resource dominance
-(which resource is the bottleneck), while fairshare handles temporal fairness (who has
-consumed more historically). They can coexist or be used independently depending on
-cluster needs.
-
-### gang plugin
-
-No interaction — gang scheduling handles minimum member requirements, while fairshare
-handles ordering among eligible jobs.
-
-## Scheduler hooks
+### Scheduler hooks
 
 | Hook | Purpose |
 |------|---------|
 | `JobOrderFn` | Orders jobs by cumulative usage (lower wins), with running-resource tiebreaker |
-| `JobEnqueueableFn` | (Optional) Blocks users at/above their max-min fair share from the scheduling pipeline |
+| `JobEnqueueableFn` | (Optional) Blocks namespaces at/above their max-min fair share from the scheduling pipeline |
 | `EventHandler` | Tracks allocations/deallocations in real-time during the scheduling cycle |
 
-## Logging
+### Testing
 
-| klog level | What it shows |
-|------------|---------------|
-| V(2) | Plugin config on creation, per-cycle queue summary (user count, running, demand) |
-| V(3) | Decay factor per cycle, fair shares, usage maps, ordering winner decisions |
-| V(4) | Session open/close, individual allocate/deallocate events |
-| V(5) | Every job comparison, every enqueue evaluation |
+#### Unit tests (47 tests)
 
-## Testing
-
-### Unit tests (33 tests)
-
-- Max-min fair share algorithm correctness (single user, equal demand, asymmetric demand, progressive elimination)
+- Max-min fair share algorithm correctness (single namespace, equal demand, asymmetric demand, progressive elimination)
 - Decay factor math (one/two half-lives, zero elapsed, zero half-life, small elapsed)
 - `decayAllUsage` (halves after one half-life, cleans up negligible entries, multi-queue)
-- Usage ordering (lower usage wins, equal usage falls to running tiebreaker, realistic multi-user scenario)
+- Usage ordering (lower usage wins, equal usage falls to running tiebreaker, realistic multi-namespace scenario)
 - Decay scenario (10-hour job decay over 4h and 24h)
 - Helpers (namespace extraction, resource key defaults/overrides)
+- `targetQueues` allowlist behavior (defaults to all queues when unset, restricts to the allowlist when set)
 - Persistence: flush creates ConfigMap, flush updates existing, load populates globals,
   load handles missing ConfigMap, load handles empty data, flush→load round-trip,
   disabled persistence is no-op, corrupt JSON returns error
+- `maybeFlush` rate limiting (disabled is a no-op, first call flushes immediately, a second
+  call within the interval is skipped, flushes again once the interval elapses)
 
-### Integration tests
+#### Integration tests
 
-Validated on a test cluster with 2 GPU nodes and 4 user namespaces:
+Validated on a test cluster with 2 GPU nodes and 4 tenant namespaces:
 
-1. **Without decay tracking**: FIFO behavior, last user waited ~7 minutes
-2. **With decay tracking**: All users got GPUs within ~2 minutes, scheduling rotated between users
-3. **Burst asymmetry** (1 user = 8 jobs, others = 1 each): Minority users' jobs completed within ~2 minutes
-4. **DAG/workflow simulation**: GPU steps interleaved across users by cumulative usage
+1. **Without decay tracking**: FIFO behavior, last tenant waited ~7 minutes
+2. **With decay tracking**: All tenants got GPUs within ~2 minutes, scheduling rotated between tenants
+3. **Burst asymmetry** (1 tenant = 8 jobs, others = 1 each): Minority tenants' jobs completed within ~2 minutes
+4. **DAG/workflow simulation**: GPU steps interleaved across tenants by cumulative usage
 5. **PriorityClass interaction**: High-priority bypassed fair share as expected
 6. **Scheduler restart**: Running jobs survived, new jobs scheduled fairly post-restart
 
-## Limitations
+### Limitations
 
 - Without `persistState`, state is in-memory only and lost on scheduler restart
-- Namespace-based identity only; no support for arbitrary user labels (can be extended)
+- Namespace-based identity only; no support for arbitrary custom labels (can be extended)
 - ConfigMap persistence has a small data-loss window equal to the flush interval on crashes
+- Fairness is scoped within a queue (as in the 2019 proposal above); this plugin does not
+  change how DRF/proportion balance resources across queues

--- a/docs/design/metrics.md
+++ b/docs/design/metrics.md
@@ -61,8 +61,9 @@ This metrics describe internal state of volcano.
 | `queue_pod_group_running_count`        | Gauge           | `queue_name`=&lt;queue_name&gt;                                   | The number of Running PodGroups in this queue |
 | `queue_pod_group_unknown_count`        | Gauge           | `queue_name`=&lt;queue_name&gt;                                   | The number of Unknown PodGroups in this queue |
 | `queue_session_start_task_count`       | Gauge           | `queue_name`=&lt;queue_name&gt;, `status`=&lt;status&gt;           | Number of tasks by status in jobs directly assigned to this queue at the beginning of the latest scheduling session |
-| `namespace_share`                      | Gauge           | `namespace_name`=&lt;namespace_name&gt;                           | Deserved CPU count for one namespace          |
+| `namespace_share`                      | Gauge           | `namespace_name`=&lt;namespace_name&gt;, `queue`=&lt;queue&gt;, `resource`=&lt;resource_name&gt; | Share for one namespace in one queue, for one resource |
 | `namespace_weight`                     | Gauge           | `namespace_name`=&lt;namespace_name&gt;                           | Weight for one namespace                      |
+| `namespace_decayed_usage`              | Gauge           | `namespace_name`=&lt;namespace_name&gt;, `queue`=&lt;queue&gt;, `resource`=&lt;resource_name&gt; | Decayed cumulative resource-seconds usage for one namespace in one queue (fairshare plugin) |
 | `job_share`                            | Gauge           | `job_id`=&lt;job_id&gt;, `job_ns`=&lt;job_ns&gt;                  | Share for one job                             |
 | `job_retry_counts`                     | Counter         | `job_id`=&lt;job_id&gt;                                           | The number of retry counts for one job        |
 | `job_completed_phase_count`            | Counter         | `job_name`=&lt;job_name&gt; `queue_name`=&lt;queue_name&gt;       | The number of job completed phase             |

--- a/docs/user-guide/how_to_use_fairshare_plugin.md
+++ b/docs/user-guide/how_to_use_fairshare_plugin.md
@@ -1,0 +1,133 @@
+# Fairshare Plugin User Guide
+
+## Introduction
+
+The `fairshare` plugin provides per-namespace temporal fair share scheduling within a
+queue, using decayed cumulative usage tracking (a SLURM-inspired algorithm). It complements
+the existing DRF plugin: DRF balances resources based on the **current allocation snapshot**
+and has no memory of past usage, so a namespace that floods a queue with jobs first keeps
+regaining priority as its jobs complete, effectively starving later arrivals. `fairshare`
+tracks historical resource-seconds consumed per namespace and applies exponential half-life
+decay, so heavy past consumers are gradually deprioritized relative to namespaces that have
+consumed less — without requiring any admin-set weights.
+
+For the design rationale and algorithm details, see the
+[fairshare design doc](../design/fairshare.md).
+
+## Can it be used together with DRF?
+
+Yes — `fairshare` and `drf` address different axes of fairness and are meant to be run
+together, not as alternatives:
+
+- **DRF** balances *which resource dimension* dominates a job's share (CPU vs. memory vs.
+  GPU) at the current snapshot.
+- **fairshare** balances *which namespace* gets scheduled next based on historical
+  consumption over time, within the same queue.
+
+**Plugin order matters here, and it isn't a "same tier vs. different tier" question.**
+`Session.JobOrderFn` walks every tier's plugin list in configured order (tiers first, then
+plugins within each tier) and returns as soon as *any* plugin's comparison is non-zero — see
+[`pkg/scheduler/framework/session_plugins.go`](https://github.com/volcano-sh/volcano/blob/master/pkg/scheduler/framework/session_plugins.go),
+`Session.JobOrderFn`. Whichever plugin appears earliest in that flattened order and returns a
+non-zero result decides the comparison; every later plugin is never consulted for that pair.
+
+Concretely: **list `fairshare` before `drf`** (as in the example config below, where
+`fairshare` is the 4th plugin overall and `drf` is the 5th). If `drf` were listed first
+instead, its dominant-resource-share comparison — which returns non-zero for almost any pair
+of jobs with differing resource requests — would decide most comparisons on its own,
+and `fairshare`'s historical-usage ordering would rarely get a chance to run at all. `priority`
+should still come before both, so a higher `PriorityClass` always wins regardless of either
+resource-share or historical-usage comparisons.
+
+## Environment setup
+
+### Install volcano
+
+Refer to the [Install Guide](https://github.com/volcano-sh/volcano/blob/master/installer/README.md) to install volcano.
+
+After installing, update the scheduler configuration:
+
+```shell
+kubectl edit cm -n volcano-system volcano-scheduler-configmap
+```
+
+```yaml
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: volcano-scheduler-configmap
+  namespace: volcano-system
+data:
+  volcano-scheduler.conf: |
+    actions: "enqueue, allocate, backfill"
+    tiers:
+    - plugins:
+      - name: priority
+      - name: gang
+      - name: conformance
+      - name: fairshare
+        arguments:
+          fairshare.targetQueues: "gpu-queue"
+          fairshare.resourceKey: "nvidia.com/gpu"
+          fairshare.halfLifeMinutes: "240"
+          fairshare.enableEnqueueGate: "false"
+          fairshare.persistState: "true"
+    - plugins:
+      - name: drf
+      - name: predicates
+      - name: nodeorder
+```
+
+## Arguments
+
+| Argument | Default | Description |
+|----------|---------|-------------|
+| `fairshare.targetQueues` | _(all queues)_ | Comma-separated queue names to apply fair share to; if unset, applies to every queue |
+| `fairshare.resourceKey` | `nvidia.com/gpu` | Default resource to track |
+| `fairshare.resourceKey.<queue>` | _(none)_ | Per-queue resource override (e.g., `amd.com/gpu`, `cpu`) |
+| `fairshare.halfLifeMinutes` | `240` | Half-life for usage decay in minutes |
+| `fairshare.enableEnqueueGate` | `false` | When `true`, blocks namespaces at/above their calculated share from entering the scheduling pipeline |
+| `fairshare.persistState` | `false` | When `true`, persists usage state to a ConfigMap so it survives scheduler restarts |
+| `fairshare.stateNamespace` | `volcano-system` | Namespace for the state ConfigMap |
+| `fairshare.stateConfigMap` | `fairshare-usage-state` | Name of the state ConfigMap |
+| `fairshare.flushIntervalSeconds` | `30` | How often to flush state to the ConfigMap (in seconds) |
+
+## Interaction with existing plugins
+
+### priority plugin
+
+The `priority` plugin should be listed before `fairshare` (see [Can it be used together with
+DRF?](#can-it-be-used-together-with-drf) above for why list order — not tier grouping — is
+what determines this). A higher PriorityClass always wins. Fair share only breaks ties at
+equal priority levels.
+
+When all competing jobs use the same PriorityClass, fair share is fully effective as the
+tiebreaker. This means using a high PriorityClass only helps when others don't — if everyone
+uses it, fair share still distributes resources equitably.
+
+### DRF plugin
+
+See [Can it be used together with DRF?](#can-it-be-used-together-with-drf) above. The two
+plugins are complementary and typically run together.
+
+### gang plugin
+
+No interaction — gang scheduling handles minimum member requirements, while fairshare
+handles ordering among eligible jobs.
+
+## Limitations
+
+`fairshare` is **advisory only** for scheduling decisions that haven't happened yet — it
+registers no `PreemptableFn`/`ReclaimableFn`. It reorders the pending queue and (optionally)
+gates enqueue, but it cannot preempt jobs that are already running. This means a namespace
+with long-lived running jobs keeps its resources regardless of how stale its usage penalty
+becomes; `fairshare` only influences which namespace's *next* job gets scheduled first.
+
+## Logging
+
+| klog level | What it shows |
+|------------|---------------|
+| V(2) | Plugin config on creation, per-cycle queue summary (namespace count, running, demand) |
+| V(3) | Decay factor per cycle, fair shares, usage maps, ordering winner decisions |
+| V(4) | Session open/close, individual allocate/deallocate events |
+| V(5) | Every job comparison, every enqueue evaluation |

--- a/docs/user-guide/how_to_use_fairshare_plugin.md
+++ b/docs/user-guide/how_to_use_fairshare_plugin.md
@@ -1,0 +1,113 @@
+# Fairshare Plugin User Guide
+
+## Introduction
+
+The `fairshare` plugin provides per-namespace temporal fair share scheduling within a
+queue, using decayed cumulative usage tracking (a SLURM-inspired algorithm). It complements
+the existing DRF plugin: DRF balances resources based on the **current allocation snapshot**
+and has no memory of past usage, so a namespace that floods a queue with jobs first keeps
+regaining priority as its jobs complete, effectively starving later arrivals. `fairshare`
+tracks historical resource-seconds consumed per namespace and applies exponential half-life
+decay, so heavy past consumers are gradually deprioritized relative to namespaces that have
+consumed less — without requiring any admin-set weights.
+
+For the design rationale and algorithm details, see the
+[fairshare design doc](../design/fairshare.md).
+
+## Can it be used together with DRF?
+
+Yes — `fairshare` and `drf` address different axes of fairness and are meant to be run
+together, not as alternatives:
+
+- **DRF** balances *which resource dimension* dominates a job's share (CPU vs. memory vs.
+  GPU) at the current snapshot.
+- **fairshare** balances *which namespace* gets scheduled next based on historical
+  consumption over time, within the same queue.
+
+Put `fairshare` in the same tier as `drf` (order between them does not matter — they operate
+on independent ordering criteria and Volcano composes `JobOrderFn` results across plugins).
+Both can coexist with `priority` and `gang` as well; `priority` should run before `fairshare`
+in the tier list so a higher `PriorityClass` always wins regardless of historical usage.
+
+## Environment setup
+
+### Install volcano
+
+Refer to the [Install Guide](https://github.com/volcano-sh/volcano/blob/master/installer/README.md) to install volcano.
+
+After installing, update the scheduler configuration:
+
+```shell
+kubectl edit cm -n volcano-system volcano-scheduler-configmap
+```
+
+```yaml
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: volcano-scheduler-configmap
+  namespace: volcano-system
+data:
+  volcano-scheduler.conf: |
+    actions: "enqueue, allocate, backfill"
+    tiers:
+    - plugins:
+      - name: priority
+      - name: gang
+      - name: conformance
+      - name: fairshare
+        arguments:
+          fairshare.targetQueues: "gpu-queue"
+          fairshare.resourceKey: "nvidia.com/gpu"
+          fairshare.halfLifeMinutes: "240"
+          fairshare.enableEnqueueGate: "false"
+          fairshare.persistState: "true"
+    - plugins:
+      - name: drf
+      - name: predicates
+      - name: nodeorder
+```
+
+## Arguments
+
+| Argument | Default | Description |
+|----------|---------|-------------|
+| `fairshare.targetQueues` | _(all queues)_ | Comma-separated queue names to apply fair share to; if unset, applies to every queue |
+| `fairshare.resourceKey` | `nvidia.com/gpu` | Default resource to track |
+| `fairshare.resourceKey.<queue>` | _(none)_ | Per-queue resource override (e.g., `amd.com/gpu`, `cpu`) |
+| `fairshare.halfLifeMinutes` | `240` | Half-life for usage decay in minutes |
+| `fairshare.enableEnqueueGate` | `false` | When `true`, blocks namespaces at/above their calculated share from entering the scheduling pipeline |
+| `fairshare.persistState` | `false` | When `true`, persists usage state to a ConfigMap so it survives scheduler restarts |
+| `fairshare.stateNamespace` | `volcano-system` | Namespace for the state ConfigMap |
+| `fairshare.stateConfigMap` | `fairshare-usage-state` | Name of the state ConfigMap |
+| `fairshare.flushIntervalSeconds` | `30` | How often to flush state to the ConfigMap (in seconds) |
+
+## Interaction with existing plugins
+
+### priority plugin
+
+The `priority` plugin should run before `fairshare` in the same tier. A higher PriorityClass
+always wins. Fair share only breaks ties at equal priority levels.
+
+When all competing jobs use the same PriorityClass, fair share is fully effective as the
+tiebreaker. This means using a high PriorityClass only helps when others don't — if everyone
+uses it, fair share still distributes resources equitably.
+
+### DRF plugin
+
+See [Can it be used together with DRF?](#can-it-be-used-together-with-drf) above. The two
+plugins are complementary and typically run together.
+
+### gang plugin
+
+No interaction — gang scheduling handles minimum member requirements, while fairshare
+handles ordering among eligible jobs.
+
+## Logging
+
+| klog level | What it shows |
+|------------|---------------|
+| V(2) | Plugin config on creation, per-cycle queue summary (namespace count, running, demand) |
+| V(3) | Decay factor per cycle, fair shares, usage maps, ordering winner decisions |
+| V(4) | Session open/close, individual allocate/deallocate events |
+| V(5) | Every job comparison, every enqueue evaluation |

--- a/docs/user-guide/how_to_use_fairshare_plugin.md
+++ b/docs/user-guide/how_to_use_fairshare_plugin.md
@@ -115,6 +115,14 @@ plugins are complementary and typically run together.
 No interaction — gang scheduling handles minimum member requirements, while fairshare
 handles ordering among eligible jobs.
 
+## Limitations
+
+`fairshare` is **advisory only** for scheduling decisions that haven't happened yet — it
+registers no `PreemptableFn`/`ReclaimableFn`. It reorders the pending queue and (optionally)
+gates enqueue, but it cannot preempt jobs that are already running. This means a namespace
+with long-lived running jobs keeps its resources regardless of how stale its usage penalty
+becomes; `fairshare` only influences which namespace's *next* job gets scheduled first.
+
 ## Logging
 
 | klog level | What it shows |

--- a/docs/user-guide/how_to_use_fairshare_plugin.md
+++ b/docs/user-guide/how_to_use_fairshare_plugin.md
@@ -24,10 +24,20 @@ together, not as alternatives:
 - **fairshare** balances *which namespace* gets scheduled next based on historical
   consumption over time, within the same queue.
 
-Put `fairshare` in the same tier as `drf` (order between them does not matter — they operate
-on independent ordering criteria and Volcano composes `JobOrderFn` results across plugins).
-Both can coexist with `priority` and `gang` as well; `priority` should run before `fairshare`
-in the tier list so a higher `PriorityClass` always wins regardless of historical usage.
+**Plugin order matters here, and it isn't a "same tier vs. different tier" question.**
+`Session.JobOrderFn` walks every tier's plugin list in configured order (tiers first, then
+plugins within each tier) and returns as soon as *any* plugin's comparison is non-zero — see
+[`pkg/scheduler/framework/session_plugins.go`](https://github.com/volcano-sh/volcano/blob/master/pkg/scheduler/framework/session_plugins.go),
+`Session.JobOrderFn`. Whichever plugin appears earliest in that flattened order and returns a
+non-zero result decides the comparison; every later plugin is never consulted for that pair.
+
+Concretely: **list `fairshare` before `drf`** (as in the example config below, where
+`fairshare` is the 4th plugin overall and `drf` is the 5th). If `drf` were listed first
+instead, its dominant-resource-share comparison — which returns non-zero for almost any pair
+of jobs with differing resource requests — would decide most comparisons on its own,
+and `fairshare`'s historical-usage ordering would rarely get a chance to run at all. `priority`
+should still come before both, so a higher `PriorityClass` always wins regardless of either
+resource-share or historical-usage comparisons.
 
 ## Environment setup
 
@@ -86,8 +96,10 @@ data:
 
 ### priority plugin
 
-The `priority` plugin should run before `fairshare` in the same tier. A higher PriorityClass
-always wins. Fair share only breaks ties at equal priority levels.
+The `priority` plugin should be listed before `fairshare` (see [Can it be used together with
+DRF?](#can-it-be-used-together-with-drf) above for why list order — not tier grouping — is
+what determines this). A higher PriorityClass always wins. Fair share only breaks ties at
+equal priority levels.
 
 When all competing jobs use the same PriorityClass, fair share is fully effective as the
 tiebreaker. This means using a high PriorityClass only helps when others don't — if everyone

--- a/pkg/scheduler/metrics/namespace.go
+++ b/pkg/scheduler/metrics/namespace.go
@@ -22,12 +22,16 @@ import (
 )
 
 var (
+	// namespaceShare carries a "queue" and "resource" label because a
+	// namespace's share is only meaningful relative to a specific queue's
+	// capacity for a specific tracked resource (e.g. a namespace can have
+	// different shares in different queues, or for cpu vs. nvidia.com/gpu).
 	namespaceShare = promauto.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Subsystem: VolcanoSubSystemName,
 			Name:      "namespace_share",
-			Help:      "Share for one namespace",
-		}, []string{"namespace_name"},
+			Help:      "Share for one namespace in one queue, for one resource",
+		}, []string{"namespace_name", "queue", "resource"},
 	)
 
 	namespaceWeight = promauto.NewGaugeVec(
@@ -45,11 +49,25 @@ var (
 			Help:      "Weighted share for one namespace",
 		}, []string{"namespace_name"},
 	)
+
+	// namespaceDecayedUsage is distinct from namespaceShare: share is a
+	// point-in-time entitlement recomputed fresh each cycle from current
+	// demand, while decayed usage is a running resource-seconds total that
+	// persists and decays across cycles (see the fairshare plugin's decay
+	// model). Different units and semantics, so it gets its own gauge
+	// rather than reusing namespace_share.
+	namespaceDecayedUsage = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Subsystem: VolcanoSubSystemName,
+			Name:      "namespace_decayed_usage",
+			Help:      "Decayed cumulative resource-seconds usage for one namespace in one queue",
+		}, []string{"namespace_name", "queue", "resource"},
+	)
 )
 
-// UpdateNamespaceShare records share for one namespace
-func UpdateNamespaceShare(namespaceName string, share float64) {
-	namespaceShare.WithLabelValues(namespaceName).Set(share)
+// UpdateNamespaceShare records share for one namespace in one queue, for one resource
+func UpdateNamespaceShare(namespaceName, queue, resource string, share float64) {
+	namespaceShare.WithLabelValues(namespaceName, queue, resource).Set(share)
 }
 
 // UpdateNamespaceWeight records weight for one namespace
@@ -60,4 +78,10 @@ func UpdateNamespaceWeight(namespaceName string, weight int64) {
 // UpdateNamespaceWeightedShare records weighted share for one namespace
 func UpdateNamespaceWeightedShare(namespaceName string, weightedShare float64) {
 	namespaceWeightedShare.WithLabelValues(namespaceName).Set(weightedShare)
+}
+
+// UpdateNamespaceDecayedUsage records decayed cumulative resource-seconds
+// usage for one namespace in one queue, for one resource
+func UpdateNamespaceDecayedUsage(namespaceName, queue, resource string, usage float64) {
+	namespaceDecayedUsage.WithLabelValues(namespaceName, queue, resource).Set(usage)
 }

--- a/pkg/scheduler/plugins/factory.go
+++ b/pkg/scheduler/plugins/factory.go
@@ -28,6 +28,7 @@ import (
 	"volcano.sh/volcano/pkg/scheduler/plugins/conformance"
 	"volcano.sh/volcano/pkg/scheduler/plugins/deviceshare"
 	"volcano.sh/volcano/pkg/scheduler/plugins/drf"
+	"volcano.sh/volcano/pkg/scheduler/plugins/fairshare"
 	"volcano.sh/volcano/pkg/scheduler/plugins/extender"
 	"volcano.sh/volcano/pkg/scheduler/plugins/gang"
 	networktopologyaware "volcano.sh/volcano/pkg/scheduler/plugins/network-topology-aware"
@@ -67,6 +68,7 @@ func init() {
 	framework.RegisterPluginBuilder(cdp.PluginName, cdp.New)
 	framework.RegisterPluginBuilder(rescheduling.PluginName, rescheduling.New)
 	framework.RegisterPluginBuilder(usage.PluginName, usage.New)
+	framework.RegisterPluginBuilder(fairshare.PluginName, fairshare.New)
 	framework.RegisterPluginBuilder(pdb.PluginName, pdb.New)
 	framework.RegisterPluginBuilder(nodegroup.PluginName, nodegroup.New)
 	framework.RegisterPluginBuilder(networktopologyaware.PluginName, networktopologyaware.New)

--- a/pkg/scheduler/plugins/factory.go
+++ b/pkg/scheduler/plugins/factory.go
@@ -29,6 +29,7 @@ import (
 	"volcano.sh/volcano/pkg/scheduler/plugins/deviceshare"
 	"volcano.sh/volcano/pkg/scheduler/plugins/drf"
 	"volcano.sh/volcano/pkg/scheduler/plugins/extender"
+	"volcano.sh/volcano/pkg/scheduler/plugins/fairshare"
 	"volcano.sh/volcano/pkg/scheduler/plugins/gang"
 	networktopologyaware "volcano.sh/volcano/pkg/scheduler/plugins/network-topology-aware"
 	"volcano.sh/volcano/pkg/scheduler/plugins/nodegroup"
@@ -67,6 +68,7 @@ func init() {
 	framework.RegisterPluginBuilder(cdp.PluginName, cdp.New)
 	framework.RegisterPluginBuilder(rescheduling.PluginName, rescheduling.New)
 	framework.RegisterPluginBuilder(usage.PluginName, usage.New)
+	framework.RegisterPluginBuilder(fairshare.PluginName, fairshare.New)
 	framework.RegisterPluginBuilder(pdb.PluginName, pdb.New)
 	framework.RegisterPluginBuilder(nodegroup.PluginName, nodegroup.New)
 	framework.RegisterPluginBuilder(networktopologyaware.PluginName, networktopologyaware.New)

--- a/pkg/scheduler/plugins/fairshare/fairshare.go
+++ b/pkg/scheduler/plugins/fairshare/fairshare.go
@@ -1,0 +1,552 @@
+/*
+Copyright 2025 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package fairshare implements a Volcano scheduler plugin that provides
+// per-user fair share scheduling within target queues using decayed cumulative
+// usage tracking. It prevents any single user from monopolizing resources when
+// multiple users have pending work, and remembers past usage across scheduling
+// cycles so that heavy consumers are deprioritized even after their jobs finish.
+//
+// User identity is derived from the job's namespace (namespace-per-user pattern).
+// The tracked resource type is configurable per queue (e.g., nvidia.com/gpu for
+// GPU queues, cpu for CPU queues).
+//
+// Historical usage decays exponentially with a configurable half-life (default
+// 4 hours). This means a user who consumed 10 GPU-hours will see their usage
+// penalty halve every 4 hours, naturally converging back to equal priority.
+package fairshare
+
+import (
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/klog/v2"
+
+	"volcano.sh/volcano/pkg/scheduler/api"
+	"volcano.sh/volcano/pkg/scheduler/framework"
+	"volcano.sh/volcano/pkg/scheduler/plugins/util"
+)
+
+// Package-level persistent state. Volcano calls New() every scheduling cycle,
+// so state stored on the plugin instance is lost between cycles. These globals
+// survive across the scheduler process lifetime.
+var (
+	globalMu        sync.Mutex
+	globalUsage     = make(map[string]map[string]float64) // [queue][user] → resource-seconds
+	globalLastCycle time.Time
+)
+
+const (
+	// PluginName is the name used to register this plugin with the framework.
+	PluginName = "fairshare"
+
+	defaultResourceKey     = "nvidia.com/gpu"
+	defaultUnknownUser     = "_unknown"
+	defaultHalfLifeMinutes = 240 // 4 hours
+	usageEpsilon           = 1.0 // 1 resource-second: treat as equal
+	usageCleanupThreshold  = 0.01
+)
+
+// queueState holds per-queue fair share tracking for one scheduling cycle.
+type queueState struct {
+	resourceKey   v1.ResourceName
+	totalResource float64
+	userRunning   map[string]float64
+	userDemand    map[string]float64
+	fairShares    map[string]float64
+}
+
+type fairSharePlugin struct {
+	pluginArguments framework.Arguments
+
+	defaultResource   string
+	enableEnqueueGate bool
+	queueResourceKeys map[string]string
+	targetQueueNames  map[string]struct{}
+	halfLife          time.Duration
+
+	queues map[string]*queueState
+
+	// sessionUsage is a per-session snapshot of globalUsage taken under lock.
+	// All reads during the scheduling cycle use this snapshot to avoid races.
+	sessionUsage map[string]map[string]float64
+}
+
+// New creates a new fairSharePlugin instance with the given plugin arguments.
+//
+// Supported arguments:
+//
+//	fairshare.targetQueues        - comma-separated queue names (required)
+//	fairshare.resourceKey         - default resource to track (default: "nvidia.com/gpu")
+//	fairshare.resourceKey.<queue> - per-queue resource override (e.g., "cpu" for a CPU queue)
+//	fairshare.enableEnqueueGate   - "true" to enable enqueue gating (default: "false", ordering only)
+//	fairshare.halfLifeMinutes     - half-life for usage decay in minutes (default: 240 = 4 hours)
+func New(arguments framework.Arguments) framework.Plugin {
+	fsp := &fairSharePlugin{
+		pluginArguments:   arguments,
+		defaultResource:   defaultResourceKey,
+		queueResourceKeys: make(map[string]string),
+		targetQueueNames:  make(map[string]struct{}),
+	}
+
+	var rk string
+	arguments.GetString(&rk, "fairshare.resourceKey")
+	if rk != "" {
+		fsp.defaultResource = rk
+	}
+
+	var queuesArg string
+	arguments.GetString(&queuesArg, "fairshare.targetQueues")
+	if queuesArg != "" {
+		for _, q := range strings.Split(queuesArg, ",") {
+			q = strings.TrimSpace(q)
+			if q != "" {
+				fsp.targetQueueNames[q] = struct{}{}
+			}
+		}
+	}
+
+	for queueName := range fsp.targetQueueNames {
+		var queueRK string
+		arguments.GetString(&queueRK, "fairshare.resourceKey."+queueName)
+		if queueRK != "" {
+			fsp.queueResourceKeys[queueName] = queueRK
+		}
+	}
+
+	var gateStr string
+	arguments.GetString(&gateStr, "fairshare.enableEnqueueGate")
+	fsp.enableEnqueueGate = strings.EqualFold(strings.TrimSpace(gateStr), "true")
+
+	fsp.halfLife = defaultHalfLifeMinutes * time.Minute
+	var halfLifeStr string
+	arguments.GetString(&halfLifeStr, "fairshare.halfLifeMinutes")
+	if halfLifeStr != "" {
+		if mins, err := strconv.Atoi(strings.TrimSpace(halfLifeStr)); err == nil && mins > 0 {
+			fsp.halfLife = time.Duration(mins) * time.Minute
+		}
+	}
+
+	klog.V(2).Infof("fairshare: plugin created — queues=%v resource=%s halfLife=%s enqueueGate=%v",
+		fsp.targetQueueNames, fsp.defaultResource, fsp.halfLife, fsp.enableEnqueueGate)
+
+	return fsp
+}
+
+func (fsp *fairSharePlugin) Name() string {
+	return PluginName
+}
+
+// OnSessionOpen is called at the beginning of each scheduling cycle. It:
+//  1. Decays historical usage and accumulates running usage for the elapsed period
+//  2. Scans all jobs in target queues, computes per-user resource demand and running counts
+//  3. Runs the max-min fairness algorithm per queue
+//  4. Registers JobOrderFn (usage-based ordering), optional JobEnqueueableFn, and EventHandler
+func (fsp *fairSharePlugin) OnSessionOpen(ssn *framework.Session) {
+	klog.V(4).Infof("fairshare: OnSessionOpen enter")
+
+	fsp.queues = make(map[string]*queueState)
+
+	for queueName := range fsp.targetQueueNames {
+		resourceKey := fsp.getResourceKey(queueName)
+		totalResource := fsp.getQueueTotalResource(ssn, queueName, resourceKey)
+
+		fsp.queues[queueName] = &queueState{
+			resourceKey:   resourceKey,
+			totalResource: totalResource,
+			userRunning:   make(map[string]float64),
+			userDemand:    make(map[string]float64),
+		}
+	}
+
+	// Hold globalMu for the entire decay + accumulation phase, then snapshot.
+	globalMu.Lock()
+	now := time.Now()
+	var elapsed time.Duration
+	if !globalLastCycle.IsZero() {
+		elapsed = now.Sub(globalLastCycle)
+		decayAllUsage(elapsed, fsp.halfLife)
+		klog.V(3).Infof("fairshare: decay applied — elapsed=%s factor=%.6f halfLife=%s",
+			elapsed.Round(time.Millisecond), DecayFactor(elapsed, fsp.halfLife), fsp.halfLife)
+	}
+	globalLastCycle = now
+
+	// Accumulate running usage under the lock.
+	for _, job := range ssn.Jobs {
+		queueName, targeted := fsp.getQueueName(ssn, job)
+		if !targeted {
+			continue
+		}
+
+		qs := fsp.queues[queueName]
+		user := fsp.getUserFromJob(job)
+
+		for status, tasks := range job.TaskStatusIndex {
+			if api.AllocatedStatus(status) {
+				for _, task := range tasks {
+					res := taskResource(task, qs.resourceKey)
+					qs.userRunning[user] += res
+
+					if elapsed > 0 {
+						ensureGlobalQueueUsage(queueName)[user] += res * elapsed.Seconds()
+					}
+				}
+			}
+		}
+
+		if pendingTasks, ok := job.TaskStatusIndex[api.Pending]; ok {
+			for _, task := range pendingTasks {
+				qs.userDemand[user] += taskResource(task, qs.resourceKey)
+			}
+		}
+	}
+
+	// Snapshot globalUsage so callbacks can read without holding the lock.
+	fsp.sessionUsage = snapshotUsage()
+	globalMu.Unlock()
+
+	for queueName, qs := range fsp.queues {
+		totalDemand := make(map[string]float64)
+		for user := range qs.userRunning {
+			totalDemand[user] = qs.userRunning[user] + qs.userDemand[user]
+		}
+		for user := range qs.userDemand {
+			if _, ok := totalDemand[user]; !ok {
+				totalDemand[user] = qs.userDemand[user]
+			}
+		}
+
+		qs.fairShares = CalculateFairShares(totalDemand, qs.totalResource)
+
+		usage := fsp.sessionUsage[queueName]
+		klog.V(2).Infof("fairshare: queue=%s users=%d totalResource=%.0f running=%v demand=%v",
+			queueName, len(totalDemand), qs.totalResource, qs.userRunning, qs.userDemand)
+		klog.V(3).Infof("fairshare: queue=%s shares=%v usage=%v halfLife=%s",
+			queueName, qs.fairShares, formatUsage(usage), fsp.halfLife)
+	}
+
+	ssn.AddJobOrderFn(fsp.Name(), func(l interface{}, r interface{}) int {
+		lJob := l.(*api.JobInfo)
+		rJob := r.(*api.JobInfo)
+
+		lQueue, lTarget := fsp.getQueueName(ssn, lJob)
+		rQueue, rTarget := fsp.getQueueName(ssn, rJob)
+
+		if !lTarget && !rTarget {
+			return 0
+		}
+		if !lTarget {
+			return -1
+		}
+		if !rTarget {
+			return 1
+		}
+		if lQueue != rQueue {
+			return 0
+		}
+
+		qs := fsp.queues[lQueue]
+		lUser := fsp.getUserFromJob(lJob)
+		rUser := fsp.getUserFromJob(rJob)
+
+		queueUsage := fsp.sessionUsage[lQueue]
+		lUsage := queueUsage[lUser]
+		rUsage := queueUsage[rUser]
+
+		klog.V(5).Infof("fairshare: JobOrderFn: <%s/%s> user=%s usage=%.1f running=%.0f, <%s/%s> user=%s usage=%.1f running=%.0f",
+			lJob.Namespace, lJob.Name, lUser, lUsage, qs.userRunning[lUser],
+			rJob.Namespace, rJob.Name, rUser, rUsage, qs.userRunning[rUser])
+
+		if lUsage < rUsage-usageEpsilon {
+			klog.V(3).Infof("fairshare: JobOrderFn: %s/%s WINS over %s/%s (usage %.1f < %.1f)",
+				lJob.Namespace, lJob.Name, rJob.Namespace, rJob.Name, lUsage, rUsage)
+			return -1
+		}
+		if lUsage > rUsage+usageEpsilon {
+			klog.V(3).Infof("fairshare: JobOrderFn: %s/%s WINS over %s/%s (usage %.1f < %.1f)",
+				rJob.Namespace, rJob.Name, lJob.Namespace, lJob.Name, rUsage, lUsage)
+			return 1
+		}
+
+		lRunning := qs.userRunning[lUser]
+		rRunning := qs.userRunning[rUser]
+		if lRunning < rRunning {
+			return -1
+		}
+		if lRunning > rRunning {
+			return 1
+		}
+
+		return 0
+	})
+
+	if fsp.enableEnqueueGate {
+		ssn.AddJobEnqueueableFn(fsp.Name(), func(obj interface{}) int {
+			job := obj.(*api.JobInfo)
+
+			queueName, targeted := fsp.getQueueName(ssn, job)
+			if !targeted {
+				return util.Abstain
+			}
+
+			qs := fsp.queues[queueName]
+			user := fsp.getUserFromJob(job)
+			share, ok := qs.fairShares[user]
+			if !ok {
+				return util.Abstain
+			}
+
+			running := qs.userRunning[user]
+			jobRes := jobTotalResource(job, qs.resourceKey)
+
+			klog.V(5).Infof("fairshare: JobEnqueueableFn: job=<%s/%s> user=%s running=%.0f jobRes=%.0f share=%.0f",
+				job.Namespace, job.Name, user, running, jobRes, share)
+
+			if running >= share && jobRes > 0 {
+				klog.V(3).Infof("fairshare: REJECT enqueue for <%s/%s>: user %s at %.0f (share=%.0f)",
+					job.Namespace, job.Name, user, running, share)
+				return util.Reject
+			}
+
+			return util.Abstain
+		})
+	}
+
+	ssn.AddEventHandler(&framework.EventHandler{
+		AllocateFunc: func(event *framework.Event) {
+			task := event.Task
+			job, ok := ssn.Jobs[task.Job]
+			if !ok {
+				return
+			}
+			queueName, targeted := fsp.getQueueName(ssn, job)
+			if !targeted {
+				return
+			}
+			qs := fsp.queues[queueName]
+			user := fsp.getUserFromJob(job)
+			res := taskResource(task, qs.resourceKey)
+			qs.userRunning[user] += res
+
+			klog.V(4).Infof("fairshare: AllocateFunc: task=<%s/%s> user=%s res=%.0f newRunning=%.0f usage=%.1f share=%.0f",
+				task.Namespace, task.Name, user, res, qs.userRunning[user],
+				fsp.sessionUsage[queueName][user], qs.fairShares[user])
+		},
+		DeallocateFunc: func(event *framework.Event) {
+			task := event.Task
+			job, ok := ssn.Jobs[task.Job]
+			if !ok {
+				return
+			}
+			queueName, targeted := fsp.getQueueName(ssn, job)
+			if !targeted {
+				return
+			}
+			qs := fsp.queues[queueName]
+			user := fsp.getUserFromJob(job)
+			res := taskResource(task, qs.resourceKey)
+			qs.userRunning[user] -= res
+			if qs.userRunning[user] < 0 {
+				qs.userRunning[user] = 0
+			}
+
+			klog.V(4).Infof("fairshare: DeallocateFunc: task=<%s/%s> user=%s res=%.0f newRunning=%.0f usage=%.1f share=%.0f",
+				task.Namespace, task.Name, user, res, qs.userRunning[user],
+				fsp.sessionUsage[queueName][user], qs.fairShares[user])
+		},
+	})
+}
+
+func (fsp *fairSharePlugin) OnSessionClose(ssn *framework.Session) {
+	klog.V(4).Infof("fairshare: OnSessionClose")
+}
+
+// decayAllUsage applies exponential decay to all historical usage:
+// usage *= 2^(-elapsed/halfLife). Caller must hold globalMu.
+func decayAllUsage(elapsed, halfLife time.Duration) {
+	if elapsed <= 0 || halfLife <= 0 {
+		return
+	}
+	factor := math.Pow(2.0, -elapsed.Seconds()/halfLife.Seconds())
+
+	for _, users := range globalUsage {
+		for user, usage := range users {
+			decayed := usage * factor
+			if decayed < usageCleanupThreshold {
+				delete(users, user)
+			} else {
+				users[user] = decayed
+			}
+		}
+	}
+}
+
+// ensureGlobalQueueUsage returns the usage map for a queue, creating it if needed.
+// Caller must hold globalMu.
+func ensureGlobalQueueUsage(queueName string) map[string]float64 {
+	if _, ok := globalUsage[queueName]; !ok {
+		globalUsage[queueName] = make(map[string]float64)
+	}
+	return globalUsage[queueName]
+}
+
+// snapshotUsage returns a deep copy of globalUsage for lock-free reads.
+// Caller must hold globalMu.
+func snapshotUsage() map[string]map[string]float64 {
+	snap := make(map[string]map[string]float64, len(globalUsage))
+	for queue, users := range globalUsage {
+		userSnap := make(map[string]float64, len(users))
+		for user, val := range users {
+			userSnap[user] = val
+		}
+		snap[queue] = userSnap
+	}
+	return snap
+}
+
+// DecayFactor computes 2^(-elapsed/halfLife), exported for testing.
+func DecayFactor(elapsed, halfLife time.Duration) float64 {
+	if halfLife <= 0 {
+		return 1.0
+	}
+	return math.Pow(2.0, -elapsed.Seconds()/halfLife.Seconds())
+}
+
+func (fsp *fairSharePlugin) getQueueName(ssn *framework.Session, job *api.JobInfo) (string, bool) {
+	queue, ok := ssn.Queues[job.Queue]
+	if !ok {
+		return "", false
+	}
+	_, targeted := fsp.targetQueueNames[queue.Name]
+	return queue.Name, targeted
+}
+
+func (fsp *fairSharePlugin) getResourceKey(queueName string) v1.ResourceName {
+	if rk, ok := fsp.queueResourceKeys[queueName]; ok {
+		return v1.ResourceName(rk)
+	}
+	return v1.ResourceName(fsp.defaultResource)
+}
+
+func (fsp *fairSharePlugin) getQueueTotalResource(ssn *framework.Session, queueName string, resourceKey v1.ResourceName) float64 {
+	if queueInfo, ok := ssn.Queues[api.QueueID(queueName)]; ok && queueInfo.Queue != nil {
+		cap := queueInfo.Queue.Spec.Capability
+		if cap != nil {
+			capResource := api.NewResource(cap)
+			if total := capResource.Get(resourceKey); total > 0 {
+				return total
+			}
+		}
+	}
+	return ssn.TotalResource.Get(resourceKey)
+}
+
+func (fsp *fairSharePlugin) getUserFromJob(job *api.JobInfo) string {
+	if job.Namespace != "" {
+		return job.Namespace
+	}
+	return defaultUnknownUser
+}
+
+func taskResource(task *api.TaskInfo, resourceKey v1.ResourceName) float64 {
+	if task.Resreq == nil {
+		return 0
+	}
+	return task.Resreq.Get(resourceKey)
+}
+
+func jobTotalResource(job *api.JobInfo, resourceKey v1.ResourceName) float64 {
+	total := 0.0
+	for _, task := range job.Tasks {
+		total += taskResource(task, resourceKey)
+	}
+	return total
+}
+
+// CalculateFairShares implements the max-min fairness algorithm.
+// Given a map of user -> total resource demand and the total available resources,
+// it returns a map of user -> fair share allocation.
+func CalculateFairShares(userDemand map[string]float64, totalResource float64) map[string]float64 {
+	shares := make(map[string]float64, len(userDemand))
+
+	if len(userDemand) == 0 || totalResource <= 0 {
+		return shares
+	}
+
+	remaining := make(map[string]float64, len(userDemand))
+	for user, demand := range userDemand {
+		if demand > 0 {
+			remaining[user] = demand
+		}
+	}
+
+	if len(remaining) == 0 {
+		return shares
+	}
+
+	available := totalResource
+
+	for len(remaining) > 0 {
+		equalShare := available / float64(len(remaining))
+
+		var satisfied []string
+		for user, demand := range remaining {
+			if demand <= equalShare {
+				shares[user] = demand
+				available -= demand
+				satisfied = append(satisfied, user)
+			}
+		}
+
+		for _, user := range satisfied {
+			delete(remaining, user)
+		}
+
+		if len(satisfied) == 0 {
+			for user := range remaining {
+				shares[user] = equalShare
+			}
+			break
+		}
+	}
+
+	return shares
+}
+
+// FormatShares returns a human-readable string of fair share allocations.
+func FormatShares(shares map[string]float64) string {
+	parts := make([]string, 0, len(shares))
+	for user, share := range shares {
+		parts = append(parts, fmt.Sprintf("%s=%.1f", user, share))
+	}
+	return strings.Join(parts, ", ")
+}
+
+func formatUsage(usage map[string]float64) string {
+	parts := make([]string, 0, len(usage))
+	for user, u := range usage {
+		parts = append(parts, fmt.Sprintf("%s=%.1f", user, u))
+	}
+	if len(parts) == 0 {
+		return "{}"
+	}
+	return strings.Join(parts, ", ")
+}

--- a/pkg/scheduler/plugins/fairshare/fairshare.go
+++ b/pkg/scheduler/plugins/fairshare/fairshare.go
@@ -82,6 +82,7 @@ type fairSharePlugin struct {
 	queueResourceKeys map[string]string
 	targetQueueNames  map[string]struct{}
 	halfLife          time.Duration
+	persistCfg        persistConfig
 
 	queues map[string]*queueState
 
@@ -94,11 +95,15 @@ type fairSharePlugin struct {
 //
 // Supported arguments:
 //
-//	fairshare.targetQueues        - comma-separated queue names (required)
-//	fairshare.resourceKey         - default resource to track (default: "nvidia.com/gpu")
-//	fairshare.resourceKey.<queue> - per-queue resource override (e.g., "cpu" for a CPU queue)
-//	fairshare.enableEnqueueGate   - "true" to enable enqueue gating (default: "false", ordering only)
-//	fairshare.halfLifeMinutes     - half-life for usage decay in minutes (default: 240 = 4 hours)
+//	fairshare.targetQueues          - comma-separated queue names (required)
+//	fairshare.resourceKey           - default resource to track (default: "nvidia.com/gpu")
+//	fairshare.resourceKey.<queue>   - per-queue resource override (e.g., "cpu" for a CPU queue)
+//	fairshare.enableEnqueueGate     - "true" to enable enqueue gating (default: "false", ordering only)
+//	fairshare.halfLifeMinutes       - half-life for usage decay in minutes (default: 240 = 4 hours)
+//	fairshare.persistState          - "true" to persist usage to a ConfigMap across restarts (default: "false")
+//	fairshare.stateNamespace        - namespace for the state ConfigMap (default: "volcano-system")
+//	fairshare.stateConfigMap        - name of the state ConfigMap (default: "fairshare-usage-state")
+//	fairshare.flushIntervalSeconds  - how often to flush state in seconds (default: 30)
 func New(arguments framework.Arguments) framework.Plugin {
 	fsp := &fairSharePlugin{
 		pluginArguments:   arguments,
@@ -145,8 +150,37 @@ func New(arguments framework.Arguments) framework.Plugin {
 		}
 	}
 
-	klog.V(2).Infof("fairshare: plugin created — queues=%v resource=%s halfLife=%s enqueueGate=%v",
-		fsp.targetQueueNames, fsp.defaultResource, fsp.halfLife, fsp.enableEnqueueGate)
+	fsp.persistCfg = persistConfig{
+		namespace:     defaultStateNamespace,
+		configMapName: defaultConfigMapName,
+		flushInterval: defaultFlushInterval,
+	}
+	var persistStr string
+	arguments.GetString(&persistStr, "fairshare.persistState")
+	fsp.persistCfg.enabled = strings.EqualFold(strings.TrimSpace(persistStr), "true")
+
+	var stateNS string
+	arguments.GetString(&stateNS, "fairshare.stateNamespace")
+	if stateNS != "" {
+		fsp.persistCfg.namespace = strings.TrimSpace(stateNS)
+	}
+
+	var stateCM string
+	arguments.GetString(&stateCM, "fairshare.stateConfigMap")
+	if stateCM != "" {
+		fsp.persistCfg.configMapName = strings.TrimSpace(stateCM)
+	}
+
+	var flushStr string
+	arguments.GetString(&flushStr, "fairshare.flushIntervalSeconds")
+	if flushStr != "" {
+		if secs, err := strconv.Atoi(strings.TrimSpace(flushStr)); err == nil && secs > 0 {
+			fsp.persistCfg.flushInterval = time.Duration(secs) * time.Second
+		}
+	}
+
+	klog.V(2).Infof("fairshare: plugin created — queues=%v resource=%s halfLife=%s enqueueGate=%v persist=%v",
+		fsp.targetQueueNames, fsp.defaultResource, fsp.halfLife, fsp.enableEnqueueGate, fsp.persistCfg.enabled)
 
 	return fsp
 }
@@ -176,6 +210,10 @@ func (fsp *fairSharePlugin) OnSessionOpen(ssn *framework.Session) {
 			userDemand:    make(map[string]float64),
 		}
 	}
+
+	// On the first cycle, load persisted state and start the flush goroutine.
+	// Must happen before acquiring globalMu (loadState takes the lock internally).
+	initPersistence(ssn.KubeClient(), fsp.persistCfg)
 
 	// Hold globalMu for the entire decay + accumulation phase, then snapshot.
 	globalMu.Lock()

--- a/pkg/scheduler/plugins/fairshare/fairshare.go
+++ b/pkg/scheduler/plugins/fairshare/fairshare.go
@@ -15,18 +15,23 @@ limitations under the License.
 */
 
 // Package fairshare implements a Volcano scheduler plugin that provides
-// per-user fair share scheduling within target queues using decayed cumulative
-// usage tracking. It prevents any single user from monopolizing resources when
-// multiple users have pending work, and remembers past usage across scheduling
-// cycles so that heavy consumers are deprioritized even after their jobs finish.
+// per-namespace fair share scheduling within target queues using decayed
+// cumulative usage tracking. It prevents any single namespace from
+// monopolizing resources when multiple namespaces have pending work, and
+// remembers past usage across scheduling cycles so that heavy consumers are
+// deprioritized even after their jobs finish.
 //
-// User identity is derived from the job's namespace (namespace-per-user pattern).
+// Tenant identity is the job's namespace — namespace is used directly rather
+// than a separate "user" concept, since not every cluster maps users to
+// namespaces one-to-one (e.g. a namespace may itself represent a team or
+// project shared by several users).
 // The tracked resource type is configurable per queue (e.g., nvidia.com/gpu for
 // GPU queues, cpu for CPU queues).
 //
 // Historical usage decays exponentially with a configurable half-life (default
-// 4 hours). This means a user who consumed 10 GPU-hours will see their usage
-// penalty halve every 4 hours, naturally converging back to equal priority.
+// 4 hours). This means a namespace that consumed 10 GPU-hours will see its
+// usage penalty halve every 4 hours, naturally converging back to equal
+// priority.
 package fairshare
 
 import (
@@ -50,7 +55,7 @@ import (
 // survive across the scheduler process lifetime.
 var (
 	globalMu        sync.Mutex
-	globalUsage     = make(map[string]map[string]float64) // [queue][user] → resource-seconds
+	globalUsage     = make(map[string]map[string]float64) // [queue][namespace] → resource-seconds
 	globalLastCycle time.Time
 )
 
@@ -58,20 +63,20 @@ const (
 	// PluginName is the name used to register this plugin with the framework.
 	PluginName = "fairshare"
 
-	defaultResourceKey     = "nvidia.com/gpu"
-	defaultUnknownUser     = "_unknown"
-	defaultHalfLifeMinutes = 240 // 4 hours
-	usageEpsilon           = 1.0 // 1 resource-second: treat as equal
-	usageCleanupThreshold  = 0.01
+	defaultResourceKey      = "nvidia.com/gpu"
+	defaultUnknownNamespace = "_unknown"
+	defaultHalfLifeMinutes  = 240 // 4 hours
+	usageEpsilon            = 1.0 // 1 resource-second: treat as equal
+	usageCleanupThreshold   = 0.01
 )
 
 // queueState holds per-queue fair share tracking for one scheduling cycle.
 type queueState struct {
-	resourceKey   v1.ResourceName
-	totalResource float64
-	userRunning   map[string]float64
-	userDemand    map[string]float64
-	fairShares    map[string]float64
+	resourceKey      v1.ResourceName
+	totalResource    float64
+	namespaceRunning map[string]float64
+	namespaceDemand  map[string]float64
+	fairShares       map[string]float64
 }
 
 type fairSharePlugin struct {
@@ -202,7 +207,7 @@ func (fsp *fairSharePlugin) Name() string {
 
 // OnSessionOpen is called at the beginning of each scheduling cycle. It:
 //  1. Decays historical usage and accumulates running usage for the elapsed period
-//  2. Scans all jobs in target queues, computes per-user resource demand and running counts
+//  2. Scans all jobs in target queues, computes per-namespace resource demand and running counts
 //  3. Runs the max-min fairness algorithm per queue
 //  4. Registers JobOrderFn (usage-based ordering), optional JobEnqueueableFn, and EventHandler
 func (fsp *fairSharePlugin) OnSessionOpen(ssn *framework.Session) {
@@ -244,16 +249,16 @@ func (fsp *fairSharePlugin) OnSessionOpen(ssn *framework.Session) {
 		}
 
 		qs := fsp.queues[queueName]
-		user := fsp.getUserFromJob(job)
+		namespace := fsp.getNamespaceFromJob(job)
 
 		for status, tasks := range job.TaskStatusIndex {
 			if api.AllocatedStatus(status) {
 				for _, task := range tasks {
 					res := taskResource(task, qs.resourceKey)
-					qs.userRunning[user] += res
+					qs.namespaceRunning[namespace] += res
 
 					if elapsed > 0 {
-						ensureGlobalQueueUsage(queueName)[user] += res * elapsed.Seconds()
+						ensureGlobalQueueUsage(queueName)[namespace] += res * elapsed.Seconds()
 					}
 				}
 			}
@@ -261,7 +266,7 @@ func (fsp *fairSharePlugin) OnSessionOpen(ssn *framework.Session) {
 
 		if pendingTasks, ok := job.TaskStatusIndex[api.Pending]; ok {
 			for _, task := range pendingTasks {
-				qs.userDemand[user] += taskResource(task, qs.resourceKey)
+				qs.namespaceDemand[namespace] += taskResource(task, qs.resourceKey)
 			}
 		}
 	}
@@ -272,20 +277,20 @@ func (fsp *fairSharePlugin) OnSessionOpen(ssn *framework.Session) {
 
 	for queueName, qs := range fsp.queues {
 		totalDemand := make(map[string]float64)
-		for user := range qs.userRunning {
-			totalDemand[user] = qs.userRunning[user] + qs.userDemand[user]
+		for namespace := range qs.namespaceRunning {
+			totalDemand[namespace] = qs.namespaceRunning[namespace] + qs.namespaceDemand[namespace]
 		}
-		for user := range qs.userDemand {
-			if _, ok := totalDemand[user]; !ok {
-				totalDemand[user] = qs.userDemand[user]
+		for namespace := range qs.namespaceDemand {
+			if _, ok := totalDemand[namespace]; !ok {
+				totalDemand[namespace] = qs.namespaceDemand[namespace]
 			}
 		}
 
 		qs.fairShares = CalculateFairShares(totalDemand, qs.totalResource)
 
 		usage := fsp.sessionUsage[queueName]
-		klog.V(2).Infof("fairshare: queue=%s users=%d totalResource=%.0f running=%v demand=%v",
-			queueName, len(totalDemand), qs.totalResource, qs.userRunning, qs.userDemand)
+		klog.V(2).Infof("fairshare: queue=%s namespaces=%d totalResource=%.0f running=%v demand=%v",
+			queueName, len(totalDemand), qs.totalResource, qs.namespaceRunning, qs.namespaceDemand)
 		klog.V(3).Infof("fairshare: queue=%s shares=%v usage=%v halfLife=%s",
 			queueName, qs.fairShares, formatUsage(usage), fsp.halfLife)
 	}
@@ -311,16 +316,16 @@ func (fsp *fairSharePlugin) OnSessionOpen(ssn *framework.Session) {
 		}
 
 		qs := fsp.queues[lQueue]
-		lUser := fsp.getUserFromJob(lJob)
-		rUser := fsp.getUserFromJob(rJob)
+		lNamespace := fsp.getNamespaceFromJob(lJob)
+		rNamespace := fsp.getNamespaceFromJob(rJob)
 
 		queueUsage := fsp.sessionUsage[lQueue]
-		lUsage := queueUsage[lUser]
-		rUsage := queueUsage[rUser]
+		lUsage := queueUsage[lNamespace]
+		rUsage := queueUsage[rNamespace]
 
-		klog.V(5).Infof("fairshare: JobOrderFn: <%s/%s> user=%s usage=%.1f running=%.0f, <%s/%s> user=%s usage=%.1f running=%.0f",
-			lJob.Namespace, lJob.Name, lUser, lUsage, qs.userRunning[lUser],
-			rJob.Namespace, rJob.Name, rUser, rUsage, qs.userRunning[rUser])
+		klog.V(5).Infof("fairshare: JobOrderFn: <%s/%s> namespace=%s usage=%.1f running=%.0f, <%s/%s> namespace=%s usage=%.1f running=%.0f",
+			lJob.Namespace, lJob.Name, lNamespace, lUsage, qs.namespaceRunning[lNamespace],
+			rJob.Namespace, rJob.Name, rNamespace, rUsage, qs.namespaceRunning[rNamespace])
 
 		if lUsage < rUsage-usageEpsilon {
 			klog.V(3).Infof("fairshare: JobOrderFn: %s/%s WINS over %s/%s (usage %.1f < %.1f)",
@@ -333,8 +338,8 @@ func (fsp *fairSharePlugin) OnSessionOpen(ssn *framework.Session) {
 			return 1
 		}
 
-		lRunning := qs.userRunning[lUser]
-		rRunning := qs.userRunning[rUser]
+		lRunning := qs.namespaceRunning[lNamespace]
+		rRunning := qs.namespaceRunning[rNamespace]
 		if lRunning < rRunning {
 			return -1
 		}
@@ -355,21 +360,21 @@ func (fsp *fairSharePlugin) OnSessionOpen(ssn *framework.Session) {
 			}
 
 			qs := fsp.queues[queueName]
-			user := fsp.getUserFromJob(job)
-			share, ok := qs.fairShares[user]
+			namespace := fsp.getNamespaceFromJob(job)
+			share, ok := qs.fairShares[namespace]
 			if !ok {
 				return util.Abstain
 			}
 
-			running := qs.userRunning[user]
+			running := qs.namespaceRunning[namespace]
 			jobRes := jobTotalResource(job, qs.resourceKey)
 
-			klog.V(5).Infof("fairshare: JobEnqueueableFn: job=<%s/%s> user=%s running=%.0f jobRes=%.0f share=%.0f",
-				job.Namespace, job.Name, user, running, jobRes, share)
+			klog.V(5).Infof("fairshare: JobEnqueueableFn: job=<%s/%s> namespace=%s running=%.0f jobRes=%.0f share=%.0f",
+				job.Namespace, job.Name, namespace, running, jobRes, share)
 
 			if running >= share && jobRes > 0 {
-				klog.V(3).Infof("fairshare: REJECT enqueue for <%s/%s>: user %s at %.0f (share=%.0f)",
-					job.Namespace, job.Name, user, running, share)
+				klog.V(3).Infof("fairshare: REJECT enqueue for <%s/%s>: namespace %s at %.0f (share=%.0f)",
+					job.Namespace, job.Name, namespace, running, share)
 				return util.Reject
 			}
 
@@ -378,6 +383,19 @@ func (fsp *fairSharePlugin) OnSessionOpen(ssn *framework.Session) {
 	}
 
 	ssn.AddEventHandler(&framework.EventHandler{
+		// AllocateFunc/DeallocateFunc only update qs.namespaceRunning, the
+		// session-local live count used by JobOrderFn/JobEnqueueableFn for
+		// the remainder of *this* cycle. They deliberately do not touch
+		// globalUsage (the persisted, decayed historical total): globalUsage
+		// grows by time-integrating running resource (res * elapsed.Seconds())
+		// once per cycle in OnSessionOpen, using the elapsed wall-clock time
+		// since the previous cycle. A mid-cycle allocation has no elapsed
+		// time associated with it yet — that only becomes known at the start
+		// of the *next* cycle, when this task shows up as already-allocated
+		// in job.TaskStatusIndex and its running time since the last cycle
+		// boundary gets integrated in. So a newly allocated task is missing
+		// from globalUsage for at most one scheduling cycle (~1s), which is
+		// negligible against the default 4h half-life.
 		AllocateFunc: func(event *framework.Event) {
 			task := event.Task
 			job, ok := ssn.Jobs[task.Job]
@@ -389,13 +407,13 @@ func (fsp *fairSharePlugin) OnSessionOpen(ssn *framework.Session) {
 				return
 			}
 			qs := fsp.queues[queueName]
-			user := fsp.getUserFromJob(job)
+			namespace := fsp.getNamespaceFromJob(job)
 			res := taskResource(task, qs.resourceKey)
-			qs.userRunning[user] += res
+			qs.namespaceRunning[namespace] += res
 
-			klog.V(4).Infof("fairshare: AllocateFunc: task=<%s/%s> user=%s res=%.0f newRunning=%.0f usage=%.1f share=%.0f",
-				task.Namespace, task.Name, user, res, qs.userRunning[user],
-				fsp.sessionUsage[queueName][user], qs.fairShares[user])
+			klog.V(4).Infof("fairshare: AllocateFunc: task=<%s/%s> namespace=%s res=%.0f newRunning=%.0f usage=%.1f share=%.0f",
+				task.Namespace, task.Name, namespace, res, qs.namespaceRunning[namespace],
+				fsp.sessionUsage[queueName][namespace], qs.fairShares[namespace])
 		},
 		DeallocateFunc: func(event *framework.Event) {
 			task := event.Task
@@ -408,22 +426,26 @@ func (fsp *fairSharePlugin) OnSessionOpen(ssn *framework.Session) {
 				return
 			}
 			qs := fsp.queues[queueName]
-			user := fsp.getUserFromJob(job)
+			namespace := fsp.getNamespaceFromJob(job)
 			res := taskResource(task, qs.resourceKey)
-			qs.userRunning[user] -= res
-			if qs.userRunning[user] < 0 {
-				qs.userRunning[user] = 0
+			qs.namespaceRunning[namespace] -= res
+			if qs.namespaceRunning[namespace] < 0 {
+				qs.namespaceRunning[namespace] = 0
 			}
 
-			klog.V(4).Infof("fairshare: DeallocateFunc: task=<%s/%s> user=%s res=%.0f newRunning=%.0f usage=%.1f share=%.0f",
-				task.Namespace, task.Name, user, res, qs.userRunning[user],
-				fsp.sessionUsage[queueName][user], qs.fairShares[user])
+			klog.V(4).Infof("fairshare: DeallocateFunc: task=<%s/%s> namespace=%s res=%.0f newRunning=%.0f usage=%.1f share=%.0f",
+				task.Namespace, task.Name, namespace, res, qs.namespaceRunning[namespace],
+				fsp.sessionUsage[queueName][namespace], qs.fairShares[namespace])
 		},
 	})
 }
 
 func (fsp *fairSharePlugin) OnSessionClose(ssn *framework.Session) {
 	klog.V(4).Infof("fairshare: OnSessionClose")
+	// Rate-limited to fairshare.flushIntervalSeconds inside maybeFlush; see
+	// its doc comment in persist.go for why this replaced a background
+	// goroutine+ticker.
+	maybeFlush(fsp.persistCfg)
 }
 
 // decayAllUsage applies exponential decay to all historical usage:
@@ -434,13 +456,13 @@ func decayAllUsage(elapsed, halfLife time.Duration) {
 	}
 	factor := math.Pow(2.0, -elapsed.Seconds()/halfLife.Seconds())
 
-	for _, users := range globalUsage {
-		for user, usage := range users {
+	for _, namespaces := range globalUsage {
+		for namespace, usage := range namespaces {
 			decayed := usage * factor
 			if decayed < usageCleanupThreshold {
-				delete(users, user)
+				delete(namespaces, namespace)
 			} else {
-				users[user] = decayed
+				namespaces[namespace] = decayed
 			}
 		}
 	}
@@ -459,12 +481,12 @@ func ensureGlobalQueueUsage(queueName string) map[string]float64 {
 // Caller must hold globalMu.
 func snapshotUsage() map[string]map[string]float64 {
 	snap := make(map[string]map[string]float64, len(globalUsage))
-	for queue, users := range globalUsage {
-		userSnap := make(map[string]float64, len(users))
-		for user, val := range users {
-			userSnap[user] = val
+	for queue, namespaces := range globalUsage {
+		namespaceSnap := make(map[string]float64, len(namespaces))
+		for namespace, val := range namespaces {
+			namespaceSnap[namespace] = val
 		}
-		snap[queue] = userSnap
+		snap[queue] = namespaceSnap
 	}
 	return snap
 }
@@ -483,10 +505,10 @@ func (fsp *fairSharePlugin) initQueueState(ssn *framework.Session, queueName str
 	totalResource := fsp.getQueueTotalResource(ssn, queueName, resourceKey)
 
 	fsp.queues[queueName] = &queueState{
-		resourceKey:   resourceKey,
-		totalResource: totalResource,
-		userRunning:   make(map[string]float64),
-		userDemand:    make(map[string]float64),
+		resourceKey:      resourceKey,
+		totalResource:    totalResource,
+		namespaceRunning: make(map[string]float64),
+		namespaceDemand:  make(map[string]float64),
 	}
 }
 
@@ -522,11 +544,11 @@ func (fsp *fairSharePlugin) getQueueTotalResource(ssn *framework.Session, queueN
 	return ssn.TotalResource.Get(resourceKey)
 }
 
-func (fsp *fairSharePlugin) getUserFromJob(job *api.JobInfo) string {
+func (fsp *fairSharePlugin) getNamespaceFromJob(job *api.JobInfo) string {
 	if job.Namespace != "" {
 		return job.Namespace
 	}
-	return defaultUnknownUser
+	return defaultUnknownNamespace
 }
 
 func taskResource(task *api.TaskInfo, resourceKey v1.ResourceName) float64 {
@@ -545,19 +567,19 @@ func jobTotalResource(job *api.JobInfo, resourceKey v1.ResourceName) float64 {
 }
 
 // CalculateFairShares implements the max-min fairness algorithm.
-// Given a map of user -> total resource demand and the total available resources,
-// it returns a map of user -> fair share allocation.
-func CalculateFairShares(userDemand map[string]float64, totalResource float64) map[string]float64 {
-	shares := make(map[string]float64, len(userDemand))
+// Given a map of namespace -> total resource demand and the total available resources,
+// it returns a map of namespace -> fair share allocation.
+func CalculateFairShares(namespaceDemand map[string]float64, totalResource float64) map[string]float64 {
+	shares := make(map[string]float64, len(namespaceDemand))
 
-	if len(userDemand) == 0 || totalResource <= 0 {
+	if len(namespaceDemand) == 0 || totalResource <= 0 {
 		return shares
 	}
 
-	remaining := make(map[string]float64, len(userDemand))
-	for user, demand := range userDemand {
+	remaining := make(map[string]float64, len(namespaceDemand))
+	for namespace, demand := range namespaceDemand {
 		if demand > 0 {
-			remaining[user] = demand
+			remaining[namespace] = demand
 		}
 	}
 
@@ -571,21 +593,21 @@ func CalculateFairShares(userDemand map[string]float64, totalResource float64) m
 		equalShare := available / float64(len(remaining))
 
 		var satisfied []string
-		for user, demand := range remaining {
+		for namespace, demand := range remaining {
 			if demand <= equalShare {
-				shares[user] = demand
+				shares[namespace] = demand
 				available -= demand
-				satisfied = append(satisfied, user)
+				satisfied = append(satisfied, namespace)
 			}
 		}
 
-		for _, user := range satisfied {
-			delete(remaining, user)
+		for _, namespace := range satisfied {
+			delete(remaining, namespace)
 		}
 
 		if len(satisfied) == 0 {
-			for user := range remaining {
-				shares[user] = equalShare
+			for namespace := range remaining {
+				shares[namespace] = equalShare
 			}
 			break
 		}
@@ -597,16 +619,16 @@ func CalculateFairShares(userDemand map[string]float64, totalResource float64) m
 // FormatShares returns a human-readable string of fair share allocations.
 func FormatShares(shares map[string]float64) string {
 	parts := make([]string, 0, len(shares))
-	for user, share := range shares {
-		parts = append(parts, fmt.Sprintf("%s=%.1f", user, share))
+	for namespace, share := range shares {
+		parts = append(parts, fmt.Sprintf("%s=%.1f", namespace, share))
 	}
 	return strings.Join(parts, ", ")
 }
 
 func formatUsage(usage map[string]float64) string {
 	parts := make([]string, 0, len(usage))
-	for user, u := range usage {
-		parts = append(parts, fmt.Sprintf("%s=%.1f", user, u))
+	for namespace, u := range usage {
+		parts = append(parts, fmt.Sprintf("%s=%.1f", namespace, u))
 	}
 	if len(parts) == 0 {
 		return "{}"

--- a/pkg/scheduler/plugins/fairshare/fairshare.go
+++ b/pkg/scheduler/plugins/fairshare/fairshare.go
@@ -81,8 +81,11 @@ type fairSharePlugin struct {
 	enableEnqueueGate bool
 	queueResourceKeys map[string]string
 	targetQueueNames  map[string]struct{}
-	halfLife          time.Duration
-	persistCfg        persistConfig
+	// targetAllQueues is true when fairshare.targetQueues is unset, meaning
+	// the plugin applies to every queue instead of a fixed allowlist.
+	targetAllQueues bool
+	halfLife        time.Duration
+	persistCfg      persistConfig
 
 	queues map[string]*queueState
 
@@ -95,7 +98,7 @@ type fairSharePlugin struct {
 //
 // Supported arguments:
 //
-//	fairshare.targetQueues          - comma-separated queue names (required)
+//	fairshare.targetQueues          - comma-separated queue names (default: all queues)
 //	fairshare.resourceKey           - default resource to track (default: "nvidia.com/gpu")
 //	fairshare.resourceKey.<queue>   - per-queue resource override (e.g., "cpu" for a CPU queue)
 //	fairshare.enableEnqueueGate     - "true" to enable enqueue gating (default: "false", ordering only)
@@ -127,6 +130,10 @@ func New(arguments framework.Arguments) framework.Plugin {
 				fsp.targetQueueNames[q] = struct{}{}
 			}
 		}
+	} else {
+		// No allowlist configured: apply fair share to every queue rather
+		// than silently doing nothing.
+		fsp.targetAllQueues = true
 	}
 
 	for queueName := range fsp.targetQueueNames {
@@ -179,8 +186,12 @@ func New(arguments framework.Arguments) framework.Plugin {
 		}
 	}
 
+	queuesLog := interface{}("all")
+	if !fsp.targetAllQueues {
+		queuesLog = fsp.targetQueueNames
+	}
 	klog.V(2).Infof("fairshare: plugin created — queues=%v resource=%s halfLife=%s enqueueGate=%v persist=%v",
-		fsp.targetQueueNames, fsp.defaultResource, fsp.halfLife, fsp.enableEnqueueGate, fsp.persistCfg.enabled)
+		queuesLog, fsp.defaultResource, fsp.halfLife, fsp.enableEnqueueGate, fsp.persistCfg.enabled)
 
 	return fsp
 }
@@ -199,15 +210,13 @@ func (fsp *fairSharePlugin) OnSessionOpen(ssn *framework.Session) {
 
 	fsp.queues = make(map[string]*queueState)
 
-	for queueName := range fsp.targetQueueNames {
-		resourceKey := fsp.getResourceKey(queueName)
-		totalResource := fsp.getQueueTotalResource(ssn, queueName, resourceKey)
-
-		fsp.queues[queueName] = &queueState{
-			resourceKey:   resourceKey,
-			totalResource: totalResource,
-			userRunning:   make(map[string]float64),
-			userDemand:    make(map[string]float64),
+	if fsp.targetAllQueues {
+		for _, queueInfo := range ssn.Queues {
+			fsp.initQueueState(ssn, queueInfo.Name)
+		}
+	} else {
+		for queueName := range fsp.targetQueueNames {
+			fsp.initQueueState(ssn, queueName)
 		}
 	}
 
@@ -468,10 +477,26 @@ func DecayFactor(elapsed, halfLife time.Duration) float64 {
 	return math.Pow(2.0, -elapsed.Seconds()/halfLife.Seconds())
 }
 
+// initQueueState creates the per-cycle queueState entry for queueName.
+func (fsp *fairSharePlugin) initQueueState(ssn *framework.Session, queueName string) {
+	resourceKey := fsp.getResourceKey(queueName)
+	totalResource := fsp.getQueueTotalResource(ssn, queueName, resourceKey)
+
+	fsp.queues[queueName] = &queueState{
+		resourceKey:   resourceKey,
+		totalResource: totalResource,
+		userRunning:   make(map[string]float64),
+		userDemand:    make(map[string]float64),
+	}
+}
+
 func (fsp *fairSharePlugin) getQueueName(ssn *framework.Session, job *api.JobInfo) (string, bool) {
 	queue, ok := ssn.Queues[job.Queue]
 	if !ok {
 		return "", false
+	}
+	if fsp.targetAllQueues {
+		return queue.Name, true
 	}
 	_, targeted := fsp.targetQueueNames[queue.Name]
 	return queue.Name, targeted

--- a/pkg/scheduler/plugins/fairshare/fairshare.go
+++ b/pkg/scheduler/plugins/fairshare/fairshare.go
@@ -159,6 +159,9 @@ func New(arguments framework.Arguments) framework.Plugin {
 	if halfLifeStr != "" {
 		if mins, err := strconv.Atoi(strings.TrimSpace(halfLifeStr)); err == nil && mins > 0 {
 			fsp.halfLife = time.Duration(mins) * time.Minute
+		} else {
+			klog.Warningf("[fairshare] invalid fairshare.halfLifeMinutes=%q (must be a positive integer); using default %s",
+				halfLifeStr, fsp.halfLife)
 		}
 	}
 
@@ -188,6 +191,9 @@ func New(arguments framework.Arguments) framework.Plugin {
 	if flushStr != "" {
 		if secs, err := strconv.Atoi(strings.TrimSpace(flushStr)); err == nil && secs > 0 {
 			fsp.persistCfg.flushInterval = time.Duration(secs) * time.Second
+		} else {
+			klog.Warningf("[fairshare] invalid fairshare.flushIntervalSeconds=%q (must be a positive integer); using default %s",
+				flushStr, fsp.persistCfg.flushInterval)
 		}
 	}
 
@@ -551,10 +557,20 @@ func (fsp *fairSharePlugin) getQueueTotalResource(ssn *framework.Session, queueN
 	return ssn.TotalResource.Get(resourceKey)
 }
 
+// emptyNamespaceWarnOnce logs a single warning the first time a job with an
+// empty namespace is encountered, so an unexpected upstream bug (a job
+// created without a namespace) doesn't silently and repeatedly get bucketed
+// into a shared _unknown namespace with no signal.
+var emptyNamespaceWarnOnce sync.Once
+
 func (fsp *fairSharePlugin) getNamespaceFromJob(job *api.JobInfo) string {
 	if job.Namespace != "" {
 		return job.Namespace
 	}
+	emptyNamespaceWarnOnce.Do(func() {
+		klog.Warningf("[fairshare] job %q has an empty namespace; bucketing into shared %q namespace — this should not happen in normal operation and may indicate a bug upstream of this plugin",
+			job.Name, defaultUnknownNamespace)
+	})
 	return defaultUnknownNamespace
 }
 

--- a/pkg/scheduler/plugins/fairshare/fairshare.go
+++ b/pkg/scheduler/plugins/fairshare/fairshare.go
@@ -1,0 +1,680 @@
+/*
+Copyright 2025 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package fairshare implements a Volcano scheduler plugin that provides
+// per-namespace fair share scheduling within target queues using decayed
+// cumulative usage tracking. It prevents any single namespace from
+// monopolizing resources when multiple namespaces have pending work, and
+// remembers past usage across scheduling cycles so that heavy consumers are
+// deprioritized even after their jobs finish.
+//
+// Tenant identity is the job's namespace — namespace is used directly rather
+// than a separate "user" concept, since not every cluster maps users to
+// namespaces one-to-one (e.g. a namespace may itself represent a team or
+// project shared by several users).
+// The tracked resource type is configurable per queue (e.g., nvidia.com/gpu for
+// GPU queues, cpu for CPU queues).
+//
+// Historical usage decays exponentially with a configurable half-life (default
+// 4 hours). This means a namespace that consumed 10 GPU-hours will see its
+// usage penalty halve every 4 hours, naturally converging back to equal
+// priority.
+package fairshare
+
+import (
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/klog/v2"
+
+	"volcano.sh/volcano/pkg/scheduler/api"
+	"volcano.sh/volcano/pkg/scheduler/framework"
+	"volcano.sh/volcano/pkg/scheduler/metrics"
+	"volcano.sh/volcano/pkg/scheduler/plugins/util"
+)
+
+// fairShareProcessState is fairshare's cross-cycle persistent state. Volcano
+// recreates the plugin instance via New() every scheduling cycle, so this
+// must live at package level to survive between cycles and across the
+// scheduler process lifetime.
+//
+// It is intentionally unguarded by a lock: OnSessionOpen/OnSessionClose are
+// only ever invoked sequentially from the single scheduler goroutine (see
+// pkg/scheduler/scheduler.go, Run()'s `go wait.Until(pc.runOnce, ...)`,
+// which calls runOnce synchronously in a loop and never overlaps
+// invocations). If Volcano ever runs sessions concurrently — e.g. a
+// multi-worker Agent Scheduler — this needs a real redesign, not a
+// reintroduced package-level lock.
+type fairShareProcessState struct {
+	usage     map[string]map[string]float64 // [queue][namespace] → resource-seconds
+	lastCycle time.Time
+
+	persistenceInitialized bool
+	lastFlushAt            time.Time
+}
+
+var state = &fairShareProcessState{
+	usage: make(map[string]map[string]float64),
+}
+
+const (
+	// PluginName is the name used to register this plugin with the framework.
+	PluginName = "fairshare"
+
+	defaultResourceKey      = "nvidia.com/gpu"
+	defaultUnknownNamespace = "_unknown"
+	defaultHalfLifeMinutes  = 240 // 4 hours
+	usageEpsilon            = 1.0 // 1 resource-second: treat as equal
+	usageCleanupThreshold   = 0.01
+)
+
+// queueState holds per-queue fair share tracking for one scheduling cycle.
+type queueState struct {
+	resourceKey      v1.ResourceName
+	totalResource    float64
+	namespaceRunning map[string]float64
+	namespaceDemand  map[string]float64
+	fairShares       map[string]float64
+}
+
+type fairSharePlugin struct {
+	pluginArguments framework.Arguments
+
+	defaultResource   string
+	enableEnqueueGate bool
+	queueResourceKeys map[string]string
+	targetQueueNames  map[string]struct{}
+	// targetAllQueues is true when fairshare.targetQueues is unset, meaning
+	// the plugin applies to every queue instead of a fixed allowlist.
+	targetAllQueues bool
+	halfLife        time.Duration
+	persistCfg      persistConfig
+
+	queues map[string]*queueState
+
+	// sessionUsage is a per-session snapshot of state.usage, taken once at
+	// the top of OnSessionOpen so the rest of the cycle reads a stable view
+	// even as state.usage keeps accumulating for the *next* cycle.
+	sessionUsage map[string]map[string]float64
+}
+
+// New creates a new fairSharePlugin instance with the given plugin arguments.
+//
+// Supported arguments:
+//
+//	fairshare.targetQueues          - comma-separated queue names (default: all queues)
+//	fairshare.resourceKey           - default resource to track (default: "nvidia.com/gpu")
+//	fairshare.resourceKey.<queue>   - per-queue resource override (e.g., "cpu" for a CPU queue)
+//	fairshare.enableEnqueueGate     - "true" to enable enqueue gating (default: "false", ordering only)
+//	fairshare.halfLifeMinutes       - half-life for usage decay in minutes (default: 240 = 4 hours)
+//	fairshare.persistState          - "true" to persist usage to a ConfigMap across restarts (default: "false")
+//	fairshare.stateNamespace        - namespace for the state ConfigMap (default: "volcano-system")
+//	fairshare.stateConfigMap        - name of the state ConfigMap (default: "fairshare-usage-state")
+//	fairshare.flushIntervalSeconds  - how often to flush state in seconds (default: 30)
+func New(arguments framework.Arguments) framework.Plugin {
+	fsp := &fairSharePlugin{
+		pluginArguments:   arguments,
+		defaultResource:   defaultResourceKey,
+		queueResourceKeys: make(map[string]string),
+		targetQueueNames:  make(map[string]struct{}),
+	}
+
+	var rk string
+	arguments.GetString(&rk, "fairshare.resourceKey")
+	if rk != "" {
+		fsp.defaultResource = rk
+	}
+
+	var queuesArg string
+	arguments.GetString(&queuesArg, "fairshare.targetQueues")
+	if queuesArg != "" {
+		for _, q := range strings.Split(queuesArg, ",") {
+			q = strings.TrimSpace(q)
+			if q != "" {
+				fsp.targetQueueNames[q] = struct{}{}
+			}
+		}
+	} else {
+		// No allowlist configured: apply fair share to every queue rather
+		// than silently doing nothing.
+		fsp.targetAllQueues = true
+	}
+
+	for queueName := range fsp.targetQueueNames {
+		var queueRK string
+		arguments.GetString(&queueRK, "fairshare.resourceKey."+queueName)
+		if queueRK != "" {
+			fsp.queueResourceKeys[queueName] = queueRK
+		}
+	}
+
+	var gateStr string
+	arguments.GetString(&gateStr, "fairshare.enableEnqueueGate")
+	fsp.enableEnqueueGate = strings.EqualFold(strings.TrimSpace(gateStr), "true")
+
+	fsp.halfLife = defaultHalfLifeMinutes * time.Minute
+	var halfLifeStr string
+	arguments.GetString(&halfLifeStr, "fairshare.halfLifeMinutes")
+	if halfLifeStr != "" {
+		if mins, err := strconv.Atoi(strings.TrimSpace(halfLifeStr)); err == nil && mins > 0 {
+			fsp.halfLife = time.Duration(mins) * time.Minute
+		} else {
+			klog.Warningf("[fairshare] invalid fairshare.halfLifeMinutes=%q (must be a positive integer); using default %s",
+				halfLifeStr, fsp.halfLife)
+		}
+	}
+
+	fsp.persistCfg = persistConfig{
+		namespace:     defaultStateNamespace,
+		configMapName: defaultConfigMapName,
+		flushInterval: defaultFlushInterval,
+	}
+	var persistStr string
+	arguments.GetString(&persistStr, "fairshare.persistState")
+	fsp.persistCfg.enabled = strings.EqualFold(strings.TrimSpace(persistStr), "true")
+
+	var stateNS string
+	arguments.GetString(&stateNS, "fairshare.stateNamespace")
+	if stateNS != "" {
+		fsp.persistCfg.namespace = strings.TrimSpace(stateNS)
+	}
+
+	var stateCM string
+	arguments.GetString(&stateCM, "fairshare.stateConfigMap")
+	if stateCM != "" {
+		fsp.persistCfg.configMapName = strings.TrimSpace(stateCM)
+	}
+
+	var flushStr string
+	arguments.GetString(&flushStr, "fairshare.flushIntervalSeconds")
+	if flushStr != "" {
+		if secs, err := strconv.Atoi(strings.TrimSpace(flushStr)); err == nil && secs > 0 {
+			fsp.persistCfg.flushInterval = time.Duration(secs) * time.Second
+		} else {
+			klog.Warningf("[fairshare] invalid fairshare.flushIntervalSeconds=%q (must be a positive integer); using default %s",
+				flushStr, fsp.persistCfg.flushInterval)
+		}
+	}
+
+	queuesLog := interface{}("all")
+	if !fsp.targetAllQueues {
+		queuesLog = fsp.targetQueueNames
+	}
+	klog.V(2).Infof("[fairshare] plugin created — queues=%v resource=%s halfLife=%s enqueueGate=%v persist=%v",
+		queuesLog, fsp.defaultResource, fsp.halfLife, fsp.enableEnqueueGate, fsp.persistCfg.enabled)
+
+	return fsp
+}
+
+func (fsp *fairSharePlugin) Name() string {
+	return PluginName
+}
+
+// OnSessionOpen is called at the beginning of each scheduling cycle. It:
+//  1. Decays historical usage and accumulates running usage for the elapsed period
+//  2. Scans all jobs in target queues, computes per-namespace resource demand and running counts
+//  3. Runs the max-min fairness algorithm per queue
+//  4. Registers JobOrderFn (usage-based ordering), optional JobEnqueueableFn, and EventHandler
+func (fsp *fairSharePlugin) OnSessionOpen(ssn *framework.Session) {
+	klog.V(4).Infof("[fairshare] OnSessionOpen enter")
+
+	fsp.queues = make(map[string]*queueState)
+
+	if fsp.targetAllQueues {
+		for _, queueInfo := range ssn.Queues {
+			fsp.initQueueState(ssn, queueInfo.Name)
+		}
+	} else {
+		for queueName := range fsp.targetQueueNames {
+			fsp.initQueueState(ssn, queueName)
+		}
+	}
+
+	// On the first cycle, load any persisted state. Flushing state back
+	// out happens later, in OnSessionClose via maybeFlush — not here, and
+	// not via a background goroutine.
+	initPersistence(ssn.KubeClient(), fsp.persistCfg)
+
+	now := time.Now()
+	var elapsed time.Duration
+	if !state.lastCycle.IsZero() {
+		elapsed = now.Sub(state.lastCycle)
+		decayAllUsage(elapsed, fsp.halfLife)
+		klog.V(3).Infof("[fairshare] decay applied — elapsed=%s factor=%.6f halfLife=%s",
+			elapsed.Round(time.Millisecond), DecayFactor(elapsed, fsp.halfLife), fsp.halfLife)
+	}
+	state.lastCycle = now
+
+	// Accumulate running usage.
+	for _, job := range ssn.Jobs {
+		queueName, targeted := fsp.getQueueName(ssn, job)
+		if !targeted {
+			continue
+		}
+
+		qs := fsp.queues[queueName]
+		namespace := fsp.getNamespaceFromJob(job)
+
+		for status, tasks := range job.TaskStatusIndex {
+			if api.AllocatedStatus(status) {
+				for _, task := range tasks {
+					res := taskResource(task, qs.resourceKey)
+					qs.namespaceRunning[namespace] += res
+
+					if elapsed > 0 {
+						ensureGlobalQueueUsage(queueName)[namespace] += res * elapsed.Seconds()
+					}
+				}
+			}
+		}
+
+		if pendingTasks, ok := job.TaskStatusIndex[api.Pending]; ok {
+			for _, task := range pendingTasks {
+				qs.namespaceDemand[namespace] += taskResource(task, qs.resourceKey)
+			}
+		}
+	}
+
+	// Snapshot state.usage so the rest of this cycle reads a stable view
+	// even as state.usage keeps accumulating for the next cycle.
+	fsp.sessionUsage = snapshotUsage()
+
+	for queueName, qs := range fsp.queues {
+		totalDemand := make(map[string]float64)
+		for namespace := range qs.namespaceRunning {
+			totalDemand[namespace] = qs.namespaceRunning[namespace] + qs.namespaceDemand[namespace]
+		}
+		for namespace := range qs.namespaceDemand {
+			if _, ok := totalDemand[namespace]; !ok {
+				totalDemand[namespace] = qs.namespaceDemand[namespace]
+			}
+		}
+
+		qs.fairShares = CalculateFairShares(totalDemand, qs.totalResource)
+
+		usage := fsp.sessionUsage[queueName]
+		klog.V(2).Infof("[fairshare] queue=%s namespaces=%d totalResource=%.0f running=%v demand=%v",
+			queueName, len(totalDemand), qs.totalResource, qs.namespaceRunning, qs.namespaceDemand)
+		klog.V(3).Infof("[fairshare] queue=%s shares=%v usage=%v halfLife=%s",
+			queueName, qs.fairShares, formatUsage(usage), fsp.halfLife)
+
+		resourceKey := string(qs.resourceKey)
+		for namespace, share := range qs.fairShares {
+			metrics.UpdateNamespaceShare(namespace, queueName, resourceKey, share)
+		}
+		for namespace, u := range usage {
+			metrics.UpdateNamespaceDecayedUsage(namespace, queueName, resourceKey, u)
+		}
+	}
+
+	ssn.AddJobOrderFn(fsp.Name(), func(l interface{}, r interface{}) int {
+		lJob := l.(*api.JobInfo)
+		rJob := r.(*api.JobInfo)
+
+		lQueue, lTarget := fsp.getQueueName(ssn, lJob)
+		rQueue, rTarget := fsp.getQueueName(ssn, rJob)
+
+		if shouldAbstainOrdering(lQueue, lTarget, rQueue, rTarget) {
+			return 0
+		}
+
+		qs := fsp.queues[lQueue]
+		lNamespace := fsp.getNamespaceFromJob(lJob)
+		rNamespace := fsp.getNamespaceFromJob(rJob)
+
+		queueUsage := fsp.sessionUsage[lQueue]
+		lUsage := queueUsage[lNamespace]
+		rUsage := queueUsage[rNamespace]
+
+		klog.V(5).Infof("[fairshare] JobOrderFn: <%s/%s> namespace=%s usage=%.1f running=%.0f, <%s/%s> namespace=%s usage=%.1f running=%.0f",
+			lJob.Namespace, lJob.Name, lNamespace, lUsage, qs.namespaceRunning[lNamespace],
+			rJob.Namespace, rJob.Name, rNamespace, rUsage, qs.namespaceRunning[rNamespace])
+
+		if lUsage < rUsage-usageEpsilon {
+			klog.V(3).Infof("[fairshare] JobOrderFn: %s/%s WINS over %s/%s (usage %.1f < %.1f)",
+				lJob.Namespace, lJob.Name, rJob.Namespace, rJob.Name, lUsage, rUsage)
+			return -1
+		}
+		if lUsage > rUsage+usageEpsilon {
+			klog.V(3).Infof("[fairshare] JobOrderFn: %s/%s WINS over %s/%s (usage %.1f < %.1f)",
+				rJob.Namespace, rJob.Name, lJob.Namespace, lJob.Name, rUsage, lUsage)
+			return 1
+		}
+
+		lRunning := qs.namespaceRunning[lNamespace]
+		rRunning := qs.namespaceRunning[rNamespace]
+		if lRunning < rRunning {
+			return -1
+		}
+		if lRunning > rRunning {
+			return 1
+		}
+
+		return 0
+	})
+
+	if fsp.enableEnqueueGate {
+		ssn.AddJobEnqueueableFn(fsp.Name(), func(obj interface{}) int {
+			job := obj.(*api.JobInfo)
+
+			queueName, targeted := fsp.getQueueName(ssn, job)
+			if !targeted {
+				return util.Abstain
+			}
+
+			qs := fsp.queues[queueName]
+			namespace := fsp.getNamespaceFromJob(job)
+			share, ok := qs.fairShares[namespace]
+			if !ok {
+				return util.Abstain
+			}
+
+			running := qs.namespaceRunning[namespace]
+			jobRes := jobTotalResource(job, qs.resourceKey)
+
+			klog.V(5).Infof("[fairshare] JobEnqueueableFn: job=<%s/%s> namespace=%s running=%.0f jobRes=%.0f share=%.0f",
+				job.Namespace, job.Name, namespace, running, jobRes, share)
+
+			if running >= share && jobRes > 0 {
+				klog.V(3).Infof("[fairshare] REJECT enqueue for <%s/%s>: namespace %s at %.0f (share=%.0f)",
+					job.Namespace, job.Name, namespace, running, share)
+				return util.Reject
+			}
+
+			return util.Abstain
+		})
+	}
+
+	ssn.AddEventHandler(&framework.EventHandler{
+		// AllocateFunc/DeallocateFunc only update qs.namespaceRunning, the
+		// session-local live count used by JobOrderFn/JobEnqueueableFn for
+		// the remainder of *this* cycle. They deliberately do not touch
+		// state.usage (the persisted, decayed historical total): state.usage
+		// grows by time-integrating running resource (res * elapsed.Seconds())
+		// once per cycle in OnSessionOpen, using the elapsed wall-clock time
+		// since the previous cycle. A mid-cycle allocation has no elapsed
+		// time associated with it yet — that only becomes known at the start
+		// of the *next* cycle, when this task shows up as already-allocated
+		// in job.TaskStatusIndex and its running time since the last cycle
+		// boundary gets integrated in. So a newly allocated task is missing
+		// from state.usage for at most one scheduling cycle (~1s), which is
+		// negligible against the default 4h half-life.
+		AllocateFunc: func(event *framework.Event) {
+			task := event.Task
+			job, ok := ssn.Jobs[task.Job]
+			if !ok {
+				return
+			}
+			queueName, targeted := fsp.getQueueName(ssn, job)
+			if !targeted {
+				return
+			}
+			qs := fsp.queues[queueName]
+			namespace := fsp.getNamespaceFromJob(job)
+			res := taskResource(task, qs.resourceKey)
+			qs.namespaceRunning[namespace] += res
+
+			klog.V(4).Infof("[fairshare] AllocateFunc: task=<%s/%s> namespace=%s res=%.0f newRunning=%.0f usage=%.1f share=%.0f",
+				task.Namespace, task.Name, namespace, res, qs.namespaceRunning[namespace],
+				fsp.sessionUsage[queueName][namespace], qs.fairShares[namespace])
+		},
+		DeallocateFunc: func(event *framework.Event) {
+			task := event.Task
+			job, ok := ssn.Jobs[task.Job]
+			if !ok {
+				return
+			}
+			queueName, targeted := fsp.getQueueName(ssn, job)
+			if !targeted {
+				return
+			}
+			qs := fsp.queues[queueName]
+			namespace := fsp.getNamespaceFromJob(job)
+			res := taskResource(task, qs.resourceKey)
+			qs.namespaceRunning[namespace] -= res
+			if qs.namespaceRunning[namespace] < 0 {
+				qs.namespaceRunning[namespace] = 0
+			}
+
+			klog.V(4).Infof("[fairshare] DeallocateFunc: task=<%s/%s> namespace=%s res=%.0f newRunning=%.0f usage=%.1f share=%.0f",
+				task.Namespace, task.Name, namespace, res, qs.namespaceRunning[namespace],
+				fsp.sessionUsage[queueName][namespace], qs.fairShares[namespace])
+		},
+	})
+}
+
+func (fsp *fairSharePlugin) OnSessionClose(ssn *framework.Session) {
+	klog.V(4).Infof("[fairshare] OnSessionClose")
+	// Rate-limited to fairshare.flushIntervalSeconds inside maybeFlush; see
+	// its doc comment in persist.go for why this replaced a background
+	// goroutine+ticker.
+	maybeFlush(ssn.KubeClient(), fsp.persistCfg)
+}
+
+// decayAllUsage applies exponential decay to all historical usage:
+// usage *= 2^(-elapsed/halfLife).
+func decayAllUsage(elapsed, halfLife time.Duration) {
+	if elapsed <= 0 || halfLife <= 0 {
+		return
+	}
+	factor := math.Pow(2.0, -elapsed.Seconds()/halfLife.Seconds())
+
+	for _, namespaces := range state.usage {
+		for namespace, usage := range namespaces {
+			decayed := usage * factor
+			if decayed < usageCleanupThreshold {
+				delete(namespaces, namespace)
+			} else {
+				namespaces[namespace] = decayed
+			}
+		}
+	}
+}
+
+// ensureGlobalQueueUsage returns the usage map for a queue, creating it if needed.
+func ensureGlobalQueueUsage(queueName string) map[string]float64 {
+	if _, ok := state.usage[queueName]; !ok {
+		state.usage[queueName] = make(map[string]float64)
+	}
+	return state.usage[queueName]
+}
+
+// snapshotUsage returns a deep copy of state.usage.
+func snapshotUsage() map[string]map[string]float64 {
+	snap := make(map[string]map[string]float64, len(state.usage))
+	for queue, namespaces := range state.usage {
+		namespaceSnap := make(map[string]float64, len(namespaces))
+		for namespace, val := range namespaces {
+			namespaceSnap[namespace] = val
+		}
+		snap[queue] = namespaceSnap
+	}
+	return snap
+}
+
+// DecayFactor computes 2^(-elapsed/halfLife), exported for testing.
+func DecayFactor(elapsed, halfLife time.Duration) float64 {
+	if halfLife <= 0 {
+		return 1.0
+	}
+	return math.Pow(2.0, -elapsed.Seconds()/halfLife.Seconds())
+}
+
+// initQueueState creates the per-cycle queueState entry for queueName.
+func (fsp *fairSharePlugin) initQueueState(ssn *framework.Session, queueName string) {
+	resourceKey := fsp.getResourceKey(queueName)
+	totalResource := fsp.getQueueTotalResource(ssn, queueName, resourceKey)
+
+	fsp.queues[queueName] = &queueState{
+		resourceKey:      resourceKey,
+		totalResource:    totalResource,
+		namespaceRunning: make(map[string]float64),
+		namespaceDemand:  make(map[string]float64),
+	}
+}
+
+// shouldAbstainOrdering reports whether JobOrderFn should abstain (return 0)
+// for a pair of jobs. fairshare is queue-scoped: it has no basis to rank a
+// job against one from a queue it doesn't cover, or two jobs from different
+// targeted queues against each other. Abstaining (rather than picking a
+// winner based on targeting alone) lets other plugins/tiers decide those
+// comparisons instead of fairshare artificially favoring non-targeted-queue
+// jobs.
+func shouldAbstainOrdering(lQueue string, lTarget bool, rQueue string, rTarget bool) bool {
+	if !lTarget || !rTarget {
+		return true
+	}
+	return lQueue != rQueue
+}
+
+func (fsp *fairSharePlugin) getQueueName(ssn *framework.Session, job *api.JobInfo) (string, bool) {
+	queue, ok := ssn.Queues[job.Queue]
+	if !ok {
+		return "", false
+	}
+	if fsp.targetAllQueues {
+		return queue.Name, true
+	}
+	_, targeted := fsp.targetQueueNames[queue.Name]
+	return queue.Name, targeted
+}
+
+func (fsp *fairSharePlugin) getResourceKey(queueName string) v1.ResourceName {
+	if rk, ok := fsp.queueResourceKeys[queueName]; ok {
+		return v1.ResourceName(rk)
+	}
+	return v1.ResourceName(fsp.defaultResource)
+}
+
+func (fsp *fairSharePlugin) getQueueTotalResource(ssn *framework.Session, queueName string, resourceKey v1.ResourceName) float64 {
+	if queueInfo, ok := ssn.Queues[api.QueueID(queueName)]; ok && queueInfo.Queue != nil {
+		cap := queueInfo.Queue.Spec.Capability
+		if cap != nil {
+			capResource := api.NewResource(cap)
+			if total := capResource.Get(resourceKey); total > 0 {
+				return total
+			}
+		}
+	}
+	return ssn.TotalResource.Get(resourceKey)
+}
+
+// emptyNamespaceWarnOnce logs a single warning the first time a job with an
+// empty namespace is encountered, so an unexpected upstream bug (a job
+// created without a namespace) doesn't silently and repeatedly get bucketed
+// into a shared _unknown namespace with no signal.
+var emptyNamespaceWarnOnce sync.Once
+
+func (fsp *fairSharePlugin) getNamespaceFromJob(job *api.JobInfo) string {
+	if job.Namespace != "" {
+		return job.Namespace
+	}
+	emptyNamespaceWarnOnce.Do(func() {
+		klog.Warningf("[fairshare] job %q has an empty namespace; bucketing into shared %q namespace — this should not happen in normal operation and may indicate a bug upstream of this plugin",
+			job.Name, defaultUnknownNamespace)
+	})
+	return defaultUnknownNamespace
+}
+
+func taskResource(task *api.TaskInfo, resourceKey v1.ResourceName) float64 {
+	if task.Resreq == nil {
+		return 0
+	}
+	return task.Resreq.Get(resourceKey)
+}
+
+func jobTotalResource(job *api.JobInfo, resourceKey v1.ResourceName) float64 {
+	total := 0.0
+	for _, task := range job.Tasks {
+		total += taskResource(task, resourceKey)
+	}
+	return total
+}
+
+// CalculateFairShares implements the max-min fairness algorithm.
+// Given a map of namespace -> total resource demand and the total available resources,
+// it returns a map of namespace -> fair share allocation.
+func CalculateFairShares(namespaceDemand map[string]float64, totalResource float64) map[string]float64 {
+	shares := make(map[string]float64, len(namespaceDemand))
+
+	if len(namespaceDemand) == 0 || totalResource <= 0 {
+		return shares
+	}
+
+	remaining := make(map[string]float64, len(namespaceDemand))
+	for namespace, demand := range namespaceDemand {
+		if demand > 0 {
+			remaining[namespace] = demand
+		}
+	}
+
+	if len(remaining) == 0 {
+		return shares
+	}
+
+	available := totalResource
+
+	for len(remaining) > 0 {
+		equalShare := available / float64(len(remaining))
+
+		var satisfied []string
+		for namespace, demand := range remaining {
+			if demand <= equalShare {
+				shares[namespace] = demand
+				available -= demand
+				satisfied = append(satisfied, namespace)
+			}
+		}
+
+		for _, namespace := range satisfied {
+			delete(remaining, namespace)
+		}
+
+		if len(satisfied) == 0 {
+			for namespace := range remaining {
+				shares[namespace] = equalShare
+			}
+			break
+		}
+	}
+
+	return shares
+}
+
+// FormatShares returns a human-readable string of fair share allocations.
+func FormatShares(shares map[string]float64) string {
+	parts := make([]string, 0, len(shares))
+	for namespace, share := range shares {
+		parts = append(parts, fmt.Sprintf("%s=%.1f", namespace, share))
+	}
+	return strings.Join(parts, ", ")
+}
+
+func formatUsage(usage map[string]float64) string {
+	parts := make([]string, 0, len(usage))
+	for namespace, u := range usage {
+		parts = append(parts, fmt.Sprintf("%s=%.1f", namespace, u))
+	}
+	if len(parts) == 0 {
+		return "{}"
+	}
+	return strings.Join(parts, ", ")
+}

--- a/pkg/scheduler/plugins/fairshare/fairshare.go
+++ b/pkg/scheduler/plugins/fairshare/fairshare.go
@@ -195,7 +195,7 @@ func New(arguments framework.Arguments) framework.Plugin {
 	if !fsp.targetAllQueues {
 		queuesLog = fsp.targetQueueNames
 	}
-	klog.V(2).Infof("fairshare: plugin created — queues=%v resource=%s halfLife=%s enqueueGate=%v persist=%v",
+	klog.V(2).Infof("[fairshare] plugin created — queues=%v resource=%s halfLife=%s enqueueGate=%v persist=%v",
 		queuesLog, fsp.defaultResource, fsp.halfLife, fsp.enableEnqueueGate, fsp.persistCfg.enabled)
 
 	return fsp
@@ -211,7 +211,7 @@ func (fsp *fairSharePlugin) Name() string {
 //  3. Runs the max-min fairness algorithm per queue
 //  4. Registers JobOrderFn (usage-based ordering), optional JobEnqueueableFn, and EventHandler
 func (fsp *fairSharePlugin) OnSessionOpen(ssn *framework.Session) {
-	klog.V(4).Infof("fairshare: OnSessionOpen enter")
+	klog.V(4).Infof("[fairshare] OnSessionOpen enter")
 
 	fsp.queues = make(map[string]*queueState)
 
@@ -238,7 +238,7 @@ func (fsp *fairSharePlugin) OnSessionOpen(ssn *framework.Session) {
 	if !globalLastCycle.IsZero() {
 		elapsed = now.Sub(globalLastCycle)
 		decayAllUsage(elapsed, fsp.halfLife)
-		klog.V(3).Infof("fairshare: decay applied — elapsed=%s factor=%.6f halfLife=%s",
+		klog.V(3).Infof("[fairshare] decay applied — elapsed=%s factor=%.6f halfLife=%s",
 			elapsed.Round(time.Millisecond), DecayFactor(elapsed, fsp.halfLife), fsp.halfLife)
 	}
 	globalLastCycle = now
@@ -291,9 +291,9 @@ func (fsp *fairSharePlugin) OnSessionOpen(ssn *framework.Session) {
 		qs.fairShares = CalculateFairShares(totalDemand, qs.totalResource)
 
 		usage := fsp.sessionUsage[queueName]
-		klog.V(2).Infof("fairshare: queue=%s namespaces=%d totalResource=%.0f running=%v demand=%v",
+		klog.V(2).Infof("[fairshare] queue=%s namespaces=%d totalResource=%.0f running=%v demand=%v",
 			queueName, len(totalDemand), qs.totalResource, qs.namespaceRunning, qs.namespaceDemand)
-		klog.V(3).Infof("fairshare: queue=%s shares=%v usage=%v halfLife=%s",
+		klog.V(3).Infof("[fairshare] queue=%s shares=%v usage=%v halfLife=%s",
 			queueName, qs.fairShares, formatUsage(usage), fsp.halfLife)
 	}
 
@@ -316,17 +316,17 @@ func (fsp *fairSharePlugin) OnSessionOpen(ssn *framework.Session) {
 		lUsage := queueUsage[lNamespace]
 		rUsage := queueUsage[rNamespace]
 
-		klog.V(5).Infof("fairshare: JobOrderFn: <%s/%s> namespace=%s usage=%.1f running=%.0f, <%s/%s> namespace=%s usage=%.1f running=%.0f",
+		klog.V(5).Infof("[fairshare] JobOrderFn: <%s/%s> namespace=%s usage=%.1f running=%.0f, <%s/%s> namespace=%s usage=%.1f running=%.0f",
 			lJob.Namespace, lJob.Name, lNamespace, lUsage, qs.namespaceRunning[lNamespace],
 			rJob.Namespace, rJob.Name, rNamespace, rUsage, qs.namespaceRunning[rNamespace])
 
 		if lUsage < rUsage-usageEpsilon {
-			klog.V(3).Infof("fairshare: JobOrderFn: %s/%s WINS over %s/%s (usage %.1f < %.1f)",
+			klog.V(3).Infof("[fairshare] JobOrderFn: %s/%s WINS over %s/%s (usage %.1f < %.1f)",
 				lJob.Namespace, lJob.Name, rJob.Namespace, rJob.Name, lUsage, rUsage)
 			return -1
 		}
 		if lUsage > rUsage+usageEpsilon {
-			klog.V(3).Infof("fairshare: JobOrderFn: %s/%s WINS over %s/%s (usage %.1f < %.1f)",
+			klog.V(3).Infof("[fairshare] JobOrderFn: %s/%s WINS over %s/%s (usage %.1f < %.1f)",
 				rJob.Namespace, rJob.Name, lJob.Namespace, lJob.Name, rUsage, lUsage)
 			return 1
 		}
@@ -362,11 +362,11 @@ func (fsp *fairSharePlugin) OnSessionOpen(ssn *framework.Session) {
 			running := qs.namespaceRunning[namespace]
 			jobRes := jobTotalResource(job, qs.resourceKey)
 
-			klog.V(5).Infof("fairshare: JobEnqueueableFn: job=<%s/%s> namespace=%s running=%.0f jobRes=%.0f share=%.0f",
+			klog.V(5).Infof("[fairshare] JobEnqueueableFn: job=<%s/%s> namespace=%s running=%.0f jobRes=%.0f share=%.0f",
 				job.Namespace, job.Name, namespace, running, jobRes, share)
 
 			if running >= share && jobRes > 0 {
-				klog.V(3).Infof("fairshare: REJECT enqueue for <%s/%s>: namespace %s at %.0f (share=%.0f)",
+				klog.V(3).Infof("[fairshare] REJECT enqueue for <%s/%s>: namespace %s at %.0f (share=%.0f)",
 					job.Namespace, job.Name, namespace, running, share)
 				return util.Reject
 			}
@@ -404,7 +404,7 @@ func (fsp *fairSharePlugin) OnSessionOpen(ssn *framework.Session) {
 			res := taskResource(task, qs.resourceKey)
 			qs.namespaceRunning[namespace] += res
 
-			klog.V(4).Infof("fairshare: AllocateFunc: task=<%s/%s> namespace=%s res=%.0f newRunning=%.0f usage=%.1f share=%.0f",
+			klog.V(4).Infof("[fairshare] AllocateFunc: task=<%s/%s> namespace=%s res=%.0f newRunning=%.0f usage=%.1f share=%.0f",
 				task.Namespace, task.Name, namespace, res, qs.namespaceRunning[namespace],
 				fsp.sessionUsage[queueName][namespace], qs.fairShares[namespace])
 		},
@@ -426,7 +426,7 @@ func (fsp *fairSharePlugin) OnSessionOpen(ssn *framework.Session) {
 				qs.namespaceRunning[namespace] = 0
 			}
 
-			klog.V(4).Infof("fairshare: DeallocateFunc: task=<%s/%s> namespace=%s res=%.0f newRunning=%.0f usage=%.1f share=%.0f",
+			klog.V(4).Infof("[fairshare] DeallocateFunc: task=<%s/%s> namespace=%s res=%.0f newRunning=%.0f usage=%.1f share=%.0f",
 				task.Namespace, task.Name, namespace, res, qs.namespaceRunning[namespace],
 				fsp.sessionUsage[queueName][namespace], qs.fairShares[namespace])
 		},
@@ -434,7 +434,7 @@ func (fsp *fairSharePlugin) OnSessionOpen(ssn *framework.Session) {
 }
 
 func (fsp *fairSharePlugin) OnSessionClose(ssn *framework.Session) {
-	klog.V(4).Infof("fairshare: OnSessionClose")
+	klog.V(4).Infof("[fairshare] OnSessionClose")
 	// Rate-limited to fairshare.flushIntervalSeconds inside maybeFlush; see
 	// its doc comment in persist.go for why this replaced a background
 	// goroutine+ticker.

--- a/pkg/scheduler/plugins/fairshare/fairshare.go
+++ b/pkg/scheduler/plugins/fairshare/fairshare.go
@@ -225,8 +225,10 @@ func (fsp *fairSharePlugin) OnSessionOpen(ssn *framework.Session) {
 		}
 	}
 
-	// On the first cycle, load persisted state and start the flush goroutine.
-	// Must happen before acquiring globalMu (loadState takes the lock internally).
+	// On the first cycle, load any persisted state. Must happen before
+	// acquiring globalMu (loadState takes the lock internally). Flushing
+	// state back out happens later, in OnSessionClose via maybeFlush — not
+	// here, and not via a background goroutine.
 	initPersistence(ssn.KubeClient(), fsp.persistCfg)
 
 	// Hold globalMu for the entire decay + accumulation phase, then snapshot.
@@ -302,16 +304,7 @@ func (fsp *fairSharePlugin) OnSessionOpen(ssn *framework.Session) {
 		lQueue, lTarget := fsp.getQueueName(ssn, lJob)
 		rQueue, rTarget := fsp.getQueueName(ssn, rJob)
 
-		if !lTarget && !rTarget {
-			return 0
-		}
-		if !lTarget {
-			return -1
-		}
-		if !rTarget {
-			return 1
-		}
-		if lQueue != rQueue {
+		if shouldAbstainOrdering(lQueue, lTarget, rQueue, rTarget) {
 			return 0
 		}
 
@@ -510,6 +503,20 @@ func (fsp *fairSharePlugin) initQueueState(ssn *framework.Session, queueName str
 		namespaceRunning: make(map[string]float64),
 		namespaceDemand:  make(map[string]float64),
 	}
+}
+
+// shouldAbstainOrdering reports whether JobOrderFn should abstain (return 0)
+// for a pair of jobs. fairshare is queue-scoped: it has no basis to rank a
+// job against one from a queue it doesn't cover, or two jobs from different
+// targeted queues against each other. Abstaining (rather than picking a
+// winner based on targeting alone) lets other plugins/tiers decide those
+// comparisons instead of fairshare artificially favoring non-targeted-queue
+// jobs.
+func shouldAbstainOrdering(lQueue string, lTarget bool, rQueue string, rTarget bool) bool {
+	if !lTarget || !rTarget {
+		return true
+	}
+	return lQueue != rQueue
 }
 
 func (fsp *fairSharePlugin) getQueueName(ssn *framework.Session, job *api.JobInfo) (string, bool) {

--- a/pkg/scheduler/plugins/fairshare/fairshare_test.go
+++ b/pkg/scheduler/plugins/fairshare/fairshare_test.go
@@ -1,0 +1,473 @@
+/*
+Copyright 2025 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fairshare
+
+import (
+	"math"
+	"testing"
+	"time"
+
+	"volcano.sh/volcano/pkg/scheduler/api"
+)
+
+const eps = 1e-9
+
+func assertShare(t *testing.T, shares map[string]float64, user string, expected float64) {
+	t.Helper()
+	got, ok := shares[user]
+	if !ok {
+		t.Errorf("user %q: not found in shares (expected %.1f)", user, expected)
+		return
+	}
+	if math.Abs(got-expected) > eps {
+		t.Errorf("user %q: got %.4f, want %.4f", user, got, expected)
+	}
+}
+
+func totalShares(shares map[string]float64) float64 {
+	total := 0.0
+	for _, s := range shares {
+		total += s
+	}
+	return total
+}
+
+// --- CalculateFairShares tests ---
+
+func TestFairShares_SingleUser(t *testing.T) {
+	demand := map[string]float64{"alice": 200}
+	shares := CalculateFairShares(demand, 87)
+	assertShare(t, shares, "alice", 87)
+}
+
+func TestFairShares_SingleUserLowDemand(t *testing.T) {
+	demand := map[string]float64{"alice": 10}
+	shares := CalculateFairShares(demand, 87)
+	assertShare(t, shares, "alice", 10)
+}
+
+func TestFairShares_TwoUsersEqual(t *testing.T) {
+	demand := map[string]float64{
+		"alice": 100,
+		"bob":   100,
+	}
+	shares := CalculateFairShares(demand, 87)
+	assertShare(t, shares, "alice", 43.5)
+	assertShare(t, shares, "bob", 43.5)
+}
+
+func TestFairShares_TwoUsersOneLow(t *testing.T) {
+	demand := map[string]float64{
+		"alice": 200,
+		"bob":   10,
+	}
+	shares := CalculateFairShares(demand, 87)
+	assertShare(t, shares, "bob", 10)
+	assertShare(t, shares, "alice", 77)
+}
+
+func TestFairShares_ThreeUsersAsymmetric(t *testing.T) {
+	demand := map[string]float64{
+		"A": 50,
+		"B": 60,
+		"C": 11,
+	}
+	shares := CalculateFairShares(demand, 87)
+	assertShare(t, shares, "C", 11)
+	assertShare(t, shares, "A", 38)
+	assertShare(t, shares, "B", 38)
+
+	if total := totalShares(shares); total > 87+eps {
+		t.Errorf("total shares %.4f exceeds 87", total)
+	}
+}
+
+func TestFairShares_ThreeUsersMixed(t *testing.T) {
+	demand := map[string]float64{
+		"A": 200,
+		"B": 150,
+		"C": 10,
+	}
+	shares := CalculateFairShares(demand, 87)
+	assertShare(t, shares, "C", 10)
+	assertShare(t, shares, "A", 38.5)
+	assertShare(t, shares, "B", 38.5)
+}
+
+func TestFairShares_AllUsersLowDemand(t *testing.T) {
+	demand := map[string]float64{
+		"alice": 5,
+		"bob":   10,
+		"carol": 3,
+	}
+	shares := CalculateFairShares(demand, 87)
+	assertShare(t, shares, "alice", 5)
+	assertShare(t, shares, "bob", 10)
+	assertShare(t, shares, "carol", 3)
+
+	if total := totalShares(shares); total > 18+eps {
+		t.Errorf("total shares %.4f exceeds sum of demands", total)
+	}
+}
+
+func TestFairShares_EmptyDemand(t *testing.T) {
+	shares := CalculateFairShares(map[string]float64{}, 87)
+	if len(shares) != 0 {
+		t.Errorf("expected empty shares, got %v", shares)
+	}
+}
+
+func TestFairShares_ZeroResource(t *testing.T) {
+	demand := map[string]float64{"alice": 10}
+	shares := CalculateFairShares(demand, 0)
+	if len(shares) != 0 {
+		t.Errorf("expected empty shares with 0 resources, got %v", shares)
+	}
+}
+
+func TestFairShares_ZeroDemandUsers(t *testing.T) {
+	demand := map[string]float64{
+		"alice": 0,
+		"bob":   50,
+	}
+	shares := CalculateFairShares(demand, 87)
+	assertShare(t, shares, "bob", 50)
+	if _, ok := shares["alice"]; ok {
+		t.Errorf("alice should not have a share (zero demand)")
+	}
+}
+
+func TestFairShares_ManyUsersProgressiveElimination(t *testing.T) {
+	demand := map[string]float64{
+		"A": 50,
+		"B": 40,
+		"C": 25,
+		"D": 15,
+		"E": 5,
+	}
+	shares := CalculateFairShares(demand, 100)
+	assertShare(t, shares, "E", 5)
+	assertShare(t, shares, "D", 15)
+	assertShare(t, shares, "C", 25)
+	assertShare(t, shares, "A", 27.5)
+	assertShare(t, shares, "B", 27.5)
+
+	if total := totalShares(shares); total > 100+eps {
+		t.Errorf("total shares %.4f exceeds 100", total)
+	}
+}
+
+func TestFairShares_NeverExceedsTotalResource(t *testing.T) {
+	testCases := []struct {
+		name   string
+		demand map[string]float64
+		total  float64
+	}{
+		{"high_demand", map[string]float64{"a": 500, "b": 500}, 87},
+		{"mixed", map[string]float64{"a": 5, "b": 500, "c": 1}, 87},
+		{"exact_fit", map[string]float64{"a": 29, "b": 29, "c": 29}, 87},
+		{"over_demand", map[string]float64{"a": 87, "b": 87, "c": 87}, 87},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			shares := CalculateFairShares(tc.demand, tc.total)
+			total := totalShares(shares)
+			if total > tc.total+eps {
+				t.Errorf("total shares %.4f exceeds %.0f; shares=%v", total, tc.total, shares)
+			}
+		})
+	}
+}
+
+func TestFairShares_NeverExceedsDemand(t *testing.T) {
+	demand := map[string]float64{
+		"a": 5,
+		"b": 10,
+		"c": 200,
+	}
+	shares := CalculateFairShares(demand, 87)
+
+	for user, share := range shares {
+		if share > demand[user]+eps {
+			t.Errorf("user %q: share %.4f exceeds demand %.4f", user, share, demand[user])
+		}
+	}
+}
+
+func TestFairShares_CPUResource(t *testing.T) {
+	demand := map[string]float64{
+		"A": 150000,
+		"B": 100000,
+		"C": 20000,
+	}
+	shares := CalculateFairShares(demand, 200000)
+	assertShare(t, shares, "C", 20000)
+	assertShare(t, shares, "A", 90000)
+	assertShare(t, shares, "B", 90000)
+}
+
+// --- DecayFactor tests ---
+
+func TestDecayFactor_OneHalfLife(t *testing.T) {
+	factor := DecayFactor(4*time.Hour, 4*time.Hour)
+	if math.Abs(factor-0.5) > eps {
+		t.Errorf("one half-life: got %f, want 0.5", factor)
+	}
+}
+
+func TestDecayFactor_TwoHalfLives(t *testing.T) {
+	factor := DecayFactor(8*time.Hour, 4*time.Hour)
+	if math.Abs(factor-0.25) > eps {
+		t.Errorf("two half-lives: got %f, want 0.25", factor)
+	}
+}
+
+func TestDecayFactor_ZeroElapsed(t *testing.T) {
+	factor := DecayFactor(0, 4*time.Hour)
+	if math.Abs(factor-1.0) > eps {
+		t.Errorf("zero elapsed: got %f, want 1.0", factor)
+	}
+}
+
+func TestDecayFactor_ZeroHalfLife(t *testing.T) {
+	factor := DecayFactor(1*time.Hour, 0)
+	if math.Abs(factor-1.0) > eps {
+		t.Errorf("zero half-life: got %f, want 1.0", factor)
+	}
+}
+
+func TestDecayFactor_SmallElapsed(t *testing.T) {
+	factor := DecayFactor(1*time.Second, 4*time.Hour)
+	expected := math.Pow(2.0, -1.0/14400.0)
+	if math.Abs(factor-expected) > eps {
+		t.Errorf("1s elapsed: got %f, want %f", factor, expected)
+	}
+	if factor < 0.999 {
+		t.Errorf("1s elapsed should be nearly 1.0, got %f", factor)
+	}
+}
+
+// --- decayAllUsage tests ---
+
+func TestDecayAllUsage_HalvesAfterOneHalfLife(t *testing.T) {
+	globalMu.Lock()
+	oldUsage := globalUsage
+	globalUsage = map[string]map[string]float64{
+		"gpu-queue": {"alice": 1000.0, "bob": 500.0},
+	}
+	decayAllUsage(4*time.Hour, 4*time.Hour)
+	alice := globalUsage["gpu-queue"]["alice"]
+	bob := globalUsage["gpu-queue"]["bob"]
+	globalUsage = oldUsage
+	globalMu.Unlock()
+
+	if math.Abs(alice-500.0) > 0.01 {
+		t.Errorf("alice: got %.2f, want 500.0", alice)
+	}
+	if math.Abs(bob-250.0) > 0.01 {
+		t.Errorf("bob: got %.2f, want 250.0", bob)
+	}
+}
+
+func TestDecayAllUsage_CleansUpNegligible(t *testing.T) {
+	globalMu.Lock()
+	oldUsage := globalUsage
+	globalUsage = map[string]map[string]float64{
+		"q": {"user": 0.005},
+	}
+	decayAllUsage(1*time.Hour, 1*time.Minute)
+	_, exists := globalUsage["q"]["user"]
+	globalUsage = oldUsage
+	globalMu.Unlock()
+
+	if exists {
+		t.Error("expected negligible usage to be cleaned up")
+	}
+}
+
+func TestDecayAllUsage_MultipleQueues(t *testing.T) {
+	globalMu.Lock()
+	oldUsage := globalUsage
+	globalUsage = map[string]map[string]float64{
+		"gpu-queue": {"alice": 800.0},
+		"cpu-queue": {"bob": 400.0},
+	}
+	decayAllUsage(4*time.Hour, 4*time.Hour)
+	alice := globalUsage["gpu-queue"]["alice"]
+	bob := globalUsage["cpu-queue"]["bob"]
+	globalUsage = oldUsage
+	globalMu.Unlock()
+
+	if math.Abs(alice-400.0) > 0.01 {
+		t.Errorf("alice: got %.2f, want 400.0", alice)
+	}
+	if math.Abs(bob-200.0) > 0.01 {
+		t.Errorf("bob: got %.2f, want 200.0", bob)
+	}
+}
+
+// --- Usage ordering simulation ---
+
+func TestUsageOrdering_LowerUsageWins(t *testing.T) {
+	usage := map[string]float64{
+		"user-a": 100.0,
+		"user-b": 0.0,
+	}
+
+	lUsage := usage["user-b"]
+	rUsage := usage["user-a"]
+
+	if lUsage >= rUsage-usageEpsilon {
+		t.Errorf("user-b (%.1f) should beat user-a (%.1f)", lUsage, rUsage)
+	}
+}
+
+func TestUsageOrdering_EqualUsageFallsToRunning(t *testing.T) {
+	lUsage := 50.0
+	rUsage := 50.0
+	lRunning := 0.0
+	rRunning := 1.0
+
+	usageTied := math.Abs(lUsage-rUsage) <= usageEpsilon
+	if !usageTied {
+		t.Fatal("usage should be tied")
+	}
+	if lRunning >= rRunning {
+		t.Error("l should win on running tiebreaker")
+	}
+}
+
+func TestUsageOrdering_RealisticScenario(t *testing.T) {
+	usage := map[string]float64{
+		"user-a": 180.0,
+		"user-b": 60.0,
+		"user-c": 0.0,
+		"user-d": 0.0,
+	}
+
+	if !(usage["user-c"] < usage["user-b"]-usageEpsilon) {
+		t.Error("user-c should beat user-b")
+	}
+	if !(usage["user-b"] < usage["user-a"]-usageEpsilon) {
+		t.Error("user-b should beat user-a")
+	}
+	if math.Abs(usage["user-c"]-usage["user-d"]) > usageEpsilon {
+		t.Error("user-c and user-d should be tied")
+	}
+}
+
+func TestDecayScenario_10HourJob(t *testing.T) {
+	initial := 36000.0
+	halfLife := 4 * time.Hour
+
+	f4 := DecayFactor(4*time.Hour, halfLife)
+	after4 := initial * f4
+	if math.Abs(after4-18000.0) > 1.0 {
+		t.Errorf("after 4h: got %.0f, want ~18000", after4)
+	}
+
+	f24 := DecayFactor(24*time.Hour, halfLife)
+	after24 := initial * f24
+	expected24 := 36000.0 / 64.0
+	if math.Abs(after24-expected24) > 1.0 {
+		t.Errorf("after 24h: got %.0f, want ~%.0f", after24, expected24)
+	}
+}
+
+// --- Helper tests ---
+
+func TestGetUserFromJob_Namespace(t *testing.T) {
+	fsp := &fairSharePlugin{}
+
+	tests := []struct {
+		name      string
+		namespace string
+		want      string
+	}{
+		{"user namespace", "team-ml", "team-ml"},
+		{"system namespace", "kube-system", "kube-system"},
+		{"empty namespace", "", defaultUnknownUser},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			job := &api.JobInfo{Namespace: tt.namespace}
+			got := fsp.getUserFromJob(job)
+			if got != tt.want {
+				t.Errorf("getUserFromJob() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetResourceKey_Default(t *testing.T) {
+	fsp := &fairSharePlugin{
+		defaultResource:   "nvidia.com/gpu",
+		queueResourceKeys: map[string]string{},
+	}
+
+	got := fsp.getResourceKey("gpu-queue")
+	if got != "nvidia.com/gpu" {
+		t.Errorf("getResourceKey() = %q, want %q", got, "nvidia.com/gpu")
+	}
+}
+
+func TestGetResourceKey_PerQueueOverride(t *testing.T) {
+	fsp := &fairSharePlugin{
+		defaultResource: "nvidia.com/gpu",
+		queueResourceKeys: map[string]string{
+			"cpu-queue": "cpu",
+		},
+	}
+
+	if got := fsp.getResourceKey("gpu-queue"); got != "nvidia.com/gpu" {
+		t.Errorf("gpu-queue: got %q, want %q", got, "nvidia.com/gpu")
+	}
+	if got := fsp.getResourceKey("cpu-queue"); got != "cpu" {
+		t.Errorf("cpu-queue: got %q, want %q", got, "cpu")
+	}
+}
+
+func TestFormatShares(t *testing.T) {
+	shares := map[string]float64{"alice": 43.5, "bob": 43.5}
+	result := FormatShares(shares)
+	if result == "" {
+		t.Error("expected non-empty format result")
+	}
+}
+
+func TestEnsureGlobalQueueUsage_CreatesMap(t *testing.T) {
+	globalMu.Lock()
+	oldUsage := globalUsage
+	globalUsage = make(map[string]map[string]float64)
+	globalMu.Unlock()
+
+	usage := ensureGlobalQueueUsage("new-queue")
+	if usage == nil {
+		t.Fatal("expected non-nil map")
+	}
+	usage["alice"] = 42.0
+
+	if globalUsage["new-queue"]["alice"] != 42.0 {
+		t.Error("expected usage to be stored in global state")
+	}
+
+	globalMu.Lock()
+	globalUsage = oldUsage
+	globalMu.Unlock()
+}

--- a/pkg/scheduler/plugins/fairshare/fairshare_test.go
+++ b/pkg/scheduler/plugins/fairshare/fairshare_test.go
@@ -1,0 +1,555 @@
+/*
+Copyright 2025 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fairshare
+
+import (
+	"math"
+	"testing"
+	"time"
+
+	"volcano.sh/volcano/pkg/scheduler/api"
+	"volcano.sh/volcano/pkg/scheduler/framework"
+)
+
+const eps = 1e-9
+
+func assertShare(t *testing.T, shares map[string]float64, namespace string, expected float64) {
+	t.Helper()
+	got, ok := shares[namespace]
+	if !ok {
+		t.Errorf("namespace %q: not found in shares (expected %.1f)", namespace, expected)
+		return
+	}
+	if math.Abs(got-expected) > eps {
+		t.Errorf("namespace %q: got %.4f, want %.4f", namespace, got, expected)
+	}
+}
+
+func totalShares(shares map[string]float64) float64 {
+	total := 0.0
+	for _, s := range shares {
+		total += s
+	}
+	return total
+}
+
+// --- CalculateFairShares tests ---
+
+func TestFairShares_SingleNamespace(t *testing.T) {
+	demand := map[string]float64{"alice": 200}
+	shares := CalculateFairShares(demand, 87)
+	assertShare(t, shares, "alice", 87)
+}
+
+func TestFairShares_SingleNamespaceLowDemand(t *testing.T) {
+	demand := map[string]float64{"alice": 10}
+	shares := CalculateFairShares(demand, 87)
+	assertShare(t, shares, "alice", 10)
+}
+
+func TestFairShares_TwoNamespacesEqual(t *testing.T) {
+	demand := map[string]float64{
+		"alice": 100,
+		"bob":   100,
+	}
+	shares := CalculateFairShares(demand, 87)
+	assertShare(t, shares, "alice", 43.5)
+	assertShare(t, shares, "bob", 43.5)
+}
+
+func TestFairShares_TwoNamespacesOneLow(t *testing.T) {
+	demand := map[string]float64{
+		"alice": 200,
+		"bob":   10,
+	}
+	shares := CalculateFairShares(demand, 87)
+	assertShare(t, shares, "bob", 10)
+	assertShare(t, shares, "alice", 77)
+}
+
+func TestFairShares_ThreeNamespacesAsymmetric(t *testing.T) {
+	demand := map[string]float64{
+		"A": 50,
+		"B": 60,
+		"C": 11,
+	}
+	shares := CalculateFairShares(demand, 87)
+	assertShare(t, shares, "C", 11)
+	assertShare(t, shares, "A", 38)
+	assertShare(t, shares, "B", 38)
+
+	if total := totalShares(shares); total > 87+eps {
+		t.Errorf("total shares %.4f exceeds 87", total)
+	}
+}
+
+func TestFairShares_ThreeNamespacesMixed(t *testing.T) {
+	demand := map[string]float64{
+		"A": 200,
+		"B": 150,
+		"C": 10,
+	}
+	shares := CalculateFairShares(demand, 87)
+	assertShare(t, shares, "C", 10)
+	assertShare(t, shares, "A", 38.5)
+	assertShare(t, shares, "B", 38.5)
+}
+
+func TestFairShares_AllNamespacesLowDemand(t *testing.T) {
+	demand := map[string]float64{
+		"alice": 5,
+		"bob":   10,
+		"carol": 3,
+	}
+	shares := CalculateFairShares(demand, 87)
+	assertShare(t, shares, "alice", 5)
+	assertShare(t, shares, "bob", 10)
+	assertShare(t, shares, "carol", 3)
+
+	if total := totalShares(shares); total > 18+eps {
+		t.Errorf("total shares %.4f exceeds sum of demands", total)
+	}
+}
+
+func TestFairShares_EmptyDemand(t *testing.T) {
+	shares := CalculateFairShares(map[string]float64{}, 87)
+	if len(shares) != 0 {
+		t.Errorf("expected empty shares, got %v", shares)
+	}
+}
+
+func TestFairShares_ZeroResource(t *testing.T) {
+	demand := map[string]float64{"alice": 10}
+	shares := CalculateFairShares(demand, 0)
+	if len(shares) != 0 {
+		t.Errorf("expected empty shares with 0 resources, got %v", shares)
+	}
+}
+
+func TestFairShares_ZeroDemandNamespaces(t *testing.T) {
+	demand := map[string]float64{
+		"alice": 0,
+		"bob":   50,
+	}
+	shares := CalculateFairShares(demand, 87)
+	assertShare(t, shares, "bob", 50)
+	if _, ok := shares["alice"]; ok {
+		t.Errorf("alice should not have a share (zero demand)")
+	}
+}
+
+func TestFairShares_ManyNamespacesProgressiveElimination(t *testing.T) {
+	demand := map[string]float64{
+		"A": 50,
+		"B": 40,
+		"C": 25,
+		"D": 15,
+		"E": 5,
+	}
+	shares := CalculateFairShares(demand, 100)
+	assertShare(t, shares, "E", 5)
+	assertShare(t, shares, "D", 15)
+	assertShare(t, shares, "C", 25)
+	assertShare(t, shares, "A", 27.5)
+	assertShare(t, shares, "B", 27.5)
+
+	if total := totalShares(shares); total > 100+eps {
+		t.Errorf("total shares %.4f exceeds 100", total)
+	}
+}
+
+func TestFairShares_NeverExceedsTotalResource(t *testing.T) {
+	testCases := []struct {
+		name   string
+		demand map[string]float64
+		total  float64
+	}{
+		{"high_demand", map[string]float64{"a": 500, "b": 500}, 87},
+		{"mixed", map[string]float64{"a": 5, "b": 500, "c": 1}, 87},
+		{"exact_fit", map[string]float64{"a": 29, "b": 29, "c": 29}, 87},
+		{"over_demand", map[string]float64{"a": 87, "b": 87, "c": 87}, 87},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			shares := CalculateFairShares(tc.demand, tc.total)
+			total := totalShares(shares)
+			if total > tc.total+eps {
+				t.Errorf("total shares %.4f exceeds %.0f; shares=%v", total, tc.total, shares)
+			}
+		})
+	}
+}
+
+func TestFairShares_NeverExceedsDemand(t *testing.T) {
+	demand := map[string]float64{
+		"a": 5,
+		"b": 10,
+		"c": 200,
+	}
+	shares := CalculateFairShares(demand, 87)
+
+	for namespace, share := range shares {
+		if share > demand[namespace]+eps {
+			t.Errorf("namespace %q: share %.4f exceeds demand %.4f", namespace, share, demand[namespace])
+		}
+	}
+}
+
+func TestFairShares_CPUResource(t *testing.T) {
+	demand := map[string]float64{
+		"A": 150000,
+		"B": 100000,
+		"C": 20000,
+	}
+	shares := CalculateFairShares(demand, 200000)
+	assertShare(t, shares, "C", 20000)
+	assertShare(t, shares, "A", 90000)
+	assertShare(t, shares, "B", 90000)
+}
+
+// --- DecayFactor tests ---
+
+func TestDecayFactor_OneHalfLife(t *testing.T) {
+	factor := DecayFactor(4*time.Hour, 4*time.Hour)
+	if math.Abs(factor-0.5) > eps {
+		t.Errorf("one half-life: got %f, want 0.5", factor)
+	}
+}
+
+func TestDecayFactor_TwoHalfLives(t *testing.T) {
+	factor := DecayFactor(8*time.Hour, 4*time.Hour)
+	if math.Abs(factor-0.25) > eps {
+		t.Errorf("two half-lives: got %f, want 0.25", factor)
+	}
+}
+
+func TestDecayFactor_ZeroElapsed(t *testing.T) {
+	factor := DecayFactor(0, 4*time.Hour)
+	if math.Abs(factor-1.0) > eps {
+		t.Errorf("zero elapsed: got %f, want 1.0", factor)
+	}
+}
+
+func TestDecayFactor_ZeroHalfLife(t *testing.T) {
+	factor := DecayFactor(1*time.Hour, 0)
+	if math.Abs(factor-1.0) > eps {
+		t.Errorf("zero half-life: got %f, want 1.0", factor)
+	}
+}
+
+func TestDecayFactor_SmallElapsed(t *testing.T) {
+	factor := DecayFactor(1*time.Second, 4*time.Hour)
+	expected := math.Pow(2.0, -1.0/14400.0)
+	if math.Abs(factor-expected) > eps {
+		t.Errorf("1s elapsed: got %f, want %f", factor, expected)
+	}
+	if factor < 0.999 {
+		t.Errorf("1s elapsed should be nearly 1.0, got %f", factor)
+	}
+}
+
+// --- decayAllUsage tests ---
+
+func TestDecayAllUsage_HalvesAfterOneHalfLife(t *testing.T) {
+	oldUsage := state.usage
+	state.usage = map[string]map[string]float64{
+		"gpu-queue": {"alice": 1000.0, "bob": 500.0},
+	}
+	decayAllUsage(4*time.Hour, 4*time.Hour)
+	alice := state.usage["gpu-queue"]["alice"]
+	bob := state.usage["gpu-queue"]["bob"]
+	state.usage = oldUsage
+
+	if math.Abs(alice-500.0) > 0.01 {
+		t.Errorf("alice: got %.2f, want 500.0", alice)
+	}
+	if math.Abs(bob-250.0) > 0.01 {
+		t.Errorf("bob: got %.2f, want 250.0", bob)
+	}
+}
+
+func TestDecayAllUsage_CleansUpNegligible(t *testing.T) {
+	oldUsage := state.usage
+	state.usage = map[string]map[string]float64{
+		"q": {"ns": 0.005},
+	}
+	decayAllUsage(1*time.Hour, 1*time.Minute)
+	_, exists := state.usage["q"]["ns"]
+	state.usage = oldUsage
+
+	if exists {
+		t.Error("expected negligible usage to be cleaned up")
+	}
+}
+
+func TestDecayAllUsage_MultipleQueues(t *testing.T) {
+	oldUsage := state.usage
+	state.usage = map[string]map[string]float64{
+		"gpu-queue": {"alice": 800.0},
+		"cpu-queue": {"bob": 400.0},
+	}
+	decayAllUsage(4*time.Hour, 4*time.Hour)
+	alice := state.usage["gpu-queue"]["alice"]
+	bob := state.usage["cpu-queue"]["bob"]
+	state.usage = oldUsage
+
+	if math.Abs(alice-400.0) > 0.01 {
+		t.Errorf("alice: got %.2f, want 400.0", alice)
+	}
+	if math.Abs(bob-200.0) > 0.01 {
+		t.Errorf("bob: got %.2f, want 200.0", bob)
+	}
+}
+
+// --- Usage ordering simulation ---
+
+func TestUsageOrdering_LowerUsageWins(t *testing.T) {
+	usage := map[string]float64{
+		"ns-a": 100.0,
+		"ns-b": 0.0,
+	}
+
+	lUsage := usage["ns-b"]
+	rUsage := usage["ns-a"]
+
+	if lUsage >= rUsage-usageEpsilon {
+		t.Errorf("ns-b (%.1f) should beat ns-a (%.1f)", lUsage, rUsage)
+	}
+}
+
+func TestUsageOrdering_EqualUsageFallsToRunning(t *testing.T) {
+	lUsage := 50.0
+	rUsage := 50.0
+	lRunning := 0.0
+	rRunning := 1.0
+
+	usageTied := math.Abs(lUsage-rUsage) <= usageEpsilon
+	if !usageTied {
+		t.Fatal("usage should be tied")
+	}
+	if lRunning >= rRunning {
+		t.Error("l should win on running tiebreaker")
+	}
+}
+
+func TestUsageOrdering_RealisticScenario(t *testing.T) {
+	usage := map[string]float64{
+		"ns-a": 180.0,
+		"ns-b": 60.0,
+		"ns-c": 0.0,
+		"ns-d": 0.0,
+	}
+
+	if !(usage["ns-c"] < usage["ns-b"]-usageEpsilon) {
+		t.Error("ns-c should beat ns-b")
+	}
+	if !(usage["ns-b"] < usage["ns-a"]-usageEpsilon) {
+		t.Error("ns-b should beat ns-a")
+	}
+	if math.Abs(usage["ns-c"]-usage["ns-d"]) > usageEpsilon {
+		t.Error("ns-c and ns-d should be tied")
+	}
+}
+
+func TestDecayScenario_10HourJob(t *testing.T) {
+	initial := 36000.0
+	halfLife := 4 * time.Hour
+
+	f4 := DecayFactor(4*time.Hour, halfLife)
+	after4 := initial * f4
+	if math.Abs(after4-18000.0) > 1.0 {
+		t.Errorf("after 4h: got %.0f, want ~18000", after4)
+	}
+
+	f24 := DecayFactor(24*time.Hour, halfLife)
+	after24 := initial * f24
+	expected24 := 36000.0 / 64.0
+	if math.Abs(after24-expected24) > 1.0 {
+		t.Errorf("after 24h: got %.0f, want ~%.0f", after24, expected24)
+	}
+}
+
+// --- Helper tests ---
+
+func TestGetNamespaceFromJob(t *testing.T) {
+	fsp := &fairSharePlugin{}
+
+	tests := []struct {
+		name      string
+		namespace string
+		want      string
+	}{
+		{"regular namespace", "team-ml", "team-ml"},
+		{"system namespace", "kube-system", "kube-system"},
+		{"empty namespace", "", defaultUnknownNamespace},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			job := &api.JobInfo{Namespace: tt.namespace}
+			got := fsp.getNamespaceFromJob(job)
+			if got != tt.want {
+				t.Errorf("getNamespaceFromJob() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetResourceKey_Default(t *testing.T) {
+	fsp := &fairSharePlugin{
+		defaultResource:   "nvidia.com/gpu",
+		queueResourceKeys: map[string]string{},
+	}
+
+	got := fsp.getResourceKey("gpu-queue")
+	if got != "nvidia.com/gpu" {
+		t.Errorf("getResourceKey() = %q, want %q", got, "nvidia.com/gpu")
+	}
+}
+
+func TestGetResourceKey_PerQueueOverride(t *testing.T) {
+	fsp := &fairSharePlugin{
+		defaultResource: "nvidia.com/gpu",
+		queueResourceKeys: map[string]string{
+			"cpu-queue": "cpu",
+		},
+	}
+
+	if got := fsp.getResourceKey("gpu-queue"); got != "nvidia.com/gpu" {
+		t.Errorf("gpu-queue: got %q, want %q", got, "nvidia.com/gpu")
+	}
+	if got := fsp.getResourceKey("cpu-queue"); got != "cpu" {
+		t.Errorf("cpu-queue: got %q, want %q", got, "cpu")
+	}
+}
+
+// --- targetQueues default-to-all-queues tests ---
+
+func TestNew_UnsetTargetQueues_DefaultsToAllQueues(t *testing.T) {
+	p := New(framework.Arguments{})
+	fsp := p.(*fairSharePlugin)
+
+	if !fsp.targetAllQueues {
+		t.Error("targetAllQueues = false, want true when fairshare.targetQueues is unset")
+	}
+	if len(fsp.targetQueueNames) != 0 {
+		t.Errorf("targetQueueNames = %v, want empty when fairshare.targetQueues is unset", fsp.targetQueueNames)
+	}
+}
+
+func TestNew_ExplicitTargetQueues_DisablesAllQueuesMode(t *testing.T) {
+	p := New(framework.Arguments{"fairshare.targetQueues": "gpu-queue, cpu-queue"})
+	fsp := p.(*fairSharePlugin)
+
+	if fsp.targetAllQueues {
+		t.Error("targetAllQueues = true, want false when fairshare.targetQueues is explicitly set")
+	}
+	for _, want := range []string{"gpu-queue", "cpu-queue"} {
+		if _, ok := fsp.targetQueueNames[want]; !ok {
+			t.Errorf("targetQueueNames missing %q: got %v", want, fsp.targetQueueNames)
+		}
+	}
+}
+
+func TestGetQueueName_TargetAllQueues_MatchesAnyQueue(t *testing.T) {
+	fsp := &fairSharePlugin{targetAllQueues: true}
+	ssn := &framework.Session{
+		Queues: map[api.QueueID]*api.QueueInfo{
+			"random-queue": {UID: "random-queue", Name: "random-queue"},
+		},
+	}
+	job := &api.JobInfo{Queue: "random-queue"}
+
+	name, targeted := fsp.getQueueName(ssn, job)
+	if !targeted || name != "random-queue" {
+		t.Errorf("getQueueName() = (%q, %v), want (%q, true)", name, targeted, "random-queue")
+	}
+}
+
+func TestGetQueueName_ExplicitAllowlist_OnlyMatchesListedQueues(t *testing.T) {
+	fsp := &fairSharePlugin{
+		targetQueueNames: map[string]struct{}{"gpu-queue": {}},
+	}
+	ssn := &framework.Session{
+		Queues: map[api.QueueID]*api.QueueInfo{
+			"gpu-queue":   {UID: "gpu-queue", Name: "gpu-queue"},
+			"other-queue": {UID: "other-queue", Name: "other-queue"},
+		},
+	}
+
+	if _, targeted := fsp.getQueueName(ssn, &api.JobInfo{Queue: "gpu-queue"}); !targeted {
+		t.Error("gpu-queue: targeted = false, want true (in allowlist)")
+	}
+	if _, targeted := fsp.getQueueName(ssn, &api.JobInfo{Queue: "other-queue"}); targeted {
+		t.Error("other-queue: targeted = true, want false (not in allowlist)")
+	}
+}
+
+func TestShouldAbstainOrdering(t *testing.T) {
+	tests := []struct {
+		name    string
+		lQueue  string
+		lTarget bool
+		rQueue  string
+		rTarget bool
+		want    bool
+	}{
+		{"both targeted, same queue", "gpu-queue", true, "gpu-queue", true, false},
+		{"both targeted, different queues", "gpu-queue", true, "cpu-queue", true, true},
+		{"left not targeted", "other-queue", false, "gpu-queue", true, true},
+		{"right not targeted", "gpu-queue", true, "other-queue", false, true},
+		{"neither targeted", "other-queue", false, "other-queue-2", false, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := shouldAbstainOrdering(tt.lQueue, tt.lTarget, tt.rQueue, tt.rTarget)
+			if got != tt.want {
+				t.Errorf("shouldAbstainOrdering(%q, %v, %q, %v) = %v, want %v",
+					tt.lQueue, tt.lTarget, tt.rQueue, tt.rTarget, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFormatShares(t *testing.T) {
+	shares := map[string]float64{"alice": 43.5, "bob": 43.5}
+	result := FormatShares(shares)
+	if result == "" {
+		t.Error("expected non-empty format result")
+	}
+}
+
+func TestEnsureGlobalQueueUsage_CreatesMap(t *testing.T) {
+	oldUsage := state.usage
+	state.usage = make(map[string]map[string]float64)
+
+	usage := ensureGlobalQueueUsage("new-queue")
+	if usage == nil {
+		state.usage = oldUsage
+		t.Fatal("expected non-nil map")
+	}
+	usage["alice"] = 42.0
+
+	got := state.usage["new-queue"]["alice"]
+	state.usage = oldUsage
+
+	if got != 42.0 {
+		t.Error("expected usage to be stored in global state")
+	}
+}

--- a/pkg/scheduler/plugins/fairshare/fairshare_test.go
+++ b/pkg/scheduler/plugins/fairshare/fairshare_test.go
@@ -506,6 +506,33 @@ func TestGetQueueName_ExplicitAllowlist_OnlyMatchesListedQueues(t *testing.T) {
 	}
 }
 
+func TestShouldAbstainOrdering(t *testing.T) {
+	tests := []struct {
+		name    string
+		lQueue  string
+		lTarget bool
+		rQueue  string
+		rTarget bool
+		want    bool
+	}{
+		{"both targeted, same queue", "gpu-queue", true, "gpu-queue", true, false},
+		{"both targeted, different queues", "gpu-queue", true, "cpu-queue", true, true},
+		{"left not targeted", "other-queue", false, "gpu-queue", true, true},
+		{"right not targeted", "gpu-queue", true, "other-queue", false, true},
+		{"neither targeted", "other-queue", false, "other-queue-2", false, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := shouldAbstainOrdering(tt.lQueue, tt.lTarget, tt.rQueue, tt.rTarget)
+			if got != tt.want {
+				t.Errorf("shouldAbstainOrdering(%q, %v, %q, %v) = %v, want %v",
+					tt.lQueue, tt.lTarget, tt.rQueue, tt.rTarget, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestFormatShares(t *testing.T) {
 	shares := map[string]float64{"alice": 43.5, "bob": 43.5}
 	result := FormatShares(shares)
@@ -515,22 +542,26 @@ func TestFormatShares(t *testing.T) {
 }
 
 func TestEnsureGlobalQueueUsage_CreatesMap(t *testing.T) {
+	// ensureGlobalQueueUsage is documented as requiring globalMu to be held
+	// by the caller (it reads/writes globalUsage directly). Hold it for the
+	// whole read-modify-check sequence here, matching the contract.
 	globalMu.Lock()
 	oldUsage := globalUsage
 	globalUsage = make(map[string]map[string]float64)
-	globalMu.Unlock()
 
 	usage := ensureGlobalQueueUsage("new-queue")
 	if usage == nil {
+		globalUsage = oldUsage
+		globalMu.Unlock()
 		t.Fatal("expected non-nil map")
 	}
 	usage["alice"] = 42.0
 
-	if globalUsage["new-queue"]["alice"] != 42.0 {
-		t.Error("expected usage to be stored in global state")
-	}
-
-	globalMu.Lock()
+	got := globalUsage["new-queue"]["alice"]
 	globalUsage = oldUsage
 	globalMu.Unlock()
+
+	if got != 42.0 {
+		t.Error("expected usage to be stored in global state")
+	}
 }

--- a/pkg/scheduler/plugins/fairshare/fairshare_test.go
+++ b/pkg/scheduler/plugins/fairshare/fairshare_test.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"volcano.sh/volcano/pkg/scheduler/api"
+	"volcano.sh/volcano/pkg/scheduler/framework"
 )
 
 const eps = 1e-9
@@ -440,6 +441,68 @@ func TestGetResourceKey_PerQueueOverride(t *testing.T) {
 	}
 	if got := fsp.getResourceKey("cpu-queue"); got != "cpu" {
 		t.Errorf("cpu-queue: got %q, want %q", got, "cpu")
+	}
+}
+
+// --- targetQueues default-to-all-queues tests ---
+
+func TestNew_UnsetTargetQueues_DefaultsToAllQueues(t *testing.T) {
+	p := New(framework.Arguments{})
+	fsp := p.(*fairSharePlugin)
+
+	if !fsp.targetAllQueues {
+		t.Error("targetAllQueues = false, want true when fairshare.targetQueues is unset")
+	}
+	if len(fsp.targetQueueNames) != 0 {
+		t.Errorf("targetQueueNames = %v, want empty when fairshare.targetQueues is unset", fsp.targetQueueNames)
+	}
+}
+
+func TestNew_ExplicitTargetQueues_DisablesAllQueuesMode(t *testing.T) {
+	p := New(framework.Arguments{"fairshare.targetQueues": "gpu-queue, cpu-queue"})
+	fsp := p.(*fairSharePlugin)
+
+	if fsp.targetAllQueues {
+		t.Error("targetAllQueues = true, want false when fairshare.targetQueues is explicitly set")
+	}
+	for _, want := range []string{"gpu-queue", "cpu-queue"} {
+		if _, ok := fsp.targetQueueNames[want]; !ok {
+			t.Errorf("targetQueueNames missing %q: got %v", want, fsp.targetQueueNames)
+		}
+	}
+}
+
+func TestGetQueueName_TargetAllQueues_MatchesAnyQueue(t *testing.T) {
+	fsp := &fairSharePlugin{targetAllQueues: true}
+	ssn := &framework.Session{
+		Queues: map[api.QueueID]*api.QueueInfo{
+			"random-queue": {UID: "random-queue", Name: "random-queue"},
+		},
+	}
+	job := &api.JobInfo{Queue: "random-queue"}
+
+	name, targeted := fsp.getQueueName(ssn, job)
+	if !targeted || name != "random-queue" {
+		t.Errorf("getQueueName() = (%q, %v), want (%q, true)", name, targeted, "random-queue")
+	}
+}
+
+func TestGetQueueName_ExplicitAllowlist_OnlyMatchesListedQueues(t *testing.T) {
+	fsp := &fairSharePlugin{
+		targetQueueNames: map[string]struct{}{"gpu-queue": {}},
+	}
+	ssn := &framework.Session{
+		Queues: map[api.QueueID]*api.QueueInfo{
+			"gpu-queue":   {UID: "gpu-queue", Name: "gpu-queue"},
+			"other-queue": {UID: "other-queue", Name: "other-queue"},
+		},
+	}
+
+	if _, targeted := fsp.getQueueName(ssn, &api.JobInfo{Queue: "gpu-queue"}); !targeted {
+		t.Error("gpu-queue: targeted = false, want true (in allowlist)")
+	}
+	if _, targeted := fsp.getQueueName(ssn, &api.JobInfo{Queue: "other-queue"}); targeted {
+		t.Error("other-queue: targeted = true, want false (not in allowlist)")
 	}
 }
 

--- a/pkg/scheduler/plugins/fairshare/fairshare_test.go
+++ b/pkg/scheduler/plugins/fairshare/fairshare_test.go
@@ -27,15 +27,15 @@ import (
 
 const eps = 1e-9
 
-func assertShare(t *testing.T, shares map[string]float64, user string, expected float64) {
+func assertShare(t *testing.T, shares map[string]float64, namespace string, expected float64) {
 	t.Helper()
-	got, ok := shares[user]
+	got, ok := shares[namespace]
 	if !ok {
-		t.Errorf("user %q: not found in shares (expected %.1f)", user, expected)
+		t.Errorf("namespace %q: not found in shares (expected %.1f)", namespace, expected)
 		return
 	}
 	if math.Abs(got-expected) > eps {
-		t.Errorf("user %q: got %.4f, want %.4f", user, got, expected)
+		t.Errorf("namespace %q: got %.4f, want %.4f", namespace, got, expected)
 	}
 }
 
@@ -49,19 +49,19 @@ func totalShares(shares map[string]float64) float64 {
 
 // --- CalculateFairShares tests ---
 
-func TestFairShares_SingleUser(t *testing.T) {
+func TestFairShares_SingleNamespace(t *testing.T) {
 	demand := map[string]float64{"alice": 200}
 	shares := CalculateFairShares(demand, 87)
 	assertShare(t, shares, "alice", 87)
 }
 
-func TestFairShares_SingleUserLowDemand(t *testing.T) {
+func TestFairShares_SingleNamespaceLowDemand(t *testing.T) {
 	demand := map[string]float64{"alice": 10}
 	shares := CalculateFairShares(demand, 87)
 	assertShare(t, shares, "alice", 10)
 }
 
-func TestFairShares_TwoUsersEqual(t *testing.T) {
+func TestFairShares_TwoNamespacesEqual(t *testing.T) {
 	demand := map[string]float64{
 		"alice": 100,
 		"bob":   100,
@@ -71,7 +71,7 @@ func TestFairShares_TwoUsersEqual(t *testing.T) {
 	assertShare(t, shares, "bob", 43.5)
 }
 
-func TestFairShares_TwoUsersOneLow(t *testing.T) {
+func TestFairShares_TwoNamespacesOneLow(t *testing.T) {
 	demand := map[string]float64{
 		"alice": 200,
 		"bob":   10,
@@ -81,7 +81,7 @@ func TestFairShares_TwoUsersOneLow(t *testing.T) {
 	assertShare(t, shares, "alice", 77)
 }
 
-func TestFairShares_ThreeUsersAsymmetric(t *testing.T) {
+func TestFairShares_ThreeNamespacesAsymmetric(t *testing.T) {
 	demand := map[string]float64{
 		"A": 50,
 		"B": 60,
@@ -97,7 +97,7 @@ func TestFairShares_ThreeUsersAsymmetric(t *testing.T) {
 	}
 }
 
-func TestFairShares_ThreeUsersMixed(t *testing.T) {
+func TestFairShares_ThreeNamespacesMixed(t *testing.T) {
 	demand := map[string]float64{
 		"A": 200,
 		"B": 150,
@@ -109,7 +109,7 @@ func TestFairShares_ThreeUsersMixed(t *testing.T) {
 	assertShare(t, shares, "B", 38.5)
 }
 
-func TestFairShares_AllUsersLowDemand(t *testing.T) {
+func TestFairShares_AllNamespacesLowDemand(t *testing.T) {
 	demand := map[string]float64{
 		"alice": 5,
 		"bob":   10,
@@ -140,7 +140,7 @@ func TestFairShares_ZeroResource(t *testing.T) {
 	}
 }
 
-func TestFairShares_ZeroDemandUsers(t *testing.T) {
+func TestFairShares_ZeroDemandNamespaces(t *testing.T) {
 	demand := map[string]float64{
 		"alice": 0,
 		"bob":   50,
@@ -152,7 +152,7 @@ func TestFairShares_ZeroDemandUsers(t *testing.T) {
 	}
 }
 
-func TestFairShares_ManyUsersProgressiveElimination(t *testing.T) {
+func TestFairShares_ManyNamespacesProgressiveElimination(t *testing.T) {
 	demand := map[string]float64{
 		"A": 50,
 		"B": 40,
@@ -203,9 +203,9 @@ func TestFairShares_NeverExceedsDemand(t *testing.T) {
 	}
 	shares := CalculateFairShares(demand, 87)
 
-	for user, share := range shares {
-		if share > demand[user]+eps {
-			t.Errorf("user %q: share %.4f exceeds demand %.4f", user, share, demand[user])
+	for namespace, share := range shares {
+		if share > demand[namespace]+eps {
+			t.Errorf("namespace %q: share %.4f exceeds demand %.4f", namespace, share, demand[namespace])
 		}
 	}
 }
@@ -289,10 +289,10 @@ func TestDecayAllUsage_CleansUpNegligible(t *testing.T) {
 	globalMu.Lock()
 	oldUsage := globalUsage
 	globalUsage = map[string]map[string]float64{
-		"q": {"user": 0.005},
+		"q": {"ns": 0.005},
 	}
 	decayAllUsage(1*time.Hour, 1*time.Minute)
-	_, exists := globalUsage["q"]["user"]
+	_, exists := globalUsage["q"]["ns"]
 	globalUsage = oldUsage
 	globalMu.Unlock()
 
@@ -326,15 +326,15 @@ func TestDecayAllUsage_MultipleQueues(t *testing.T) {
 
 func TestUsageOrdering_LowerUsageWins(t *testing.T) {
 	usage := map[string]float64{
-		"user-a": 100.0,
-		"user-b": 0.0,
+		"ns-a": 100.0,
+		"ns-b": 0.0,
 	}
 
-	lUsage := usage["user-b"]
-	rUsage := usage["user-a"]
+	lUsage := usage["ns-b"]
+	rUsage := usage["ns-a"]
 
 	if lUsage >= rUsage-usageEpsilon {
-		t.Errorf("user-b (%.1f) should beat user-a (%.1f)", lUsage, rUsage)
+		t.Errorf("ns-b (%.1f) should beat ns-a (%.1f)", lUsage, rUsage)
 	}
 }
 
@@ -355,20 +355,20 @@ func TestUsageOrdering_EqualUsageFallsToRunning(t *testing.T) {
 
 func TestUsageOrdering_RealisticScenario(t *testing.T) {
 	usage := map[string]float64{
-		"user-a": 180.0,
-		"user-b": 60.0,
-		"user-c": 0.0,
-		"user-d": 0.0,
+		"ns-a": 180.0,
+		"ns-b": 60.0,
+		"ns-c": 0.0,
+		"ns-d": 0.0,
 	}
 
-	if !(usage["user-c"] < usage["user-b"]-usageEpsilon) {
-		t.Error("user-c should beat user-b")
+	if !(usage["ns-c"] < usage["ns-b"]-usageEpsilon) {
+		t.Error("ns-c should beat ns-b")
 	}
-	if !(usage["user-b"] < usage["user-a"]-usageEpsilon) {
-		t.Error("user-b should beat user-a")
+	if !(usage["ns-b"] < usage["ns-a"]-usageEpsilon) {
+		t.Error("ns-b should beat ns-a")
 	}
-	if math.Abs(usage["user-c"]-usage["user-d"]) > usageEpsilon {
-		t.Error("user-c and user-d should be tied")
+	if math.Abs(usage["ns-c"]-usage["ns-d"]) > usageEpsilon {
+		t.Error("ns-c and ns-d should be tied")
 	}
 }
 
@@ -392,7 +392,7 @@ func TestDecayScenario_10HourJob(t *testing.T) {
 
 // --- Helper tests ---
 
-func TestGetUserFromJob_Namespace(t *testing.T) {
+func TestGetNamespaceFromJob(t *testing.T) {
 	fsp := &fairSharePlugin{}
 
 	tests := []struct {
@@ -400,17 +400,17 @@ func TestGetUserFromJob_Namespace(t *testing.T) {
 		namespace string
 		want      string
 	}{
-		{"user namespace", "team-ml", "team-ml"},
+		{"regular namespace", "team-ml", "team-ml"},
 		{"system namespace", "kube-system", "kube-system"},
-		{"empty namespace", "", defaultUnknownUser},
+		{"empty namespace", "", defaultUnknownNamespace},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			job := &api.JobInfo{Namespace: tt.namespace}
-			got := fsp.getUserFromJob(job)
+			got := fsp.getNamespaceFromJob(job)
 			if got != tt.want {
-				t.Errorf("getUserFromJob() = %q, want %q", got, tt.want)
+				t.Errorf("getNamespaceFromJob() = %q, want %q", got, tt.want)
 			}
 		})
 	}

--- a/pkg/scheduler/plugins/fairshare/persist.go
+++ b/pkg/scheduler/plugins/fairshare/persist.go
@@ -1,0 +1,200 @@
+/*
+Copyright 2025 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fairshare
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/klog/v2"
+)
+
+const (
+	defaultConfigMapName  = "fairshare-usage-state"
+	defaultStateNamespace = "volcano-system"
+	defaultFlushInterval  = 30 * time.Second
+	stateDataKey          = "state.json"
+)
+
+// persistedState is the JSON structure stored in the ConfigMap.
+type persistedState struct {
+	LastCycle time.Time                    `json:"lastCycle"`
+	Queues    map[string]map[string]float64 `json:"queues"`
+}
+
+// persistConfig holds persistence settings parsed from plugin arguments.
+type persistConfig struct {
+	enabled       bool
+	namespace     string
+	configMapName string
+	flushInterval time.Duration
+}
+
+var (
+	persistOnce   sync.Once
+	persistClient kubernetes.Interface
+)
+
+// initPersistence loads existing state from the ConfigMap and starts a
+// background goroutine that periodically flushes globalUsage back.
+// Uses sync.Once so only the first call (first scheduling cycle) has effect.
+// Must be called BEFORE acquiring globalMu to avoid deadlock.
+func initPersistence(client kubernetes.Interface, cfg persistConfig) {
+	if !cfg.enabled {
+		return
+	}
+	persistOnce.Do(func() {
+		persistClient = client
+		if err := loadState(cfg); err != nil {
+			klog.Warningf("fairshare: failed to load persisted state: %v (starting fresh)", err)
+		}
+		go flushLoop(cfg)
+		klog.V(2).Infof("fairshare: persistence enabled — namespace=%s configMap=%s flushInterval=%s",
+			cfg.namespace, cfg.configMapName, cfg.flushInterval)
+	})
+}
+
+func flushLoop(cfg persistConfig) {
+	ticker := time.NewTicker(cfg.flushInterval)
+	defer ticker.Stop()
+	for range ticker.C {
+		if err := flushState(cfg); err != nil {
+			klog.Warningf("fairshare: flush failed: %v", err)
+		}
+	}
+}
+
+// apiCallTimeout returns a timeout for individual API calls. We use half the
+// flush interval so a slow/stalled request can't block the next flush tick
+// (time.Ticker drops ticks if the handler runs long).
+func apiCallTimeout(cfg persistConfig) time.Duration {
+	if cfg.flushInterval <= 0 {
+		return 15 * time.Second
+	}
+	return cfg.flushInterval / 2
+}
+
+// loadState reads the ConfigMap and populates globalUsage / globalLastCycle.
+func loadState(cfg persistConfig) error {
+	ctx, cancel := context.WithTimeout(context.Background(), apiCallTimeout(cfg))
+	defer cancel()
+	cm, err := persistClient.CoreV1().ConfigMaps(cfg.namespace).Get(
+		ctx, cfg.configMapName, metav1.GetOptions{})
+	if err != nil {
+		if errors.IsNotFound(err) {
+			klog.V(2).Infof("fairshare: no persisted state found, starting fresh")
+			return nil
+		}
+		return fmt.Errorf("get ConfigMap %s/%s: %w", cfg.namespace, cfg.configMapName, err)
+	}
+
+	data, ok := cm.Data[stateDataKey]
+	if !ok || data == "" {
+		klog.V(2).Infof("fairshare: ConfigMap exists but no %s key, starting fresh", stateDataKey)
+		return nil
+	}
+
+	var state persistedState
+	if err := json.Unmarshal([]byte(data), &state); err != nil {
+		return fmt.Errorf("unmarshal state: %w", err)
+	}
+
+	globalMu.Lock()
+	defer globalMu.Unlock()
+
+	if state.Queues != nil {
+		globalUsage = state.Queues
+	} else {
+		globalUsage = make(map[string]map[string]float64)
+	}
+	globalLastCycle = state.LastCycle
+
+	totalUsers := 0
+	for _, users := range globalUsage {
+		totalUsers += len(users)
+	}
+	klog.V(2).Infof("fairshare: loaded persisted state — lastCycle=%s queues=%d users=%d",
+		state.LastCycle.Format(time.RFC3339), len(state.Queues), totalUsers)
+	return nil
+}
+
+// flushState serializes the current globalUsage to the ConfigMap.
+func flushState(cfg persistConfig) error {
+	globalMu.Lock()
+	state := persistedState{
+		LastCycle: globalLastCycle,
+		Queues:   snapshotUsage(),
+	}
+	globalMu.Unlock()
+
+	data, err := json.Marshal(state)
+	if err != nil {
+		return fmt.Errorf("marshal state: %w", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), apiCallTimeout(cfg))
+	defer cancel()
+	cm, err := persistClient.CoreV1().ConfigMaps(cfg.namespace).Get(
+		ctx, cfg.configMapName, metav1.GetOptions{})
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return createStateConfigMap(ctx, cfg, string(data))
+		}
+		return fmt.Errorf("get ConfigMap: %w", err)
+	}
+
+	if cm.Data == nil {
+		cm.Data = make(map[string]string)
+	}
+	cm.Data[stateDataKey] = string(data)
+	if _, err := persistClient.CoreV1().ConfigMaps(cfg.namespace).Update(
+		ctx, cm, metav1.UpdateOptions{}); err != nil {
+		return fmt.Errorf("update ConfigMap: %w", err)
+	}
+
+	klog.V(4).Infof("fairshare: flushed state to ConfigMap (%d bytes)", len(data))
+	return nil
+}
+
+func createStateConfigMap(ctx context.Context, cfg persistConfig, data string) error {
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cfg.configMapName,
+			Namespace: cfg.namespace,
+			Labels: map[string]string{
+				"app":       "volcano-scheduler",
+				"component": "fairshare",
+			},
+		},
+		Data: map[string]string{
+			stateDataKey: data,
+		},
+	}
+	if _, err := persistClient.CoreV1().ConfigMaps(cfg.namespace).Create(
+		ctx, cm, metav1.CreateOptions{}); err != nil {
+		return fmt.Errorf("create ConfigMap: %w", err)
+	}
+	klog.V(2).Infof("fairshare: created state ConfigMap %s/%s", cfg.namespace, cfg.configMapName)
+	return nil
+}

--- a/pkg/scheduler/plugins/fairshare/persist.go
+++ b/pkg/scheduler/plugins/fairshare/persist.go
@@ -72,9 +72,9 @@ func initPersistence(client kubernetes.Interface, cfg persistConfig) {
 	persistOnce.Do(func() {
 		persistClient = client
 		if err := loadState(cfg); err != nil {
-			klog.Warningf("fairshare: failed to load persisted state: %v (starting fresh)", err)
+			klog.Warningf("[fairshare] failed to load persisted state: %v (starting fresh)", err)
 		}
-		klog.V(2).Infof("fairshare: persistence enabled — namespace=%s configMap=%s flushInterval=%s",
+		klog.V(2).Infof("[fairshare] persistence enabled — namespace=%s configMap=%s flushInterval=%s",
 			cfg.namespace, cfg.configMapName, cfg.flushInterval)
 	})
 }
@@ -115,7 +115,7 @@ func maybeFlush(cfg persistConfig) {
 	// failure (e.g. a momentary apiserver error) is retried on the very
 	// next cycle instead of being suppressed for a full flushInterval.
 	if err := flushState(cfg); err != nil {
-		klog.Warningf("fairshare: flush failed: %v", err)
+		klog.Warningf("[fairshare] flush failed: %v", err)
 		return
 	}
 
@@ -141,7 +141,7 @@ func loadState(cfg persistConfig) error {
 		ctx, cfg.configMapName, metav1.GetOptions{})
 	if err != nil {
 		if errors.IsNotFound(err) {
-			klog.V(2).Infof("fairshare: no persisted state found, starting fresh")
+			klog.V(2).Infof("[fairshare] no persisted state found, starting fresh")
 			return nil
 		}
 		return fmt.Errorf("get ConfigMap %s/%s: %w", cfg.namespace, cfg.configMapName, err)
@@ -149,7 +149,7 @@ func loadState(cfg persistConfig) error {
 
 	data, ok := cm.Data[stateDataKey]
 	if !ok || data == "" {
-		klog.V(2).Infof("fairshare: ConfigMap exists but no %s key, starting fresh", stateDataKey)
+		klog.V(2).Infof("[fairshare] ConfigMap exists but no %s key, starting fresh", stateDataKey)
 		return nil
 	}
 
@@ -172,7 +172,7 @@ func loadState(cfg persistConfig) error {
 	for _, namespaces := range globalUsage {
 		totalNamespaces += len(namespaces)
 	}
-	klog.V(2).Infof("fairshare: loaded persisted state — lastCycle=%s queues=%d namespaces=%d",
+	klog.V(2).Infof("[fairshare] loaded persisted state — lastCycle=%s queues=%d namespaces=%d",
 		state.LastCycle.Format(time.RFC3339), len(state.Queues), totalNamespaces)
 	return nil
 }
@@ -211,7 +211,7 @@ func flushState(cfg persistConfig) error {
 		return fmt.Errorf("update ConfigMap: %w", err)
 	}
 
-	klog.V(4).Infof("fairshare: flushed state to ConfigMap (%d bytes)", len(data))
+	klog.V(4).Infof("[fairshare] flushed state to ConfigMap (%d bytes)", len(data))
 	return nil
 }
 
@@ -233,6 +233,6 @@ func createStateConfigMap(ctx context.Context, cfg persistConfig, data string) e
 		ctx, cm, metav1.CreateOptions{}); err != nil {
 		return fmt.Errorf("create ConfigMap: %w", err)
 	}
-	klog.V(2).Infof("fairshare: created state ConfigMap %s/%s", cfg.namespace, cfg.configMapName)
+	klog.V(2).Infof("[fairshare] created state ConfigMap %s/%s", cfg.namespace, cfg.configMapName)
 	return nil
 }

--- a/pkg/scheduler/plugins/fairshare/persist.go
+++ b/pkg/scheduler/plugins/fairshare/persist.go
@@ -96,18 +96,24 @@ func maybeFlush(cfg persistConfig) {
 
 	flushMu.Lock()
 	due := time.Since(lastFlushAt) >= cfg.flushInterval
-	if due {
-		lastFlushAt = time.Now()
-	}
 	flushMu.Unlock()
 
 	if !due {
 		return
 	}
 
+	// lastFlushAt tracks the last *successful* flush, not the last attempt.
+	// Only advance it once flushState actually succeeds, so a transient
+	// failure (e.g. a momentary apiserver error) is retried on the very
+	// next cycle instead of being suppressed for a full flushInterval.
 	if err := flushState(cfg); err != nil {
 		klog.Warningf("fairshare: flush failed: %v", err)
+		return
 	}
+
+	flushMu.Lock()
+	lastFlushAt = time.Now()
+	flushMu.Unlock()
 }
 
 // apiCallTimeout returns a timeout for individual API calls. We use half the

--- a/pkg/scheduler/plugins/fairshare/persist.go
+++ b/pkg/scheduler/plugins/fairshare/persist.go
@@ -39,7 +39,7 @@ const (
 
 // persistedState is the JSON structure stored in the ConfigMap.
 type persistedState struct {
-	LastCycle time.Time                    `json:"lastCycle"`
+	LastCycle time.Time                     `json:"lastCycle"`
 	Queues    map[string]map[string]float64 `json:"queues"`
 }
 
@@ -54,11 +54,16 @@ type persistConfig struct {
 var (
 	persistOnce   sync.Once
 	persistClient kubernetes.Interface
+
+	// flushMu guards lastFlushAt. Kept separate from globalMu so checking
+	// the flush deadline never contends with the scheduling-critical usage
+	// lock.
+	flushMu     sync.Mutex
+	lastFlushAt time.Time
 )
 
-// initPersistence loads existing state from the ConfigMap and starts a
-// background goroutine that periodically flushes globalUsage back.
-// Uses sync.Once so only the first call (first scheduling cycle) has effect.
+// initPersistence loads existing state from the ConfigMap on the first
+// scheduling cycle. Uses sync.Once so only the first call has effect.
 // Must be called BEFORE acquiring globalMu to avoid deadlock.
 func initPersistence(client kubernetes.Interface, cfg persistConfig) {
 	if !cfg.enabled {
@@ -69,19 +74,39 @@ func initPersistence(client kubernetes.Interface, cfg persistConfig) {
 		if err := loadState(cfg); err != nil {
 			klog.Warningf("fairshare: failed to load persisted state: %v (starting fresh)", err)
 		}
-		go flushLoop(cfg)
 		klog.V(2).Infof("fairshare: persistence enabled — namespace=%s configMap=%s flushInterval=%s",
 			cfg.namespace, cfg.configMapName, cfg.flushInterval)
 	})
 }
 
-func flushLoop(cfg persistConfig) {
-	ticker := time.NewTicker(cfg.flushInterval)
-	defer ticker.Stop()
-	for range ticker.C {
-		if err := flushState(cfg); err != nil {
-			klog.Warningf("fairshare: flush failed: %v", err)
-		}
+// maybeFlush flushes globalUsage to the ConfigMap if at least
+// cfg.flushInterval has elapsed since the last flush. Called from
+// OnSessionClose (once per scheduling cycle, ~1s) rather than from a
+// detached goroutine+ticker: a ticker outlives the plugin's config —
+// removing `fairshare` from the tier list (or a scheduler config hot
+// reload) doesn't stop it, so it keeps writing stale state forever. Tying
+// the flush to OnSessionClose means persistence naturally stops the moment
+// the plugin stops being invoked, with no separate shutdown path needed.
+// Rate-limiting here keeps the ConfigMap write cadence the same as before
+// (every flushInterval) rather than once per ~1s scheduling cycle.
+func maybeFlush(cfg persistConfig) {
+	if !cfg.enabled {
+		return
+	}
+
+	flushMu.Lock()
+	due := time.Since(lastFlushAt) >= cfg.flushInterval
+	if due {
+		lastFlushAt = time.Now()
+	}
+	flushMu.Unlock()
+
+	if !due {
+		return
+	}
+
+	if err := flushState(cfg); err != nil {
+		klog.Warningf("fairshare: flush failed: %v", err)
 	}
 }
 
@@ -130,12 +155,12 @@ func loadState(cfg persistConfig) error {
 	}
 	globalLastCycle = state.LastCycle
 
-	totalUsers := 0
-	for _, users := range globalUsage {
-		totalUsers += len(users)
+	totalNamespaces := 0
+	for _, namespaces := range globalUsage {
+		totalNamespaces += len(namespaces)
 	}
-	klog.V(2).Infof("fairshare: loaded persisted state — lastCycle=%s queues=%d users=%d",
-		state.LastCycle.Format(time.RFC3339), len(state.Queues), totalUsers)
+	klog.V(2).Infof("fairshare: loaded persisted state — lastCycle=%s queues=%d namespaces=%d",
+		state.LastCycle.Format(time.RFC3339), len(state.Queues), totalNamespaces)
 	return nil
 }
 
@@ -144,7 +169,7 @@ func flushState(cfg persistConfig) error {
 	globalMu.Lock()
 	state := persistedState{
 		LastCycle: globalLastCycle,
-		Queues:   snapshotUsage(),
+		Queues:    snapshotUsage(),
 	}
 	globalMu.Unlock()
 

--- a/pkg/scheduler/plugins/fairshare/persist.go
+++ b/pkg/scheduler/plugins/fairshare/persist.go
@@ -94,11 +94,19 @@ func maybeFlush(cfg persistConfig) {
 		return
 	}
 
+	// Hold flushMu across the due-check *and* the flush itself (not just
+	// the check). Volcano's main scheduler calls OnSessionClose
+	// sequentially today, but nothing here should assume that forever —
+	// if maybeFlush were ever called concurrently (e.g. from an
+	// Agent-Scheduler-style multi-worker setup), releasing the lock
+	// between the check and the flush would let two callers both observe
+	// due=true and both call flushState in parallel: duplicate API calls
+	// and a possible resourceVersion conflict on Update. Holding the lock
+	// for the whole sequence serializes flush attempts instead.
 	flushMu.Lock()
-	due := time.Since(lastFlushAt) >= cfg.flushInterval
-	flushMu.Unlock()
+	defer flushMu.Unlock()
 
-	if !due {
+	if time.Since(lastFlushAt) < cfg.flushInterval {
 		return
 	}
 
@@ -111,14 +119,13 @@ func maybeFlush(cfg persistConfig) {
 		return
 	}
 
-	flushMu.Lock()
 	lastFlushAt = time.Now()
-	flushMu.Unlock()
 }
 
 // apiCallTimeout returns a timeout for individual API calls. We use half the
-// flush interval so a slow/stalled request can't block the next flush tick
-// (time.Ticker drops ticks if the handler runs long).
+// flush interval so a slow/stalled apiserver call can't hold flushMu (and
+// therefore delay the next OnSessionClose-driven flush attempt) for longer
+// than half of flushInterval.
 func apiCallTimeout(cfg persistConfig) time.Duration {
 	if cfg.flushInterval <= 0 {
 		return 15 * time.Second

--- a/pkg/scheduler/plugins/fairshare/persist.go
+++ b/pkg/scheduler/plugins/fairshare/persist.go
@@ -1,0 +1,209 @@
+/*
+Copyright 2025 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fairshare
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/klog/v2"
+)
+
+const (
+	defaultConfigMapName  = "fairshare-usage-state"
+	defaultStateNamespace = "volcano-system"
+	defaultFlushInterval  = 30 * time.Second
+	stateDataKey          = "state.json"
+)
+
+// persistedState is the JSON structure stored in the ConfigMap.
+type persistedState struct {
+	LastCycle time.Time                     `json:"lastCycle"`
+	Queues    map[string]map[string]float64 `json:"queues"`
+}
+
+// persistConfig holds persistence settings parsed from plugin arguments.
+type persistConfig struct {
+	enabled       bool
+	namespace     string
+	configMapName string
+	flushInterval time.Duration
+}
+
+// initPersistence loads existing state from the ConfigMap on the first
+// scheduling cycle. Guarded by state.persistenceInitialized instead of a
+// sync.Once: safe because OnSessionOpen (the only caller) runs sequentially
+// from a single goroutine — see the doc comment on fairShareProcessState in
+// fairshare.go.
+func initPersistence(client kubernetes.Interface, cfg persistConfig) {
+	if !cfg.enabled || state.persistenceInitialized {
+		return
+	}
+	state.persistenceInitialized = true
+
+	if err := loadState(client, cfg); err != nil {
+		klog.Warningf("[fairshare] failed to load persisted state: %v (starting fresh)", err)
+	}
+	klog.V(2).Infof("[fairshare] persistence enabled — namespace=%s configMap=%s flushInterval=%s",
+		cfg.namespace, cfg.configMapName, cfg.flushInterval)
+}
+
+// maybeFlush flushes state.usage to the ConfigMap if at least
+// cfg.flushInterval has elapsed since the last flush. Called from
+// OnSessionClose (once per scheduling cycle, ~1s) rather than from a
+// detached goroutine+ticker: a ticker outlives the plugin's config —
+// removing `fairshare` from the tier list (or a scheduler config hot
+// reload) doesn't stop it, so it keeps writing stale state forever. Tying
+// the flush to OnSessionClose means persistence naturally stops the moment
+// the plugin stops being invoked, with no separate shutdown path needed.
+// Rate-limiting here keeps the ConfigMap write cadence the same as before
+// (every flushInterval) rather than once per ~1s scheduling cycle.
+func maybeFlush(client kubernetes.Interface, cfg persistConfig) {
+	if !cfg.enabled {
+		return
+	}
+
+	if time.Since(state.lastFlushAt) < cfg.flushInterval {
+		return
+	}
+
+	// lastFlushAt tracks the last *successful* flush, not the last attempt.
+	// Only advance it once flushState actually succeeds, so a transient
+	// failure (e.g. a momentary apiserver error) is retried on the very
+	// next cycle instead of being suppressed for a full flushInterval.
+	if err := flushState(client, cfg); err != nil {
+		klog.Warningf("[fairshare] flush failed: %v", err)
+		return
+	}
+
+	state.lastFlushAt = time.Now()
+}
+
+// apiCallTimeout returns a timeout for individual API calls. We use half the
+// flush interval so a slow/stalled apiserver call can't delay the next
+// OnSessionClose-driven flush attempt for longer than half of flushInterval.
+func apiCallTimeout(cfg persistConfig) time.Duration {
+	if cfg.flushInterval <= 0 {
+		return 15 * time.Second
+	}
+	return cfg.flushInterval / 2
+}
+
+// loadState reads the ConfigMap and populates state.usage / state.lastCycle.
+func loadState(client kubernetes.Interface, cfg persistConfig) error {
+	ctx, cancel := context.WithTimeout(context.Background(), apiCallTimeout(cfg))
+	defer cancel()
+	cm, err := client.CoreV1().ConfigMaps(cfg.namespace).Get(
+		ctx, cfg.configMapName, metav1.GetOptions{})
+	if err != nil {
+		if errors.IsNotFound(err) {
+			klog.V(2).Infof("[fairshare] no persisted state found, starting fresh")
+			return nil
+		}
+		return fmt.Errorf("get ConfigMap %s/%s: %w", cfg.namespace, cfg.configMapName, err)
+	}
+
+	data, ok := cm.Data[stateDataKey]
+	if !ok || data == "" {
+		klog.V(2).Infof("[fairshare] ConfigMap exists but no %s key, starting fresh", stateDataKey)
+		return nil
+	}
+
+	var loaded persistedState
+	if err := json.Unmarshal([]byte(data), &loaded); err != nil {
+		return fmt.Errorf("unmarshal state: %w", err)
+	}
+
+	if loaded.Queues != nil {
+		state.usage = loaded.Queues
+	} else {
+		state.usage = make(map[string]map[string]float64)
+	}
+	state.lastCycle = loaded.LastCycle
+
+	totalNamespaces := 0
+	for _, namespaces := range state.usage {
+		totalNamespaces += len(namespaces)
+	}
+	klog.V(2).Infof("[fairshare] loaded persisted state — lastCycle=%s queues=%d namespaces=%d",
+		loaded.LastCycle.Format(time.RFC3339), len(loaded.Queues), totalNamespaces)
+	return nil
+}
+
+// flushState serializes the current state.usage to the ConfigMap.
+func flushState(client kubernetes.Interface, cfg persistConfig) error {
+	toPersist := persistedState{
+		LastCycle: state.lastCycle,
+		Queues:    snapshotUsage(),
+	}
+
+	data, err := json.Marshal(toPersist)
+	if err != nil {
+		return fmt.Errorf("marshal state: %w", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), apiCallTimeout(cfg))
+	defer cancel()
+	cm, err := client.CoreV1().ConfigMaps(cfg.namespace).Get(
+		ctx, cfg.configMapName, metav1.GetOptions{})
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return createStateConfigMap(ctx, client, cfg, string(data))
+		}
+		return fmt.Errorf("get ConfigMap: %w", err)
+	}
+
+	if cm.Data == nil {
+		cm.Data = make(map[string]string)
+	}
+	cm.Data[stateDataKey] = string(data)
+	if _, err := client.CoreV1().ConfigMaps(cfg.namespace).Update(
+		ctx, cm, metav1.UpdateOptions{}); err != nil {
+		return fmt.Errorf("update ConfigMap: %w", err)
+	}
+
+	klog.V(4).Infof("[fairshare] flushed state to ConfigMap (%d bytes)", len(data))
+	return nil
+}
+
+func createStateConfigMap(ctx context.Context, client kubernetes.Interface, cfg persistConfig, data string) error {
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cfg.configMapName,
+			Namespace: cfg.namespace,
+			Labels: map[string]string{
+				"app":       "volcano-scheduler",
+				"component": "fairshare",
+			},
+		},
+		Data: map[string]string{
+			stateDataKey: data,
+		},
+	}
+	if _, err := client.CoreV1().ConfigMaps(cfg.namespace).Create(
+		ctx, cm, metav1.CreateOptions{}); err != nil {
+		return fmt.Errorf("create ConfigMap: %w", err)
+	}
+	klog.V(2).Infof("[fairshare] created state ConfigMap %s/%s", cfg.namespace, cfg.configMapName)
+	return nil
+}

--- a/pkg/scheduler/plugins/fairshare/persist_test.go
+++ b/pkg/scheduler/plugins/fairshare/persist_test.go
@@ -1,0 +1,331 @@
+/*
+Copyright 2025 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fairshare
+
+import (
+	"context"
+	"encoding/json"
+	"math"
+	"sync"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func testPersistConfig() persistConfig {
+	return persistConfig{
+		enabled:       true,
+		namespace:     "test-ns",
+		configMapName: "test-fairshare-state",
+		flushInterval: 1 * time.Second,
+	}
+}
+
+func saveAndResetGlobals(t *testing.T) func() {
+	t.Helper()
+	globalMu.Lock()
+	savedUsage := globalUsage
+	savedLastCycle := globalLastCycle
+	globalUsage = make(map[string]map[string]float64)
+	globalLastCycle = time.Time{}
+	globalMu.Unlock()
+
+	persistOnce = sync.Once{}
+	savedClient := persistClient
+	persistClient = nil
+
+	return func() {
+		globalMu.Lock()
+		globalUsage = savedUsage
+		globalLastCycle = savedLastCycle
+		globalMu.Unlock()
+		persistOnce = sync.Once{}
+		persistClient = savedClient
+	}
+}
+
+func TestFlushState_CreatesConfigMap(t *testing.T) {
+	restore := saveAndResetGlobals(t)
+	defer restore()
+
+	client := fake.NewSimpleClientset()
+	persistClient = client
+	cfg := testPersistConfig()
+
+	now := time.Now().Truncate(time.Second)
+	globalMu.Lock()
+	globalUsage = map[string]map[string]float64{
+		"gpu-queue": {"alice": 1000.0, "bob": 500.0},
+	}
+	globalLastCycle = now
+	globalMu.Unlock()
+
+	if err := flushState(cfg); err != nil {
+		t.Fatalf("flushState: %v", err)
+	}
+
+	cm, err := client.CoreV1().ConfigMaps(cfg.namespace).Get(
+		context.TODO(), cfg.configMapName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get ConfigMap: %v", err)
+	}
+
+	data, ok := cm.Data[stateDataKey]
+	if !ok {
+		t.Fatal("ConfigMap missing state.json key")
+	}
+
+	var state persistedState
+	if err := json.Unmarshal([]byte(data), &state); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if math.Abs(state.Queues["gpu-queue"]["alice"]-1000.0) > 0.01 {
+		t.Errorf("alice: got %.2f, want 1000.0", state.Queues["gpu-queue"]["alice"])
+	}
+	if math.Abs(state.Queues["gpu-queue"]["bob"]-500.0) > 0.01 {
+		t.Errorf("bob: got %.2f, want 500.0", state.Queues["gpu-queue"]["bob"])
+	}
+	if !state.LastCycle.Equal(now) {
+		t.Errorf("lastCycle: got %v, want %v", state.LastCycle, now)
+	}
+}
+
+func TestFlushState_UpdatesExistingConfigMap(t *testing.T) {
+	restore := saveAndResetGlobals(t)
+	defer restore()
+
+	cfg := testPersistConfig()
+	existing := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cfg.configMapName,
+			Namespace: cfg.namespace,
+		},
+		Data: map[string]string{stateDataKey: `{"lastCycle":"2020-01-01T00:00:00Z","queues":{}}`},
+	}
+	client := fake.NewSimpleClientset(existing)
+	persistClient = client
+
+	now := time.Now().Truncate(time.Second)
+	globalMu.Lock()
+	globalUsage = map[string]map[string]float64{
+		"gpu-queue": {"carol": 200.0},
+	}
+	globalLastCycle = now
+	globalMu.Unlock()
+
+	if err := flushState(cfg); err != nil {
+		t.Fatalf("flushState: %v", err)
+	}
+
+	cm, err := client.CoreV1().ConfigMaps(cfg.namespace).Get(
+		context.TODO(), cfg.configMapName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get ConfigMap: %v", err)
+	}
+
+	var state persistedState
+	if err := json.Unmarshal([]byte(cm.Data[stateDataKey]), &state); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if math.Abs(state.Queues["gpu-queue"]["carol"]-200.0) > 0.01 {
+		t.Errorf("carol: got %.2f, want 200.0", state.Queues["gpu-queue"]["carol"])
+	}
+}
+
+func TestLoadState_PopulatesGlobals(t *testing.T) {
+	restore := saveAndResetGlobals(t)
+	defer restore()
+
+	cfg := testPersistConfig()
+	now := time.Date(2026, 4, 7, 12, 0, 0, 0, time.UTC)
+
+	stateJSON, _ := json.Marshal(persistedState{
+		LastCycle: now,
+		Queues: map[string]map[string]float64{
+			"gpu-queue": {"alice": 800.0, "bob": 300.0},
+			"cpu-queue": {"carol": 50.0},
+		},
+	})
+
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cfg.configMapName,
+			Namespace: cfg.namespace,
+		},
+		Data: map[string]string{stateDataKey: string(stateJSON)},
+	}
+	client := fake.NewSimpleClientset(cm)
+	persistClient = client
+
+	if err := loadState(cfg); err != nil {
+		t.Fatalf("loadState: %v", err)
+	}
+
+	globalMu.Lock()
+	defer globalMu.Unlock()
+
+	if !globalLastCycle.Equal(now) {
+		t.Errorf("globalLastCycle: got %v, want %v", globalLastCycle, now)
+	}
+	if math.Abs(globalUsage["gpu-queue"]["alice"]-800.0) > 0.01 {
+		t.Errorf("alice: got %.2f, want 800.0", globalUsage["gpu-queue"]["alice"])
+	}
+	if math.Abs(globalUsage["gpu-queue"]["bob"]-300.0) > 0.01 {
+		t.Errorf("bob: got %.2f, want 300.0", globalUsage["gpu-queue"]["bob"])
+	}
+	if math.Abs(globalUsage["cpu-queue"]["carol"]-50.0) > 0.01 {
+		t.Errorf("carol: got %.2f, want 50.0", globalUsage["cpu-queue"]["carol"])
+	}
+}
+
+func TestLoadState_NoConfigMap_StartsFresh(t *testing.T) {
+	restore := saveAndResetGlobals(t)
+	defer restore()
+
+	client := fake.NewSimpleClientset()
+	persistClient = client
+	cfg := testPersistConfig()
+
+	if err := loadState(cfg); err != nil {
+		t.Fatalf("loadState should not error on missing ConfigMap: %v", err)
+	}
+
+	globalMu.Lock()
+	defer globalMu.Unlock()
+
+	if len(globalUsage) != 0 {
+		t.Errorf("expected empty globalUsage, got %v", globalUsage)
+	}
+	if !globalLastCycle.IsZero() {
+		t.Errorf("expected zero globalLastCycle, got %v", globalLastCycle)
+	}
+}
+
+func TestLoadState_EmptyData_StartsFresh(t *testing.T) {
+	restore := saveAndResetGlobals(t)
+	defer restore()
+
+	cfg := testPersistConfig()
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cfg.configMapName,
+			Namespace: cfg.namespace,
+		},
+		Data: map[string]string{},
+	}
+	client := fake.NewSimpleClientset(cm)
+	persistClient = client
+
+	if err := loadState(cfg); err != nil {
+		t.Fatalf("loadState: %v", err)
+	}
+
+	globalMu.Lock()
+	defer globalMu.Unlock()
+
+	if len(globalUsage) != 0 {
+		t.Errorf("expected empty globalUsage, got %v", globalUsage)
+	}
+}
+
+func TestRoundTrip_FlushThenLoad(t *testing.T) {
+	restore := saveAndResetGlobals(t)
+	defer restore()
+
+	client := fake.NewSimpleClientset()
+	persistClient = client
+	cfg := testPersistConfig()
+
+	now := time.Now().Truncate(time.Second)
+	globalMu.Lock()
+	globalUsage = map[string]map[string]float64{
+		"q1": {"user-a": 123.45, "user-b": 678.90},
+		"q2": {"user-c": 42.0},
+	}
+	globalLastCycle = now
+	globalMu.Unlock()
+
+	if err := flushState(cfg); err != nil {
+		t.Fatalf("flushState: %v", err)
+	}
+
+	// Clear globals to simulate restart
+	globalMu.Lock()
+	globalUsage = make(map[string]map[string]float64)
+	globalLastCycle = time.Time{}
+	globalMu.Unlock()
+
+	if err := loadState(cfg); err != nil {
+		t.Fatalf("loadState: %v", err)
+	}
+
+	globalMu.Lock()
+	defer globalMu.Unlock()
+
+	if !globalLastCycle.Equal(now) {
+		t.Errorf("lastCycle: got %v, want %v", globalLastCycle, now)
+	}
+	if math.Abs(globalUsage["q1"]["user-a"]-123.45) > 0.01 {
+		t.Errorf("user-a: got %.2f, want 123.45", globalUsage["q1"]["user-a"])
+	}
+	if math.Abs(globalUsage["q1"]["user-b"]-678.90) > 0.01 {
+		t.Errorf("user-b: got %.2f, want 678.90", globalUsage["q1"]["user-b"])
+	}
+	if math.Abs(globalUsage["q2"]["user-c"]-42.0) > 0.01 {
+		t.Errorf("user-c: got %.2f, want 42.0", globalUsage["q2"]["user-c"])
+	}
+}
+
+func TestInitPersistence_DisabledIsNoop(t *testing.T) {
+	restore := saveAndResetGlobals(t)
+	defer restore()
+
+	client := fake.NewSimpleClientset()
+	cfg := persistConfig{enabled: false}
+
+	initPersistence(client, cfg)
+
+	if persistClient != nil {
+		t.Error("persistClient should remain nil when disabled")
+	}
+}
+
+func TestLoadState_CorruptJSON_ReturnsError(t *testing.T) {
+	restore := saveAndResetGlobals(t)
+	defer restore()
+
+	cfg := testPersistConfig()
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cfg.configMapName,
+			Namespace: cfg.namespace,
+		},
+		Data: map[string]string{stateDataKey: "not-valid-json{{{"},
+	}
+	client := fake.NewSimpleClientset(cm)
+	persistClient = client
+
+	err := loadState(cfg)
+	if err == nil {
+		t.Fatal("expected error for corrupt JSON")
+	}
+}

--- a/pkg/scheduler/plugins/fairshare/persist_test.go
+++ b/pkg/scheduler/plugins/fairshare/persist_test.go
@@ -1,0 +1,433 @@
+/*
+Copyright 2025 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fairshare
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"math"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+	ktesting "k8s.io/client-go/testing"
+)
+
+func testPersistConfig() persistConfig {
+	return persistConfig{
+		enabled:       true,
+		namespace:     "test-ns",
+		configMapName: "test-fairshare-state",
+		flushInterval: 1 * time.Second,
+	}
+}
+
+// saveAndResetState snapshots the package-level state so each test can
+// mutate it freely, then restores it on cleanup. state is unguarded by a
+// lock (see its doc comment in fairshare.go) since tests, like production,
+// run single-threaded against it.
+func saveAndResetState(t *testing.T) func() {
+	t.Helper()
+	savedUsage := state.usage
+	savedLastCycle := state.lastCycle
+	savedPersistenceInitialized := state.persistenceInitialized
+	savedLastFlushAt := state.lastFlushAt
+
+	state.usage = make(map[string]map[string]float64)
+	state.lastCycle = time.Time{}
+	state.persistenceInitialized = false
+	state.lastFlushAt = time.Time{}
+
+	return func() {
+		state.usage = savedUsage
+		state.lastCycle = savedLastCycle
+		state.persistenceInitialized = savedPersistenceInitialized
+		state.lastFlushAt = savedLastFlushAt
+	}
+}
+
+func TestFlushState_CreatesConfigMap(t *testing.T) {
+	restore := saveAndResetState(t)
+	defer restore()
+
+	client := fake.NewSimpleClientset()
+	cfg := testPersistConfig()
+
+	now := time.Now().Truncate(time.Second)
+	state.usage = map[string]map[string]float64{
+		"gpu-queue": {"alice": 1000.0, "bob": 500.0},
+	}
+	state.lastCycle = now
+
+	if err := flushState(client, cfg); err != nil {
+		t.Fatalf("flushState: %v", err)
+	}
+
+	cm, err := client.CoreV1().ConfigMaps(cfg.namespace).Get(
+		context.TODO(), cfg.configMapName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get ConfigMap: %v", err)
+	}
+
+	data, ok := cm.Data[stateDataKey]
+	if !ok {
+		t.Fatal("ConfigMap missing state.json key")
+	}
+
+	var persisted persistedState
+	if err := json.Unmarshal([]byte(data), &persisted); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if math.Abs(persisted.Queues["gpu-queue"]["alice"]-1000.0) > 0.01 {
+		t.Errorf("alice: got %.2f, want 1000.0", persisted.Queues["gpu-queue"]["alice"])
+	}
+	if math.Abs(persisted.Queues["gpu-queue"]["bob"]-500.0) > 0.01 {
+		t.Errorf("bob: got %.2f, want 500.0", persisted.Queues["gpu-queue"]["bob"])
+	}
+	if !persisted.LastCycle.Equal(now) {
+		t.Errorf("lastCycle: got %v, want %v", persisted.LastCycle, now)
+	}
+}
+
+func TestFlushState_UpdatesExistingConfigMap(t *testing.T) {
+	restore := saveAndResetState(t)
+	defer restore()
+
+	cfg := testPersistConfig()
+	existing := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cfg.configMapName,
+			Namespace: cfg.namespace,
+		},
+		Data: map[string]string{stateDataKey: `{"lastCycle":"2020-01-01T00:00:00Z","queues":{}}`},
+	}
+	client := fake.NewSimpleClientset(existing)
+
+	now := time.Now().Truncate(time.Second)
+	state.usage = map[string]map[string]float64{
+		"gpu-queue": {"carol": 200.0},
+	}
+	state.lastCycle = now
+
+	if err := flushState(client, cfg); err != nil {
+		t.Fatalf("flushState: %v", err)
+	}
+
+	cm, err := client.CoreV1().ConfigMaps(cfg.namespace).Get(
+		context.TODO(), cfg.configMapName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get ConfigMap: %v", err)
+	}
+
+	var persisted persistedState
+	if err := json.Unmarshal([]byte(cm.Data[stateDataKey]), &persisted); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if math.Abs(persisted.Queues["gpu-queue"]["carol"]-200.0) > 0.01 {
+		t.Errorf("carol: got %.2f, want 200.0", persisted.Queues["gpu-queue"]["carol"])
+	}
+}
+
+func TestLoadState_PopulatesGlobals(t *testing.T) {
+	restore := saveAndResetState(t)
+	defer restore()
+
+	cfg := testPersistConfig()
+	now := time.Date(2026, 4, 7, 12, 0, 0, 0, time.UTC)
+
+	stateJSON, _ := json.Marshal(persistedState{
+		LastCycle: now,
+		Queues: map[string]map[string]float64{
+			"gpu-queue": {"alice": 800.0, "bob": 300.0},
+			"cpu-queue": {"carol": 50.0},
+		},
+	})
+
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cfg.configMapName,
+			Namespace: cfg.namespace,
+		},
+		Data: map[string]string{stateDataKey: string(stateJSON)},
+	}
+	client := fake.NewSimpleClientset(cm)
+
+	if err := loadState(client, cfg); err != nil {
+		t.Fatalf("loadState: %v", err)
+	}
+
+	if !state.lastCycle.Equal(now) {
+		t.Errorf("lastCycle: got %v, want %v", state.lastCycle, now)
+	}
+	if math.Abs(state.usage["gpu-queue"]["alice"]-800.0) > 0.01 {
+		t.Errorf("alice: got %.2f, want 800.0", state.usage["gpu-queue"]["alice"])
+	}
+	if math.Abs(state.usage["gpu-queue"]["bob"]-300.0) > 0.01 {
+		t.Errorf("bob: got %.2f, want 300.0", state.usage["gpu-queue"]["bob"])
+	}
+	if math.Abs(state.usage["cpu-queue"]["carol"]-50.0) > 0.01 {
+		t.Errorf("carol: got %.2f, want 50.0", state.usage["cpu-queue"]["carol"])
+	}
+}
+
+func TestLoadState_NoConfigMap_StartsFresh(t *testing.T) {
+	restore := saveAndResetState(t)
+	defer restore()
+
+	client := fake.NewSimpleClientset()
+	cfg := testPersistConfig()
+
+	if err := loadState(client, cfg); err != nil {
+		t.Fatalf("loadState should not error on missing ConfigMap: %v", err)
+	}
+
+	if len(state.usage) != 0 {
+		t.Errorf("expected empty usage, got %v", state.usage)
+	}
+	if !state.lastCycle.IsZero() {
+		t.Errorf("expected zero lastCycle, got %v", state.lastCycle)
+	}
+}
+
+func TestLoadState_EmptyData_StartsFresh(t *testing.T) {
+	restore := saveAndResetState(t)
+	defer restore()
+
+	cfg := testPersistConfig()
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cfg.configMapName,
+			Namespace: cfg.namespace,
+		},
+		Data: map[string]string{},
+	}
+	client := fake.NewSimpleClientset(cm)
+
+	if err := loadState(client, cfg); err != nil {
+		t.Fatalf("loadState: %v", err)
+	}
+
+	if len(state.usage) != 0 {
+		t.Errorf("expected empty usage, got %v", state.usage)
+	}
+}
+
+func TestRoundTrip_FlushThenLoad(t *testing.T) {
+	restore := saveAndResetState(t)
+	defer restore()
+
+	client := fake.NewSimpleClientset()
+	cfg := testPersistConfig()
+
+	now := time.Now().Truncate(time.Second)
+	state.usage = map[string]map[string]float64{
+		"q1": {"ns-a": 123.45, "ns-b": 678.90},
+		"q2": {"ns-c": 42.0},
+	}
+	state.lastCycle = now
+
+	if err := flushState(client, cfg); err != nil {
+		t.Fatalf("flushState: %v", err)
+	}
+
+	// Clear state to simulate restart
+	state.usage = make(map[string]map[string]float64)
+	state.lastCycle = time.Time{}
+
+	if err := loadState(client, cfg); err != nil {
+		t.Fatalf("loadState: %v", err)
+	}
+
+	if !state.lastCycle.Equal(now) {
+		t.Errorf("lastCycle: got %v, want %v", state.lastCycle, now)
+	}
+	if math.Abs(state.usage["q1"]["ns-a"]-123.45) > 0.01 {
+		t.Errorf("ns-a: got %.2f, want 123.45", state.usage["q1"]["ns-a"])
+	}
+	if math.Abs(state.usage["q1"]["ns-b"]-678.90) > 0.01 {
+		t.Errorf("ns-b: got %.2f, want 678.90", state.usage["q1"]["ns-b"])
+	}
+	if math.Abs(state.usage["q2"]["ns-c"]-42.0) > 0.01 {
+		t.Errorf("ns-c: got %.2f, want 42.0", state.usage["q2"]["ns-c"])
+	}
+}
+
+func TestInitPersistence_DisabledIsNoop(t *testing.T) {
+	restore := saveAndResetState(t)
+	defer restore()
+
+	client := fake.NewSimpleClientset()
+	cfg := persistConfig{enabled: false}
+
+	initPersistence(client, cfg)
+
+	if state.persistenceInitialized {
+		t.Error("persistenceInitialized should remain false when disabled")
+	}
+}
+
+// --- maybeFlush tests (OnSessionClose-driven, rate-limited flush) ---
+
+func TestMaybeFlush_DisabledIsNoop(t *testing.T) {
+	restore := saveAndResetState(t)
+	defer restore()
+
+	client := fake.NewSimpleClientset()
+	cfg := testPersistConfig()
+	cfg.enabled = false
+
+	maybeFlush(client, cfg)
+
+	if _, err := client.CoreV1().ConfigMaps(cfg.namespace).Get(
+		context.TODO(), cfg.configMapName, metav1.GetOptions{}); err == nil {
+		t.Error("ConfigMap should not be created when persistence is disabled")
+	}
+}
+
+func TestMaybeFlush_FirstCallFlushesImmediately(t *testing.T) {
+	restore := saveAndResetState(t)
+	defer restore()
+
+	client := fake.NewSimpleClientset()
+	cfg := testPersistConfig()
+
+	state.usage = map[string]map[string]float64{"gpu-queue": {"alice": 100.0}}
+
+	maybeFlush(client, cfg)
+
+	if _, err := client.CoreV1().ConfigMaps(cfg.namespace).Get(
+		context.TODO(), cfg.configMapName, metav1.GetOptions{}); err != nil {
+		t.Errorf("expected ConfigMap to be created on first flush, get failed: %v", err)
+	}
+}
+
+func TestMaybeFlush_RateLimited_SkipsSecondCallWithinInterval(t *testing.T) {
+	restore := saveAndResetState(t)
+	defer restore()
+
+	client := fake.NewSimpleClientset()
+	cfg := testPersistConfig()
+	cfg.flushInterval = 1 * time.Hour // long enough that a second immediate call must be skipped
+
+	state.usage = map[string]map[string]float64{"gpu-queue": {"alice": 100.0}}
+	maybeFlush(client, cfg) // first call: flushes alice=100.0
+
+	state.usage = map[string]map[string]float64{"gpu-queue": {"alice": 999.0}}
+	maybeFlush(client, cfg) // second call, immediately after: should be skipped
+
+	cm, err := client.CoreV1().ConfigMaps(cfg.namespace).Get(
+		context.TODO(), cfg.configMapName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get ConfigMap: %v", err)
+	}
+	var persisted persistedState
+	if err := json.Unmarshal([]byte(cm.Data[stateDataKey]), &persisted); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if math.Abs(persisted.Queues["gpu-queue"]["alice"]-100.0) > 0.01 {
+		t.Errorf("second maybeFlush within the interval should have been skipped: got alice=%.2f, want 100.0 (from first flush)",
+			persisted.Queues["gpu-queue"]["alice"])
+	}
+}
+
+func TestMaybeFlush_FlushesAgainAfterIntervalElapses(t *testing.T) {
+	restore := saveAndResetState(t)
+	defer restore()
+
+	client := fake.NewSimpleClientset()
+	cfg := testPersistConfig()
+	cfg.flushInterval = 1 * time.Millisecond
+
+	state.usage = map[string]map[string]float64{"gpu-queue": {"alice": 100.0}}
+	maybeFlush(client, cfg)
+
+	time.Sleep(5 * time.Millisecond)
+
+	state.usage = map[string]map[string]float64{"gpu-queue": {"alice": 999.0}}
+	maybeFlush(client, cfg)
+
+	cm, err := client.CoreV1().ConfigMaps(cfg.namespace).Get(
+		context.TODO(), cfg.configMapName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get ConfigMap: %v", err)
+	}
+	var persisted persistedState
+	if err := json.Unmarshal([]byte(cm.Data[stateDataKey]), &persisted); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if math.Abs(persisted.Queues["gpu-queue"]["alice"]-999.0) > 0.01 {
+		t.Errorf("maybeFlush after the interval elapsed should have flushed again: got alice=%.2f, want 999.0",
+			persisted.Queues["gpu-queue"]["alice"])
+	}
+}
+
+func TestMaybeFlush_FailedFlushDoesNotAdvanceLastFlushAt(t *testing.T) {
+	restore := saveAndResetState(t)
+	defer restore()
+
+	client := fake.NewSimpleClientset()
+	client.PrependReactor("get", "configmaps", func(action ktesting.Action) (bool, runtime.Object, error) {
+		return true, nil, fmt.Errorf("simulated transient apiserver error")
+	})
+	cfg := testPersistConfig()
+	cfg.flushInterval = 1 * time.Hour // long enough that a retry-on-next-call only happens if the failed attempt didn't set lastFlushAt
+
+	state.usage = map[string]map[string]float64{"gpu-queue": {"alice": 100.0}}
+
+	maybeFlush(client, cfg) // fails (simulated), must not advance lastFlushAt
+
+	if !state.lastFlushAt.IsZero() {
+		t.Error("lastFlushAt should remain zero after a failed flush, so the next call retries promptly")
+	}
+
+	// Remove the failing reactor and retry immediately — should succeed
+	// despite the long flushInterval, because the failed attempt never
+	// counted as "due" having been satisfied.
+	client.ReactionChain = client.ReactionChain[1:]
+	maybeFlush(client, cfg)
+
+	if _, err := client.CoreV1().ConfigMaps(cfg.namespace).Get(
+		context.TODO(), cfg.configMapName, metav1.GetOptions{}); err != nil {
+		t.Errorf("expected the retry to succeed and create the ConfigMap, get failed: %v", err)
+	}
+}
+
+func TestLoadState_CorruptJSON_ReturnsError(t *testing.T) {
+	restore := saveAndResetState(t)
+	defer restore()
+
+	cfg := testPersistConfig()
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cfg.configMapName,
+			Namespace: cfg.namespace,
+		},
+		Data: map[string]string{stateDataKey: "not-valid-json{{{"},
+	}
+	client := fake.NewSimpleClientset(cm)
+
+	err := loadState(client, cfg)
+	if err == nil {
+		t.Fatal("expected error for corrupt JSON")
+	}
+}

--- a/pkg/scheduler/plugins/fairshare/persist_test.go
+++ b/pkg/scheduler/plugins/fairshare/persist_test.go
@@ -19,6 +19,7 @@ package fairshare
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"math"
 	"sync"
 	"testing"
@@ -26,7 +27,9 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
+	ktesting "k8s.io/client-go/testing"
 )
 
 func testPersistConfig() persistConfig {
@@ -423,6 +426,43 @@ func TestMaybeFlush_FlushesAgainAfterIntervalElapses(t *testing.T) {
 	if math.Abs(state.Queues["gpu-queue"]["alice"]-999.0) > 0.01 {
 		t.Errorf("maybeFlush after the interval elapsed should have flushed again: got alice=%.2f, want 999.0",
 			state.Queues["gpu-queue"]["alice"])
+	}
+}
+
+func TestMaybeFlush_FailedFlushDoesNotAdvanceLastFlushAt(t *testing.T) {
+	restore := saveAndResetGlobals(t)
+	defer restore()
+
+	client := fake.NewSimpleClientset()
+	client.PrependReactor("get", "configmaps", func(action ktesting.Action) (bool, runtime.Object, error) {
+		return true, nil, fmt.Errorf("simulated transient apiserver error")
+	})
+	persistClient = client
+	cfg := testPersistConfig()
+	cfg.flushInterval = 1 * time.Hour // long enough that a retry-on-next-call only happens if the failed attempt didn't set lastFlushAt
+
+	globalMu.Lock()
+	globalUsage = map[string]map[string]float64{"gpu-queue": {"alice": 100.0}}
+	globalMu.Unlock()
+
+	maybeFlush(cfg) // fails (simulated), must not advance lastFlushAt
+
+	flushMu.Lock()
+	notAdvanced := lastFlushAt.IsZero()
+	flushMu.Unlock()
+	if !notAdvanced {
+		t.Error("lastFlushAt should remain zero after a failed flush, so the next call retries promptly")
+	}
+
+	// Remove the failing reactor and retry immediately — should succeed
+	// despite the long flushInterval, because the failed attempt never
+	// counted as "due" having been satisfied.
+	client.ReactionChain = client.ReactionChain[1:]
+	maybeFlush(cfg)
+
+	if _, err := client.CoreV1().ConfigMaps(cfg.namespace).Get(
+		context.TODO(), cfg.configMapName, metav1.GetOptions{}); err != nil {
+		t.Errorf("expected the retry to succeed and create the ConfigMap, get failed: %v", err)
 	}
 }
 

--- a/pkg/scheduler/plugins/fairshare/persist_test.go
+++ b/pkg/scheduler/plugins/fairshare/persist_test.go
@@ -51,6 +51,11 @@ func saveAndResetGlobals(t *testing.T) func() {
 	savedClient := persistClient
 	persistClient = nil
 
+	flushMu.Lock()
+	savedLastFlushAt := lastFlushAt
+	lastFlushAt = time.Time{}
+	flushMu.Unlock()
+
 	return func() {
 		globalMu.Lock()
 		globalUsage = savedUsage
@@ -58,6 +63,9 @@ func saveAndResetGlobals(t *testing.T) func() {
 		globalMu.Unlock()
 		persistOnce = sync.Once{}
 		persistClient = savedClient
+		flushMu.Lock()
+		lastFlushAt = savedLastFlushAt
+		flushMu.Unlock()
 	}
 }
 
@@ -258,8 +266,8 @@ func TestRoundTrip_FlushThenLoad(t *testing.T) {
 	now := time.Now().Truncate(time.Second)
 	globalMu.Lock()
 	globalUsage = map[string]map[string]float64{
-		"q1": {"user-a": 123.45, "user-b": 678.90},
-		"q2": {"user-c": 42.0},
+		"q1": {"ns-a": 123.45, "ns-b": 678.90},
+		"q2": {"ns-c": 42.0},
 	}
 	globalLastCycle = now
 	globalMu.Unlock()
@@ -284,14 +292,14 @@ func TestRoundTrip_FlushThenLoad(t *testing.T) {
 	if !globalLastCycle.Equal(now) {
 		t.Errorf("lastCycle: got %v, want %v", globalLastCycle, now)
 	}
-	if math.Abs(globalUsage["q1"]["user-a"]-123.45) > 0.01 {
-		t.Errorf("user-a: got %.2f, want 123.45", globalUsage["q1"]["user-a"])
+	if math.Abs(globalUsage["q1"]["ns-a"]-123.45) > 0.01 {
+		t.Errorf("ns-a: got %.2f, want 123.45", globalUsage["q1"]["ns-a"])
 	}
-	if math.Abs(globalUsage["q1"]["user-b"]-678.90) > 0.01 {
-		t.Errorf("user-b: got %.2f, want 678.90", globalUsage["q1"]["user-b"])
+	if math.Abs(globalUsage["q1"]["ns-b"]-678.90) > 0.01 {
+		t.Errorf("ns-b: got %.2f, want 678.90", globalUsage["q1"]["ns-b"])
 	}
-	if math.Abs(globalUsage["q2"]["user-c"]-42.0) > 0.01 {
-		t.Errorf("user-c: got %.2f, want 42.0", globalUsage["q2"]["user-c"])
+	if math.Abs(globalUsage["q2"]["ns-c"]-42.0) > 0.01 {
+		t.Errorf("ns-c: got %.2f, want 42.0", globalUsage["q2"]["ns-c"])
 	}
 }
 
@@ -306,6 +314,115 @@ func TestInitPersistence_DisabledIsNoop(t *testing.T) {
 
 	if persistClient != nil {
 		t.Error("persistClient should remain nil when disabled")
+	}
+}
+
+// --- maybeFlush tests (OnSessionClose-driven, rate-limited flush) ---
+
+func TestMaybeFlush_DisabledIsNoop(t *testing.T) {
+	restore := saveAndResetGlobals(t)
+	defer restore()
+
+	client := fake.NewSimpleClientset()
+	persistClient = client
+	cfg := testPersistConfig()
+	cfg.enabled = false
+
+	maybeFlush(cfg)
+
+	if _, err := client.CoreV1().ConfigMaps(cfg.namespace).Get(
+		context.TODO(), cfg.configMapName, metav1.GetOptions{}); err == nil {
+		t.Error("ConfigMap should not be created when persistence is disabled")
+	}
+}
+
+func TestMaybeFlush_FirstCallFlushesImmediately(t *testing.T) {
+	restore := saveAndResetGlobals(t)
+	defer restore()
+
+	client := fake.NewSimpleClientset()
+	persistClient = client
+	cfg := testPersistConfig()
+
+	globalMu.Lock()
+	globalUsage = map[string]map[string]float64{"gpu-queue": {"alice": 100.0}}
+	globalMu.Unlock()
+
+	maybeFlush(cfg)
+
+	if _, err := client.CoreV1().ConfigMaps(cfg.namespace).Get(
+		context.TODO(), cfg.configMapName, metav1.GetOptions{}); err != nil {
+		t.Errorf("expected ConfigMap to be created on first flush, get failed: %v", err)
+	}
+}
+
+func TestMaybeFlush_RateLimited_SkipsSecondCallWithinInterval(t *testing.T) {
+	restore := saveAndResetGlobals(t)
+	defer restore()
+
+	client := fake.NewSimpleClientset()
+	persistClient = client
+	cfg := testPersistConfig()
+	cfg.flushInterval = 1 * time.Hour // long enough that a second immediate call must be skipped
+
+	globalMu.Lock()
+	globalUsage = map[string]map[string]float64{"gpu-queue": {"alice": 100.0}}
+	globalMu.Unlock()
+	maybeFlush(cfg) // first call: flushes alice=100.0
+
+	globalMu.Lock()
+	globalUsage = map[string]map[string]float64{"gpu-queue": {"alice": 999.0}}
+	globalMu.Unlock()
+	maybeFlush(cfg) // second call, immediately after: should be skipped
+
+	cm, err := client.CoreV1().ConfigMaps(cfg.namespace).Get(
+		context.TODO(), cfg.configMapName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get ConfigMap: %v", err)
+	}
+	var state persistedState
+	if err := json.Unmarshal([]byte(cm.Data[stateDataKey]), &state); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if math.Abs(state.Queues["gpu-queue"]["alice"]-100.0) > 0.01 {
+		t.Errorf("second maybeFlush within the interval should have been skipped: got alice=%.2f, want 100.0 (from first flush)",
+			state.Queues["gpu-queue"]["alice"])
+	}
+}
+
+func TestMaybeFlush_FlushesAgainAfterIntervalElapses(t *testing.T) {
+	restore := saveAndResetGlobals(t)
+	defer restore()
+
+	client := fake.NewSimpleClientset()
+	persistClient = client
+	cfg := testPersistConfig()
+	cfg.flushInterval = 1 * time.Millisecond
+
+	globalMu.Lock()
+	globalUsage = map[string]map[string]float64{"gpu-queue": {"alice": 100.0}}
+	globalMu.Unlock()
+	maybeFlush(cfg)
+
+	time.Sleep(5 * time.Millisecond)
+
+	globalMu.Lock()
+	globalUsage = map[string]map[string]float64{"gpu-queue": {"alice": 999.0}}
+	globalMu.Unlock()
+	maybeFlush(cfg)
+
+	cm, err := client.CoreV1().ConfigMaps(cfg.namespace).Get(
+		context.TODO(), cfg.configMapName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get ConfigMap: %v", err)
+	}
+	var state persistedState
+	if err := json.Unmarshal([]byte(cm.Data[stateDataKey]), &state); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if math.Abs(state.Queues["gpu-queue"]["alice"]-999.0) > 0.01 {
+		t.Errorf("maybeFlush after the interval elapsed should have flushed again: got alice=%.2f, want 999.0",
+			state.Queues["gpu-queue"]["alice"])
 	}
 }
 

--- a/test/e2e/schedulingaction/fairshare.go
+++ b/test/e2e/schedulingaction/fairshare.go
@@ -1,0 +1,171 @@
+/*
+Copyright 2025 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package schedulingaction
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	e2eutil "volcano.sh/volcano/test/e2e/util"
+)
+
+var _ = ginkgo.Describe("Fairshare Plugin E2E Test", func() {
+	ginkgo.It("should schedule jobs from low-usage users before high-usage users", func() {
+		// Enable the fairshare plugin in the scheduler config, targeting a test queue
+		// that tracks CPU resources for testability (no GPU hardware required).
+		cmc := e2eutil.NewConfigMapCase("volcano-system", "integration-scheduler-configmap")
+		modifier := func(sc *e2eutil.SchedulerConfiguration) bool {
+			fairsharePlugin := e2eutil.PluginOption{
+				Name: "fairshare",
+				Arguments: map[string]string{
+					"fairshare.targetQueues":    "default",
+					"fairshare.resourceKey":     "cpu",
+					"fairshare.halfLifeMinutes": "60",
+				},
+			}
+			if len(sc.Tiers) > 0 {
+				sc.Tiers[0].Plugins = append(sc.Tiers[0].Plugins, fairsharePlugin)
+			} else {
+				sc.Tiers = append(sc.Tiers, e2eutil.Tier{
+					Plugins: []e2eutil.PluginOption{fairsharePlugin},
+				})
+			}
+			return true
+		}
+		cmc.ChangeBy(func(data map[string]string) (changed bool, changedBefore map[string]string) {
+			return e2eutil.ModifySchedulerConfig(data, modifier)
+		})
+		defer cmc.UndoChanged()
+
+		// Wait for config to take effect
+		time.Sleep(5 * time.Second)
+
+		// Create test contexts for two different namespaces (simulating two users).
+		ctx1 := e2eutil.InitTestContext(e2eutil.Options{
+			Namespace: "fairshare-user-a",
+			Queues:    []string{"default"},
+			NodesNumLimit: 2,
+			NodesResourceLimit: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("2000m"),
+				corev1.ResourceMemory: resource.MustParse("2048Mi"),
+			},
+		})
+		defer e2eutil.CleanupTestContext(ctx1)
+
+		ctx2 := e2eutil.InitTestContext(e2eutil.Options{
+			Namespace: "fairshare-user-b",
+			Queues:    []string{"default"},
+		})
+		defer e2eutil.CleanupTestContext(ctx2)
+
+		cpuSlot := corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("500m"),
+			corev1.ResourceMemory: resource.MustParse("256Mi"),
+		}
+
+		// User A submits 4 jobs first, filling available capacity.
+		userAJobs := make([]string, 4)
+		for i := 0; i < 4; i++ {
+			jobName := fmt.Sprintf("user-a-job-%d", i)
+			userAJobs[i] = jobName
+			job := &e2eutil.JobSpec{
+				Name:      jobName,
+				Namespace: "fairshare-user-a",
+				Queue:     "default",
+				Tasks: []e2eutil.TaskSpec{
+					{
+						Img: e2eutil.DefaultNginxImage,
+						Req: cpuSlot,
+						Min: 1,
+						Rep: 1,
+					},
+				},
+			}
+			createdJob := e2eutil.CreateJob(ctx1, job)
+			err := e2eutil.WaitJobReady(ctx1, createdJob)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}
+
+		// Let User A accumulate some usage history.
+		time.Sleep(10 * time.Second)
+
+		// Now User B submits a job. Even though User A has pending work,
+		// User B should be scheduled first because User B has zero usage.
+		userBJob := &e2eutil.JobSpec{
+			Name:      "user-b-job-0",
+			Namespace: "fairshare-user-b",
+			Queue:     "default",
+			Tasks: []e2eutil.TaskSpec{
+				{
+					Img: e2eutil.DefaultNginxImage,
+					Req: cpuSlot,
+					Min: 1,
+					Rep: 1,
+				},
+			},
+		}
+		createdBJob := e2eutil.CreateJob(ctx2, userBJob)
+
+		// User A also submits another job.
+		userAExtraJob := &e2eutil.JobSpec{
+			Name:      "user-a-job-extra",
+			Namespace: "fairshare-user-a",
+			Queue:     "default",
+			Tasks: []e2eutil.TaskSpec{
+				{
+					Img: e2eutil.DefaultNginxImage,
+					Req: cpuSlot,
+					Min: 1,
+					Rep: 1,
+				},
+			},
+		}
+		createdAExtraJob := e2eutil.CreateJob(ctx1, userAExtraJob)
+
+		// Delete one of User A's running jobs to free capacity.
+		err := ctx1.Vcclient.BatchV1alpha1().Jobs("fairshare-user-a").Delete(
+			context.TODO(), userAJobs[0], metav1.DeleteOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// User B's job should become ready (scheduled) before User A's extra job,
+		// because User B has lower historical usage.
+		err = e2eutil.WaitJobReady(ctx2, createdBJob)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// Verify User A's extra job is still pending (or at least was scheduled after User B).
+		err = wait.Poll(2*time.Second, 30*time.Second, func() (bool, error) {
+			job, getErr := ctx1.Vcclient.BatchV1alpha1().Jobs("fairshare-user-a").Get(
+				context.TODO(), createdAExtraJob.Name, metav1.GetOptions{})
+			if getErr != nil {
+				return false, getErr
+			}
+			// If User A's extra job is still pending, fairshare is working correctly.
+			// If it becomes ready, we check the timeline against User B's job.
+			return job.Status.Running > 0 || job.Status.Pending > 0, nil
+		})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	})
+})

--- a/test/e2e/schedulingaction/fairshare.go
+++ b/test/e2e/schedulingaction/fairshare.go
@@ -46,6 +46,30 @@ var _ = ginkgo.Describe("Fairshare Plugin E2E Test", func() {
 					"fairshare.halfLifeMinutes": "60",
 				},
 			}
+			// Session.JobOrderFn walks tiers-then-plugins in configured
+			// order and returns as soon as any plugin's comparison is
+			// non-zero. drf's dominant-resource-share comparison returns
+			// non-zero for almost any pair of jobs with differing resource
+			// requests, so fairshare must be inserted *before* drf — not
+			// appended after whatever's already configured — or its
+			// comparator would rarely get a chance to run at all. See
+			// docs/user-guide/how_to_use_fairshare_plugin.md, "Can it be
+			// used together with DRF?".
+			for i := range sc.Tiers {
+				idx := sc.Tiers[i].GetPluginIdxOf("drf")
+				if idx < 0 {
+					continue
+				}
+				plugins := sc.Tiers[i].Plugins
+				inserted := make([]e2eutil.PluginOption, 0, len(plugins)+1)
+				inserted = append(inserted, plugins[:idx]...)
+				inserted = append(inserted, fairsharePlugin)
+				inserted = append(inserted, plugins[idx:]...)
+				sc.Tiers[i].Plugins = inserted
+				return true
+			}
+			// No drf plugin configured: relative order doesn't matter, so
+			// appending is fine.
 			if len(sc.Tiers) > 0 {
 				sc.Tiers[0].Plugins = append(sc.Tiers[0].Plugins, fairsharePlugin)
 			} else {
@@ -60,14 +84,23 @@ var _ = ginkgo.Describe("Fairshare Plugin E2E Test", func() {
 		})
 		defer cmc.UndoChanged()
 
-		// Wait for config to take effect
-		time.Sleep(5 * time.Second)
+		// No extra sleep here: ChangeBy already waits for the config
+		// change to take effect (it bumps a "refreshts" annotation on the
+		// scheduler pods to force an immediate ConfigMap remount), matching
+		// the pattern used by the other scheduler-config-modifying E2E
+		// tests (e.g. enqueue.go) — none of them add a sleep after ChangeBy.
 
 		// Create test contexts for two different namespaces (simulating two users).
+		// A single node sized to exactly match User A's 4 jobs (4*500m =
+		// 2000m) so those jobs genuinely saturate all schedulable CPU —
+		// otherwise User B's job could schedule on free capacity without
+		// deleting anything, and without fairshare's ordering ever being
+		// exercised, making the test pass regardless of whether fairshare
+		// works.
 		ctx1 := e2eutil.InitTestContext(e2eutil.Options{
 			Namespace:     "fairshare-user-a",
 			Queues:        []string{"default"},
-			NodesNumLimit: 2,
+			NodesNumLimit: 1,
 			NodesResourceLimit: corev1.ResourceList{
 				corev1.ResourceCPU:    resource.MustParse("2000m"),
 				corev1.ResourceMemory: resource.MustParse("2048Mi"),

--- a/test/e2e/schedulingaction/fairshare.go
+++ b/test/e2e/schedulingaction/fairshare.go
@@ -65,8 +65,8 @@ var _ = ginkgo.Describe("Fairshare Plugin E2E Test", func() {
 
 		// Create test contexts for two different namespaces (simulating two users).
 		ctx1 := e2eutil.InitTestContext(e2eutil.Options{
-			Namespace: "fairshare-user-a",
-			Queues:    []string{"default"},
+			Namespace:     "fairshare-user-a",
+			Queues:        []string{"default"},
 			NodesNumLimit: 2,
 			NodesResourceLimit: corev1.ResourceList{
 				corev1.ResourceCPU:    resource.MustParse("2000m"),
@@ -155,16 +155,24 @@ var _ = ginkgo.Describe("Fairshare Plugin E2E Test", func() {
 		err = e2eutil.WaitJobReady(ctx2, createdBJob)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-		// Verify User A's extra job is still pending (or at least was scheduled after User B).
+		// Verify User A's extra job remains pending. The single slot freed by
+		// deleting userAJobs[0] must go to User B's job (lower historical
+		// usage), not to User A's extra job — that's the actual ordering
+		// claim fairshare makes. Treat Running>0 as an explicit failure
+		// (not just a falsy poll result) so a fairshare ordering regression
+		// fails loudly instead of the poll silently succeeding either way.
 		err = wait.Poll(2*time.Second, 30*time.Second, func() (bool, error) {
 			job, getErr := ctx1.Vcclient.BatchV1alpha1().Jobs("fairshare-user-a").Get(
 				context.TODO(), createdAExtraJob.Name, metav1.GetOptions{})
 			if getErr != nil {
 				return false, getErr
 			}
-			// If User A's extra job is still pending, fairshare is working correctly.
-			// If it becomes ready, we check the timeline against User B's job.
-			return job.Status.Running > 0 || job.Status.Pending > 0, nil
+			if job.Status.Running > 0 {
+				return false, fmt.Errorf(
+					"fairshare ordering violated: user-a-job-extra was scheduled (Running=%d) instead of staying pending behind lower-usage user-b-job-0",
+					job.Status.Running)
+			}
+			return job.Status.Pending > 0, nil
 		})
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	})

--- a/test/e2e/schedulingaction/fairshare.go
+++ b/test/e2e/schedulingaction/fairshare.go
@@ -1,0 +1,253 @@
+/*
+Copyright 2025 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package schedulingaction
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	schedulingv1beta1 "volcano.sh/apis/pkg/apis/scheduling/v1beta1"
+	e2eutil "volcano.sh/volcano/test/e2e/util"
+)
+
+// fairshareQueueName is a dedicated queue created for this test rather than
+// reusing "default": the admission webhook refuses to delete the built-in
+// "default" queue, and test cleanup closes-then-deletes every queue it owns.
+// Pointing this test at "default" left it permanently Closed after this
+// test's cleanup failed to delete it, breaking every subsequent E2E test in
+// the same suite that submits to "default".
+const fairshareQueueName = "fairshare-e2e-queue"
+
+var _ = ginkgo.Describe("Fairshare Plugin E2E Test", func() {
+	ginkgo.It("should schedule jobs from low-usage users before high-usage users", func() {
+		// Enable the fairshare plugin in the scheduler config, targeting a test queue
+		// that tracks CPU resources for testability (no GPU hardware required).
+		cmc := e2eutil.NewConfigMapCase("volcano-system", "integration-scheduler-configmap")
+		modifier := func(sc *e2eutil.SchedulerConfiguration) bool {
+			fairsharePlugin := e2eutil.PluginOption{
+				Name: "fairshare",
+				Arguments: map[string]string{
+					"fairshare.targetQueues":    fairshareQueueName,
+					"fairshare.resourceKey":     "cpu",
+					"fairshare.halfLifeMinutes": "60",
+				},
+			}
+			// Session.JobOrderFn walks tiers-then-plugins in configured
+			// order and returns as soon as any plugin's comparison is
+			// non-zero. drf's dominant-resource-share comparison returns
+			// non-zero for almost any pair of jobs with differing resource
+			// requests, so fairshare must be inserted *before* drf — not
+			// appended after whatever's already configured — or its
+			// comparator would rarely get a chance to run at all. See
+			// docs/user-guide/how_to_use_fairshare_plugin.md, "Can it be
+			// used together with DRF?".
+			for i := range sc.Tiers {
+				idx := sc.Tiers[i].GetPluginIdxOf("drf")
+				if idx < 0 {
+					continue
+				}
+				plugins := sc.Tiers[i].Plugins
+				inserted := make([]e2eutil.PluginOption, 0, len(plugins)+1)
+				inserted = append(inserted, plugins[:idx]...)
+				inserted = append(inserted, fairsharePlugin)
+				inserted = append(inserted, plugins[idx:]...)
+				sc.Tiers[i].Plugins = inserted
+				return true
+			}
+			// No drf plugin configured: relative order doesn't matter, so
+			// appending is fine.
+			if len(sc.Tiers) > 0 {
+				sc.Tiers[0].Plugins = append(sc.Tiers[0].Plugins, fairsharePlugin)
+			} else {
+				sc.Tiers = append(sc.Tiers, e2eutil.Tier{
+					Plugins: []e2eutil.PluginOption{fairsharePlugin},
+				})
+			}
+			return true
+		}
+		cmc.ChangeBy(func(data map[string]string) (changed bool, changedBefore map[string]string) {
+			return e2eutil.ModifySchedulerConfig(data, modifier)
+		})
+		defer cmc.UndoChanged()
+
+		// No extra sleep here: ChangeBy already waits for the config
+		// change to take effect (it bumps a "refreshts" annotation on the
+		// scheduler pods to force an immediate ConfigMap remount), matching
+		// the pattern used by the other scheduler-config-modifying E2E
+		// tests (e.g. enqueue.go) — none of them add a sleep after ChangeBy.
+
+		// Create test contexts for two different namespaces (simulating two users).
+		// A single node sized to exactly match User A's 4 jobs (4*500m =
+		// 2000m) so those jobs genuinely saturate all schedulable CPU —
+		// otherwise User B's job could schedule on free capacity without
+		// deleting anything, and without fairshare's ordering ever being
+		// exercised, making the test pass regardless of whether fairshare
+		// works.
+		ctx1 := e2eutil.InitTestContext(e2eutil.Options{
+			Namespace:     "fairshare-user-a",
+			NodesNumLimit: 1,
+			NodesResourceLimit: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("2000m"),
+				corev1.ResourceMemory: resource.MustParse("2048Mi"),
+			},
+		})
+		defer e2eutil.CleanupTestContext(ctx1)
+
+		// Both users share this one queue so fairshare's per-namespace usage
+		// tracking within it applies to both. Created/deleted explicitly
+		// (outside ctx.Queues) so it isn't tied to either context's
+		// lifecycle — see the fairshareQueueName comment for why.
+		e2eutil.CreateQueue(ctx1, fairshareQueueName, nil, nil, "")
+		queueErr := e2eutil.WaitQueueStatus(func() (bool, error) {
+			queue, err := ctx1.Vcclient.SchedulingV1beta1().Queues().Get(context.TODO(), fairshareQueueName, metav1.GetOptions{})
+			if err != nil {
+				return false, err
+			}
+			return queue.Status.State == schedulingv1beta1.QueueStateOpen, nil
+		})
+		gomega.Expect(queueErr).NotTo(gomega.HaveOccurred())
+		defer e2eutil.DeleteQueue(ctx1, fairshareQueueName)
+
+		ctx2 := e2eutil.InitTestContext(e2eutil.Options{
+			Namespace: "fairshare-user-b",
+		})
+		defer e2eutil.CleanupTestContext(ctx2)
+
+		cpuSlot := corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("500m"),
+			corev1.ResourceMemory: resource.MustParse("256Mi"),
+		}
+
+		// User A submits 4 jobs first, filling available capacity.
+		userAJobs := make([]string, 4)
+		for i := 0; i < 4; i++ {
+			jobName := fmt.Sprintf("user-a-job-%d", i)
+			userAJobs[i] = jobName
+			job := &e2eutil.JobSpec{
+				Name:      jobName,
+				Namespace: "fairshare-user-a",
+				Queue:     fairshareQueueName,
+				Tasks: []e2eutil.TaskSpec{
+					{
+						Img: e2eutil.DefaultNginxImage,
+						Req: cpuSlot,
+						Min: 1,
+						Rep: 1,
+					},
+				},
+			}
+			createdJob := e2eutil.CreateJob(ctx1, job)
+			err := e2eutil.WaitJobReady(ctx1, createdJob)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}
+
+		// Let User A accumulate some usage history.
+		time.Sleep(10 * time.Second)
+
+		// User A submits another job *first*, while capacity is still fully
+		// saturated by userAJobs — it must land Pending immediately.
+		userAExtraJob := &e2eutil.JobSpec{
+			Name:      "user-a-job-extra",
+			Namespace: "fairshare-user-a",
+			Queue:     fairshareQueueName,
+			Tasks: []e2eutil.TaskSpec{
+				{
+					Img: e2eutil.DefaultNginxImage,
+					Req: cpuSlot,
+					Min: 1,
+					Rep: 1,
+				},
+			},
+		}
+		createdAExtraJob := e2eutil.CreateJob(ctx1, userAExtraJob)
+		err := e2eutil.WaitJobPending(ctx1, createdAExtraJob)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// User B submits its job *after* User A's extra job, so plain FIFO
+		// would favor User A's earlier-created job for any capacity freed
+		// up next. Only fairshare's usage-based ordering (User B has zero
+		// usage vs. User A's accumulated usage) can make User B win instead
+		// — which is exactly the behavior this test needs to distinguish.
+		userBJob := &e2eutil.JobSpec{
+			Name:      "user-b-job-0",
+			Namespace: "fairshare-user-b",
+			Queue:     fairshareQueueName,
+			Tasks: []e2eutil.TaskSpec{
+				{
+					Img: e2eutil.DefaultNginxImage,
+					Req: cpuSlot,
+					Min: 1,
+					Rep: 1,
+				},
+			},
+		}
+		createdBJob := e2eutil.CreateJob(ctx2, userBJob)
+		err = e2eutil.WaitJobPending(ctx2, createdBJob)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// Both jobs are now genuinely competing for the same not-yet-freed
+		// slot. Re-confirm User A's extra job is still pending (capacity
+		// hasn't changed yet) before freeing a slot below.
+		aExtraJob, err := ctx1.Vcclient.BatchV1alpha1().Jobs("fairshare-user-a").Get(
+			context.TODO(), createdAExtraJob.Name, metav1.GetOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(aExtraJob.Status.Running).To(gomega.BeZero(),
+			"user-a-job-extra should still be pending before any capacity is freed")
+
+		// Delete one of User A's original running jobs to free exactly one slot.
+		err = ctx1.Vcclient.BatchV1alpha1().Jobs("fairshare-user-a").Delete(
+			context.TODO(), userAJobs[0], metav1.DeleteOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// The freed slot should go to User B's job — created *after* User
+		// A's extra job, but with lower historical usage — because
+		// fairshare's usage-based ordering wins. Plain FIFO would instead
+		// pick User A's earlier-created extra job, so this assertion fails
+		// under FIFO fallback and only passes when fairshare actually
+		// governs the ordering.
+		err = e2eutil.WaitJobReady(ctx2, createdBJob)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// Verify User A's extra job remains pending. Treat Running>0 as an
+		// explicit failure (not just a falsy poll result) so a fairshare
+		// ordering regression fails loudly instead of the poll silently
+		// succeeding either way.
+		err = wait.Poll(2*time.Second, 30*time.Second, func() (bool, error) {
+			job, getErr := ctx1.Vcclient.BatchV1alpha1().Jobs("fairshare-user-a").Get(
+				context.TODO(), createdAExtraJob.Name, metav1.GetOptions{})
+			if getErr != nil {
+				return false, getErr
+			}
+			if job.Status.Running > 0 {
+				return false, fmt.Errorf(
+					"fairshare ordering violated: user-a-job-extra (created before user-b-job-0) was scheduled (Running=%d) instead of staying pending behind lower-usage, later-created user-b-job-0",
+					job.Status.Running)
+			}
+			return job.Status.Pending > 0, nil
+		})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	})
+})


### PR DESCRIPTION
## What type of PR is this?

/kind feature

## What this PR does / why we need it

Adds a new `fairshare` scheduler plugin that provides per-namespace temporal fairness using decayed cumulative usage tracking. This addresses the namespace-level fair share gap identified in #4165 and proposed in #5160.

### Problem

The existing DRF plugin provides snapshot-based dominant resource fairness but has **no memory of past usage**. In multi-tenant GPU clusters this causes:

- Namespace A submits hundreds of GPU jobs and fills the cluster
- Namespace B arrives later with a few jobs
- As namespace A's jobs complete, its new pending jobs immediately regain priority, starving namespace B

### Solution

A SLURM-inspired fair share algorithm that:

1. **Tracks cumulative resource-seconds per namespace** across scheduling cycles
2. **Applies exponential half-life decay** (configurable, default 4h) so past usage is gradually forgiven
3. **Orders jobs by cumulative usage** — lower historical usage = higher priority
4. **Complements existing plugins** — runs alongside `priority` (which takes precedence) and `gang`, and needs to be listed before `drf` (see the user guide for why)
5. **Defaults to all queues** if `fairshare.targetQueues` is left unset

### Configuration

```yaml
- name: fairshare
  arguments:
    fairshare.targetQueues: "gpu-queue"
    fairshare.resourceKey: "nvidia.com/gpu"
    fairshare.halfLifeMinutes: "240"
```

See [docs/user-guide/how_to_use_fairshare_plugin.md](https://github.com/dmildh-absci/volcano/blob/feat/fairshare-plugin/docs/user-guide/how_to_use_fairshare_plugin.md) for the full arguments list and plugin-interaction guidance, and [docs/design/fairshare.md](https://github.com/dmildh-absci/volcano/blob/feat/fairshare-plugin/docs/design/fairshare.md) for design rationale.

## Which issue(s) this PR fixes

Fixes #5160
Relates to #4165

## Does this PR introduce a user-facing change?

```release-note
Add fairshare scheduler plugin for per-namespace temporal fair share scheduling with configurable half-life decay.
```

## Testing

### Unit tests (49 tests)

- Max-min fair share algorithm correctness
- Decay factor math (one/two half-lives, zero elapsed, zero half-life, small elapsed)
- decayAllUsage (halves after one half-life, cleans up negligible entries, multi-queue)
- Usage ordering (lower usage wins, equal usage falls to running tiebreaker, realistic multi-namespace scenario)
- Helper functions (namespace extraction, resource key defaults/overrides)
- targetQueues allowlist behavior (defaults to all queues when unset)
- JobOrderFn abstain behavior (only compares jobs within the same targeted queue)
- Persistence: ConfigMap create/update/load/round-trip, disabled no-op, corrupt data, rate-limited flush (including retry-promptly-on-failure)

All tests pass with `-race`.

### Integration testing

Validated on a test cluster with 2 GPU nodes, 4 tenant namespaces:

| Scenario | Result |
|----------|--------|
| Without fairshare (baseline) | FIFO behavior, last tenant waited ~7 min |
| With fairshare + decay | All tenants got GPUs within ~2 min |
| Burst asymmetry (1 tenant = 8 jobs, others = 1) | Minority tenants' jobs completed within ~2 min |
| DAG/workflow simulation | GPU steps interleaved across tenants |
| PriorityClass interaction | High-priority bypassed fair share as expected |
| Scheduler restart | Running jobs survived, new jobs scheduled fairly |

> **Note**: This PR is a draft. We will update with additional production cluster data as we roll this out.

### E2E test

`test/e2e/schedulingaction/fairshare.go` — CPU-based fairshare ordering test on a single capacity-constrained node.

## Files changed

| File | Description |
|------|-------------|
| docs/design/fairshare.md | Design document (2019 namespace-weight proposal + 2026 decayed-usage-tracking proposal) |
| docs/user-guide/how_to_use_fairshare_plugin.md | Usage guide: arguments, config examples, DRF/priority/gang interaction |
| pkg/scheduler/plugins/fairshare/fairshare.go | Plugin implementation |
| pkg/scheduler/plugins/fairshare/persist.go | ConfigMap-based state persistence, flushed from OnSessionClose |
| pkg/scheduler/plugins/factory.go | Plugin registration |
| test/e2e/schedulingaction/fairshare.go | E2E test |

/cc @william-wang @Thor-wl @lowang-bh