### PR TITLE
feat(metrics): expose queue guarantee resource metrics

### DIFF
--- a/docs/design/metrics.md
+++ b/docs/design/metrics.md
@@ -42,13 +42,16 @@ This metrics describe internal state of volcano.
 | `queue_request_scalar_resources`       | Gauge           | `queue_name`=&lt;queue_name&gt;, `resource`=&lt;resource_name&gt; | Requested scalar resource for one queue       |
 | `queue_deserved_milli_cpu`             | Gauge           | `queue_name`=&lt;queue_name&gt;                                   | Deserved CPU count for one queue              |
 | `queue_deserved_memory_bytes`          | Gauge           | `queue_name`=&lt;queue_name&gt;                                   | Deserved memory for one queue                 |
-| `queue_deserved_scalar_resources`      | Gauge           | `queue_name`=&lt;queue_name&gt;,                                  | Deserved scalar resource for one queue        |
-| `queue_capacity_mill_cpu`              | Gauge           | `queue_name`=&lt;queue_name&gt;,                                  | CPU count capacity for one queue              |
-| `queue_capacity_memory_bytes`          | Gauge           | `queue_name`=&lt;queue_name&gt;,                                  | memory capacity for one queue                 |
+| `queue_deserved_scalar_resources`      | Gauge           | `queue_name`=&lt;queue_name&gt;, `resource`=&lt;resource_name&gt; | Deserved scalar resource for one queue        |
+| `queue_capacity_milli_cpu`             | Gauge           | `queue_name`=&lt;queue_name&gt;                                   | CPU count capacity for one queue              |
+| `queue_capacity_memory_bytes`          | Gauge           | `queue_name`=&lt;queue_name&gt;                                   | Memory capacity for one queue                 |
 | `queue_capacity_scalar_resources`      | Gauge           | `queue_name`=&lt;queue_name&gt;, `resource`=&lt;resource_name&gt; | Scalar resource capacity for one queue        |
-| `queue_real_capacity_mill_cpu`         | Gauge           | `queue_name`=&lt;queue_name&gt;,                                  | CPU count real capacity for one queue         |
-| `queue_real_capacity_memory_bytes`     | Gauge           | `queue_name`=&lt;queue_name&gt;,                                  | Memory real capacity for one queue            |
+| `queue_real_capacity_milli_cpu`        | Gauge           | `queue_name`=&lt;queue_name&gt;                                   | CPU count real capacity for one queue         |
+| `queue_real_capacity_memory_bytes`     | Gauge           | `queue_name`=&lt;queue_name&gt;                                   | Memory real capacity for one queue            |
 | `queue_real_capacity_scalar_resources` | Gauge           | `queue_name`=&lt;queue_name&gt;, `resource`=&lt;resource_name&gt; | Scalar resource real capacity for one queue   |
+| `queue_guarantee_milli_cpu`            | Gauge           | `queue_name`=&lt;queue_name&gt;                                   | Guaranteed CPU count for one queue            |
+| `queue_guarantee_memory_bytes`         | Gauge           | `queue_name`=&lt;queue_name&gt;                                   | Guaranteed memory for one queue               |
+| `queue_guarantee_scalar_resources`     | Gauge           | `queue_name`=&lt;queue_name&gt;, `resource`=&lt;resource_name&gt; | Guaranteed scalar resource for one queue      |
 | `queue_inqueue_milli_cpu`              | Gauge           | `queue_name`=&lt;queue_name&gt;                                   | Inqueue CPU for admitted but not yet running jobs in one queue              |
 | `queue_inqueue_memory_bytes`           | Gauge           | `queue_name`=&lt;queue_name&gt;                                   | Inqueue memory for admitted but not yet running jobs in one queue           |
 | `queue_inqueue_scalar_resources`       | Gauge           | `queue_name`=&lt;queue_name&gt;, `resource`=&lt;resource_name&gt; | Inqueue scalar resources for admitted but not yet running jobs in one queue |

