### PR TITLE
Fix vGPU cache double-counting in HAMICoreFactory.AddPod

### DIFF
--- a/pkg/scheduler/api/devices/nvidia/vgpu/hamicore.go
+++ b/pkg/scheduler/api/devices/nvidia/vgpu/hamicore.go
@@ -67,8 +67,10 @@ func (f HAMICoreFactory) SubPod(gd *GPUDevice, mem uint, core uint, podUID strin
 	gd.UsedNum--
 	gd.UsedMem -= mem
 	gd.UsedCore -= core
-	gd.PodMap[podUID].UsedMem -= mem
-	gd.PodMap[podUID].UsedCore -= core
-	klog.V(4).Infoln("sub Pod: ", podUID, mem, gd.PodMap[podUID].UsedMem, gd.PodMap[podUID].UsedCore)
+	klog.V(4).Infoln("sub Pod: ", podUID, mem)
+	// Remove the per-pod entry so the AddPod idempotency guard does not
+	// see a stale entry if the same UID is added again, and so PodMap
+	// does not grow without bound between SetNode rebuilds.
+	delete(gd.PodMap, podUID)
 	return nil
 }

--- a/pkg/scheduler/api/devices/nvidia/vgpu/hamicore.go
+++ b/pkg/scheduler/api/devices/nvidia/vgpu/hamicore.go
@@ -37,10 +37,7 @@ func (f HAMICoreFactory) TryAddPod(gd *GPUDevice, mem uint, core uint) (bool, st
 }
 
 func (f HAMICoreFactory) AddPod(gd *GPUDevice, mem uint, core uint, podUID string, devID string) error {
-	_, ok := gd.PodMap[podUID]
-	if ok {
-		// Keep AddPod idempotent in case the same pod allocation is replayed
-		// during cache/node refresh.
+	if _, ok := gd.PodMap[podUID]; ok {
 		return nil
 	}
 	gd.PodMap[podUID] = &GPUUsage{
@@ -68,9 +65,6 @@ func (f HAMICoreFactory) SubPod(gd *GPUDevice, mem uint, core uint, podUID strin
 	gd.UsedMem -= mem
 	gd.UsedCore -= core
 	klog.V(4).Infoln("sub Pod: ", podUID, mem)
-	// Remove the per-pod entry so the AddPod idempotency guard does not
-	// see a stale entry if the same UID is added again, and so PodMap
-	// does not grow without bound between SetNode rebuilds.
 	delete(gd.PodMap, podUID)
 	return nil
 }

--- a/pkg/scheduler/api/devices/nvidia/vgpu/hamicore_test.go
+++ b/pkg/scheduler/api/devices/nvidia/vgpu/hamicore_test.go
@@ -1,0 +1,126 @@
+/*
+Copyright 2026 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vgpu
+
+import "testing"
+
+func newHAMITestDevice() *GPUDevice {
+	return &GPUDevice{
+		ID:     0,
+		UUID:   "GPU-0",
+		Number: 4,
+		Memory: 16384,
+		Type:   "NVIDIA",
+		Health: true,
+		PodMap: make(map[string]*GPUUsage),
+	}
+}
+
+func TestHAMICoreFactory_AddPod(t *testing.T) {
+	const podUID = "pod-a"
+	testCases := []struct {
+		name         string
+		setup        func(gd *GPUDevice)
+		wantUsedNum  uint
+		wantUsedMem  uint
+		wantUsedCore uint
+	}{
+		{
+			name:         "fresh add increments counters and seeds PodMap",
+			setup:        func(gd *GPUDevice) {},
+			wantUsedNum:  1,
+			wantUsedMem:  1000,
+			wantUsedCore: 25,
+		},
+		{
+			name: "duplicate add is a no-op",
+			setup: func(gd *GPUDevice) {
+				gd.UsedNum, gd.UsedMem, gd.UsedCore = 1, 1000, 25
+				gd.PodMap[podUID] = &GPUUsage{UsedMem: 1000, UsedCore: 25}
+			},
+			wantUsedNum:  1,
+			wantUsedMem:  1000,
+			wantUsedCore: 25,
+		},
+		{
+			name: "add after Allocate's TryAddPod and addToPodMap does not double-count",
+			setup: func(gd *GPUDevice) {
+				HAMICoreFactory{}.TryAddPod(gd, 1000, 25)
+				gd.PodMap[podUID] = &GPUUsage{UsedMem: 1000, UsedCore: 25}
+			},
+			wantUsedNum:  1,
+			wantUsedMem:  1000,
+			wantUsedCore: 25,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			gd := newHAMITestDevice()
+			tc.setup(gd)
+			if err := (HAMICoreFactory{}).AddPod(gd, 1000, 25, podUID, gd.UUID); err != nil {
+				t.Fatalf("AddPod: %v", err)
+			}
+			if gd.UsedNum != tc.wantUsedNum || gd.UsedMem != tc.wantUsedMem || gd.UsedCore != tc.wantUsedCore {
+				t.Errorf("counters: got %d/%d/%d, want %d/%d/%d",
+					gd.UsedNum, gd.UsedMem, gd.UsedCore,
+					tc.wantUsedNum, tc.wantUsedMem, tc.wantUsedCore)
+			}
+			if _, ok := gd.PodMap[podUID]; !ok {
+				t.Errorf("PodMap[%q] missing after AddPod", podUID)
+			}
+		})
+	}
+}
+
+func TestHAMICoreFactory_AddPodDistinctUIDsAccumulate(t *testing.T) {
+	gd := newHAMITestDevice()
+	for _, uid := range []string{"pod-a", "pod-b", "pod-c"} {
+		if err := (HAMICoreFactory{}).AddPod(gd, 1000, 25, uid, gd.UUID); err != nil {
+			t.Fatalf("AddPod(%s): %v", uid, err)
+		}
+	}
+	if gd.UsedNum != 3 || gd.UsedMem != 3000 || gd.UsedCore != 75 {
+		t.Errorf("counters after 3 distinct adds: got %d/%d/%d, want 3/3000/75",
+			gd.UsedNum, gd.UsedMem, gd.UsedCore)
+	}
+}
+
+func TestHAMICoreFactory_SubPodRemovesEntry(t *testing.T) {
+	const podUID = "pod-a"
+	f := HAMICoreFactory{}
+	gd := newHAMITestDevice()
+
+	if err := f.AddPod(gd, 1000, 25, podUID, gd.UUID); err != nil {
+		t.Fatalf("AddPod: %v", err)
+	}
+	if err := f.SubPod(gd, 1000, 25, podUID, gd.UUID); err != nil {
+		t.Fatalf("SubPod: %v", err)
+	}
+	if _, ok := gd.PodMap[podUID]; ok {
+		t.Errorf("SubPod left a stale PodMap entry")
+	}
+	if gd.UsedNum != 0 || gd.UsedMem != 0 || gd.UsedCore != 0 {
+		t.Errorf("after SubPod: got %d/%d/%d, want 0/0/0", gd.UsedNum, gd.UsedMem, gd.UsedCore)
+	}
+	// Same-UID re-add after Sub must increment, not no-op against a stale entry.
+	if err := f.AddPod(gd, 1000, 25, podUID, gd.UUID); err != nil {
+		t.Fatalf("re-AddPod: %v", err)
+	}
+	if gd.UsedNum != 1 || gd.UsedMem != 1000 {
+		t.Errorf("re-AddPod after SubPod: got %d/%d, want 1/1000", gd.UsedNum, gd.UsedMem)
+	}
+}

--- a/pkg/scheduler/api/devices/nvidia/vgpu/hamicore_test.go
+++ b/pkg/scheduler/api/devices/nvidia/vgpu/hamicore_test.go
@@ -116,7 +116,6 @@ func TestHAMICoreFactory_SubPodRemovesEntry(t *testing.T) {
 	if gd.UsedNum != 0 || gd.UsedMem != 0 || gd.UsedCore != 0 {
 		t.Errorf("after SubPod: got %d/%d/%d, want 0/0/0", gd.UsedNum, gd.UsedMem, gd.UsedCore)
 	}
-	// Same-UID re-add after Sub must increment, not no-op against a stale entry.
 	if err := f.AddPod(gd, 1000, 25, podUID, gd.UUID); err != nil {
 		t.Fatalf("re-AddPod: %v", err)
 	}

--- a/pkg/scheduler/api/devices/nvidia/vgpu/mig.go
+++ b/pkg/scheduler/api/devices/nvidia/vgpu/mig.go
@@ -90,9 +90,6 @@ func (f MIGFactory) SubPod(gd *GPUDevice, mem uint, core uint, podUID string, de
 	gd.UsedCore -= core
 
 	klog.V(4).Infoln("sub Pod: ", podUID, usedMem)
-	// Remove the per-pod entry so the AddPod idempotency guard does not
-	// see a stale entry if the same UID is added again, and so PodMap
-	// does not grow without bound between SetNode rebuilds.
 	delete(gd.PodMap, podUID)
 	return nil
 }

--- a/pkg/scheduler/api/devices/nvidia/vgpu/mig.go
+++ b/pkg/scheduler/api/devices/nvidia/vgpu/mig.go
@@ -89,10 +89,11 @@ func (f MIGFactory) SubPod(gd *GPUDevice, mem uint, core uint, podUID string, de
 	gd.UsedMem -= mem
 	gd.UsedCore -= core
 
-	gd.PodMap[podUID].UsedMem -= usedMem
-	gd.PodMap[podUID].UsedCore -= core
-
-	klog.V(4).Infoln("sub Pod: ", podUID, usedMem, gd.PodMap[podUID].UsedMem, gd.PodMap[podUID].UsedCore)
+	klog.V(4).Infoln("sub Pod: ", podUID, usedMem)
+	// Remove the per-pod entry so the AddPod idempotency guard does not
+	// see a stale entry if the same UID is added again, and so PodMap
+	// does not grow without bound between SetNode rebuilds.
+	delete(gd.PodMap, podUID)
 	return nil
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Follow-up to #5245, which made `HAMICoreFactory.AddPod` idempotent on a present `PodMap` entry to prevent the deviceshare cache from double-counting pod allocations on the Allocate→bind→informer-update path.

That guard relies on `PodMap` being an accurate signal of "this pod is already accounted for on this device." However, both `HAMICoreFactory.SubPod` and `MIGFactory.SubPod` were leaving stale per-pod entries behind on removal. Two consequences:

1. `PodMap` could grow without bound between `SetNode` rebuilds (~30s).
2. A re-add of the same UID after a Sub would silently no-op — counters wouldn't re-increment, leading to undercount.

**Fix:** both `SubPod` implementations now `delete(gd.PodMap, podUID)` after decrementing device counters, restoring symmetry with `AddPod` (which seeds the entry).

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

- Originally this PR also carried the `HAMICoreFactory.AddPod` idempotency fix; that commit was dropped in rebase because upstream merged the equivalent fix in #5245. The remaining commits are the SubPod cleanup and a restructured unit-test suite.
- Verified end-to-end on minikube: 42/42 integration assertions pass, including the strict-binpack scenarios that originally surfaced this class of bug (5 single-GPU pods on a node with `Number=2` slots per GPU correctly land on 3 GPUs, not 5).
- Unit tests in `hamicore_test.go` cover:
  - `AddPod` idempotency on duplicate UIDs (still passes after upstream's fix)
  - The `Allocate`-then-`AddPod` sequence reproducing the original bug
  - Distinct UIDs accumulate correctly (multi-pod guard)
  - `SubPod` removes the entry so a same-UID re-`AddPod` re-increments
- AI disclosure: this PR was prepared with AI-assisted authoring (Claude). I have read and understand every change.

#### Does this PR introduce a user-facing change?

```release-note
HAMICoreFactory.SubPod and MIGFactory.SubPod now delete the per-pod entry from PodMap on removal, complementing the AddPod idempotency guard added in #5245. This prevents PodMap from growing unbounded between node refreshes and ensures that re-adding the same pod UID after a Sub correctly re-increments device counters.
```