### PR TITLE
fix nil check in deviceshare batch scoring

### DIFF
--- a/pkg/scheduler/plugins/deviceshare/deviceshare.go
+++ b/pkg/scheduler/plugins/deviceshare/deviceshare.go
@@ -18,7 +18,6 @@ package deviceshare
 
 import (
 	"context"
-	"fmt"
 	"math"
 	"reflect"
 	"sync"
@@ -276,10 +275,11 @@ func (dp *deviceSharePlugin) OnSessionOpen(ssn *framework.Session) {
 					if ok {
 						if deviceInterface, isDeviceInterface := device.(api.Devices); isDeviceInterface {
 							if reflect.ValueOf(deviceInterface).IsNil() {
-								if deviceInterface == nil || deviceInterface.HasDeviceRequest(task.Pod) {
-									return nil, fmt.Errorf("node not initialized with device %s", deviceType)
-								}
-								klog.V(4).Infof("pod %s/%s did not request device %s on %s, skipping it", task.Pod.Namespace, task.Pod.Name, deviceType, nodes[0].Name)
+								klog.V(4).Infof("device %s is null on node %s, skipping", deviceType, node.Name)
+								continue
+							}
+							if !deviceInterface.HasDeviceRequest(task.Pod) {
+								klog.V(4).Infof("pod %s/%s did not request device %s on %s, skipping it", task.Pod.Namespace, task.Pod.Name, deviceType, node.Name)
 								continue
 							}
 							allDevices = append(allDevices, deviceInterface)


### PR DESCRIPTION
fixes #5216

**what changed**

Fixed a logic error in `BatchNodeOrderFn` (`pkg/scheduler/plugins/deviceshare/deviceshare.go:278`) where a typed nil interface check was always false, causing `HasDeviceRequest` to be called on a nil concrete pointer.

**the bug**

When `reflect.ValueOf(deviceInterface).IsNil()` returns true, the interface wraps a typed nil pointer. The subsequent `deviceInterface == nil` check is dead code (always false in Go for typed nil interfaces), so `HasDeviceRequest` is always evaluated on a nil receiver. For device implementations that dereference `self` (e.g. `AscendDevices.HasDeviceRequest` calls `ads.getFirstDevice()`), this would panic.

**the fix**

Aligned the nil check pattern with the correct existing pattern at lines 215-220 in the same file (single node scoring path):
1. Check `IsNil()` first, log and skip
2. Call `HasDeviceRequest` only on non-nil devices
3. Removed unused `fmt` import (was only used by the removed `fmt.Errorf`)