### PR TITLE
Enable dra option

### DIFF
--- a/pkg/scheduler/plugins/predicates/predicates.go
+++ b/pkg/scheduler/plugins/predicates/predicates.go
@@ -125,7 +125,7 @@ func New(arguments framework.Arguments) framework.Plugin {
 		podTopologySpreadEnable:         true,
 		cacheEnable:                     false,
 		volumeBindingEnable:             true,
-		dynamicResourceAllocationEnable: false,
+		dynamicResourceAllocationEnable: utilFeature.DefaultFeatureGate.Enabled(features.DynamicResourceAllocation),
 	}
 
 	// Checks whether predicate enable args is provided or not.
@@ -138,7 +138,6 @@ func New(arguments framework.Arguments) framework.Plugin {
 	arguments.GetBool(&predicate.volumeZoneEnable, VolumeZoneEnable)
 	arguments.GetBool(&predicate.podTopologySpreadEnable, PodTopologySpreadEnable)
 	arguments.GetBool(&predicate.volumeBindingEnable, VolumeBindingEnable)
-	arguments.GetBool(&predicate.dynamicResourceAllocationEnable, DynamicResourceAllocationEnable)
 	arguments.GetBool(&predicate.cacheEnable, CachePredicate)
 
 	features := feature.Features{


### PR DESCRIPTION
#### What type of PR is this?
Feature
#### What this PR does / why we need it:

- Change the default value of DynamicResourceAllocationEnable from false to true
- Dynamic Resource Allocation has been enabled by default starting with Kubernetes v1.34; to better align Volcano with upstream Kubernetes resource management trends, it is recommended to turn on this option by default as well.

#### Which issue(s) this PR fixes:
Fixes #
#### Special notes for your reviewer:
NONE
#### Does this PR introduce a user-facing change?
Yes
```release-note
Dynamic Resource Allocation (DRA) is now controlled directly by the DynamicResourceAllocation feature gate now.
This can be disabled by setting `predicate.DynamicResourceAllocationEnable` to `false` in the scheduler configuration.
```