--- a/pkg/scheduler/metrics/queue.go
+++ b/pkg/scheduler/metrics/queue.go
@@ -169,6 +169,30 @@ var (
 		}, []string{"queue_name", "resource"},
 	)
 
+	queueGuaranteeMilliCPU = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Subsystem: VolcanoSubSystemName,
+			Name:      "queue_guarantee_milli_cpu",
+			Help:      "Guaranteed CPU count for one queue",
+		}, []string{"queue_name"},
+	)
+
+	queueGuaranteeMemory = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Subsystem: VolcanoSubSystemName,
+			Name:      "queue_guarantee_memory_bytes",
+			Help:      "Guaranteed memory for one queue",
+		}, []string{"queue_name"},
+	)
+
+	queueGuaranteeScalarResource = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Subsystem: VolcanoSubSystemName,
+			Name:      "queue_guarantee_scalar_resources",
+			Help:      "Guaranteed scalar resources for one queue",
+		}, []string{"queue_name", "resource"},
+	)
+
 	queueInqueueMilliCPU = promauto.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Subsystem: VolcanoSubSystemName,
@@ -276,6 +300,13 @@ func UpdateQueueRealCapacity(queueName string, milliCPU, memory float64, scalarR
 	updateScalarResourceMetrics(queueRealCapacityScalarResource, queueName, scalarResources)
 }
 
