### PR TITLE
Fix nil pointer dereference in AddTestTaskLabel

### DIFF
--- a/pkg/controllers/jobtemplate/jobtemplate_controller_handler.go
+++ b/pkg/controllers/jobtemplate/jobtemplate_controller_handler.go
@@ -59,6 +59,7 @@ func (jt *jobtemplatecontroller) addJob(obj interface{}) {
 	//Filter vcjobs created by JobFlow
 	namespaceName := strings.Split(job.Labels[CreatedByJobTemplate], ".")
 	if len(namespaceName) != CreateByJobTemplateValueNum {
+		klog.Errorf("invalid key format: %s", job.Labels[CreatedByJobTemplate])
 		return
 	}
 	namespace, name := namespaceName[0], namespaceName[1]

--- a/pkg/controllers/jobtemplate/jobtemplate_controller_handler.go
+++ b/pkg/controllers/jobtemplate/jobtemplate_controller_handler.go
@@ -56,7 +56,7 @@ func (jt *jobtemplatecontroller) addJob(obj interface{}) {
 		return
 	}
 
-	// Filter vcjobs created by JobFlow. The namespace cannot contain dots,
+	// Filter vcjobs created by JobTemplate. The namespace cannot contain dots,
 	// but the JobTemplate name can, so only split on the first separator.
 	namespaceName := strings.SplitN(job.Labels[CreatedByJobTemplate], ".", 2)
 	if len(namespaceName) != CreateByJobTemplateValueNum {

--- a/pkg/controllers/jobtemplate/jobtemplate_controller_handler.go
+++ b/pkg/controllers/jobtemplate/jobtemplate_controller_handler.go
@@ -60,10 +60,14 @@ func (jt *jobtemplatecontroller) addJob(obj interface{}) {
 	// but the JobTemplate name can, so only split on the first separator.
 	namespaceName := strings.SplitN(job.Labels[CreatedByJobTemplate], ".", 2)
 	if len(namespaceName) != CreateByJobTemplateValueNum {
-		klog.Warningf("invalid key format: %s", job.Labels[CreatedByJobTemplate])
+		klog.Warningf("invalid label value for %q: %q, expected format %q", CreatedByJobTemplate, job.Labels[CreatedByJobTemplate], "<namespace>.<jobTemplateName>")
 		return
 	}
 	namespace, name := namespaceName[0], namespaceName[1]
+	if len(namespace) == 0 || len(name) == 0 {
+		klog.Warningf("invalid label value for %q: %q, namespace and name cannot be empty", CreatedByJobTemplate, job.Labels[CreatedByJobTemplate])
+		return
+	}
 
 	req := apis.FlowRequest{
 		Namespace:       namespace,

--- a/pkg/controllers/jobtemplate/jobtemplate_controller_handler.go
+++ b/pkg/controllers/jobtemplate/jobtemplate_controller_handler.go
@@ -56,10 +56,11 @@ func (jt *jobtemplatecontroller) addJob(obj interface{}) {
 		return
 	}
 
-	//Filter vcjobs created by JobFlow
-	namespaceName := strings.Split(job.Labels[CreatedByJobTemplate], ".")
+	// Filter vcjobs created by JobFlow. The namespace cannot contain dots,
+	// but the JobTemplate name can, so only split on the first separator.
+	namespaceName := strings.SplitN(job.Labels[CreatedByJobTemplate], ".", 2)
 	if len(namespaceName) != CreateByJobTemplateValueNum {
-		klog.Errorf("invalid key format: %s", job.Labels[CreatedByJobTemplate])
+		klog.Warningf("invalid key format: %s", job.Labels[CreatedByJobTemplate])
 		return
 	}
 	namespace, name := namespaceName[0], namespaceName[1]

--- a/pkg/controllers/jobtemplate/jobtemplate_controller_handler_test.go
+++ b/pkg/controllers/jobtemplate/jobtemplate_controller_handler_test.go
@@ -81,9 +81,9 @@ func TestAddJob(t *testing.T) {
 			Name: "Valid with dots in name",
 			job: &batch.Job{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:        "job2",
-					Namespace:   namespace,
-					Labels:      map[string]string{CreatedByJobTemplate: "test.my.template"},
+					Name:      "job2",
+					Namespace: namespace,
+					Labels:    map[string]string{CreatedByJobTemplate: "test.my.template"},
 				},
 			},
 			ExpectValue: 1,
@@ -92,9 +92,9 @@ func TestAddJob(t *testing.T) {
 			Name: "Invalid no dots",
 			job: &batch.Job{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:        "job3",
-					Namespace:   namespace,
-					Labels:      map[string]string{CreatedByJobTemplate: "nonamespaceorname"},
+					Name:      "job3",
+					Namespace: namespace,
+					Labels:    map[string]string{CreatedByJobTemplate: "nonamespaceorname"},
 				},
 			},
 			ExpectValue: 0,
@@ -103,9 +103,9 @@ func TestAddJob(t *testing.T) {
 			Name: "Invalid empty name",
 			job: &batch.Job{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:        "job4",
-					Namespace:   namespace,
-					Labels:      map[string]string{CreatedByJobTemplate: "test."},
+					Name:      "job4",
+					Namespace: namespace,
+					Labels:    map[string]string{CreatedByJobTemplate: "test."},
 				},
 			},
 			ExpectValue: 0,
@@ -114,9 +114,9 @@ func TestAddJob(t *testing.T) {
 			Name: "Invalid empty namespace",
 			job: &batch.Job{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:        "job5",
-					Namespace:   namespace,
-					Labels:      map[string]string{CreatedByJobTemplate: ".name"},
+					Name:      "job5",
+					Namespace: namespace,
+					Labels:    map[string]string{CreatedByJobTemplate: ".name"},
 				},
 			},
 			ExpectValue: 0,
@@ -125,8 +125,8 @@ func TestAddJob(t *testing.T) {
 			Name: "Invalid empty value",
 			job: &batch.Job{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:        "job6",
-					Namespace:   namespace,
+					Name:      "job6",
+					Namespace: namespace,
 					Labels:    map[string]string{CreatedByJobTemplate: ""},
 				},
 			},

--- a/pkg/controllers/jobtemplate/jobtemplate_controller_handler_test.go
+++ b/pkg/controllers/jobtemplate/jobtemplate_controller_handler_test.go
@@ -127,7 +127,7 @@ func TestAddJob(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        "job6",
 					Namespace:   namespace,
-					Labels:      map[string]string{CreatedByJobTemplate: ""},
+					Labels:    map[string]string{CreatedByJobTemplate: ""},
 				},
 			},
 			ExpectValue: 0,

--- a/pkg/controllers/jobtemplate/jobtemplate_controller_handler_test.go
+++ b/pkg/controllers/jobtemplate/jobtemplate_controller_handler_test.go
@@ -77,6 +77,61 @@ func TestAddJob(t *testing.T) {
 			},
 			ExpectValue: 1,
 		},
+		{
+			Name: "Valid with dots in name",
+			job: &batch.Job{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "job2",
+					Namespace:   namespace,
+					Labels:      map[string]string{CreatedByJobTemplate: "test.my.template"},
+				},
+			},
+			ExpectValue: 1,
+		},
+		{
+			Name: "Invalid no dots",
+			job: &batch.Job{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "job3",
+					Namespace:   namespace,
+					Labels:      map[string]string{CreatedByJobTemplate: "nonamespaceorname"},
+				},
+			},
+			ExpectValue: 0,
+		},
+		{
+			Name: "Invalid empty name",
+			job: &batch.Job{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "job4",
+					Namespace:   namespace,
+					Labels:      map[string]string{CreatedByJobTemplate: "test."},
+				},
+			},
+			ExpectValue: 0,
+		},
+		{
+			Name: "Invalid empty namespace",
+			job: &batch.Job{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "job5",
+					Namespace:   namespace,
+					Labels:      map[string]string{CreatedByJobTemplate: ".name"},
+				},
+			},
+			ExpectValue: 0,
+		},
+		{
+			Name: "Invalid empty value",
+			job: &batch.Job{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "job6",
+					Namespace:   namespace,
+					Labels:      map[string]string{CreatedByJobTemplate: ""},
+				},
+			},
+			ExpectValue: 0,
+		},
 	}
 	for i, testcase := range testCases {
 		t.Run(testcase.Name, func(t *testing.T) {

--- a/third_party/mindcluster/test/pod.go
+++ b/third_party/mindcluster/test/pod.go
@@ -177,6 +177,10 @@ func SetFakeNPUPodStatus(fPod *v1.Pod, status v1.PodPhase) {
 
 // AddTestTaskLabel add test job's label.
 func AddTestTaskLabel(task *api.TaskInfo, labelKey, labelValue string) {
+	if task == nil || task.Pod == nil {
+		return
+	}
+
 	if len(task.Pod.Spec.NodeSelector) == 0 {
 		task.Pod.Spec.NodeSelector = make(map[string]string, npuIndex3)
 	}

--- a/third_party/mindcluster/test/pod_test.go
+++ b/third_party/mindcluster/test/pod_test.go
@@ -1,0 +1,254 @@
+/*
+Copyright 2024 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package test
+
+import (
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"volcano.sh/volcano/pkg/scheduler/api"
+)
+
+// TestAddTestTaskLabelNilTask verifies the function handles nil task gracefully without panic.
+func TestAddTestTaskLabelNilTask(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("AddTestTaskLabel panicked with nil task: %v", r)
+		}
+	}()
+
+	// Should not panic
+	AddTestTaskLabel(nil, "key", "value")
+}
+
+// TestAddTestTaskLabelNilPod verifies the function handles nil Pod field gracefully without panic.
+func TestAddTestTaskLabelNilPod(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("AddTestTaskLabel panicked with nil Pod: %v", r)
+		}
+	}()
+
+	task := &api.TaskInfo{
+		Pod: nil,
+	}
+
+	// Should not panic
+	AddTestTaskLabel(task, "key", "value")
+}
+
+// TestAddTestTaskLabelNilNodeSelector verifies proper initialization of nil NodeSelector.
+func TestAddTestTaskLabelNilNodeSelector(t *testing.T) {
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod",
+			Namespace: "default",
+		},
+		Spec: v1.PodSpec{
+			NodeSelector: nil, // Explicitly nil
+		},
+	}
+
+	task := &api.TaskInfo{
+		Pod: pod,
+	}
+
+	AddTestTaskLabel(task, "test-key", "test-value")
+
+	if task.Pod.Spec.NodeSelector == nil {
+		t.Error("NodeSelector should be initialized")
+	}
+
+	if task.Pod.Spec.NodeSelector["test-key"] != "test-value" {
+		t.Errorf("expected NodeSelector['test-key']='test-value', got '%v'",
+			task.Pod.Spec.NodeSelector["test-key"])
+	}
+}
+
+// TestAddTestTaskLabelNilLabels verifies proper initialization of nil Labels map.
+func TestAddTestTaskLabelNilLabels(t *testing.T) {
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod",
+			Namespace: "default",
+			Labels:    nil, // Explicitly nil
+		},
+	}
+
+	task := &api.TaskInfo{
+		Pod: pod,
+	}
+
+	AddTestTaskLabel(task, "test-key", "test-value")
+
+	if task.Pod.Labels == nil {
+		t.Error("Labels should be initialized")
+	}
+
+	if task.Pod.Labels["test-key"] != "test-value" {
+		t.Errorf("expected Labels['test-key']='test-value', got '%v'",
+			task.Pod.Labels["test-key"])
+	}
+}
+
+// TestAddTestTaskLabelNormalCase verifies correct behavior with valid populated maps.
+func TestAddTestTaskLabelNormalCase(t *testing.T) {
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod",
+			Namespace: "default",
+			Labels: map[string]string{
+				"existing-key": "existing-value",
+			},
+		},
+		Spec: v1.PodSpec{
+			NodeSelector: map[string]string{
+				"node-existing-key": "node-existing-value",
+			},
+		},
+	}
+
+	task := &api.TaskInfo{
+		Pod: pod,
+	}
+
+	AddTestTaskLabel(task, "new-key", "new-value")
+
+	// Verify existing entries are preserved
+	if task.Pod.Labels["existing-key"] != "existing-value" {
+		t.Error("Existing label should be preserved")
+	}
+
+	if task.Pod.Spec.NodeSelector["node-existing-key"] != "node-existing-value" {
+		t.Error("Existing node selector should be preserved")
+	}
+
+	// Verify new entries are added
+	if task.Pod.Labels["new-key"] != "new-value" {
+		t.Errorf("expected Labels['new-key']='new-value', got '%v'",
+			task.Pod.Labels["new-key"])
+	}
+
+	if task.Pod.Spec.NodeSelector["new-key"] != "new-value" {
+		t.Errorf("expected NodeSelector['new-key']='new-value', got '%v'",
+			task.Pod.Spec.NodeSelector["new-key"])
+	}
+}
+
+// TestAddTestTaskLabelIdempotent verifies the function can be called multiple times safely.
+func TestAddTestTaskLabelIdempotent(t *testing.T) {
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod",
+			Namespace: "default",
+		},
+	}
+
+	task := &api.TaskInfo{
+		Pod: pod,
+	}
+
+	// Call multiple times
+	AddTestTaskLabel(task, "key1", "value1")
+	AddTestTaskLabel(task, "key2", "value2")
+	AddTestTaskLabel(task, "key1", "updated-value1") // Update existing
+
+	if task.Pod.Labels["key1"] != "updated-value1" {
+		t.Errorf("expected Labels['key1']='updated-value1', got '%v'",
+			task.Pod.Labels["key1"])
+	}
+
+	if task.Pod.Labels["key2"] != "value2" {
+		t.Errorf("expected Labels['key2']='value2', got '%v'",
+			task.Pod.Labels["key2"])
+	}
+
+	if task.Pod.Spec.NodeSelector["key1"] != "updated-value1" {
+		t.Errorf("expected NodeSelector['key1']='updated-value1', got '%v'",
+			task.Pod.Spec.NodeSelector["key1"])
+	}
+
+	if task.Pod.Spec.NodeSelector["key2"] != "value2" {
+		t.Errorf("expected NodeSelector['key2']='value2', got '%v'",
+			task.Pod.Spec.NodeSelector["key2"])
+	}
+}
+
+// TestAddTestTaskLabelEmptyKeyValue verifies proper handling of empty key/value strings.
+func TestAddTestTaskLabelEmptyKeyValue(t *testing.T) {
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod",
+			Namespace: "default",
+		},
+	}
+
+	task := &api.TaskInfo{
+		Pod: pod,
+	}
+
+	// Empty key and value should still be added
+	AddTestTaskLabel(task, "", "")
+
+	if task.Pod.Labels[""] != "" {
+		t.Error("Empty key with empty value should be added to Labels")
+	}
+
+	if task.Pod.Spec.NodeSelector[""] != "" {
+		t.Error("Empty key with empty value should be added to NodeSelector")
+	}
+}
+
+// TestAddTestTaskLabelBothMapsNil verifies initialization of both nil maps simultaneously.
+func TestAddTestTaskLabelBothMapsNil(t *testing.T) {
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod",
+			Namespace: "default",
+			Labels:    nil,
+		},
+		Spec: v1.PodSpec{
+			NodeSelector: nil,
+		},
+	}
+
+	task := &api.TaskInfo{
+		Pod: pod,
+	}
+
+	AddTestTaskLabel(task, "testkey", "testvalue")
+
+	// Both maps should be initialized
+	if task.Pod.Labels == nil {
+		t.Error("Labels should be initialized")
+	}
+
+	if task.Pod.Spec.NodeSelector == nil {
+		t.Error("NodeSelector should be initialized")
+	}
+
+	// Both maps should contain the label
+	if task.Pod.Labels["testkey"] != "testvalue" {
+		t.Error("Label not added correctly")
+	}
+
+	if task.Pod.Spec.NodeSelector["testkey"] != "testvalue" {
+		t.Error("NodeSelector not added correctly")
+	}
+}


### PR DESCRIPTION
## Description

This PR improves robustness by preventing potential nil-pointer panics when applying labels to test tasks, and hardens the parsing logic for `CreatedByJobTemplate` labels when enqueueing JobTemplate-related events.

### Changes Included

1. **Fix Nil-Pointer in AddTestTaskLabel**: 
   - Added early-return guards in `third_party/mindcluster/test/pod.go` to prevent panics when `task` or `task.Pod` is nil. 
   - Unit tests covering these nil-input scenarios are included in `pod_test.go`.

2. **Improve CreatedByJobTemplate Parsing**: 
   - Switched to `strings.SplitN(..., ".", 2)` in `addJob` to correctly parse JobTemplate names that contain dots (as namespaces cannot contain dots, but object names can).
   - Added validation to ensure neither the parsed namespace nor the name is empty.
   - Lowered the log severity for malformed labels from `Error` to `Warning`, and improved the error message context for easier debugging.

### Motivation
These changes address code review feedback to improve safety and logging hygiene, ensuring the controller does not panic on invalid inputs and accurately reflects malformed inputs without adding unnecessary noise to error logs.

