### PR TITLE
fix: fix permission denied errors in cgroup handler unit tests

### DIFF
--- a/pkg/agent/events/handlers/cpuburst/cpu_burst_linux_test.go
+++ b/pkg/agent/events/handlers/cpuburst/cpu_burst_linux_test.go
@@ -259,7 +259,7 @@ type info struct {
 func prepare(t *testing.T, tmpDir, podUID string, infos []info) {
 	for _, info := range infos {
 		dir := path.Join(tmpDir, "cpu", "kubepods", "pod"+podUID, info.dir)
-		err := os.MkdirAll(dir, 0644)
+		err := os.MkdirAll(dir, 0755)
 		assert.NoError(t, err)
 		filePath := path.Join(dir, info.path)
 		f, err := os.OpenFile(filePath, os.O_RDWR|os.O_CREATE, 0644)
@@ -399,7 +399,7 @@ type infoV2 struct {
 func prepareV2(t *testing.T, tmpDir, podUID string, infos []infoV2) {
 	for _, info := range infos {
 		dir := path.Join(tmpDir, "kubepods", "pod"+podUID, info.dir)
-		err := os.MkdirAll(dir, 0644)
+		err := os.MkdirAll(dir, 0755)
 		assert.NoError(t, err)
 		filePath := path.Join(dir, info.path)
 		f, err := os.OpenFile(filePath, os.O_RDWR|os.O_CREATE, 0644)

--- a/pkg/agent/events/handlers/cpuqos/cpuqos_linux_test.go
+++ b/pkg/agent/events/handlers/cpuqos/cpuqos_linux_test.go
@@ -32,7 +32,7 @@ func TestCPUQoSHandle_Handle(t *testing.T) {
 	// make a fake pod cgroup path first.
 	tmpDir := t.TempDir()
 	dir := path.Join(tmpDir, "cpu", "kubepods", "podfake-id2")
-	err := os.MkdirAll(dir, 0644)
+	err := os.MkdirAll(dir, 0755)
 	assert.NoError(t, err)
 	filePath := path.Join(dir, "cpu.qos_level")
 	_, err = os.OpenFile(filePath, os.O_RDWR|os.O_CREATE, 0644)

--- a/pkg/agent/events/handlers/resources/resources_test.go
+++ b/pkg/agent/events/handlers/resources/resources_test.go
@@ -321,7 +321,7 @@ func prepare(t *testing.T, tmpDir, podUID, containerID1, containerID2 string) {
 		for _, ss := range subSystems {
 			podDir := path.Join(tmpDir, ss, "kubepods", "burstable", "pod"+podUID)
 			containerDir := path.Join(podDir, c)
-			err := os.MkdirAll(containerDir, 0644)
+			err := os.MkdirAll(containerDir, 0755)
 			assert.NoError(t, err)
 			for _, cgrouPath := range cgroupPaths {
 				// create pod level cgroup.


### PR DESCRIPTION
## What this PR does
Fix unit test failures in three cgroup-related handler packages caused by
incorrect directory permission mode in test scaffolding.

## Why this PR
Running `go test ./pkg/...` as a non-root user produced consistent failures
in the following packages:

- `pkg/agent/events/handlers/cpuburst`
- `pkg/agent/events/handlers/cpuqos`
- `pkg/agent/events/handlers/resources`

All failures shared the same root cause:
mkdir /tmp/TestXxx.../001/cpu/kubepods: permission denied
open  /tmp/TestXxx.../cpu.cfs_burst_us: permission denied

## Root Cause
The test setup was calling `os.MkdirAll` with mode `0644` to create fake
cgroup directory hierarchies. Mode `0644` does not include the execute bit
on directories, which means the directories are not traversable. As a result,
any attempt to create files or subdirectories inside them failed with
`permission denied` when running as a non-root user.

Note: this is a test setup bug, not an environment issue. Other handler
tests in the same directory (cputhrottle, memoryqos, eviction) passed
without issue, confirming the problem was isolated to these three packages.

## Fix
Change directory creation mode from `0644` to `0755` in the affected test
files so that fake cgroup directories are properly traversable. No changes
were made to production code.

## How to verify
```bash
go test ./pkg/agent/events/handlers/cpuburst/... -v
go test ./pkg/agent/events/handlers/cpuqos/... -v
go test ./pkg/agent/events/handlers/resources/... -v
```

All tests should pass without requiring root privileges.