+// UpdateQueueGuarantee records guaranteed resources for one queue
+func UpdateQueueGuarantee(queueName string, milliCPU, memory float64, scalarResources map[v1.ResourceName]float64) {
+	queueGuaranteeMilliCPU.WithLabelValues(queueName).Set(milliCPU)
+	queueGuaranteeMemory.WithLabelValues(queueName).Set(memory)
+	updateScalarResourceMetrics(queueGuaranteeScalarResource, queueName, scalarResources)
+}
+
 // UpdateQueueInqueue records resources for admitted but not yet running jobs in one queue
 func UpdateQueueInqueue(queueName string, milliCPU, memory float64, scalarResources map[v1.ResourceName]float64) {
 	queueInqueueMilliCPU.WithLabelValues(queueName).Set(milliCPU)
@@ -298,6 +329,8 @@ func DeleteQueueMetrics(queueName string) {
 	queueCapacityMemory.DeleteLabelValues(queueName)
 	queueRealCapacityMilliCPU.DeleteLabelValues(queueName)
 	queueRealCapacityMemory.DeleteLabelValues(queueName)
+	queueGuaranteeMilliCPU.DeleteLabelValues(queueName)
+	queueGuaranteeMemory.DeleteLabelValues(queueName)
 	queueInqueueMilliCPU.DeleteLabelValues(queueName)
 	queueInqueueMemory.DeleteLabelValues(queueName)
 	partialLabelMap := map[string]string{"queue_name": queueName}
@@ -306,6 +339,7 @@ func DeleteQueueMetrics(queueName string) {
 	queueDeservedScalarResource.DeletePartialMatch(partialLabelMap)
 	queueCapacityScalarResource.DeletePartialMatch(partialLabelMap)
 	queueRealCapacityScalarResource.DeletePartialMatch(partialLabelMap)
+	queueGuaranteeScalarResource.DeletePartialMatch(partialLabelMap)
 	queueInqueueScalarResource.DeletePartialMatch(partialLabelMap)
 	knownScalarResourcesLock.Lock()
 	delete(knownScalarResources, queueName)

--- a/pkg/scheduler/metrics/queue_scalar_test.go
+++ b/pkg/scheduler/metrics/queue_scalar_test.go
@@ -7,6 +7,50 @@ import (
 	v1 "k8s.io/api/core/v1"
 )
 
+func TestUpdateQueueGuarantee_ScalarResource(t *testing.T) {
+	queueGuaranteeScalarResource.Reset()
+	knownScalarResourcesLock.Lock()
+	knownScalarResources = make(map[string]map[string]struct{})
+	knownScalarResourcesLock.Unlock()
+
+	queueName := "testqueue-guarantee"
+	resourceA := v1.ResourceName("nvidia.com/gpu")
+	resourceB := v1.ResourceName("amd.com/gpu")
+
+	// 1. Set resourceA to 8, resourceB to 16
+	UpdateQueueGuarantee(queueName, 0, 0, map[v1.ResourceName]float64{resourceA: 8, resourceB: 16})
+	if got := testutil.ToFloat64(queueGuaranteeScalarResource.WithLabelValues(queueName, string(resourceA))); got != 8 {
+		t.Errorf("expected %s to be 8, got %v", resourceA, got)
+	}
+	if got := testutil.ToFloat64(queueGuaranteeScalarResource.WithLabelValues(queueName, string(resourceB))); got != 16 {
+		t.Errorf("expected %s to be 16, got %v", resourceB, got)
+	}
+
+	// 2. Update with only resourceA; resourceB should be zeroed
+	UpdateQueueGuarantee(queueName, 0, 0, map[v1.ResourceName]float64{resourceA: 4})
+	if got := testutil.ToFloat64(queueGuaranteeScalarResource.WithLabelValues(queueName, string(resourceA))); got != 4 {
+		t.Errorf("expected %s to be 4, got %v", resourceA, got)
+	}
+	if got := testutil.ToFloat64(queueGuaranteeScalarResource.WithLabelValues(queueName, string(resourceB))); got != 0 {
+		t.Errorf("expected %s to be 0 after missing in update, got %v", resourceB, got)
+	}
+
+	// 3. Update with nil (queue has no guarantee configured); all known resources should be zeroed
+	UpdateQueueGuarantee(queueName, 0, 0, nil)
+	if got := testutil.ToFloat64(queueGuaranteeScalarResource.WithLabelValues(queueName, string(resourceA))); got != 0 {
+		t.Errorf("expected %s to be 0 after nil update, got %v", resourceA, got)
+	}
+	if got := testutil.ToFloat64(queueGuaranteeScalarResource.WithLabelValues(queueName, string(resourceB))); got != 0 {
+		t.Errorf("expected %s to be 0 after nil update, got %v", resourceB, got)
+	}
+
+	// 4. Delete metrics and ensure they are gone
+	DeleteQueueMetrics(queueName)
+	if count := testutil.CollectAndCount(queueGuaranteeScalarResource); count != 0 {
+		t.Errorf("expected no metrics for queueGuaranteeScalarResource after delete, got %d", count)
+	}
+}
+
 func TestUpdateScalarResourceMetrics_ZeroAndCleanup(t *testing.T) {
 	// Reset global state for this test to ensure isolation.
 	queueAllocatedScalarResource.Reset()

--- a/pkg/scheduler/metrics/queue_test.go
+++ b/pkg/scheduler/metrics/queue_test.go
@@ -81,6 +81,7 @@ func TestQueueResourceMetric(t *testing.T) {
 	UpdateQueueDeserved("queue3", 300, 3096, map[v1.ResourceName]float64{"nvidia.com/gpu": 2})
 	UpdateQueueCapacity("queue1", 200., 2048., map[v1.ResourceName]float64{v1.ResourceName("nvidia.com/gpu"): 10.})
 	UpdateQueueRealCapacity("queue2", 200., 2048., map[v1.ResourceName]float64{v1.ResourceName("nvidia.com/gpu"): 10.})
+	UpdateQueueGuarantee("queue4", 400, 4096, map[v1.ResourceName]float64{"nvidia.com/gpu": 4})
 	UpdateQueueInqueue("queue4", 500, 5120, map[v1.ResourceName]float64{"nvidia.com/gpu": 3})
 	go func() {
 		http.Handle("/metrics", promhttp.Handler())
@@ -116,6 +117,11 @@ func TestQueueResourceMetric(t *testing.T) {
 			assert.Contains(t, m, "volcano_queue_real_capacity_scalar_resources{queue_name=\"queue2\",resource=\"nvidia.com/gpu\"}",
 				"volcano_queue_real_capacity_scalar_resources for queue1 and resource nvidia.com/gpu should be present")
 			assert.Equal(t, 10., m["volcano_queue_real_capacity_scalar_resources{queue_name=\"queue2\",resource=\"nvidia.com/gpu\"}"])
+			assert.Equal(t, 400., m["volcano_queue_guarantee_milli_cpu{queue_name=\"queue4\"}"])
+			assert.Equal(t, 4096., m["volcano_queue_guarantee_memory_bytes{queue_name=\"queue4\"}"])
+			assert.Contains(t, m, "volcano_queue_guarantee_scalar_resources{queue_name=\"queue4\",resource=\"nvidia.com/gpu\"}",
+				"volcano_queue_guarantee_scalar_resources for queue4 and resource nvidia.com/gpu should be present")
+			assert.Equal(t, 4., m["volcano_queue_guarantee_scalar_resources{queue_name=\"queue4\",resource=\"nvidia.com/gpu\"}"])
 			assert.Equal(t, 500., m["volcano_queue_inqueue_milli_cpu{queue_name=\"queue4\"}"])
 			assert.Equal(t, 5120., m["volcano_queue_inqueue_memory_bytes{queue_name=\"queue4\"}"])
 			assert.Contains(t, m, "volcano_queue_inqueue_scalar_resources{queue_name=\"queue4\",resource=\"nvidia.com/gpu\"}",
@@ -155,6 +161,12 @@ func TestQueueResourceMetric(t *testing.T) {
 				"volcano_queue_request_memory_bytes for queue2 should be removed")
 			assert.NotContains(t, m, "volcano_queue_request_scalar_resources{queue_name=\"queue2\",resource=\"nvidia.com/gpu\"}",
 				"volcano_queue_request_scalar_resources for queue2 should be removed")
+			assert.NotContains(t, m, "volcano_queue_guarantee_milli_cpu{queue_name=\"queue4\"}",
+				"volcano_queue_guarantee_milli_cpu for queue4 should be removed")
+			assert.NotContains(t, m, "volcano_queue_guarantee_memory_bytes{queue_name=\"queue4\"}",
+				"volcano_queue_guarantee_memory_bytes for queue4 should be removed")
+			assert.NotContains(t, m, "volcano_queue_guarantee_scalar_resources{queue_name=\"queue4\",resource=\"nvidia.com/gpu\"}",
+				"volcano_queue_guarantee_scalar_resources for queue4 should be removed")
 			assert.NotContains(t, m, "volcano_queue_inqueue_milli_cpu{queue_name=\"queue4\"}",
 				"volcano_queue_inqueue_milli_cpu for queue4 should be removed")
 			assert.NotContains(t, m, "volcano_queue_inqueue_memory_bytes{queue_name=\"queue4\"}",

--- a/pkg/scheduler/plugins/capacity/capacity.go
+++ b/pkg/scheduler/plugins/capacity/capacity.go
@@ -1170,6 +1170,7 @@ func (cp *capacityPlugin) buildQueueAttrs(ssn *framework.Session) {
 				metrics.UpdateQueueCapacity(attr.name, attr.capability.MilliCPU, attr.capability.Memory, attr.capability.ScalarResources)
 			}
 			metrics.UpdateQueueRealCapacity(attr.name, attr.realCapability.MilliCPU, attr.realCapability.Memory, attr.realCapability.ScalarResources)
+			metrics.UpdateQueueGuarantee(attr.name, attr.guarantee.MilliCPU, attr.guarantee.Memory, attr.guarantee.ScalarResources)
 			continue
 		}
 		deservedCPU, deservedMem, scalarResources := 0.0, 0.0, map[v1.ResourceName]float64{}
@@ -1194,6 +1195,7 @@ func (cp *capacityPlugin) buildQueueAttrs(ssn *framework.Session) {
 			metrics.UpdateQueueCapacity(queueInfo.Name, capacity.MilliCPU, capacity.Memory, capacity.ScalarResources)
 		}
 		metrics.UpdateQueueRealCapacity(queueInfo.Name, realCapacity.MilliCPU, realCapacity.Memory, realCapacity.ScalarResources)
+		metrics.UpdateQueueGuarantee(queueInfo.Name, guarantee.MilliCPU, guarantee.Memory, guarantee.ScalarResources)
 	}
 
 	ssn.AddQueueOrderFn(cp.Name(), func(l, r interface{}) int {
@@ -1360,6 +1362,7 @@ func (cp *capacityPlugin) buildHierarchicalQueueAttrs(ssn *framework.Session) bo
 		metrics.UpdateQueueInqueue(attr.name, attr.inqueue.MilliCPU, attr.inqueue.Memory, attr.inqueue.ScalarResources)
 		metrics.UpdateQueueCapacity(attr.name, attr.capability.MilliCPU, attr.capability.Memory, attr.capability.ScalarResources)
 		metrics.UpdateQueueRealCapacity(attr.name, attr.realCapability.MilliCPU, attr.realCapability.Memory, attr.realCapability.ScalarResources)
+		metrics.UpdateQueueGuarantee(attr.name, attr.guarantee.MilliCPU, attr.guarantee.Memory, attr.guarantee.ScalarResources)
 	}
 
 	ssn.AddQueueOrderFn(cp.Name(), func(l, r interface{}) int {

--- a/pkg/scheduler/plugins/proportion/proportion.go
+++ b/pkg/scheduler/plugins/proportion/proportion.go
@@ -189,10 +189,13 @@ func (pp *proportionPlugin) OnSessionOpen(ssn *framework.Session) {
 			metrics.UpdateQueueRequest(attr.name, attr.request.MilliCPU, attr.request.Memory, attr.request.ScalarResources)
 			metrics.UpdateQueueInqueue(attr.name, attr.inqueue.MilliCPU, attr.inqueue.Memory, attr.inqueue.ScalarResources)
 			metrics.UpdateQueueWeight(attr.name, attr.weight)
+			metrics.UpdateQueueGuarantee(attr.name, attr.guarantee.MilliCPU, attr.guarantee.Memory, attr.guarantee.ScalarResources)
 			continue
 		}
 		metrics.UpdateQueueAllocated(queueInfo.Name, 0, 0, map[v1.ResourceName]float64{})
 		metrics.UpdateQueueRequest(queueInfo.Name, 0, 0, map[v1.ResourceName]float64{})
+		guarantee := api.NewResource(queueInfo.Queue.Spec.Guarantee.Resource)
+		metrics.UpdateQueueGuarantee(queueInfo.Name, guarantee.MilliCPU, guarantee.Memory, guarantee.ScalarResources)
 		metrics.UpdateQueueInqueue(queueInfo.Name, 0, 0, map[v1.ResourceName]float64{})
 	}
 


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it:**

`guarantee` is the one `queueAttr` field that actually represents a contractual SLA; it floors `deserved` in proportion and blocks reclaim from evicting a queue below its minimum in capacity; but it never made it into Prometheus. Every other field that drives a scheduling decision has a metric. This one didn't.

Adds `volcano_queue_guarantee_{milli_cpu,memory_bytes,scalar_resources}` emitted each session from both plugins. Jobless queues still get the metric read straight from the queue spec, same pattern as the no-attr branch in capacity already uses for `realCapacity`. Hierarchical queues get it for free since `attr.guarantee` already accumulates child guarantees by the time we hit the metrics loop. `DeleteQueueMetrics` cleans it up.

**Which issue(s) this PR fixes:**
Fixes #NA

**Special notes for your reviewer:**

The no-attr branch in proportion now does a small spec read to get the guarantee for queues with no jobs; same thing capacity's no-attr branch already does for `realCapacity` at the equivalent spot, so the pattern is consistent. Everything else is a straight copy of the inqueue metric shape.

AI Disclosure: This change was developed with AI assistance (Claude). The author has reviewed and understands all changes.

**Does this PR introduce a user-facing change?**

Added Prometheus metrics for queue guarantee resources: `volcano_queue_guarantee_milli_cpu`, `volcano_queue_guarantee_memory_bytes`, and `volcano_queue_guarantee_scalar_resources`. Emitted by both proportion and capacity plugins.