### PR TITLE
fix: display friendly "infinity" for max resource values in logs

### DIFF
--- a/pkg/scheduler/api/resource_info.go
+++ b/pkg/scheduler/api/resource_info.go
@@ -166,9 +166,18 @@ func (r *Resource) Clone() *Resource {
 	return clone
 }
 
+// formatFloat returns a human-readable string for a resource float value.
+// math.MaxFloat64 is displayed as "infinity" to avoid noisy log output.
+func formatFloat(v float64) string {
+	if v == math.MaxFloat64 {
+		return "infinity"
+	}
+	return fmt.Sprintf("%0.2f", v)
+}
+
 // String returns resource details in string format
 func (r *Resource) String() string {
-	str := fmt.Sprintf("cpu %0.2f, memory %0.2f", r.MilliCPU, r.Memory)
+	str := fmt.Sprintf("cpu %s, memory %s", formatFloat(r.MilliCPU), formatFloat(r.Memory))
 	// Sort scalar resource names to ensure consistent string output
 	var resourceNames []string
 	for rName := range r.ScalarResources {
@@ -176,7 +185,7 @@ func (r *Resource) String() string {
 	}
 	sort.Strings(resourceNames)
 	for _, rName := range resourceNames {
-		str = fmt.Sprintf("%s, %s %0.2f", str, rName, r.ScalarResources[v1.ResourceName(rName)])
+		str = fmt.Sprintf("%s, %s %s", str, rName, formatFloat(r.ScalarResources[v1.ResourceName(rName)]))
 	}
 	return str
 }

--- a/pkg/scheduler/api/resource_info.go
+++ b/pkg/scheduler/api/resource_info.go
@@ -177,17 +177,19 @@ func formatFloat(v float64) string {
 
 // String returns resource details in string format
 func (r *Resource) String() string {
-	str := fmt.Sprintf("cpu %s, memory %s", formatFloat(r.MilliCPU), formatFloat(r.Memory))
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "cpu %s, memory %s", formatFloat(r.MilliCPU), formatFloat(r.Memory))
+
 	// Sort scalar resource names to ensure consistent string output
-	var resourceNames []string
+	resourceNames := make([]string, 0, len(r.ScalarResources))
 	for rName := range r.ScalarResources {
 		resourceNames = append(resourceNames, string(rName))
 	}
 	sort.Strings(resourceNames)
 	for _, rName := range resourceNames {
-		str = fmt.Sprintf("%s, %s %s", str, rName, formatFloat(r.ScalarResources[v1.ResourceName(rName)]))
+		fmt.Fprintf(&sb, ", %s %s", rName, formatFloat(r.ScalarResources[v1.ResourceName(rName)]))
 	}
-	return str
+	return sb.String()
 }
 
 // ResourceNames returns all resource types

--- a/pkg/scheduler/api/resource_info_test.go
+++ b/pkg/scheduler/api/resource_info_test.go
@@ -1922,3 +1922,47 @@ func TestIntersectionWithIgnoredScalarResources(t *testing.T) {
 		}
 	}
 }
+
+func TestResource_String(t *testing.T) {
+	tests := []struct {
+		name     string
+		resource *Resource
+		want     string
+	}{
+		{
+			name:     "normal values",
+			resource: &Resource{MilliCPU: 4.00, Memory: 8192.00},
+			want:     "cpu 4.00, memory 8192.00",
+		},
+		{
+			name:     "infinite resource shows infinity",
+			resource: InfiniteResource(),
+			want:     "cpu infinity, memory infinity",
+		},
+		{
+			name: "mixed finite and infinite with scalars",
+			resource: &Resource{
+				MilliCPU: 2.00,
+				Memory:   math.MaxFloat64,
+				ScalarResources: map[v1.ResourceName]float64{
+					"nvidia.com/gpu": 4.00,
+				},
+			},
+			want: "cpu 2.00, memory infinity, nvidia.com/gpu 4.00",
+		},
+		{
+			name:     "zero values",
+			resource: &Resource{MilliCPU: 0, Memory: 0},
+			want:     "cpu 0.00, memory 0.00",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.resource.String()
+			if got != tt.want {
+				t.Errorf("Resource.String() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #5148

Replaces noisy `math.MaxFloat64` log output with a readable `"infinity"` string.

## Problem

Since #4973, raising the scheduler log level produces extremely long log lines:
```
realCapability <cpu 17976931348623157081452742373170435679807056752584..., memory 17976931348623157...>
```

This happens because `Resource.String()` formats `math.MaxFloat64` with `%0.2f`, producing hundreds of digits.

## Changes

- **`resource_info.go`**: Added `formatFloat()` helper that returns `"infinity"` for `math.MaxFloat64` and normal `%0.2f` formatting otherwise. Updated `Resource.String()` to use it.
- **`resource_info_test.go`**: Added `TestResource_String` covering normal values, infinite resources, mixed finite/infinite, and zero values.

## Before
```
<cpu 17976931348623157081452742373170435679807056752584..., memory 17976931348623157081452742...>
```

## After
```
<cpu infinity, memory infinity>
```

## Testing

```
=== RUN   TestResource_String
--- PASS: TestResource_String (0.00s)
    --- PASS: normal_values
    --- PASS: infinite_resource_shows_infinity
    --- PASS   mixed_finite_and_infinite_with_scalars
    --- PASS   zero_values
ok  volcano.sh/volcano/pkg/scheduler/api
```

All existing tests in `pkg/scheduler/api/` continue to pass.