### PR TITLE
fix: `highestTierName` in partitionPolicy or subGroupPolicy fails to restrict scheduling to specified HyperNode tiers

### DIFF
--- a/pkg/scheduler/actions/allocate/allocate.go
+++ b/pkg/scheduler/actions/allocate/allocate.go
@@ -297,7 +297,6 @@ func (alloc *Action) allocateResources(actx *allocateContext) {
 		}
 
 		job := jobs.Pop().(*api.JobInfo)
-		updateJobTier(ssn.HyperNodeTierNameMap, job)
 		// Currently, both hard-mode network topology scheduling and subjob level scheduling use allocateForJob.
 		// TODO: In the future, we may need to unify the logic of network topology-aware scheduling and normal scheduling.
 		if job.ContainsHardTopology() || job.ContainsSubJobPolicy() {
@@ -668,30 +667,6 @@ func (alloc *Action) allocateResourcesForTasks(subJob *api.SubJobInfo, tasks *ut
 
 	stmt.Discard()
 	return nil
-}
-
-func updateJobTier(hyperNodeTierNameMap api.HyperNodeTierNameMap, job *api.JobInfo) {
-	klog.V(4).InfoS("updateJobTier", "job", job.UID, "hyperNodeTierNameMap", hyperNodeTierNameMap)
-	if job.PodGroup.Spec.NetworkTopology != nil && job.PodGroup.Spec.NetworkTopology.HighestTierName != "" && job.PodGroup.Spec.NetworkTopology.HighestTierAllowed == nil {
-		if tier, ok := hyperNodeTierNameMap[job.PodGroup.Spec.NetworkTopology.HighestTierName]; ok {
-			job.PodGroup.Spec.NetworkTopology.HighestTierAllowed = &tier
-			job.PodGroup.Spec.NetworkTopology.HighestTierName = ""
-		} else {
-			klog.Warningf("The tier corresponding to highestTierName %s is not found, job <%s>",
-				job.PodGroup.Spec.NetworkTopology.HighestTierName, job.UID)
-		}
-	}
-	for _, subGroupPolicy := range job.PodGroup.Spec.SubGroupPolicy {
-		if subGroupPolicy.NetworkTopology != nil && subGroupPolicy.NetworkTopology.HighestTierName != "" && subGroupPolicy.NetworkTopology.HighestTierAllowed == nil {
-			if tier, ok := hyperNodeTierNameMap[subGroupPolicy.NetworkTopology.HighestTierName]; ok {
-				subGroupPolicy.NetworkTopology.HighestTierAllowed = &tier
-				subGroupPolicy.NetworkTopology.HighestTierName = ""
-			} else {
-				klog.Warningf("The tier corresponding to highestTierName %s in subGroupPolicy %s is not found, job <%s>",
-					subGroupPolicy.NetworkTopology.HighestTierName, subGroupPolicy.Name, job.UID)
-			}
-		}
-	}
 }
 
 // getNewAllocatedHyperNode Obtain the newly allocated hyperNode for the job in soft topology mode

--- a/pkg/scheduler/api/sub_job_info.go
+++ b/pkg/scheduler/api/sub_job_info.go
@@ -52,7 +52,7 @@ type SubJobInfo struct {
 
 	AllocatedHyperNode string
 
-	networkTopology *scheduling.NetworkTopologySpec
+	NetworkTopology *scheduling.NetworkTopologySpec
 }
 
 func NewSubJobInfo(gid SubJobGID, uid SubJobID, job JobID, policy *scheduling.SubGroupPolicySpec, matchValues []string) *SubJobInfo {
@@ -70,7 +70,7 @@ func NewSubJobInfo(gid SubJobGID, uid SubJobID, job JobID, policy *scheduling.Su
 			sji.MinAvailable = *policy.SubGroupSize
 		}
 		if policy.NetworkTopology != nil {
-			sji.networkTopology = policy.NetworkTopology.DeepCopy()
+			sji.NetworkTopology = policy.NetworkTopology.DeepCopy()
 		}
 	}
 	if len(matchValues) > 0 {
@@ -83,24 +83,24 @@ func NewSubJobInfo(gid SubJobGID, uid SubJobID, job JobID, policy *scheduling.Su
 
 // IsHardTopologyMode return whether the subJob's network topology mode is hard and also return the highest allowed tier
 func (sji *SubJobInfo) IsHardTopologyMode() (bool, int) {
-	if sji.networkTopology == nil || sji.networkTopology.HighestTierAllowed == nil {
+	if sji.NetworkTopology == nil || sji.NetworkTopology.HighestTierAllowed == nil {
 		return false, 0
 	}
 
-	return sji.networkTopology.Mode == scheduling.HardNetworkTopologyMode, *sji.networkTopology.HighestTierAllowed
+	return sji.NetworkTopology.Mode == scheduling.HardNetworkTopologyMode, *sji.NetworkTopology.HighestTierAllowed
 }
 
 // IsSoftTopologyMode returns whether the subJob has configured network topologies with soft mode.
 func (sji *SubJobInfo) IsSoftTopologyMode() bool {
-	if sji.networkTopology == nil {
+	if sji.NetworkTopology == nil {
 		return false
 	}
-	return sji.networkTopology.Mode == scheduling.SoftNetworkTopologyMode
+	return sji.NetworkTopology.Mode == scheduling.SoftNetworkTopologyMode
 }
 
 // WithNetworkTopology returns whether the subJob has configured network topologies
 func (sji *SubJobInfo) WithNetworkTopology() bool {
-	return sji.networkTopology != nil
+	return sji.NetworkTopology != nil
 }
 
 func (sji *SubJobInfo) addTask(ti *TaskInfo) {

--- a/pkg/scheduler/api/sub_job_info_test.go
+++ b/pkg/scheduler/api/sub_job_info_test.go
@@ -65,7 +65,7 @@ func TestNewSubJobInfo(t *testing.T) {
 				Tasks:           make(map[TaskID]*TaskInfo),
 				TaskStatusIndex: make(map[TaskStatus]TasksMap),
 				taskPriorities:  make(map[int32]sets.Set[TaskID]),
-				networkTopology: &scheduling.NetworkTopologySpec{
+				NetworkTopology: &scheduling.NetworkTopologySpec{
 					Mode:               scheduling.HardNetworkTopologyMode,
 					HighestTierAllowed: ptr.To(1),
 				},
@@ -89,7 +89,7 @@ func TestNewSubJobInfo(t *testing.T) {
 				Tasks:           make(map[TaskID]*TaskInfo),
 				TaskStatusIndex: make(map[TaskStatus]TasksMap),
 				taskPriorities:  make(map[int32]sets.Set[TaskID]),
-				networkTopology: nil,
+				NetworkTopology: nil,
 			},
 		},
 		{
@@ -115,14 +115,14 @@ func TestNewSubJobInfo(t *testing.T) {
 				Tasks:           make(map[TaskID]*TaskInfo),
 				TaskStatusIndex: make(map[TaskStatus]TasksMap),
 				taskPriorities:  make(map[int32]sets.Set[TaskID]),
-				networkTopology: &scheduling.NetworkTopologySpec{
+				NetworkTopology: &scheduling.NetworkTopologySpec{
 					Mode:               scheduling.HardNetworkTopologyMode,
 					HighestTierAllowed: ptr.To(1),
 				},
 			},
 		},
 		{
-			name: "No networkTopology provided",
+			name: "No NetworkTopology provided",
 			args: args{
 				gid: "test-gid",
 				uid: "test-uid",
@@ -141,7 +141,7 @@ func TestNewSubJobInfo(t *testing.T) {
 				Tasks:           make(map[TaskID]*TaskInfo),
 				TaskStatusIndex: make(map[TaskStatus]TasksMap),
 				taskPriorities:  make(map[int32]sets.Set[TaskID]),
-				networkTopology: nil,
+				NetworkTopology: nil,
 			},
 		},
 	}
@@ -172,7 +172,7 @@ func TestSubJobInfo_IsHardTopologyMode(t *testing.T) {
 		expectedTier int
 	}{
 		{
-			name: "networkTopology is nil",
+			name: "NetworkTopology is nil",
 			fields: fields{
 				networkTopology: nil,
 			},
@@ -223,7 +223,7 @@ func TestSubJobInfo_IsHardTopologyMode(t *testing.T) {
 				TaskStatusIndex:    tt.fields.TaskStatusIndex,
 				taskPriorities:     tt.fields.taskPriorities,
 				AllocatedHyperNode: tt.fields.AllocateHyperNode,
-				networkTopology:    tt.fields.networkTopology,
+				NetworkTopology:    tt.fields.networkTopology,
 			}
 			gotIsHard, gotTier := sji.IsHardTopologyMode()
 			assert.Equal(t, tt.expectedHard, gotIsHard, "IsHardTopologyMode()")
@@ -250,7 +250,7 @@ func TestSubJobInfo_IsSoftTopologyMode(t *testing.T) {
 		expectedHard bool
 	}{
 		{
-			name: "networkTopology is nil",
+			name: "NetworkTopology is nil",
 			fields: fields{
 				networkTopology: nil,
 			},
@@ -278,7 +278,7 @@ func TestSubJobInfo_IsSoftTopologyMode(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			sji := &SubJobInfo{
-				networkTopology: tt.fields.networkTopology,
+				NetworkTopology: tt.fields.networkTopology,
 			}
 			assert.Equalf(t, tt.expectedHard, sji.IsSoftTopologyMode(), "IsSoftTopologyMode()")
 		})

--- a/pkg/scheduler/framework/session.go
+++ b/pkg/scheduler/framework/session.go
@@ -238,6 +238,7 @@ func openSession(cache cache.Cache) *Session {
 	ssn.HyperNodesReadyToSchedule = snapshot.HyperNodesReadyToSchedule
 	ssn.addClusterTopHyperNode(ssn.NodeList)
 	ssn.parseHyperNodesTiers()
+	ssn.adjustNetworkTopologySpec()
 
 	if ssn.HyperNodesReadyToSchedule {
 		// hyperNodes in ssn has ClusterTopHyperNode
@@ -1005,4 +1006,61 @@ func (ssn *Session) String() string {
 
 func (ssn *Session) IsJobTerminated(jobId api.JobID) bool {
 	return ssn.cache.IsJobTerminated(jobId)
+}
+
+// adjustNetworkTopologySpec translates highestTierName in network topology spec into highestTierAllowed.
+// As a result, once adjustNetworkTopologySpec is invoked, it is no need to consider highestTierName anymore.
+func (ssn *Session) adjustNetworkTopologySpec() {
+	klog.V(3).Infof("Start adjusting jobs' network topology spec according to hyperNodeTierNameMap %v", ssn.HyperNodeTierNameMap)
+	defer klog.V(3).Infof("Finish adjusting jobs' network topology spec according to hyperNodeTierNameMap %v", ssn.HyperNodeTierNameMap)
+
+	for _, job := range ssn.Jobs {
+		if !job.ContainsNetworkTopology() {
+			continue
+		}
+
+		translated, err := translateHighestTierNameToAllowed(job.PodGroup.Spec.NetworkTopology, ssn.HyperNodeTierNameMap)
+		if err != nil {
+			klog.Warningf("Failed to translate highestTierName for job %s/%s: %v, skip translation", job.Namespace, job.Name, err)
+		} else if translated {
+			klog.V(4).Infof("Translated highestTierName for job %s/%s, new highestTierAllowed is %d",
+				job.Namespace, job.Name, *job.PodGroup.Spec.NetworkTopology.HighestTierAllowed)
+		}
+		for _, subGroupPolicy := range job.PodGroup.Spec.SubGroupPolicy {
+			translated, err = translateHighestTierNameToAllowed(subGroupPolicy.NetworkTopology, ssn.HyperNodeTierNameMap)
+			if err != nil {
+				klog.Warningf("Failed to translate highestTierName for subGroupPolicy %s of job %s/%s: %v, skip translation",
+					subGroupPolicy.Name, job.Namespace, job.Name, err)
+			} else if translated {
+				klog.V(4).Infof("Translated highestTierName in subGroupPolicy %s for job %s/%s, new highestTierAllowed is %d",
+					subGroupPolicy.Name, job.Namespace, job.Name, *subGroupPolicy.NetworkTopology.HighestTierAllowed)
+			}
+		}
+
+		// NetworkTopology of SubJob is derived from the original SubGroupPolicy.NetworkTopology, and will be used by plugins like network-topology-aware.
+		// Therefore, for the sake of consistency, NetworkTopology of SubJob should also be updated.
+		for _, subJob := range job.SubJobs {
+			translated, err = translateHighestTierNameToAllowed(subJob.NetworkTopology, ssn.HyperNodeTierNameMap)
+			if err != nil {
+				klog.Warningf("Failed to translate highestTierName for subJob %s of job %s/%s: %v, skip translation",
+					subJob.UID, job.Namespace, job.Name, err)
+			} else if translated {
+				klog.V(4).Infof("Translated highestTierName for subJob %s of job %s/%s, new highestTierAllowed is %d",
+					subJob.UID, job.Namespace, job.Name, *subJob.NetworkTopology.HighestTierAllowed)
+			}
+		}
+	}
+}
+
+func translateHighestTierNameToAllowed(spec *scheduling.NetworkTopologySpec, nameMap api.HyperNodeTierNameMap) (bool, error) {
+	if spec != nil && spec.HighestTierAllowed == nil && spec.HighestTierName != "" {
+		if tier, ok := nameMap[spec.HighestTierName]; ok {
+			spec.HighestTierAllowed = &tier
+			spec.HighestTierName = ""
+			return true, nil
+		} else {
+			return false, fmt.Errorf("failed to find hypernode tier name %s", spec.HighestTierName)
+		}
+	}
+	return false, nil
 }

--- a/pkg/scheduler/framework/session_test.go
+++ b/pkg/scheduler/framework/session_test.go
@@ -1,0 +1,251 @@
+package framework
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/utils/ptr"
+
+	"volcano.sh/apis/pkg/apis/scheduling"
+	"volcano.sh/volcano/pkg/scheduler/api"
+)
+
+func TestSession_adjustNetworkTopologySpec(t *testing.T) {
+	tests := []struct {
+		name         string
+		jobs         map[api.JobID]*api.JobInfo
+		nameMap      api.HyperNodeTierNameMap
+		expectedJobs map[api.JobID]*api.JobInfo
+	}{
+		{
+			name: "job with highestTierAllowed, no translation",
+			jobs: map[api.JobID]*api.JobInfo{
+				"test-uid": {
+					PodGroup: &api.PodGroup{
+						PodGroup: scheduling.PodGroup{
+							Spec: scheduling.PodGroupSpec{
+								NetworkTopology: &scheduling.NetworkTopologySpec{
+									HighestTierName:    "",
+									HighestTierAllowed: ptr.To(2),
+								},
+								SubGroupPolicy: []scheduling.SubGroupPolicySpec{
+									{
+										NetworkTopology: &scheduling.NetworkTopologySpec{
+											HighestTierName:    "",
+											HighestTierAllowed: ptr.To(1),
+										},
+									},
+								},
+							},
+						},
+					},
+					SubJobs: map[api.SubJobID]*api.SubJobInfo{
+						"test-uid": {
+							NetworkTopology: &scheduling.NetworkTopologySpec{
+								HighestTierName:    "",
+								HighestTierAllowed: ptr.To(1),
+							},
+						},
+					},
+				},
+			},
+			nameMap: api.HyperNodeTierNameMap{
+				"volcano.sh/hypernode":    1,
+				"volcano.sh/hypercluster": 2,
+			},
+			expectedJobs: map[api.JobID]*api.JobInfo{
+				"test-uid": {
+					PodGroup: &api.PodGroup{
+						PodGroup: scheduling.PodGroup{
+							Spec: scheduling.PodGroupSpec{
+								NetworkTopology: &scheduling.NetworkTopologySpec{
+									HighestTierName:    "",
+									HighestTierAllowed: ptr.To(2),
+								},
+								SubGroupPolicy: []scheduling.SubGroupPolicySpec{
+									{
+										NetworkTopology: &scheduling.NetworkTopologySpec{
+											HighestTierName:    "",
+											HighestTierAllowed: ptr.To(1),
+										},
+									},
+								},
+							},
+						},
+					},
+					SubJobs: map[api.SubJobID]*api.SubJobInfo{
+						"test-uid": {
+							NetworkTopology: &scheduling.NetworkTopologySpec{
+								HighestTierName:    "",
+								HighestTierAllowed: ptr.To(1),
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "job with highestTierName, need translation",
+			jobs: map[api.JobID]*api.JobInfo{
+				"test-uid": {
+					PodGroup: &api.PodGroup{
+						PodGroup: scheduling.PodGroup{
+							Spec: scheduling.PodGroupSpec{
+								NetworkTopology: &scheduling.NetworkTopologySpec{
+									HighestTierName:    "volcano.sh/hypercluster",
+									HighestTierAllowed: nil,
+								},
+								SubGroupPolicy: []scheduling.SubGroupPolicySpec{
+									{
+										NetworkTopology: &scheduling.NetworkTopologySpec{
+											HighestTierName:    "volcano.sh/hypernode",
+											HighestTierAllowed: nil,
+										},
+									},
+								},
+							},
+						},
+					},
+					SubJobs: map[api.SubJobID]*api.SubJobInfo{
+						"test-uid": {
+							NetworkTopology: &scheduling.NetworkTopologySpec{
+								HighestTierName:    "volcano.sh/hypernode",
+								HighestTierAllowed: nil,
+							},
+						},
+					},
+				},
+			},
+			nameMap: api.HyperNodeTierNameMap{
+				"volcano.sh/hypernode":    1,
+				"volcano.sh/hypercluster": 2,
+			},
+			expectedJobs: map[api.JobID]*api.JobInfo{
+				"test-uid": {
+					PodGroup: &api.PodGroup{
+						PodGroup: scheduling.PodGroup{
+							Spec: scheduling.PodGroupSpec{
+								NetworkTopology: &scheduling.NetworkTopologySpec{
+									HighestTierName:    "",
+									HighestTierAllowed: ptr.To(2),
+								},
+								SubGroupPolicy: []scheduling.SubGroupPolicySpec{
+									{
+										NetworkTopology: &scheduling.NetworkTopologySpec{
+											HighestTierName:    "",
+											HighestTierAllowed: ptr.To(1),
+										},
+									},
+								},
+							},
+						},
+					},
+					SubJobs: map[api.SubJobID]*api.SubJobInfo{
+						"test-uid": {
+							NetworkTopology: &scheduling.NetworkTopologySpec{
+								HighestTierName:    "",
+								HighestTierAllowed: ptr.To(1),
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "job with highestTierName, failed to translate",
+			jobs: map[api.JobID]*api.JobInfo{
+				"test-uid": {
+					PodGroup: &api.PodGroup{
+						PodGroup: scheduling.PodGroup{
+							Spec: scheduling.PodGroupSpec{
+								NetworkTopology: &scheduling.NetworkTopologySpec{
+									HighestTierName:    "volcano.sh/hypercluster-test",
+									HighestTierAllowed: nil,
+								},
+								SubGroupPolicy: []scheduling.SubGroupPolicySpec{
+									{
+										NetworkTopology: &scheduling.NetworkTopologySpec{
+											HighestTierName:    "volcano.sh/hypernode-test",
+											HighestTierAllowed: nil,
+										},
+									},
+								},
+							},
+						},
+					},
+					SubJobs: map[api.SubJobID]*api.SubJobInfo{
+						"test-uid": {
+							NetworkTopology: &scheduling.NetworkTopologySpec{
+								HighestTierName:    "volcano.sh/hypernode",
+								HighestTierAllowed: ptr.To(1),
+							},
+						},
+					},
+				},
+			},
+			nameMap: api.HyperNodeTierNameMap{
+				"volcano.sh/hypernode":    1,
+				"volcano.sh/hypercluster": 2,
+			},
+			expectedJobs: map[api.JobID]*api.JobInfo{
+				"test-uid": {
+					PodGroup: &api.PodGroup{
+						PodGroup: scheduling.PodGroup{
+							Spec: scheduling.PodGroupSpec{
+								NetworkTopology: &scheduling.NetworkTopologySpec{
+									HighestTierName:    "volcano.sh/hypercluster-test",
+									HighestTierAllowed: nil,
+								},
+								SubGroupPolicy: []scheduling.SubGroupPolicySpec{
+									{
+										NetworkTopology: &scheduling.NetworkTopologySpec{
+											HighestTierName:    "volcano.sh/hypernode-test",
+											HighestTierAllowed: nil,
+										},
+									},
+								},
+							},
+						},
+					},
+					SubJobs: map[api.SubJobID]*api.SubJobInfo{
+						"test-uid": {
+							NetworkTopology: &scheduling.NetworkTopologySpec{
+								HighestTierName:    "volcano.sh/hypernode",
+								HighestTierAllowed: ptr.To(1),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ssn := &Session{
+				Jobs:                 test.jobs,
+				HyperNodeTierNameMap: test.nameMap,
+			}
+			ssn.adjustNetworkTopologySpec()
+			for jobID, expectedJob := range test.expectedJobs {
+				gotJob := ssn.Jobs[jobID]
+				assert.Equal(t, expectedJob.PodGroup.Spec.NetworkTopology.HighestTierName,
+					gotJob.PodGroup.Spec.NetworkTopology.HighestTierName, "job highestTierName should be equal")
+				assert.Equal(t, expectedJob.PodGroup.Spec.NetworkTopology.HighestTierAllowed,
+					gotJob.PodGroup.Spec.NetworkTopology.HighestTierAllowed, "job highestTierAllowed should be equal")
+				for index := range expectedJob.PodGroup.Spec.SubGroupPolicy {
+					assert.Equal(t, expectedJob.PodGroup.Spec.SubGroupPolicy[index].NetworkTopology.HighestTierName,
+						gotJob.PodGroup.Spec.SubGroupPolicy[index].NetworkTopology.HighestTierName, "subGroupPolicy highestTierName should be equal")
+					assert.Equal(t, expectedJob.PodGroup.Spec.SubGroupPolicy[index].NetworkTopology.HighestTierAllowed,
+						gotJob.PodGroup.Spec.SubGroupPolicy[index].NetworkTopology.HighestTierAllowed, "subGroupPolicy highestTierAllowed should be equal")
+				}
+				for subJobID := range expectedJob.SubJobs {
+					assert.Equal(t, expectedJob.SubJobs[subJobID].NetworkTopology.HighestTierName,
+						gotJob.SubJobs[subJobID].NetworkTopology.HighestTierName, "subJob highestTierName should be equal")
+					assert.Equal(t, expectedJob.SubJobs[subJobID].NetworkTopology.HighestTierAllowed,
+						gotJob.SubJobs[subJobID].NetworkTopology.HighestTierAllowed, "subJob highestTierAllowed should be equal")
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
The `highestTierName` in partitionPolicy or subGroupPolicy is not functional. When users submit a volcano job, specifying highestTierName in its partitionPolicy, like follows:
partitionPolicy:
totalPartitions: 1
partitionSize: 2
networkTopology:
mode: hard
highestTierName: volcano.sh/hypernode
Volcano may schedule the pods of this group to multiple hypernodes with the tier name of volcano.sh/hypernode, which fails to satisfy the hard network topology constraint.

This PR fixes this bug.

#### Which issue(s) this PR fixes:
Fixes #5189 

#### Does this PR introduce a user-facing change?
```release-note
"NONE"
```