### PR TITLE
Support Preemption for VGPU jobs

### DIFF
--- a/pkg/scheduler/api/devices/ascend/hami/device_info.go
+++ b/pkg/scheduler/api/devices/ascend/hami/device_info.go
@@ -335,6 +335,38 @@ func (ads *AscendDevices) GetStatus() string {
 	return ""
 }
 
+// DeepCopy returns a deep copy of AscendDevices for use in dry-run simulation.
+func (ads *AscendDevices) DeepCopy() interface{} {
+	if ads == nil {
+		return nil
+	}
+	cp := &AscendDevices{
+		NodeName: ads.NodeName,
+		Type:     ads.Type,
+		Policy:   ads.Policy,
+		Devices:  make(map[string]*AscendDevice, len(ads.Devices)),
+	}
+	for id, dev := range ads.Devices {
+		newUsage := &devices.DeviceUsage{
+			Used:      dev.DeviceUsage.Used,
+			Usedmem:   dev.DeviceUsage.Usedmem,
+			Usedcores: dev.DeviceUsage.Usedcores,
+		}
+		newDev := &AscendDevice{
+			config:           dev.config,
+			nodeRegisterAnno: dev.nodeRegisterAnno,
+			useUUIDAnno:      dev.useUUIDAnno,
+			noUseUUIDAnno:    dev.noUseUUIDAnno,
+			handshakeAnno:    dev.handshakeAnno,
+			DeviceInfo:       dev.DeviceInfo,
+			DeviceUsage:      newUsage,
+			Score:            dev.Score,
+		}
+		cp.Devices[id] = newDev
+	}
+	return cp
+}
+
 func (ads *AscendDevices) selectDevices(pod *v1.Pod, schedulePolicy string) (devices.PodSingleDevice, error) {
 	dupDevs := getDeviceSnapshot(ads)
 	if len(dupDevs) == 0 {

--- a/pkg/scheduler/api/devices/ascend/mindcluster/ascend310p/vnpu/device_info.go
+++ b/pkg/scheduler/api/devices/ascend/mindcluster/ascend310p/vnpu/device_info.go
@@ -219,3 +219,101 @@ func (ns *NPUDevices) GetStatus() string {
 func (ns *NPUDevices) GetIgnoredDevices() []string {
 	return []string{""}
 }
+
+// DeepCopy returns a deep copy of NPUDevices for use in dry-run simulation.
+func (ns *NPUDevices) DeepCopy() interface{} {
+	if ns == nil {
+		return nil
+	}
+	cp := &NPUDevices{
+		Name:      ns.Name,
+		FrameAttr: ns.FrameAttr,
+	}
+
+	// Deep copy NodeInf maps
+	cp.NodeInf = NodeInf{
+		Name:              ns.NodeInf.Name,
+		BaseDeviceInfo:    ns.NodeInf.BaseDeviceInfo,
+		Address:           ns.NodeInf.Address,
+		SuperPodID:        ns.NodeInf.SuperPodID,
+		DevInfoUpdateTime: ns.NodeInf.DevInfoUpdateTime,
+		Capability:        make(map[v1.ResourceName]float64, len(ns.NodeInf.Capability)),
+		Allocate:          make(map[v1.ResourceName]float64, len(ns.NodeInf.Allocate)),
+		Idle:              make(map[v1.ResourceName]float64, len(ns.NodeInf.Idle)),
+		Annotation:        make(map[string]string, len(ns.NodeInf.Annotation)),
+		Label:             make(map[string]string, len(ns.NodeInf.Label)),
+	}
+	for k, v := range ns.NodeInf.Capability {
+		cp.NodeInf.Capability[k] = v
+	}
+	for k, v := range ns.NodeInf.Allocate {
+		cp.NodeInf.Allocate[k] = v
+	}
+	for k, v := range ns.NodeInf.Idle {
+		cp.NodeInf.Idle[k] = v
+	}
+	for k, v := range ns.NodeInf.Annotation {
+		cp.NodeInf.Annotation[k] = v
+	}
+	for k, v := range ns.NodeInf.Label {
+		cp.NodeInf.Label[k] = v
+	}
+
+	// Deep copy NPUDevice
+	cp.NPUDevice = NPUDevice{
+		VT: VTemplate{
+			Temp: ns.NPUDevice.VT.Temp,
+			Data: make(map[string]VResource, len(ns.NPUDevice.VT.Data)),
+		},
+		ChipKind:         ns.NPUDevice.ChipKind,
+		ServerType:       ns.NPUDevice.ServerType,
+		TotalChipNum:     ns.NPUDevice.TotalChipNum,
+		AiCorePerChip:    ns.NPUDevice.AiCorePerChip,
+		FreeChipNum:      ns.NPUDevice.FreeChipNum,
+		TotalRes:         ns.NPUDevice.TotalRes,
+		ValidVNode:       ns.NPUDevice.ValidVNode,
+		ChipType:         ns.NPUDevice.ChipType,
+		Chips:            make(map[int]*VChip, len(ns.NPUDevice.Chips)),
+		UnhealthyChipIds: make(map[int]struct{}, len(ns.NPUDevice.UnhealthyChipIds)),
+		DowngradeCache:   make(map[string]struct{}, len(ns.NPUDevice.DowngradeCache)),
+		ConCache:         make(map[string]map[types.UID]struct{}, len(ns.NPUDevice.ConCache)),
+	}
+	for k, v := range ns.NPUDevice.VT.Data {
+		cp.NPUDevice.VT.Data[k] = v
+	}
+	for k := range ns.NPUDevice.UnhealthyChipIds {
+		cp.NPUDevice.UnhealthyChipIds[k] = struct{}{}
+	}
+	for k := range ns.NPUDevice.DowngradeCache {
+		cp.NPUDevice.DowngradeCache[k] = struct{}{}
+	}
+	for k, inner := range ns.NPUDevice.ConCache {
+		newInner := make(map[types.UID]struct{}, len(inner))
+		for uid := range inner {
+			newInner[uid] = struct{}{}
+		}
+		cp.NPUDevice.ConCache[k] = newInner
+	}
+	for id, chip := range ns.NPUDevice.Chips {
+		newChip := &VChip{
+			Name:        chip.Name,
+			Kind:        chip.Kind,
+			IsDual:      chip.IsDual,
+			Unstable:    chip.Unstable,
+			CoreNum:     chip.CoreNum,
+			SegmentFlag: chip.SegmentFlag,
+			TotalRes:    chip.TotalRes,
+			UsedRes:     chip.UsedRes,
+			FreeRes:     chip.FreeRes,
+			ID:          make([]string, len(chip.ID)),
+			PodMap:      make(map[string]*v1.Pod, len(chip.PodMap)),
+		}
+		copy(newChip.ID, chip.ID)
+		for uid, pod := range chip.PodMap {
+			newChip.PodMap[uid] = pod
+		}
+		cp.NPUDevice.Chips[id] = newChip
+	}
+
+	return cp
+}

--- a/pkg/scheduler/api/devices/nvidia/gpushare/device_info.go
+++ b/pkg/scheduler/api/devices/nvidia/gpushare/device_info.go
@@ -178,6 +178,29 @@ func (gs *GPUDevices) GetStatus() string {
 	return ""
 }
 
+// DeepCopy returns a deep copy of GPUDevices for use in dry-run simulation.
+func (gs *GPUDevices) DeepCopy() interface{} {
+	if gs == nil {
+		return nil
+	}
+	cp := &GPUDevices{
+		Name:   gs.Name,
+		Device: make(map[int]*GPUDevice, len(gs.Device)),
+	}
+	for id, dev := range gs.Device {
+		newDev := &GPUDevice{
+			ID:     dev.ID,
+			Memory: dev.Memory,
+			PodMap: make(map[string]*v1.Pod, len(dev.PodMap)),
+		}
+		for uid, pod := range dev.PodMap {
+			newDev.PodMap[uid] = pod
+		}
+		cp.Device[id] = newDev
+	}
+	return cp
+}
+
 func (gs *GPUDevices) ScoreNode(pod *v1.Pod, schedulePolicy string) float64 {
 	return 0
 }

--- a/pkg/scheduler/api/devices/nvidia/vgpu/device_info.go
+++ b/pkg/scheduler/api/devices/nvidia/vgpu/device_info.go
@@ -275,6 +275,9 @@ func (gs *GPUDevices) HasDeviceRequest(pod *v1.Pod) bool {
 }
 
 func (gs *GPUDevices) Release(kubeClient kubernetes.Interface, pod *v1.Pod) error {
+	// Release is required for rollback paths (e.g. UnPipeline) where NodeInfo
+	// does not invoke subResource for Pipelined tasks.
+	gs.SubResource(pod)
 	return nil
 }
 
@@ -295,6 +298,11 @@ func (gs *GPUDevices) FilterNode(pod *v1.Pod, schedulePolicy string) (int, strin
 func (gs *GPUDevices) Allocate(kubeClient kubernetes.Interface, pod *v1.Pod) error {
 	if VGPUEnable {
 		klog.V(4).Infoln("hami-vgpu DeviceSharing:Into AllocateToPod", pod.Name)
+		if alreadyAssignedOnNode(pod, gs.Name) {
+			klog.V(4).InfoS("hami-vgpu DeviceSharing: skip duplicate AllocateToPod",
+				"pod", pod.Name, "namespace", pod.Namespace, "node", gs.Name)
+			return nil
+		}
 		fit, device, _, err := checkNodeGPUSharingPredicateAndScore(pod, gs, false, SchedulePolicy)
 		if err != nil || !fit {
 			klog.ErrorS(err, "Failed to allocate vgpu task", "pod", pod.Name)
@@ -316,6 +324,15 @@ func (gs *GPUDevices) Allocate(kubeClient kubernetes.Interface, pod *v1.Pod) err
 
 		annotations[DeviceBindPhase] = "allocating"
 		annotations[BindTimeAnnotations] = strconv.FormatInt(time.Now().Unix(), 10)
+		// Keep in-memory pod object in sync so rollback paths (UnPipeline ->
+		// Deallocate -> Release) can see allocated IDs before apiserver watch
+		// catches up.
+		if pod.Annotations == nil {
+			pod.Annotations = map[string]string{}
+		}
+		for k, v := range annotations {
+			pod.Annotations[k] = v
+		}
 		// To avoid that the pod allocated info updating latency, add it first
 		gs.addToPodMap(annotations, pod)
 		err = patchPodAnnotations(kubeClient, pod, annotations)
@@ -326,4 +343,64 @@ func (gs *GPUDevices) Allocate(kubeClient kubernetes.Interface, pod *v1.Pod) err
 		klog.V(3).Infoln("DeviceSharing:Allocate Success")
 	}
 	return nil
+}
+
+// DeepCopy returns a deep copy of GPUDevices for use in dry-run simulation.
+func (gs *GPUDevices) DeepCopy() interface{} {
+	if gs == nil {
+		return nil
+	}
+	cp := &GPUDevices{
+		Name:    gs.Name,
+		Mode:    gs.Mode,
+		Score:   gs.Score,
+		Sharing: gs.Sharing,
+		Device:  make(map[int]*GPUDevice, len(gs.Device)),
+	}
+	for id, dev := range gs.Device {
+		newDev := &GPUDevice{
+			ID:       dev.ID,
+			Node:     dev.Node,
+			UUID:     dev.UUID,
+			Memory:   dev.Memory,
+			Number:   dev.Number,
+			Type:     dev.Type,
+			Health:   dev.Health,
+			UsedNum:  dev.UsedNum,
+			UsedMem:  dev.UsedMem,
+			UsedCore: dev.UsedCore,
+			MigUsage: deviceconfig.MigInUse{
+				Index:     dev.MigUsage.Index,
+				UsageList: make(deviceconfig.MIGS, len(dev.MigUsage.UsageList)),
+			},
+			PodMap: make(map[string]*GPUUsage, len(dev.PodMap)),
+		}
+		copy(newDev.MigUsage.UsageList, dev.MigUsage.UsageList)
+		if len(dev.MigTemplate) > 0 {
+			newDev.MigTemplate = make([]deviceconfig.Geometry, len(dev.MigTemplate))
+			for i, g := range dev.MigTemplate {
+				ng := deviceconfig.Geometry{
+					Group:     g.Group,
+					Instances: make([]deviceconfig.MigTemplate, len(g.Instances)),
+				}
+				copy(ng.Instances, g.Instances)
+				newDev.MigTemplate[i] = ng
+			}
+		}
+		for uid, usage := range dev.PodMap {
+			u := *usage
+			newDev.PodMap[uid] = &u
+		}
+		cp.Device[id] = newDev
+	}
+	return cp
+}
+
+func alreadyAssignedOnNode(pod *v1.Pod, nodeName string) bool {
+	if pod == nil || pod.Annotations == nil || nodeName == "" {
+		return false
+	}
+
+	return pod.Annotations[AssignedNodeAnnotations] == nodeName &&
+		pod.Annotations[AssignedIDsAnnotations] != ""
 }

--- a/pkg/scheduler/api/devices/nvidia/vgpu/hamicore.go
+++ b/pkg/scheduler/api/devices/nvidia/vgpu/hamicore.go
@@ -38,11 +38,14 @@ func (f HAMICoreFactory) TryAddPod(gd *GPUDevice, mem uint, core uint) (bool, st
 
 func (f HAMICoreFactory) AddPod(gd *GPUDevice, mem uint, core uint, podUID string, devID string) error {
 	_, ok := gd.PodMap[podUID]
-	if !ok {
-		gd.PodMap[podUID] = &GPUUsage{
-			UsedMem:  0,
-			UsedCore: 0,
-		}
+	if ok {
+		// Keep AddPod idempotent in case the same pod allocation is replayed
+		// during cache/node refresh.
+		return nil
+	}
+	gd.PodMap[podUID] = &GPUUsage{
+		UsedMem:  0,
+		UsedCore: 0,
 	}
 	gd.UsedNum++
 	gd.UsedMem += mem

--- a/pkg/scheduler/api/devices/nvidia/vgpu/metrics.go
+++ b/pkg/scheduler/api/devices/nvidia/vgpu/metrics.go
@@ -100,6 +100,12 @@ func (gs *GPUDevices) AddPodMetrics(index int, podUID, podName string) {
 	UUID := gs.Device[index].UUID
 	NodeName := gs.Device[index].Node
 	usage := gs.Device[index].PodMap[podUID]
+	if usage == nil {
+		VGPUDevicesSharedNumber.WithLabelValues(UUID, NodeName).Set(float64(gs.Device[index].UsedNum))
+		VGPUDevicesAllocatedCores.WithLabelValues(UUID, NodeName).Set(float64(gs.Device[index].UsedCore))
+		VGPUDevicesAllocatedMemory.WithLabelValues(UUID, NodeName).Set(float64(gs.Device[index].UsedMem))
+		return
+	}
 	VGPUPodMemoryAllocated.WithLabelValues(UUID, NodeName, podName).Set(float64(usage.UsedMem))
 	VGPUPodCoreAllocated.WithLabelValues(UUID, NodeName, podName).Set(float64(usage.UsedCore))
 	VGPUDevicesSharedNumber.WithLabelValues(UUID, NodeName).Inc()
@@ -111,6 +117,14 @@ func (gs *GPUDevices) SubPodMetrics(index int, podUID, podName string) {
 	UUID := gs.Device[index].UUID
 	NodeName := gs.Device[index].Node
 	usage := gs.Device[index].PodMap[podUID]
+	if usage == nil {
+		VGPUPodMemoryAllocated.DeleteLabelValues(UUID, NodeName, podName)
+		VGPUPodCoreAllocated.DeleteLabelValues(UUID, NodeName, podName)
+		VGPUDevicesSharedNumber.WithLabelValues(UUID, NodeName).Set(float64(gs.Device[index].UsedNum))
+		VGPUDevicesAllocatedCores.WithLabelValues(UUID, NodeName).Set(float64(gs.Device[index].UsedCore))
+		VGPUDevicesAllocatedMemory.WithLabelValues(UUID, NodeName).Set(float64(gs.Device[index].UsedMem))
+		return
+	}
 	VGPUPodMemoryAllocated.WithLabelValues(UUID, NodeName, podName).Set(float64(usage.UsedMem))
 	VGPUPodCoreAllocated.WithLabelValues(UUID, NodeName, podName).Set(float64(usage.UsedCore))
 	if usage.UsedMem == 0 {

--- a/pkg/scheduler/api/devices/nvidia/vgpu/utils.go
+++ b/pkg/scheduler/api/devices/nvidia/vgpu/utils.go
@@ -361,17 +361,46 @@ func checkNodeGPUSharingPredicateAndScore(pod *v1.Pod, gssnap *GPUDevices, repli
 	if pod.Annotations[VGPUPodGroupPolicyAnnotation] == VGPUPodGroupPolicySpreadValue {
 		currentPodGroupKey = getPodGroupKey(pod)
 	}
+
+	type tentativeAlloc struct {
+		device *GPUDevice
+		mem    uint
+		core   uint
+	}
+	rollbackTentative := func(allocs []tentativeAlloc) {
+		for _, alloc := range allocs {
+			if alloc.device == nil {
+				continue
+			}
+			if alloc.device.UsedNum > 0 {
+				alloc.device.UsedNum--
+			}
+			if alloc.device.UsedMem >= alloc.mem {
+				alloc.device.UsedMem -= alloc.mem
+			} else {
+				alloc.device.UsedMem = 0
+			}
+			if alloc.device.UsedCore >= alloc.core {
+				alloc.device.UsedCore -= alloc.core
+			} else {
+				alloc.device.UsedCore = 0
+			}
+		}
+	}
+
+	tentativeAllocs := []tentativeAlloc{}
 	ctrdevs := []ContainerDevices{}
 	for _, val := range ctrReq {
 		devs := []ContainerDevice{}
 		if int(val.Nums) > len(gs.Device) {
+			rollbackTentative(tentativeAllocs)
 			return false, []ContainerDevices{}, 0, fmt.Errorf("no enough gpu cards on node %s", gs.Name)
 		}
 		klog.V(3).InfoS("Allocating device for container", "request", val)
 
 		for _, i := range sortedDeviceIndicesByPolicy(gs, schedulePolicy) {
 			klog.V(3).InfoS("Scoring pod request", "memReq", val.Memreq, "memPercentageReq", val.MemPercentagereq, "coresReq", val.Coresreq, "Nums", val.Nums, "Index", i, "ID", gs.Device[i].ID)
-			klog.V(3).InfoS("Current Device", "Index", i, "TotalMemory", gs.Device[i].Memory, "UsedMemory", gs.Device[i].UsedMem, "UsedCores", gs.Device[i].UsedCore, "replicate", replicate)
+			klog.V(3).InfoS("Current Device", "Index", i, "TotalMemory", gs.Device[i].Memory, "UsedMemory", gs.Device[i].UsedMem, "UsedCores", gs.Device[i].UsedCore, "UsedNum", gs.Device[i].UsedNum, "Number", gs.Device[i].Number, "replicate", replicate)
 			if gs.Device[i].Number <= uint(gs.Device[i].UsedNum) {
 				continue
 			}
@@ -408,6 +437,11 @@ func checkNodeGPUSharingPredicateAndScore(pod *v1.Pod, gssnap *GPUDevices, repli
 				klog.V(3).Info(gs.Device[i].ID, "not fit")
 				continue
 			}
+			tentativeAllocs = append(tentativeAllocs, tentativeAlloc{
+				device: gs.Device[i],
+				mem:    memreqForCard,
+				core:   uint(val.Coresreq),
+			})
 			//total += gs.Devices[i].Count
 			//free += node.Devices[i].Count - node.Devices[i].Used
 			if val.Nums > 0 {
@@ -426,6 +460,7 @@ func checkNodeGPUSharingPredicateAndScore(pod *v1.Pod, gssnap *GPUDevices, repli
 			}
 		}
 		if val.Nums > 0 {
+			rollbackTentative(tentativeAllocs)
 			return false, []ContainerDevices{}, 0, fmt.Errorf("not enough gpu fitted on this node")
 		}
 		ctrdevs = append(ctrdevs, devs)

--- a/pkg/scheduler/api/node_info.go
+++ b/pkg/scheduler/api/node_info.go
@@ -407,7 +407,6 @@ func (ni *NodeInfo) setNode(node *v1.Node) {
 			ni.allocateIdleResource(ti)
 			ni.Releasing.Add(ti.Resreq)
 			ni.Used.Add(ti.Resreq)
-			ni.addResource(ti.Pod)
 		case Pipelined:
 			ni.Pipelined.Add(ti.Resreq)
 		default:
@@ -455,7 +454,6 @@ func (ni *NodeInfo) AddTask(task *TaskInfo) error {
 			ni.allocateIdleResource(ti)
 			ni.Releasing.Add(ti.Resreq)
 			ni.Used.Add(ti.Resreq)
-			ni.addResource(ti.Pod)
 		case Pipelined:
 			ni.Pipelined.Add(ti.Resreq)
 		case Binding:
@@ -502,7 +500,6 @@ func (ni *NodeInfo) RemoveTask(ti *TaskInfo) {
 			ni.Releasing.Sub(task.Resreq)
 			ni.Idle.Add(task.Resreq)
 			ni.Used.Sub(task.Resreq)
-			ni.subResource(ti.Pod)
 		case Pipelined:
 			ni.Pipelined.Sub(task.Resreq)
 		default:
@@ -640,11 +637,15 @@ func (ni *NodeInfo) CloneImageSummary() map[string]*fwk.ImageStateSummary {
 	return nodeImageStates
 }
 
-// CloneOthers clone other map resources
+// CloneOthers clone other map resources using deepcopy
 func (ni *NodeInfo) CloneOthers() map[string]interface{} {
 	others := make(map[string]interface{})
 	for k, v := range ni.Others {
-		others[k] = v
+		if d, ok := v.(Devices); ok {
+			others[k] = d.DeepCopy()
+		} else {
+			others[k] = v
+		}
 	}
 	return others
 }

--- a/pkg/scheduler/api/shared_device_pool.go
+++ b/pkg/scheduler/api/shared_device_pool.go
@@ -74,6 +74,12 @@ type Devices interface {
 
 	// GetStatus used for debug and monitor
 	GetStatus() string
+
+	// DeepCopy returns a deep copy of this device object for use in dry-run
+	// simulation (e.g. topology-aware preemption).  The return type is
+	// interface{} to avoid circular imports: each device package does not
+	// import the top-level api package.
+	DeepCopy() interface{}
 }
 
 // make sure GPUDevices implements Devices interface

--- a/pkg/scheduler/plugins/deviceshare/gpuexclusive.go
+++ b/pkg/scheduler/plugins/deviceshare/gpuexclusive.go
@@ -385,6 +385,44 @@ func (a *exclusiveGPUDevices) GetStatus() string {
 	return a.inner.GetStatus()
 }
 
+// DeepCopy returns a deep copy of exclusiveGPUDevices for use in dry-run simulation.
+// cfg, plugin, and nodeName are configuration/references shared safely; only the
+// mutable tracking maps and inner device state are deep-copied.
+func (a *exclusiveGPUDevices) DeepCopy() interface{} {
+	if a == nil {
+		return nil
+	}
+	cp := &exclusiveGPUDevices{
+		cfg:      a.cfg,
+		nodeName: a.nodeName,
+		plugin:   a.plugin,
+		ruleGPUs: make(map[int]map[int]struct{}, len(a.ruleGPUs)),
+		podRules: make(map[string]map[int]struct{}, len(a.podRules)),
+		podUIDs:  make(map[string]string, len(a.podUIDs)),
+	}
+	for ruleIdx, gpuSet := range a.ruleGPUs {
+		newSet := make(map[int]struct{}, len(gpuSet))
+		for g := range gpuSet {
+			newSet[g] = struct{}{}
+		}
+		cp.ruleGPUs[ruleIdx] = newSet
+	}
+	for podKey, ruleSet := range a.podRules {
+		newSet := make(map[int]struct{}, len(ruleSet))
+		for r := range ruleSet {
+			newSet[r] = struct{}{}
+		}
+		cp.podRules[podKey] = newSet
+	}
+	for k, v := range a.podUIDs {
+		cp.podUIDs[k] = v
+	}
+	if a.inner != nil {
+		cp.inner = a.inner.DeepCopy().(*vgpu.GPUDevices)
+	}
+	return cp
+}
+
 // wrapGPUDevicesForExclusivity wraps each node's GPUDevices with the exclusivity-aware
 // wrapper during OnSessionOpen. Called from deviceshare's OnSessionOpen.
 func (dp *deviceSharePlugin) wrapGPUDevicesForExclusivity(ssn *framework.Session) {

--- a/pkg/scheduler/plugins/predicates/predicates.go
+++ b/pkg/scheduler/plugins/predicates/predicates.go
@@ -394,6 +394,28 @@ func (pp *PredicatesPlugin) OnSessionOpen(ssn *framework.Session) {
 				}
 			}
 		}
+
+		// Device-aware check: use FilterNode (pure read, no side effects) so that
+		// the topology-aware preemption dry-run correctly accounts for device
+		// availability after simulated victim removals.
+		for _, val := range api.RegisteredDevices {
+			devObj, ok := node.Others[val]
+			if !ok {
+				continue
+			}
+			devs, ok := devObj.(api.Devices)
+			if !ok {
+				continue
+			}
+			if !devs.HasDeviceRequest(task.Pod) {
+				continue
+			}
+			if code, msg, err := devs.FilterNode(task.Pod, ""); code != 0 || err != nil {
+				klog.Errorf("SimulatePredicate device %s FilterNode failed for task %s/%s on node %s: code=%d msg=%s err=%v",
+					val, task.Namespace, task.Name, node.Name, code, msg, err)
+				return fmt.Errorf("device %s cannot fit task %s/%s on node %s: %s", val, task.Namespace, task.Name, node.Name, msg)
+			}
+		}
 		return nil
 	})
 }


### PR DESCRIPTION
Fix issue: https://github.com/volcano-sh/volcano/issues/4863

This PR fixes:

1. Making preemption checks device-aware, preemption no longer relies only on scalar-resource fit to decide whether eviction is sufficient; it uses an allocate-equivalent predicate path to avoid stopping preemption too early.
2. Fixing vGPU allocate/release rollback consistency
3. Adjusting predicates callback behavior, avoids duplicate device allocation on task-restore paths(because the restored task is already in running state).