### PR TITLE
hypernode: skip restart for unchanged discoverer config

### DIFF
--- a/pkg/controllers/hypernode/configmap_handler.go
+++ b/pkg/controllers/hypernode/configmap_handler.go
@@ -59,7 +59,6 @@ func (hn *hyperNodeController) setupConfigMapInformer() {
 		return filteredInformer
 	})
 	hn.configMapInformer = hn.informerFactory.Core().V1().ConfigMaps()
-	// TODO: Only trigger handler when networkTopologyDiscovery config changed.
 	hn.configMapInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc:    hn.addConfigMap,
 		UpdateFunc: hn.updateConfigMap,
@@ -78,13 +77,22 @@ func (hn *hyperNodeController) addConfigMap(obj interface{}) {
 }
 
 func (hn *hyperNodeController) updateConfigMap(oldObj, newObj interface{}) {
-	cm, ok := newObj.(*v1.ConfigMap)
+	newCm, ok := newObj.(*v1.ConfigMap)
 	if !ok {
 		klog.ErrorS(nil, "Cannot convert to *v1.ConfigMap", "obj", newObj)
 		return
 	}
-	klog.V(3).InfoS("Update ConfigMap", "namespace", cm.Namespace, "name", cm.Name)
-	hn.enqueueConfigMap(cm)
+	oldCm, ok := oldObj.(*v1.ConfigMap)
+	if !ok {
+		klog.ErrorS(nil, "Cannot convert to *v1.ConfigMap", "obj", oldObj)
+		return
+	}
+	if oldCm.Data[config.DefaultConfigKey] == newCm.Data[config.DefaultConfigKey] {
+		klog.V(5).InfoS("topology config unchanged, skipping", "namespace", newCm.Namespace, "name", newCm.Name)
+		return
+	}
+	klog.V(3).InfoS("Update ConfigMap", "namespace", newCm.Namespace, "name", newCm.Name)
+	hn.enqueueConfigMap(newCm)
 }
 
 func (hn *hyperNodeController) deleteConfigMap(obj interface{}) {

--- a/pkg/controllers/hypernode/configmap_handler_test.go
+++ b/pkg/controllers/hypernode/configmap_handler_test.go
@@ -132,34 +132,81 @@ func TestAddConfigMap(t *testing.T) {
 }
 
 func TestUpdateConfigMap(t *testing.T) {
-	controller := newFakeConfigMapController()
-
-	oldConfigMap := &v1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-configmap",
-			Namespace: "test-namespace",
+	testCases := []struct {
+		name        string
+		oldData     map[string]string
+		newData     map[string]string
+		expectedLen int
+	}{
+		{
+			name: "topology config changed enqueues",
+			oldData: map[string]string{
+				config.DefaultConfigKey: "old-topology-config",
+			},
+			newData: map[string]string{
+				config.DefaultConfigKey: "new-topology-config",
+			},
+			expectedLen: 1,
 		},
-		Data: map[string]string{
-			"key1": "value1",
+		{
+			name: "topology config unchanged skips enqueue",
+			oldData: map[string]string{
+				config.DefaultConfigKey: "same-topology-config",
+				"other-key":             "value1",
+			},
+			newData: map[string]string{
+				config.DefaultConfigKey: "same-topology-config",
+				"other-key":             "value2",
+			},
+			expectedLen: 0,
 		},
 	}
 
-	newConfigMap := oldConfigMap.DeepCopy()
-	newConfigMap.Data["key2"] = "value2"
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			controller := newFakeConfigMapController()
 
-	controller.updateConfigMap(oldConfigMap, newConfigMap)
+			oldConfigMap := &v1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-configmap",
+					Namespace: "test-namespace",
+				},
+				Data: tc.oldData,
+			}
+			newConfigMap := &v1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-configmap",
+					Namespace: "test-namespace",
+				},
+				Data: tc.newData,
+			}
 
-	// Verify the ConfigMap was added to the queue
-	assert.Equal(t, 1, controller.configMapQueue.Len())
-
-	// Test invalid object (non-ConfigMap)
-	pod := &v1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "test-pod",
-		},
+			controller.updateConfigMap(oldConfigMap, newConfigMap)
+			assert.Equal(t, tc.expectedLen, controller.configMapQueue.Len())
+		})
 	}
