### PR TITLE
fix(statement): prevent double-finalize by clearing operations slice 

### DIFF
--- a/pkg/scheduler/framework/statement.go
+++ b/pkg/scheduler/framework/statement.go
@@ -377,6 +377,7 @@ func (s *Statement) Discard() {
 			}
 		}
 	}
+	s.operations = nil
 }
 
 // Commit operation for evict and pipeline
@@ -402,6 +403,7 @@ func (s *Statement) Commit() {
 			}
 		}
 	}
+	s.operations = nil
 }
 
 // Merge transfers operations from the given statements into this statement.


### PR DESCRIPTION
#### What type of PR is this?                                                                                                                                                                                                                                                                                                           
  /kind bug                                                                                                                                                            
  /kind cleanup                                                                                                                                                      
                                                                                                                                                                       
Defensive correctness fix to the Statement transactional primitive.                                                                                                

#### What this PR does / why we need it:                                                                                                                              
While reading through `Statement` in `pkg/scheduler/framework/statement.go`, I noticed that `Discard()` and `Commit()` both replay their recorded operations but never clear `s.operations` afterwards. The slice just sits on the struct after finalization. `Merge()` already clears its source operations for exactly this reason  the comment on `Merge()` explicitly calls out that it prevents "double-commit or double-discard" , but `Discard` and `Commit` themselves don't apply the same hygiene to their own receiver.

 This matters because the event callbacks these operations fire are non-idempotent. If anything ever finalizes a Statement twice, every `Evict` reversal re-runs  `unevict` → `AllocateFunc`, and every `Pipeline` reversal re-runs `UnPipeline` → `DeallocateFunc`. In the capacity and proportion plugins those callbacks unconditionally mutate queue accounting:                                                                                                                           
  
  ```go
  // pkg/scheduler/plugins/capacity/capacity.go
  AllocateFunc: func(event *framework.Event) {                                                                                                                             ...
      attr.allocated.Add(event.Task.Resreq)   // no idempotency guard                                                                                                
      ...                                                                                                                                                              },
  DeallocateFunc: func(event *framework.Event) {                                                                                                                     
      ...
      attr.allocated.Sub(event.Task.Resreq)   // no idempotency guard                                                                                                      ...
  },                                                                                                                                                                 
  ```
  So a double-finalize silently inflates or deflates attr.allocated for the queue (and every ancestor queue when hierarchy is enabled), and the drift persists for  the rest of the scheduling cycle. It would break Allocatable() decisions with no error, no log, and no metric that makes the root cause obvious.
Today I can't point at a caller in the current tree that actually triggers this , every action finalizes each Statement exactly once. But the invariant is implicit   and fragile: any future refactor in preempt, reclaim, backfill, or topology-aware preemption that routes a Statement through two code paths would silently corrupt   queue accounting. I'd rather make Statement safe by construction.                                                                                                 
  
The fix is two lines. I set s.operations = nil at the end of both Discard() and Commit(), so a finalized Statement becomes inert to any further calls:    
```            
  func (s *Statement) Discard() {                                                                                                                                    
      klog.V(3).Info("Discarding operations ...")
      for i := len(s.operations) - 1; i >= 0; i-- {
          // ... reversal switch unchanged ...                                                                                                                       
      }                                                                                                                                                                    
      s.operations = nil                                                                                                                                             
  }                                                                                                                                                                  

  func (s *Statement) Commit() {
      klog.V(3).Info("Committing operations ...")
      for _, op := range s.operations {                                                                                                                                        
      // ... commit switch unchanged ...
      }                                                                                                                                                              
      s.operations = nil
  }
```                                                                                                                                                                       
Now Discard, Commit, and Merge all share the same post-finalization contract: the operations slice is empty, a second call is a no-op.                                                                                                                                                                                                  
                                                                  
####  Special notes for your reviewer:                                                                                                                                      
  - Zero behavior change for any currently correct caller. All existing callers finalize each Statement exactly once, so clearing the slice afterwards is observationally invisible to them.
  - This is explicitly a defensive hardening, not a fix for a live regression I can reproduce on master. I'd argue it's still worth merging because the failure mode 
  (silent queue accounting drift) is exactly the kind of bug that takes weeks to diagnose if someone accidentally introduces a double-finalize later. 
  - I considered adding a guard inside the capacity/proportion callbacks instead, but fixing it at the Statement layer is narrower and matches what Merge() already does. One place, one contract.                                                                                                                                       - No new tests added , the change is only observable under a double-finalize, which no current caller does. If reviewers want, 
 
 I'm happy to add a unit test in statement_test.go that calls Discard() twice and asserts the event handlers fire only once.                                                                           
 
 #### Does this PR introduce a user-facing change?                                                                                                                       
  
  NONE