### PR TITLE
fix(capacity): avoid false exceeds on missing parent scalar keys

### DIFF
--- a/pkg/scheduler/api/resource_info_test.go
+++ b/pkg/scheduler/api/resource_info_test.go
@@ -1835,6 +1835,67 @@ func TestResource_LessEqualResource(t *testing.T) {
 	}
 }
 
+func TestResource_GreaterPartly(t *testing.T) {
+	tests := []struct {
+		name              string
+		child             *Resource
+		parent            *Resource
+		expectedExceeds   bool
+		expectedResources []string
+	}{
+		{
+			name: "missing parent scalar key with zero child value",
+			child: &Resource{
+				ScalarResources: map[v1.ResourceName]float64{"vendor.com/gpu-x": 0},
+			},
+			parent:            &Resource{},
+			expectedExceeds:   false,
+			expectedResources: []string{},
+		},
+		{
+			name: "missing parent scalar key with positive child value",
+			child: &Resource{
+				ScalarResources: map[v1.ResourceName]float64{"vendor.com/gpu-x": 8},
+			},
+			parent:            &Resource{},
+			expectedExceeds:   false,
+			expectedResources: []string{},
+		},
+		{
+			name: "shared scalar key where child exceeds parent",
+			child: &Resource{
+				ScalarResources: map[v1.ResourceName]float64{"vendor.com/gpu-x": 8},
+			},
+			parent: &Resource{
+				ScalarResources: map[v1.ResourceName]float64{"vendor.com/gpu-x": 4},
+			},
+			expectedExceeds:   true,
+			expectedResources: []string{"vendor.com/gpu-x"},
+		},
+		{
+			name: "cpu exceeds parent",
+			child: &Resource{
+				MilliCPU: 8000,
+			},
+			parent: &Resource{
+				MilliCPU: 4000,
+			},
+			expectedExceeds:   true,
+			expectedResources: []string{"cpu"},
+		},
+	}
+
+	for _, test := range tests {
+		exceeds, resources := test.child.GreaterPartly(test.parent, Infinity)
+		sort.Strings(resources)
+		sort.Strings(test.expectedResources)
+		if exceeds != test.expectedExceeds || !equality.Semantic.DeepEqual(resources, test.expectedResources) {
+			t.Errorf("test %q: expected exceeds=%v resources=%v, got exceeds=%v resources=%v",
+				test.name, test.expectedExceeds, test.expectedResources, exceeds, resources)
+		}
+	}
+}
+
 func TestIntersection(t *testing.T) {
 	cases := []struct {
 		name   string

--- a/pkg/scheduler/plugins/capacity/capacity.go
+++ b/pkg/scheduler/plugins/capacity/capacity.go
@@ -856,11 +856,11 @@ func (cp *capacityPlugin) checkHierarchicalQueue(attr *queueAttr) {
 			}
 		}
 
-		// Check if the parent queue's capability is less than the child queue's capability
-		if attr.capability.LessPartly(childAttr.capability, api.Zero) {
-			klog.Errorf("Child queue %s capability (%s) exceeds parent queue %s capability (%s). "+
+		// Check if child queue's capability exceeds parent queue's capability.
+		if exceeds, resources := childAttr.capability.GreaterPartly(attr.capability, api.Infinity); exceeds {
+			klog.Errorf("Child queue %s capability (%s) exceeds parent queue %s capability (%s) on resources %v. "+
 				"Child's effective capability will be limited by parent.",
-				childAttr.name, childAttr.capability, attr.name, attr.capability)
+				childAttr.name, childAttr.capability, attr.name, attr.capability, resources)
 		}
 	}
 


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
This PR fixes false-positive hierarchical capability exceed errors in the capacity plugin when child queues contain scalar resource keys that are missing from parent/root capability maps.

The issue is visible in real clusters when resource classes disappear after reconfiguration. In our case, MIG-related `nvidia-gpu-h100-mig-1g.10gb` keys were removed from cluster resources but remained in child queue capability specs, which flooded scheduler error logs.

The fix changes the check from:
- `parent.LessPartly(child, Zero)`
to:
- `child.GreaterPartly(parent, Infinity)`

This preserves real exceed detection on shared dimensions while avoiding false positives for missing parent-only dimensions.

This behavior predates #4973 (introduced in #3917), while #4973 made it more visible by promoting this message to error level and changing root capability initialization behavior.

Also added unit test coverage for `GreaterPartly` semantics around missing scalar keys and real exceed cases.

#### Which issue(s) this PR fixes:
Fixes #5175

#### Special notes for your reviewer:
AI usage disclosure: I used AI assistance for investigation support, test generation and PR text preparation. I manually validated the final code changes and test results.

Volcano rhyme (tests were AI generated but they look fine to me):
When magma shifts beneath the queueing sky,  
stale MIG keys can make loud errors fly.  
We map true bounds where parent limits are,  
and quiet false alarms from resources gone afar.

#### Does this PR introduce a user-facing change?
```release-note
Fix false-positive hierarchical queue capability exceed errors when child queues contain scalar resource keys absent from parent/root capability maps (for example after MIG resource class removal).
```