-	controller.updateConfigMap(oldConfigMap, pod)
-	assert.Equal(t, 1, controller.configMapQueue.Len())
+
+	// Test invalid new object (non-ConfigMap)
+	t.Run("invalid new object skips enqueue", func(t *testing.T) {
+		controller := newFakeConfigMapController()
+		oldConfigMap := &v1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-configmap", Namespace: "test-namespace"},
+		}
+		pod := &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "test-pod"}}
+		controller.updateConfigMap(oldConfigMap, pod)
+		assert.Equal(t, 0, controller.configMapQueue.Len())
+	})
+
+	// Test invalid old object (non-ConfigMap)
+	t.Run("invalid old object skips enqueue", func(t *testing.T) {
+		controller := newFakeConfigMapController()
+		newConfigMap := &v1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-configmap", Namespace: "test-namespace"},
+		}
+		pod := &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "test-pod"}}
+		controller.updateConfigMap(pod, newConfigMap)
+		assert.Equal(t, 0, controller.configMapQueue.Len())
+	})
 }
 
 func TestDeleteConfigMap(t *testing.T) {
@@ -238,7 +285,7 @@ func TestIntegrationConfigMapHandling(t *testing.T) {
 			Namespace: "test-namespace",
 		},
 		Data: map[string]string{
-			"config": "initial",
+			config.DefaultConfigKey: "initial",
 		},
 	}
 
