### PR TITLE
fix: reverse potentialVictims order to reprieve higher priority pods first

### DIFF
--- a/pkg/scheduler/actions/preempt/preempt.go
+++ b/pkg/scheduler/actions/preempt/preempt.go
@@ -28,7 +28,6 @@ import (
 	"fmt"
 	"math"
 	"math/rand"
-	"sort"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -38,7 +37,6 @@ import (
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2"
-	k8sutil "k8s.io/kubernetes/pkg/scheduler/util"
 
 	fwk "k8s.io/kube-scheduler/framework"
 
@@ -761,10 +759,6 @@ func SelectVictimsOnNode(
 
 	klog.V(3).Infof("allVictims: %v", allVictims)
 
-	// Sort potentialVictims by pod priority from high to low, which ensures to
-	// reprieve higher priority pods first.
-	sort.Slice(allVictims, func(i, j int) bool { return k8sutil.MoreImportantPod(allVictims[i].Pod, allVictims[j].Pod) })
-
 	victimsQueue := ssn.BuildVictimsPriorityQueue(allVictims, preemptor)
 
 	for !victimsQueue.Empty() {
@@ -825,6 +819,13 @@ func SelectVictimsOnNode(
 		klog.Infof("reprievePod for task: %v, fits: %v", pi.Name, fits)
 		return fits, nil
 	}
+
+        // Reverse potentialVictims to reprieve higher priority pods first.
+        // potentialVictims is collected from victimsQueue.Pop() which returns lower priority first,
+        // so we need to reverse it to ensure higher priority pods are reprieved first.
+        for i, j := 0, len(potentialVictims)-1; i < j; i, j = i+1, j-1 {
+                potentialVictims[i], potentialVictims[j] = potentialVictims[j], potentialVictims[i]
+        } 
 
 	// Now we try to reprieve non-violating victims.
 	for _, p := range potentialVictims {

--- a/pkg/scheduler/actions/preempt/preempt.go
+++ b/pkg/scheduler/actions/preempt/preempt.go
@@ -28,7 +28,6 @@ import (
 	"fmt"
 	"math"
 	"math/rand"
-	"sort"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -38,7 +37,6 @@ import (
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2"
-	k8sutil "k8s.io/kubernetes/pkg/scheduler/util"
 
 	fwk "k8s.io/kube-scheduler/framework"
 
@@ -752,10 +750,6 @@ func SelectVictimsOnNode(
 
 	klog.V(3).Infof("allVictims: %v", allVictims)
 
-	// Sort potentialVictims by pod priority from high to low, which ensures to
-	// reprieve higher priority pods first.
-	sort.Slice(allVictims, func(i, j int) bool { return k8sutil.MoreImportantPod(allVictims[i].Pod, allVictims[j].Pod) })
-
 	victimsQueue := ssn.BuildVictimsPriorityQueue(allVictims, preemptor)
 
 	for !victimsQueue.Empty() {
@@ -816,6 +810,13 @@ func SelectVictimsOnNode(
 		klog.Infof("reprievePod for task: %v, fits: %v", pi.Name, fits)
 		return fits, nil
 	}
+
+        // Reverse potentialVictims to reprieve higher priority pods first.
+        // potentialVictims is collected from victimsQueue.Pop() which returns lower priority first,
+        // so we need to reverse it to ensure higher priority pods are reprieved first.
+        for i, j := 0, len(potentialVictims)-1; i < j; i, j = i+1, j-1 {
+                potentialVictims[i], potentialVictims[j] = potentialVictims[j], potentialVictims[i]
+        } 
 
 	// Now we try to reprieve non-violating victims.
 	for _, p := range potentialVictims {

--- a/pkg/scheduler/actions/preempt/preempt.go
+++ b/pkg/scheduler/actions/preempt/preempt.go
@@ -820,12 +820,12 @@ func SelectVictimsOnNode(
 		return fits, nil
 	}
 
-        // Reverse potentialVictims to reprieve higher priority pods first.
-        // potentialVictims is collected from victimsQueue.Pop() which returns lower priority first,
-        // so we need to reverse it to ensure higher priority pods are reprieved first.
-        for i, j := 0, len(potentialVictims)-1; i < j; i, j = i+1, j-1 {
-                potentialVictims[i], potentialVictims[j] = potentialVictims[j], potentialVictims[i]
-        } 
+	// Reverse potentialVictims to reprieve higher priority pods first.
+	// potentialVictims is collected from victimsQueue.Pop() which returns lower priority first,
+	// so we need to reverse it to ensure higher priority pods are reprieved first.
+	for i, j := 0, len(potentialVictims)-1; i < j; i, j = i+1, j-1 {
+		potentialVictims[i], potentialVictims[j] = potentialVictims[j], potentialVictims[i]
+	}
 
 	// Now we try to reprieve non-violating victims.
 	for _, p := range potentialVictims {


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
In `SelectVictimsOnNode`, `potentialVictims` was collected from `victimsQueue.Pop()` which returns lower priority pods first. This caused lower priority pods to be reprieved first, contradicting the expected behavior described in the code comment.
This fix reverses `potentialVictims` before the reprieve loop to ensure higher priority pods are reprieved first.
#### Which issue(s) this PR fixes:
Fixes #5208 

#### Special notes for your reviewer:
The root cause is that `BuildVictimsPriorityQueue` uses `!ssn.TaskOrderFn` with negation, so `Pop()` returns pods in [low→high] priority order, which is opposite to the `sort.Slice` order [high→low].

#### Does this PR introduce a user-facing change?
None

```release-note
Fixed victim reprieve logic in preempt action to reprieve higher priority pods first as intended.
```