### PR TITLE
test(job/state): add unit tests for job controller state machine

### DIFF
--- a/pkg/controllers/job/state/aborted_test.go
+++ b/pkg/controllers/job/state/aborted_test.go
@@ -1,0 +1,250 @@
+/*
+Copyright 2024 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package state
+
+import (
+	"errors"
+	"testing"
+
+	vcbatch "volcano.sh/apis/pkg/apis/batch/v1alpha1"
+	"volcano.sh/apis/pkg/apis/bus/v1alpha1"
+
+	"volcano.sh/volcano/pkg/controllers/apis"
+)
+
+// capturedKillJob records one KillJob invocation and preserves the updateFn
+// so tests can invoke it directly to verify the state-transition logic.
+type capturedKillJob struct {
+	job            *apis.JobInfo
+	podRetainPhase PhaseMap
+	updateFn       UpdateStatusFn
+}
+
+// captureKillJob replaces KillJob with a stub that records its arguments and
+// returns returnErr. The original value is restored via t.Cleanup.
+func captureKillJob(t *testing.T, returnErr error) *capturedKillJob {
+	t.Helper()
+	original := KillJob
+	cap := &capturedKillJob{}
+	KillJob = func(job *apis.JobInfo, podRetainPhase PhaseMap, fn UpdateStatusFn) error {
+		cap.job = job
+		cap.podRetainPhase = podRetainPhase
+		cap.updateFn = fn
+		return returnErr
+	}
+	t.Cleanup(func() { KillJob = original })
+	return cap
+}
+
+// --- ResumeJobAction branch ---
+
+// TestAbortedState_Execute_ResumeCallsKillJob verifies that ResumeJobAction
+// delegates to KillJob (not SyncJob or KillTarget).
+func TestAbortedState_Execute_ResumeCallsKillJob(t *testing.T) {
+	cap := captureKillJob(t, nil)
+	s := &abortedState{job: makeJobInfo(vcbatch.Aborted)}
+
+	if err := s.Execute(Action{Action: v1alpha1.ResumeJobAction}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cap.job == nil {
+		t.Fatal("KillJob was not called")
+	}
+}
+
+// TestAbortedState_Execute_ResumeUsesSoftRetainPhase verifies that
+// ResumeJobAction retains Succeeded/Failed pods (soft, not none).
+func TestAbortedState_Execute_ResumeUsesSoftRetainPhase(t *testing.T) {
+	cap := captureKillJob(t, nil)
+	s := &abortedState{job: makeJobInfo(vcbatch.Aborted)}
+
+	if err := s.Execute(Action{Action: v1alpha1.ResumeJobAction}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for phase := range PodRetainPhaseSoft {
+		if _, ok := cap.podRetainPhase[phase]; !ok {
+			t.Errorf("podRetainPhase missing %q", phase)
+		}
+	}
+	if len(cap.podRetainPhase) != len(PodRetainPhaseSoft) {
+		t.Errorf("podRetainPhase has %d entries, want %d", len(cap.podRetainPhase), len(PodRetainPhaseSoft))
+	}
+}
+
+// TestAbortedState_Execute_ResumeUpdateFnSetsRestarting verifies the updateFn
+// passed by ResumeJobAction transitions the phase to Restarting.
+func TestAbortedState_Execute_ResumeUpdateFnSetsRestarting(t *testing.T) {
+	cap := captureKillJob(t, nil)
+	s := &abortedState{job: makeJobInfo(vcbatch.Aborted)}
+
+	if err := s.Execute(Action{Action: v1alpha1.ResumeJobAction}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cap.updateFn == nil {
+		t.Fatal("expected non-nil updateFn for ResumeJobAction")
+	}
+
+	status := &vcbatch.JobStatus{State: vcbatch.JobState{Phase: vcbatch.Aborted}}
+	changed := cap.updateFn(status)
+
+	if !changed {
+		t.Error("updateFn should return true (phase changed)")
+	}
+	if status.State.Phase != vcbatch.Restarting {
+		t.Errorf("phase = %q, want %q", status.State.Phase, vcbatch.Restarting)
+	}
+}
+
+// TestAbortedState_Execute_ResumeUpdateFnIncrementsRetryCount verifies the
+// updateFn increments RetryCount on each Resume.
+func TestAbortedState_Execute_ResumeUpdateFnIncrementsRetryCount(t *testing.T) {
+	tests := []struct {
+		name          string
+		initialRetry  int32
+		wantRetry     int32
+	}{
+		{"from zero", 0, 1},
+		{"from non-zero", 3, 4},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cap := captureKillJob(t, nil)
+			s := &abortedState{job: makeJobInfo(vcbatch.Aborted)}
+
+			if err := s.Execute(Action{Action: v1alpha1.ResumeJobAction}); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if cap.updateFn == nil {
+				t.Fatal("expected non-nil updateFn")
+			}
+
+			status := &vcbatch.JobStatus{RetryCount: tc.initialRetry}
+			cap.updateFn(status)
+
+			if status.RetryCount != tc.wantRetry {
+				t.Errorf("RetryCount = %d, want %d", status.RetryCount, tc.wantRetry)
+			}
+		})
+	}
+}
+
+// TestAbortedState_Execute_ResumePassesJobInfo verifies the correct JobInfo
+// pointer is forwarded to KillJob for ResumeJobAction.
+func TestAbortedState_Execute_ResumePassesJobInfo(t *testing.T) {
+	cap := captureKillJob(t, nil)
+	info := makeJobInfo(vcbatch.Aborted)
+	s := &abortedState{job: info}
+
+	if err := s.Execute(Action{Action: v1alpha1.ResumeJobAction}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cap.job != info {
+		t.Errorf("KillJob received wrong JobInfo: got %p, want %p", cap.job, info)
+	}
+}
+
+// TestAbortedState_Execute_ResumePropagatesError verifies that KillJob errors
+// are surfaced for ResumeJobAction.
+func TestAbortedState_Execute_ResumePropagatesError(t *testing.T) {
+	want := errors.New("kill failed")
+	captureKillJob(t, want)
+	s := &abortedState{job: makeJobInfo(vcbatch.Aborted)}
+
+	if got := s.Execute(Action{Action: v1alpha1.ResumeJobAction}); !errors.Is(got, want) {
+		t.Errorf("Execute returned %v, want %v", got, want)
+	}
+}
+
+// --- default branch (all non-Resume actions) ---
+
+// TestAbortedState_Execute_DefaultActionsCallKillJob verifies that every
+// non-Resume action also delegates to KillJob.
+func TestAbortedState_Execute_DefaultActionsCallKillJob(t *testing.T) {
+	defaultActions := []struct {
+		name   string
+		action v1alpha1.Action
+	}{
+		{"SyncJobAction", v1alpha1.SyncJobAction},
+		{"RestartJobAction", v1alpha1.RestartJobAction},
+		{"AbortJobAction", v1alpha1.AbortJobAction},
+		{"TerminateJobAction", v1alpha1.TerminateJobAction},
+		{"CompleteJobAction", v1alpha1.CompleteJobAction},
+		{"RestartTaskAction", v1alpha1.RestartTaskAction},
+		{"RestartPodAction", v1alpha1.RestartPodAction},
+		{"RestartPartitionAction", v1alpha1.RestartPartitionAction},
+		{"UnknownAction", v1alpha1.Action("Unknown")},
+	}
+
+	for _, tc := range defaultActions {
+		t.Run(tc.name, func(t *testing.T) {
+			cap := captureKillJob(t, nil)
+			s := &abortedState{job: makeJobInfo(vcbatch.Aborted)}
+
+			if err := s.Execute(Action{Action: tc.action}); err != nil {
+				t.Fatalf("Execute(%q) returned unexpected error: %v", tc.action, err)
+			}
+			if cap.job == nil {
+				t.Fatal("KillJob was not called")
+			}
+		})
+	}
+}
+
+// TestAbortedState_Execute_DefaultNilUpdateFn verifies that the default branch
+// passes a nil updateFn — it must not alter the job phase.
+func TestAbortedState_Execute_DefaultNilUpdateFn(t *testing.T) {
+	cap := captureKillJob(t, nil)
+	s := &abortedState{job: makeJobInfo(vcbatch.Aborted)}
+
+	if err := s.Execute(Action{Action: v1alpha1.SyncJobAction}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cap.updateFn != nil {
+		t.Error("default branch should pass nil updateFn to KillJob")
+	}
+}
+
+// TestAbortedState_Execute_DefaultUsesSoftRetainPhase verifies that the
+// default branch also retains Succeeded/Failed pods.
+func TestAbortedState_Execute_DefaultUsesSoftRetainPhase(t *testing.T) {
+	cap := captureKillJob(t, nil)
+	s := &abortedState{job: makeJobInfo(vcbatch.Aborted)}
+
+	if err := s.Execute(Action{Action: v1alpha1.SyncJobAction}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for phase := range PodRetainPhaseSoft {
+		if _, ok := cap.podRetainPhase[phase]; !ok {
+			t.Errorf("podRetainPhase missing %q", phase)
+		}
+	}
+	if len(cap.podRetainPhase) != len(PodRetainPhaseSoft) {
+		t.Errorf("podRetainPhase has %d entries, want %d", len(cap.podRetainPhase), len(PodRetainPhaseSoft))
+	}
+}
+
+// TestAbortedState_Execute_DefaultPropagatesError verifies that KillJob errors
+// are surfaced for default-branch actions.
+func TestAbortedState_Execute_DefaultPropagatesError(t *testing.T) {
+	want := errors.New("kill failed")
+	captureKillJob(t, want)
+	s := &abortedState{job: makeJobInfo(vcbatch.Aborted)}
+
+	if got := s.Execute(Action{Action: v1alpha1.SyncJobAction}); !errors.Is(got, want) {
+		t.Errorf("Execute returned %v, want %v", got, want)
+	}
+}

--- a/pkg/controllers/job/state/aborted_test.go
+++ b/pkg/controllers/job/state/aborted_test.go
@@ -39,15 +39,15 @@ type capturedKillJob struct {
 func captureKillJob(t *testing.T, returnErr error) *capturedKillJob {
 	t.Helper()
 	original := KillJob
-	cap := &capturedKillJob{}
+	c := &capturedKillJob{}
 	KillJob = func(job *apis.JobInfo, podRetainPhase PhaseMap, fn UpdateStatusFn) error {
-		cap.job = job
-		cap.podRetainPhase = podRetainPhase
-		cap.updateFn = fn
+		c.job = job
+		c.podRetainPhase = podRetainPhase
+		c.updateFn = fn
 		return returnErr
 	}
 	t.Cleanup(func() { KillJob = original })
-	return cap
+	return c
 }
 
 // --- ResumeJobAction branch ---
@@ -55,13 +55,13 @@ func captureKillJob(t *testing.T, returnErr error) *capturedKillJob {
 // TestAbortedState_Execute_ResumeCallsKillJob verifies that ResumeJobAction
 // delegates to KillJob (not SyncJob or KillTarget).
 func TestAbortedState_Execute_ResumeCallsKillJob(t *testing.T) {
-	cap := captureKillJob(t, nil)
+	c := captureKillJob(t, nil)
 	s := &abortedState{job: makeJobInfo(vcbatch.Aborted)}
 
 	if err := s.Execute(Action{Action: v1alpha1.ResumeJobAction}); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if cap.job == nil {
+	if c.job == nil {
 		t.Fatal("KillJob was not called")
 	}
 }
@@ -69,37 +69,37 @@ func TestAbortedState_Execute_ResumeCallsKillJob(t *testing.T) {
 // TestAbortedState_Execute_ResumeUsesSoftRetainPhase verifies that
 // ResumeJobAction retains Succeeded/Failed pods (soft, not none).
 func TestAbortedState_Execute_ResumeUsesSoftRetainPhase(t *testing.T) {
-	cap := captureKillJob(t, nil)
+	c := captureKillJob(t, nil)
 	s := &abortedState{job: makeJobInfo(vcbatch.Aborted)}
 
 	if err := s.Execute(Action{Action: v1alpha1.ResumeJobAction}); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	for phase := range PodRetainPhaseSoft {
-		if _, ok := cap.podRetainPhase[phase]; !ok {
+		if _, ok := c.podRetainPhase[phase]; !ok {
 			t.Errorf("podRetainPhase missing %q", phase)
 		}
 	}
-	if len(cap.podRetainPhase) != len(PodRetainPhaseSoft) {
-		t.Errorf("podRetainPhase has %d entries, want %d", len(cap.podRetainPhase), len(PodRetainPhaseSoft))
+	if len(c.podRetainPhase) != len(PodRetainPhaseSoft) {
+		t.Errorf("podRetainPhase has %d entries, want %d", len(c.podRetainPhase), len(PodRetainPhaseSoft))
 	}
 }
 
 // TestAbortedState_Execute_ResumeUpdateFnSetsRestarting verifies the updateFn
 // passed by ResumeJobAction transitions the phase to Restarting.
 func TestAbortedState_Execute_ResumeUpdateFnSetsRestarting(t *testing.T) {
-	cap := captureKillJob(t, nil)
+	c := captureKillJob(t, nil)
 	s := &abortedState{job: makeJobInfo(vcbatch.Aborted)}
 
 	if err := s.Execute(Action{Action: v1alpha1.ResumeJobAction}); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if cap.updateFn == nil {
+	if c.updateFn == nil {
 		t.Fatal("expected non-nil updateFn for ResumeJobAction")
 	}
 
 	status := &vcbatch.JobStatus{State: vcbatch.JobState{Phase: vcbatch.Aborted}}
-	changed := cap.updateFn(status)
+	changed := c.updateFn(status)
 
 	if !changed {
 		t.Error("updateFn should return true (phase changed)")
@@ -122,18 +122,18 @@ func TestAbortedState_Execute_ResumeUpdateFnIncrementsRetryCount(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			cap := captureKillJob(t, nil)
+			c := captureKillJob(t, nil)
 			s := &abortedState{job: makeJobInfo(vcbatch.Aborted)}
 
 			if err := s.Execute(Action{Action: v1alpha1.ResumeJobAction}); err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
-			if cap.updateFn == nil {
+			if c.updateFn == nil {
 				t.Fatal("expected non-nil updateFn")
 			}
 
 			status := &vcbatch.JobStatus{RetryCount: tc.initialRetry}
-			cap.updateFn(status)
+			c.updateFn(status)
 
 			if status.RetryCount != tc.wantRetry {
 				t.Errorf("RetryCount = %d, want %d", status.RetryCount, tc.wantRetry)
@@ -145,15 +145,15 @@ func TestAbortedState_Execute_ResumeUpdateFnIncrementsRetryCount(t *testing.T) {
 // TestAbortedState_Execute_ResumePassesJobInfo verifies the correct JobInfo
 // pointer is forwarded to KillJob for ResumeJobAction.
 func TestAbortedState_Execute_ResumePassesJobInfo(t *testing.T) {
-	cap := captureKillJob(t, nil)
+	c := captureKillJob(t, nil)
 	info := makeJobInfo(vcbatch.Aborted)
 	s := &abortedState{job: info}
 
 	if err := s.Execute(Action{Action: v1alpha1.ResumeJobAction}); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if cap.job != info {
-		t.Errorf("KillJob received wrong JobInfo: got %p, want %p", cap.job, info)
+	if c.job != info {
+		t.Errorf("KillJob received wrong JobInfo: got %p, want %p", c.job, info)
 	}
 }
 
@@ -191,13 +191,13 @@ func TestAbortedState_Execute_DefaultActionsCallKillJob(t *testing.T) {
 
 	for _, tc := range defaultActions {
 		t.Run(tc.name, func(t *testing.T) {
-			cap := captureKillJob(t, nil)
+			c := captureKillJob(t, nil)
 			s := &abortedState{job: makeJobInfo(vcbatch.Aborted)}
 
 			if err := s.Execute(Action{Action: tc.action}); err != nil {
 				t.Fatalf("Execute(%q) returned unexpected error: %v", tc.action, err)
 			}
-			if cap.job == nil {
+			if c.job == nil {
 				t.Fatal("KillJob was not called")
 			}
 		})
@@ -207,13 +207,13 @@ func TestAbortedState_Execute_DefaultActionsCallKillJob(t *testing.T) {
 // TestAbortedState_Execute_DefaultNilUpdateFn verifies that the default branch
 // passes a nil updateFn — it must not alter the job phase.
 func TestAbortedState_Execute_DefaultNilUpdateFn(t *testing.T) {
-	cap := captureKillJob(t, nil)
+	c := captureKillJob(t, nil)
 	s := &abortedState{job: makeJobInfo(vcbatch.Aborted)}
 
 	if err := s.Execute(Action{Action: v1alpha1.SyncJobAction}); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if cap.updateFn != nil {
+	if c.updateFn != nil {
 		t.Error("default branch should pass nil updateFn to KillJob")
 	}
 }
@@ -221,19 +221,19 @@ func TestAbortedState_Execute_DefaultNilUpdateFn(t *testing.T) {
 // TestAbortedState_Execute_DefaultUsesSoftRetainPhase verifies that the
 // default branch also retains Succeeded/Failed pods.
 func TestAbortedState_Execute_DefaultUsesSoftRetainPhase(t *testing.T) {
-	cap := captureKillJob(t, nil)
+	c := captureKillJob(t, nil)
 	s := &abortedState{job: makeJobInfo(vcbatch.Aborted)}
 
 	if err := s.Execute(Action{Action: v1alpha1.SyncJobAction}); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	for phase := range PodRetainPhaseSoft {
-		if _, ok := cap.podRetainPhase[phase]; !ok {
+		if _, ok := c.podRetainPhase[phase]; !ok {
 			t.Errorf("podRetainPhase missing %q", phase)
 		}
 	}
-	if len(cap.podRetainPhase) != len(PodRetainPhaseSoft) {
-		t.Errorf("podRetainPhase has %d entries, want %d", len(cap.podRetainPhase), len(PodRetainPhaseSoft))
+	if len(c.podRetainPhase) != len(PodRetainPhaseSoft) {
+		t.Errorf("podRetainPhase has %d entries, want %d", len(c.podRetainPhase), len(PodRetainPhaseSoft))
 	}
 }
 

--- a/pkg/controllers/job/state/aborted_test.go
+++ b/pkg/controllers/job/state/aborted_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Volcano Authors.
+Copyright 2017 The Volcano Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -22,38 +22,8 @@ import (
 
 	vcbatch "volcano.sh/apis/pkg/apis/batch/v1alpha1"
 	"volcano.sh/apis/pkg/apis/bus/v1alpha1"
-
-	"volcano.sh/volcano/pkg/controllers/apis"
 )
 
-// capturedKillJob records one KillJob invocation and preserves the updateFn
-// so tests can invoke it directly to verify the state-transition logic.
-type capturedKillJob struct {
-	job            *apis.JobInfo
-	podRetainPhase PhaseMap
-	updateFn       UpdateStatusFn
-}
-
-// captureKillJob replaces KillJob with a stub that records its arguments and
-// returns returnErr. The original value is restored via t.Cleanup.
-func captureKillJob(t *testing.T, returnErr error) *capturedKillJob {
-	t.Helper()
-	original := KillJob
-	c := &capturedKillJob{}
-	KillJob = func(job *apis.JobInfo, podRetainPhase PhaseMap, fn UpdateStatusFn) error {
-		c.job = job
-		c.podRetainPhase = podRetainPhase
-		c.updateFn = fn
-		return returnErr
-	}
-	t.Cleanup(func() { KillJob = original })
-	return c
-}
-
-// --- ResumeJobAction branch ---
-
-// TestAbortedState_Execute_ResumeCallsKillJob verifies that ResumeJobAction
-// delegates to KillJob (not SyncJob or KillTarget).
 func TestAbortedState_Execute_ResumeCallsKillJob(t *testing.T) {
 	c := captureKillJob(t, nil)
 	s := &abortedState{job: makeJobInfo(vcbatch.Aborted)}
@@ -66,8 +36,6 @@ func TestAbortedState_Execute_ResumeCallsKillJob(t *testing.T) {
 	}
 }
 
-// TestAbortedState_Execute_ResumeUsesSoftRetainPhase verifies that
-// ResumeJobAction retains Succeeded/Failed pods (soft, not none).
 func TestAbortedState_Execute_ResumeUsesSoftRetainPhase(t *testing.T) {
 	c := captureKillJob(t, nil)
 	s := &abortedState{job: makeJobInfo(vcbatch.Aborted)}
@@ -85,8 +53,6 @@ func TestAbortedState_Execute_ResumeUsesSoftRetainPhase(t *testing.T) {
 	}
 }
 
-// TestAbortedState_Execute_ResumeUpdateFnSetsRestarting verifies the updateFn
-// passed by ResumeJobAction transitions the phase to Restarting.
 func TestAbortedState_Execute_ResumeUpdateFnSetsRestarting(t *testing.T) {
 	c := captureKillJob(t, nil)
 	s := &abortedState{job: makeJobInfo(vcbatch.Aborted)}
@@ -109,8 +75,6 @@ func TestAbortedState_Execute_ResumeUpdateFnSetsRestarting(t *testing.T) {
 	}
 }
 
-// TestAbortedState_Execute_ResumeUpdateFnIncrementsRetryCount verifies the
-// updateFn increments RetryCount on each Resume.
 func TestAbortedState_Execute_ResumeUpdateFnIncrementsRetryCount(t *testing.T) {
 	tests := []struct {
 		name         string
@@ -142,8 +106,6 @@ func TestAbortedState_Execute_ResumeUpdateFnIncrementsRetryCount(t *testing.T) {
 	}
 }
 
-// TestAbortedState_Execute_ResumePassesJobInfo verifies the correct JobInfo
-// pointer is forwarded to KillJob for ResumeJobAction.
 func TestAbortedState_Execute_ResumePassesJobInfo(t *testing.T) {
 	c := captureKillJob(t, nil)
 	info := makeJobInfo(vcbatch.Aborted)
@@ -157,8 +119,6 @@ func TestAbortedState_Execute_ResumePassesJobInfo(t *testing.T) {
 	}
 }
 
-// TestAbortedState_Execute_ResumePropagatesError verifies that KillJob errors
-// are surfaced for ResumeJobAction.
 func TestAbortedState_Execute_ResumePropagatesError(t *testing.T) {
 	want := errors.New("kill failed")
 	captureKillJob(t, want)
@@ -169,10 +129,6 @@ func TestAbortedState_Execute_ResumePropagatesError(t *testing.T) {
 	}
 }
 
-// --- default branch (all non-Resume actions) ---
-
-// TestAbortedState_Execute_DefaultActionsCallKillJob verifies that every
-// non-Resume action also delegates to KillJob.
 func TestAbortedState_Execute_DefaultActionsCallKillJob(t *testing.T) {
 	defaultActions := []struct {
 		name   string
@@ -204,8 +160,7 @@ func TestAbortedState_Execute_DefaultActionsCallKillJob(t *testing.T) {
 	}
 }
 
-// TestAbortedState_Execute_DefaultNilUpdateFn verifies that the default branch
-// passes a nil updateFn — it must not alter the job phase.
+// Default branch must pass nil updateFn so KillJob does not change the phase.
 func TestAbortedState_Execute_DefaultNilUpdateFn(t *testing.T) {
 	c := captureKillJob(t, nil)
 	s := &abortedState{job: makeJobInfo(vcbatch.Aborted)}
@@ -218,8 +173,6 @@ func TestAbortedState_Execute_DefaultNilUpdateFn(t *testing.T) {
 	}
 }
 
-// TestAbortedState_Execute_DefaultUsesSoftRetainPhase verifies that the
-// default branch also retains Succeeded/Failed pods.
 func TestAbortedState_Execute_DefaultUsesSoftRetainPhase(t *testing.T) {
 	c := captureKillJob(t, nil)
 	s := &abortedState{job: makeJobInfo(vcbatch.Aborted)}
@@ -237,8 +190,6 @@ func TestAbortedState_Execute_DefaultUsesSoftRetainPhase(t *testing.T) {
 	}
 }
 
-// TestAbortedState_Execute_DefaultPropagatesError verifies that KillJob errors
-// are surfaced for default-branch actions.
 func TestAbortedState_Execute_DefaultPropagatesError(t *testing.T) {
 	want := errors.New("kill failed")
 	captureKillJob(t, want)

--- a/pkg/controllers/job/state/aborted_test.go
+++ b/pkg/controllers/job/state/aborted_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2024 The Volcano Authors.
+Copyright 2026 The Volcano Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -113,9 +113,9 @@ func TestAbortedState_Execute_ResumeUpdateFnSetsRestarting(t *testing.T) {
 // updateFn increments RetryCount on each Resume.
 func TestAbortedState_Execute_ResumeUpdateFnIncrementsRetryCount(t *testing.T) {
 	tests := []struct {
-		name          string
-		initialRetry  int32
-		wantRetry     int32
+		name         string
+		initialRetry int32
+		wantRetry    int32
 	}{
 		{"from zero", 0, 1},
 		{"from non-zero", 3, 4},

--- a/pkg/controllers/job/state/aborting_test.go
+++ b/pkg/controllers/job/state/aborting_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Volcano Authors.
+Copyright 2017 The Volcano Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -24,10 +24,6 @@ import (
 	"volcano.sh/apis/pkg/apis/bus/v1alpha1"
 )
 
-// --- ResumeJobAction branch ---
-
-// TestAbortingState_Execute_ResumeCallsKillJob verifies that ResumeJobAction
-// delegates to KillJob.
 func TestAbortingState_Execute_ResumeCallsKillJob(t *testing.T) {
 	c := captureKillJob(t, nil)
 	s := &abortingState{job: makeJobInfo(vcbatch.Aborting)}
@@ -40,8 +36,6 @@ func TestAbortingState_Execute_ResumeCallsKillJob(t *testing.T) {
 	}
 }
 
-// TestAbortingState_Execute_ResumeUsesSoftRetainPhase verifies that
-// ResumeJobAction passes PodRetainPhaseSoft to KillJob.
 func TestAbortingState_Execute_ResumeUsesSoftRetainPhase(t *testing.T) {
 	c := captureKillJob(t, nil)
 	s := &abortingState{job: makeJobInfo(vcbatch.Aborting)}
@@ -59,8 +53,6 @@ func TestAbortingState_Execute_ResumeUsesSoftRetainPhase(t *testing.T) {
 	}
 }
 
-// TestAbortingState_Execute_ResumeUpdateFnSetsRestarting verifies the
-// updateFn transitions the phase to Restarting and returns true.
 func TestAbortingState_Execute_ResumeUpdateFnSetsRestarting(t *testing.T) {
 	c := captureKillJob(t, nil)
 	s := &abortingState{job: makeJobInfo(vcbatch.Aborting)}
@@ -83,8 +75,6 @@ func TestAbortingState_Execute_ResumeUpdateFnSetsRestarting(t *testing.T) {
 	}
 }
 
-// TestAbortingState_Execute_ResumeUpdateFnIncrementsRetryCount verifies the
-// updateFn increments RetryCount on each Resume.
 func TestAbortingState_Execute_ResumeUpdateFnIncrementsRetryCount(t *testing.T) {
 	tests := []struct {
 		name         string
@@ -116,8 +106,6 @@ func TestAbortingState_Execute_ResumeUpdateFnIncrementsRetryCount(t *testing.T) 
 	}
 }
 
-// TestAbortingState_Execute_ResumePassesJobInfo verifies the correct JobInfo
-// pointer is forwarded to KillJob for ResumeJobAction.
 func TestAbortingState_Execute_ResumePassesJobInfo(t *testing.T) {
 	c := captureKillJob(t, nil)
 	info := makeJobInfo(vcbatch.Aborting)
@@ -131,8 +119,6 @@ func TestAbortingState_Execute_ResumePassesJobInfo(t *testing.T) {
 	}
 }
 
-// TestAbortingState_Execute_ResumePropagatesError verifies that KillJob errors
-// are surfaced for ResumeJobAction.
 func TestAbortingState_Execute_ResumePropagatesError(t *testing.T) {
 	want := errors.New("kill failed")
 	captureKillJob(t, want)
@@ -143,10 +129,6 @@ func TestAbortingState_Execute_ResumePropagatesError(t *testing.T) {
 	}
 }
 
-// --- default branch (all non-Resume actions) ---
-
-// TestAbortingState_Execute_DefaultActionsCallKillJob verifies that every
-// non-Resume action delegates to KillJob.
 func TestAbortingState_Execute_DefaultActionsCallKillJob(t *testing.T) {
 	defaultActions := []struct {
 		name   string
@@ -178,8 +160,6 @@ func TestAbortingState_Execute_DefaultActionsCallKillJob(t *testing.T) {
 	}
 }
 
-// TestAbortingState_Execute_DefaultUsesSoftRetainPhase verifies the default
-// branch also passes PodRetainPhaseSoft to KillJob.
 func TestAbortingState_Execute_DefaultUsesSoftRetainPhase(t *testing.T) {
 	c := captureKillJob(t, nil)
 	s := &abortingState{job: makeJobInfo(vcbatch.Aborting)}
@@ -197,8 +177,8 @@ func TestAbortingState_Execute_DefaultUsesSoftRetainPhase(t *testing.T) {
 	}
 }
 
-// TestAbortingState_Execute_DefaultNonNilUpdateFn verifies the default branch
-// passes a non-nil updateFn (unlike abortedState which passes nil).
+// abortingState (unlike abortedState) drives a phase transition, so updateFn
+// cannot be nil.
 func TestAbortingState_Execute_DefaultNonNilUpdateFn(t *testing.T) {
 	c := captureKillJob(t, nil)
 	s := &abortingState{job: makeJobInfo(vcbatch.Aborting)}
@@ -211,9 +191,8 @@ func TestAbortingState_Execute_DefaultNonNilUpdateFn(t *testing.T) {
 	}
 }
 
-// TestAbortingState_Execute_DefaultUpdateFnAlivePods verifies that the default
-// updateFn returns false and keeps the phase unchanged while any "alive" pod
-// counter (Terminating, Pending, or Running) is non-zero.
+// "Alive" counters = Terminating | Pending | Running. Any of them being
+// non-zero must keep the job in Aborting.
 func TestAbortingState_Execute_DefaultUpdateFnAlivePods(t *testing.T) {
 	tests := []struct {
 		name   string
@@ -267,9 +246,6 @@ func TestAbortingState_Execute_DefaultUpdateFnAlivePods(t *testing.T) {
 	}
 }
 
-// TestAbortingState_Execute_DefaultUpdateFnAllPodsGone verifies that the
-// default updateFn returns true and transitions the phase to Aborted when all
-// alive pod counters are zero.
 func TestAbortingState_Execute_DefaultUpdateFnAllPodsGone(t *testing.T) {
 	tests := []struct {
 		name   string
@@ -312,8 +288,6 @@ func TestAbortingState_Execute_DefaultUpdateFnAllPodsGone(t *testing.T) {
 	}
 }
 
-// TestAbortingState_Execute_DefaultPropagatesError verifies that KillJob
-// errors are surfaced for default-branch actions.
 func TestAbortingState_Execute_DefaultPropagatesError(t *testing.T) {
 	want := errors.New("kill failed")
 	captureKillJob(t, want)

--- a/pkg/controllers/job/state/aborting_test.go
+++ b/pkg/controllers/job/state/aborting_test.go
@@ -1,0 +1,329 @@
+/*
+Copyright 2024 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package state
+
+import (
+	"errors"
+	"testing"
+
+	vcbatch "volcano.sh/apis/pkg/apis/batch/v1alpha1"
+	"volcano.sh/apis/pkg/apis/bus/v1alpha1"
+)
+
+// ═══════════════════════════════════════════════════════════
+// ResumeJobAction branch
+// ═══════════════════════════════════════════════════════════
+
+// TestAbortingState_Execute_ResumeCallsKillJob verifies that ResumeJobAction
+// delegates to KillJob.
+func TestAbortingState_Execute_ResumeCallsKillJob(t *testing.T) {
+	cap := captureKillJob(t, nil)
+	s := &abortingState{job: makeJobInfo(vcbatch.Aborting)}
+
+	if err := s.Execute(Action{Action: v1alpha1.ResumeJobAction}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cap.job == nil {
+		t.Fatal("KillJob was not called")
+	}
+}
+
+// TestAbortingState_Execute_ResumeUsesSoftRetainPhase verifies that
+// ResumeJobAction passes PodRetainPhaseSoft to KillJob.
+func TestAbortingState_Execute_ResumeUsesSoftRetainPhase(t *testing.T) {
+	cap := captureKillJob(t, nil)
+	s := &abortingState{job: makeJobInfo(vcbatch.Aborting)}
+
+	if err := s.Execute(Action{Action: v1alpha1.ResumeJobAction}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for phase := range PodRetainPhaseSoft {
+		if _, ok := cap.podRetainPhase[phase]; !ok {
+			t.Errorf("podRetainPhase missing %q", phase)
+		}
+	}
+	if len(cap.podRetainPhase) != len(PodRetainPhaseSoft) {
+		t.Errorf("podRetainPhase has %d entries, want %d", len(cap.podRetainPhase), len(PodRetainPhaseSoft))
+	}
+}
+
+// TestAbortingState_Execute_ResumeUpdateFnSetsRestarting verifies the
+// updateFn transitions the phase to Restarting and returns true.
+func TestAbortingState_Execute_ResumeUpdateFnSetsRestarting(t *testing.T) {
+	cap := captureKillJob(t, nil)
+	s := &abortingState{job: makeJobInfo(vcbatch.Aborting)}
+
+	if err := s.Execute(Action{Action: v1alpha1.ResumeJobAction}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cap.updateFn == nil {
+		t.Fatal("expected non-nil updateFn for ResumeJobAction")
+	}
+
+	status := &vcbatch.JobStatus{State: vcbatch.JobState{Phase: vcbatch.Aborting}}
+	changed := cap.updateFn(status)
+
+	if !changed {
+		t.Error("updateFn should return true")
+	}
+	if status.State.Phase != vcbatch.Restarting {
+		t.Errorf("phase = %q, want %q", status.State.Phase, vcbatch.Restarting)
+	}
+}
+
+// TestAbortingState_Execute_ResumeUpdateFnIncrementsRetryCount verifies the
+// updateFn increments RetryCount on each Resume.
+func TestAbortingState_Execute_ResumeUpdateFnIncrementsRetryCount(t *testing.T) {
+	tests := []struct {
+		name         string
+		initialRetry int32
+		wantRetry    int32
+	}{
+		{"from zero", 0, 1},
+		{"from non-zero", 5, 6},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cap := captureKillJob(t, nil)
+			s := &abortingState{job: makeJobInfo(vcbatch.Aborting)}
+
+			if err := s.Execute(Action{Action: v1alpha1.ResumeJobAction}); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if cap.updateFn == nil {
+				t.Fatal("expected non-nil updateFn")
+			}
+
+			status := &vcbatch.JobStatus{RetryCount: tc.initialRetry}
+			cap.updateFn(status)
+
+			if status.RetryCount != tc.wantRetry {
+				t.Errorf("RetryCount = %d, want %d", status.RetryCount, tc.wantRetry)
+			}
+		})
+	}
+}
+
+// TestAbortingState_Execute_ResumePassesJobInfo verifies the correct JobInfo
+// pointer is forwarded to KillJob for ResumeJobAction.
+func TestAbortingState_Execute_ResumePassesJobInfo(t *testing.T) {
+	cap := captureKillJob(t, nil)
+	info := makeJobInfo(vcbatch.Aborting)
+	s := &abortingState{job: info}
+
+	if err := s.Execute(Action{Action: v1alpha1.ResumeJobAction}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cap.job != info {
+		t.Errorf("KillJob received wrong JobInfo: got %p, want %p", cap.job, info)
+	}
+}
+
+// TestAbortingState_Execute_ResumePropagatesError verifies that KillJob errors
+// are surfaced for ResumeJobAction.
+func TestAbortingState_Execute_ResumePropagatesError(t *testing.T) {
+	want := errors.New("kill failed")
+	captureKillJob(t, want)
+	s := &abortingState{job: makeJobInfo(vcbatch.Aborting)}
+
+	if got := s.Execute(Action{Action: v1alpha1.ResumeJobAction}); !errors.Is(got, want) {
+		t.Errorf("Execute returned %v, want %v", got, want)
+	}
+}
+
+// ═══════════════════════════════════════════════════════════
+// default branch (all non-Resume actions)
+// ═══════════════════════════════════════════════════════════
+
+// TestAbortingState_Execute_DefaultActionsCallKillJob verifies that every
+// non-Resume action delegates to KillJob.
+func TestAbortingState_Execute_DefaultActionsCallKillJob(t *testing.T) {
+	defaultActions := []struct {
+		name   string
+		action v1alpha1.Action
+	}{
+		{"SyncJobAction", v1alpha1.SyncJobAction},
+		{"RestartJobAction", v1alpha1.RestartJobAction},
+		{"AbortJobAction", v1alpha1.AbortJobAction},
+		{"TerminateJobAction", v1alpha1.TerminateJobAction},
+		{"CompleteJobAction", v1alpha1.CompleteJobAction},
+		{"RestartTaskAction", v1alpha1.RestartTaskAction},
+		{"RestartPodAction", v1alpha1.RestartPodAction},
+		{"RestartPartitionAction", v1alpha1.RestartPartitionAction},
+		{"UnknownAction", v1alpha1.Action("Unknown")},
+	}
+
+	for _, tc := range defaultActions {
+		t.Run(tc.name, func(t *testing.T) {
+			cap := captureKillJob(t, nil)
+			s := &abortingState{job: makeJobInfo(vcbatch.Aborting)}
+
+			if err := s.Execute(Action{Action: tc.action}); err != nil {
+				t.Fatalf("Execute(%q) returned unexpected error: %v", tc.action, err)
+			}
+			if cap.job == nil {
+				t.Fatal("KillJob was not called")
+			}
+		})
+	}
+}
+
+// TestAbortingState_Execute_DefaultUsesSoftRetainPhase verifies the default
+// branch also passes PodRetainPhaseSoft to KillJob.
+func TestAbortingState_Execute_DefaultUsesSoftRetainPhase(t *testing.T) {
+	cap := captureKillJob(t, nil)
+	s := &abortingState{job: makeJobInfo(vcbatch.Aborting)}
+
+	if err := s.Execute(Action{Action: v1alpha1.SyncJobAction}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for phase := range PodRetainPhaseSoft {
+		if _, ok := cap.podRetainPhase[phase]; !ok {
+			t.Errorf("podRetainPhase missing %q", phase)
+		}
+	}
+	if len(cap.podRetainPhase) != len(PodRetainPhaseSoft) {
+		t.Errorf("podRetainPhase has %d entries, want %d", len(cap.podRetainPhase), len(PodRetainPhaseSoft))
+	}
+}
+
+// TestAbortingState_Execute_DefaultNonNilUpdateFn verifies the default branch
+// passes a non-nil updateFn (unlike abortedState which passes nil).
+func TestAbortingState_Execute_DefaultNonNilUpdateFn(t *testing.T) {
+	cap := captureKillJob(t, nil)
+	s := &abortingState{job: makeJobInfo(vcbatch.Aborting)}
+
+	if err := s.Execute(Action{Action: v1alpha1.SyncJobAction}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cap.updateFn == nil {
+		t.Error("default branch updateFn must not be nil for abortingState")
+	}
+}
+
+// TestAbortingState_Execute_DefaultUpdateFnAlivePods verifies that the default
+// updateFn returns false and keeps the phase unchanged while any "alive" pod
+// counter (Terminating, Pending, or Running) is non-zero.
+func TestAbortingState_Execute_DefaultUpdateFnAlivePods(t *testing.T) {
+	tests := []struct {
+		name   string
+		status vcbatch.JobStatus
+	}{
+		{
+			name:   "only Terminating pods remain",
+			status: vcbatch.JobStatus{Terminating: 1},
+		},
+		{
+			name:   "only Pending pods remain",
+			status: vcbatch.JobStatus{Pending: 1},
+		},
+		{
+			name:   "only Running pods remain",
+			status: vcbatch.JobStatus{Running: 1},
+		},
+		{
+			name:   "all three counters non-zero",
+			status: vcbatch.JobStatus{Terminating: 2, Pending: 3, Running: 1},
+		},
+		{
+			name:   "Terminating and Pending non-zero",
+			status: vcbatch.JobStatus{Terminating: 1, Pending: 1},
+		},
+		{
+			name:   "Pending and Running non-zero",
+			status: vcbatch.JobStatus{Pending: 1, Running: 1},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cap := captureKillJob(t, nil)
+			s := &abortingState{job: makeJobInfo(vcbatch.Aborting)}
+
+			if err := s.Execute(Action{Action: v1alpha1.SyncJobAction}); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			originalPhase := tc.status.State.Phase
+			changed := cap.updateFn(&tc.status)
+
+			if changed {
+				t.Error("updateFn should return false while alive pods exist")
+			}
+			if tc.status.State.Phase != originalPhase {
+				t.Errorf("phase should not change: got %q, want %q", tc.status.State.Phase, originalPhase)
+			}
+		})
+	}
+}
+
+// TestAbortingState_Execute_DefaultUpdateFnAllPodsGone verifies that the
+// default updateFn returns true and transitions the phase to Aborted when all
+// alive pod counters are zero.
+func TestAbortingState_Execute_DefaultUpdateFnAllPodsGone(t *testing.T) {
+	tests := []struct {
+		name   string
+		status vcbatch.JobStatus
+	}{
+		{
+			name:   "all counters zero",
+			status: vcbatch.JobStatus{Terminating: 0, Pending: 0, Running: 0},
+		},
+		{
+			name: "has Succeeded and Failed but no alive pods",
+			status: vcbatch.JobStatus{
+				Terminating: 0,
+				Pending:     0,
+				Running:     0,
+				Succeeded:   3,
+				Failed:      1,
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cap := captureKillJob(t, nil)
+			s := &abortingState{job: makeJobInfo(vcbatch.Aborting)}
+
+			if err := s.Execute(Action{Action: v1alpha1.SyncJobAction}); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			changed := cap.updateFn(&tc.status)
+
+			if !changed {
+				t.Error("updateFn should return true when no alive pods remain")
+			}
+			if tc.status.State.Phase != vcbatch.Aborted {
+				t.Errorf("phase = %q, want %q", tc.status.State.Phase, vcbatch.Aborted)
+			}
+		})
+	}
+}
+
+// TestAbortingState_Execute_DefaultPropagatesError verifies that KillJob
+// errors are surfaced for default-branch actions.
+func TestAbortingState_Execute_DefaultPropagatesError(t *testing.T) {
+	want := errors.New("kill failed")
+	captureKillJob(t, want)
+	s := &abortingState{job: makeJobInfo(vcbatch.Aborting)}
+
+	if got := s.Execute(Action{Action: v1alpha1.SyncJobAction}); !errors.Is(got, want) {
+		t.Errorf("Execute returned %v, want %v", got, want)
+	}
+}

--- a/pkg/controllers/job/state/aborting_test.go
+++ b/pkg/controllers/job/state/aborting_test.go
@@ -24,20 +24,18 @@ import (
 	"volcano.sh/apis/pkg/apis/bus/v1alpha1"
 )
 
-// ═══════════════════════════════════════════════════════════
-// ResumeJobAction branch
-// ═══════════════════════════════════════════════════════════
+// --- ResumeJobAction branch ---
 
 // TestAbortingState_Execute_ResumeCallsKillJob verifies that ResumeJobAction
 // delegates to KillJob.
 func TestAbortingState_Execute_ResumeCallsKillJob(t *testing.T) {
-	cap := captureKillJob(t, nil)
+	c := captureKillJob(t, nil)
 	s := &abortingState{job: makeJobInfo(vcbatch.Aborting)}
 
 	if err := s.Execute(Action{Action: v1alpha1.ResumeJobAction}); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if cap.job == nil {
+	if c.job == nil {
 		t.Fatal("KillJob was not called")
 	}
 }
@@ -45,37 +43,37 @@ func TestAbortingState_Execute_ResumeCallsKillJob(t *testing.T) {
 // TestAbortingState_Execute_ResumeUsesSoftRetainPhase verifies that
 // ResumeJobAction passes PodRetainPhaseSoft to KillJob.
 func TestAbortingState_Execute_ResumeUsesSoftRetainPhase(t *testing.T) {
-	cap := captureKillJob(t, nil)
+	c := captureKillJob(t, nil)
 	s := &abortingState{job: makeJobInfo(vcbatch.Aborting)}
 
 	if err := s.Execute(Action{Action: v1alpha1.ResumeJobAction}); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	for phase := range PodRetainPhaseSoft {
-		if _, ok := cap.podRetainPhase[phase]; !ok {
+		if _, ok := c.podRetainPhase[phase]; !ok {
 			t.Errorf("podRetainPhase missing %q", phase)
 		}
 	}
-	if len(cap.podRetainPhase) != len(PodRetainPhaseSoft) {
-		t.Errorf("podRetainPhase has %d entries, want %d", len(cap.podRetainPhase), len(PodRetainPhaseSoft))
+	if len(c.podRetainPhase) != len(PodRetainPhaseSoft) {
+		t.Errorf("podRetainPhase has %d entries, want %d", len(c.podRetainPhase), len(PodRetainPhaseSoft))
 	}
 }
 
 // TestAbortingState_Execute_ResumeUpdateFnSetsRestarting verifies the
 // updateFn transitions the phase to Restarting and returns true.
 func TestAbortingState_Execute_ResumeUpdateFnSetsRestarting(t *testing.T) {
-	cap := captureKillJob(t, nil)
+	c := captureKillJob(t, nil)
 	s := &abortingState{job: makeJobInfo(vcbatch.Aborting)}
 
 	if err := s.Execute(Action{Action: v1alpha1.ResumeJobAction}); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if cap.updateFn == nil {
+	if c.updateFn == nil {
 		t.Fatal("expected non-nil updateFn for ResumeJobAction")
 	}
 
 	status := &vcbatch.JobStatus{State: vcbatch.JobState{Phase: vcbatch.Aborting}}
-	changed := cap.updateFn(status)
+	changed := c.updateFn(status)
 
 	if !changed {
 		t.Error("updateFn should return true")
@@ -98,18 +96,18 @@ func TestAbortingState_Execute_ResumeUpdateFnIncrementsRetryCount(t *testing.T) 
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			cap := captureKillJob(t, nil)
+			c := captureKillJob(t, nil)
 			s := &abortingState{job: makeJobInfo(vcbatch.Aborting)}
 
 			if err := s.Execute(Action{Action: v1alpha1.ResumeJobAction}); err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
-			if cap.updateFn == nil {
+			if c.updateFn == nil {
 				t.Fatal("expected non-nil updateFn")
 			}
 
 			status := &vcbatch.JobStatus{RetryCount: tc.initialRetry}
-			cap.updateFn(status)
+			c.updateFn(status)
 
 			if status.RetryCount != tc.wantRetry {
 				t.Errorf("RetryCount = %d, want %d", status.RetryCount, tc.wantRetry)
@@ -121,15 +119,15 @@ func TestAbortingState_Execute_ResumeUpdateFnIncrementsRetryCount(t *testing.T) 
 // TestAbortingState_Execute_ResumePassesJobInfo verifies the correct JobInfo
 // pointer is forwarded to KillJob for ResumeJobAction.
 func TestAbortingState_Execute_ResumePassesJobInfo(t *testing.T) {
-	cap := captureKillJob(t, nil)
+	c := captureKillJob(t, nil)
 	info := makeJobInfo(vcbatch.Aborting)
 	s := &abortingState{job: info}
 
 	if err := s.Execute(Action{Action: v1alpha1.ResumeJobAction}); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if cap.job != info {
-		t.Errorf("KillJob received wrong JobInfo: got %p, want %p", cap.job, info)
+	if c.job != info {
+		t.Errorf("KillJob received wrong JobInfo: got %p, want %p", c.job, info)
 	}
 }
 
@@ -145,9 +143,7 @@ func TestAbortingState_Execute_ResumePropagatesError(t *testing.T) {
 	}
 }
 
-// ═══════════════════════════════════════════════════════════
-// default branch (all non-Resume actions)
-// ═══════════════════════════════════════════════════════════
+// --- default branch (all non-Resume actions) ---
 
 // TestAbortingState_Execute_DefaultActionsCallKillJob verifies that every
 // non-Resume action delegates to KillJob.
@@ -169,13 +165,13 @@ func TestAbortingState_Execute_DefaultActionsCallKillJob(t *testing.T) {
 
 	for _, tc := range defaultActions {
 		t.Run(tc.name, func(t *testing.T) {
-			cap := captureKillJob(t, nil)
+			c := captureKillJob(t, nil)
 			s := &abortingState{job: makeJobInfo(vcbatch.Aborting)}
 
 			if err := s.Execute(Action{Action: tc.action}); err != nil {
 				t.Fatalf("Execute(%q) returned unexpected error: %v", tc.action, err)
 			}
-			if cap.job == nil {
+			if c.job == nil {
 				t.Fatal("KillJob was not called")
 			}
 		})
@@ -185,32 +181,32 @@ func TestAbortingState_Execute_DefaultActionsCallKillJob(t *testing.T) {
 // TestAbortingState_Execute_DefaultUsesSoftRetainPhase verifies the default
 // branch also passes PodRetainPhaseSoft to KillJob.
 func TestAbortingState_Execute_DefaultUsesSoftRetainPhase(t *testing.T) {
-	cap := captureKillJob(t, nil)
+	c := captureKillJob(t, nil)
 	s := &abortingState{job: makeJobInfo(vcbatch.Aborting)}
 
 	if err := s.Execute(Action{Action: v1alpha1.SyncJobAction}); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	for phase := range PodRetainPhaseSoft {
-		if _, ok := cap.podRetainPhase[phase]; !ok {
+		if _, ok := c.podRetainPhase[phase]; !ok {
 			t.Errorf("podRetainPhase missing %q", phase)
 		}
 	}
-	if len(cap.podRetainPhase) != len(PodRetainPhaseSoft) {
-		t.Errorf("podRetainPhase has %d entries, want %d", len(cap.podRetainPhase), len(PodRetainPhaseSoft))
+	if len(c.podRetainPhase) != len(PodRetainPhaseSoft) {
+		t.Errorf("podRetainPhase has %d entries, want %d", len(c.podRetainPhase), len(PodRetainPhaseSoft))
 	}
 }
 
 // TestAbortingState_Execute_DefaultNonNilUpdateFn verifies the default branch
 // passes a non-nil updateFn (unlike abortedState which passes nil).
 func TestAbortingState_Execute_DefaultNonNilUpdateFn(t *testing.T) {
-	cap := captureKillJob(t, nil)
+	c := captureKillJob(t, nil)
 	s := &abortingState{job: makeJobInfo(vcbatch.Aborting)}
 
 	if err := s.Execute(Action{Action: v1alpha1.SyncJobAction}); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if cap.updateFn == nil {
+	if c.updateFn == nil {
 		t.Error("default branch updateFn must not be nil for abortingState")
 	}
 }
@@ -251,7 +247,7 @@ func TestAbortingState_Execute_DefaultUpdateFnAlivePods(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			cap := captureKillJob(t, nil)
+			c := captureKillJob(t, nil)
 			s := &abortingState{job: makeJobInfo(vcbatch.Aborting)}
 
 			if err := s.Execute(Action{Action: v1alpha1.SyncJobAction}); err != nil {
@@ -259,7 +255,7 @@ func TestAbortingState_Execute_DefaultUpdateFnAlivePods(t *testing.T) {
 			}
 
 			originalPhase := tc.status.State.Phase
-			changed := cap.updateFn(&tc.status)
+			changed := c.updateFn(&tc.status)
 
 			if changed {
 				t.Error("updateFn should return false while alive pods exist")
@@ -297,14 +293,14 @@ func TestAbortingState_Execute_DefaultUpdateFnAllPodsGone(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			cap := captureKillJob(t, nil)
+			c := captureKillJob(t, nil)
 			s := &abortingState{job: makeJobInfo(vcbatch.Aborting)}
 
 			if err := s.Execute(Action{Action: v1alpha1.SyncJobAction}); err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
 
-			changed := cap.updateFn(&tc.status)
+			changed := c.updateFn(&tc.status)
 
 			if !changed {
 				t.Error("updateFn should return true when no alive pods remain")

--- a/pkg/controllers/job/state/aborting_test.go
+++ b/pkg/controllers/job/state/aborting_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2024 The Volcano Authors.
+Copyright 2026 The Volcano Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/controllers/job/state/completing_test.go
+++ b/pkg/controllers/job/state/completing_test.go
@@ -24,7 +24,7 @@ import (
 	"volcano.sh/apis/pkg/apis/bus/v1alpha1"
 )
 
-// ── action-agnostic behaviour ────────────────────────────────────────────────
+// --- action-agnostic behaviour ---
 
 // TestCompletingState_Execute_ActionAgnostic verifies that Execute always
 // delegates to KillJob regardless of the action type received.
@@ -47,50 +47,50 @@ func TestCompletingState_Execute_ActionAgnostic(t *testing.T) {
 
 	for _, tc := range actions {
 		t.Run(tc.name, func(t *testing.T) {
-			cap := captureKillJob(t, nil)
+			c := captureKillJob(t, nil)
 			s := &completingState{job: makeJobInfo(vcbatch.Completing)}
 
 			if err := s.Execute(Action{Action: tc.action}); err != nil {
 				t.Fatalf("Execute(%q) returned unexpected error: %v", tc.action, err)
 			}
-			if cap.job == nil {
+			if c.job == nil {
 				t.Fatal("KillJob was not called")
 			}
 		})
 	}
 }
 
-// ── KillJob call arguments ───────────────────────────────────────────────────
+// --- KillJob call arguments ---
 
 // TestCompletingState_Execute_UsesSoftRetainPhase verifies that Execute passes
 // PodRetainPhaseSoft so Succeeded/Failed pods are preserved during draining.
 func TestCompletingState_Execute_UsesSoftRetainPhase(t *testing.T) {
-	cap := captureKillJob(t, nil)
+	c := captureKillJob(t, nil)
 	s := &completingState{job: makeJobInfo(vcbatch.Completing)}
 
 	if err := s.Execute(Action{Action: v1alpha1.SyncJobAction}); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	for phase := range PodRetainPhaseSoft {
-		if _, ok := cap.podRetainPhase[phase]; !ok {
+		if _, ok := c.podRetainPhase[phase]; !ok {
 			t.Errorf("podRetainPhase missing %q", phase)
 		}
 	}
-	if len(cap.podRetainPhase) != len(PodRetainPhaseSoft) {
-		t.Errorf("podRetainPhase has %d entries, want %d", len(cap.podRetainPhase), len(PodRetainPhaseSoft))
+	if len(c.podRetainPhase) != len(PodRetainPhaseSoft) {
+		t.Errorf("podRetainPhase has %d entries, want %d", len(c.podRetainPhase), len(PodRetainPhaseSoft))
 	}
 }
 
 // TestCompletingState_Execute_NonNilUpdateFn verifies the updateFn is not nil
 // — completingState drives a phase transition, unlike finishedState.
 func TestCompletingState_Execute_NonNilUpdateFn(t *testing.T) {
-	cap := captureKillJob(t, nil)
+	c := captureKillJob(t, nil)
 	s := &completingState{job: makeJobInfo(vcbatch.Completing)}
 
 	if err := s.Execute(Action{Action: v1alpha1.SyncJobAction}); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if cap.updateFn == nil {
+	if c.updateFn == nil {
 		t.Error("updateFn must not be nil for completingState")
 	}
 }
@@ -98,15 +98,15 @@ func TestCompletingState_Execute_NonNilUpdateFn(t *testing.T) {
 // TestCompletingState_Execute_PassesJobInfo verifies the correct JobInfo
 // pointer is forwarded to KillJob.
 func TestCompletingState_Execute_PassesJobInfo(t *testing.T) {
-	cap := captureKillJob(t, nil)
+	c := captureKillJob(t, nil)
 	info := makeJobInfo(vcbatch.Completing)
 	s := &completingState{job: info}
 
 	if err := s.Execute(Action{Action: v1alpha1.SyncJobAction}); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if cap.job != info {
-		t.Errorf("KillJob received wrong JobInfo: got %p, want %p", cap.job, info)
+	if c.job != info {
+		t.Errorf("KillJob received wrong JobInfo: got %p, want %p", c.job, info)
 	}
 }
 
@@ -122,7 +122,7 @@ func TestCompletingState_Execute_PropagatesError(t *testing.T) {
 	}
 }
 
-// ── updateFn: alive pods present → stay Completing ───────────────────────────
+// --- updateFn: alive pods present -> stay Completing ---
 
 // TestCompletingState_Execute_UpdateFnAlivePods verifies that the updateFn
 // returns false and leaves the phase unchanged whenever any "alive" pod counter
@@ -160,7 +160,7 @@ func TestCompletingState_Execute_UpdateFnAlivePods(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			cap := captureKillJob(t, nil)
+			c := captureKillJob(t, nil)
 			s := &completingState{job: makeJobInfo(vcbatch.Completing)}
 
 			if err := s.Execute(Action{Action: v1alpha1.SyncJobAction}); err != nil {
@@ -168,7 +168,7 @@ func TestCompletingState_Execute_UpdateFnAlivePods(t *testing.T) {
 			}
 
 			originalPhase := tc.status.State.Phase
-			changed := cap.updateFn(&tc.status)
+			changed := c.updateFn(&tc.status)
 
 			if changed {
 				t.Error("updateFn should return false while alive pods exist")
@@ -180,7 +180,7 @@ func TestCompletingState_Execute_UpdateFnAlivePods(t *testing.T) {
 	}
 }
 
-// ── updateFn: all alive pods drained → Completed ─────────────────────────────
+// --- updateFn: all alive pods drained -> Completed ---
 
 // TestCompletingState_Execute_UpdateFnAllPodsGone verifies that the updateFn
 // returns true and transitions the phase to Completed when all alive pod
@@ -209,14 +209,14 @@ func TestCompletingState_Execute_UpdateFnAllPodsGone(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			cap := captureKillJob(t, nil)
+			c := captureKillJob(t, nil)
 			s := &completingState{job: makeJobInfo(vcbatch.Completing)}
 
 			if err := s.Execute(Action{Action: v1alpha1.SyncJobAction}); err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
 
-			changed := cap.updateFn(&tc.status)
+			changed := c.updateFn(&tc.status)
 
 			if !changed {
 				t.Error("updateFn should return true when no alive pods remain")

--- a/pkg/controllers/job/state/completing_test.go
+++ b/pkg/controllers/job/state/completing_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Volcano Authors.
+Copyright 2017 The Volcano Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -24,10 +24,6 @@ import (
 	"volcano.sh/apis/pkg/apis/bus/v1alpha1"
 )
 
-// --- action-agnostic behaviour ---
-
-// TestCompletingState_Execute_ActionAgnostic verifies that Execute always
-// delegates to KillJob regardless of the action type received.
 func TestCompletingState_Execute_ActionAgnostic(t *testing.T) {
 	actions := []struct {
 		name   string
@@ -60,10 +56,6 @@ func TestCompletingState_Execute_ActionAgnostic(t *testing.T) {
 	}
 }
 
-// --- KillJob call arguments ---
-
-// TestCompletingState_Execute_UsesSoftRetainPhase verifies that Execute passes
-// PodRetainPhaseSoft so Succeeded/Failed pods are preserved during draining.
 func TestCompletingState_Execute_UsesSoftRetainPhase(t *testing.T) {
 	c := captureKillJob(t, nil)
 	s := &completingState{job: makeJobInfo(vcbatch.Completing)}
@@ -81,8 +73,8 @@ func TestCompletingState_Execute_UsesSoftRetainPhase(t *testing.T) {
 	}
 }
 
-// TestCompletingState_Execute_NonNilUpdateFn verifies the updateFn is not nil
-// — completingState drives a phase transition, unlike finishedState.
+// completingState (unlike finishedState) must drive a phase transition, so
+// updateFn cannot be nil.
 func TestCompletingState_Execute_NonNilUpdateFn(t *testing.T) {
 	c := captureKillJob(t, nil)
 	s := &completingState{job: makeJobInfo(vcbatch.Completing)}
@@ -95,8 +87,6 @@ func TestCompletingState_Execute_NonNilUpdateFn(t *testing.T) {
 	}
 }
 
-// TestCompletingState_Execute_PassesJobInfo verifies the correct JobInfo
-// pointer is forwarded to KillJob.
 func TestCompletingState_Execute_PassesJobInfo(t *testing.T) {
 	c := captureKillJob(t, nil)
 	info := makeJobInfo(vcbatch.Completing)
@@ -110,8 +100,6 @@ func TestCompletingState_Execute_PassesJobInfo(t *testing.T) {
 	}
 }
 
-// TestCompletingState_Execute_PropagatesError verifies that any error returned
-// by KillJob is surfaced to the caller unchanged.
 func TestCompletingState_Execute_PropagatesError(t *testing.T) {
 	want := errors.New("kill failed")
 	captureKillJob(t, want)
@@ -122,11 +110,8 @@ func TestCompletingState_Execute_PropagatesError(t *testing.T) {
 	}
 }
 
-// --- updateFn: alive pods present -> stay Completing ---
-
-// TestCompletingState_Execute_UpdateFnAlivePods verifies that the updateFn
-// returns false and leaves the phase unchanged whenever any "alive" pod counter
-// (Terminating, Pending, or Running) is non-zero.
+// "Alive" counters = Terminating | Pending | Running. Any of them being
+// non-zero must keep the job in Completing.
 func TestCompletingState_Execute_UpdateFnAlivePods(t *testing.T) {
 	tests := []struct {
 		name   string
@@ -180,12 +165,6 @@ func TestCompletingState_Execute_UpdateFnAlivePods(t *testing.T) {
 	}
 }
 
-// --- updateFn: all alive pods drained -> Completed ---
-
-// TestCompletingState_Execute_UpdateFnAllPodsGone verifies that the updateFn
-// returns true and transitions the phase to Completed when all alive pod
-// counters are zero. UpdateJobCompleted is also called at this point; since it
-// only increments a Prometheus counter it requires no separate assertion.
 func TestCompletingState_Execute_UpdateFnAllPodsGone(t *testing.T) {
 	tests := []struct {
 		name   string

--- a/pkg/controllers/job/state/completing_test.go
+++ b/pkg/controllers/job/state/completing_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2024 The Volcano Authors.
+Copyright 2026 The Volcano Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/controllers/job/state/completing_test.go
+++ b/pkg/controllers/job/state/completing_test.go
@@ -1,0 +1,229 @@
+/*
+Copyright 2024 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package state
+
+import (
+	"errors"
+	"testing"
+
+	vcbatch "volcano.sh/apis/pkg/apis/batch/v1alpha1"
+	"volcano.sh/apis/pkg/apis/bus/v1alpha1"
+)
+
+// ── action-agnostic behaviour ────────────────────────────────────────────────
+
+// TestCompletingState_Execute_ActionAgnostic verifies that Execute always
+// delegates to KillJob regardless of the action type received.
+func TestCompletingState_Execute_ActionAgnostic(t *testing.T) {
+	actions := []struct {
+		name   string
+		action v1alpha1.Action
+	}{
+		{"SyncJobAction", v1alpha1.SyncJobAction},
+		{"RestartJobAction", v1alpha1.RestartJobAction},
+		{"AbortJobAction", v1alpha1.AbortJobAction},
+		{"TerminateJobAction", v1alpha1.TerminateJobAction},
+		{"CompleteJobAction", v1alpha1.CompleteJobAction},
+		{"ResumeJobAction", v1alpha1.ResumeJobAction},
+		{"RestartTaskAction", v1alpha1.RestartTaskAction},
+		{"RestartPodAction", v1alpha1.RestartPodAction},
+		{"RestartPartitionAction", v1alpha1.RestartPartitionAction},
+		{"UnknownAction", v1alpha1.Action("Unknown")},
+	}
+
+	for _, tc := range actions {
+		t.Run(tc.name, func(t *testing.T) {
+			cap := captureKillJob(t, nil)
+			s := &completingState{job: makeJobInfo(vcbatch.Completing)}
+
+			if err := s.Execute(Action{Action: tc.action}); err != nil {
+				t.Fatalf("Execute(%q) returned unexpected error: %v", tc.action, err)
+			}
+			if cap.job == nil {
+				t.Fatal("KillJob was not called")
+			}
+		})
+	}
+}
+
+// ── KillJob call arguments ───────────────────────────────────────────────────
+
+// TestCompletingState_Execute_UsesSoftRetainPhase verifies that Execute passes
+// PodRetainPhaseSoft so Succeeded/Failed pods are preserved during draining.
+func TestCompletingState_Execute_UsesSoftRetainPhase(t *testing.T) {
+	cap := captureKillJob(t, nil)
+	s := &completingState{job: makeJobInfo(vcbatch.Completing)}
+
+	if err := s.Execute(Action{Action: v1alpha1.SyncJobAction}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for phase := range PodRetainPhaseSoft {
+		if _, ok := cap.podRetainPhase[phase]; !ok {
+			t.Errorf("podRetainPhase missing %q", phase)
+		}
+	}
+	if len(cap.podRetainPhase) != len(PodRetainPhaseSoft) {
+		t.Errorf("podRetainPhase has %d entries, want %d", len(cap.podRetainPhase), len(PodRetainPhaseSoft))
+	}
+}
+
+// TestCompletingState_Execute_NonNilUpdateFn verifies the updateFn is not nil
+// — completingState drives a phase transition, unlike finishedState.
+func TestCompletingState_Execute_NonNilUpdateFn(t *testing.T) {
+	cap := captureKillJob(t, nil)
+	s := &completingState{job: makeJobInfo(vcbatch.Completing)}
+
+	if err := s.Execute(Action{Action: v1alpha1.SyncJobAction}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cap.updateFn == nil {
+		t.Error("updateFn must not be nil for completingState")
+	}
+}
+
+// TestCompletingState_Execute_PassesJobInfo verifies the correct JobInfo
+// pointer is forwarded to KillJob.
+func TestCompletingState_Execute_PassesJobInfo(t *testing.T) {
+	cap := captureKillJob(t, nil)
+	info := makeJobInfo(vcbatch.Completing)
+	s := &completingState{job: info}
+
+	if err := s.Execute(Action{Action: v1alpha1.SyncJobAction}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cap.job != info {
+		t.Errorf("KillJob received wrong JobInfo: got %p, want %p", cap.job, info)
+	}
+}
+
+// TestCompletingState_Execute_PropagatesError verifies that any error returned
+// by KillJob is surfaced to the caller unchanged.
+func TestCompletingState_Execute_PropagatesError(t *testing.T) {
+	want := errors.New("kill failed")
+	captureKillJob(t, want)
+	s := &completingState{job: makeJobInfo(vcbatch.Completing)}
+
+	if got := s.Execute(Action{Action: v1alpha1.SyncJobAction}); !errors.Is(got, want) {
+		t.Errorf("Execute returned %v, want %v", got, want)
+	}
+}
+
+// ── updateFn: alive pods present → stay Completing ───────────────────────────
+
+// TestCompletingState_Execute_UpdateFnAlivePods verifies that the updateFn
+// returns false and leaves the phase unchanged whenever any "alive" pod counter
+// (Terminating, Pending, or Running) is non-zero.
+func TestCompletingState_Execute_UpdateFnAlivePods(t *testing.T) {
+	tests := []struct {
+		name   string
+		status vcbatch.JobStatus
+	}{
+		{
+			name:   "only Terminating pods remain",
+			status: vcbatch.JobStatus{Terminating: 1},
+		},
+		{
+			name:   "only Pending pods remain",
+			status: vcbatch.JobStatus{Pending: 1},
+		},
+		{
+			name:   "only Running pods remain",
+			status: vcbatch.JobStatus{Running: 1},
+		},
+		{
+			name:   "all three counters non-zero",
+			status: vcbatch.JobStatus{Terminating: 2, Pending: 3, Running: 1},
+		},
+		{
+			name:   "Terminating and Pending non-zero",
+			status: vcbatch.JobStatus{Terminating: 1, Pending: 1},
+		},
+		{
+			name:   "Pending and Running non-zero",
+			status: vcbatch.JobStatus{Pending: 1, Running: 1},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cap := captureKillJob(t, nil)
+			s := &completingState{job: makeJobInfo(vcbatch.Completing)}
+
+			if err := s.Execute(Action{Action: v1alpha1.SyncJobAction}); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			originalPhase := tc.status.State.Phase
+			changed := cap.updateFn(&tc.status)
+
+			if changed {
+				t.Error("updateFn should return false while alive pods exist")
+			}
+			if tc.status.State.Phase != originalPhase {
+				t.Errorf("phase should not change: got %q, want %q", tc.status.State.Phase, originalPhase)
+			}
+		})
+	}
+}
+
+// ── updateFn: all alive pods drained → Completed ─────────────────────────────
+
+// TestCompletingState_Execute_UpdateFnAllPodsGone verifies that the updateFn
+// returns true and transitions the phase to Completed when all alive pod
+// counters are zero. UpdateJobCompleted is also called at this point; since it
+// only increments a Prometheus counter it requires no separate assertion.
+func TestCompletingState_Execute_UpdateFnAllPodsGone(t *testing.T) {
+	tests := []struct {
+		name   string
+		status vcbatch.JobStatus
+	}{
+		{
+			name:   "all counters zero from start",
+			status: vcbatch.JobStatus{Terminating: 0, Pending: 0, Running: 0},
+		},
+		{
+			name: "has Succeeded and Failed but no alive pods",
+			status: vcbatch.JobStatus{
+				Terminating: 0,
+				Pending:     0,
+				Running:     0,
+				Succeeded:   5,
+				Failed:      2,
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cap := captureKillJob(t, nil)
+			s := &completingState{job: makeJobInfo(vcbatch.Completing)}
+
+			if err := s.Execute(Action{Action: v1alpha1.SyncJobAction}); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			changed := cap.updateFn(&tc.status)
+
+			if !changed {
+				t.Error("updateFn should return true when no alive pods remain")
+			}
+			if tc.status.State.Phase != vcbatch.Completed {
+				t.Errorf("phase = %q, want %q", tc.status.State.Phase, vcbatch.Completed)
+			}
+		})
+	}
+}

--- a/pkg/controllers/job/state/factory_test.go
+++ b/pkg/controllers/job/state/factory_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Volcano Authors.
+Copyright 2017 The Volcano Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -21,26 +21,32 @@ import (
 	"testing"
 
 	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	vcbatch "volcano.sh/apis/pkg/apis/batch/v1alpha1"
 
 	"volcano.sh/volcano/pkg/controllers/apis"
 )
 
-// makeJobInfo constructs a minimal JobInfo with the given phase.
-func makeJobInfo(phase vcbatch.JobPhase) *apis.JobInfo {
-	return &apis.JobInfo{
-		Job: &vcbatch.Job{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test-job",
-				Namespace: "default",
-			},
-			Status: vcbatch.JobStatus{
-				State: vcbatch.JobState{Phase: phase},
-			},
-		},
+func extractJobInfo(s State) *apis.JobInfo {
+	switch v := s.(type) {
+	case *pendingState:
+		return v.job
+	case *runningState:
+		return v.job
+	case *restartingState:
+		return v.job
+	case *abortingState:
+		return v.job
+	case *abortedState:
+		return v.job
+	case *completingState:
+		return v.job
+	case *terminatingState:
+		return v.job
+	case *finishedState:
+		return v.job
 	}
+	return nil
 }
 
 func TestNewState_KnownPhases(t *testing.T) {
@@ -96,7 +102,6 @@ func TestNewState_KnownPhases(t *testing.T) {
 	}
 }
 
-// Terminated, Completed, and Failed all map to finishedState.
 func TestNewState_FinishedPhases(t *testing.T) {
 	finishedType := reflect.TypeOf(&finishedState{})
 	phases := []vcbatch.JobPhase{
@@ -114,7 +119,6 @@ func TestNewState_FinishedPhases(t *testing.T) {
 	}
 }
 
-// Unknown or empty phase falls back to pendingState.
 func TestNewState_DefaultPhase(t *testing.T) {
 	tests := []struct {
 		name  string
@@ -133,97 +137,38 @@ func TestNewState_DefaultPhase(t *testing.T) {
 	}
 }
 
-// NewState must embed the same JobInfo pointer that was passed in.
 func TestNewState_JobInfoBinding(t *testing.T) {
-	tests := []struct {
-		name      string
-		phase     vcbatch.JobPhase
-		checkFunc func(got State) *apis.JobInfo
-	}{
-		{
-			name:  "pendingState binds jobInfo",
-			phase: vcbatch.Pending,
-			checkFunc: func(got State) *apis.JobInfo {
-				s, _ := got.(*pendingState)
-				return s.job
-			},
-		},
-		{
-			name:  "runningState binds jobInfo",
-			phase: vcbatch.Running,
-			checkFunc: func(got State) *apis.JobInfo {
-				s, _ := got.(*runningState)
-				return s.job
-			},
-		},
-		{
-			name:  "restartingState binds jobInfo",
-			phase: vcbatch.Restarting,
-			checkFunc: func(got State) *apis.JobInfo {
-				s, _ := got.(*restartingState)
-				return s.job
-			},
-		},
-		{
-			name:  "abortingState binds jobInfo",
-			phase: vcbatch.Aborting,
-			checkFunc: func(got State) *apis.JobInfo {
-				s, _ := got.(*abortingState)
-				return s.job
-			},
-		},
-		{
-			name:  "abortedState binds jobInfo",
-			phase: vcbatch.Aborted,
-			checkFunc: func(got State) *apis.JobInfo {
-				s, _ := got.(*abortedState)
-				return s.job
-			},
-		},
-		{
-			name:  "completingState binds jobInfo",
-			phase: vcbatch.Completing,
-			checkFunc: func(got State) *apis.JobInfo {
-				s, _ := got.(*completingState)
-				return s.job
-			},
-		},
-		{
-			name:  "terminatingState binds jobInfo",
-			phase: vcbatch.Terminating,
-			checkFunc: func(got State) *apis.JobInfo {
-				s, _ := got.(*terminatingState)
-				return s.job
-			},
-		},
-		{
-			name:  "finishedState binds jobInfo",
-			phase: vcbatch.Completed,
-			checkFunc: func(got State) *apis.JobInfo {
-				s, _ := got.(*finishedState)
-				return s.job
-			},
-		},
+	phases := []vcbatch.JobPhase{
+		vcbatch.Pending,
+		vcbatch.Running,
+		vcbatch.Restarting,
+		vcbatch.Aborting,
+		vcbatch.Aborted,
+		vcbatch.Completing,
+		vcbatch.Terminating,
+		vcbatch.Completed,
 	}
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			info := makeJobInfo(tc.phase)
+	for _, phase := range phases {
+		t.Run(string(phase), func(t *testing.T) {
+			info := makeJobInfo(phase)
 			got := NewState(info)
-			if bound := tc.checkFunc(got); bound != info {
+			bound := extractJobInfo(got)
+			if bound == nil {
+				t.Fatalf("extractJobInfo returned nil for state %T", got)
+			}
+			if bound != info {
 				t.Errorf("state.job pointer mismatch: got %p, want %p", bound, info)
 			}
 		})
 	}
 }
 
-// PodRetainPhaseNone must be an empty set — no phases are retained.
 func TestNewState_PodRetainPhaseNone(t *testing.T) {
 	if len(PodRetainPhaseNone) != 0 {
 		t.Errorf("PodRetainPhaseNone should be empty, got %v", PodRetainPhaseNone)
 	}
 }
 
-// PodRetainPhaseSoft must contain exactly PodSucceeded and PodFailed.
 func TestNewState_PodRetainPhaseSoft(t *testing.T) {
 	if _, ok := PodRetainPhaseSoft[v1.PodSucceeded]; !ok {
 		t.Error("PodRetainPhaseSoft missing PodSucceeded")

--- a/pkg/controllers/job/state/factory_test.go
+++ b/pkg/controllers/job/state/factory_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2024 The Volcano Authors.
+Copyright 2026 The Volcano Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/controllers/job/state/factory_test.go
+++ b/pkg/controllers/job/state/factory_test.go
@@ -1,0 +1,236 @@
+/*
+Copyright 2024 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package state
+
+import (
+	"reflect"
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	vcbatch "volcano.sh/apis/pkg/apis/batch/v1alpha1"
+
+	"volcano.sh/volcano/pkg/controllers/apis"
+)
+
+// makeJobInfo constructs a minimal JobInfo with the given phase.
+func makeJobInfo(phase vcbatch.JobPhase) *apis.JobInfo {
+	return &apis.JobInfo{
+		Job: &vcbatch.Job{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-job",
+				Namespace: "default",
+			},
+			Status: vcbatch.JobStatus{
+				State: vcbatch.JobState{Phase: phase},
+			},
+		},
+	}
+}
+
+func TestNewState_KnownPhases(t *testing.T) {
+	tests := []struct {
+		name     string
+		phase    vcbatch.JobPhase
+		wantType reflect.Type
+	}{
+		{
+			name:     "Pending phase returns pendingState",
+			phase:    vcbatch.Pending,
+			wantType: reflect.TypeOf(&pendingState{}),
+		},
+		{
+			name:     "Running phase returns runningState",
+			phase:    vcbatch.Running,
+			wantType: reflect.TypeOf(&runningState{}),
+		},
+		{
+			name:     "Restarting phase returns restartingState",
+			phase:    vcbatch.Restarting,
+			wantType: reflect.TypeOf(&restartingState{}),
+		},
+		{
+			name:     "Terminating phase returns terminatingState",
+			phase:    vcbatch.Terminating,
+			wantType: reflect.TypeOf(&terminatingState{}),
+		},
+		{
+			name:     "Aborting phase returns abortingState",
+			phase:    vcbatch.Aborting,
+			wantType: reflect.TypeOf(&abortingState{}),
+		},
+		{
+			name:     "Aborted phase returns abortedState",
+			phase:    vcbatch.Aborted,
+			wantType: reflect.TypeOf(&abortedState{}),
+		},
+		{
+			name:     "Completing phase returns completingState",
+			phase:    vcbatch.Completing,
+			wantType: reflect.TypeOf(&completingState{}),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := NewState(makeJobInfo(tc.phase))
+			if reflect.TypeOf(got) != tc.wantType {
+				t.Errorf("NewState(%q) = %T, want %s", tc.phase, got, tc.wantType)
+			}
+		})
+	}
+}
+
+// Terminated, Completed, and Failed all map to finishedState.
+func TestNewState_FinishedPhases(t *testing.T) {
+	finishedType := reflect.TypeOf(&finishedState{})
+	phases := []vcbatch.JobPhase{
+		vcbatch.Terminated,
+		vcbatch.Completed,
+		vcbatch.Failed,
+	}
+	for _, phase := range phases {
+		t.Run(string(phase), func(t *testing.T) {
+			got := NewState(makeJobInfo(phase))
+			if reflect.TypeOf(got) != finishedType {
+				t.Errorf("NewState(%q) = %T, want *finishedState", phase, got)
+			}
+		})
+	}
+}
+
+// Unknown or empty phase falls back to pendingState.
+func TestNewState_DefaultPhase(t *testing.T) {
+	tests := []struct {
+		name  string
+		phase vcbatch.JobPhase
+	}{
+		{"empty string", ""},
+		{"unknown phase", "Unknown"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := NewState(makeJobInfo(tc.phase))
+			if _, ok := got.(*pendingState); !ok {
+				t.Errorf("NewState(%q) = %T, want *pendingState", tc.phase, got)
+			}
+		})
+	}
+}
+
+// NewState must embed the same JobInfo pointer that was passed in.
+func TestNewState_JobInfoBinding(t *testing.T) {
+	tests := []struct {
+		name      string
+		phase     vcbatch.JobPhase
+		checkFunc func(got State) *apis.JobInfo
+	}{
+		{
+			name:  "pendingState binds jobInfo",
+			phase: vcbatch.Pending,
+			checkFunc: func(got State) *apis.JobInfo {
+				s, _ := got.(*pendingState)
+				return s.job
+			},
+		},
+		{
+			name:  "runningState binds jobInfo",
+			phase: vcbatch.Running,
+			checkFunc: func(got State) *apis.JobInfo {
+				s, _ := got.(*runningState)
+				return s.job
+			},
+		},
+		{
+			name:  "restartingState binds jobInfo",
+			phase: vcbatch.Restarting,
+			checkFunc: func(got State) *apis.JobInfo {
+				s, _ := got.(*restartingState)
+				return s.job
+			},
+		},
+		{
+			name:  "abortingState binds jobInfo",
+			phase: vcbatch.Aborting,
+			checkFunc: func(got State) *apis.JobInfo {
+				s, _ := got.(*abortingState)
+				return s.job
+			},
+		},
+		{
+			name:  "abortedState binds jobInfo",
+			phase: vcbatch.Aborted,
+			checkFunc: func(got State) *apis.JobInfo {
+				s, _ := got.(*abortedState)
+				return s.job
+			},
+		},
+		{
+			name:  "completingState binds jobInfo",
+			phase: vcbatch.Completing,
+			checkFunc: func(got State) *apis.JobInfo {
+				s, _ := got.(*completingState)
+				return s.job
+			},
+		},
+		{
+			name:  "terminatingState binds jobInfo",
+			phase: vcbatch.Terminating,
+			checkFunc: func(got State) *apis.JobInfo {
+				s, _ := got.(*terminatingState)
+				return s.job
+			},
+		},
+		{
+			name:  "finishedState binds jobInfo",
+			phase: vcbatch.Completed,
+			checkFunc: func(got State) *apis.JobInfo {
+				s, _ := got.(*finishedState)
+				return s.job
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			info := makeJobInfo(tc.phase)
+			got := NewState(info)
+			if bound := tc.checkFunc(got); bound != info {
+				t.Errorf("state.job pointer mismatch: got %p, want %p", bound, info)
+			}
+		})
+	}
+}
+
+// PodRetainPhaseNone must be an empty set — no phases are retained.
+func TestNewState_PodRetainPhaseNone(t *testing.T) {
+	if len(PodRetainPhaseNone) != 0 {
+		t.Errorf("PodRetainPhaseNone should be empty, got %v", PodRetainPhaseNone)
+	}
+}
+
+// PodRetainPhaseSoft must contain exactly PodSucceeded and PodFailed.
+func TestNewState_PodRetainPhaseSoft(t *testing.T) {
+	if _, ok := PodRetainPhaseSoft[v1.PodSucceeded]; !ok {
+		t.Error("PodRetainPhaseSoft missing PodSucceeded")
+	}
+	if _, ok := PodRetainPhaseSoft[v1.PodFailed]; !ok {
+		t.Error("PodRetainPhaseSoft missing PodFailed")
+	}
+	if len(PodRetainPhaseSoft) != 2 {
+		t.Errorf("PodRetainPhaseSoft should have exactly 2 entries, got %d", len(PodRetainPhaseSoft))
+	}
+}

--- a/pkg/controllers/job/state/factory_test.go
+++ b/pkg/controllers/job/state/factory_test.go
@@ -22,6 +22,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	vcbatch "volcano.sh/apis/pkg/apis/batch/v1alpha1"
 
 	"volcano.sh/volcano/pkg/controllers/apis"

--- a/pkg/controllers/job/state/finished_test.go
+++ b/pkg/controllers/job/state/finished_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2024 The Volcano Authors.
+Copyright 2026 The Volcano Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -29,9 +29,9 @@ import (
 
 // killJobCall records one invocation of the KillJob stub.
 type killJobCall struct {
-	job             *apis.JobInfo
-	podRetainPhase  PhaseMap
-	updateFnIsNil   bool
+	job            *apis.JobInfo
+	podRetainPhase PhaseMap
+	updateFnIsNil  bool
 }
 
 // stubKillJob replaces the KillJob package variable with a stub that records

--- a/pkg/controllers/job/state/finished_test.go
+++ b/pkg/controllers/job/state/finished_test.go
@@ -21,35 +21,10 @@ import (
 	"testing"
 
 	v1 "k8s.io/api/core/v1"
+
 	vcbatch "volcano.sh/apis/pkg/apis/batch/v1alpha1"
 	"volcano.sh/apis/pkg/apis/bus/v1alpha1"
-
-	"volcano.sh/volcano/pkg/controllers/apis"
 )
-
-// killJobCall records one invocation of the KillJob stub.
-type killJobCall struct {
-	job            *apis.JobInfo
-	podRetainPhase PhaseMap
-	updateFnIsNil  bool
-}
-
-// stubKillJob replaces the KillJob package variable with a stub that records
-// its arguments and returns the given error. It restores the original value
-// via t.Cleanup so parallel tests are not affected.
-func stubKillJob(t *testing.T, returnErr error) *killJobCall {
-	t.Helper()
-	original := KillJob
-	call := &killJobCall{}
-	KillJob = func(job *apis.JobInfo, podRetainPhase PhaseMap, fn UpdateStatusFn) error {
-		call.job = job
-		call.podRetainPhase = podRetainPhase
-		call.updateFnIsNil = fn == nil
-		return returnErr
-	}
-	t.Cleanup(func() { KillJob = original })
-	return call
-}
 
 // TestFinishedState_Execute_ActionAgnostic verifies that Execute always
 // delegates to KillJob regardless of the action type.
@@ -72,14 +47,14 @@ func TestFinishedState_Execute_ActionAgnostic(t *testing.T) {
 
 	for _, tc := range actions {
 		t.Run(tc.name, func(t *testing.T) {
-			call := stubKillJob(t, nil)
+			c := captureKillJob(t, nil)
 			info := makeJobInfo(vcbatch.Completed)
 			s := &finishedState{job: info}
 
 			if err := s.Execute(Action{Action: tc.action}); err != nil {
 				t.Fatalf("Execute(%q) returned unexpected error: %v", tc.action, err)
 			}
-			if call.job == nil {
+			if c.job == nil {
 				t.Fatal("KillJob was not called")
 			}
 		})
@@ -90,7 +65,7 @@ func TestFinishedState_Execute_ActionAgnostic(t *testing.T) {
 // PodRetainPhaseSoft (Succeeded + Failed retained) rather than
 // PodRetainPhaseNone (all pods killed).
 func TestFinishedState_Execute_UsesSoftRetainPhase(t *testing.T) {
-	call := stubKillJob(t, nil)
+	c := captureKillJob(t, nil)
 	s := &finishedState{job: makeJobInfo(vcbatch.Completed)}
 
 	if err := s.Execute(Action{Action: v1alpha1.SyncJobAction}); err != nil {
@@ -98,25 +73,25 @@ func TestFinishedState_Execute_UsesSoftRetainPhase(t *testing.T) {
 	}
 
 	for _, phase := range []v1.PodPhase{v1.PodSucceeded, v1.PodFailed} {
-		if _, ok := call.podRetainPhase[phase]; !ok {
-			t.Errorf("podRetainPhase missing %q; got %v", phase, call.podRetainPhase)
+		if _, ok := c.podRetainPhase[phase]; !ok {
+			t.Errorf("podRetainPhase missing %q; got %v", phase, c.podRetainPhase)
 		}
 	}
-	if len(call.podRetainPhase) != 2 {
-		t.Errorf("podRetainPhase should have exactly 2 entries, got %d", len(call.podRetainPhase))
+	if len(c.podRetainPhase) != 2 {
+		t.Errorf("podRetainPhase should have exactly 2 entries, got %d", len(c.podRetainPhase))
 	}
 }
 
 // TestFinishedState_Execute_NilUpdateFn verifies that Execute passes a nil
-// update function — the finished state must not change job phase.
+// update function: the finished state must not change job phase.
 func TestFinishedState_Execute_NilUpdateFn(t *testing.T) {
-	call := stubKillJob(t, nil)
+	c := captureKillJob(t, nil)
 	s := &finishedState{job: makeJobInfo(vcbatch.Completed)}
 
 	if err := s.Execute(Action{Action: v1alpha1.SyncJobAction}); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if !call.updateFnIsNil {
+	if c.updateFn != nil {
 		t.Error("KillJob updateFn should be nil for finishedState")
 	}
 }
@@ -124,15 +99,15 @@ func TestFinishedState_Execute_NilUpdateFn(t *testing.T) {
 // TestFinishedState_Execute_PassesJobInfo verifies that Execute forwards the
 // correct JobInfo pointer to KillJob.
 func TestFinishedState_Execute_PassesJobInfo(t *testing.T) {
-	call := stubKillJob(t, nil)
+	c := captureKillJob(t, nil)
 	info := makeJobInfo(vcbatch.Terminated)
 	s := &finishedState{job: info}
 
 	if err := s.Execute(Action{Action: v1alpha1.SyncJobAction}); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if call.job != info {
-		t.Errorf("KillJob received wrong JobInfo: got %p, want %p", call.job, info)
+	if c.job != info {
+		t.Errorf("KillJob received wrong JobInfo: got %p, want %p", c.job, info)
 	}
 }
 
@@ -140,7 +115,7 @@ func TestFinishedState_Execute_PassesJobInfo(t *testing.T) {
 // by KillJob is surfaced to the caller unchanged.
 func TestFinishedState_Execute_PropagatesError(t *testing.T) {
 	want := errors.New("kill failed")
-	stubKillJob(t, want)
+	captureKillJob(t, want)
 	s := &finishedState{job: makeJobInfo(vcbatch.Failed)}
 
 	if got := s.Execute(Action{Action: v1alpha1.SyncJobAction}); !errors.Is(got, want) {

--- a/pkg/controllers/job/state/finished_test.go
+++ b/pkg/controllers/job/state/finished_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Volcano Authors.
+Copyright 2017 The Volcano Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -26,8 +26,6 @@ import (
 	"volcano.sh/apis/pkg/apis/bus/v1alpha1"
 )
 
-// TestFinishedState_Execute_ActionAgnostic verifies that Execute always
-// delegates to KillJob regardless of the action type.
 func TestFinishedState_Execute_ActionAgnostic(t *testing.T) {
 	actions := []struct {
 		name   string
@@ -61,9 +59,6 @@ func TestFinishedState_Execute_ActionAgnostic(t *testing.T) {
 	}
 }
 
-// TestFinishedState_Execute_UsesSoftRetainPhase verifies that Execute passes
-// PodRetainPhaseSoft (Succeeded + Failed retained) rather than
-// PodRetainPhaseNone (all pods killed).
 func TestFinishedState_Execute_UsesSoftRetainPhase(t *testing.T) {
 	c := captureKillJob(t, nil)
 	s := &finishedState{job: makeJobInfo(vcbatch.Completed)}
@@ -82,8 +77,7 @@ func TestFinishedState_Execute_UsesSoftRetainPhase(t *testing.T) {
 	}
 }
 
-// TestFinishedState_Execute_NilUpdateFn verifies that Execute passes a nil
-// update function: the finished state must not change job phase.
+// finishedState is terminal: updateFn must be nil so KillJob never mutates phase.
 func TestFinishedState_Execute_NilUpdateFn(t *testing.T) {
 	c := captureKillJob(t, nil)
 	s := &finishedState{job: makeJobInfo(vcbatch.Completed)}
@@ -96,8 +90,6 @@ func TestFinishedState_Execute_NilUpdateFn(t *testing.T) {
 	}
 }
 
-// TestFinishedState_Execute_PassesJobInfo verifies that Execute forwards the
-// correct JobInfo pointer to KillJob.
 func TestFinishedState_Execute_PassesJobInfo(t *testing.T) {
 	c := captureKillJob(t, nil)
 	info := makeJobInfo(vcbatch.Terminated)
@@ -111,8 +103,6 @@ func TestFinishedState_Execute_PassesJobInfo(t *testing.T) {
 	}
 }
 
-// TestFinishedState_Execute_PropagatesError verifies that any error returned
-// by KillJob is surfaced to the caller unchanged.
 func TestFinishedState_Execute_PropagatesError(t *testing.T) {
 	want := errors.New("kill failed")
 	captureKillJob(t, want)

--- a/pkg/controllers/job/state/finished_test.go
+++ b/pkg/controllers/job/state/finished_test.go
@@ -1,0 +1,149 @@
+/*
+Copyright 2024 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package state
+
+import (
+	"errors"
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	vcbatch "volcano.sh/apis/pkg/apis/batch/v1alpha1"
+	"volcano.sh/apis/pkg/apis/bus/v1alpha1"
+
+	"volcano.sh/volcano/pkg/controllers/apis"
+)
+
+// killJobCall records one invocation of the KillJob stub.
+type killJobCall struct {
+	job             *apis.JobInfo
+	podRetainPhase  PhaseMap
+	updateFnIsNil   bool
+}
+
+// stubKillJob replaces the KillJob package variable with a stub that records
+// its arguments and returns the given error. It restores the original value
+// via t.Cleanup so parallel tests are not affected.
+func stubKillJob(t *testing.T, returnErr error) *killJobCall {
+	t.Helper()
+	original := KillJob
+	call := &killJobCall{}
+	KillJob = func(job *apis.JobInfo, podRetainPhase PhaseMap, fn UpdateStatusFn) error {
+		call.job = job
+		call.podRetainPhase = podRetainPhase
+		call.updateFnIsNil = fn == nil
+		return returnErr
+	}
+	t.Cleanup(func() { KillJob = original })
+	return call
+}
+
+// TestFinishedState_Execute_ActionAgnostic verifies that Execute always
+// delegates to KillJob regardless of the action type.
+func TestFinishedState_Execute_ActionAgnostic(t *testing.T) {
+	actions := []struct {
+		name   string
+		action v1alpha1.Action
+	}{
+		{"SyncJobAction", v1alpha1.SyncJobAction},
+		{"RestartJobAction", v1alpha1.RestartJobAction},
+		{"AbortJobAction", v1alpha1.AbortJobAction},
+		{"TerminateJobAction", v1alpha1.TerminateJobAction},
+		{"CompleteJobAction", v1alpha1.CompleteJobAction},
+		{"ResumeJobAction", v1alpha1.ResumeJobAction},
+		{"RestartTaskAction", v1alpha1.RestartTaskAction},
+		{"RestartPodAction", v1alpha1.RestartPodAction},
+		{"RestartPartitionAction", v1alpha1.RestartPartitionAction},
+		{"UnknownAction", v1alpha1.Action("Unknown")},
+	}
+
+	for _, tc := range actions {
+		t.Run(tc.name, func(t *testing.T) {
+			call := stubKillJob(t, nil)
+			info := makeJobInfo(vcbatch.Completed)
+			s := &finishedState{job: info}
+
+			if err := s.Execute(Action{Action: tc.action}); err != nil {
+				t.Fatalf("Execute(%q) returned unexpected error: %v", tc.action, err)
+			}
+			if call.job == nil {
+				t.Fatal("KillJob was not called")
+			}
+		})
+	}
+}
+
+// TestFinishedState_Execute_UsesSoftRetainPhase verifies that Execute passes
+// PodRetainPhaseSoft (Succeeded + Failed retained) rather than
+// PodRetainPhaseNone (all pods killed).
+func TestFinishedState_Execute_UsesSoftRetainPhase(t *testing.T) {
+	call := stubKillJob(t, nil)
+	s := &finishedState{job: makeJobInfo(vcbatch.Completed)}
+
+	if err := s.Execute(Action{Action: v1alpha1.SyncJobAction}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	for _, phase := range []v1.PodPhase{v1.PodSucceeded, v1.PodFailed} {
+		if _, ok := call.podRetainPhase[phase]; !ok {
+			t.Errorf("podRetainPhase missing %q; got %v", phase, call.podRetainPhase)
+		}
+	}
+	if len(call.podRetainPhase) != 2 {
+		t.Errorf("podRetainPhase should have exactly 2 entries, got %d", len(call.podRetainPhase))
+	}
+}
+
+// TestFinishedState_Execute_NilUpdateFn verifies that Execute passes a nil
+// update function — the finished state must not change job phase.
+func TestFinishedState_Execute_NilUpdateFn(t *testing.T) {
+	call := stubKillJob(t, nil)
+	s := &finishedState{job: makeJobInfo(vcbatch.Completed)}
+
+	if err := s.Execute(Action{Action: v1alpha1.SyncJobAction}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !call.updateFnIsNil {
+		t.Error("KillJob updateFn should be nil for finishedState")
+	}
+}
+
+// TestFinishedState_Execute_PassesJobInfo verifies that Execute forwards the
+// correct JobInfo pointer to KillJob.
+func TestFinishedState_Execute_PassesJobInfo(t *testing.T) {
+	call := stubKillJob(t, nil)
+	info := makeJobInfo(vcbatch.Terminated)
+	s := &finishedState{job: info}
+
+	if err := s.Execute(Action{Action: v1alpha1.SyncJobAction}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if call.job != info {
+		t.Errorf("KillJob received wrong JobInfo: got %p, want %p", call.job, info)
+	}
+}
+
+// TestFinishedState_Execute_PropagatesError verifies that any error returned
+// by KillJob is surfaced to the caller unchanged.
+func TestFinishedState_Execute_PropagatesError(t *testing.T) {
+	want := errors.New("kill failed")
+	stubKillJob(t, want)
+	s := &finishedState{job: makeJobInfo(vcbatch.Failed)}
+
+	if got := s.Execute(Action{Action: v1alpha1.SyncJobAction}); !errors.Is(got, want) {
+		t.Errorf("Execute returned %v, want %v", got, want)
+	}
+}

--- a/pkg/controllers/job/state/helpers_test.go
+++ b/pkg/controllers/job/state/helpers_test.go
@@ -1,0 +1,124 @@
+/*
+Copyright 2017 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package state
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	vcbatch "volcano.sh/apis/pkg/apis/batch/v1alpha1"
+
+	"volcano.sh/volcano/pkg/controllers/apis"
+)
+
+func int32Ptr(v int32) *int32 { return &v }
+
+type jobOption func(*vcbatch.Job)
+
+func withMinAvailable(n int32) jobOption {
+	return func(j *vcbatch.Job) { j.Spec.MinAvailable = n }
+}
+
+func withMinSuccess(n *int32) jobOption {
+	return func(j *vcbatch.Job) { j.Spec.MinSuccess = n }
+}
+
+func withMaxRetry(n int32) jobOption {
+	return func(j *vcbatch.Job) { j.Spec.MaxRetry = n }
+}
+
+func withTasks(tasks ...vcbatch.TaskSpec) jobOption {
+	return func(j *vcbatch.Job) { j.Spec.Tasks = tasks }
+}
+
+func withTaskReplicas(replicas ...int32) jobOption {
+	tasks := make([]vcbatch.TaskSpec, len(replicas))
+	for i, r := range replicas {
+		tasks[i] = vcbatch.TaskSpec{Replicas: r}
+	}
+	return withTasks(tasks...)
+}
+
+func makeJobInfo(phase vcbatch.JobPhase, opts ...jobOption) *apis.JobInfo {
+	job := &vcbatch.Job{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-job", Namespace: "default"},
+		Status:     vcbatch.JobStatus{State: vcbatch.JobState{Phase: phase}},
+	}
+	for _, opt := range opts {
+		opt(job)
+	}
+	return &apis.JobInfo{Job: job}
+}
+
+type capturedKillJob struct {
+	job            *apis.JobInfo
+	podRetainPhase PhaseMap
+	updateFn       UpdateStatusFn
+}
+
+func captureKillJob(t *testing.T, returnErr error) *capturedKillJob {
+	t.Helper()
+	original := KillJob
+	c := &capturedKillJob{}
+	KillJob = func(job *apis.JobInfo, podRetainPhase PhaseMap, fn UpdateStatusFn) error {
+		c.job = job
+		c.podRetainPhase = podRetainPhase
+		c.updateFn = fn
+		return returnErr
+	}
+	t.Cleanup(func() { KillJob = original })
+	return c
+}
+
+type capturedKillTarget struct {
+	job      *apis.JobInfo
+	target   Target
+	updateFn UpdateStatusFn
+}
+
+func captureKillTarget(t *testing.T, returnErr error) *capturedKillTarget {
+	t.Helper()
+	original := KillTarget
+	c := &capturedKillTarget{}
+	KillTarget = func(job *apis.JobInfo, target Target, fn UpdateStatusFn) error {
+		c.job = job
+		c.target = target
+		c.updateFn = fn
+		return returnErr
+	}
+	t.Cleanup(func() { KillTarget = original })
+	return c
+}
+
+type capturedSyncJob struct {
+	job      *apis.JobInfo
+	updateFn UpdateStatusFn
+}
+
+func captureSyncJob(t *testing.T, returnErr error) *capturedSyncJob {
+	t.Helper()
+	original := SyncJob
+	c := &capturedSyncJob{}
+	SyncJob = func(job *apis.JobInfo, fn UpdateStatusFn) error {
+		c.job = job
+		c.updateFn = fn
+		return returnErr
+	}
+	t.Cleanup(func() { SyncJob = original })
+	return c
+}

--- a/pkg/controllers/job/state/pending_test.go
+++ b/pkg/controllers/job/state/pending_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Volcano Authors.
+Copyright 2017 The Volcano Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -20,72 +20,10 @@ import (
 	"errors"
 	"testing"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	vcbatch "volcano.sh/apis/pkg/apis/batch/v1alpha1"
 	"volcano.sh/apis/pkg/apis/bus/v1alpha1"
-
-	"volcano.sh/volcano/pkg/controllers/apis"
 )
 
-// --- stub helpers ---
-
-// capturedKillTarget records one KillTarget invocation and preserves the
-// updateFn so tests can invoke it to verify state-transition logic.
-type capturedKillTarget struct {
-	job      *apis.JobInfo
-	target   Target
-	updateFn UpdateStatusFn
-}
-
-func captureKillTarget(t *testing.T, returnErr error) *capturedKillTarget {
-	t.Helper()
-	original := KillTarget
-	c := &capturedKillTarget{}
-	KillTarget = func(job *apis.JobInfo, target Target, fn UpdateStatusFn) error {
-		c.job = job
-		c.target = target
-		c.updateFn = fn
-		return returnErr
-	}
-	t.Cleanup(func() { KillTarget = original })
-	return c
-}
-
-// capturedSyncJob records one SyncJob invocation and preserves the updateFn.
-type capturedSyncJob struct {
-	job      *apis.JobInfo
-	updateFn UpdateStatusFn
-}
-
-func captureSyncJob(t *testing.T, returnErr error) *capturedSyncJob {
-	t.Helper()
-	original := SyncJob
-	c := &capturedSyncJob{}
-	SyncJob = func(job *apis.JobInfo, fn UpdateStatusFn) error {
-		c.job = job
-		c.updateFn = fn
-		return returnErr
-	}
-	t.Cleanup(func() { SyncJob = original })
-	return c
-}
-
-// makeJobInfoWithSpec builds a JobInfo with the given phase and MinAvailable.
-func makeJobInfoWithSpec(phase vcbatch.JobPhase, minAvailable int32) *apis.JobInfo {
-	return &apis.JobInfo{
-		Job: &vcbatch.Job{
-			ObjectMeta: metav1.ObjectMeta{Name: "test-job", Namespace: "default"},
-			Spec:       vcbatch.JobSpec{MinAvailable: minAvailable},
-			Status:     vcbatch.JobStatus{State: vcbatch.JobState{Phase: phase}},
-		},
-	}
-}
-
-// --- RestartJobAction branch ---
-
-// TestPendingState_Execute_RestartJobCallsKillJob verifies RestartJobAction
-// delegates to KillJob (not SyncJob or KillTarget).
 func TestPendingState_Execute_RestartJobCallsKillJob(t *testing.T) {
 	c := captureKillJob(t, nil)
 	s := &pendingState{job: makeJobInfo(vcbatch.Pending)}
@@ -98,9 +36,8 @@ func TestPendingState_Execute_RestartJobCallsKillJob(t *testing.T) {
 	}
 }
 
-// TestPendingState_Execute_RestartJobUsesRetainPhaseNone verifies that
-// RestartJobAction passes PodRetainPhaseNone — all pods are killed, including
-// already-completed ones (unlike Abort/Complete/Terminate which use Soft).
+// RestartJobAction uses PodRetainPhaseNone (kills completed pods too) — unlike
+// Abort/Complete/Terminate which use Soft.
 func TestPendingState_Execute_RestartJobUsesRetainPhaseNone(t *testing.T) {
 	c := captureKillJob(t, nil)
 	s := &pendingState{job: makeJobInfo(vcbatch.Pending)}
@@ -113,8 +50,6 @@ func TestPendingState_Execute_RestartJobUsesRetainPhaseNone(t *testing.T) {
 	}
 }
 
-// TestPendingState_Execute_RestartJobUpdateFn verifies the updateFn sets
-// Phase to Restarting, increments RetryCount, and returns true.
 func TestPendingState_Execute_RestartJobUpdateFn(t *testing.T) {
 	tests := []struct {
 		name         string
@@ -155,8 +90,6 @@ func TestPendingState_Execute_RestartJobUpdateFn(t *testing.T) {
 	}
 }
 
-// TestPendingState_Execute_RestartJobPassesJobInfo verifies the correct
-// JobInfo pointer is forwarded to KillJob.
 func TestPendingState_Execute_RestartJobPassesJobInfo(t *testing.T) {
 	c := captureKillJob(t, nil)
 	info := makeJobInfo(vcbatch.Pending)
@@ -170,8 +103,6 @@ func TestPendingState_Execute_RestartJobPassesJobInfo(t *testing.T) {
 	}
 }
 
-// TestPendingState_Execute_RestartJobPropagatesError verifies KillJob errors
-// are surfaced.
 func TestPendingState_Execute_RestartJobPropagatesError(t *testing.T) {
 	want := errors.New("kill failed")
 	captureKillJob(t, want)
@@ -182,10 +113,6 @@ func TestPendingState_Execute_RestartJobPropagatesError(t *testing.T) {
 	}
 }
 
-// --- RestartTask / RestartPod / RestartPartition branch ---
-
-// TestPendingState_Execute_RestartTargetActionsCallKillTarget verifies that
-// all three granular restart actions delegate to KillTarget.
 func TestPendingState_Execute_RestartTargetActionsCallKillTarget(t *testing.T) {
 	actions := []struct {
 		name   string
@@ -210,8 +137,6 @@ func TestPendingState_Execute_RestartTargetActionsCallKillTarget(t *testing.T) {
 	}
 }
 
-// TestPendingState_Execute_RestartTargetForwardsTarget verifies that the
-// Target embedded in the Action is forwarded unchanged to KillTarget.
 func TestPendingState_Execute_RestartTargetForwardsTarget(t *testing.T) {
 	tests := []struct {
 		name   string
@@ -249,8 +174,6 @@ func TestPendingState_Execute_RestartTargetForwardsTarget(t *testing.T) {
 	}
 }
 
-// TestPendingState_Execute_RestartTargetUpdateFn verifies the updateFn sets
-// Phase to Restarting, increments RetryCount, and returns true.
 func TestPendingState_Execute_RestartTargetUpdateFn(t *testing.T) {
 	c := captureKillTarget(t, nil)
 	s := &pendingState{job: makeJobInfo(vcbatch.Pending)}
@@ -276,8 +199,6 @@ func TestPendingState_Execute_RestartTargetUpdateFn(t *testing.T) {
 	}
 }
 
-// TestPendingState_Execute_RestartTargetPropagatesError verifies KillTarget
-// errors are surfaced.
 func TestPendingState_Execute_RestartTargetPropagatesError(t *testing.T) {
 	want := errors.New("kill target failed")
 	captureKillTarget(t, want)
@@ -288,10 +209,6 @@ func TestPendingState_Execute_RestartTargetPropagatesError(t *testing.T) {
 	}
 }
 
-// --- AbortJobAction / CompleteJobAction / TerminateJobAction branches ---
-
-// TestPendingState_Execute_KillJobBranchesUsesSoftRetainPhase verifies that
-// Abort, Complete, and Terminate all call KillJob with PodRetainPhaseSoft.
 func TestPendingState_Execute_KillJobBranchesUsesSoftRetainPhase(t *testing.T) {
 	actions := []v1alpha1.Action{
 		v1alpha1.AbortJobAction,
@@ -318,8 +235,6 @@ func TestPendingState_Execute_KillJobBranchesUsesSoftRetainPhase(t *testing.T) {
 	}
 }
 
-// TestPendingState_Execute_KillJobBranchesUpdateFn verifies each action's
-// updateFn transitions to the correct target phase and returns true.
 func TestPendingState_Execute_KillJobBranchesUpdateFn(t *testing.T) {
 	tests := []struct {
 		action    v1alpha1.Action
@@ -354,8 +269,6 @@ func TestPendingState_Execute_KillJobBranchesUpdateFn(t *testing.T) {
 	}
 }
 
-// TestPendingState_Execute_KillJobBranchesPropagatesError verifies KillJob
-// errors are surfaced for Abort, Complete, and Terminate.
 func TestPendingState_Execute_KillJobBranchesPropagatesError(t *testing.T) {
 	want := errors.New("kill failed")
 	actions := []v1alpha1.Action{
@@ -375,10 +288,6 @@ func TestPendingState_Execute_KillJobBranchesPropagatesError(t *testing.T) {
 	}
 }
 
-// --- default branch (SyncJob) ---
-
-// TestPendingState_Execute_DefaultCallsSyncJob verifies the default path
-// calls SyncJob (not KillJob or KillTarget).
 func TestPendingState_Execute_DefaultCallsSyncJob(t *testing.T) {
 	c := captureSyncJob(t, nil)
 	s := &pendingState{job: makeJobInfo(vcbatch.Pending)}
@@ -391,11 +300,9 @@ func TestPendingState_Execute_DefaultCallsSyncJob(t *testing.T) {
 	}
 }
 
-// TestPendingState_Execute_DefaultPassesJobInfo verifies the correct JobInfo
-// pointer is forwarded to SyncJob.
 func TestPendingState_Execute_DefaultPassesJobInfo(t *testing.T) {
 	c := captureSyncJob(t, nil)
-	info := makeJobInfoWithSpec(vcbatch.Pending, 1)
+	info := makeJobInfo(vcbatch.Pending, withMinAvailable(1))
 	s := &pendingState{job: info}
 
 	if err := s.Execute(Action{Action: v1alpha1.SyncJobAction}); err != nil {
@@ -406,8 +313,6 @@ func TestPendingState_Execute_DefaultPassesJobInfo(t *testing.T) {
 	}
 }
 
-// TestPendingState_Execute_DefaultUpdateFnTransitionsToRunning verifies the
-// updateFn transitions to Running when Running+Succeeded+Failed >= MinAvailable.
 func TestPendingState_Execute_DefaultUpdateFnTransitionsToRunning(t *testing.T) {
 	tests := []struct {
 		name         string
@@ -443,7 +348,7 @@ func TestPendingState_Execute_DefaultUpdateFnTransitionsToRunning(t *testing.T) 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			c := captureSyncJob(t, nil)
-			s := &pendingState{job: makeJobInfoWithSpec(vcbatch.Pending, tc.minAvailable)}
+			s := &pendingState{job: makeJobInfo(vcbatch.Pending, withMinAvailable(tc.minAvailable))}
 
 			if err := s.Execute(Action{Action: v1alpha1.SyncJobAction}); err != nil {
 				t.Fatalf("unexpected error: %v", err)
@@ -464,9 +369,6 @@ func TestPendingState_Execute_DefaultUpdateFnTransitionsToRunning(t *testing.T) 
 	}
 }
 
-// TestPendingState_Execute_DefaultUpdateFnStaysPending verifies the updateFn
-// returns false and leaves phase unchanged when Running+Succeeded+Failed <
-// MinAvailable.
 func TestPendingState_Execute_DefaultUpdateFnStaysPending(t *testing.T) {
 	tests := []struct {
 		name         string
@@ -484,6 +386,7 @@ func TestPendingState_Execute_DefaultUpdateFnStaysPending(t *testing.T) {
 			status:       vcbatch.JobStatus{Running: 1, Succeeded: 1},
 		},
 		{
+			// Pending pods do not count toward MinAvailable.
 			name:         "only Pending pods, not counted",
 			minAvailable: 2,
 			status:       vcbatch.JobStatus{Pending: 5, Running: 0},
@@ -492,7 +395,7 @@ func TestPendingState_Execute_DefaultUpdateFnStaysPending(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			c := captureSyncJob(t, nil)
-			s := &pendingState{job: makeJobInfoWithSpec(vcbatch.Pending, tc.minAvailable)}
+			s := &pendingState{job: makeJobInfo(vcbatch.Pending, withMinAvailable(tc.minAvailable))}
 
 			if err := s.Execute(Action{Action: v1alpha1.SyncJobAction}); err != nil {
 				t.Fatalf("unexpected error: %v", err)
@@ -514,8 +417,6 @@ func TestPendingState_Execute_DefaultUpdateFnStaysPending(t *testing.T) {
 	}
 }
 
-// TestPendingState_Execute_DefaultPropagatesError verifies SyncJob errors are
-// surfaced for the default branch.
 func TestPendingState_Execute_DefaultPropagatesError(t *testing.T) {
 	want := errors.New("sync failed")
 	captureSyncJob(t, want)

--- a/pkg/controllers/job/state/pending_test.go
+++ b/pkg/controllers/job/state/pending_test.go
@@ -21,13 +21,14 @@ import (
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	vcbatch "volcano.sh/apis/pkg/apis/batch/v1alpha1"
 	"volcano.sh/apis/pkg/apis/bus/v1alpha1"
 
 	"volcano.sh/volcano/pkg/controllers/apis"
 )
 
-// ── stub helpers ────────────────────────────────────────────────────────────
+// --- stub helpers ---
 
 // capturedKillTarget records one KillTarget invocation and preserves the
 // updateFn so tests can invoke it to verify state-transition logic.
@@ -40,15 +41,15 @@ type capturedKillTarget struct {
 func captureKillTarget(t *testing.T, returnErr error) *capturedKillTarget {
 	t.Helper()
 	original := KillTarget
-	cap := &capturedKillTarget{}
+	c := &capturedKillTarget{}
 	KillTarget = func(job *apis.JobInfo, target Target, fn UpdateStatusFn) error {
-		cap.job = job
-		cap.target = target
-		cap.updateFn = fn
+		c.job = job
+		c.target = target
+		c.updateFn = fn
 		return returnErr
 	}
 	t.Cleanup(func() { KillTarget = original })
-	return cap
+	return c
 }
 
 // capturedSyncJob records one SyncJob invocation and preserves the updateFn.
@@ -60,14 +61,14 @@ type capturedSyncJob struct {
 func captureSyncJob(t *testing.T, returnErr error) *capturedSyncJob {
 	t.Helper()
 	original := SyncJob
-	cap := &capturedSyncJob{}
+	c := &capturedSyncJob{}
 	SyncJob = func(job *apis.JobInfo, fn UpdateStatusFn) error {
-		cap.job = job
-		cap.updateFn = fn
+		c.job = job
+		c.updateFn = fn
 		return returnErr
 	}
 	t.Cleanup(func() { SyncJob = original })
-	return cap
+	return c
 }
 
 // makeJobInfoWithSpec builds a JobInfo with the given phase and MinAvailable.
@@ -81,18 +82,18 @@ func makeJobInfoWithSpec(phase vcbatch.JobPhase, minAvailable int32) *apis.JobIn
 	}
 }
 
-// ── RestartJobAction branch ──────────────────────────────────────────────────
+// --- RestartJobAction branch ---
 
 // TestPendingState_Execute_RestartJobCallsKillJob verifies RestartJobAction
 // delegates to KillJob (not SyncJob or KillTarget).
 func TestPendingState_Execute_RestartJobCallsKillJob(t *testing.T) {
-	cap := captureKillJob(t, nil)
+	c := captureKillJob(t, nil)
 	s := &pendingState{job: makeJobInfo(vcbatch.Pending)}
 
 	if err := s.Execute(Action{Action: v1alpha1.RestartJobAction}); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if cap.job == nil {
+	if c.job == nil {
 		t.Fatal("KillJob was not called")
 	}
 }
@@ -101,14 +102,14 @@ func TestPendingState_Execute_RestartJobCallsKillJob(t *testing.T) {
 // RestartJobAction passes PodRetainPhaseNone — all pods are killed, including
 // already-completed ones (unlike Abort/Complete/Terminate which use Soft).
 func TestPendingState_Execute_RestartJobUsesRetainPhaseNone(t *testing.T) {
-	cap := captureKillJob(t, nil)
+	c := captureKillJob(t, nil)
 	s := &pendingState{job: makeJobInfo(vcbatch.Pending)}
 
 	if err := s.Execute(Action{Action: v1alpha1.RestartJobAction}); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if len(cap.podRetainPhase) != 0 {
-		t.Errorf("podRetainPhase should be empty (PhaseNone), got %v", cap.podRetainPhase)
+	if len(c.podRetainPhase) != 0 {
+		t.Errorf("podRetainPhase should be empty (PhaseNone), got %v", c.podRetainPhase)
 	}
 }
 
@@ -125,13 +126,13 @@ func TestPendingState_Execute_RestartJobUpdateFn(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			cap := captureKillJob(t, nil)
+			c := captureKillJob(t, nil)
 			s := &pendingState{job: makeJobInfo(vcbatch.Pending)}
 
 			if err := s.Execute(Action{Action: v1alpha1.RestartJobAction}); err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
-			if cap.updateFn == nil {
+			if c.updateFn == nil {
 				t.Fatal("expected non-nil updateFn")
 			}
 
@@ -139,7 +140,7 @@ func TestPendingState_Execute_RestartJobUpdateFn(t *testing.T) {
 				RetryCount: tc.initialRetry,
 				State:      vcbatch.JobState{Phase: vcbatch.Pending},
 			}
-			changed := cap.updateFn(status)
+			changed := c.updateFn(status)
 
 			if !changed {
 				t.Error("updateFn should return true")
@@ -157,15 +158,15 @@ func TestPendingState_Execute_RestartJobUpdateFn(t *testing.T) {
 // TestPendingState_Execute_RestartJobPassesJobInfo verifies the correct
 // JobInfo pointer is forwarded to KillJob.
 func TestPendingState_Execute_RestartJobPassesJobInfo(t *testing.T) {
-	cap := captureKillJob(t, nil)
+	c := captureKillJob(t, nil)
 	info := makeJobInfo(vcbatch.Pending)
 	s := &pendingState{job: info}
 
 	if err := s.Execute(Action{Action: v1alpha1.RestartJobAction}); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if cap.job != info {
-		t.Errorf("KillJob received wrong JobInfo: got %p, want %p", cap.job, info)
+	if c.job != info {
+		t.Errorf("KillJob received wrong JobInfo: got %p, want %p", c.job, info)
 	}
 }
 
@@ -181,7 +182,7 @@ func TestPendingState_Execute_RestartJobPropagatesError(t *testing.T) {
 	}
 }
 
-// ── RestartTask / RestartPod / RestartPartition branch ───────────────────────
+// --- RestartTask / RestartPod / RestartPartition branch ---
 
 // TestPendingState_Execute_RestartTargetActionsCallKillTarget verifies that
 // all three granular restart actions delegate to KillTarget.
@@ -196,13 +197,13 @@ func TestPendingState_Execute_RestartTargetActionsCallKillTarget(t *testing.T) {
 	}
 	for _, tc := range actions {
 		t.Run(tc.name, func(t *testing.T) {
-			cap := captureKillTarget(t, nil)
+			c := captureKillTarget(t, nil)
 			s := &pendingState{job: makeJobInfo(vcbatch.Pending)}
 
 			if err := s.Execute(Action{Action: tc.action}); err != nil {
 				t.Fatalf("Execute(%q) returned unexpected error: %v", tc.action, err)
 			}
-			if cap.job == nil {
+			if c.job == nil {
 				t.Fatal("KillTarget was not called")
 			}
 		})
@@ -235,14 +236,14 @@ func TestPendingState_Execute_RestartTargetForwardsTarget(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			cap := captureKillTarget(t, nil)
+			c := captureKillTarget(t, nil)
 			s := &pendingState{job: makeJobInfo(vcbatch.Pending)}
 
 			if err := s.Execute(Action{Action: tc.action, Target: tc.target}); err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
-			if cap.target != tc.target {
-				t.Errorf("KillTarget received target %+v, want %+v", cap.target, tc.target)
+			if c.target != tc.target {
+				t.Errorf("KillTarget received target %+v, want %+v", c.target, tc.target)
 			}
 		})
 	}
@@ -251,18 +252,18 @@ func TestPendingState_Execute_RestartTargetForwardsTarget(t *testing.T) {
 // TestPendingState_Execute_RestartTargetUpdateFn verifies the updateFn sets
 // Phase to Restarting, increments RetryCount, and returns true.
 func TestPendingState_Execute_RestartTargetUpdateFn(t *testing.T) {
-	cap := captureKillTarget(t, nil)
+	c := captureKillTarget(t, nil)
 	s := &pendingState{job: makeJobInfo(vcbatch.Pending)}
 
 	if err := s.Execute(Action{Action: v1alpha1.RestartTaskAction}); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if cap.updateFn == nil {
+	if c.updateFn == nil {
 		t.Fatal("expected non-nil updateFn")
 	}
 
 	status := &vcbatch.JobStatus{RetryCount: 1, State: vcbatch.JobState{Phase: vcbatch.Pending}}
-	changed := cap.updateFn(status)
+	changed := c.updateFn(status)
 
 	if !changed {
 		t.Error("updateFn should return true")
@@ -287,7 +288,7 @@ func TestPendingState_Execute_RestartTargetPropagatesError(t *testing.T) {
 	}
 }
 
-// ── AbortJobAction / CompleteJobAction / TerminateJobAction branches ─────────
+// --- AbortJobAction / CompleteJobAction / TerminateJobAction branches ---
 
 // TestPendingState_Execute_KillJobBranchesUsesSoftRetainPhase verifies that
 // Abort, Complete, and Terminate all call KillJob with PodRetainPhaseSoft.
@@ -299,19 +300,19 @@ func TestPendingState_Execute_KillJobBranchesUsesSoftRetainPhase(t *testing.T) {
 	}
 	for _, action := range actions {
 		t.Run(string(action), func(t *testing.T) {
-			cap := captureKillJob(t, nil)
+			c := captureKillJob(t, nil)
 			s := &pendingState{job: makeJobInfo(vcbatch.Pending)}
 
 			if err := s.Execute(Action{Action: action}); err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
 			for phase := range PodRetainPhaseSoft {
-				if _, ok := cap.podRetainPhase[phase]; !ok {
+				if _, ok := c.podRetainPhase[phase]; !ok {
 					t.Errorf("podRetainPhase missing %q", phase)
 				}
 			}
-			if len(cap.podRetainPhase) != len(PodRetainPhaseSoft) {
-				t.Errorf("podRetainPhase has %d entries, want %d", len(cap.podRetainPhase), len(PodRetainPhaseSoft))
+			if len(c.podRetainPhase) != len(PodRetainPhaseSoft) {
+				t.Errorf("podRetainPhase has %d entries, want %d", len(c.podRetainPhase), len(PodRetainPhaseSoft))
 			}
 		})
 	}
@@ -330,18 +331,18 @@ func TestPendingState_Execute_KillJobBranchesUpdateFn(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(string(tc.action), func(t *testing.T) {
-			cap := captureKillJob(t, nil)
+			c := captureKillJob(t, nil)
 			s := &pendingState{job: makeJobInfo(vcbatch.Pending)}
 
 			if err := s.Execute(Action{Action: tc.action}); err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
-			if cap.updateFn == nil {
+			if c.updateFn == nil {
 				t.Fatal("expected non-nil updateFn")
 			}
 
 			status := &vcbatch.JobStatus{State: vcbatch.JobState{Phase: vcbatch.Pending}}
-			changed := cap.updateFn(status)
+			changed := c.updateFn(status)
 
 			if !changed {
 				t.Error("updateFn should return true")
@@ -374,18 +375,18 @@ func TestPendingState_Execute_KillJobBranchesPropagatesError(t *testing.T) {
 	}
 }
 
-// ── default branch (SyncJob) ─────────────────────────────────────────────────
+// --- default branch (SyncJob) ---
 
 // TestPendingState_Execute_DefaultCallsSyncJob verifies the default path
 // calls SyncJob (not KillJob or KillTarget).
 func TestPendingState_Execute_DefaultCallsSyncJob(t *testing.T) {
-	cap := captureSyncJob(t, nil)
+	c := captureSyncJob(t, nil)
 	s := &pendingState{job: makeJobInfo(vcbatch.Pending)}
 
 	if err := s.Execute(Action{Action: v1alpha1.SyncJobAction}); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if cap.job == nil {
+	if c.job == nil {
 		t.Fatal("SyncJob was not called")
 	}
 }
@@ -393,15 +394,15 @@ func TestPendingState_Execute_DefaultCallsSyncJob(t *testing.T) {
 // TestPendingState_Execute_DefaultPassesJobInfo verifies the correct JobInfo
 // pointer is forwarded to SyncJob.
 func TestPendingState_Execute_DefaultPassesJobInfo(t *testing.T) {
-	cap := captureSyncJob(t, nil)
+	c := captureSyncJob(t, nil)
 	info := makeJobInfoWithSpec(vcbatch.Pending, 1)
 	s := &pendingState{job: info}
 
 	if err := s.Execute(Action{Action: v1alpha1.SyncJobAction}); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if cap.job != info {
-		t.Errorf("SyncJob received wrong JobInfo: got %p, want %p", cap.job, info)
+	if c.job != info {
+		t.Errorf("SyncJob received wrong JobInfo: got %p, want %p", c.job, info)
 	}
 }
 
@@ -441,17 +442,17 @@ func TestPendingState_Execute_DefaultUpdateFnTransitionsToRunning(t *testing.T) 
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			cap := captureSyncJob(t, nil)
+			c := captureSyncJob(t, nil)
 			s := &pendingState{job: makeJobInfoWithSpec(vcbatch.Pending, tc.minAvailable)}
 
 			if err := s.Execute(Action{Action: v1alpha1.SyncJobAction}); err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
-			if cap.updateFn == nil {
+			if c.updateFn == nil {
 				t.Fatal("expected non-nil updateFn")
 			}
 
-			changed := cap.updateFn(&tc.status)
+			changed := c.updateFn(&tc.status)
 
 			if !changed {
 				t.Error("updateFn should return true when MinAvailable is met")
@@ -490,18 +491,18 @@ func TestPendingState_Execute_DefaultUpdateFnStaysPending(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			cap := captureSyncJob(t, nil)
+			c := captureSyncJob(t, nil)
 			s := &pendingState{job: makeJobInfoWithSpec(vcbatch.Pending, tc.minAvailable)}
 
 			if err := s.Execute(Action{Action: v1alpha1.SyncJobAction}); err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
-			if cap.updateFn == nil {
+			if c.updateFn == nil {
 				t.Fatal("expected non-nil updateFn")
 			}
 
 			originalPhase := tc.status.State.Phase
-			changed := cap.updateFn(&tc.status)
+			changed := c.updateFn(&tc.status)
 
 			if changed {
 				t.Error("updateFn should return false when MinAvailable is not met")

--- a/pkg/controllers/job/state/pending_test.go
+++ b/pkg/controllers/job/state/pending_test.go
@@ -1,0 +1,526 @@
+/*
+Copyright 2024 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package state
+
+import (
+	"errors"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	vcbatch "volcano.sh/apis/pkg/apis/batch/v1alpha1"
+	"volcano.sh/apis/pkg/apis/bus/v1alpha1"
+
+	"volcano.sh/volcano/pkg/controllers/apis"
+)
+
+// ── stub helpers ────────────────────────────────────────────────────────────
+
+// capturedKillTarget records one KillTarget invocation and preserves the
+// updateFn so tests can invoke it to verify state-transition logic.
+type capturedKillTarget struct {
+	job      *apis.JobInfo
+	target   Target
+	updateFn UpdateStatusFn
+}
+
+func captureKillTarget(t *testing.T, returnErr error) *capturedKillTarget {
+	t.Helper()
+	original := KillTarget
+	cap := &capturedKillTarget{}
+	KillTarget = func(job *apis.JobInfo, target Target, fn UpdateStatusFn) error {
+		cap.job = job
+		cap.target = target
+		cap.updateFn = fn
+		return returnErr
+	}
+	t.Cleanup(func() { KillTarget = original })
+	return cap
+}
+
+// capturedSyncJob records one SyncJob invocation and preserves the updateFn.
+type capturedSyncJob struct {
+	job      *apis.JobInfo
+	updateFn UpdateStatusFn
+}
+
+func captureSyncJob(t *testing.T, returnErr error) *capturedSyncJob {
+	t.Helper()
+	original := SyncJob
+	cap := &capturedSyncJob{}
+	SyncJob = func(job *apis.JobInfo, fn UpdateStatusFn) error {
+		cap.job = job
+		cap.updateFn = fn
+		return returnErr
+	}
+	t.Cleanup(func() { SyncJob = original })
+	return cap
+}
+
+// makeJobInfoWithSpec builds a JobInfo with the given phase and MinAvailable.
+func makeJobInfoWithSpec(phase vcbatch.JobPhase, minAvailable int32) *apis.JobInfo {
+	return &apis.JobInfo{
+		Job: &vcbatch.Job{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-job", Namespace: "default"},
+			Spec:       vcbatch.JobSpec{MinAvailable: minAvailable},
+			Status:     vcbatch.JobStatus{State: vcbatch.JobState{Phase: phase}},
+		},
+	}
+}
+
+// ── RestartJobAction branch ──────────────────────────────────────────────────
+
+// TestPendingState_Execute_RestartJobCallsKillJob verifies RestartJobAction
+// delegates to KillJob (not SyncJob or KillTarget).
+func TestPendingState_Execute_RestartJobCallsKillJob(t *testing.T) {
+	cap := captureKillJob(t, nil)
+	s := &pendingState{job: makeJobInfo(vcbatch.Pending)}
+
+	if err := s.Execute(Action{Action: v1alpha1.RestartJobAction}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cap.job == nil {
+		t.Fatal("KillJob was not called")
+	}
+}
+
+// TestPendingState_Execute_RestartJobUsesRetainPhaseNone verifies that
+// RestartJobAction passes PodRetainPhaseNone — all pods are killed, including
+// already-completed ones (unlike Abort/Complete/Terminate which use Soft).
+func TestPendingState_Execute_RestartJobUsesRetainPhaseNone(t *testing.T) {
+	cap := captureKillJob(t, nil)
+	s := &pendingState{job: makeJobInfo(vcbatch.Pending)}
+
+	if err := s.Execute(Action{Action: v1alpha1.RestartJobAction}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(cap.podRetainPhase) != 0 {
+		t.Errorf("podRetainPhase should be empty (PhaseNone), got %v", cap.podRetainPhase)
+	}
+}
+
+// TestPendingState_Execute_RestartJobUpdateFn verifies the updateFn sets
+// Phase to Restarting, increments RetryCount, and returns true.
+func TestPendingState_Execute_RestartJobUpdateFn(t *testing.T) {
+	tests := []struct {
+		name         string
+		initialRetry int32
+		wantRetry    int32
+	}{
+		{"from zero", 0, 1},
+		{"from non-zero", 2, 3},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cap := captureKillJob(t, nil)
+			s := &pendingState{job: makeJobInfo(vcbatch.Pending)}
+
+			if err := s.Execute(Action{Action: v1alpha1.RestartJobAction}); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if cap.updateFn == nil {
+				t.Fatal("expected non-nil updateFn")
+			}
+
+			status := &vcbatch.JobStatus{
+				RetryCount: tc.initialRetry,
+				State:      vcbatch.JobState{Phase: vcbatch.Pending},
+			}
+			changed := cap.updateFn(status)
+
+			if !changed {
+				t.Error("updateFn should return true")
+			}
+			if status.State.Phase != vcbatch.Restarting {
+				t.Errorf("phase = %q, want %q", status.State.Phase, vcbatch.Restarting)
+			}
+			if status.RetryCount != tc.wantRetry {
+				t.Errorf("RetryCount = %d, want %d", status.RetryCount, tc.wantRetry)
+			}
+		})
+	}
+}
+
+// TestPendingState_Execute_RestartJobPassesJobInfo verifies the correct
+// JobInfo pointer is forwarded to KillJob.
+func TestPendingState_Execute_RestartJobPassesJobInfo(t *testing.T) {
+	cap := captureKillJob(t, nil)
+	info := makeJobInfo(vcbatch.Pending)
+	s := &pendingState{job: info}
+
+	if err := s.Execute(Action{Action: v1alpha1.RestartJobAction}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cap.job != info {
+		t.Errorf("KillJob received wrong JobInfo: got %p, want %p", cap.job, info)
+	}
+}
+
+// TestPendingState_Execute_RestartJobPropagatesError verifies KillJob errors
+// are surfaced.
+func TestPendingState_Execute_RestartJobPropagatesError(t *testing.T) {
+	want := errors.New("kill failed")
+	captureKillJob(t, want)
+	s := &pendingState{job: makeJobInfo(vcbatch.Pending)}
+
+	if got := s.Execute(Action{Action: v1alpha1.RestartJobAction}); !errors.Is(got, want) {
+		t.Errorf("Execute returned %v, want %v", got, want)
+	}
+}
+
+// ── RestartTask / RestartPod / RestartPartition branch ───────────────────────
+
+// TestPendingState_Execute_RestartTargetActionsCallKillTarget verifies that
+// all three granular restart actions delegate to KillTarget.
+func TestPendingState_Execute_RestartTargetActionsCallKillTarget(t *testing.T) {
+	actions := []struct {
+		name   string
+		action v1alpha1.Action
+	}{
+		{"RestartTaskAction", v1alpha1.RestartTaskAction},
+		{"RestartPodAction", v1alpha1.RestartPodAction},
+		{"RestartPartitionAction", v1alpha1.RestartPartitionAction},
+	}
+	for _, tc := range actions {
+		t.Run(tc.name, func(t *testing.T) {
+			cap := captureKillTarget(t, nil)
+			s := &pendingState{job: makeJobInfo(vcbatch.Pending)}
+
+			if err := s.Execute(Action{Action: tc.action}); err != nil {
+				t.Fatalf("Execute(%q) returned unexpected error: %v", tc.action, err)
+			}
+			if cap.job == nil {
+				t.Fatal("KillTarget was not called")
+			}
+		})
+	}
+}
+
+// TestPendingState_Execute_RestartTargetForwardsTarget verifies that the
+// Target embedded in the Action is forwarded unchanged to KillTarget.
+func TestPendingState_Execute_RestartTargetForwardsTarget(t *testing.T) {
+	tests := []struct {
+		name   string
+		action v1alpha1.Action
+		target Target
+	}{
+		{
+			name:   "task target",
+			action: v1alpha1.RestartTaskAction,
+			target: Target{TaskName: "worker", Type: TargetTypeTask},
+		},
+		{
+			name:   "pod target",
+			action: v1alpha1.RestartPodAction,
+			target: Target{TaskName: "worker", PodName: "worker-0", Type: TargetTypePod},
+		},
+		{
+			name:   "partition target",
+			action: v1alpha1.RestartPartitionAction,
+			target: Target{TaskName: "worker", PodName: "worker-0", PartitionName: "p0", Type: TargetTypePartition},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cap := captureKillTarget(t, nil)
+			s := &pendingState{job: makeJobInfo(vcbatch.Pending)}
+
+			if err := s.Execute(Action{Action: tc.action, Target: tc.target}); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if cap.target != tc.target {
+				t.Errorf("KillTarget received target %+v, want %+v", cap.target, tc.target)
+			}
+		})
+	}
+}
+
+// TestPendingState_Execute_RestartTargetUpdateFn verifies the updateFn sets
+// Phase to Restarting, increments RetryCount, and returns true.
+func TestPendingState_Execute_RestartTargetUpdateFn(t *testing.T) {
+	cap := captureKillTarget(t, nil)
+	s := &pendingState{job: makeJobInfo(vcbatch.Pending)}
+
+	if err := s.Execute(Action{Action: v1alpha1.RestartTaskAction}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cap.updateFn == nil {
+		t.Fatal("expected non-nil updateFn")
+	}
+
+	status := &vcbatch.JobStatus{RetryCount: 1, State: vcbatch.JobState{Phase: vcbatch.Pending}}
+	changed := cap.updateFn(status)
+
+	if !changed {
+		t.Error("updateFn should return true")
+	}
+	if status.State.Phase != vcbatch.Restarting {
+		t.Errorf("phase = %q, want %q", status.State.Phase, vcbatch.Restarting)
+	}
+	if status.RetryCount != 2 {
+		t.Errorf("RetryCount = %d, want 2", status.RetryCount)
+	}
+}
+
+// TestPendingState_Execute_RestartTargetPropagatesError verifies KillTarget
+// errors are surfaced.
+func TestPendingState_Execute_RestartTargetPropagatesError(t *testing.T) {
+	want := errors.New("kill target failed")
+	captureKillTarget(t, want)
+	s := &pendingState{job: makeJobInfo(vcbatch.Pending)}
+
+	if got := s.Execute(Action{Action: v1alpha1.RestartTaskAction}); !errors.Is(got, want) {
+		t.Errorf("Execute returned %v, want %v", got, want)
+	}
+}
+
+// ── AbortJobAction / CompleteJobAction / TerminateJobAction branches ─────────
+
+// TestPendingState_Execute_KillJobBranchesUsesSoftRetainPhase verifies that
+// Abort, Complete, and Terminate all call KillJob with PodRetainPhaseSoft.
+func TestPendingState_Execute_KillJobBranchesUsesSoftRetainPhase(t *testing.T) {
+	actions := []v1alpha1.Action{
+		v1alpha1.AbortJobAction,
+		v1alpha1.CompleteJobAction,
+		v1alpha1.TerminateJobAction,
+	}
+	for _, action := range actions {
+		t.Run(string(action), func(t *testing.T) {
+			cap := captureKillJob(t, nil)
+			s := &pendingState{job: makeJobInfo(vcbatch.Pending)}
+
+			if err := s.Execute(Action{Action: action}); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			for phase := range PodRetainPhaseSoft {
+				if _, ok := cap.podRetainPhase[phase]; !ok {
+					t.Errorf("podRetainPhase missing %q", phase)
+				}
+			}
+			if len(cap.podRetainPhase) != len(PodRetainPhaseSoft) {
+				t.Errorf("podRetainPhase has %d entries, want %d", len(cap.podRetainPhase), len(PodRetainPhaseSoft))
+			}
+		})
+	}
+}
+
+// TestPendingState_Execute_KillJobBranchesUpdateFn verifies each action's
+// updateFn transitions to the correct target phase and returns true.
+func TestPendingState_Execute_KillJobBranchesUpdateFn(t *testing.T) {
+	tests := []struct {
+		action    v1alpha1.Action
+		wantPhase vcbatch.JobPhase
+	}{
+		{v1alpha1.AbortJobAction, vcbatch.Aborting},
+		{v1alpha1.CompleteJobAction, vcbatch.Completing},
+		{v1alpha1.TerminateJobAction, vcbatch.Terminating},
+	}
+	for _, tc := range tests {
+		t.Run(string(tc.action), func(t *testing.T) {
+			cap := captureKillJob(t, nil)
+			s := &pendingState{job: makeJobInfo(vcbatch.Pending)}
+
+			if err := s.Execute(Action{Action: tc.action}); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if cap.updateFn == nil {
+				t.Fatal("expected non-nil updateFn")
+			}
+
+			status := &vcbatch.JobStatus{State: vcbatch.JobState{Phase: vcbatch.Pending}}
+			changed := cap.updateFn(status)
+
+			if !changed {
+				t.Error("updateFn should return true")
+			}
+			if status.State.Phase != tc.wantPhase {
+				t.Errorf("phase = %q, want %q", status.State.Phase, tc.wantPhase)
+			}
+		})
+	}
+}
+
+// TestPendingState_Execute_KillJobBranchesPropagatesError verifies KillJob
+// errors are surfaced for Abort, Complete, and Terminate.
+func TestPendingState_Execute_KillJobBranchesPropagatesError(t *testing.T) {
+	want := errors.New("kill failed")
+	actions := []v1alpha1.Action{
+		v1alpha1.AbortJobAction,
+		v1alpha1.CompleteJobAction,
+		v1alpha1.TerminateJobAction,
+	}
+	for _, action := range actions {
+		t.Run(string(action), func(t *testing.T) {
+			captureKillJob(t, want)
+			s := &pendingState{job: makeJobInfo(vcbatch.Pending)}
+
+			if got := s.Execute(Action{Action: action}); !errors.Is(got, want) {
+				t.Errorf("Execute returned %v, want %v", got, want)
+			}
+		})
+	}
+}
+
+// ── default branch (SyncJob) ─────────────────────────────────────────────────
+
+// TestPendingState_Execute_DefaultCallsSyncJob verifies the default path
+// calls SyncJob (not KillJob or KillTarget).
+func TestPendingState_Execute_DefaultCallsSyncJob(t *testing.T) {
+	cap := captureSyncJob(t, nil)
+	s := &pendingState{job: makeJobInfo(vcbatch.Pending)}
+
+	if err := s.Execute(Action{Action: v1alpha1.SyncJobAction}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cap.job == nil {
+		t.Fatal("SyncJob was not called")
+	}
+}
+
+// TestPendingState_Execute_DefaultPassesJobInfo verifies the correct JobInfo
+// pointer is forwarded to SyncJob.
+func TestPendingState_Execute_DefaultPassesJobInfo(t *testing.T) {
+	cap := captureSyncJob(t, nil)
+	info := makeJobInfoWithSpec(vcbatch.Pending, 1)
+	s := &pendingState{job: info}
+
+	if err := s.Execute(Action{Action: v1alpha1.SyncJobAction}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cap.job != info {
+		t.Errorf("SyncJob received wrong JobInfo: got %p, want %p", cap.job, info)
+	}
+}
+
+// TestPendingState_Execute_DefaultUpdateFnTransitionsToRunning verifies the
+// updateFn transitions to Running when Running+Succeeded+Failed >= MinAvailable.
+func TestPendingState_Execute_DefaultUpdateFnTransitionsToRunning(t *testing.T) {
+	tests := []struct {
+		name         string
+		minAvailable int32
+		status       vcbatch.JobStatus
+	}{
+		{
+			name:         "sum equals MinAvailable",
+			minAvailable: 3,
+			status:       vcbatch.JobStatus{Running: 3},
+		},
+		{
+			name:         "sum exceeds MinAvailable",
+			minAvailable: 2,
+			status:       vcbatch.JobStatus{Running: 1, Succeeded: 1, Failed: 1},
+		},
+		{
+			name:         "only Succeeded meets MinAvailable",
+			minAvailable: 2,
+			status:       vcbatch.JobStatus{Succeeded: 2},
+		},
+		{
+			name:         "only Failed meets MinAvailable",
+			minAvailable: 1,
+			status:       vcbatch.JobStatus{Failed: 1},
+		},
+		{
+			name:         "MinAvailable is zero",
+			minAvailable: 0,
+			status:       vcbatch.JobStatus{},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cap := captureSyncJob(t, nil)
+			s := &pendingState{job: makeJobInfoWithSpec(vcbatch.Pending, tc.minAvailable)}
+
+			if err := s.Execute(Action{Action: v1alpha1.SyncJobAction}); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if cap.updateFn == nil {
+				t.Fatal("expected non-nil updateFn")
+			}
+
+			changed := cap.updateFn(&tc.status)
+
+			if !changed {
+				t.Error("updateFn should return true when MinAvailable is met")
+			}
+			if tc.status.State.Phase != vcbatch.Running {
+				t.Errorf("phase = %q, want %q", tc.status.State.Phase, vcbatch.Running)
+			}
+		})
+	}
+}
+
+// TestPendingState_Execute_DefaultUpdateFnStaysPending verifies the updateFn
+// returns false and leaves phase unchanged when Running+Succeeded+Failed <
+// MinAvailable.
+func TestPendingState_Execute_DefaultUpdateFnStaysPending(t *testing.T) {
+	tests := []struct {
+		name         string
+		minAvailable int32
+		status       vcbatch.JobStatus
+	}{
+		{
+			name:         "no pods at all",
+			minAvailable: 1,
+			status:       vcbatch.JobStatus{},
+		},
+		{
+			name:         "sum one short of MinAvailable",
+			minAvailable: 3,
+			status:       vcbatch.JobStatus{Running: 1, Succeeded: 1},
+		},
+		{
+			name:         "only Pending pods, not counted",
+			minAvailable: 2,
+			status:       vcbatch.JobStatus{Pending: 5, Running: 0},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cap := captureSyncJob(t, nil)
+			s := &pendingState{job: makeJobInfoWithSpec(vcbatch.Pending, tc.minAvailable)}
+
+			if err := s.Execute(Action{Action: v1alpha1.SyncJobAction}); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if cap.updateFn == nil {
+				t.Fatal("expected non-nil updateFn")
+			}
+
+			originalPhase := tc.status.State.Phase
+			changed := cap.updateFn(&tc.status)
+
+			if changed {
+				t.Error("updateFn should return false when MinAvailable is not met")
+			}
+			if tc.status.State.Phase != originalPhase {
+				t.Errorf("phase should not change: got %q, want %q", tc.status.State.Phase, originalPhase)
+			}
+		})
+	}
+}
+
+// TestPendingState_Execute_DefaultPropagatesError verifies SyncJob errors are
+// surfaced for the default branch.
+func TestPendingState_Execute_DefaultPropagatesError(t *testing.T) {
+	want := errors.New("sync failed")
+	captureSyncJob(t, want)
+	s := &pendingState{job: makeJobInfo(vcbatch.Pending)}
+
+	if got := s.Execute(Action{Action: v1alpha1.SyncJobAction}); !errors.Is(got, want) {
+		t.Errorf("Execute returned %v, want %v", got, want)
+	}
+}

--- a/pkg/controllers/job/state/pending_test.go
+++ b/pkg/controllers/job/state/pending_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2024 The Volcano Authors.
+Copyright 2026 The Volcano Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/controllers/job/state/restarting_test.go
+++ b/pkg/controllers/job/state/restarting_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Volcano Authors.
+Copyright 2017 The Volcano Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -20,40 +20,18 @@ import (
 	"errors"
 	"testing"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	vcbatch "volcano.sh/apis/pkg/apis/batch/v1alpha1"
 	"volcano.sh/apis/pkg/apis/bus/v1alpha1"
 
 	"volcano.sh/volcano/pkg/controllers/apis"
 )
 
-// makeRestartingJobInfo builds a JobInfo configured for restarting-state tests.
-// taskReplicas controls how many replicas each task has; maxRetry sets the
-// job-level retry ceiling.
 func makeRestartingJobInfo(maxRetry int32, taskReplicas ...int32) *apis.JobInfo {
-	tasks := make([]vcbatch.TaskSpec, len(taskReplicas))
-	for i, r := range taskReplicas {
-		tasks[i] = vcbatch.TaskSpec{Replicas: r}
-	}
-	return &apis.JobInfo{
-		Job: &vcbatch.Job{
-			ObjectMeta: metav1.ObjectMeta{Name: "test-job", Namespace: "default"},
-			Spec: vcbatch.JobSpec{
-				MaxRetry: maxRetry,
-				Tasks:    tasks,
-			},
-			Status: vcbatch.JobStatus{
-				State: vcbatch.JobState{Phase: vcbatch.Restarting},
-			},
-		},
-	}
+	return makeJobInfo(vcbatch.Restarting,
+		withMaxRetry(maxRetry),
+		withTaskReplicas(taskReplicas...))
 }
 
-// --- restartingUpdateStatus: direct method tests ---
-
-// TestRestartingState_UpdateStatus_ExceedsMaxRetry verifies that when
-// RetryCount >= MaxRetry the method sets Phase to Failed and returns true.
 func TestRestartingState_UpdateStatus_ExceedsMaxRetry(t *testing.T) {
 	tests := []struct {
 		name       string
@@ -84,46 +62,43 @@ func TestRestartingState_UpdateStatus_ExceedsMaxRetry(t *testing.T) {
 	}
 }
 
-// TestRestartingState_UpdateStatus_MeetsMinAvailable verifies that when
-// RetryCount < MaxRetry and (total replicas - Terminating) >= status.MinAvailable
-// the method sets Phase to Pending and returns true.
 func TestRestartingState_UpdateStatus_MeetsMinAvailable(t *testing.T) {
 	tests := []struct {
 		name         string
-		taskReplicas []int32 // total is their sum
+		taskReplicas []int32
 		terminating  int32
 		minAvailable int32
 	}{
 		{
 			name:         "no terminating pods, exactly meets minAvailable",
-			taskReplicas: []int32{3, 2}, // total = 5
+			taskReplicas: []int32{3, 2},
 			terminating:  0,
-			minAvailable: 5, // 5-0=5 >= 5
+			minAvailable: 5,
 		},
 		{
 			name:         "some terminating pods, still meets minAvailable",
-			taskReplicas: []int32{3, 2}, // total = 5
+			taskReplicas: []int32{3, 2},
 			terminating:  2,
-			minAvailable: 2, // 5-2=3 >= 2
+			minAvailable: 2,
 		},
 		{
 			name:         "single task, minAvailable is zero",
 			taskReplicas: []int32{3},
 			terminating:  3,
-			minAvailable: 0, // 3-3=0 >= 0
+			minAvailable: 0,
 		},
 		{
 			name:         "total exceeds minAvailable",
 			taskReplicas: []int32{5},
 			terminating:  1,
-			minAvailable: 2, // 5-1=4 >= 2
+			minAvailable: 2,
 		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			s := &restartingState{job: makeRestartingJobInfo(10, tc.taskReplicas...)}
 			status := &vcbatch.JobStatus{
-				RetryCount:   1, // < MaxRetry (10)
+				RetryCount:   1,
 				Terminating:  tc.terminating,
 				MinAvailable: tc.minAvailable,
 				State:        vcbatch.JobState{Phase: vcbatch.Restarting},
@@ -141,9 +116,6 @@ func TestRestartingState_UpdateStatus_MeetsMinAvailable(t *testing.T) {
 	}
 }
 
-// TestRestartingState_UpdateStatus_StillWaiting verifies that when
-// RetryCount < MaxRetry and (total - Terminating) < status.MinAvailable the
-// method returns false and leaves the phase unchanged.
 func TestRestartingState_UpdateStatus_StillWaiting(t *testing.T) {
 	tests := []struct {
 		name         string
@@ -153,28 +125,28 @@ func TestRestartingState_UpdateStatus_StillWaiting(t *testing.T) {
 	}{
 		{
 			name:         "one pod short after terminating subtracted",
-			taskReplicas: []int32{3}, // total = 3
+			taskReplicas: []int32{3},
 			terminating:  1,
-			minAvailable: 3, // 3-1=2 < 3
+			minAvailable: 3,
 		},
 		{
 			name:         "all pods are terminating",
-			taskReplicas: []int32{4}, // total = 4
+			taskReplicas: []int32{4},
 			terminating:  4,
-			minAvailable: 1, // 4-4=0 < 1
+			minAvailable: 1,
 		},
 		{
 			name:         "no tasks at all",
-			taskReplicas: []int32{}, // total = 0
+			taskReplicas: []int32{},
 			terminating:  0,
-			minAvailable: 1, // 0-0=0 < 1
+			minAvailable: 1,
 		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			s := &restartingState{job: makeRestartingJobInfo(10, tc.taskReplicas...)}
 			status := &vcbatch.JobStatus{
-				RetryCount:   1, // < MaxRetry (10)
+				RetryCount:   1,
 				Terminating:  tc.terminating,
 				MinAvailable: tc.minAvailable,
 				State:        vcbatch.JobState{Phase: vcbatch.Restarting},
@@ -193,15 +165,14 @@ func TestRestartingState_UpdateStatus_StillWaiting(t *testing.T) {
 	}
 }
 
-// TestRestartingState_UpdateStatus_MaxRetryTakesPrecedence verifies that the
-// RetryCount >= MaxRetry check runs before the minAvailable check — even when
-// the minAvailable condition would also be satisfied.
+// MaxRetry check must run before the minAvailable check, even when both
+// conditions hold simultaneously.
 func TestRestartingState_UpdateStatus_MaxRetryTakesPrecedence(t *testing.T) {
 	s := &restartingState{job: makeRestartingJobInfo(3, 5)}
 	status := &vcbatch.JobStatus{
-		RetryCount:   3, // == MaxRetry → should trigger Failed
+		RetryCount:   3,
 		Terminating:  0,
-		MinAvailable: 1, // 5-0=5 >= 1, would satisfy Pending — but Failed wins
+		MinAvailable: 1,
 		State:        vcbatch.JobState{Phase: vcbatch.Restarting},
 	}
 
@@ -215,10 +186,6 @@ func TestRestartingState_UpdateStatus_MaxRetryTakesPrecedence(t *testing.T) {
 	}
 }
 
-// --- Execute: SyncJobAction branch ---
-
-// TestRestartingState_Execute_SyncJobCallsSyncJob verifies that SyncJobAction
-// delegates to SyncJob.
 func TestRestartingState_Execute_SyncJobCallsSyncJob(t *testing.T) {
 	c := captureSyncJob(t, nil)
 	s := &restartingState{job: makeRestartingJobInfo(5, 3)}
@@ -231,8 +198,6 @@ func TestRestartingState_Execute_SyncJobCallsSyncJob(t *testing.T) {
 	}
 }
 
-// TestRestartingState_Execute_SyncJobPassesJobInfo verifies the correct
-// JobInfo pointer is forwarded to SyncJob.
 func TestRestartingState_Execute_SyncJobPassesJobInfo(t *testing.T) {
 	c := captureSyncJob(t, nil)
 	info := makeRestartingJobInfo(5, 3)
@@ -246,12 +211,10 @@ func TestRestartingState_Execute_SyncJobPassesJobInfo(t *testing.T) {
 	}
 }
 
-// TestRestartingState_Execute_SyncJobUpdateFnIsRestartingUpdateStatus verifies
-// that the updateFn passed to SyncJob is restartingUpdateStatus by calling it
-// and observing its output.
+// MaxRetry==RetryCount makes restartingUpdateStatus produce Failed; we use
+// that signature to verify SyncJob received the right updateFn.
 func TestRestartingState_Execute_SyncJobUpdateFnIsRestartingUpdateStatus(t *testing.T) {
 	c := captureSyncJob(t, nil)
-	// MaxRetry=2, RetryCount=2 → updateFn should set Failed
 	s := &restartingState{job: makeRestartingJobInfo(2, 3)}
 
 	if err := s.Execute(Action{Action: v1alpha1.SyncJobAction}); err != nil {
@@ -272,8 +235,6 @@ func TestRestartingState_Execute_SyncJobUpdateFnIsRestartingUpdateStatus(t *test
 	}
 }
 
-// TestRestartingState_Execute_SyncJobPropagatesError verifies SyncJob errors
-// are surfaced.
 func TestRestartingState_Execute_SyncJobPropagatesError(t *testing.T) {
 	want := errors.New("sync failed")
 	captureSyncJob(t, want)
@@ -284,10 +245,6 @@ func TestRestartingState_Execute_SyncJobPropagatesError(t *testing.T) {
 	}
 }
 
-// --- Execute: RestartTask / RestartPod / RestartPartition branch ---
-
-// TestRestartingState_Execute_RestartTargetActionsCallKillTarget verifies that
-// all three granular restart actions delegate to KillTarget.
 func TestRestartingState_Execute_RestartTargetActionsCallKillTarget(t *testing.T) {
 	actions := []struct {
 		name   string
@@ -312,8 +269,6 @@ func TestRestartingState_Execute_RestartTargetActionsCallKillTarget(t *testing.T
 	}
 }
 
-// TestRestartingState_Execute_RestartTargetForwardsTarget verifies the Target
-// embedded in the Action is passed unchanged to KillTarget.
 func TestRestartingState_Execute_RestartTargetForwardsTarget(t *testing.T) {
 	tests := []struct {
 		name   string
@@ -351,11 +306,8 @@ func TestRestartingState_Execute_RestartTargetForwardsTarget(t *testing.T) {
 	}
 }
 
-// TestRestartingState_Execute_RestartTargetUpdateFnIsRestartingUpdateStatus
-// verifies the updateFn forwarded to KillTarget is restartingUpdateStatus.
 func TestRestartingState_Execute_RestartTargetUpdateFnIsRestartingUpdateStatus(t *testing.T) {
 	c := captureKillTarget(t, nil)
-	// MaxRetry=2, RetryCount=2 → updateFn should set Failed
 	s := &restartingState{job: makeRestartingJobInfo(2, 3)}
 
 	if err := s.Execute(Action{Action: v1alpha1.RestartTaskAction}); err != nil {
@@ -376,8 +328,6 @@ func TestRestartingState_Execute_RestartTargetUpdateFnIsRestartingUpdateStatus(t
 	}
 }
 
-// TestRestartingState_Execute_RestartTargetPropagatesError verifies KillTarget
-// errors are surfaced.
 func TestRestartingState_Execute_RestartTargetPropagatesError(t *testing.T) {
 	want := errors.New("kill target failed")
 	captureKillTarget(t, want)
@@ -388,10 +338,6 @@ func TestRestartingState_Execute_RestartTargetPropagatesError(t *testing.T) {
 	}
 }
 
-// --- Execute: default branch (all other actions -> KillJob) ---
-
-// TestRestartingState_Execute_DefaultActionsCallKillJob verifies that every
-// action not handled explicitly delegates to KillJob.
 func TestRestartingState_Execute_DefaultActionsCallKillJob(t *testing.T) {
 	defaultActions := []struct {
 		name   string
@@ -419,9 +365,8 @@ func TestRestartingState_Execute_DefaultActionsCallKillJob(t *testing.T) {
 	}
 }
 
-// TestRestartingState_Execute_DefaultUsesRetainPhaseNone verifies the default
-// branch passes PodRetainPhaseNone — all pods are killed including completed
-// ones, to allow a clean restart.
+// Default branch uses PodRetainPhaseNone so all pods (including completed)
+// are killed for a clean restart.
 func TestRestartingState_Execute_DefaultUsesRetainPhaseNone(t *testing.T) {
 	c := captureKillJob(t, nil)
 	s := &restartingState{job: makeRestartingJobInfo(5, 3)}
@@ -434,8 +379,6 @@ func TestRestartingState_Execute_DefaultUsesRetainPhaseNone(t *testing.T) {
 	}
 }
 
-// TestRestartingState_Execute_DefaultPassesJobInfo verifies the correct
-// JobInfo pointer is forwarded to KillJob.
 func TestRestartingState_Execute_DefaultPassesJobInfo(t *testing.T) {
 	c := captureKillJob(t, nil)
 	info := makeRestartingJobInfo(5, 3)
@@ -449,11 +392,8 @@ func TestRestartingState_Execute_DefaultPassesJobInfo(t *testing.T) {
 	}
 }
 
-// TestRestartingState_Execute_DefaultUpdateFnIsRestartingUpdateStatus verifies
-// the updateFn passed to KillJob is restartingUpdateStatus.
 func TestRestartingState_Execute_DefaultUpdateFnIsRestartingUpdateStatus(t *testing.T) {
 	c := captureKillJob(t, nil)
-	// MaxRetry=2, RetryCount=2 → updateFn should set Failed
 	s := &restartingState{job: makeRestartingJobInfo(2, 3)}
 
 	if err := s.Execute(Action{Action: v1alpha1.RestartJobAction}); err != nil {
@@ -474,8 +414,6 @@ func TestRestartingState_Execute_DefaultUpdateFnIsRestartingUpdateStatus(t *test
 	}
 }
 
-// TestRestartingState_Execute_DefaultPropagatesError verifies KillJob errors
-// are surfaced for the default branch.
 func TestRestartingState_Execute_DefaultPropagatesError(t *testing.T) {
 	want := errors.New("kill failed")
 	captureKillJob(t, want)

--- a/pkg/controllers/job/state/restarting_test.go
+++ b/pkg/controllers/job/state/restarting_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	vcbatch "volcano.sh/apis/pkg/apis/batch/v1alpha1"
 	"volcano.sh/apis/pkg/apis/bus/v1alpha1"
 
@@ -49,9 +50,7 @@ func makeRestartingJobInfo(maxRetry int32, taskReplicas ...int32) *apis.JobInfo 
 	}
 }
 
-// ══════════════════════════════════════════════════════════════════════════════
-// restartingUpdateStatus — direct method tests
-// ══════════════════════════════════════════════════════════════════════════════
+// --- restartingUpdateStatus: direct method tests ---
 
 // TestRestartingState_UpdateStatus_ExceedsMaxRetry verifies that when
 // RetryCount >= MaxRetry the method sets Phase to Failed and returns true.
@@ -216,20 +215,18 @@ func TestRestartingState_UpdateStatus_MaxRetryTakesPrecedence(t *testing.T) {
 	}
 }
 
-// ══════════════════════════════════════════════════════════════════════════════
-// Execute — SyncJobAction branch
-// ══════════════════════════════════════════════════════════════════════════════
+// --- Execute: SyncJobAction branch ---
 
 // TestRestartingState_Execute_SyncJobCallsSyncJob verifies that SyncJobAction
 // delegates to SyncJob.
 func TestRestartingState_Execute_SyncJobCallsSyncJob(t *testing.T) {
-	cap := captureSyncJob(t, nil)
+	c := captureSyncJob(t, nil)
 	s := &restartingState{job: makeRestartingJobInfo(5, 3)}
 
 	if err := s.Execute(Action{Action: v1alpha1.SyncJobAction}); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if cap.job == nil {
+	if c.job == nil {
 		t.Fatal("SyncJob was not called")
 	}
 }
@@ -237,15 +234,15 @@ func TestRestartingState_Execute_SyncJobCallsSyncJob(t *testing.T) {
 // TestRestartingState_Execute_SyncJobPassesJobInfo verifies the correct
 // JobInfo pointer is forwarded to SyncJob.
 func TestRestartingState_Execute_SyncJobPassesJobInfo(t *testing.T) {
-	cap := captureSyncJob(t, nil)
+	c := captureSyncJob(t, nil)
 	info := makeRestartingJobInfo(5, 3)
 	s := &restartingState{job: info}
 
 	if err := s.Execute(Action{Action: v1alpha1.SyncJobAction}); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if cap.job != info {
-		t.Errorf("SyncJob received wrong JobInfo: got %p, want %p", cap.job, info)
+	if c.job != info {
+		t.Errorf("SyncJob received wrong JobInfo: got %p, want %p", c.job, info)
 	}
 }
 
@@ -253,19 +250,19 @@ func TestRestartingState_Execute_SyncJobPassesJobInfo(t *testing.T) {
 // that the updateFn passed to SyncJob is restartingUpdateStatus by calling it
 // and observing its output.
 func TestRestartingState_Execute_SyncJobUpdateFnIsRestartingUpdateStatus(t *testing.T) {
-	cap := captureSyncJob(t, nil)
+	c := captureSyncJob(t, nil)
 	// MaxRetry=2, RetryCount=2 → updateFn should set Failed
 	s := &restartingState{job: makeRestartingJobInfo(2, 3)}
 
 	if err := s.Execute(Action{Action: v1alpha1.SyncJobAction}); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if cap.updateFn == nil {
+	if c.updateFn == nil {
 		t.Fatal("expected non-nil updateFn")
 	}
 
 	status := &vcbatch.JobStatus{RetryCount: 2}
-	changed := cap.updateFn(status)
+	changed := c.updateFn(status)
 
 	if !changed {
 		t.Error("updateFn should return true")
@@ -287,9 +284,7 @@ func TestRestartingState_Execute_SyncJobPropagatesError(t *testing.T) {
 	}
 }
 
-// ══════════════════════════════════════════════════════════════════════════════
-// Execute — RestartTask / RestartPod / RestartPartition branch
-// ══════════════════════════════════════════════════════════════════════════════
+// --- Execute: RestartTask / RestartPod / RestartPartition branch ---
 
 // TestRestartingState_Execute_RestartTargetActionsCallKillTarget verifies that
 // all three granular restart actions delegate to KillTarget.
@@ -304,13 +299,13 @@ func TestRestartingState_Execute_RestartTargetActionsCallKillTarget(t *testing.T
 	}
 	for _, tc := range actions {
 		t.Run(tc.name, func(t *testing.T) {
-			cap := captureKillTarget(t, nil)
+			c := captureKillTarget(t, nil)
 			s := &restartingState{job: makeRestartingJobInfo(5, 3)}
 
 			if err := s.Execute(Action{Action: tc.action}); err != nil {
 				t.Fatalf("Execute(%q) returned unexpected error: %v", tc.action, err)
 			}
-			if cap.job == nil {
+			if c.job == nil {
 				t.Fatal("KillTarget was not called")
 			}
 		})
@@ -343,14 +338,14 @@ func TestRestartingState_Execute_RestartTargetForwardsTarget(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			cap := captureKillTarget(t, nil)
+			c := captureKillTarget(t, nil)
 			s := &restartingState{job: makeRestartingJobInfo(5, 3)}
 
 			if err := s.Execute(Action{Action: tc.action, Target: tc.target}); err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
-			if cap.target != tc.target {
-				t.Errorf("KillTarget received target %+v, want %+v", cap.target, tc.target)
+			if c.target != tc.target {
+				t.Errorf("KillTarget received target %+v, want %+v", c.target, tc.target)
 			}
 		})
 	}
@@ -359,19 +354,19 @@ func TestRestartingState_Execute_RestartTargetForwardsTarget(t *testing.T) {
 // TestRestartingState_Execute_RestartTargetUpdateFnIsRestartingUpdateStatus
 // verifies the updateFn forwarded to KillTarget is restartingUpdateStatus.
 func TestRestartingState_Execute_RestartTargetUpdateFnIsRestartingUpdateStatus(t *testing.T) {
-	cap := captureKillTarget(t, nil)
+	c := captureKillTarget(t, nil)
 	// MaxRetry=2, RetryCount=2 → updateFn should set Failed
 	s := &restartingState{job: makeRestartingJobInfo(2, 3)}
 
 	if err := s.Execute(Action{Action: v1alpha1.RestartTaskAction}); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if cap.updateFn == nil {
+	if c.updateFn == nil {
 		t.Fatal("expected non-nil updateFn")
 	}
 
 	status := &vcbatch.JobStatus{RetryCount: 2}
-	changed := cap.updateFn(status)
+	changed := c.updateFn(status)
 
 	if !changed {
 		t.Error("updateFn should return true")
@@ -393,9 +388,7 @@ func TestRestartingState_Execute_RestartTargetPropagatesError(t *testing.T) {
 	}
 }
 
-// ══════════════════════════════════════════════════════════════════════════════
-// Execute — default branch (all other actions → KillJob)
-// ══════════════════════════════════════════════════════════════════════════════
+// --- Execute: default branch (all other actions -> KillJob) ---
 
 // TestRestartingState_Execute_DefaultActionsCallKillJob verifies that every
 // action not handled explicitly delegates to KillJob.
@@ -413,13 +406,13 @@ func TestRestartingState_Execute_DefaultActionsCallKillJob(t *testing.T) {
 	}
 	for _, tc := range defaultActions {
 		t.Run(tc.name, func(t *testing.T) {
-			cap := captureKillJob(t, nil)
+			c := captureKillJob(t, nil)
 			s := &restartingState{job: makeRestartingJobInfo(5, 3)}
 
 			if err := s.Execute(Action{Action: tc.action}); err != nil {
 				t.Fatalf("Execute(%q) returned unexpected error: %v", tc.action, err)
 			}
-			if cap.job == nil {
+			if c.job == nil {
 				t.Fatal("KillJob was not called")
 			}
 		})
@@ -430,48 +423,48 @@ func TestRestartingState_Execute_DefaultActionsCallKillJob(t *testing.T) {
 // branch passes PodRetainPhaseNone — all pods are killed including completed
 // ones, to allow a clean restart.
 func TestRestartingState_Execute_DefaultUsesRetainPhaseNone(t *testing.T) {
-	cap := captureKillJob(t, nil)
+	c := captureKillJob(t, nil)
 	s := &restartingState{job: makeRestartingJobInfo(5, 3)}
 
 	if err := s.Execute(Action{Action: v1alpha1.RestartJobAction}); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if len(cap.podRetainPhase) != 0 {
-		t.Errorf("podRetainPhase should be empty (PhaseNone), got %v", cap.podRetainPhase)
+	if len(c.podRetainPhase) != 0 {
+		t.Errorf("podRetainPhase should be empty (PhaseNone), got %v", c.podRetainPhase)
 	}
 }
 
 // TestRestartingState_Execute_DefaultPassesJobInfo verifies the correct
 // JobInfo pointer is forwarded to KillJob.
 func TestRestartingState_Execute_DefaultPassesJobInfo(t *testing.T) {
-	cap := captureKillJob(t, nil)
+	c := captureKillJob(t, nil)
 	info := makeRestartingJobInfo(5, 3)
 	s := &restartingState{job: info}
 
 	if err := s.Execute(Action{Action: v1alpha1.RestartJobAction}); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if cap.job != info {
-		t.Errorf("KillJob received wrong JobInfo: got %p, want %p", cap.job, info)
+	if c.job != info {
+		t.Errorf("KillJob received wrong JobInfo: got %p, want %p", c.job, info)
 	}
 }
 
 // TestRestartingState_Execute_DefaultUpdateFnIsRestartingUpdateStatus verifies
 // the updateFn passed to KillJob is restartingUpdateStatus.
 func TestRestartingState_Execute_DefaultUpdateFnIsRestartingUpdateStatus(t *testing.T) {
-	cap := captureKillJob(t, nil)
+	c := captureKillJob(t, nil)
 	// MaxRetry=2, RetryCount=2 → updateFn should set Failed
 	s := &restartingState{job: makeRestartingJobInfo(2, 3)}
 
 	if err := s.Execute(Action{Action: v1alpha1.RestartJobAction}); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if cap.updateFn == nil {
+	if c.updateFn == nil {
 		t.Fatal("expected non-nil updateFn")
 	}
 
 	status := &vcbatch.JobStatus{RetryCount: 2}
-	changed := cap.updateFn(status)
+	changed := c.updateFn(status)
 
 	if !changed {
 		t.Error("updateFn should return true")

--- a/pkg/controllers/job/state/restarting_test.go
+++ b/pkg/controllers/job/state/restarting_test.go
@@ -1,0 +1,494 @@
+/*
+Copyright 2024 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package state
+
+import (
+	"errors"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	vcbatch "volcano.sh/apis/pkg/apis/batch/v1alpha1"
+	"volcano.sh/apis/pkg/apis/bus/v1alpha1"
+
+	"volcano.sh/volcano/pkg/controllers/apis"
+)
+
+// makeRestartingJobInfo builds a JobInfo configured for restarting-state tests.
+// taskReplicas controls how many replicas each task has; maxRetry sets the
+// job-level retry ceiling.
+func makeRestartingJobInfo(maxRetry int32, taskReplicas ...int32) *apis.JobInfo {
+	tasks := make([]vcbatch.TaskSpec, len(taskReplicas))
+	for i, r := range taskReplicas {
+		tasks[i] = vcbatch.TaskSpec{Replicas: r}
+	}
+	return &apis.JobInfo{
+		Job: &vcbatch.Job{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-job", Namespace: "default"},
+			Spec: vcbatch.JobSpec{
+				MaxRetry: maxRetry,
+				Tasks:    tasks,
+			},
+			Status: vcbatch.JobStatus{
+				State: vcbatch.JobState{Phase: vcbatch.Restarting},
+			},
+		},
+	}
+}
+
+// ══════════════════════════════════════════════════════════════════════════════
+// restartingUpdateStatus — direct method tests
+// ══════════════════════════════════════════════════════════════════════════════
+
+// TestRestartingState_UpdateStatus_ExceedsMaxRetry verifies that when
+// RetryCount >= MaxRetry the method sets Phase to Failed and returns true.
+func TestRestartingState_UpdateStatus_ExceedsMaxRetry(t *testing.T) {
+	tests := []struct {
+		name       string
+		maxRetry   int32
+		retryCount int32
+	}{
+		{"equal to maxRetry", 3, 3},
+		{"greater than maxRetry", 3, 5},
+		{"maxRetry is zero", 0, 0},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			s := &restartingState{job: makeRestartingJobInfo(tc.maxRetry, 3)}
+			status := &vcbatch.JobStatus{
+				RetryCount: tc.retryCount,
+				State:      vcbatch.JobState{Phase: vcbatch.Restarting},
+			}
+
+			changed := s.restartingUpdateStatus(status)
+
+			if !changed {
+				t.Error("expected true when RetryCount >= MaxRetry")
+			}
+			if status.State.Phase != vcbatch.Failed {
+				t.Errorf("phase = %q, want %q", status.State.Phase, vcbatch.Failed)
+			}
+		})
+	}
+}
+
+// TestRestartingState_UpdateStatus_MeetsMinAvailable verifies that when
+// RetryCount < MaxRetry and (total replicas - Terminating) >= status.MinAvailable
+// the method sets Phase to Pending and returns true.
+func TestRestartingState_UpdateStatus_MeetsMinAvailable(t *testing.T) {
+	tests := []struct {
+		name         string
+		taskReplicas []int32 // total is their sum
+		terminating  int32
+		minAvailable int32
+	}{
+		{
+			name:         "no terminating pods, exactly meets minAvailable",
+			taskReplicas: []int32{3, 2}, // total = 5
+			terminating:  0,
+			minAvailable: 5, // 5-0=5 >= 5
+		},
+		{
+			name:         "some terminating pods, still meets minAvailable",
+			taskReplicas: []int32{3, 2}, // total = 5
+			terminating:  2,
+			minAvailable: 2, // 5-2=3 >= 2
+		},
+		{
+			name:         "single task, minAvailable is zero",
+			taskReplicas: []int32{3},
+			terminating:  3,
+			minAvailable: 0, // 3-3=0 >= 0
+		},
+		{
+			name:         "total exceeds minAvailable",
+			taskReplicas: []int32{5},
+			terminating:  1,
+			minAvailable: 2, // 5-1=4 >= 2
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			s := &restartingState{job: makeRestartingJobInfo(10, tc.taskReplicas...)}
+			status := &vcbatch.JobStatus{
+				RetryCount:   1, // < MaxRetry (10)
+				Terminating:  tc.terminating,
+				MinAvailable: tc.minAvailable,
+				State:        vcbatch.JobState{Phase: vcbatch.Restarting},
+			}
+
+			changed := s.restartingUpdateStatus(status)
+
+			if !changed {
+				t.Error("expected true when minAvailable condition is met")
+			}
+			if status.State.Phase != vcbatch.Pending {
+				t.Errorf("phase = %q, want %q", status.State.Phase, vcbatch.Pending)
+			}
+		})
+	}
+}
+
+// TestRestartingState_UpdateStatus_StillWaiting verifies that when
+// RetryCount < MaxRetry and (total - Terminating) < status.MinAvailable the
+// method returns false and leaves the phase unchanged.
+func TestRestartingState_UpdateStatus_StillWaiting(t *testing.T) {
+	tests := []struct {
+		name         string
+		taskReplicas []int32
+		terminating  int32
+		minAvailable int32
+	}{
+		{
+			name:         "one pod short after terminating subtracted",
+			taskReplicas: []int32{3},    // total = 3
+			terminating:  1,
+			minAvailable: 3, // 3-1=2 < 3
+		},
+		{
+			name:         "all pods are terminating",
+			taskReplicas: []int32{4},    // total = 4
+			terminating:  4,
+			minAvailable: 1, // 4-4=0 < 1
+		},
+		{
+			name:         "no tasks at all",
+			taskReplicas: []int32{},     // total = 0
+			terminating:  0,
+			minAvailable: 1, // 0-0=0 < 1
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			s := &restartingState{job: makeRestartingJobInfo(10, tc.taskReplicas...)}
+			status := &vcbatch.JobStatus{
+				RetryCount:   1, // < MaxRetry (10)
+				Terminating:  tc.terminating,
+				MinAvailable: tc.minAvailable,
+				State:        vcbatch.JobState{Phase: vcbatch.Restarting},
+			}
+			originalPhase := status.State.Phase
+
+			changed := s.restartingUpdateStatus(status)
+
+			if changed {
+				t.Error("expected false while waiting for pods to terminate")
+			}
+			if status.State.Phase != originalPhase {
+				t.Errorf("phase should not change: got %q, want %q", status.State.Phase, originalPhase)
+			}
+		})
+	}
+}
+
+// TestRestartingState_UpdateStatus_MaxRetryTakesPrecedence verifies that the
+// RetryCount >= MaxRetry check runs before the minAvailable check — even when
+// the minAvailable condition would also be satisfied.
+func TestRestartingState_UpdateStatus_MaxRetryTakesPrecedence(t *testing.T) {
+	s := &restartingState{job: makeRestartingJobInfo(3, 5)}
+	status := &vcbatch.JobStatus{
+		RetryCount:   3,    // == MaxRetry → should trigger Failed
+		Terminating:  0,
+		MinAvailable: 1,    // 5-0=5 >= 1, would satisfy Pending — but Failed wins
+		State:        vcbatch.JobState{Phase: vcbatch.Restarting},
+	}
+
+	changed := s.restartingUpdateStatus(status)
+
+	if !changed {
+		t.Error("expected true")
+	}
+	if status.State.Phase != vcbatch.Failed {
+		t.Errorf("phase = %q, want %q (MaxRetry check must take precedence)", status.State.Phase, vcbatch.Failed)
+	}
+}
+
+// ══════════════════════════════════════════════════════════════════════════════
+// Execute — SyncJobAction branch
+// ══════════════════════════════════════════════════════════════════════════════
+
+// TestRestartingState_Execute_SyncJobCallsSyncJob verifies that SyncJobAction
+// delegates to SyncJob.
+func TestRestartingState_Execute_SyncJobCallsSyncJob(t *testing.T) {
+	cap := captureSyncJob(t, nil)
+	s := &restartingState{job: makeRestartingJobInfo(5, 3)}
+
+	if err := s.Execute(Action{Action: v1alpha1.SyncJobAction}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cap.job == nil {
+		t.Fatal("SyncJob was not called")
+	}
+}
+
+// TestRestartingState_Execute_SyncJobPassesJobInfo verifies the correct
+// JobInfo pointer is forwarded to SyncJob.
+func TestRestartingState_Execute_SyncJobPassesJobInfo(t *testing.T) {
+	cap := captureSyncJob(t, nil)
+	info := makeRestartingJobInfo(5, 3)
+	s := &restartingState{job: info}
+
+	if err := s.Execute(Action{Action: v1alpha1.SyncJobAction}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cap.job != info {
+		t.Errorf("SyncJob received wrong JobInfo: got %p, want %p", cap.job, info)
+	}
+}
+
+// TestRestartingState_Execute_SyncJobUpdateFnIsRestartingUpdateStatus verifies
+// that the updateFn passed to SyncJob is restartingUpdateStatus by calling it
+// and observing its output.
+func TestRestartingState_Execute_SyncJobUpdateFnIsRestartingUpdateStatus(t *testing.T) {
+	cap := captureSyncJob(t, nil)
+	// MaxRetry=2, RetryCount=2 → updateFn should set Failed
+	s := &restartingState{job: makeRestartingJobInfo(2, 3)}
+
+	if err := s.Execute(Action{Action: v1alpha1.SyncJobAction}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cap.updateFn == nil {
+		t.Fatal("expected non-nil updateFn")
+	}
+
+	status := &vcbatch.JobStatus{RetryCount: 2}
+	changed := cap.updateFn(status)
+
+	if !changed {
+		t.Error("updateFn should return true")
+	}
+	if status.State.Phase != vcbatch.Failed {
+		t.Errorf("phase = %q, want %q", status.State.Phase, vcbatch.Failed)
+	}
+}
+
+// TestRestartingState_Execute_SyncJobPropagatesError verifies SyncJob errors
+// are surfaced.
+func TestRestartingState_Execute_SyncJobPropagatesError(t *testing.T) {
+	want := errors.New("sync failed")
+	captureSyncJob(t, want)
+	s := &restartingState{job: makeRestartingJobInfo(5, 3)}
+
+	if got := s.Execute(Action{Action: v1alpha1.SyncJobAction}); !errors.Is(got, want) {
+		t.Errorf("Execute returned %v, want %v", got, want)
+	}
+}
+
+// ══════════════════════════════════════════════════════════════════════════════
+// Execute — RestartTask / RestartPod / RestartPartition branch
+// ══════════════════════════════════════════════════════════════════════════════
+
+// TestRestartingState_Execute_RestartTargetActionsCallKillTarget verifies that
+// all three granular restart actions delegate to KillTarget.
+func TestRestartingState_Execute_RestartTargetActionsCallKillTarget(t *testing.T) {
+	actions := []struct {
+		name   string
+		action v1alpha1.Action
+	}{
+		{"RestartTaskAction", v1alpha1.RestartTaskAction},
+		{"RestartPodAction", v1alpha1.RestartPodAction},
+		{"RestartPartitionAction", v1alpha1.RestartPartitionAction},
+	}
+	for _, tc := range actions {
+		t.Run(tc.name, func(t *testing.T) {
+			cap := captureKillTarget(t, nil)
+			s := &restartingState{job: makeRestartingJobInfo(5, 3)}
+
+			if err := s.Execute(Action{Action: tc.action}); err != nil {
+				t.Fatalf("Execute(%q) returned unexpected error: %v", tc.action, err)
+			}
+			if cap.job == nil {
+				t.Fatal("KillTarget was not called")
+			}
+		})
+	}
+}
+
+// TestRestartingState_Execute_RestartTargetForwardsTarget verifies the Target
+// embedded in the Action is passed unchanged to KillTarget.
+func TestRestartingState_Execute_RestartTargetForwardsTarget(t *testing.T) {
+	tests := []struct {
+		name   string
+		action v1alpha1.Action
+		target Target
+	}{
+		{
+			name:   "task target",
+			action: v1alpha1.RestartTaskAction,
+			target: Target{TaskName: "worker", Type: TargetTypeTask},
+		},
+		{
+			name:   "pod target",
+			action: v1alpha1.RestartPodAction,
+			target: Target{TaskName: "worker", PodName: "worker-0", Type: TargetTypePod},
+		},
+		{
+			name:   "partition target",
+			action: v1alpha1.RestartPartitionAction,
+			target: Target{TaskName: "worker", PodName: "worker-0", PartitionName: "p0", Type: TargetTypePartition},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cap := captureKillTarget(t, nil)
+			s := &restartingState{job: makeRestartingJobInfo(5, 3)}
+
+			if err := s.Execute(Action{Action: tc.action, Target: tc.target}); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if cap.target != tc.target {
+				t.Errorf("KillTarget received target %+v, want %+v", cap.target, tc.target)
+			}
+		})
+	}
+}
+
+// TestRestartingState_Execute_RestartTargetUpdateFnIsRestartingUpdateStatus
+// verifies the updateFn forwarded to KillTarget is restartingUpdateStatus.
+func TestRestartingState_Execute_RestartTargetUpdateFnIsRestartingUpdateStatus(t *testing.T) {
+	cap := captureKillTarget(t, nil)
+	// MaxRetry=2, RetryCount=2 → updateFn should set Failed
+	s := &restartingState{job: makeRestartingJobInfo(2, 3)}
+
+	if err := s.Execute(Action{Action: v1alpha1.RestartTaskAction}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cap.updateFn == nil {
+		t.Fatal("expected non-nil updateFn")
+	}
+
+	status := &vcbatch.JobStatus{RetryCount: 2}
+	changed := cap.updateFn(status)
+
+	if !changed {
+		t.Error("updateFn should return true")
+	}
+	if status.State.Phase != vcbatch.Failed {
+		t.Errorf("phase = %q, want %q", status.State.Phase, vcbatch.Failed)
+	}
+}
+
+// TestRestartingState_Execute_RestartTargetPropagatesError verifies KillTarget
+// errors are surfaced.
+func TestRestartingState_Execute_RestartTargetPropagatesError(t *testing.T) {
+	want := errors.New("kill target failed")
+	captureKillTarget(t, want)
+	s := &restartingState{job: makeRestartingJobInfo(5, 3)}
+
+	if got := s.Execute(Action{Action: v1alpha1.RestartTaskAction}); !errors.Is(got, want) {
+		t.Errorf("Execute returned %v, want %v", got, want)
+	}
+}
+
+// ══════════════════════════════════════════════════════════════════════════════
+// Execute — default branch (all other actions → KillJob)
+// ══════════════════════════════════════════════════════════════════════════════
+
+// TestRestartingState_Execute_DefaultActionsCallKillJob verifies that every
+// action not handled explicitly delegates to KillJob.
+func TestRestartingState_Execute_DefaultActionsCallKillJob(t *testing.T) {
+	defaultActions := []struct {
+		name   string
+		action v1alpha1.Action
+	}{
+		{"RestartJobAction", v1alpha1.RestartJobAction},
+		{"AbortJobAction", v1alpha1.AbortJobAction},
+		{"TerminateJobAction", v1alpha1.TerminateJobAction},
+		{"CompleteJobAction", v1alpha1.CompleteJobAction},
+		{"ResumeJobAction", v1alpha1.ResumeJobAction},
+		{"UnknownAction", v1alpha1.Action("Unknown")},
+	}
+	for _, tc := range defaultActions {
+		t.Run(tc.name, func(t *testing.T) {
+			cap := captureKillJob(t, nil)
+			s := &restartingState{job: makeRestartingJobInfo(5, 3)}
+
+			if err := s.Execute(Action{Action: tc.action}); err != nil {
+				t.Fatalf("Execute(%q) returned unexpected error: %v", tc.action, err)
+			}
+			if cap.job == nil {
+				t.Fatal("KillJob was not called")
+			}
+		})
+	}
+}
+
+// TestRestartingState_Execute_DefaultUsesRetainPhaseNone verifies the default
+// branch passes PodRetainPhaseNone — all pods are killed including completed
+// ones, to allow a clean restart.
+func TestRestartingState_Execute_DefaultUsesRetainPhaseNone(t *testing.T) {
+	cap := captureKillJob(t, nil)
+	s := &restartingState{job: makeRestartingJobInfo(5, 3)}
+
+	if err := s.Execute(Action{Action: v1alpha1.RestartJobAction}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(cap.podRetainPhase) != 0 {
+		t.Errorf("podRetainPhase should be empty (PhaseNone), got %v", cap.podRetainPhase)
+	}
+}
+
+// TestRestartingState_Execute_DefaultPassesJobInfo verifies the correct
+// JobInfo pointer is forwarded to KillJob.
+func TestRestartingState_Execute_DefaultPassesJobInfo(t *testing.T) {
+	cap := captureKillJob(t, nil)
+	info := makeRestartingJobInfo(5, 3)
+	s := &restartingState{job: info}
+
+	if err := s.Execute(Action{Action: v1alpha1.RestartJobAction}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cap.job != info {
+		t.Errorf("KillJob received wrong JobInfo: got %p, want %p", cap.job, info)
+	}
+}
+
+// TestRestartingState_Execute_DefaultUpdateFnIsRestartingUpdateStatus verifies
+// the updateFn passed to KillJob is restartingUpdateStatus.
+func TestRestartingState_Execute_DefaultUpdateFnIsRestartingUpdateStatus(t *testing.T) {
+	cap := captureKillJob(t, nil)
+	// MaxRetry=2, RetryCount=2 → updateFn should set Failed
+	s := &restartingState{job: makeRestartingJobInfo(2, 3)}
+
+	if err := s.Execute(Action{Action: v1alpha1.RestartJobAction}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cap.updateFn == nil {
+		t.Fatal("expected non-nil updateFn")
+	}
+
+	status := &vcbatch.JobStatus{RetryCount: 2}
+	changed := cap.updateFn(status)
+
+	if !changed {
+		t.Error("updateFn should return true")
+	}
+	if status.State.Phase != vcbatch.Failed {
+		t.Errorf("phase = %q, want %q", status.State.Phase, vcbatch.Failed)
+	}
+}
+
+// TestRestartingState_Execute_DefaultPropagatesError verifies KillJob errors
+// are surfaced for the default branch.
+func TestRestartingState_Execute_DefaultPropagatesError(t *testing.T) {
+	want := errors.New("kill failed")
+	captureKillJob(t, want)
+	s := &restartingState{job: makeRestartingJobInfo(5, 3)}
+
+	if got := s.Execute(Action{Action: v1alpha1.RestartJobAction}); !errors.Is(got, want) {
+		t.Errorf("Execute returned %v, want %v", got, want)
+	}
+}

--- a/pkg/controllers/job/state/restarting_test.go
+++ b/pkg/controllers/job/state/restarting_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2024 The Volcano Authors.
+Copyright 2026 The Volcano Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -154,19 +154,19 @@ func TestRestartingState_UpdateStatus_StillWaiting(t *testing.T) {
 	}{
 		{
 			name:         "one pod short after terminating subtracted",
-			taskReplicas: []int32{3},    // total = 3
+			taskReplicas: []int32{3}, // total = 3
 			terminating:  1,
 			minAvailable: 3, // 3-1=2 < 3
 		},
 		{
 			name:         "all pods are terminating",
-			taskReplicas: []int32{4},    // total = 4
+			taskReplicas: []int32{4}, // total = 4
 			terminating:  4,
 			minAvailable: 1, // 4-4=0 < 1
 		},
 		{
 			name:         "no tasks at all",
-			taskReplicas: []int32{},     // total = 0
+			taskReplicas: []int32{}, // total = 0
 			terminating:  0,
 			minAvailable: 1, // 0-0=0 < 1
 		},
@@ -200,9 +200,9 @@ func TestRestartingState_UpdateStatus_StillWaiting(t *testing.T) {
 func TestRestartingState_UpdateStatus_MaxRetryTakesPrecedence(t *testing.T) {
 	s := &restartingState{job: makeRestartingJobInfo(3, 5)}
 	status := &vcbatch.JobStatus{
-		RetryCount:   3,    // == MaxRetry → should trigger Failed
+		RetryCount:   3, // == MaxRetry → should trigger Failed
 		Terminating:  0,
-		MinAvailable: 1,    // 5-0=5 >= 1, would satisfy Pending — but Failed wins
+		MinAvailable: 1, // 5-0=5 >= 1, would satisfy Pending — but Failed wins
 		State:        vcbatch.JobState{Phase: vcbatch.Restarting},
 	}
 

--- a/pkg/controllers/job/state/running_test.go
+++ b/pkg/controllers/job/state/running_test.go
@@ -22,6 +22,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	vcbatch "volcano.sh/apis/pkg/apis/batch/v1alpha1"
 	"volcano.sh/apis/pkg/apis/bus/v1alpha1"
 
@@ -53,31 +54,29 @@ func taskStatus(succeeded int32) vcbatch.TaskState {
 	}
 }
 
-// ══════════════════════════════════════════════════════════════════════════════
-// RestartJobAction branch
-// ══════════════════════════════════════════════════════════════════════════════
+// --- RestartJobAction branch ---
 
 func TestRunningState_Execute_RestartJobCallsKillJob(t *testing.T) {
-	cap := captureKillJob(t, nil)
+	c := captureKillJob(t, nil)
 	s := &runningState{job: makeJobInfo(vcbatch.Running)}
 
 	if err := s.Execute(Action{Action: v1alpha1.RestartJobAction}); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if cap.job == nil {
+	if c.job == nil {
 		t.Fatal("KillJob was not called")
 	}
 }
 
 func TestRunningState_Execute_RestartJobUsesRetainPhaseNone(t *testing.T) {
-	cap := captureKillJob(t, nil)
+	c := captureKillJob(t, nil)
 	s := &runningState{job: makeJobInfo(vcbatch.Running)}
 
 	if err := s.Execute(Action{Action: v1alpha1.RestartJobAction}); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if len(cap.podRetainPhase) != 0 {
-		t.Errorf("podRetainPhase should be empty (PhaseNone), got %v", cap.podRetainPhase)
+	if len(c.podRetainPhase) != 0 {
+		t.Errorf("podRetainPhase should be empty (PhaseNone), got %v", c.podRetainPhase)
 	}
 }
 
@@ -92,13 +91,13 @@ func TestRunningState_Execute_RestartJobUpdateFn(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			cap := captureKillJob(t, nil)
+			c := captureKillJob(t, nil)
 			s := &runningState{job: makeJobInfo(vcbatch.Running)}
 
 			if err := s.Execute(Action{Action: v1alpha1.RestartJobAction}); err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
-			if cap.updateFn == nil {
+			if c.updateFn == nil {
 				t.Fatal("expected non-nil updateFn")
 			}
 
@@ -106,7 +105,7 @@ func TestRunningState_Execute_RestartJobUpdateFn(t *testing.T) {
 				RetryCount: tc.initialRetry,
 				State:      vcbatch.JobState{Phase: vcbatch.Running},
 			}
-			changed := cap.updateFn(status)
+			changed := c.updateFn(status)
 
 			if !changed {
 				t.Error("updateFn should return true")
@@ -131,9 +130,7 @@ func TestRunningState_Execute_RestartJobPropagatesError(t *testing.T) {
 	}
 }
 
-// ══════════════════════════════════════════════════════════════════════════════
-// RestartTask / RestartPod / RestartPartition branch
-// ══════════════════════════════════════════════════════════════════════════════
+// --- RestartTask / RestartPod / RestartPartition branch ---
 
 func TestRunningState_Execute_RestartTargetActionsCallKillTarget(t *testing.T) {
 	actions := []struct {
@@ -146,13 +143,13 @@ func TestRunningState_Execute_RestartTargetActionsCallKillTarget(t *testing.T) {
 	}
 	for _, tc := range actions {
 		t.Run(tc.name, func(t *testing.T) {
-			cap := captureKillTarget(t, nil)
+			c := captureKillTarget(t, nil)
 			s := &runningState{job: makeJobInfo(vcbatch.Running)}
 
 			if err := s.Execute(Action{Action: tc.action}); err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
-			if cap.job == nil {
+			if c.job == nil {
 				t.Fatal("KillTarget was not called")
 			}
 		})
@@ -183,32 +180,32 @@ func TestRunningState_Execute_RestartTargetForwardsTarget(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			cap := captureKillTarget(t, nil)
+			c := captureKillTarget(t, nil)
 			s := &runningState{job: makeJobInfo(vcbatch.Running)}
 
 			if err := s.Execute(Action{Action: tc.action, Target: tc.target}); err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
-			if cap.target != tc.target {
-				t.Errorf("KillTarget received target %+v, want %+v", cap.target, tc.target)
+			if c.target != tc.target {
+				t.Errorf("KillTarget received target %+v, want %+v", c.target, tc.target)
 			}
 		})
 	}
 }
 
 func TestRunningState_Execute_RestartTargetUpdateFn(t *testing.T) {
-	cap := captureKillTarget(t, nil)
+	c := captureKillTarget(t, nil)
 	s := &runningState{job: makeJobInfo(vcbatch.Running)}
 
 	if err := s.Execute(Action{Action: v1alpha1.RestartTaskAction}); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if cap.updateFn == nil {
+	if c.updateFn == nil {
 		t.Fatal("expected non-nil updateFn")
 	}
 
 	status := &vcbatch.JobStatus{RetryCount: 1, State: vcbatch.JobState{Phase: vcbatch.Running}}
-	changed := cap.updateFn(status)
+	changed := c.updateFn(status)
 
 	if !changed {
 		t.Error("updateFn should return true")
@@ -231,9 +228,7 @@ func TestRunningState_Execute_RestartTargetPropagatesError(t *testing.T) {
 	}
 }
 
-// ══════════════════════════════════════════════════════════════════════════════
-// AbortJobAction / TerminateJobAction / CompleteJobAction branches
-// ══════════════════════════════════════════════════════════════════════════════
+// --- AbortJobAction / TerminateJobAction / CompleteJobAction branches ---
 
 func TestRunningState_Execute_KillJobBranchesUsesSoftRetainPhase(t *testing.T) {
 	for _, action := range []v1alpha1.Action{
@@ -242,19 +237,19 @@ func TestRunningState_Execute_KillJobBranchesUsesSoftRetainPhase(t *testing.T) {
 		v1alpha1.CompleteJobAction,
 	} {
 		t.Run(string(action), func(t *testing.T) {
-			cap := captureKillJob(t, nil)
+			c := captureKillJob(t, nil)
 			s := &runningState{job: makeJobInfo(vcbatch.Running)}
 
 			if err := s.Execute(Action{Action: action}); err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
 			for phase := range PodRetainPhaseSoft {
-				if _, ok := cap.podRetainPhase[phase]; !ok {
+				if _, ok := c.podRetainPhase[phase]; !ok {
 					t.Errorf("podRetainPhase missing %q", phase)
 				}
 			}
-			if len(cap.podRetainPhase) != len(PodRetainPhaseSoft) {
-				t.Errorf("podRetainPhase has %d entries, want %d", len(cap.podRetainPhase), len(PodRetainPhaseSoft))
+			if len(c.podRetainPhase) != len(PodRetainPhaseSoft) {
+				t.Errorf("podRetainPhase has %d entries, want %d", len(c.podRetainPhase), len(PodRetainPhaseSoft))
 			}
 		})
 	}
@@ -271,18 +266,18 @@ func TestRunningState_Execute_KillJobBranchesUpdateFn(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(string(tc.action), func(t *testing.T) {
-			cap := captureKillJob(t, nil)
+			c := captureKillJob(t, nil)
 			s := &runningState{job: makeJobInfo(vcbatch.Running)}
 
 			if err := s.Execute(Action{Action: tc.action}); err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
-			if cap.updateFn == nil {
+			if c.updateFn == nil {
 				t.Fatal("expected non-nil updateFn")
 			}
 
 			status := &vcbatch.JobStatus{State: vcbatch.JobState{Phase: vcbatch.Running}}
-			changed := cap.updateFn(status)
+			changed := c.updateFn(status)
 
 			if !changed {
 				t.Error("updateFn should return true")
@@ -312,18 +307,16 @@ func TestRunningState_Execute_KillJobBranchesPropagatesError(t *testing.T) {
 	}
 }
 
-// ══════════════════════════════════════════════════════════════════════════════
-// default branch (SyncJob) — updateFn logic
-// ══════════════════════════════════════════════════════════════════════════════
+// --- default branch (SyncJob): updateFn logic ---
 
 func TestRunningState_Execute_DefaultCallsSyncJob(t *testing.T) {
-	cap := captureSyncJob(t, nil)
+	c := captureSyncJob(t, nil)
 	s := &runningState{job: makeJobInfo(vcbatch.Running)}
 
 	if err := s.Execute(Action{Action: v1alpha1.SyncJobAction}); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if cap.job == nil {
+	if c.job == nil {
 		t.Fatal("SyncJob was not called")
 	}
 }
@@ -342,7 +335,7 @@ func TestRunningState_Execute_DefaultPropagatesError(t *testing.T) {
 // total replicas is zero (scale-to-zero) the updateFn returns false and leaves
 // the phase unchanged.
 func TestRunningState_Execute_DefaultUpdateFnScaleToZero(t *testing.T) {
-	cap := captureSyncJob(t, nil)
+	c := captureSyncJob(t, nil)
 	s := &runningState{job: makeRunningJobInfo(0, nil, []vcbatch.TaskSpec{{Replicas: 0}})}
 
 	if err := s.Execute(Action{Action: v1alpha1.SyncJobAction}); err != nil {
@@ -350,7 +343,7 @@ func TestRunningState_Execute_DefaultUpdateFnScaleToZero(t *testing.T) {
 	}
 
 	status := &vcbatch.JobStatus{State: vcbatch.JobState{Phase: vcbatch.Running}}
-	changed := cap.updateFn(status)
+	changed := c.updateFn(status)
 
 	if changed {
 		t.Error("updateFn should return false for scale-to-zero")
@@ -373,7 +366,7 @@ func TestRunningState_Execute_DefaultUpdateFnMinSuccessEarlyExit(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			cap := captureSyncJob(t, nil)
+			c := captureSyncJob(t, nil)
 			s := &runningState{job: makeRunningJobInfo(1, int32Ptr(tc.minSuc),
 				[]vcbatch.TaskSpec{{Replicas: 5}})}
 
@@ -382,7 +375,7 @@ func TestRunningState_Execute_DefaultUpdateFnMinSuccessEarlyExit(t *testing.T) {
 			}
 
 			status := &vcbatch.JobStatus{Succeeded: tc.succeeded, Running: 2}
-			changed := cap.updateFn(status)
+			changed := c.updateFn(status)
 
 			if !changed {
 				t.Error("updateFn should return true")
@@ -400,7 +393,7 @@ func TestRunningState_Execute_DefaultUpdateFnMinSuccessEarlyExit(t *testing.T) {
 func TestRunningState_Execute_DefaultUpdateFnPerTaskCheckFails(t *testing.T) {
 	// MinAvailable(3) >= totalTaskMinAvailable(2) → per-task loop runs.
 	// Task "worker" needs 2 succeeded but only 1 succeeded → Failed.
-	cap := captureSyncJob(t, nil)
+	c := captureSyncJob(t, nil)
 	s := &runningState{job: makeRunningJobInfo(3, nil, []vcbatch.TaskSpec{
 		{Name: "worker", Replicas: 3, MinAvailable: int32Ptr(2)},
 	})}
@@ -416,7 +409,7 @@ func TestRunningState_Execute_DefaultUpdateFnPerTaskCheckFails(t *testing.T) {
 			"worker": taskStatus(1), // only 1 succeeded, need 2
 		},
 	}
-	changed := cap.updateFn(status)
+	changed := c.updateFn(status)
 
 	if !changed {
 		t.Error("updateFn should return true")
@@ -431,7 +424,7 @@ func TestRunningState_Execute_DefaultUpdateFnPerTaskCheckFails(t *testing.T) {
 func TestRunningState_Execute_DefaultUpdateFnPerTaskCheckSkipped(t *testing.T) {
 	// MinAvailable(1) < totalTaskMinAvailable(3) → loop skipped → use 3b.
 	// Succeeded(3) >= MinAvailable(1) → Completed.
-	cap := captureSyncJob(t, nil)
+	c := captureSyncJob(t, nil)
 	s := &runningState{job: makeRunningJobInfo(1, nil, []vcbatch.TaskSpec{
 		{Name: "worker", Replicas: 3, MinAvailable: int32Ptr(3)},
 	})}
@@ -447,7 +440,7 @@ func TestRunningState_Execute_DefaultUpdateFnPerTaskCheckSkipped(t *testing.T) {
 			"worker": taskStatus(3),
 		},
 	}
-	changed := cap.updateFn(status)
+	changed := c.updateFn(status)
 
 	if !changed {
 		t.Error("updateFn should return true")
@@ -464,7 +457,7 @@ func TestRunningState_Execute_DefaultUpdateFnPerTaskNoStatus(t *testing.T) {
 	// MinAvailable(2) >= totalTaskMinAvailable(2) → loop runs.
 	// "worker" has MinAvailable but has NO entry in TaskStatusCount → ok=false,
 	// loop continues without failing → falls through to 3b → Completed.
-	cap := captureSyncJob(t, nil)
+	c := captureSyncJob(t, nil)
 	s := &runningState{job: makeRunningJobInfo(2, nil, []vcbatch.TaskSpec{
 		{Name: "worker", Replicas: 2, MinAvailable: int32Ptr(2)},
 	})}
@@ -478,7 +471,7 @@ func TestRunningState_Execute_DefaultUpdateFnPerTaskNoStatus(t *testing.T) {
 		Failed:          0, // all terminal
 		TaskStatusCount: map[string]vcbatch.TaskState{},
 	}
-	changed := cap.updateFn(status)
+	changed := c.updateFn(status)
 
 	if !changed {
 		t.Error("updateFn should return true")
@@ -528,7 +521,7 @@ func TestRunningState_Execute_DefaultUpdateFnAllTerminalOutcomes(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			cap := captureSyncJob(t, nil)
+			c := captureSyncJob(t, nil)
 			// No tasks with per-task MinAvailable so the loop is a no-op.
 			s := &runningState{job: makeRunningJobInfo(tc.minAvailable, tc.minSuccess,
 				[]vcbatch.TaskSpec{{Replicas: 3}})}
@@ -537,7 +530,7 @@ func TestRunningState_Execute_DefaultUpdateFnAllTerminalOutcomes(t *testing.T) {
 				t.Fatalf("unexpected error: %v", err)
 			}
 
-			changed := cap.updateFn(&tc.status)
+			changed := c.updateFn(&tc.status)
 
 			if !changed {
 				t.Error("updateFn should return true when all pods are terminal")
@@ -575,7 +568,7 @@ func TestRunningState_Execute_DefaultUpdateFnTooManyPending(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			cap := captureSyncJob(t, nil)
+			c := captureSyncJob(t, nil)
 			s := &runningState{job: makeRunningJobInfo(tc.minAvailable, nil,
 				[]vcbatch.TaskSpec{{Replicas: tc.taskReplicas}})}
 
@@ -584,7 +577,7 @@ func TestRunningState_Execute_DefaultUpdateFnTooManyPending(t *testing.T) {
 			}
 
 			status := &vcbatch.JobStatus{Pending: tc.pending}
-			changed := cap.updateFn(status)
+			changed := c.updateFn(status)
 
 			if !changed {
 				t.Error("updateFn should return true")
@@ -623,7 +616,7 @@ func TestRunningState_Execute_DefaultUpdateFnKeepsRunning(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			cap := captureSyncJob(t, nil)
+			c := captureSyncJob(t, nil)
 			s := &runningState{job: makeRunningJobInfo(tc.minAvailable, nil,
 				[]vcbatch.TaskSpec{{Replicas: tc.taskReplicas}})}
 
@@ -632,7 +625,7 @@ func TestRunningState_Execute_DefaultUpdateFnKeepsRunning(t *testing.T) {
 			}
 
 			status := tc.status
-			changed := cap.updateFn(&status)
+			changed := c.updateFn(&status)
 
 			if changed {
 				t.Error("updateFn should return false when no terminal condition met")

--- a/pkg/controllers/job/state/running_test.go
+++ b/pkg/controllers/job/state/running_test.go
@@ -1,0 +1,645 @@
+/*
+Copyright 2024 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package state
+
+import (
+	"errors"
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	vcbatch "volcano.sh/apis/pkg/apis/batch/v1alpha1"
+	"volcano.sh/apis/pkg/apis/bus/v1alpha1"
+
+	"volcano.sh/volcano/pkg/controllers/apis"
+)
+
+// makeRunningJobInfo builds a JobInfo tuned for running-state default-branch
+// tests. minSuccess may be nil to leave it unset.
+func makeRunningJobInfo(minAvailable int32, minSuccess *int32, tasks []vcbatch.TaskSpec) *apis.JobInfo {
+	return &apis.JobInfo{
+		Job: &vcbatch.Job{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-job", Namespace: "default"},
+			Spec: vcbatch.JobSpec{
+				MinAvailable: minAvailable,
+				MinSuccess:   minSuccess,
+				Tasks:        tasks,
+			},
+			Status: vcbatch.JobStatus{
+				State: vcbatch.JobState{Phase: vcbatch.Running},
+			},
+		},
+	}
+}
+
+// taskStatus is a convenience constructor for TaskStatusCount entries.
+func taskStatus(succeeded int32) vcbatch.TaskState {
+	return vcbatch.TaskState{
+		Phase: map[v1.PodPhase]int32{v1.PodSucceeded: succeeded},
+	}
+}
+
+// ══════════════════════════════════════════════════════════════════════════════
+// RestartJobAction branch
+// ══════════════════════════════════════════════════════════════════════════════
+
+func TestRunningState_Execute_RestartJobCallsKillJob(t *testing.T) {
+	cap := captureKillJob(t, nil)
+	s := &runningState{job: makeJobInfo(vcbatch.Running)}
+
+	if err := s.Execute(Action{Action: v1alpha1.RestartJobAction}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cap.job == nil {
+		t.Fatal("KillJob was not called")
+	}
+}
+
+func TestRunningState_Execute_RestartJobUsesRetainPhaseNone(t *testing.T) {
+	cap := captureKillJob(t, nil)
+	s := &runningState{job: makeJobInfo(vcbatch.Running)}
+
+	if err := s.Execute(Action{Action: v1alpha1.RestartJobAction}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(cap.podRetainPhase) != 0 {
+		t.Errorf("podRetainPhase should be empty (PhaseNone), got %v", cap.podRetainPhase)
+	}
+}
+
+func TestRunningState_Execute_RestartJobUpdateFn(t *testing.T) {
+	tests := []struct {
+		name         string
+		initialRetry int32
+		wantRetry    int32
+	}{
+		{"from zero", 0, 1},
+		{"from non-zero", 2, 3},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cap := captureKillJob(t, nil)
+			s := &runningState{job: makeJobInfo(vcbatch.Running)}
+
+			if err := s.Execute(Action{Action: v1alpha1.RestartJobAction}); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if cap.updateFn == nil {
+				t.Fatal("expected non-nil updateFn")
+			}
+
+			status := &vcbatch.JobStatus{
+				RetryCount: tc.initialRetry,
+				State:      vcbatch.JobState{Phase: vcbatch.Running},
+			}
+			changed := cap.updateFn(status)
+
+			if !changed {
+				t.Error("updateFn should return true")
+			}
+			if status.State.Phase != vcbatch.Restarting {
+				t.Errorf("phase = %q, want %q", status.State.Phase, vcbatch.Restarting)
+			}
+			if status.RetryCount != tc.wantRetry {
+				t.Errorf("RetryCount = %d, want %d", status.RetryCount, tc.wantRetry)
+			}
+		})
+	}
+}
+
+func TestRunningState_Execute_RestartJobPropagatesError(t *testing.T) {
+	want := errors.New("kill failed")
+	captureKillJob(t, want)
+	s := &runningState{job: makeJobInfo(vcbatch.Running)}
+
+	if got := s.Execute(Action{Action: v1alpha1.RestartJobAction}); !errors.Is(got, want) {
+		t.Errorf("Execute returned %v, want %v", got, want)
+	}
+}
+
+// ══════════════════════════════════════════════════════════════════════════════
+// RestartTask / RestartPod / RestartPartition branch
+// ══════════════════════════════════════════════════════════════════════════════
+
+func TestRunningState_Execute_RestartTargetActionsCallKillTarget(t *testing.T) {
+	actions := []struct {
+		name   string
+		action v1alpha1.Action
+	}{
+		{"RestartTaskAction", v1alpha1.RestartTaskAction},
+		{"RestartPodAction", v1alpha1.RestartPodAction},
+		{"RestartPartitionAction", v1alpha1.RestartPartitionAction},
+	}
+	for _, tc := range actions {
+		t.Run(tc.name, func(t *testing.T) {
+			cap := captureKillTarget(t, nil)
+			s := &runningState{job: makeJobInfo(vcbatch.Running)}
+
+			if err := s.Execute(Action{Action: tc.action}); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if cap.job == nil {
+				t.Fatal("KillTarget was not called")
+			}
+		})
+	}
+}
+
+func TestRunningState_Execute_RestartTargetForwardsTarget(t *testing.T) {
+	tests := []struct {
+		name   string
+		action v1alpha1.Action
+		target Target
+	}{
+		{
+			name:   "task target",
+			action: v1alpha1.RestartTaskAction,
+			target: Target{TaskName: "worker", Type: TargetTypeTask},
+		},
+		{
+			name:   "pod target",
+			action: v1alpha1.RestartPodAction,
+			target: Target{TaskName: "worker", PodName: "worker-0", Type: TargetTypePod},
+		},
+		{
+			name:   "partition target",
+			action: v1alpha1.RestartPartitionAction,
+			target: Target{TaskName: "worker", PodName: "worker-0", PartitionName: "p0", Type: TargetTypePartition},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cap := captureKillTarget(t, nil)
+			s := &runningState{job: makeJobInfo(vcbatch.Running)}
+
+			if err := s.Execute(Action{Action: tc.action, Target: tc.target}); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if cap.target != tc.target {
+				t.Errorf("KillTarget received target %+v, want %+v", cap.target, tc.target)
+			}
+		})
+	}
+}
+
+func TestRunningState_Execute_RestartTargetUpdateFn(t *testing.T) {
+	cap := captureKillTarget(t, nil)
+	s := &runningState{job: makeJobInfo(vcbatch.Running)}
+
+	if err := s.Execute(Action{Action: v1alpha1.RestartTaskAction}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cap.updateFn == nil {
+		t.Fatal("expected non-nil updateFn")
+	}
+
+	status := &vcbatch.JobStatus{RetryCount: 1, State: vcbatch.JobState{Phase: vcbatch.Running}}
+	changed := cap.updateFn(status)
+
+	if !changed {
+		t.Error("updateFn should return true")
+	}
+	if status.State.Phase != vcbatch.Restarting {
+		t.Errorf("phase = %q, want %q", status.State.Phase, vcbatch.Restarting)
+	}
+	if status.RetryCount != 2 {
+		t.Errorf("RetryCount = %d, want 2", status.RetryCount)
+	}
+}
+
+func TestRunningState_Execute_RestartTargetPropagatesError(t *testing.T) {
+	want := errors.New("kill target failed")
+	captureKillTarget(t, want)
+	s := &runningState{job: makeJobInfo(vcbatch.Running)}
+
+	if got := s.Execute(Action{Action: v1alpha1.RestartTaskAction}); !errors.Is(got, want) {
+		t.Errorf("Execute returned %v, want %v", got, want)
+	}
+}
+
+// ══════════════════════════════════════════════════════════════════════════════
+// AbortJobAction / TerminateJobAction / CompleteJobAction branches
+// ══════════════════════════════════════════════════════════════════════════════
+
+func TestRunningState_Execute_KillJobBranchesUsesSoftRetainPhase(t *testing.T) {
+	for _, action := range []v1alpha1.Action{
+		v1alpha1.AbortJobAction,
+		v1alpha1.TerminateJobAction,
+		v1alpha1.CompleteJobAction,
+	} {
+		t.Run(string(action), func(t *testing.T) {
+			cap := captureKillJob(t, nil)
+			s := &runningState{job: makeJobInfo(vcbatch.Running)}
+
+			if err := s.Execute(Action{Action: action}); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			for phase := range PodRetainPhaseSoft {
+				if _, ok := cap.podRetainPhase[phase]; !ok {
+					t.Errorf("podRetainPhase missing %q", phase)
+				}
+			}
+			if len(cap.podRetainPhase) != len(PodRetainPhaseSoft) {
+				t.Errorf("podRetainPhase has %d entries, want %d", len(cap.podRetainPhase), len(PodRetainPhaseSoft))
+			}
+		})
+	}
+}
+
+func TestRunningState_Execute_KillJobBranchesUpdateFn(t *testing.T) {
+	tests := []struct {
+		action    v1alpha1.Action
+		wantPhase vcbatch.JobPhase
+	}{
+		{v1alpha1.AbortJobAction, vcbatch.Aborting},
+		{v1alpha1.TerminateJobAction, vcbatch.Terminating},
+		{v1alpha1.CompleteJobAction, vcbatch.Completing},
+	}
+	for _, tc := range tests {
+		t.Run(string(tc.action), func(t *testing.T) {
+			cap := captureKillJob(t, nil)
+			s := &runningState{job: makeJobInfo(vcbatch.Running)}
+
+			if err := s.Execute(Action{Action: tc.action}); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if cap.updateFn == nil {
+				t.Fatal("expected non-nil updateFn")
+			}
+
+			status := &vcbatch.JobStatus{State: vcbatch.JobState{Phase: vcbatch.Running}}
+			changed := cap.updateFn(status)
+
+			if !changed {
+				t.Error("updateFn should return true")
+			}
+			if status.State.Phase != tc.wantPhase {
+				t.Errorf("phase = %q, want %q", status.State.Phase, tc.wantPhase)
+			}
+		})
+	}
+}
+
+func TestRunningState_Execute_KillJobBranchesPropagatesError(t *testing.T) {
+	want := errors.New("kill failed")
+	for _, action := range []v1alpha1.Action{
+		v1alpha1.AbortJobAction,
+		v1alpha1.TerminateJobAction,
+		v1alpha1.CompleteJobAction,
+	} {
+		t.Run(string(action), func(t *testing.T) {
+			captureKillJob(t, want)
+			s := &runningState{job: makeJobInfo(vcbatch.Running)}
+
+			if got := s.Execute(Action{Action: action}); !errors.Is(got, want) {
+				t.Errorf("Execute returned %v, want %v", got, want)
+			}
+		})
+	}
+}
+
+// ══════════════════════════════════════════════════════════════════════════════
+// default branch (SyncJob) — updateFn logic
+// ══════════════════════════════════════════════════════════════════════════════
+
+func TestRunningState_Execute_DefaultCallsSyncJob(t *testing.T) {
+	cap := captureSyncJob(t, nil)
+	s := &runningState{job: makeJobInfo(vcbatch.Running)}
+
+	if err := s.Execute(Action{Action: v1alpha1.SyncJobAction}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cap.job == nil {
+		t.Fatal("SyncJob was not called")
+	}
+}
+
+func TestRunningState_Execute_DefaultPropagatesError(t *testing.T) {
+	want := errors.New("sync failed")
+	captureSyncJob(t, want)
+	s := &runningState{job: makeJobInfo(vcbatch.Running)}
+
+	if got := s.Execute(Action{Action: v1alpha1.SyncJobAction}); !errors.Is(got, want) {
+		t.Errorf("Execute returned %v, want %v", got, want)
+	}
+}
+
+// TestRunningState_Execute_DefaultUpdateFnScaleToZero verifies that when
+// total replicas is zero (scale-to-zero) the updateFn returns false and leaves
+// the phase unchanged.
+func TestRunningState_Execute_DefaultUpdateFnScaleToZero(t *testing.T) {
+	cap := captureSyncJob(t, nil)
+	s := &runningState{job: makeRunningJobInfo(0, nil, []vcbatch.TaskSpec{{Replicas: 0}})}
+
+	if err := s.Execute(Action{Action: v1alpha1.SyncJobAction}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	status := &vcbatch.JobStatus{State: vcbatch.JobState{Phase: vcbatch.Running}}
+	changed := cap.updateFn(status)
+
+	if changed {
+		t.Error("updateFn should return false for scale-to-zero")
+	}
+	if status.State.Phase != vcbatch.Running {
+		t.Errorf("phase should stay Running, got %q", status.State.Phase)
+	}
+}
+
+// TestRunningState_Execute_DefaultUpdateFnMinSuccessEarlyExit verifies that
+// when Succeeded >= MinSuccess the job completes before checking all-terminal.
+func TestRunningState_Execute_DefaultUpdateFnMinSuccessEarlyExit(t *testing.T) {
+	tests := []struct {
+		name      string
+		minSuc    int32
+		succeeded int32
+	}{
+		{"exactly meets minSuccess", 3, 3},
+		{"exceeds minSuccess", 3, 5},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cap := captureSyncJob(t, nil)
+			s := &runningState{job: makeRunningJobInfo(1, int32Ptr(tc.minSuc),
+				[]vcbatch.TaskSpec{{Replicas: 5}})}
+
+			if err := s.Execute(Action{Action: v1alpha1.SyncJobAction}); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			status := &vcbatch.JobStatus{Succeeded: tc.succeeded, Running: 2}
+			changed := cap.updateFn(status)
+
+			if !changed {
+				t.Error("updateFn should return true")
+			}
+			if status.State.Phase != vcbatch.Completed {
+				t.Errorf("phase = %q, want %q", status.State.Phase, vcbatch.Completed)
+			}
+		})
+	}
+}
+
+// TestRunningState_Execute_DefaultUpdateFnPerTaskCheckFails verifies that when
+// all pods are terminal and a task's per-task MinAvailable is not met the job
+// transitions to Failed.
+func TestRunningState_Execute_DefaultUpdateFnPerTaskCheckFails(t *testing.T) {
+	// MinAvailable(3) >= totalTaskMinAvailable(2) → per-task loop runs.
+	// Task "worker" needs 2 succeeded but only 1 succeeded → Failed.
+	cap := captureSyncJob(t, nil)
+	s := &runningState{job: makeRunningJobInfo(3, nil, []vcbatch.TaskSpec{
+		{Name: "worker", Replicas: 3, MinAvailable: int32Ptr(2)},
+	})}
+
+	if err := s.Execute(Action{Action: v1alpha1.SyncJobAction}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	status := &vcbatch.JobStatus{
+		Succeeded: 1,
+		Failed:    2, // Succeeded+Failed == jobReplicas (3)
+		TaskStatusCount: map[string]vcbatch.TaskState{
+			"worker": taskStatus(1), // only 1 succeeded, need 2
+		},
+	}
+	changed := cap.updateFn(status)
+
+	if !changed {
+		t.Error("updateFn should return true")
+	}
+	if status.State.Phase != vcbatch.Failed {
+		t.Errorf("phase = %q, want %q", status.State.Phase, vcbatch.Failed)
+	}
+}
+
+// TestRunningState_Execute_DefaultUpdateFnPerTaskCheckSkipped verifies that
+// the per-task loop is skipped when MinAvailable < totalTaskMinAvailable.
+func TestRunningState_Execute_DefaultUpdateFnPerTaskCheckSkipped(t *testing.T) {
+	// MinAvailable(1) < totalTaskMinAvailable(3) → loop skipped → use 3b.
+	// Succeeded(3) >= MinAvailable(1) → Completed.
+	cap := captureSyncJob(t, nil)
+	s := &runningState{job: makeRunningJobInfo(1, nil, []vcbatch.TaskSpec{
+		{Name: "worker", Replicas: 3, MinAvailable: int32Ptr(3)},
+	})}
+
+	if err := s.Execute(Action{Action: v1alpha1.SyncJobAction}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	status := &vcbatch.JobStatus{
+		Succeeded: 3,
+		Failed:    0, // all terminal (3+0=3=jobReplicas)
+		TaskStatusCount: map[string]vcbatch.TaskState{
+			"worker": taskStatus(3),
+		},
+	}
+	changed := cap.updateFn(status)
+
+	if !changed {
+		t.Error("updateFn should return true")
+	}
+	if status.State.Phase != vcbatch.Completed {
+		t.Errorf("phase = %q, want %q", status.State.Phase, vcbatch.Completed)
+	}
+}
+
+// TestRunningState_Execute_DefaultUpdateFnPerTaskNoStatus verifies that a task
+// with MinAvailable set but absent from TaskStatusCount does not block
+// completion (ok=false skips the inner check).
+func TestRunningState_Execute_DefaultUpdateFnPerTaskNoStatus(t *testing.T) {
+	// MinAvailable(2) >= totalTaskMinAvailable(2) → loop runs.
+	// "worker" has MinAvailable but has NO entry in TaskStatusCount → ok=false,
+	// loop continues without failing → falls through to 3b → Completed.
+	cap := captureSyncJob(t, nil)
+	s := &runningState{job: makeRunningJobInfo(2, nil, []vcbatch.TaskSpec{
+		{Name: "worker", Replicas: 2, MinAvailable: int32Ptr(2)},
+	})}
+
+	if err := s.Execute(Action{Action: v1alpha1.SyncJobAction}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	status := &vcbatch.JobStatus{
+		Succeeded:       2,
+		Failed:          0, // all terminal
+		TaskStatusCount: map[string]vcbatch.TaskState{},
+	}
+	changed := cap.updateFn(status)
+
+	if !changed {
+		t.Error("updateFn should return true")
+	}
+	if status.State.Phase != vcbatch.Completed {
+		t.Errorf("phase = %q, want %q", status.State.Phase, vcbatch.Completed)
+	}
+}
+
+// TestRunningState_Execute_DefaultUpdateFnAllTerminalOutcomes verifies the
+// 3b sub-branch that runs after per-task checks pass (or are skipped).
+func TestRunningState_Execute_DefaultUpdateFnAllTerminalOutcomes(t *testing.T) {
+	tests := []struct {
+		name         string
+		minAvailable int32
+		minSuccess   *int32
+		status       vcbatch.JobStatus
+		wantPhase    vcbatch.JobPhase
+	}{
+		{
+			// minSuccess set, Succeeded < minSuccess → Failed
+			name:         "minSuccess not met → Failed",
+			minAvailable: 1,
+			minSuccess:   int32Ptr(4),
+			// jobReplicas=3, all terminal, Succeeded=2 < minSuccess=4
+			status:    vcbatch.JobStatus{Succeeded: 2, Failed: 1},
+			wantPhase: vcbatch.Failed,
+		},
+		{
+			// no minSuccess, Succeeded >= MinAvailable → Completed
+			name:         "Succeeded meets MinAvailable → Completed",
+			minAvailable: 2,
+			minSuccess:   nil,
+			// jobReplicas=3, all terminal, Succeeded=2 >= MinAvailable=2
+			status:    vcbatch.JobStatus{Succeeded: 2, Failed: 1},
+			wantPhase: vcbatch.Completed,
+		},
+		{
+			// no minSuccess, Succeeded < MinAvailable → Failed
+			name:         "Succeeded below MinAvailable → Failed",
+			minAvailable: 3,
+			minSuccess:   nil,
+			// jobReplicas=3, all terminal, Succeeded=1 < MinAvailable=3
+			status:    vcbatch.JobStatus{Succeeded: 1, Failed: 2},
+			wantPhase: vcbatch.Failed,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cap := captureSyncJob(t, nil)
+			// No tasks with per-task MinAvailable so the loop is a no-op.
+			s := &runningState{job: makeRunningJobInfo(tc.minAvailable, tc.minSuccess,
+				[]vcbatch.TaskSpec{{Replicas: 3}})}
+
+			if err := s.Execute(Action{Action: v1alpha1.SyncJobAction}); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			changed := cap.updateFn(&tc.status)
+
+			if !changed {
+				t.Error("updateFn should return true when all pods are terminal")
+			}
+			if tc.status.State.Phase != tc.wantPhase {
+				t.Errorf("phase = %q, want %q", tc.status.State.Phase, tc.wantPhase)
+			}
+		})
+	}
+}
+
+// TestRunningState_Execute_DefaultUpdateFnTooManyPending verifies that when
+// too many pods are Pending the job falls back to Pending phase.
+func TestRunningState_Execute_DefaultUpdateFnTooManyPending(t *testing.T) {
+	tests := []struct {
+		name         string
+		minAvailable int32
+		taskReplicas int32
+		pending      int32
+	}{
+		{
+			// jobReplicas=4, MinAvailable=2, threshold=4-2=2; Pending=3 > 2 → Pending
+			name:         "pending exceeds threshold",
+			minAvailable: 2,
+			taskReplicas: 4,
+			pending:      3,
+		},
+		{
+			// jobReplicas=5, MinAvailable=1, threshold=5-1=4; Pending=5 > 4 → Pending
+			name:         "all pods pending",
+			minAvailable: 1,
+			taskReplicas: 5,
+			pending:      5,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cap := captureSyncJob(t, nil)
+			s := &runningState{job: makeRunningJobInfo(tc.minAvailable, nil,
+				[]vcbatch.TaskSpec{{Replicas: tc.taskReplicas}})}
+
+			if err := s.Execute(Action{Action: v1alpha1.SyncJobAction}); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			status := &vcbatch.JobStatus{Pending: tc.pending}
+			changed := cap.updateFn(status)
+
+			if !changed {
+				t.Error("updateFn should return true")
+			}
+			if status.State.Phase != vcbatch.Pending {
+				t.Errorf("phase = %q, want %q", status.State.Phase, vcbatch.Pending)
+			}
+		})
+	}
+}
+
+// TestRunningState_Execute_DefaultUpdateFnKeepsRunning verifies that when no
+// terminal condition is met the updateFn returns false and stays Running.
+func TestRunningState_Execute_DefaultUpdateFnKeepsRunning(t *testing.T) {
+	tests := []struct {
+		name         string
+		minAvailable int32
+		taskReplicas int32
+		status       vcbatch.JobStatus
+	}{
+		{
+			// Some pods running, no terminal condition triggered.
+			name:         "pods still running",
+			minAvailable: 2,
+			taskReplicas: 4,
+			status:       vcbatch.JobStatus{Running: 2, Pending: 2},
+		},
+		{
+			// Pending exactly at threshold (not strictly greater).
+			name:         "pending at threshold boundary",
+			minAvailable: 2,
+			taskReplicas: 4,
+			// threshold = 4-2=2; Pending=2 is NOT > 2 → no Pending transition
+			status: vcbatch.JobStatus{Pending: 2, Running: 2},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cap := captureSyncJob(t, nil)
+			s := &runningState{job: makeRunningJobInfo(tc.minAvailable, nil,
+				[]vcbatch.TaskSpec{{Replicas: tc.taskReplicas}})}
+
+			if err := s.Execute(Action{Action: v1alpha1.SyncJobAction}); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			status := tc.status
+			changed := cap.updateFn(&status)
+
+			if changed {
+				t.Error("updateFn should return false when no terminal condition met")
+			}
+			if status.State.Phase != vcbatch.Running && status.State.Phase != "" {
+				t.Errorf("phase should remain unchanged, got %q", status.State.Phase)
+			}
+		})
+	}
+}

--- a/pkg/controllers/job/state/running_test.go
+++ b/pkg/controllers/job/state/running_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2024 The Volcano Authors.
+Copyright 2026 The Volcano Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/controllers/job/state/running_test.go
+++ b/pkg/controllers/job/state/running_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Volcano Authors.
+Copyright 2017 The Volcano Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -21,40 +21,16 @@ import (
 	"testing"
 
 	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	vcbatch "volcano.sh/apis/pkg/apis/batch/v1alpha1"
 	"volcano.sh/apis/pkg/apis/bus/v1alpha1"
-
-	"volcano.sh/volcano/pkg/controllers/apis"
 )
 
-// makeRunningJobInfo builds a JobInfo tuned for running-state default-branch
-// tests. minSuccess may be nil to leave it unset.
-func makeRunningJobInfo(minAvailable int32, minSuccess *int32, tasks []vcbatch.TaskSpec) *apis.JobInfo {
-	return &apis.JobInfo{
-		Job: &vcbatch.Job{
-			ObjectMeta: metav1.ObjectMeta{Name: "test-job", Namespace: "default"},
-			Spec: vcbatch.JobSpec{
-				MinAvailable: minAvailable,
-				MinSuccess:   minSuccess,
-				Tasks:        tasks,
-			},
-			Status: vcbatch.JobStatus{
-				State: vcbatch.JobState{Phase: vcbatch.Running},
-			},
-		},
-	}
-}
-
-// taskStatus is a convenience constructor for TaskStatusCount entries.
 func taskStatus(succeeded int32) vcbatch.TaskState {
 	return vcbatch.TaskState{
 		Phase: map[v1.PodPhase]int32{v1.PodSucceeded: succeeded},
 	}
 }
-
-// --- RestartJobAction branch ---
 
 func TestRunningState_Execute_RestartJobCallsKillJob(t *testing.T) {
 	c := captureKillJob(t, nil)
@@ -129,8 +105,6 @@ func TestRunningState_Execute_RestartJobPropagatesError(t *testing.T) {
 		t.Errorf("Execute returned %v, want %v", got, want)
 	}
 }
-
-// --- RestartTask / RestartPod / RestartPartition branch ---
 
 func TestRunningState_Execute_RestartTargetActionsCallKillTarget(t *testing.T) {
 	actions := []struct {
@@ -228,8 +202,6 @@ func TestRunningState_Execute_RestartTargetPropagatesError(t *testing.T) {
 	}
 }
 
-// --- AbortJobAction / TerminateJobAction / CompleteJobAction branches ---
-
 func TestRunningState_Execute_KillJobBranchesUsesSoftRetainPhase(t *testing.T) {
 	for _, action := range []v1alpha1.Action{
 		v1alpha1.AbortJobAction,
@@ -307,8 +279,6 @@ func TestRunningState_Execute_KillJobBranchesPropagatesError(t *testing.T) {
 	}
 }
 
-// --- default branch (SyncJob): updateFn logic ---
-
 func TestRunningState_Execute_DefaultCallsSyncJob(t *testing.T) {
 	c := captureSyncJob(t, nil)
 	s := &runningState{job: makeJobInfo(vcbatch.Running)}
@@ -331,12 +301,9 @@ func TestRunningState_Execute_DefaultPropagatesError(t *testing.T) {
 	}
 }
 
-// TestRunningState_Execute_DefaultUpdateFnScaleToZero verifies that when
-// total replicas is zero (scale-to-zero) the updateFn returns false and leaves
-// the phase unchanged.
 func TestRunningState_Execute_DefaultUpdateFnScaleToZero(t *testing.T) {
 	c := captureSyncJob(t, nil)
-	s := &runningState{job: makeRunningJobInfo(0, nil, []vcbatch.TaskSpec{{Replicas: 0}})}
+	s := &runningState{job: makeJobInfo(vcbatch.Running, withTasks(vcbatch.TaskSpec{Replicas: 0}))}
 
 	if err := s.Execute(Action{Action: v1alpha1.SyncJobAction}); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -353,8 +320,7 @@ func TestRunningState_Execute_DefaultUpdateFnScaleToZero(t *testing.T) {
 	}
 }
 
-// TestRunningState_Execute_DefaultUpdateFnMinSuccessEarlyExit verifies that
-// when Succeeded >= MinSuccess the job completes before checking all-terminal.
+// MinSuccess satisfaction must short-circuit before the all-terminal check.
 func TestRunningState_Execute_DefaultUpdateFnMinSuccessEarlyExit(t *testing.T) {
 	tests := []struct {
 		name      string
@@ -367,8 +333,10 @@ func TestRunningState_Execute_DefaultUpdateFnMinSuccessEarlyExit(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			c := captureSyncJob(t, nil)
-			s := &runningState{job: makeRunningJobInfo(1, int32Ptr(tc.minSuc),
-				[]vcbatch.TaskSpec{{Replicas: 5}})}
+			s := &runningState{job: makeJobInfo(vcbatch.Running,
+				withMinAvailable(1),
+				withMinSuccess(int32Ptr(tc.minSuc)),
+				withTasks(vcbatch.TaskSpec{Replicas: 5}))}
 
 			if err := s.Execute(Action{Action: v1alpha1.SyncJobAction}); err != nil {
 				t.Fatalf("unexpected error: %v", err)
@@ -387,16 +355,13 @@ func TestRunningState_Execute_DefaultUpdateFnMinSuccessEarlyExit(t *testing.T) {
 	}
 }
 
-// TestRunningState_Execute_DefaultUpdateFnPerTaskCheckFails verifies that when
-// all pods are terminal and a task's per-task MinAvailable is not met the job
-// transitions to Failed.
 func TestRunningState_Execute_DefaultUpdateFnPerTaskCheckFails(t *testing.T) {
-	// MinAvailable(3) >= totalTaskMinAvailable(2) → per-task loop runs.
-	// Task "worker" needs 2 succeeded but only 1 succeeded → Failed.
+	// MinAvailable(3) >= totalTaskMinAvailable(2) so the per-task loop runs;
+	// "worker" needs 2 succeeded but only got 1 → Failed.
 	c := captureSyncJob(t, nil)
-	s := &runningState{job: makeRunningJobInfo(3, nil, []vcbatch.TaskSpec{
-		{Name: "worker", Replicas: 3, MinAvailable: int32Ptr(2)},
-	})}
+	s := &runningState{job: makeJobInfo(vcbatch.Running,
+		withMinAvailable(3),
+		withTasks(vcbatch.TaskSpec{Name: "worker", Replicas: 3, MinAvailable: int32Ptr(2)}))}
 
 	if err := s.Execute(Action{Action: v1alpha1.SyncJobAction}); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -404,9 +369,9 @@ func TestRunningState_Execute_DefaultUpdateFnPerTaskCheckFails(t *testing.T) {
 
 	status := &vcbatch.JobStatus{
 		Succeeded: 1,
-		Failed:    2, // Succeeded+Failed == jobReplicas (3)
+		Failed:    2,
 		TaskStatusCount: map[string]vcbatch.TaskState{
-			"worker": taskStatus(1), // only 1 succeeded, need 2
+			"worker": taskStatus(1),
 		},
 	}
 	changed := c.updateFn(status)
@@ -419,15 +384,13 @@ func TestRunningState_Execute_DefaultUpdateFnPerTaskCheckFails(t *testing.T) {
 	}
 }
 
-// TestRunningState_Execute_DefaultUpdateFnPerTaskCheckSkipped verifies that
-// the per-task loop is skipped when MinAvailable < totalTaskMinAvailable.
 func TestRunningState_Execute_DefaultUpdateFnPerTaskCheckSkipped(t *testing.T) {
-	// MinAvailable(1) < totalTaskMinAvailable(3) → loop skipped → use 3b.
-	// Succeeded(3) >= MinAvailable(1) → Completed.
+	// MinAvailable(1) < totalTaskMinAvailable(3) so per-task loop is skipped
+	// and the all-terminal branch decides the outcome.
 	c := captureSyncJob(t, nil)
-	s := &runningState{job: makeRunningJobInfo(1, nil, []vcbatch.TaskSpec{
-		{Name: "worker", Replicas: 3, MinAvailable: int32Ptr(3)},
-	})}
+	s := &runningState{job: makeJobInfo(vcbatch.Running,
+		withMinAvailable(1),
+		withTasks(vcbatch.TaskSpec{Name: "worker", Replicas: 3, MinAvailable: int32Ptr(3)}))}
 
 	if err := s.Execute(Action{Action: v1alpha1.SyncJobAction}); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -435,7 +398,7 @@ func TestRunningState_Execute_DefaultUpdateFnPerTaskCheckSkipped(t *testing.T) {
 
 	status := &vcbatch.JobStatus{
 		Succeeded: 3,
-		Failed:    0, // all terminal (3+0=3=jobReplicas)
+		Failed:    0,
 		TaskStatusCount: map[string]vcbatch.TaskState{
 			"worker": taskStatus(3),
 		},
@@ -450,17 +413,13 @@ func TestRunningState_Execute_DefaultUpdateFnPerTaskCheckSkipped(t *testing.T) {
 	}
 }
 
-// TestRunningState_Execute_DefaultUpdateFnPerTaskNoStatus verifies that a task
-// with MinAvailable set but absent from TaskStatusCount does not block
-// completion (ok=false skips the inner check).
+// A task with MinAvailable but missing from TaskStatusCount must not block
+// completion (TaskStatusCount lookup ok=false skips the inner check).
 func TestRunningState_Execute_DefaultUpdateFnPerTaskNoStatus(t *testing.T) {
-	// MinAvailable(2) >= totalTaskMinAvailable(2) → loop runs.
-	// "worker" has MinAvailable but has NO entry in TaskStatusCount → ok=false,
-	// loop continues without failing → falls through to 3b → Completed.
 	c := captureSyncJob(t, nil)
-	s := &runningState{job: makeRunningJobInfo(2, nil, []vcbatch.TaskSpec{
-		{Name: "worker", Replicas: 2, MinAvailable: int32Ptr(2)},
-	})}
+	s := &runningState{job: makeJobInfo(vcbatch.Running,
+		withMinAvailable(2),
+		withTasks(vcbatch.TaskSpec{Name: "worker", Replicas: 2, MinAvailable: int32Ptr(2)}))}
 
 	if err := s.Execute(Action{Action: v1alpha1.SyncJobAction}); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -468,7 +427,7 @@ func TestRunningState_Execute_DefaultUpdateFnPerTaskNoStatus(t *testing.T) {
 
 	status := &vcbatch.JobStatus{
 		Succeeded:       2,
-		Failed:          0, // all terminal
+		Failed:          0,
 		TaskStatusCount: map[string]vcbatch.TaskState{},
 	}
 	changed := c.updateFn(status)
@@ -481,8 +440,6 @@ func TestRunningState_Execute_DefaultUpdateFnPerTaskNoStatus(t *testing.T) {
 	}
 }
 
-// TestRunningState_Execute_DefaultUpdateFnAllTerminalOutcomes verifies the
-// 3b sub-branch that runs after per-task checks pass (or are skipped).
 func TestRunningState_Execute_DefaultUpdateFnAllTerminalOutcomes(t *testing.T) {
 	tests := []struct {
 		name         string
@@ -492,39 +449,36 @@ func TestRunningState_Execute_DefaultUpdateFnAllTerminalOutcomes(t *testing.T) {
 		wantPhase    vcbatch.JobPhase
 	}{
 		{
-			// minSuccess set, Succeeded < minSuccess → Failed
 			name:         "minSuccess not met → Failed",
 			minAvailable: 1,
 			minSuccess:   int32Ptr(4),
-			// jobReplicas=3, all terminal, Succeeded=2 < minSuccess=4
-			status:    vcbatch.JobStatus{Succeeded: 2, Failed: 1},
-			wantPhase: vcbatch.Failed,
+			status:       vcbatch.JobStatus{Succeeded: 2, Failed: 1},
+			wantPhase:    vcbatch.Failed,
 		},
 		{
-			// no minSuccess, Succeeded >= MinAvailable → Completed
 			name:         "Succeeded meets MinAvailable → Completed",
 			minAvailable: 2,
 			minSuccess:   nil,
-			// jobReplicas=3, all terminal, Succeeded=2 >= MinAvailable=2
-			status:    vcbatch.JobStatus{Succeeded: 2, Failed: 1},
-			wantPhase: vcbatch.Completed,
+			status:       vcbatch.JobStatus{Succeeded: 2, Failed: 1},
+			wantPhase:    vcbatch.Completed,
 		},
 		{
-			// no minSuccess, Succeeded < MinAvailable → Failed
 			name:         "Succeeded below MinAvailable → Failed",
 			minAvailable: 3,
 			minSuccess:   nil,
-			// jobReplicas=3, all terminal, Succeeded=1 < MinAvailable=3
-			status:    vcbatch.JobStatus{Succeeded: 1, Failed: 2},
-			wantPhase: vcbatch.Failed,
+			status:       vcbatch.JobStatus{Succeeded: 1, Failed: 2},
+			wantPhase:    vcbatch.Failed,
 		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			c := captureSyncJob(t, nil)
-			// No tasks with per-task MinAvailable so the loop is a no-op.
-			s := &runningState{job: makeRunningJobInfo(tc.minAvailable, tc.minSuccess,
-				[]vcbatch.TaskSpec{{Replicas: 3}})}
+			// No per-task MinAvailable so the per-task loop is a no-op and
+			// only the all-terminal branch decides the phase.
+			s := &runningState{job: makeJobInfo(vcbatch.Running,
+				withMinAvailable(tc.minAvailable),
+				withMinSuccess(tc.minSuccess),
+				withTasks(vcbatch.TaskSpec{Replicas: 3}))}
 
 			if err := s.Execute(Action{Action: v1alpha1.SyncJobAction}); err != nil {
 				t.Fatalf("unexpected error: %v", err)
@@ -542,8 +496,6 @@ func TestRunningState_Execute_DefaultUpdateFnAllTerminalOutcomes(t *testing.T) {
 	}
 }
 
-// TestRunningState_Execute_DefaultUpdateFnTooManyPending verifies that when
-// too many pods are Pending the job falls back to Pending phase.
 func TestRunningState_Execute_DefaultUpdateFnTooManyPending(t *testing.T) {
 	tests := []struct {
 		name         string
@@ -552,14 +504,14 @@ func TestRunningState_Execute_DefaultUpdateFnTooManyPending(t *testing.T) {
 		pending      int32
 	}{
 		{
-			// jobReplicas=4, MinAvailable=2, threshold=4-2=2; Pending=3 > 2 → Pending
+			// threshold = 4-2=2; Pending=3 > 2 → Pending
 			name:         "pending exceeds threshold",
 			minAvailable: 2,
 			taskReplicas: 4,
 			pending:      3,
 		},
 		{
-			// jobReplicas=5, MinAvailable=1, threshold=5-1=4; Pending=5 > 4 → Pending
+			// threshold = 5-1=4; Pending=5 > 4 → Pending
 			name:         "all pods pending",
 			minAvailable: 1,
 			taskReplicas: 5,
@@ -569,8 +521,9 @@ func TestRunningState_Execute_DefaultUpdateFnTooManyPending(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			c := captureSyncJob(t, nil)
-			s := &runningState{job: makeRunningJobInfo(tc.minAvailable, nil,
-				[]vcbatch.TaskSpec{{Replicas: tc.taskReplicas}})}
+			s := &runningState{job: makeJobInfo(vcbatch.Running,
+				withMinAvailable(tc.minAvailable),
+				withTasks(vcbatch.TaskSpec{Replicas: tc.taskReplicas}))}
 
 			if err := s.Execute(Action{Action: v1alpha1.SyncJobAction}); err != nil {
 				t.Fatalf("unexpected error: %v", err)
@@ -589,8 +542,6 @@ func TestRunningState_Execute_DefaultUpdateFnTooManyPending(t *testing.T) {
 	}
 }
 
-// TestRunningState_Execute_DefaultUpdateFnKeepsRunning verifies that when no
-// terminal condition is met the updateFn returns false and stays Running.
 func TestRunningState_Execute_DefaultUpdateFnKeepsRunning(t *testing.T) {
 	tests := []struct {
 		name         string
@@ -599,39 +550,39 @@ func TestRunningState_Execute_DefaultUpdateFnKeepsRunning(t *testing.T) {
 		status       vcbatch.JobStatus
 	}{
 		{
-			// Some pods running, no terminal condition triggered.
 			name:         "pods still running",
 			minAvailable: 2,
 			taskReplicas: 4,
 			status:       vcbatch.JobStatus{Running: 2, Pending: 2},
 		},
 		{
-			// Pending exactly at threshold (not strictly greater).
+			// threshold = 4-2=2; Pending=2 is NOT > 2 → no transition.
 			name:         "pending at threshold boundary",
 			minAvailable: 2,
 			taskReplicas: 4,
-			// threshold = 4-2=2; Pending=2 is NOT > 2 → no Pending transition
-			status: vcbatch.JobStatus{Pending: 2, Running: 2},
+			status:       vcbatch.JobStatus{Pending: 2, Running: 2},
 		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			c := captureSyncJob(t, nil)
-			s := &runningState{job: makeRunningJobInfo(tc.minAvailable, nil,
-				[]vcbatch.TaskSpec{{Replicas: tc.taskReplicas}})}
+			s := &runningState{job: makeJobInfo(vcbatch.Running,
+				withMinAvailable(tc.minAvailable),
+				withTasks(vcbatch.TaskSpec{Replicas: tc.taskReplicas}))}
 
 			if err := s.Execute(Action{Action: v1alpha1.SyncJobAction}); err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
 
 			status := tc.status
+			originalPhase := status.State.Phase
 			changed := c.updateFn(&status)
 
 			if changed {
 				t.Error("updateFn should return false when no terminal condition met")
 			}
-			if status.State.Phase != vcbatch.Running && status.State.Phase != "" {
-				t.Errorf("phase should remain unchanged, got %q", status.State.Phase)
+			if status.State.Phase != originalPhase {
+				t.Errorf("phase should remain %q, got %q", originalPhase, status.State.Phase)
 			}
 		})
 	}

--- a/pkg/controllers/job/state/terminating_test.go
+++ b/pkg/controllers/job/state/terminating_test.go
@@ -1,0 +1,228 @@
+/*
+Copyright 2024 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package state
+
+import (
+	"errors"
+	"testing"
+
+	vcbatch "volcano.sh/apis/pkg/apis/batch/v1alpha1"
+	"volcano.sh/apis/pkg/apis/bus/v1alpha1"
+)
+
+// --- action-agnostic behaviour ---
+
+// TestTerminatingState_Execute_ActionAgnostic verifies that Execute always
+// delegates to KillJob regardless of the action type received.
+func TestTerminatingState_Execute_ActionAgnostic(t *testing.T) {
+	actions := []struct {
+		name   string
+		action v1alpha1.Action
+	}{
+		{"SyncJobAction", v1alpha1.SyncJobAction},
+		{"RestartJobAction", v1alpha1.RestartJobAction},
+		{"AbortJobAction", v1alpha1.AbortJobAction},
+		{"TerminateJobAction", v1alpha1.TerminateJobAction},
+		{"CompleteJobAction", v1alpha1.CompleteJobAction},
+		{"ResumeJobAction", v1alpha1.ResumeJobAction},
+		{"RestartTaskAction", v1alpha1.RestartTaskAction},
+		{"RestartPodAction", v1alpha1.RestartPodAction},
+		{"RestartPartitionAction", v1alpha1.RestartPartitionAction},
+		{"UnknownAction", v1alpha1.Action("Unknown")},
+	}
+
+	for _, tc := range actions {
+		t.Run(tc.name, func(t *testing.T) {
+			cap := captureKillJob(t, nil)
+			s := &terminatingState{job: makeJobInfo(vcbatch.Terminating)}
+
+			if err := s.Execute(Action{Action: tc.action}); err != nil {
+				t.Fatalf("Execute(%q) returned unexpected error: %v", tc.action, err)
+			}
+			if cap.job == nil {
+				t.Fatal("KillJob was not called")
+			}
+		})
+	}
+}
+
+// --- KillJob call arguments ---
+
+// TestTerminatingState_Execute_UsesSoftRetainPhase verifies that Execute
+// passes PodRetainPhaseSoft so Succeeded/Failed pods are preserved.
+func TestTerminatingState_Execute_UsesSoftRetainPhase(t *testing.T) {
+	cap := captureKillJob(t, nil)
+	s := &terminatingState{job: makeJobInfo(vcbatch.Terminating)}
+
+	if err := s.Execute(Action{Action: v1alpha1.SyncJobAction}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for phase := range PodRetainPhaseSoft {
+		if _, ok := cap.podRetainPhase[phase]; !ok {
+			t.Errorf("podRetainPhase missing %q", phase)
+		}
+	}
+	if len(cap.podRetainPhase) != len(PodRetainPhaseSoft) {
+		t.Errorf("podRetainPhase has %d entries, want %d", len(cap.podRetainPhase), len(PodRetainPhaseSoft))
+	}
+}
+
+// TestTerminatingState_Execute_NonNilUpdateFn verifies the updateFn is not nil
+// — unlike finishedState, terminatingState drives a phase transition.
+func TestTerminatingState_Execute_NonNilUpdateFn(t *testing.T) {
+	cap := captureKillJob(t, nil)
+	s := &terminatingState{job: makeJobInfo(vcbatch.Terminating)}
+
+	if err := s.Execute(Action{Action: v1alpha1.SyncJobAction}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cap.updateFn == nil {
+		t.Error("updateFn must not be nil for terminatingState")
+	}
+}
+
+// TestTerminatingState_Execute_PassesJobInfo verifies the correct JobInfo
+// pointer is forwarded to KillJob.
+func TestTerminatingState_Execute_PassesJobInfo(t *testing.T) {
+	cap := captureKillJob(t, nil)
+	info := makeJobInfo(vcbatch.Terminating)
+	s := &terminatingState{job: info}
+
+	if err := s.Execute(Action{Action: v1alpha1.SyncJobAction}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cap.job != info {
+		t.Errorf("KillJob received wrong JobInfo: got %p, want %p", cap.job, info)
+	}
+}
+
+// TestTerminatingState_Execute_PropagatesError verifies that any error
+// returned by KillJob is surfaced to the caller unchanged.
+func TestTerminatingState_Execute_PropagatesError(t *testing.T) {
+	want := errors.New("kill failed")
+	captureKillJob(t, want)
+	s := &terminatingState{job: makeJobInfo(vcbatch.Terminating)}
+
+	if got := s.Execute(Action{Action: v1alpha1.SyncJobAction}); !errors.Is(got, want) {
+		t.Errorf("Execute returned %v, want %v", got, want)
+	}
+}
+
+// --- updateFn logic: alive pods present → stay Terminating ---
+
+// TestTerminatingState_Execute_UpdateFnAlivePods verifies that the updateFn
+// returns false and leaves the phase unchanged whenever any "alive" pod
+// counter (Terminating, Pending, or Running) is non-zero.
+func TestTerminatingState_Execute_UpdateFnAlivePods(t *testing.T) {
+	tests := []struct {
+		name   string
+		status vcbatch.JobStatus
+	}{
+		{
+			name:   "only Terminating pods remain",
+			status: vcbatch.JobStatus{Terminating: 1},
+		},
+		{
+			name:   "only Pending pods remain",
+			status: vcbatch.JobStatus{Pending: 1},
+		},
+		{
+			name:   "only Running pods remain",
+			status: vcbatch.JobStatus{Running: 1},
+		},
+		{
+			name:   "all three counters non-zero",
+			status: vcbatch.JobStatus{Terminating: 2, Pending: 3, Running: 1},
+		},
+		{
+			name:   "Terminating and Pending non-zero",
+			status: vcbatch.JobStatus{Terminating: 1, Pending: 1},
+		},
+		{
+			name:   "Pending and Running non-zero",
+			status: vcbatch.JobStatus{Pending: 1, Running: 1},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cap := captureKillJob(t, nil)
+			s := &terminatingState{job: makeJobInfo(vcbatch.Terminating)}
+
+			if err := s.Execute(Action{Action: v1alpha1.SyncJobAction}); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			originalPhase := tc.status.State.Phase
+			changed := cap.updateFn(&tc.status)
+
+			if changed {
+				t.Error("updateFn should return false while alive pods exist")
+			}
+			if tc.status.State.Phase != originalPhase {
+				t.Errorf("phase should not change: got %q, want %q", tc.status.State.Phase, originalPhase)
+			}
+		})
+	}
+}
+
+// --- updateFn logic: all alive pods drained → Terminated ---
+
+// TestTerminatingState_Execute_UpdateFnAllPodsGone verifies that the updateFn
+// returns true and transitions the phase to Terminated when all alive pod
+// counters are zero.
+func TestTerminatingState_Execute_UpdateFnAllPodsGone(t *testing.T) {
+	tests := []struct {
+		name   string
+		status vcbatch.JobStatus
+	}{
+		{
+			name:   "all counters zero from start",
+			status: vcbatch.JobStatus{Terminating: 0, Pending: 0, Running: 0},
+		},
+		{
+			name: "has Succeeded and Failed but no alive pods",
+			status: vcbatch.JobStatus{
+				Terminating: 0,
+				Pending:     0,
+				Running:     0,
+				Succeeded:   5,
+				Failed:      2,
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cap := captureKillJob(t, nil)
+			s := &terminatingState{job: makeJobInfo(vcbatch.Terminating)}
+
+			if err := s.Execute(Action{Action: v1alpha1.SyncJobAction}); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			changed := cap.updateFn(&tc.status)
+
+			if !changed {
+				t.Error("updateFn should return true when no alive pods remain")
+			}
+			if tc.status.State.Phase != vcbatch.Terminated {
+				t.Errorf("phase = %q, want %q", tc.status.State.Phase, vcbatch.Terminated)
+			}
+		})
+	}
+}

--- a/pkg/controllers/job/state/terminating_test.go
+++ b/pkg/controllers/job/state/terminating_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Volcano Authors.
+Copyright 2017 The Volcano Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -24,10 +24,6 @@ import (
 	"volcano.sh/apis/pkg/apis/bus/v1alpha1"
 )
 
-// --- action-agnostic behaviour ---
-
-// TestTerminatingState_Execute_ActionAgnostic verifies that Execute always
-// delegates to KillJob regardless of the action type received.
 func TestTerminatingState_Execute_ActionAgnostic(t *testing.T) {
 	actions := []struct {
 		name   string
@@ -60,10 +56,6 @@ func TestTerminatingState_Execute_ActionAgnostic(t *testing.T) {
 	}
 }
 
-// --- KillJob call arguments ---
-
-// TestTerminatingState_Execute_UsesSoftRetainPhase verifies that Execute
-// passes PodRetainPhaseSoft so Succeeded/Failed pods are preserved.
 func TestTerminatingState_Execute_UsesSoftRetainPhase(t *testing.T) {
 	c := captureKillJob(t, nil)
 	s := &terminatingState{job: makeJobInfo(vcbatch.Terminating)}
@@ -81,8 +73,8 @@ func TestTerminatingState_Execute_UsesSoftRetainPhase(t *testing.T) {
 	}
 }
 
-// TestTerminatingState_Execute_NonNilUpdateFn verifies the updateFn is not nil
-// — unlike finishedState, terminatingState drives a phase transition.
+// terminatingState (unlike finishedState) drives a phase transition, so
+// updateFn cannot be nil.
 func TestTerminatingState_Execute_NonNilUpdateFn(t *testing.T) {
 	c := captureKillJob(t, nil)
 	s := &terminatingState{job: makeJobInfo(vcbatch.Terminating)}
@@ -95,8 +87,6 @@ func TestTerminatingState_Execute_NonNilUpdateFn(t *testing.T) {
 	}
 }
 
-// TestTerminatingState_Execute_PassesJobInfo verifies the correct JobInfo
-// pointer is forwarded to KillJob.
 func TestTerminatingState_Execute_PassesJobInfo(t *testing.T) {
 	c := captureKillJob(t, nil)
 	info := makeJobInfo(vcbatch.Terminating)
@@ -110,8 +100,6 @@ func TestTerminatingState_Execute_PassesJobInfo(t *testing.T) {
 	}
 }
 
-// TestTerminatingState_Execute_PropagatesError verifies that any error
-// returned by KillJob is surfaced to the caller unchanged.
 func TestTerminatingState_Execute_PropagatesError(t *testing.T) {
 	want := errors.New("kill failed")
 	captureKillJob(t, want)
@@ -122,11 +110,8 @@ func TestTerminatingState_Execute_PropagatesError(t *testing.T) {
 	}
 }
 
-// --- updateFn logic: alive pods present → stay Terminating ---
-
-// TestTerminatingState_Execute_UpdateFnAlivePods verifies that the updateFn
-// returns false and leaves the phase unchanged whenever any "alive" pod
-// counter (Terminating, Pending, or Running) is non-zero.
+// "Alive" counters = Terminating | Pending | Running. Any of them being
+// non-zero must keep the job in Terminating.
 func TestTerminatingState_Execute_UpdateFnAlivePods(t *testing.T) {
 	tests := []struct {
 		name   string
@@ -180,11 +165,6 @@ func TestTerminatingState_Execute_UpdateFnAlivePods(t *testing.T) {
 	}
 }
 
-// --- updateFn logic: all alive pods drained → Terminated ---
-
-// TestTerminatingState_Execute_UpdateFnAllPodsGone verifies that the updateFn
-// returns true and transitions the phase to Terminated when all alive pod
-// counters are zero.
 func TestTerminatingState_Execute_UpdateFnAllPodsGone(t *testing.T) {
 	tests := []struct {
 		name   string

--- a/pkg/controllers/job/state/terminating_test.go
+++ b/pkg/controllers/job/state/terminating_test.go
@@ -47,13 +47,13 @@ func TestTerminatingState_Execute_ActionAgnostic(t *testing.T) {
 
 	for _, tc := range actions {
 		t.Run(tc.name, func(t *testing.T) {
-			cap := captureKillJob(t, nil)
+			c := captureKillJob(t, nil)
 			s := &terminatingState{job: makeJobInfo(vcbatch.Terminating)}
 
 			if err := s.Execute(Action{Action: tc.action}); err != nil {
 				t.Fatalf("Execute(%q) returned unexpected error: %v", tc.action, err)
 			}
-			if cap.job == nil {
+			if c.job == nil {
 				t.Fatal("KillJob was not called")
 			}
 		})
@@ -65,32 +65,32 @@ func TestTerminatingState_Execute_ActionAgnostic(t *testing.T) {
 // TestTerminatingState_Execute_UsesSoftRetainPhase verifies that Execute
 // passes PodRetainPhaseSoft so Succeeded/Failed pods are preserved.
 func TestTerminatingState_Execute_UsesSoftRetainPhase(t *testing.T) {
-	cap := captureKillJob(t, nil)
+	c := captureKillJob(t, nil)
 	s := &terminatingState{job: makeJobInfo(vcbatch.Terminating)}
 
 	if err := s.Execute(Action{Action: v1alpha1.SyncJobAction}); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	for phase := range PodRetainPhaseSoft {
-		if _, ok := cap.podRetainPhase[phase]; !ok {
+		if _, ok := c.podRetainPhase[phase]; !ok {
 			t.Errorf("podRetainPhase missing %q", phase)
 		}
 	}
-	if len(cap.podRetainPhase) != len(PodRetainPhaseSoft) {
-		t.Errorf("podRetainPhase has %d entries, want %d", len(cap.podRetainPhase), len(PodRetainPhaseSoft))
+	if len(c.podRetainPhase) != len(PodRetainPhaseSoft) {
+		t.Errorf("podRetainPhase has %d entries, want %d", len(c.podRetainPhase), len(PodRetainPhaseSoft))
 	}
 }
 
 // TestTerminatingState_Execute_NonNilUpdateFn verifies the updateFn is not nil
 // — unlike finishedState, terminatingState drives a phase transition.
 func TestTerminatingState_Execute_NonNilUpdateFn(t *testing.T) {
-	cap := captureKillJob(t, nil)
+	c := captureKillJob(t, nil)
 	s := &terminatingState{job: makeJobInfo(vcbatch.Terminating)}
 
 	if err := s.Execute(Action{Action: v1alpha1.SyncJobAction}); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if cap.updateFn == nil {
+	if c.updateFn == nil {
 		t.Error("updateFn must not be nil for terminatingState")
 	}
 }
@@ -98,15 +98,15 @@ func TestTerminatingState_Execute_NonNilUpdateFn(t *testing.T) {
 // TestTerminatingState_Execute_PassesJobInfo verifies the correct JobInfo
 // pointer is forwarded to KillJob.
 func TestTerminatingState_Execute_PassesJobInfo(t *testing.T) {
-	cap := captureKillJob(t, nil)
+	c := captureKillJob(t, nil)
 	info := makeJobInfo(vcbatch.Terminating)
 	s := &terminatingState{job: info}
 
 	if err := s.Execute(Action{Action: v1alpha1.SyncJobAction}); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if cap.job != info {
-		t.Errorf("KillJob received wrong JobInfo: got %p, want %p", cap.job, info)
+	if c.job != info {
+		t.Errorf("KillJob received wrong JobInfo: got %p, want %p", c.job, info)
 	}
 }
 
@@ -160,7 +160,7 @@ func TestTerminatingState_Execute_UpdateFnAlivePods(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			cap := captureKillJob(t, nil)
+			c := captureKillJob(t, nil)
 			s := &terminatingState{job: makeJobInfo(vcbatch.Terminating)}
 
 			if err := s.Execute(Action{Action: v1alpha1.SyncJobAction}); err != nil {
@@ -168,7 +168,7 @@ func TestTerminatingState_Execute_UpdateFnAlivePods(t *testing.T) {
 			}
 
 			originalPhase := tc.status.State.Phase
-			changed := cap.updateFn(&tc.status)
+			changed := c.updateFn(&tc.status)
 
 			if changed {
 				t.Error("updateFn should return false while alive pods exist")
@@ -208,14 +208,14 @@ func TestTerminatingState_Execute_UpdateFnAllPodsGone(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			cap := captureKillJob(t, nil)
+			c := captureKillJob(t, nil)
 			s := &terminatingState{job: makeJobInfo(vcbatch.Terminating)}
 
 			if err := s.Execute(Action{Action: v1alpha1.SyncJobAction}); err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
 
-			changed := cap.updateFn(&tc.status)
+			changed := c.updateFn(&tc.status)
 
 			if !changed {
 				t.Error("updateFn should return true when no alive pods remain")

--- a/pkg/controllers/job/state/terminating_test.go
+++ b/pkg/controllers/job/state/terminating_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2024 The Volcano Authors.
+Copyright 2026 The Volcano Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/controllers/job/state/util_test.go
+++ b/pkg/controllers/job/state/util_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Volcano Authors.
+Copyright 2017 The Volcano Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -21,8 +21,6 @@ import (
 
 	vcbatch "volcano.sh/apis/pkg/apis/batch/v1alpha1"
 )
-
-func int32Ptr(v int32) *int32 { return &v }
 
 func TestUtilTotalTasks_NoTasks(t *testing.T) {
 	job := &vcbatch.Job{}
@@ -106,7 +104,7 @@ func TestUtilTotalTaskMinAvailable_NoTasks(t *testing.T) {
 	}
 }
 
-// MinAvailable == nil → falls back to Replicas.
+// MinAvailable == nil falls back to Replicas.
 func TestUtilTotalTaskMinAvailable_MinAvailableNil(t *testing.T) {
 	tests := []struct {
 		name  string
@@ -137,7 +135,7 @@ func TestUtilTotalTaskMinAvailable_MinAvailableNil(t *testing.T) {
 	}
 }
 
-// MinAvailable set → uses MinAvailable value, ignores Replicas.
+// MinAvailable set wins over Replicas.
 func TestUtilTotalTaskMinAvailable_MinAvailableSet(t *testing.T) {
 	tests := []struct {
 		name  string
@@ -178,7 +176,6 @@ func TestUtilTotalTaskMinAvailable_MinAvailableSet(t *testing.T) {
 	}
 }
 
-// Mixed: some tasks have MinAvailable set, others don't.
 func TestUtilTotalTaskMinAvailable_Mixed(t *testing.T) {
 	tests := []struct {
 		name  string

--- a/pkg/controllers/job/state/util_test.go
+++ b/pkg/controllers/job/state/util_test.go
@@ -1,0 +1,222 @@
+/*
+Copyright 2024 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package state
+
+import (
+	"testing"
+
+	vcbatch "volcano.sh/apis/pkg/apis/batch/v1alpha1"
+)
+
+func int32Ptr(v int32) *int32 { return &v }
+
+func TestUtilTotalTasks_NoTasks(t *testing.T) {
+	job := &vcbatch.Job{}
+	if got := TotalTasks(job); got != 0 {
+		t.Errorf("expected 0, got %d", got)
+	}
+}
+
+func TestUtilTotalTasks_SingleTask(t *testing.T) {
+	tests := []struct {
+		name     string
+		replicas int32
+		want     int32
+	}{
+		{"zero replicas", 0, 0},
+		{"one replica", 1, 1},
+		{"many replicas", 5, 5},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			job := &vcbatch.Job{
+				Spec: vcbatch.JobSpec{
+					Tasks: []vcbatch.TaskSpec{
+						{Replicas: tc.replicas},
+					},
+				},
+			}
+			if got := TotalTasks(job); got != tc.want {
+				t.Errorf("expected %d, got %d", tc.want, got)
+			}
+		})
+	}
+}
+
+func TestUtilTotalTasks_MultipleTasks(t *testing.T) {
+	tests := []struct {
+		name  string
+		tasks []vcbatch.TaskSpec
+		want  int32
+	}{
+		{
+			name: "two tasks summed",
+			tasks: []vcbatch.TaskSpec{
+				{Replicas: 3},
+				{Replicas: 4},
+			},
+			want: 7,
+		},
+		{
+			name: "zero in middle ignored",
+			tasks: []vcbatch.TaskSpec{
+				{Replicas: 2},
+				{Replicas: 0},
+				{Replicas: 5},
+			},
+			want: 7,
+		},
+		{
+			name: "all zero replicas",
+			tasks: []vcbatch.TaskSpec{
+				{Replicas: 0},
+				{Replicas: 0},
+			},
+			want: 0,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			job := &vcbatch.Job{Spec: vcbatch.JobSpec{Tasks: tc.tasks}}
+			if got := TotalTasks(job); got != tc.want {
+				t.Errorf("expected %d, got %d", tc.want, got)
+			}
+		})
+	}
+}
+
+func TestUtilTotalTaskMinAvailable_NoTasks(t *testing.T) {
+	job := &vcbatch.Job{}
+	if got := TotalTaskMinAvailable(job); got != 0 {
+		t.Errorf("expected 0, got %d", got)
+	}
+}
+
+// MinAvailable == nil → falls back to Replicas.
+func TestUtilTotalTaskMinAvailable_MinAvailableNil(t *testing.T) {
+	tests := []struct {
+		name  string
+		tasks []vcbatch.TaskSpec
+		want  int32
+	}{
+		{
+			name:  "single task nil minAvailable uses replicas",
+			tasks: []vcbatch.TaskSpec{{Replicas: 3, MinAvailable: nil}},
+			want:  3,
+		},
+		{
+			name: "multiple tasks all nil minAvailable",
+			tasks: []vcbatch.TaskSpec{
+				{Replicas: 2, MinAvailable: nil},
+				{Replicas: 4, MinAvailable: nil},
+			},
+			want: 6,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			job := &vcbatch.Job{Spec: vcbatch.JobSpec{Tasks: tc.tasks}}
+			if got := TotalTaskMinAvailable(job); got != tc.want {
+				t.Errorf("expected %d, got %d", tc.want, got)
+			}
+		})
+	}
+}
+
+// MinAvailable set → uses MinAvailable value, ignores Replicas.
+func TestUtilTotalTaskMinAvailable_MinAvailableSet(t *testing.T) {
+	tests := []struct {
+		name  string
+		tasks []vcbatch.TaskSpec
+		want  int32
+	}{
+		{
+			name:  "minAvailable less than replicas",
+			tasks: []vcbatch.TaskSpec{{Replicas: 5, MinAvailable: int32Ptr(2)}},
+			want:  2,
+		},
+		{
+			name:  "minAvailable equals replicas",
+			tasks: []vcbatch.TaskSpec{{Replicas: 3, MinAvailable: int32Ptr(3)}},
+			want:  3,
+		},
+		{
+			name:  "minAvailable is zero",
+			tasks: []vcbatch.TaskSpec{{Replicas: 4, MinAvailable: int32Ptr(0)}},
+			want:  0,
+		},
+		{
+			name: "multiple tasks all with minAvailable",
+			tasks: []vcbatch.TaskSpec{
+				{Replicas: 5, MinAvailable: int32Ptr(2)},
+				{Replicas: 4, MinAvailable: int32Ptr(1)},
+			},
+			want: 3,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			job := &vcbatch.Job{Spec: vcbatch.JobSpec{Tasks: tc.tasks}}
+			if got := TotalTaskMinAvailable(job); got != tc.want {
+				t.Errorf("expected %d, got %d", tc.want, got)
+			}
+		})
+	}
+}
+
+// Mixed: some tasks have MinAvailable set, others don't.
+func TestUtilTotalTaskMinAvailable_Mixed(t *testing.T) {
+	tests := []struct {
+		name  string
+		tasks []vcbatch.TaskSpec
+		want  int32
+	}{
+		{
+			name: "first set second nil",
+			tasks: []vcbatch.TaskSpec{
+				{Replicas: 5, MinAvailable: int32Ptr(2)},
+				{Replicas: 3, MinAvailable: nil},
+			},
+			want: 5, // 2 (minAvailable) + 3 (replicas fallback)
+		},
+		{
+			name: "first nil second set",
+			tasks: []vcbatch.TaskSpec{
+				{Replicas: 4, MinAvailable: nil},
+				{Replicas: 6, MinAvailable: int32Ptr(1)},
+			},
+			want: 5, // 4 (replicas fallback) + 1 (minAvailable)
+		},
+		{
+			name: "three tasks alternating",
+			tasks: []vcbatch.TaskSpec{
+				{Replicas: 3, MinAvailable: int32Ptr(2)},
+				{Replicas: 5, MinAvailable: nil},
+				{Replicas: 2, MinAvailable: int32Ptr(0)},
+			},
+			want: 7, // 2 + 5 + 0
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			job := &vcbatch.Job{Spec: vcbatch.JobSpec{Tasks: tc.tasks}}
+			if got := TotalTaskMinAvailable(job); got != tc.want {
+				t.Errorf("expected %d, got %d", tc.want, got)
+			}
+		})
+	}
+}

--- a/pkg/controllers/job/state/util_test.go
+++ b/pkg/controllers/job/state/util_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2024 The Volcano Authors.
+Copyright 2026 The Volcano Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Summary
  Add unit tests for `pkg/controllers/job/state/` package, which previously
  had 0% test coverage. This package implements the Volcano Job lifecycle
  state machine (Pending → Running → Completing/Terminating/Aborting/
  Restarting → terminal states).

  ## Changes
  | File | Test File | Coverage |
  |---|---|---|
  | util.go | util_test.go | 100% |
  | factory.go | factory_test.go | 100% |
  | finished.go | finished_test.go | 100% |
  | aborted.go | aborted_test.go | 100% |
  | terminating.go | terminating_test.go | 100% |
  | aborting.go | aborting_test.go | 100% |
  | pending.go | pending_test.go | 100% |
  | completing.go | completing_test.go | 100% |
  | restarting.go | restarting_test.go | 100% |
  | running.go | running_test.go | 100% |

  ## Test Coverage
  Before: `0.0%`
  After:  `98.6%`

  ## How to Verify
  go test ./pkg/controllers/job/state/... -v -coverprofile=cover.out
  go tool cover -func=cover.out