### PR TITLE
scheduler: respect MinResources in JobInfo.IsReady

### DIFF
--- a/pkg/scheduler/api/job_info.go
+++ b/pkg/scheduler/api/job_info.go
@@ -1167,7 +1167,14 @@ func (ji *JobInfo) CheckSubJobPipelined() bool {
 }
 
 func (ji *JobInfo) IsReady() bool {
-	return ji.ReadyTaskNum()+ji.PendingBestEffortTaskNum() >= ji.MinAvailable
+	if ji.ReadyTaskNum()+ji.PendingBestEffortTaskNum() < ji.MinAvailable {
+		return false
+	}
+	if ji.PodGroup == nil || ji.PodGroup.Spec.MinResources == nil {
+		return true
+	}
+	minRes := ji.GetMinResources()
+	return minRes.IsEmpty() || minRes.LessEqual(ji.Allocated, Zero)
 }
 
 func (ji *JobInfo) IsPipelined() bool {

--- a/pkg/scheduler/api/job_info.go
+++ b/pkg/scheduler/api/job_info.go
@@ -1174,11 +1174,35 @@ func (ji *JobInfo) IsReady() bool {
 		return true
 	}
 	minRes := ji.GetMinResources()
-	return minRes.IsEmpty() || minRes.LessEqual(ji.Allocated, Zero)
+	if minRes.IsEmpty() || minRes.LessEqual(ji.Allocated, Zero) {
+		return true
+	}
+	readyRes := ji.Allocated.Clone()
+	for _, task := range ji.TaskStatusIndex[Succeeded] {
+		readyRes.Add(task.Resreq)
+	}
+	return minRes.LessEqual(readyRes, Zero)
 }
 
 func (ji *JobInfo) IsPipelined() bool {
-	return ji.WaitingTaskNum()+ji.ReadyTaskNum()+ji.PendingBestEffortTaskNum() >= ji.MinAvailable
+	if ji.WaitingTaskNum()+ji.ReadyTaskNum()+ji.PendingBestEffortTaskNum() < ji.MinAvailable {
+		return false
+	}
+	if ji.PodGroup == nil || ji.PodGroup.Spec.MinResources == nil {
+		return true
+	}
+	minRes := ji.GetMinResources()
+	if minRes.IsEmpty() {
+		return true
+	}
+	res := ji.Allocated.Clone()
+	for _, task := range ji.TaskStatusIndex[Succeeded] {
+		res.Add(task.Resreq)
+	}
+	for _, task := range ji.TaskStatusIndex[Pipelined] {
+		res.Add(task.Resreq)
+	}
+	return minRes.LessEqual(res, Zero)
 }
 
 func (ji *JobInfo) IsStarving() bool {

--- a/pkg/scheduler/api/job_info_test.go
+++ b/pkg/scheduler/api/job_info_test.go
@@ -500,7 +500,7 @@ func TestJobInfoMinResources(t *testing.T) {
 			InitResreq:         res,
 		}
 	}
-	running := func(uid string, res *Resource) *TaskInfo  { return taskWithStatus(uid, res, Running) }
+	running := func(uid string, res *Resource) *TaskInfo { return taskWithStatus(uid, res, Running) }
 	succeeded := func(uid string, res *Resource) *TaskInfo { return taskWithStatus(uid, res, Succeeded) }
 
 	tests := []struct {
@@ -576,7 +576,7 @@ func TestJobInfoIsPipelinedMinResources(t *testing.T) {
 			InitResreq:         res,
 		}
 	}
-	running   := func(uid string, res *Resource) *TaskInfo { return taskWithStatus(uid, res, Running) }
+	running := func(uid string, res *Resource) *TaskInfo { return taskWithStatus(uid, res, Running) }
 	pipelined := func(uid string, res *Resource) *TaskInfo { return taskWithStatus(uid, res, Pipelined) }
 
 	tests := []struct {

--- a/pkg/scheduler/api/job_info_test.go
+++ b/pkg/scheduler/api/job_info_test.go
@@ -486,6 +486,68 @@ func TestJobInfo(t *testing.T) {
 	}
 }
 
