### PR TITLE
[Helm chart enhancement] support scheduler_percentage_nodes_to_find arg

### DIFF
--- a/installer/helm/chart/volcano/templates/scheduler.yaml
+++ b/installer/helm/chart/volcano/templates/scheduler.yaml
@@ -229,6 +229,9 @@ spec:
             {{- if .Values.custom.scheduler_node_worker_threads }}
             - --node-worker-threads={{.Values.custom.scheduler_node_worker_threads}}
             {{- end }}
+            {{- if ne .Values.custom.scheduler_percentage_nodes_to_find nil }}
+            - --percentage-nodes-to-find={{.Values.custom.scheduler_percentage_nodes_to_find}}
+            {{- end }}
             {{- if .Values.custom.scheduler_plugins_dir }}
             - --plugins-dir={{ .Values.custom.scheduler_plugins_dir }}
             {{- end }}

--- a/installer/helm/chart/volcano/values.yaml
+++ b/installer/helm/chart/volcano/values.yaml
@@ -53,6 +53,7 @@ custom:
   scheduler_kube_api_burst: 2000
   scheduler_schedule_period: 1s
   scheduler_node_worker_threads: 20
+  scheduler_percentage_nodes_to_find: ~
   agent_scheduler_worker_count: 1
   enabled_admissions: "/jobs/mutate,/jobs/validate,/podgroups/validate,/queues/mutate,/queues/validate,/hypernodes/validate,/cronjobs/validate"
   colocation_enable: false


### PR DESCRIPTION

#### What type of PR is this?
Feature / Helm chart enhancement

#### What this PR does / why we need it:
This PR adds support for configuring scheduler `--percentage-nodes-to-find` via Helm values.
- Added a new optional values key: `custom.scheduler_percentage_nodes_to_find: ~`
- Added conditional scheduler arg rendering in `scheduler.yaml`:
  - when value is not `nil`, render `--percentage-nodes-to-find=<value>`

This makes scheduler behavior tunable from chart values without editing templates, while keeping backward compatibility.

This is especially needed for HyperNode-aware scheduling, where percentage-nodes-to-find should be set to 100.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Notice that do not add `Fixes` if the issue is associated with multiple PRs.
-->
Fixes #

#### Special notes for your reviewer:
- The template uses `if ne ... nil` intentionally, so `0` is treated as a valid explicit value and will still be rendered.
- Suggested verification:
  1. `helm template` without setting `scheduler_percentage_nodes_to_find` (arg should not appear)
  2. `helm template --set custom.scheduler_percentage_nodes_to_find=0` (arg should appear as `0`)
  3. `helm template --set custom.scheduler_percentage_nodes_to_find=30` (arg should appear as `30`)


#### Does this PR introduce a user-facing change?
```release-note
Helm chart: added optional `custom.scheduler_percentage_nodes_to_find` value to configure scheduler argument `--percentage-nodes-to-find`.
```