### PR TITLE
fix(scheduler cache): evict goroutine leak, premature event, silent errors

### DIFF
--- a/pkg/scheduler/cache/cache.go
+++ b/pkg/scheduler/cache/cache.go
@@ -168,6 +168,10 @@ type SchedulerCache struct {
 
 	registeredHandlers map[string]cache.ResourceEventHandlerRegistration
 
+	// stopCh is stored at Run time so background workers spawned for
+	// per-task operations (e.g., Evict) can observe scheduler shutdown.
+	stopCh <-chan struct{}
+
 	BindFlowChannel chan *BindContext
 	bindCache       []*BindContext
 	batchNum        int
@@ -849,6 +853,7 @@ func (sc *SchedulerCache) addEventHandler() {
 
 // Run  starts the schedulerCache
 func (sc *SchedulerCache) Run(stopCh <-chan struct{}) {
+	sc.stopCh = stopCh
 	sc.informerFactory.Start(stopCh)
 	sc.vcInformerFactory.Start(stopCh)
 	sc.WaitForCacheSync(stopCh)
@@ -964,13 +969,27 @@ func (sc *SchedulerCache) Evict(taskInfo *schedulingapi.TaskInfo, reason string)
 	p := task.Pod
 
 	go func() {
-		err := sc.Evictor.Evict(p, reason)
-		if err != nil {
-			sc.resyncTask(task)
+		// Skip eviction if the scheduler is shutting down to avoid holding the
+		// apiserver connection open past shutdown and firing misleading events.
+		if sc.stopCh != nil {
+			select {
+			case <-sc.stopCh:
+				klog.V(3).Infof("Skipping evict of pod %s/%s: scheduler is shutting down", p.Namespace, p.Name)
+				return
+			default:
+			}
 		}
+
+		if err := sc.Evictor.Evict(p, reason); err != nil {
+			klog.Errorf("Failed to evict pod %s/%s: %v", p.Namespace, p.Name, err)
+			sc.Recorder.Eventf(podgroup, v1.EventTypeWarning, "EvictFailed",
+				"Failed to evict pod %s/%s: %v", p.Namespace, p.Name, err)
+			sc.resyncTask(task)
+			return
+		}
+		sc.Recorder.Eventf(podgroup, v1.EventTypeNormal, "Evict", reason)
 	}()
 
-	sc.Recorder.Eventf(podgroup, v1.EventTypeNormal, "Evict", reason)
 	return nil
 }
 


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
`SchedulerCache.Evict()` spawns a background goroutine to call `Evictor.Evict()` against the apiserver. Three issues in that goroutine:

1. It has no stopCh awareness, so in flight evictions keep running past scheduler shutdown while every other worker spawned from `Run()` stops.
2. The `Recorder.Eventf(..., "Evict", ...)` kubernetes event fires synchronously before the evict call, so the event is recorded even when the evict later fails.
3. On error the goroutine silently calls `resyncTask` and throws the error away, with no log and no event.

Fix: store `stopCh` on `SchedulerCache` and skip the call on shutdown, move the Normal event to the success branch, emit a Warning `EvictFailed` event and `klog.Errorf` on failure.

#### Which issue(s) this PR fixes:
Fixes #5224

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```