### PR TITLE
fix(backfill): commit statements for pipelined tasks

### DIFF
--- a/pkg/scheduler/actions/backfill/backfill.go
+++ b/pkg/scheduler/actions/backfill/backfill.go
@@ -161,8 +161,10 @@ func (backfill *Action) pickUpPendingTasks(ssn *framework.Session) []*api.TaskIn
 			err := stmt.UnPipeline(task)
 			if err != nil {
 				klog.Errorf("Failed to unpipeline task: %s", err.Error())
+				stmt.Discard()
 				continue
 			}
+			stmt.Commit()
 			if _, existed := tasks[job.UID]; !existed {
 				tasks[job.UID] = util.NewPriorityQueue(ssn.TaskOrderFn)
 			}

--- a/pkg/scheduler/actions/backfill/backfill_test.go
+++ b/pkg/scheduler/actions/backfill/backfill_test.go
@@ -162,6 +162,7 @@ func TestPickUpPendingTasks(t *testing.T) {
 			task, found := ssn.Jobs[jobID].Tasks[api.PodKey(pod)]
 			if found {
 				stmt.Pipeline(task, "node1", false)
+				stmt.Commit()
 			}
 		}
 


### PR DESCRIPTION
## Summary

- Add `stmt.Commit()` after successful `UnPipeline` operations in `pickUpPendingTasks()` so statements are properly finalized instead of abandoned
- Add `stmt.Discard()` on the error path to explicitly clean up failed statements
- Fix the same issue in `backfill_test.go` where `Pipeline` statements were also never committed

Fixes Bug 4 of #5048.

## Details

In `pkg/scheduler/actions/backfill/backfill.go`, the `pickUpPendingTasks` function creates a `Statement` and calls `stmt.UnPipeline(task)` for best-effort pipelined tasks, but never calls `stmt.Commit()` or `stmt.Discard()`. This violates the Statement contract which requires statements to be either committed or discarded.

The test at `backfill_test.go` had the same issue: it created statements for `Pipeline` operations but never committed them, masking the problem.

## Test plan

- [x] `go build ./pkg/scheduler/...` compiles successfully
- [x] `go test ./pkg/scheduler/actions/backfill/...` passes