### PR TITLE
fix(scheduler): display maxFloat/maxInt in Resource.String() for infinite values

### DIFF
--- a/pkg/scheduler/api/resource_info.go
+++ b/pkg/scheduler/api/resource_info.go
@@ -168,29 +168,27 @@ func (r *Resource) Clone() *Resource {
 
 // String returns resource details in string format
 func (r *Resource) String() string {
-	cpuStr := "maxFloat"
-	if r.MilliCPU != math.MaxFloat64 {
-		cpuStr = fmt.Sprintf("%0.2f", r.MilliCPU)
+	format := func(val float64) string {
+		if val == math.MaxFloat64 {
+			return "maxFloat"
+		}
+		if val == float64(math.MaxInt64) {
+			return "maxInt"
+		}
+		return fmt.Sprintf("%0.2f", val)
 	}
-	memStr := "maxFloat"
-	if r.Memory != math.MaxFloat64 {
-		memStr = fmt.Sprintf("%0.2f", r.Memory)
-	}
-	str := fmt.Sprintf("cpu %s, memory %s", cpuStr, memStr)
+
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "cpu %s, memory %s", format(r.MilliCPU), format(r.Memory))
 	var resourceNames []string
 	for rName := range r.ScalarResources {
 		resourceNames = append(resourceNames, string(rName))
 	}
 	sort.Strings(resourceNames)
 	for _, rName := range resourceNames {
-		val := r.ScalarResources[v1.ResourceName(rName)]
-		valStr := "maxInt"
-		if val != math.MaxInt64 {
-			valStr = fmt.Sprintf("%0.2f", val)
-		}
-		str = fmt.Sprintf("%s, %s %s", str, rName, valStr)
+		fmt.Fprintf(&sb, ", %s %s", rName, format(r.ScalarResources[v1.ResourceName(rName)]))
 	}
-	return str
+	return sb.String()
 }
 
 // ResourceNames returns all resource types

--- a/pkg/scheduler/api/resource_info.go
+++ b/pkg/scheduler/api/resource_info.go
@@ -168,15 +168,27 @@ func (r *Resource) Clone() *Resource {
 
 // String returns resource details in string format
 func (r *Resource) String() string {
-	str := fmt.Sprintf("cpu %0.2f, memory %0.2f", r.MilliCPU, r.Memory)
-	// Sort scalar resource names to ensure consistent string output
+	cpuStr := "maxFloat"
+	if r.MilliCPU != math.MaxFloat64 {
+		cpuStr = fmt.Sprintf("%0.2f", r.MilliCPU)
+	}
+	memStr := "maxFloat"
+	if r.Memory != math.MaxFloat64 {
+		memStr = fmt.Sprintf("%0.2f", r.Memory)
+	}
+	str := fmt.Sprintf("cpu %s, memory %s", cpuStr, memStr)
 	var resourceNames []string
 	for rName := range r.ScalarResources {
 		resourceNames = append(resourceNames, string(rName))
 	}
 	sort.Strings(resourceNames)
 	for _, rName := range resourceNames {
-		str = fmt.Sprintf("%s, %s %0.2f", str, rName, r.ScalarResources[v1.ResourceName(rName)])
+		val := r.ScalarResources[v1.ResourceName(rName)]
+		valStr := "maxInt"
+		if val != math.MaxInt64 {
+			valStr = fmt.Sprintf("%0.2f", val)
+		}
+		str = fmt.Sprintf("%s, %s %s", str, rName, valStr)
 	}
 	return str
 }

--- a/pkg/scheduler/api/resource_info_test.go
+++ b/pkg/scheduler/api/resource_info_test.go
@@ -1983,3 +1983,50 @@ func TestIntersectionWithIgnoredScalarResources(t *testing.T) {
 		}
 	}
 }
+
+func TestResourceString(t *testing.T) {
+	cases := []struct {
+		name     string
+		resource *Resource
+		expected string
+	}{
+		{
+			name:     "normal values",
+			resource: &Resource{MilliCPU: 2000, Memory: 4096},
+			expected: "cpu 2000.00, memory 4096.00",
+		},
+		{
+			name:     "infinite cpu and memory",
+			resource: &Resource{MilliCPU: math.MaxFloat64, Memory: math.MaxFloat64},
+			expected: "cpu maxFloat, memory maxFloat",
+		},
+		{
+			name: "infinite scalar resource",
+			resource: &Resource{
+				MilliCPU: 1000,
+				Memory:   2048,
+				ScalarResources: map[v1.ResourceName]float64{
+					"nvidia.com/gpu": float64(math.MaxInt64),
+				},
+			},
+			expected: "cpu 1000.00, memory 2048.00, nvidia.com/gpu maxInt",
+		},
+		{
+			name: "mixed normal and infinite scalar",
+			resource: &Resource{
+				MilliCPU: math.MaxFloat64,
+				Memory:   math.MaxFloat64,
+				ScalarResources: map[v1.ResourceName]float64{
+					"nvidia.com/gpu": float64(math.MaxInt64),
+				},
+			},
+			expected: "cpu maxFloat, memory maxFloat, nvidia.com/gpu maxInt",
+		},
+	}
+	for _, c := range cases {
+		got := c.resource.String()
+		if got != c.expected {
+			t.Errorf("%s: got %q, want %q", c.name, got, c.expected)
+		}
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

kind/bug

#### What this PR does / why we need it:

Verbose scheduler logs were printing raw sentinel values like math.MaxFloat64
and math.MaxInt64 for unbounded resources, making the output near unreadable.
The String() method on Resource now shows "maxFloat" and "maxInt" in those
cases instead.

#### Which issue(s) this PR fixes:

Fixes #5148

#### Special notes for your reviewer:

Only the String() method is affected, no logic changes anywhere.

#### Does this PR introduce a user-facing change?



