### PR TITLE
Add gpuexclusive plugin for rule-based GPU isolation

### DIFF
--- a/pkg/scheduler/api/devices/nvidia/vgpu/device_info.go
+++ b/pkg/scheduler/api/devices/nvidia/vgpu/device_info.go
@@ -159,7 +159,7 @@ func (gs *GPUDevices) AddQueueResource(pod *v1.Pod) map[string]float64 {
 		klog.Errorf("pod %s has no annotation volcano.sh/devices-to-allocate", pod.Name)
 		return res
 	}
-	podDev := decodePodDevices(ids)
+	podDev := DecodePodDevices(ids)
 	for _, val := range podDev {
 		for _, deviceused := range val {
 			for _, gsdevice := range gs.Device {
@@ -189,7 +189,7 @@ func (gs *GPUDevices) addResource(annotations map[string]string, pod *v1.Pod) {
 		klog.Errorf("pod %s has no annotation volcano.sh/devices-to-allocate", pod.Name)
 		return
 	}
-	podDev := decodePodDevices(ids)
+	podDev := DecodePodDevices(ids)
 	for _, val := range podDev {
 		for _, deviceused := range val {
 			for index, gsdevice := range gs.Device {
@@ -216,7 +216,7 @@ func (gs *GPUDevices) addToPodMap(annotations map[string]string, pod *v1.Pod) {
 		klog.Errorf("pod %s has no annotation volcano.sh/devices-to-allocate", pod.Name)
 		return
 	}
-	podDev := decodePodDevices(ids)
+	podDev := DecodePodDevices(ids)
 	for _, val := range podDev {
 		for _, deviceused := range val {
 			for _, gsdevice := range gs.Device {
@@ -249,7 +249,7 @@ func (gs *GPUDevices) SubResource(pod *v1.Pod) {
 	if !ok {
 		return
 	}
-	podDev := decodePodDevices(ids)
+	podDev := DecodePodDevices(ids)
 	for _, val := range podDev {
 		for _, deviceused := range val {
 			for index, gsdevice := range gs.Device {

--- a/pkg/scheduler/api/devices/nvidia/vgpu/utils.go
+++ b/pkg/scheduler/api/devices/nvidia/vgpu/utils.go
@@ -145,7 +145,8 @@ func decodeContainerDevices(str string) ContainerDevices {
 	return contdev
 }
 
-func decodePodDevices(str string) []ContainerDevices {
+// DecodePodDevices parses the vgpu-ids-new annotation into per-container device lists.
+func DecodePodDevices(str string) []ContainerDevices {
 	if len(str) == 0 {
 		return []ContainerDevices{}
 	}

--- a/pkg/scheduler/plugins/factory.go
+++ b/pkg/scheduler/plugins/factory.go
@@ -30,6 +30,7 @@ import (
 	"volcano.sh/volcano/pkg/scheduler/plugins/drf"
 	"volcano.sh/volcano/pkg/scheduler/plugins/extender"
 	"volcano.sh/volcano/pkg/scheduler/plugins/gang"
+	"volcano.sh/volcano/pkg/scheduler/plugins/gpuexclusive"
 	networktopologyaware "volcano.sh/volcano/pkg/scheduler/plugins/network-topology-aware"
 	"volcano.sh/volcano/pkg/scheduler/plugins/nodegroup"
 	"volcano.sh/volcano/pkg/scheduler/plugins/nodeorder"
@@ -53,6 +54,7 @@ func init() {
 	framework.RegisterPluginBuilder(drf.PluginName, drf.New)
 	framework.RegisterPluginBuilder(gang.PluginName, gang.New)
 	framework.RegisterPluginBuilder(deviceshare.PluginName, deviceshare.New)
+	framework.RegisterPluginBuilder(gpuexclusive.PluginName, gpuexclusive.New)
 	framework.RegisterPluginBuilder(predicates.PluginName, predicates.New)
 	framework.RegisterPluginBuilder(priority.PluginName, priority.New)
 	framework.RegisterPluginBuilder(nodeorder.PluginName, nodeorder.New)

--- a/pkg/scheduler/plugins/gpuexclusive/gpuexclusive.go
+++ b/pkg/scheduler/plugins/gpuexclusive/gpuexclusive.go
@@ -1,0 +1,612 @@
+/*
+Copyright 2024 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gpuexclusive
+
+import (
+	"fmt"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/klog/v2"
+
+	"volcano.sh/volcano/pkg/scheduler/api"
+	"volcano.sh/volcano/pkg/scheduler/api/devices/nvidia/vgpu"
+	"volcano.sh/volcano/pkg/scheduler/framework"
+)
+
+const (
+	// PluginName is the name of the plugin used in the plugin registry and scheduler configuration.
+	PluginName = "gpuexclusive"
+
+	// VGPUResourceNameKey is the argument key for configuring the vGPU resource name.
+	VGPUResourceNameKey = "gpuexclusive.vgpuResourceName"
+	// RulesKey is the argument key for exclusivity rules.
+	// Each rule is a map of label key → value. Pods matching ALL labels in a rule
+	// get exclusive GPU access — no sharing with other rule-matching pods.
+	RulesKey = "gpuexclusive.rules"
+
+	defaultVGPUResourceName = "volcano.sh/vgpu-number"
+)
+
+// exclusiveRule defines a set of label key-value pairs.
+// A pod matches this rule if it carries ALL specified labels with matching values.
+type exclusiveRule struct {
+	labels map[string]string
+}
+
+func (r exclusiveRule) String() string {
+	return fmt.Sprintf("%v", r.labels)
+}
+
+type gpuExclusivePlugin struct {
+	arguments framework.Arguments
+	// persistedGPUs survives across scheduling sessions. Maps
+	// nodeName → podName → set of GPU indices allocated to that pod.
+	// Updated by Allocate, pruned by OnSessionOpen.
+	persistedGPUs map[string]map[string]map[int]struct{}
+	// persistedPodRules maps nodeName → podName → set of rule indices.
+	persistedPodRules map[string]map[string]map[int]struct{}
+}
+
+func New(arguments framework.Arguments) framework.Plugin {
+	return &gpuExclusivePlugin{
+		arguments:         arguments,
+		persistedGPUs:     make(map[string]map[string]map[int]struct{}),
+		persistedPodRules: make(map[string]map[string]map[int]struct{}),
+	}
+}
+
+func (p *gpuExclusivePlugin) Name() string {
+	return PluginName
+}
+
+type pluginConfig struct {
+	vgpuResourceName string
+	rules            []exclusiveRule
+}
+
+func loadConfig(args framework.Arguments) pluginConfig {
+	cfg := pluginConfig{
+		vgpuResourceName: defaultVGPUResourceName,
+	}
+	if v, ok := args[VGPUResourceNameKey].(string); ok && v != "" {
+		cfg.vgpuResourceName = v
+	}
+	if rawRules, ok := args[RulesKey]; ok {
+		cfg.rules = parseRules(rawRules)
+	}
+	return cfg
+}
+
+// parseRules converts the raw YAML-decoded rules into typed exclusiveRule slices.
+// Expected input: []interface{} where each element is a map of label key → value.
+func parseRules(raw interface{}) []exclusiveRule {
+	slice, ok := raw.([]interface{})
+	if !ok {
+		return nil
+	}
+	var rules []exclusiveRule
+	for _, item := range slice {
+		labels := make(map[string]string)
+		switch m := item.(type) {
+		case map[string]interface{}:
+			for k, v := range m {
+				if sv, ok := v.(string); ok {
+					labels[k] = sv
+				}
+			}
+		case map[interface{}]interface{}:
+			for k, v := range m {
+				if sk, ok := k.(string); ok {
+					if sv, ok := v.(string); ok {
+						labels[sk] = sv
+					}
+				}
+			}
+		}
+		if len(labels) > 0 {
+			rules = append(rules, exclusiveRule{labels: labels})
+		}
+	}
+	return rules
+}
+
+// matchingRules returns the indices of rules that the pod matches.
+// A pod matches a rule if it has ALL label:value pairs specified in that rule.
+func matchingRules(pod *v1.Pod, rules []exclusiveRule) []int {
+	if pod.Labels == nil {
+		return nil
+	}
+	var matched []int
+	for i, rule := range rules {
+		if podMatchesRule(pod, rule) {
+			matched = append(matched, i)
+		}
+	}
+	return matched
+}
+
+// podMatchesRule returns true if the pod has ALL label:value pairs in the rule.
+func podMatchesRule(pod *v1.Pod, rule exclusiveRule) bool {
+	if pod.Labels == nil {
+		return false
+	}
+	for k, v := range rule.labels {
+		if podVal, ok := pod.Labels[k]; !ok || podVal != v {
+			return false
+		}
+	}
+	return true
+}
+
+// exclusiveGPUDevices wraps vgpu.GPUDevices to enforce that pods matching
+// an exclusivity rule get dedicated physical GPUs, not shared with other rule-matching pods.
+//
+// For pods that don't match any rule, all operations delegate directly to the
+// inner GPUDevices.
+//
+// For pods matching one or more rules, FilterNode and Allocate temporarily cap
+// reserved GPUs (set Number = UsedNum) so the vGPU allocator skips them,
+// then restore Number afterwards.
+type exclusiveGPUDevices struct {
+	inner    *vgpu.GPUDevices
+	cfg      pluginConfig
+	nodeName string
+	plugin   *gpuExclusivePlugin
+	// ruleGPUs[ruleIndex] = set of GPU indices used by pods matching that rule
+	ruleGPUs map[int]map[int]struct{}
+	// podRules[podName] = set of rule indices the pod matches
+	podRules map[string]map[int]struct{}
+	// podUIDs maps podName → podUID for PodMap lookups (upstream uses UID as key)
+	podUIDs map[string]string
+}
+
+// Compile-time check that exclusiveGPUDevices implements api.Devices.
+var _ api.Devices = (*exclusiveGPUDevices)(nil)
+
+// reservedGPUsForPod returns the union of GPU indices reserved by ALL rules
+// if the pod matches at least one rule. This ensures cross-rule exclusivity:
+// a training pod avoids GPUs used by high-priority batch pods and vice versa.
+func (a *exclusiveGPUDevices) reservedGPUsForPod(pod *v1.Pod) map[int]struct{} {
+	matched := matchingRules(pod, a.cfg.rules)
+	if len(matched) == 0 {
+		return nil
+	}
+	result := make(map[int]struct{})
+	for _, gpuSet := range a.ruleGPUs {
+		for gpuIdx := range gpuSet {
+			result[gpuIdx] = struct{}{}
+		}
+	}
+	return result
+}
+
+// capGPUs temporarily sets Number = UsedNum on the given GPU indices so the
+// vGPU allocator skips them. Returns saved values for restoreGPUs.
+func (a *exclusiveGPUDevices) capGPUs(gpuIndices map[int]struct{}) map[int]uint {
+	saved := make(map[int]uint, len(gpuIndices))
+	for idx := range gpuIndices {
+		if dev, ok := a.inner.Device[idx]; ok && dev != nil {
+			saved[idx] = dev.Number
+			dev.Number = dev.UsedNum
+		}
+	}
+	return saved
+}
+
+func (a *exclusiveGPUDevices) restoreGPUs(saved map[int]uint) {
+	for idx, num := range saved {
+		if dev, ok := a.inner.Device[idx]; ok && dev != nil {
+			dev.Number = num
+		}
+	}
+}
+
+func (a *exclusiveGPUDevices) snapshotUsedNum() map[int]uint {
+	snap := make(map[int]uint, len(a.inner.Device))
+	for idx, dev := range a.inner.Device {
+		snap[idx] = dev.UsedNum
+	}
+	return snap
+}
+
+// trackPodFromPodMap registers a pod in podRules and adds GPU mappings based
+// on PodMap entries only. This is safe to call from AddResource because it
+// does NOT rebuild ruleGPUs from scratch — it only adds new entries.
+// Pods that were allocated in the current scheduling cycle (not yet in PodMap)
+// are tracked by Allocate directly.
+func (a *exclusiveGPUDevices) trackPodFromPodMap(pod *v1.Pod) {
+	matched := matchingRules(pod, a.cfg.rules)
+	if len(matched) == 0 {
+		return
+	}
+	ruleSet := make(map[int]struct{}, len(matched))
+	for _, idx := range matched {
+		ruleSet[idx] = struct{}{}
+	}
+	a.podRules[pod.Name] = ruleSet
+
+	// Only add GPU mappings for this pod if it appears in PodMap.
+	// Don't rebuild from scratch — that would wipe out in-flight allocations.
+	// Note: upstream PodMap uses string(pod.UID) as key.
+	podUID := string(pod.UID)
+	for gpuIdx, dev := range a.inner.Device {
+		if _, ok := dev.PodMap[podUID]; ok {
+			for ruleIdx := range ruleSet {
+				if a.ruleGPUs[ruleIdx] == nil {
+					a.ruleGPUs[ruleIdx] = make(map[int]struct{})
+				}
+				a.ruleGPUs[ruleIdx][gpuIdx] = struct{}{}
+			}
+		}
+	}
+}
+
+// untrackPod removes a pod's rule associations and GPU reservations.
+func (a *exclusiveGPUDevices) untrackPod(pod *v1.Pod) {
+	ruleSet, ok := a.podRules[pod.Name]
+	if !ok {
+		return
+	}
+	delete(a.podRules, pod.Name)
+
+	// Remove GPU entries for this pod. We need to check if any other tracked
+	// pod still uses each GPU before removing it from ruleGPUs.
+	for ruleIdx := range ruleSet {
+		gpuSet := a.ruleGPUs[ruleIdx]
+		if gpuSet == nil {
+			continue
+		}
+		for gpuIdx := range gpuSet {
+			dev, ok := a.inner.Device[gpuIdx]
+			if !ok {
+				continue
+			}
+			// Check if any other tracked pod still uses this GPU.
+			// PodMap keys are UIDs, so check via podUIDs reverse mapping.
+			podUID := string(pod.UID)
+			stillUsed := false
+			for uid := range dev.PodMap {
+				if uid != podUID {
+					// Check if this UID belongs to a tracked pod.
+					for otherName := range a.podRules {
+						if a.podUIDs[otherName] == uid {
+							stillUsed = true
+							break
+						}
+					}
+					if stillUsed {
+						break
+					}
+				}
+			}
+			if !stillUsed {
+				delete(gpuSet, gpuIdx)
+			}
+		}
+		if len(gpuSet) == 0 {
+			delete(a.ruleGPUs, ruleIdx)
+		}
+	}
+}
+
+// --- api.Devices interface ---
+
+func (a *exclusiveGPUDevices) AddResource(pod *v1.Pod) {
+	a.inner.AddResource(pod)
+	a.podUIDs[pod.Name] = string(pod.UID)
+	a.trackPodFromPodMap(pod)
+}
+
+func (a *exclusiveGPUDevices) SubResource(pod *v1.Pod) {
+	a.inner.SubResource(pod)
+	a.untrackPod(pod)
+	delete(a.podUIDs, pod.Name)
+}
+
+func (a *exclusiveGPUDevices) AddQueueResource(pod *v1.Pod) map[string]float64 {
+	return a.inner.AddQueueResource(pod)
+}
+
+func (a *exclusiveGPUDevices) HasDeviceRequest(pod *v1.Pod) bool {
+	return a.inner.HasDeviceRequest(pod)
+}
+
+func (a *exclusiveGPUDevices) FilterNode(pod *v1.Pod, policy string) (int, string, error) {
+	reserved := a.reservedGPUsForPod(pod)
+	if len(reserved) > 0 {
+		saved := a.capGPUs(reserved)
+		code, msg, err := a.inner.FilterNode(pod, policy)
+		a.restoreGPUs(saved)
+		return code, msg, err
+	}
+	return a.inner.FilterNode(pod, policy)
+}
+
+func (a *exclusiveGPUDevices) ScoreNode(pod *v1.Pod, policy string) float64 {
+	return a.inner.ScoreNode(pod, policy)
+}
+
+func (a *exclusiveGPUDevices) Allocate(kubeClient kubernetes.Interface, pod *v1.Pod) error {
+	matched := matchingRules(pod, a.cfg.rules)
+	if len(matched) == 0 {
+		// Pod doesn't match any rule — no tracking needed.
+		return a.inner.Allocate(kubeClient, pod)
+	}
+
+	// Snapshot UsedNum before allocation to detect which GPUs get assigned.
+	before := a.snapshotUsedNum()
+
+	// Cap GPUs reserved by the rules this pod matches so the allocator skips them.
+	reserved := a.reservedGPUsForPod(pod)
+	klog.V(4).Infof("gpuexclusive: Allocate pod=%s, matched=%v, reserved=%v, ruleGPUs=%v", pod.Name, matched, reserved, a.ruleGPUs)
+	if len(reserved) > 0 {
+		saved := a.capGPUs(reserved)
+		err := a.inner.Allocate(kubeClient, pod)
+		a.restoreGPUs(saved)
+		if err != nil {
+			return err
+		}
+	} else {
+		if err := a.inner.Allocate(kubeClient, pod); err != nil {
+			return err
+		}
+	}
+
+	// Track the pod and mark newly assigned GPUs in ruleGPUs.
+	ruleSet := make(map[int]struct{}, len(matched))
+	for _, idx := range matched {
+		ruleSet[idx] = struct{}{}
+	}
+	a.podRules[pod.Name] = ruleSet
+
+	newGPUs := make(map[int]struct{})
+	for idx, dev := range a.inner.Device {
+		if dev.UsedNum > before[idx] {
+			newGPUs[idx] = struct{}{}
+			for ruleIdx := range ruleSet {
+				if a.ruleGPUs[ruleIdx] == nil {
+					a.ruleGPUs[ruleIdx] = make(map[int]struct{})
+				}
+				a.ruleGPUs[ruleIdx][idx] = struct{}{}
+			}
+		}
+	}
+
+	// Persist across scheduling sessions so the next cycle's OnSessionOpen
+	// can see this allocation even if the informer hasn't caught up yet.
+	if a.plugin != nil && a.nodeName != "" {
+		if a.plugin.persistedGPUs[a.nodeName] == nil {
+			a.plugin.persistedGPUs[a.nodeName] = make(map[string]map[int]struct{})
+		}
+		a.plugin.persistedGPUs[a.nodeName][pod.Name] = newGPUs
+		if a.plugin.persistedPodRules[a.nodeName] == nil {
+			a.plugin.persistedPodRules[a.nodeName] = make(map[string]map[int]struct{})
+		}
+		a.plugin.persistedPodRules[a.nodeName][pod.Name] = ruleSet
+	}
+
+	klog.V(4).Infof("gpuexclusive: allocated pod %s, newGPUs=%v, ruleGPUs=%v",
+		pod.Name, newGPUs, a.ruleGPUs)
+	return nil
+}
+
+func (a *exclusiveGPUDevices) Release(kubeClient kubernetes.Interface, pod *v1.Pod) error {
+	err := a.inner.Release(kubeClient, pod)
+	if err != nil {
+		return err
+	}
+	a.untrackPod(pod)
+	return nil
+}
+
+func (a *exclusiveGPUDevices) GetIgnoredDevices() []string {
+	return a.inner.GetIgnoredDevices()
+}
+
+func (a *exclusiveGPUDevices) GetStatus() string {
+	return a.inner.GetStatus()
+}
+
+// --- Plugin lifecycle ---
+
+func (p *gpuExclusivePlugin) OnSessionOpen(ssn *framework.Session) {
+	cfg := loadConfig(p.arguments)
+
+	klog.V(4).Infof("gpuexclusive plugin config: vgpuResourceName=%s, rules=%v",
+		cfg.vgpuResourceName, cfg.rules)
+
+	if len(cfg.rules) == 0 {
+		klog.V(2).Info("gpuexclusive: no rules configured, plugin is a no-op")
+		return
+	}
+
+	// Wrap each node's GPUDevices with our exclusivity-aware wrapper.
+	for _, node := range ssn.Nodes {
+		if node.Others == nil {
+			continue
+		}
+		devObj, ok := node.Others[vgpu.DeviceName]
+		if !ok || devObj == nil {
+			continue
+		}
+		inner, ok := devObj.(*vgpu.GPUDevices)
+		if !ok || inner == nil {
+			continue
+		}
+
+		// Find existing pods on this node and compute their rule matches.
+		podRules := make(map[string]map[int]struct{})
+		podUIDs := make(map[string]string) // podName → podUID
+		uidToName := make(map[string]string) // podUID → podName (for PodMap lookups)
+		for _, task := range node.Tasks {
+			if task.Pod == nil {
+				continue
+			}
+			uid := string(task.Pod.UID)
+			podUIDs[task.Pod.Name] = uid
+			uidToName[uid] = task.Pod.Name
+			matched := matchingRules(task.Pod, cfg.rules)
+			if len(matched) == 0 {
+				continue
+			}
+			ruleSet := make(map[int]struct{}, len(matched))
+			for _, idx := range matched {
+				ruleSet[idx] = struct{}{}
+			}
+			podRules[task.Pod.Name] = ruleSet
+		}
+
+		// Build UUID → device index map for annotation-based lookup.
+		uuidToIdx := make(map[string]int, len(inner.Device))
+		for idx, dev := range inner.Device {
+			if dev != nil {
+				uuidToIdx[dev.UUID] = idx
+			}
+		}
+
+		// Build initial ruleGPUs from two sources:
+		// 1. PodMap entries (populated by AddResource for cached pods)
+		// 2. Pod annotations (fallback for recently allocated pods whose
+		//    informer update hasn't been processed yet)
+		ruleGPUs := make(map[int]map[int]struct{})
+
+		// Source 1: PodMap (keys are pod UIDs in upstream)
+		for gpuIdx, dev := range inner.Device {
+			for podUID := range dev.PodMap {
+				podName := uidToName[podUID]
+				if ruleSet, ok := podRules[podName]; ok {
+					for ruleIdx := range ruleSet {
+						if ruleGPUs[ruleIdx] == nil {
+							ruleGPUs[ruleIdx] = make(map[int]struct{})
+						}
+						ruleGPUs[ruleIdx][gpuIdx] = struct{}{}
+					}
+				}
+			}
+		}
+
+		// Source 2: Pod annotations (catches pods allocated in recent cycles
+		// whose PodMap entries may not be populated yet).
+		for podName, ruleSet := range podRules {
+			podUID := podUIDs[podName]
+			alreadyTracked := false
+			for _, dev := range inner.Device {
+				if _, ok := dev.PodMap[podUID]; ok {
+					alreadyTracked = true
+					break
+				}
+			}
+			if alreadyTracked {
+				continue
+			}
+			for _, task := range node.Tasks {
+				if task.Pod == nil || task.Pod.Name != podName {
+					continue
+				}
+				ann, ok := task.Pod.Annotations[vgpu.AssignedIDsAnnotations]
+				if !ok || ann == "" {
+					break
+				}
+				for _, contDevs := range vgpu.DecodePodDevices(ann) {
+					for _, cd := range contDevs {
+						if gpuIdx, ok := uuidToIdx[cd.UUID]; ok {
+							for ruleIdx := range ruleSet {
+								if ruleGPUs[ruleIdx] == nil {
+									ruleGPUs[ruleIdx] = make(map[int]struct{})
+								}
+								ruleGPUs[ruleIdx][gpuIdx] = struct{}{}
+							}
+						}
+					}
+				}
+				break
+			}
+		}
+
+		// Source 3: Persisted state from previous scheduling cycles.
+		// This catches allocations made in the immediately prior cycle that
+		// the informer hasn't propagated yet (neither PodMap nor annotations).
+		if persisted, ok := p.persistedGPUs[node.Name]; ok {
+			persistedRules := p.persistedPodRules[node.Name]
+			for podName, gpuSet := range persisted {
+				// Only use persisted data if the pod is still in node.Tasks
+				// (not yet deleted) and wasn't already found via PodMap/annotations.
+				if _, inPodRules := podRules[podName]; !inPodRules {
+					continue // pod no longer matches rules or was removed
+				}
+				podUID := podUIDs[podName]
+				alreadyTracked := false
+				for _, dev := range inner.Device {
+					if _, ok := dev.PodMap[podUID]; ok {
+						alreadyTracked = true
+						break
+					}
+				}
+				if alreadyTracked {
+					continue // PodMap is authoritative; skip persisted
+				}
+				ruleSet := persistedRules[podName]
+				if ruleSet == nil {
+					continue
+				}
+				for gpuIdx := range gpuSet {
+					for ruleIdx := range ruleSet {
+						if ruleGPUs[ruleIdx] == nil {
+							ruleGPUs[ruleIdx] = make(map[int]struct{})
+						}
+						ruleGPUs[ruleIdx][gpuIdx] = struct{}{}
+					}
+				}
+			}
+		}
+
+		// Prune persisted entries for pods no longer on this node.
+		activePods := make(map[string]bool, len(node.Tasks))
+		for _, task := range node.Tasks {
+			if task.Pod != nil {
+				activePods[task.Pod.Name] = true
+			}
+		}
+		if persisted, ok := p.persistedGPUs[node.Name]; ok {
+			for podName := range persisted {
+				if !activePods[podName] {
+					delete(persisted, podName)
+					if pr, ok := p.persistedPodRules[node.Name]; ok {
+						delete(pr, podName)
+					}
+				}
+			}
+		}
+
+		wrapper := &exclusiveGPUDevices{
+			inner:    inner,
+			cfg:      cfg,
+			nodeName: node.Name,
+			plugin:   p,
+			ruleGPUs: ruleGPUs,
+			podRules: podRules,
+			podUIDs:  podUIDs,
+		}
+		node.Others[vgpu.DeviceName] = wrapper
+
+		klog.V(4).Infof("gpuexclusive: OnSessionOpen node=%s, podRules=%v, ruleGPUs=%v, tasks=%d",
+			node.Name, podRules, ruleGPUs, len(node.Tasks))
+	}
+}
+
+func (p *gpuExclusivePlugin) OnSessionClose(ssn *framework.Session) {}

--- a/pkg/scheduler/plugins/gpuexclusive/gpuexclusive_test.go
+++ b/pkg/scheduler/plugins/gpuexclusive/gpuexclusive_test.go
@@ -1,0 +1,740 @@
+/*
+Copyright 2024 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gpuexclusive
+
+import (
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"volcano.sh/volcano/pkg/scheduler/api"
+	"volcano.sh/volcano/pkg/scheduler/api/devices/nvidia/vgpu"
+	"volcano.sh/volcano/pkg/scheduler/framework"
+)
+
+func makePod(name string, labels map[string]string, vgpuNum int64) *v1.Pod {
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "default",
+			Labels:    labels,
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				{
+					Name: "main",
+					Resources: v1.ResourceRequirements{
+						Limits: v1.ResourceList{},
+					},
+				},
+			},
+		},
+	}
+	if vgpuNum > 0 {
+		pod.Spec.Containers[0].Resources.Limits[v1.ResourceName(defaultVGPUResourceName)] = *resource.NewQuantity(vgpuNum, resource.DecimalSI)
+	}
+	return pod
+}
+
+func makeGPUDevice(id int, number uint, usedNum uint, podMap map[string]*vgpu.GPUUsage) *vgpu.GPUDevice {
+	if podMap == nil {
+		podMap = make(map[string]*vgpu.GPUUsage)
+	}
+	return &vgpu.GPUDevice{
+		ID:      id,
+		UUID:    "GPU-" + string(rune('0'+id)),
+		Memory:  16384,
+		Number:  number,
+		UsedNum: usedNum,
+		PodMap:  podMap,
+		Health:  true,
+		Type:    "NVIDIA",
+	}
+}
+
+func testRules() []exclusiveRule {
+	return []exclusiveRule{
+		{labels: map[string]string{"app": "training", "team": "ml"}},
+		{labels: map[string]string{"workload": "inference"}},
+	}
+}
+
+func testConfig() pluginConfig {
+	return pluginConfig{
+		vgpuResourceName: defaultVGPUResourceName,
+		rules:            testRules(),
+	}
+}
+
+func makeWrapper(devices map[int]*vgpu.GPUDevice, cfg pluginConfig, podRules map[string]map[int]struct{}, ruleGPUs map[int]map[int]struct{}) *exclusiveGPUDevices {
+	inner := &vgpu.GPUDevices{
+		Name:   "test-node",
+		Device: devices,
+	}
+	if podRules == nil {
+		podRules = make(map[string]map[int]struct{})
+	}
+	if ruleGPUs == nil {
+		ruleGPUs = make(map[int]map[int]struct{})
+	}
+	return &exclusiveGPUDevices{
+		inner:    inner,
+		cfg:      cfg,
+		ruleGPUs: ruleGPUs,
+		podRules: podRules,
+	}
+}
+
+// --- Tests for rule matching ---
+
+func TestPodMatchesRule(t *testing.T) {
+	rules := testRules()
+
+	tests := []struct {
+		name     string
+		pod      *v1.Pod
+		ruleIdx  int
+		expected bool
+	}{
+		{
+			name:     "pod matches rule 0 (app=training, team=ml)",
+			pod:      makePod("p1", map[string]string{"app": "training", "team": "ml"}, 1),
+			ruleIdx:  0,
+			expected: true,
+		},
+		{
+			name:     "pod matches rule 0 with extra labels",
+			pod:      makePod("p2", map[string]string{"app": "training", "team": "ml", "env": "prod"}, 1),
+			ruleIdx:  0,
+			expected: true,
+		},
+		{
+			name:     "pod missing one label from rule 0",
+			pod:      makePod("p3", map[string]string{"app": "training"}, 1),
+			ruleIdx:  0,
+			expected: false,
+		},
+		{
+			name:     "pod has wrong value for rule 0",
+			pod:      makePod("p4", map[string]string{"app": "training", "team": "data"}, 1),
+			ruleIdx:  0,
+			expected: false,
+		},
+		{
+			name:     "pod matches rule 1 (workload=inference)",
+			pod:      makePod("p5", map[string]string{"workload": "inference"}, 1),
+			ruleIdx:  1,
+			expected: true,
+		},
+		{
+			name:     "pod with nil labels matches nothing",
+			pod:      makePod("p6", nil, 1),
+			ruleIdx:  0,
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := podMatchesRule(tt.pod, rules[tt.ruleIdx])
+			if got != tt.expected {
+				t.Errorf("podMatchesRule() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestMatchingRules(t *testing.T) {
+	rules := testRules()
+
+	tests := []struct {
+		name        string
+		pod         *v1.Pod
+		expectedLen int
+	}{
+		{
+			name:        "matches rule 0 only",
+			pod:         makePod("p1", map[string]string{"app": "training", "team": "ml"}, 1),
+			expectedLen: 1,
+		},
+		{
+			name:        "matches rule 1 only",
+			pod:         makePod("p2", map[string]string{"workload": "inference"}, 1),
+			expectedLen: 1,
+		},
+		{
+			name:        "matches both rules",
+			pod:         makePod("p3", map[string]string{"app": "training", "team": "ml", "workload": "inference"}, 1),
+			expectedLen: 2,
+		},
+		{
+			name:        "matches no rules",
+			pod:         makePod("p4", map[string]string{"app": "serving"}, 1),
+			expectedLen: 0,
+		},
+		{
+			name:        "nil labels matches nothing",
+			pod:         makePod("p5", nil, 1),
+			expectedLen: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := matchingRules(tt.pod, rules)
+			if len(got) != tt.expectedLen {
+				t.Errorf("matchingRules() returned %d rules, want %d", len(got), tt.expectedLen)
+			}
+		})
+	}
+}
+
+// --- Tests for config loading ---
+
+func TestLoadConfig(t *testing.T) {
+	t.Run("defaults with no rules", func(t *testing.T) {
+		cfg := loadConfig(framework.Arguments{})
+		if cfg.vgpuResourceName != defaultVGPUResourceName {
+			t.Errorf("vgpuResourceName = %q, want %q", cfg.vgpuResourceName, defaultVGPUResourceName)
+		}
+		if len(cfg.rules) != 0 {
+			t.Errorf("rules = %v, want empty", cfg.rules)
+		}
+	})
+
+	t.Run("custom vgpu resource name", func(t *testing.T) {
+		args := framework.Arguments{
+			VGPUResourceNameKey: "custom.io/gpu",
+		}
+		cfg := loadConfig(args)
+		if cfg.vgpuResourceName != "custom.io/gpu" {
+			t.Errorf("vgpuResourceName = %q, want %q", cfg.vgpuResourceName, "custom.io/gpu")
+		}
+	})
+
+	t.Run("rules from map[string]interface{}", func(t *testing.T) {
+		args := framework.Arguments{
+			RulesKey: []interface{}{
+				map[string]interface{}{"app": "training", "team": "ml"},
+				map[string]interface{}{"workload": "inference"},
+			},
+		}
+		cfg := loadConfig(args)
+		if len(cfg.rules) != 2 {
+			t.Fatalf("rules count = %d, want 2", len(cfg.rules))
+		}
+		if cfg.rules[0].labels["app"] != "training" || cfg.rules[0].labels["team"] != "ml" {
+			t.Errorf("rule 0 = %v, want {app:training, team:ml}", cfg.rules[0].labels)
+		}
+		if cfg.rules[1].labels["workload"] != "inference" {
+			t.Errorf("rule 1 = %v, want {workload:inference}", cfg.rules[1].labels)
+		}
+	})
+
+	t.Run("rules from map[interface{}]interface{}", func(t *testing.T) {
+		args := framework.Arguments{
+			RulesKey: []interface{}{
+				map[interface{}]interface{}{"app": "training"},
+			},
+		}
+		cfg := loadConfig(args)
+		if len(cfg.rules) != 1 {
+			t.Fatalf("rules count = %d, want 1", len(cfg.rules))
+		}
+		if cfg.rules[0].labels["app"] != "training" {
+			t.Errorf("rule 0 = %v, want {app:training}", cfg.rules[0].labels)
+		}
+	})
+}
+
+func TestNewPlugin(t *testing.T) {
+	p := New(framework.Arguments{})
+	if p.Name() != PluginName {
+		t.Errorf("Name() = %q, want %q", p.Name(), PluginName)
+	}
+}
+
+// --- Tests for GPU capping behavior ---
+
+func TestCapGPUsOnlyAffectsSpecifiedIndices(t *testing.T) {
+	devices := map[int]*vgpu.GPUDevice{
+		0: makeGPUDevice(0, 10, 1, nil),
+		1: makeGPUDevice(1, 10, 1, nil),
+		2: makeGPUDevice(2, 10, 0, nil),
+		3: makeGPUDevice(3, 10, 0, nil),
+	}
+	w := makeWrapper(devices, testConfig(), nil, nil)
+
+	toCap := map[int]struct{}{0: {}, 1: {}}
+	saved := w.capGPUs(toCap)
+
+	// Capped GPUs should have Number == UsedNum
+	if devices[0].Number != 1 {
+		t.Errorf("GPU 0 Number = %d, want 1 (capped)", devices[0].Number)
+	}
+	if devices[1].Number != 1 {
+		t.Errorf("GPU 1 Number = %d, want 1 (capped)", devices[1].Number)
+	}
+	// Uncapped GPUs should be unchanged
+	if devices[2].Number != 10 {
+		t.Errorf("GPU 2 Number = %d, want 10 (unchanged)", devices[2].Number)
+	}
+	if devices[3].Number != 10 {
+		t.Errorf("GPU 3 Number = %d, want 10 (unchanged)", devices[3].Number)
+	}
+
+	w.restoreGPUs(saved)
+
+	for i := 0; i < 4; i++ {
+		if devices[i].Number != 10 {
+			t.Errorf("after restore: GPU %d Number = %d, want 10", i, devices[i].Number)
+		}
+	}
+}
+
+// --- Tests for tracking and reservation ---
+
+func TestTrackAndUntrackPod(t *testing.T) {
+	cfg := testConfig()
+	devices := map[int]*vgpu.GPUDevice{
+		0: makeGPUDevice(0, 10, 1, map[string]*vgpu.GPUUsage{"pod-a": {}}),
+		1: makeGPUDevice(1, 10, 0, nil),
+	}
+	w := makeWrapper(devices, cfg, nil, nil)
+
+	podA := makePod("pod-a", map[string]string{"app": "training", "team": "ml"}, 1)
+	w.trackPod(podA)
+
+	// pod-a matches rule 0, GPU 0 should be in ruleGPUs[0]
+	if _, ok := w.podRules["pod-a"]; !ok {
+		t.Fatal("pod-a should be in podRules")
+	}
+	if _, ok := w.ruleGPUs[0][0]; !ok {
+		t.Fatal("GPU 0 should be in ruleGPUs[0]")
+	}
+
+	w.untrackPod(podA)
+
+	if _, ok := w.podRules["pod-a"]; ok {
+		t.Fatal("pod-a should be removed from podRules")
+	}
+	if len(w.ruleGPUs[0]) != 0 {
+		t.Errorf("ruleGPUs[0] should be empty after untrack, got %v", w.ruleGPUs[0])
+	}
+}
+
+func TestReservedGPUsForPod(t *testing.T) {
+	cfg := testConfig()
+	// pod-a (rule 0) on GPU 0, pod-b (rule 1) on GPU 1
+	devices := map[int]*vgpu.GPUDevice{
+		0: makeGPUDevice(0, 10, 1, map[string]*vgpu.GPUUsage{"pod-a": {}}),
+		1: makeGPUDevice(1, 10, 1, map[string]*vgpu.GPUUsage{"pod-b": {}}),
+		2: makeGPUDevice(2, 10, 0, nil),
+	}
+	podRules := map[string]map[int]struct{}{
+		"pod-a": {0: {}},
+		"pod-b": {1: {}},
+	}
+	ruleGPUs := map[int]map[int]struct{}{
+		0: {0: {}},
+		1: {1: {}},
+	}
+	w := makeWrapper(devices, cfg, podRules, ruleGPUs)
+
+	// A new pod matching rule 0 should see GPU 0 as reserved
+	newPod := makePod("pod-c", map[string]string{"app": "training", "team": "ml"}, 1)
+	reserved := w.reservedGPUsForPod(newPod)
+	if _, ok := reserved[0]; !ok {
+		t.Error("GPU 0 should be reserved for pod matching rule 0")
+	}
+	if _, ok := reserved[1]; ok {
+		t.Error("GPU 1 should NOT be reserved for pod matching rule 0")
+	}
+
+	// A new pod matching rule 1 should see GPU 1 as reserved
+	inferPod := makePod("pod-d", map[string]string{"workload": "inference"}, 1)
+	reserved = w.reservedGPUsForPod(inferPod)
+	if _, ok := reserved[1]; !ok {
+		t.Error("GPU 1 should be reserved for pod matching rule 1")
+	}
+	if _, ok := reserved[0]; ok {
+		t.Error("GPU 0 should NOT be reserved for pod matching rule 1")
+	}
+
+	// A pod matching no rules should have no reservations
+	otherPod := makePod("pod-e", map[string]string{"app": "serving"}, 1)
+	reserved = w.reservedGPUsForPod(otherPod)
+	if len(reserved) != 0 {
+		t.Errorf("unmatched pod should have no reserved GPUs, got %v", reserved)
+	}
+}
+
+func TestPodMatchingMultipleRulesSeesUnionOfReservedGPUs(t *testing.T) {
+	cfg := testConfig()
+	// rule 0 reserves GPU 0, rule 1 reserves GPU 1
+	devices := map[int]*vgpu.GPUDevice{
+		0: makeGPUDevice(0, 10, 1, map[string]*vgpu.GPUUsage{"pod-a": {}}),
+		1: makeGPUDevice(1, 10, 1, map[string]*vgpu.GPUUsage{"pod-b": {}}),
+		2: makeGPUDevice(2, 10, 0, nil),
+	}
+	podRules := map[string]map[int]struct{}{
+		"pod-a": {0: {}},
+		"pod-b": {1: {}},
+	}
+	ruleGPUs := map[int]map[int]struct{}{
+		0: {0: {}},
+		1: {1: {}},
+	}
+	w := makeWrapper(devices, cfg, podRules, ruleGPUs)
+
+	// Pod matching BOTH rules should see GPU 0 and GPU 1 as reserved
+	bothPod := makePod("pod-x", map[string]string{"app": "training", "team": "ml", "workload": "inference"}, 1)
+	reserved := w.reservedGPUsForPod(bothPod)
+	if _, ok := reserved[0]; !ok {
+		t.Error("GPU 0 should be reserved (from rule 0)")
+	}
+	if _, ok := reserved[1]; !ok {
+		t.Error("GPU 1 should be reserved (from rule 1)")
+	}
+	if _, ok := reserved[2]; ok {
+		t.Error("GPU 2 should NOT be reserved")
+	}
+}
+
+func TestAllocateUpdatesRuleGPUs(t *testing.T) {
+	cfg := testConfig()
+	// pod-a (rule 0) already on GPU 0
+	devices := map[int]*vgpu.GPUDevice{
+		0: makeGPUDevice(0, 10, 1, map[string]*vgpu.GPUUsage{"pod-a": {}}),
+		1: makeGPUDevice(1, 10, 0, nil),
+	}
+	podRules := map[string]map[int]struct{}{
+		"pod-a": {0: {}},
+	}
+	ruleGPUs := map[int]map[int]struct{}{
+		0: {0: {}},
+	}
+	w := makeWrapper(devices, cfg, podRules, ruleGPUs)
+
+	// Simulate: new training pod allocates on GPU 1
+	before := w.snapshotUsedNum()
+	devices[1].UsedNum = 1
+
+	newPod := makePod("pod-b", map[string]string{"app": "training", "team": "ml"}, 1)
+	matched := matchingRules(newPod, cfg.rules)
+	ruleSet := make(map[int]struct{}, len(matched))
+	for _, idx := range matched {
+		ruleSet[idx] = struct{}{}
+	}
+	w.podRules[newPod.Name] = ruleSet
+
+	for idx, dev := range w.inner.Device {
+		if dev.UsedNum > before[idx] {
+			for ruleIdx := range ruleSet {
+				if w.ruleGPUs[ruleIdx] == nil {
+					w.ruleGPUs[ruleIdx] = make(map[int]struct{})
+				}
+				w.ruleGPUs[ruleIdx][idx] = struct{}{}
+			}
+		}
+	}
+
+	// Both GPU 0 and GPU 1 should now be in ruleGPUs[0]
+	if len(w.ruleGPUs[0]) != 2 {
+		t.Fatalf("ruleGPUs[0] should have 2 GPUs, got %d", len(w.ruleGPUs[0]))
+	}
+	if _, ok := w.ruleGPUs[0][0]; !ok {
+		t.Error("GPU 0 should be in ruleGPUs[0]")
+	}
+	if _, ok := w.ruleGPUs[0][1]; !ok {
+		t.Error("GPU 1 should be in ruleGPUs[0]")
+	}
+}
+
+func TestNonMatchingPodDoesNotReserve(t *testing.T) {
+	cfg := testConfig()
+	devices := map[int]*vgpu.GPUDevice{
+		0: makeGPUDevice(0, 10, 0, nil),
+	}
+	w := makeWrapper(devices, cfg, nil, nil)
+
+	otherPod := makePod("pod-x", map[string]string{"app": "serving"}, 1)
+	reserved := w.reservedGPUsForPod(otherPod)
+	if len(reserved) != 0 {
+		t.Errorf("non-matching pod should not have reserved GPUs, got %v", reserved)
+	}
+	if len(w.podRules) != 0 {
+		t.Errorf("podRules should be empty, got %v", w.podRules)
+	}
+}
+
+func TestSubResourceCleansUp(t *testing.T) {
+	cfg := testConfig()
+	devices := map[int]*vgpu.GPUDevice{
+		0: makeGPUDevice(0, 10, 1, map[string]*vgpu.GPUUsage{"pod-a": {}}),
+		1: makeGPUDevice(1, 10, 0, nil),
+	}
+	podRules := map[string]map[int]struct{}{
+		"pod-a": {0: {}},
+	}
+	ruleGPUs := map[int]map[int]struct{}{
+		0: {0: {}},
+	}
+	w := makeWrapper(devices, cfg, podRules, ruleGPUs)
+
+	podA := makePod("pod-a", map[string]string{"app": "training", "team": "ml"}, 1)
+
+	// Simulate inner.SubResource removing pod-a from PodMap
+	delete(devices[0].PodMap, "pod-a")
+
+	// Wrapper cleanup
+	delete(w.podRules, podA.Name)
+	w.recomputeRuleGPUs()
+
+	if _, ok := w.podRules["pod-a"]; ok {
+		t.Error("pod-a should be removed from podRules")
+	}
+	if len(w.ruleGPUs[0]) != 0 {
+		t.Errorf("ruleGPUs[0] should be empty, got %v", w.ruleGPUs[0])
+	}
+}
+
+func TestTwoRulesIndependentReservation(t *testing.T) {
+	cfg := testConfig()
+	// pod-a matches rule 0, on GPU 0
+	// pod-b matches rule 1, on GPU 0 too (different rule, allowed)
+	devices := map[int]*vgpu.GPUDevice{
+		0: makeGPUDevice(0, 10, 2, map[string]*vgpu.GPUUsage{"pod-a": {}, "pod-b": {}}),
+		1: makeGPUDevice(1, 10, 0, nil),
+	}
+	podRules := map[string]map[int]struct{}{
+		"pod-a": {0: {}},
+		"pod-b": {1: {}},
+	}
+	ruleGPUs := map[int]map[int]struct{}{
+		0: {0: {}},
+		1: {0: {}},
+	}
+	w := makeWrapper(devices, cfg, podRules, ruleGPUs)
+
+	// A new pod matching rule 0 sees GPU 0 reserved (from pod-a)
+	newTraining := makePod("pod-c", map[string]string{"app": "training", "team": "ml"}, 1)
+	reserved := w.reservedGPUsForPod(newTraining)
+	if _, ok := reserved[0]; !ok {
+		t.Error("GPU 0 should be reserved for rule 0 pods")
+	}
+
+	// A new pod matching rule 1 also sees GPU 0 reserved (from pod-b)
+	newInfer := makePod("pod-d", map[string]string{"workload": "inference"}, 1)
+	reserved = w.reservedGPUsForPod(newInfer)
+	if _, ok := reserved[0]; !ok {
+		t.Error("GPU 0 should be reserved for rule 1 pods")
+	}
+
+	// A pod matching NEITHER rule sees no reservations
+	otherPod := makePod("pod-e", map[string]string{"app": "serving"}, 1)
+	reserved = w.reservedGPUsForPod(otherPod)
+	if len(reserved) != 0 {
+		t.Errorf("non-matching pod should see no reservations, got %v", reserved)
+	}
+}
+
+func TestOnSessionOpenWrapsDevices(t *testing.T) {
+	cfg := testConfig()
+	podA := makePod("pod-a", map[string]string{"app": "training", "team": "ml"}, 1)
+	taskUID := api.TaskID("default/pod-a")
+
+	devices := map[int]*vgpu.GPUDevice{
+		0: makeGPUDevice(0, 10, 1, map[string]*vgpu.GPUUsage{"pod-a": {}}),
+		1: makeGPUDevice(1, 10, 0, nil),
+	}
+	inner := &vgpu.GPUDevices{Name: "node-1", Device: devices}
+	node := &api.NodeInfo{
+		Name:   "node-1",
+		Others: map[string]interface{}{vgpu.DeviceName: inner},
+		Tasks: map[api.TaskID]*api.TaskInfo{
+			taskUID: {UID: taskUID, Pod: podA},
+		},
+	}
+
+	// Simulate OnSessionOpen wrapping logic
+	podRules := make(map[string]map[int]struct{})
+	for _, task := range node.Tasks {
+		if task.Pod == nil {
+			continue
+		}
+		matched := matchingRules(task.Pod, cfg.rules)
+		if len(matched) == 0 {
+			continue
+		}
+		ruleSet := make(map[int]struct{}, len(matched))
+		for _, idx := range matched {
+			ruleSet[idx] = struct{}{}
+		}
+		podRules[task.Pod.Name] = ruleSet
+	}
+
+	ruleGPUs := make(map[int]map[int]struct{})
+	for gpuIdx, dev := range inner.Device {
+		for podName := range dev.PodMap {
+			if ruleSet, ok := podRules[podName]; ok {
+				for ruleIdx := range ruleSet {
+					if ruleGPUs[ruleIdx] == nil {
+						ruleGPUs[ruleIdx] = make(map[int]struct{})
+					}
+					ruleGPUs[ruleIdx][gpuIdx] = struct{}{}
+				}
+			}
+		}
+	}
+
+	wrapper := &exclusiveGPUDevices{
+		inner:    inner,
+		cfg:      cfg,
+		ruleGPUs: ruleGPUs,
+		podRules: podRules,
+	}
+	node.Others[vgpu.DeviceName] = wrapper
+
+	w, ok := node.Others[vgpu.DeviceName].(*exclusiveGPUDevices)
+	if !ok {
+		t.Fatal("expected exclusiveGPUDevices in node.Others")
+	}
+
+	// GPU 0 should be in ruleGPUs[0] (pod-a matches rule 0)
+	if _, ok := w.ruleGPUs[0][0]; !ok {
+		t.Error("GPU 0 should be in ruleGPUs[0]")
+	}
+	// GPU 1 should not be in any ruleGPUs
+	if _, ok := w.ruleGPUs[0][1]; ok {
+		t.Error("GPU 1 should NOT be in ruleGPUs[0]")
+	}
+
+	var _ api.Devices = w
+}
+
+func TestEndToEndExclusive(t *testing.T) {
+	cfg := testConfig()
+
+	// Node with 4 GPUs. pod-a (rule 0) on GPU 0, pod-b (rule 1) on GPU 1.
+	devices := map[int]*vgpu.GPUDevice{
+		0: makeGPUDevice(0, 10, 1, map[string]*vgpu.GPUUsage{"pod-a": {}}),
+		1: makeGPUDevice(1, 10, 1, map[string]*vgpu.GPUUsage{"pod-b": {}}),
+		2: makeGPUDevice(2, 10, 0, nil),
+		3: makeGPUDevice(3, 10, 0, nil),
+	}
+	podRules := map[string]map[int]struct{}{
+		"pod-a": {0: {}},
+		"pod-b": {1: {}},
+	}
+	ruleGPUs := map[int]map[int]struct{}{
+		0: {0: {}},
+		1: {1: {}},
+	}
+	w := makeWrapper(devices, cfg, podRules, ruleGPUs)
+
+	// 1. New training pod (rule 0): GPU 0 is capped, GPUs 1,2,3 available
+	trainPod := makePod("pod-c", map[string]string{"app": "training", "team": "ml"}, 1)
+	reserved := w.reservedGPUsForPod(trainPod)
+	saved := w.capGPUs(reserved)
+	available := 0
+	for _, dev := range devices {
+		if dev.Number > dev.UsedNum {
+			available++
+		}
+	}
+	w.restoreGPUs(saved)
+	if available != 3 {
+		t.Errorf("training pod should see 3 available GPUs, got %d", available)
+	}
+
+	// 2. New inference pod (rule 1): GPU 1 is capped, GPUs 0,2,3 available
+	inferPod := makePod("pod-d", map[string]string{"workload": "inference"}, 1)
+	reserved = w.reservedGPUsForPod(inferPod)
+	saved = w.capGPUs(reserved)
+	available = 0
+	for _, dev := range devices {
+		if dev.Number > dev.UsedNum {
+			available++
+		}
+	}
+	w.restoreGPUs(saved)
+	if available != 3 {
+		t.Errorf("inference pod should see 3 available GPUs, got %d", available)
+	}
+
+	// 3. Unrelated pod: all 4 GPUs visible, no capping
+	otherPod := makePod("pod-e", map[string]string{"app": "serving"}, 1)
+	reserved = w.reservedGPUsForPod(otherPod)
+	if len(reserved) != 0 {
+		t.Errorf("unrelated pod should have no reservations, got %v", reserved)
+	}
+	for i := 0; i < 4; i++ {
+		if devices[i].Number != 10 {
+			t.Errorf("GPU %d Number = %d, want 10 (fully visible to unrelated pod)", i, devices[i].Number)
+		}
+	}
+
+	// 4. Pod matching both rules: GPUs 0 and 1 both capped, only 2,3 available
+	bothPod := makePod("pod-f", map[string]string{"app": "training", "team": "ml", "workload": "inference"}, 1)
+	reserved = w.reservedGPUsForPod(bothPod)
+	saved = w.capGPUs(reserved)
+	available = 0
+	for _, dev := range devices {
+		if dev.Number > dev.UsedNum {
+			available++
+		}
+	}
+	w.restoreGPUs(saved)
+	if available != 2 {
+		t.Errorf("pod matching both rules should see 2 available GPUs, got %d", available)
+	}
+}
+
+func TestParseRulesHandlesEdgeCases(t *testing.T) {
+	t.Run("nil input", func(t *testing.T) {
+		rules := parseRules(nil)
+		if len(rules) != 0 {
+			t.Errorf("expected 0 rules, got %d", len(rules))
+		}
+	})
+
+	t.Run("wrong type", func(t *testing.T) {
+		rules := parseRules("not a slice")
+		if len(rules) != 0 {
+			t.Errorf("expected 0 rules, got %d", len(rules))
+		}
+	})
+
+	t.Run("empty slice", func(t *testing.T) {
+		rules := parseRules([]interface{}{})
+		if len(rules) != 0 {
+			t.Errorf("expected 0 rules, got %d", len(rules))
+		}
+	})
+
+	t.Run("empty map skipped", func(t *testing.T) {
+		rules := parseRules([]interface{}{
+			map[string]interface{}{},
+		})
+		if len(rules) != 0 {
+			t.Errorf("empty label map should be skipped, got %d rules", len(rules))
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Adds a `gpuexclusive` scheduler plugin that enforces rule-based GPU exclusivity for vGPU sharing. Pods matching configured label rules get dedicated physical GPUs — no sharing with other rule-matching pods.

**Key features:**
- Multiple exclusivity rules, each defined as a set of label key-value pairs
- Cross-rule exclusivity: pods matching different rules also cannot share GPUs
- Pods not matching any rule are unaffected and can share GPUs freely
- Plugin is a no-op when no rules are configured
- GPU release/reclaim: when a rule-matching pod is deleted, its GPUs become available

## Configuration

```yaml
plugins:
  - name: gpuexclusive
    arguments:
      gpuexclusive.rules:
        - workloadType: training
        - workloadType: batch
          priority: high
```

- **Rule 0**: Pods with label `workloadType=training` get exclusive GPUs
- **Rule 1**: Pods with BOTH `workloadType=batch` AND `priority=high` get exclusive GPUs
- Training and batch-hi pods cannot share GPUs with each other (cross-rule exclusivity)

## How it works

The plugin wraps `vgpu.GPUDevices` on each node with an exclusivity-aware decorator. For pods matching one or more rules, `FilterNode` and `Allocate` temporarily cap reserved GPUs (set `Number = UsedNum`) so the vGPU allocator skips them, then restore afterwards.

## Changes

- `pkg/scheduler/plugins/gpuexclusive/` — new plugin (plugin + unit tests)
- `pkg/scheduler/plugins/factory.go` — register the plugin
- `pkg/scheduler/api/devices/nvidia/vgpu/utils.go` — export `DecodePodDevices`
- `pkg/scheduler/api/devices/nvidia/vgpu/device_info.go` — update callers

## Test plan

- [x] Unit tests for rule matching, config parsing, GPU capping/restore, pod tracking
- [x] End-to-end test verifying exclusivity across multiple rules
- [x] Minikube integration test — **44/44 checks passed** across 11 scenarios