### PR TITLE
fix: validate key format before accessing split result to prevent panic

### DIFF
--- a/pkg/controllers/jobtemplate/jobtemplate_controller_handler.go
+++ b/pkg/controllers/jobtemplate/jobtemplate_controller_handler.go
@@ -59,6 +59,7 @@ func (jt *jobtemplatecontroller) addJob(obj interface{}) {
 	//Filter vcjobs created by JobFlow
 	namespaceName := strings.Split(job.Labels[CreatedByJobTemplate], ".")
 	if len(namespaceName) != CreateByJobTemplateValueNum {
+		klog.Errorf("invalid key format: %s", job.Labels[CreatedByJobTemplate])
 		return
 	}
 	namespace, name := namespaceName[0], namespaceName[1]


### PR DESCRIPTION
### Summary

Adds a validation check for the key format before accessing elements after splitting by `/` to prevent a potential runtime panic.

### Details

The existing implementation assumes the key is always in `namespace/name` format and directly indexes the split result. This can lead to an out-of-range panic if the input is malformed.

This change ensures the split result contains exactly two elements before accessing them. If the format is invalid, the controller logs an error and safely returns without interrupting the reconciliation flow.

### Impact

* Prevents potential runtime panic
* Preserves existing behavior for valid inputs
* Maintains controller stability by avoiding hard failures