@@ -258,7 +305,7 @@ func TestIntegrationConfigMapHandling(t *testing.T) {
 	controller.configMapQueue.Done(key)
 
 	updatedConfigMap := configMap.DeepCopy()
-	updatedConfigMap.Data["config"] = "updated"
+	updatedConfigMap.Data[config.DefaultConfigKey] = "updated"
 
 	_, err = controller.kubeClient.CoreV1().ConfigMaps("test-namespace").Update(
 		context.Background(), updatedConfigMap, metav1.UpdateOptions{})

--- a/pkg/controllers/hypernode/discovery/manager.go
+++ b/pkg/controllers/hypernode/discovery/manager.go
@@ -18,6 +18,7 @@ package discovery
 
 import (
 	"fmt"
+	"reflect"
 	"sync"
 
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -238,8 +239,14 @@ func (m *manager) syncHandler(key string) error {
 		return err
 	}
 
-	// TODO: Only restart changed discoverers.
 	for _, source := range newConfig.GetEnabledDiscoverySources() {
+		_, running := m.discoverers[source]
+		oldSourceConfig := m.config.GetDiscoveryConfig(source)
+		newSourceConfig := newConfig.GetDiscoveryConfig(source)
+		if running && reflect.DeepEqual(oldSourceConfig, newSourceConfig) {
+			klog.V(5).InfoS("source config unchanged, skipping restart", "source", source)
+			continue
+		}
 		klog.InfoS("Restarting network discovery", "source", source)
 		if err = m.stopSingleDiscoverer(source); err != nil {
 			return err

--- a/pkg/controllers/hypernode/discovery/manager_test.go
+++ b/pkg/controllers/hypernode/discovery/manager_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package discovery
 
 import (
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -170,5 +171,106 @@ func TestManager_syncHandler(t *testing.T) {
 	assert.False(t, exists, "Discoverer should be stopped")
 
 	// Stop the manager
+	m.Stop()
+}
+
+func TestManager_UnchangedSourceConfigSkipsRestart(t *testing.T) {
+	var startCount int32
+
+	constructor := api.DiscovererConstructor(func(cfg api.DiscoveryConfig, kubeClient clientset.Interface, vcClient vcclientset.Interface) api.Discoverer {
+		atomic.AddInt32(&startCount, 1)
+		return fakedisc.NewFakeDiscoverer([]*topologyv1alpha1.HyperNode{}, cfg)
+	})
+	api.RegisterDiscoverer("unchangedSrc", constructor)
+
+	discoveryConfig := &api.NetworkTopologyConfig{
+		NetworkTopologyDiscovery: []api.DiscoveryConfig{
+			{
+				Source:  "unchangedSrc",
+				Enabled: true,
+				Config:  map[string]interface{}{"key": "value"},
+			},
+		},
+	}
+	loader := config.NewFakeLoader(discoveryConfig)
+	queue := workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[string]())
+	fakeClient := fake.NewSimpleClientset()
+	fakeVcClient := fakevcclientset.NewSimpleClientset()
+	m := NewManager(loader, queue, fakeClient, fakeVcClient)
+
+	err := m.Start()
+	assert.NoError(t, err)
+
+	// First sync: new source not yet running, should start the discoverer
+	queue.Add("test-namespace/test-config")
+	timeout := time.After(time.Second)
+	select {
+	case <-m.ResultChannel():
+	case <-timeout:
+		t.Fatal("timed out waiting for first result")
+	}
+	assert.Equal(t, int32(1), atomic.LoadInt32(&startCount), "discoverer should start once on first sync")
+
+	// Second sync with same config: discoverer is running and config unchanged, should skip restart
+	queue.Add("test-namespace/test-config")
+	time.Sleep(100 * time.Millisecond)
+	assert.Equal(t, int32(1), atomic.LoadInt32(&startCount), "discoverer should not restart when config is unchanged")
+
+	m.Stop()
+}
+
+func TestManager_ChangedSourceConfigRestartsDiscoverer(t *testing.T) {
+	var startCount int32
+
+	constructor := api.DiscovererConstructor(func(cfg api.DiscoveryConfig, kubeClient clientset.Interface, vcClient vcclientset.Interface) api.Discoverer {
+		atomic.AddInt32(&startCount, 1)
+		return fakedisc.NewFakeDiscoverer([]*topologyv1alpha1.HyperNode{}, cfg)
+	})
+	api.RegisterDiscoverer("changedSrc", constructor)
+
+	discoveryConfigV1 := &api.NetworkTopologyConfig{
+		NetworkTopologyDiscovery: []api.DiscoveryConfig{
+			{
+				Source:  "changedSrc",
+				Enabled: true,
+				Config:  map[string]interface{}{"key": "value1"},
+			},
+		},
+	}
+	discoveryConfigV2 := &api.NetworkTopologyConfig{
+		NetworkTopologyDiscovery: []api.DiscoveryConfig{
+			{
+				Source:  "changedSrc",
+				Enabled: true,
+				Config:  map[string]interface{}{"key": "value2"},
+			},
+		},
+	}
+
+	loader := config.NewFakeLoader(discoveryConfigV1)
+	queue := workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[string]())
+	fakeClient := fake.NewSimpleClientset()
+	fakeVcClient := fakevcclientset.NewSimpleClientset()
+	m := NewManager(loader, queue, fakeClient, fakeVcClient)
+
+	err := m.Start()
+	assert.NoError(t, err)
+
+	// First sync: should start the discoverer
+	queue.Add("test-namespace/test-config")
+	timeout := time.After(time.Second)
+	select {
+	case <-m.ResultChannel():
+	case <-timeout:
+		t.Fatal("timed out waiting for first result")
+	}
+	assert.Equal(t, int32(1), atomic.LoadInt32(&startCount), "discoverer should start once on first sync")
+
+	// Second sync with updated config: should restart the discoverer
+	loader.SetConfig(discoveryConfigV2)
+	queue.Add("test-namespace/test-config")
+	time.Sleep(100 * time.Millisecond)
+	assert.Equal(t, int32(2), atomic.LoadInt32(&startCount), "discoverer should restart when config changes")
+
 	m.Stop()
 }


### PR DESCRIPTION
fixes #5191

**what changed**

two optimizations to avoid unnecessary work when a configmap update comes in:

1. `configmap_handler.go` - `updateConfigMap` now compares the `volcano-controller.conf` key between old and new configmaps before enqueuing. if the topology config string is identical, we skip enqueue entirely instead of triggering a full sync cycle.

2. `discovery/manager.go` - `syncHandler` now checks per-source whether the discoverer is already running and its config is unchanged (via `reflect.DeepEqual`). if both are true it skips the stop/start cycle for that source. new sources (not yet running) are always started.

**tests**

- updated `TestUpdateConfigMap` to cover: topology key changed (enqueue), topology key unchanged (skip), invalid objects (skip)
- updated `TestIntegrationConfigMapHandling` to use the correct `config.DefaultConfigKey`
- added `TestManager_UnchangedSourceConfigSkipsRestart`: verifies discoverer is not restarted when config is identical
- added `TestManager_ChangedSourceConfigRestartsDiscoverer`: verifies discoverer restarts when config changes

all existing tests continue to pass.

/cc @JesseStutler 