+func TestJobInfoMinResources(t *testing.T) {
+	cpu := func(c string) *Resource {
+		return NewResource(v1.ResourceList{"cpu": resource.MustParse(c)})
+	}
+	running := func(uid string, res *Resource) *TaskInfo {
+		return &TaskInfo{
+			UID:                TaskID(uid),
+			Job:                "j",
+			Name:               uid,
+			TransactionContext: TransactionContext{Status: Running},
+			Resreq:             res,
+			InitResreq:         res,
+		}
+	}
+
+	tests := []struct {
+		name      string
+		minMember int32
+		minRes    *v1.ResourceList
+		tasks     []*TaskInfo
+		want      bool
+	}{
+		{
+			name: "no gating",
+			want: true,
+		},
+		{
+			name:   "minRes unmet, no minMember",
+			minRes: &v1.ResourceList{"cpu": resource.MustParse("4")},
+			tasks:  []*TaskInfo{running("t1", cpu("1"))},
+			want:   false,
+		},
+		{
+			name:   "minRes met, no minMember",
+			minRes: &v1.ResourceList{"cpu": resource.MustParse("2")},
+			tasks:  []*TaskInfo{running("t1", cpu("1")), running("t2", cpu("1"))},
+			want:   true,
+		},
+		{
+			name:      "minMember met, minRes unmet",
+			minMember: 1,
+			minRes:    &v1.ResourceList{"cpu": resource.MustParse("4")},
+			tasks:     []*TaskInfo{running("t1", cpu("1"))},
+			want:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		ji := NewJobInfo("j")
+		for _, ti := range tt.tasks {
+			ji.AddTaskInfo(ti)
+		}
+		ji.SetPodGroup(&PodGroup{PodGroup: scheduling.PodGroup{
+			ObjectMeta: metav1.ObjectMeta{Name: "pg", Namespace: "ns"},
+			Spec:       scheduling.PodGroupSpec{MinMember: tt.minMember, MinResources: tt.minRes},
+		}})
+		if got := ji.IsReady(); got != tt.want {
+			t.Errorf("%s: IsReady() = %v, want %v", tt.name, got, tt.want)
+		}
+	}
+}
+
 func TestGetElasticResources(t *testing.T) {
 	resNoGPU := BuildResourceList("1", "1G")
 	resWithGPU := BuildResourceListWithGPU("1", "1G", "1")

--- a/pkg/scheduler/api/job_info_test.go
+++ b/pkg/scheduler/api/job_info_test.go
@@ -490,16 +490,18 @@ func TestJobInfoMinResources(t *testing.T) {
 	cpu := func(c string) *Resource {
 		return NewResource(v1.ResourceList{"cpu": resource.MustParse(c)})
 	}
-	running := func(uid string, res *Resource) *TaskInfo {
+	taskWithStatus := func(uid string, res *Resource, status TaskStatus) *TaskInfo {
 		return &TaskInfo{
 			UID:                TaskID(uid),
 			Job:                "j",
 			Name:               uid,
-			TransactionContext: TransactionContext{Status: Running},
+			TransactionContext: TransactionContext{Status: status},
 			Resreq:             res,
 			InitResreq:         res,
 		}
 	}
+	running := func(uid string, res *Resource) *TaskInfo  { return taskWithStatus(uid, res, Running) }
+	succeeded := func(uid string, res *Resource) *TaskInfo { return taskWithStatus(uid, res, Succeeded) }
 
 	tests := []struct {
 		name      string
@@ -531,6 +533,18 @@ func TestJobInfoMinResources(t *testing.T) {
 			tasks:     []*TaskInfo{running("t1", cpu("1"))},
 			want:      false,
 		},
+		{
+			name:   "minRes met via succeeded task",
+			minRes: &v1.ResourceList{"cpu": resource.MustParse("2")},
+			tasks:  []*TaskInfo{running("t1", cpu("1")), succeeded("t2", cpu("1"))},
+			want:   true,
+		},
+		{
+			name:   "minRes unmet even with succeeded task",
+			minRes: &v1.ResourceList{"cpu": resource.MustParse("4")},
+			tasks:  []*TaskInfo{running("t1", cpu("1")), succeeded("t2", cpu("1"))},
+			want:   false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -544,6 +558,72 @@ func TestJobInfoMinResources(t *testing.T) {
 		}})
 		if got := ji.IsReady(); got != tt.want {
 			t.Errorf("%s: IsReady() = %v, want %v", tt.name, got, tt.want)
+		}
+	}
+}
+
+func TestJobInfoIsPipelinedMinResources(t *testing.T) {
+	cpu := func(c string) *Resource {
+		return NewResource(v1.ResourceList{"cpu": resource.MustParse(c)})
+	}
+	taskWithStatus := func(uid string, res *Resource, status TaskStatus) *TaskInfo {
+		return &TaskInfo{
+			UID:                TaskID(uid),
+			Job:                "j",
+			Name:               uid,
+			TransactionContext: TransactionContext{Status: status},
+			Resreq:             res,
+			InitResreq:         res,
+		}
+	}
+	running   := func(uid string, res *Resource) *TaskInfo { return taskWithStatus(uid, res, Running) }
+	pipelined := func(uid string, res *Resource) *TaskInfo { return taskWithStatus(uid, res, Pipelined) }
+
+	tests := []struct {
+		name      string
+		minMember int32
+		minRes    *v1.ResourceList
+		tasks     []*TaskInfo
+		want      bool
+	}{
+		{
+			name: "no gating",
+			want: true,
+		},
+		{
+			name:      "minMember and minRes both met",
+			minMember: 2,
+			minRes:    &v1.ResourceList{"cpu": resource.MustParse("2")},
+			tasks:     []*TaskInfo{running("t1", cpu("1")), pipelined("t2", cpu("1"))},
+			want:      true,
+		},
+		{
+			name:      "minMember met, minRes unmet",
+			minMember: 2,
+			minRes:    &v1.ResourceList{"cpu": resource.MustParse("4")},
+			tasks:     []*TaskInfo{running("t1", cpu("1")), pipelined("t2", cpu("1"))},
+			want:      false,
+		},
+		{
+			name:      "minMember unmet",
+			minMember: 3,
+			minRes:    &v1.ResourceList{"cpu": resource.MustParse("2")},
+			tasks:     []*TaskInfo{running("t1", cpu("1")), pipelined("t2", cpu("1"))},
+			want:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		ji := NewJobInfo("j")
+		for _, ti := range tt.tasks {
+			ji.AddTaskInfo(ti)
+		}
+		ji.SetPodGroup(&PodGroup{PodGroup: scheduling.PodGroup{
+			ObjectMeta: metav1.ObjectMeta{Name: "pg", Namespace: "ns"},
+			Spec:       scheduling.PodGroupSpec{MinMember: tt.minMember, MinResources: tt.minRes},
+		}})
+		if got := ji.IsPipelined(); got != tt.want {
+			t.Errorf("%s: IsPipelined() = %v, want %v", tt.name, got, tt.want)
 		}
 	}
 }

--- a/pkg/scheduler/plugins/gang/gang.go
+++ b/pkg/scheduler/plugins/gang/gang.go
@@ -240,6 +240,9 @@ func (gp *gangPlugin) OnSessionClose(ssn *framework.Session) {
 				return num + job.ReadyTaskNum()
 			}
 			unreadyTaskCount = job.MinAvailable - schedulableTaskNum()
+			if unreadyTaskCount < 0 {
+				unreadyTaskCount = 0
+			}
 			msg := fmt.Sprintf("%v/%v tasks in gang unschedulable: %v",
 				unreadyTaskCount, len(job.Tasks), job.FitError())
 


### PR DESCRIPTION
**What type of PR is this?**
kind/bug

**What this PR does / why we need it:**

`IsReady()` previously only gated on task count against `MinAvailable`, completely ignoring `MinResources`. This meant a gang job could be scheduled before its allocated resources met the PodGroup's minimum resource requirement.

This fix adds a resource check after the task count gate, ensuring `IsReady()` returns true only when both `MinAvailable` and `MinResources` are satisfied.


**Which issue(s) this PR fixes:**

Fixes #5075

**Special notes for your reviewer:**

The `Allocated` field on `JobInfo` is already maintained incrementally (added/subtracted as tasks transition between states), so the added resource check has negligible overhead — no recomputation needed.

**Does this PR introduce a user-facing change?**

