### PR TITLE
fix(scheduler): preserve typed-nil Devices through CloneOthers

### DIFF
--- a/pkg/scheduler/api/node_info.go
+++ b/pkg/scheduler/api/node_info.go
@@ -643,7 +643,7 @@ func (ni *NodeInfo) CloneOthers() map[string]interface{} {
 	others := make(map[string]interface{})
 	for k, v := range ni.Others {
 		if d, ok := v.(Devices); ok {
-			if reflect.ValueOf(v).IsNil() {
+			if rv := reflect.ValueOf(v); rv.Kind() == reflect.Ptr && rv.IsNil() {
 				others[k] = v
 				continue
 			}

--- a/pkg/scheduler/api/node_info.go
+++ b/pkg/scheduler/api/node_info.go
@@ -18,6 +18,7 @@ package api
 
 import (
 	"fmt"
+	"reflect"
 	"strconv"
 	"sync/atomic"
 	"time"
@@ -642,6 +643,10 @@ func (ni *NodeInfo) CloneOthers() map[string]interface{} {
 	others := make(map[string]interface{})
 	for k, v := range ni.Others {
 		if d, ok := v.(Devices); ok {
+			if reflect.ValueOf(v).IsNil() {
+				others[k] = v
+				continue
+			}
 			others[k] = d.DeepCopy()
 		} else {
 			others[k] = v

--- a/pkg/scheduler/api/node_info.go
+++ b/pkg/scheduler/api/node_info.go
@@ -18,7 +18,6 @@ package api
 
 import (
 	"fmt"
-	"reflect"
 	"strconv"
 	"sync/atomic"
 	"time"
@@ -643,7 +642,7 @@ func (ni *NodeInfo) CloneOthers() map[string]interface{} {
 	others := make(map[string]interface{})
 	for k, v := range ni.Others {
 		if d, ok := v.(Devices); ok {
-			if rv := reflect.ValueOf(v); rv.Kind() == reflect.Ptr && rv.IsNil() {
+			if IsNilDevice(d) {
 				others[k] = v
 				continue
 			}

--- a/pkg/scheduler/api/node_info_test.go
+++ b/pkg/scheduler/api/node_info_test.go
@@ -290,3 +290,33 @@ func TestNodeInfo_SetNode(t *testing.T) {
 		}
 	}
 }
+
+func TestCloneOthersPreservesTypedNilDevices(t *testing.T) {
+	ni := &NodeInfo{
+		Name: "test-node",
+		Others: map[string]interface{}{
+			vgpu.DeviceName:     (*vgpu.GPUDevices)(nil),
+			gpushare.DeviceName: (*gpushare.GPUDevices)(nil),
+			vnpu.DeviceName:     (*vnpu.NPUDevices)(nil),
+		},
+	}
+
+	cloned := ni.CloneOthers()
+
+	for k := range ni.Others {
+		cv, present := cloned[k]
+		if !present {
+			t.Errorf("cloned map missing key %q", k)
+			continue
+		}
+		d, ok := cv.(Devices)
+		if !ok {
+			t.Errorf("cloned[%q] does not satisfy Devices interface (typed-nil was lost)", k)
+			continue
+		}
+		rv := reflect.ValueOf(d)
+		if rv.Kind() != reflect.Ptr || !rv.IsNil() {
+			t.Errorf("cloned[%q] should be a typed-nil pointer, got kind=%v", k, rv.Kind())
+		}
+	}
+}

--- a/pkg/scheduler/api/node_info_test.go
+++ b/pkg/scheduler/api/node_info_test.go
@@ -314,9 +314,8 @@ func TestCloneOthersPreservesTypedNilDevices(t *testing.T) {
 			t.Errorf("cloned[%q] does not satisfy Devices interface (typed-nil was lost)", k)
 			continue
 		}
-		rv := reflect.ValueOf(d)
-		if rv.Kind() != reflect.Ptr || !rv.IsNil() {
-			t.Errorf("cloned[%q] should be a typed-nil pointer, got kind=%v", k, rv.Kind())
+		if !IsNilDevice(d) {
+			t.Errorf("cloned[%q] should be a typed-nil pointer", k)
 		}
 	}
 }

--- a/pkg/scheduler/api/shared_device_pool.go
+++ b/pkg/scheduler/api/shared_device_pool.go
@@ -17,6 +17,7 @@
 package api
 
 import (
+	"reflect"
 	"slices"
 	"sync"
 
@@ -97,6 +98,12 @@ func RegisterDevice(deviceName string) {
 		}
 	}
 	RegisteredDevices = append(RegisteredDevices, deviceName)
+}
+
+// IsNilDevice reports whether d wraps a typed-nil pointer.
+func IsNilDevice(d Devices) bool {
+	rv := reflect.ValueOf(d)
+	return rv.Kind() == reflect.Ptr && rv.IsNil()
 }
 
 var IgnoredDevicesList = ignoredDevicesList{}

--- a/pkg/scheduler/plugins/predicates/predicates.go
+++ b/pkg/scheduler/plugins/predicates/predicates.go
@@ -233,7 +233,7 @@ func (pp *PredicatesPlugin) OnSessionOpen(ssn *framework.Session) {
 			//predicate gpu sharing
 			for _, val := range api.RegisteredDevices {
 				if devices, ok := nodeInfo.Others[val].(api.Devices); ok {
-					if reflect.ValueOf(devices).IsNil() {
+					if rv := reflect.ValueOf(devices); rv.Kind() == reflect.Ptr && rv.IsNil() {
 						continue
 					}
 					if !devices.HasDeviceRequest(pod) {
@@ -278,7 +278,7 @@ func (pp *PredicatesPlugin) OnSessionOpen(ssn *framework.Session) {
 
 			for _, val := range api.RegisteredDevices {
 				if devices, ok := nodeInfo.Others[val].(api.Devices); ok {
-					if reflect.ValueOf(devices).IsNil() {
+					if rv := reflect.ValueOf(devices); rv.Kind() == reflect.Ptr && rv.IsNil() {
 						continue
 					}
 					if !devices.HasDeviceRequest(pod) {
@@ -418,6 +418,9 @@ func (pp *PredicatesPlugin) OnSessionOpen(ssn *framework.Session) {
 			}
 			devs, ok := devObj.(api.Devices)
 			if !ok {
+				continue
+			}
+			if rv := reflect.ValueOf(devs); rv.Kind() == reflect.Ptr && rv.IsNil() {
 				continue
 			}
 			if !devs.HasDeviceRequest(task.Pod) {

--- a/pkg/scheduler/plugins/predicates/predicates.go
+++ b/pkg/scheduler/plugins/predicates/predicates.go
@@ -24,7 +24,6 @@ package predicates
 import (
 	"context"
 	"fmt"
-	"reflect"
 	"sync"
 
 	v1 "k8s.io/api/core/v1"
@@ -233,7 +232,7 @@ func (pp *PredicatesPlugin) OnSessionOpen(ssn *framework.Session) {
 			//predicate gpu sharing
 			for _, val := range api.RegisteredDevices {
 				if devices, ok := nodeInfo.Others[val].(api.Devices); ok {
-					if rv := reflect.ValueOf(devices); rv.Kind() == reflect.Ptr && rv.IsNil() {
+					if api.IsNilDevice(devices) {
 						continue
 					}
 					if !devices.HasDeviceRequest(pod) {
@@ -278,7 +277,7 @@ func (pp *PredicatesPlugin) OnSessionOpen(ssn *framework.Session) {
 
 			for _, val := range api.RegisteredDevices {
 				if devices, ok := nodeInfo.Others[val].(api.Devices); ok {
-					if rv := reflect.ValueOf(devices); rv.Kind() == reflect.Ptr && rv.IsNil() {
+					if api.IsNilDevice(devices) {
 						continue
 					}
 					if !devices.HasDeviceRequest(pod) {
@@ -420,7 +419,7 @@ func (pp *PredicatesPlugin) OnSessionOpen(ssn *framework.Session) {
 			if !ok {
 				continue
 			}
-			if rv := reflect.ValueOf(devs); rv.Kind() == reflect.Ptr && rv.IsNil() {
+			if api.IsNilDevice(devs) {
 				continue
 			}
 			if !devs.HasDeviceRequest(task.Pod) {

--- a/pkg/scheduler/plugins/predicates/predicates.go
+++ b/pkg/scheduler/plugins/predicates/predicates.go
@@ -24,6 +24,7 @@ package predicates
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"sync"
 
 	v1 "k8s.io/api/core/v1"
@@ -232,6 +233,9 @@ func (pp *PredicatesPlugin) OnSessionOpen(ssn *framework.Session) {
 			//predicate gpu sharing
 			for _, val := range api.RegisteredDevices {
 				if devices, ok := nodeInfo.Others[val].(api.Devices); ok {
+					if reflect.ValueOf(devices).IsNil() {
+						continue
+					}
 					if !devices.HasDeviceRequest(pod) {
 						continue
 					}
@@ -274,6 +278,9 @@ func (pp *PredicatesPlugin) OnSessionOpen(ssn *framework.Session) {
 
 			for _, val := range api.RegisteredDevices {
 				if devices, ok := nodeInfo.Others[val].(api.Devices); ok {
+					if reflect.ValueOf(devices).IsNil() {
+						continue
+					}
 					if !devices.HasDeviceRequest(pod) {
 						continue
 					}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it

Fixes a regression introduced by #5235 where the device-aware predicate / Allocate / Release paths are silently skipped on every node that doesn't have a registered device of a given type.

**The chain:**

1. For nodes without vGPU annotations, `vgpu.NewGPUDevices(name, node)` returns `nil`. After `node_info.go:368` does `ni.Others[vgpu.DeviceName] = vgpu.NewGPUDevices(...)`, the entry is a typed-nil interface (type=`*GPUDevices`, data=nil). Same for `gpushare`, `vnpu`, `hami`, `exclusiveGPU`.
2. `NodeInfo.CloneOthers` (introduced/changed by #5235) calls `d.DeepCopy()` on this typed-nil. Every Devices implementation's DeepCopy starts with `if gs == nil { return nil }`, returning **untyped** nil.
3. The cloned snapshot's `node.Others[k]` is now untyped nil.
4. Downstream `node.Others[val].(api.Devices)` in `plugins/predicates/predicates.go:235,277,419` and `plugins/deviceshare/deviceshare.go:235` now returns `ok=false` (untyped nil does not satisfy any interface).
5. The whole device-aware path is skipped for that node, accompanied by:
   ```
   W ... predicates.go:236] Devices hamivgpu assertion conversion failed, skip
   W ... deviceshare.go:256] Devices hamivgpu assertion conversion failed, skip
   ```
6. vGPU pods that land on such a node never go through `deviceshare.Allocate`, so `volcano.sh/vgpu-ids-new` is never patched and the runtime container can't determine which physical GPU it should use.

`deviceshare.go` already had a `reflect.ValueOf(dev).IsNil()` guard at line 236 that was meant to handle this case, but it never fires because the assertion above it fails first.

#### Production impact

We have observed this in production, not only in test environments. The visible symptom is `UnexpectedAdmissionError` on vGPU pods, with messages like:

> Allocate failed due to no healthy devices present; cannot allocate unhealthy devices volcano.sh/vgpu-number, which is unexpected

Pods bind to a node (because Volcano's deviceshare predicate is silently skipped, leaving k8s extended-resource accounting alone to gate scheduling), but never receive the `volcano.sh/vgpu-ids-new` annotation. The HAMi-core init container / device-plugin admission then has no device assignment to honor and rejects the pod with `UnexpectedAdmissionError`. The pod is left stuck and the user has to delete and resubmit.

Concrete scenarios where this fires in our fleet:

- **Mixed CPU + GPU clusters.** Every CPU-only node returns nil GPUDevices. The skip-warning fires every scheduling cycle for those nodes, and a vGPU pod that loses its preferred GPU node and falls back through capacity checks can land on one.
- **vGPU device-plugin restart.** Image upgrades, OOMKilled, or routine rolling updates of the device-plugin DaemonSet briefly stop the handshake keepalive. After 60s the scheduler marks the handshake `Deleted` and `NewGPUDevices` returns nil. Until the plugin recovers, vGPU pods scheduled in that window hit `UnexpectedAdmissionError` even though the node is otherwise healthy.
- **Scheduler restart.** Right after a scheduler pod restart, the new pod re-reads node annotations. If the keepalive happens to be mid-cycle and the scheduler reads a stale `Requesting_*` timestamp past the 60s grace window, the node appears vGPU-less for one or more sessions.

In all three cases the failure is silent (only the warning log) and the only operator-visible signal is the eventual `UnexpectedAdmissionError` at the kubelet level.

#### Fix

49 lines (20 prod + 29 test) across 4 files:

1. `pkg/scheduler/api/shared_device_pool.go` — new `api.IsNilDevice(d Devices) bool` helper that returns true when the wrapped value is a typed-nil pointer. Uses `rv.Kind() == reflect.Ptr && rv.IsNil()` so a future non-pointer Devices implementation doesn't cause `IsNil()` to panic.
2. `pkg/scheduler/api/node_info.go` — in `CloneOthers`, when the underlying `Devices` value is a typed-nil pointer (`api.IsNilDevice` true), preserve the original interface value instead of calling `DeepCopy`. The clone is then still a typed-nil that satisfies the downstream type assertion, and the existing `IsNil` guard in `deviceshare.go` does its job.
3. `pkg/scheduler/plugins/predicates/predicates.go` — three device-iteration loops lacked the `IsNil` guard that `deviceshare.go` already has: the Allocate path, the Release path, and the `AddSimulatePredicateFn` topology-aware preemption simulation loop. Without these, `devices.Allocate` / `devices.Release` / `devices.FilterNode` would dispatch onto a typed-nil receiver and panic at the first field access (e.g. `gs.Name`). All three call `api.IsNilDevice` consistently.
4. `pkg/scheduler/api/node_info_test.go` — `TestCloneOthersPreservesTypedNilDevices` regression test that populates `NodeInfo.Others` with typed-nil pointers for `vgpu`, `gpushare`, and `vnpu` device types, calls `CloneOthers()`, and asserts every cloned entry still satisfies the `api.Devices` type assertion and reports `IsNilDevice() == true`.

#### Which issue(s) this PR fixes

Fixes #

#### Special notes for your reviewer

- The fix in `CloneOthers` is at the source — picking it up here means each `Devices` implementation's DeepCopy doesn't need to remember to return a typed-nil pointer instead of plain nil. New Device types added in the future are also covered.
- All four call sites use the same `api.IsNilDevice` helper to keep the check consistent and avoid drift if the typed-nil contract changes.

#### Does this PR introduce a user-facing change?

```release-note
Fixed a regression where the deviceshare predicate, Allocate, and Release paths were silently skipped for any node that did not have a registered device of a given type (e.g. CPU-only nodes or vGPU nodes between device-plugin restarts). Symptom: the scheduler logged "Devices <name> assertion conversion failed, skip" warnings, and vGPU pods that landed on such nodes never received the volcano.sh/vgpu-ids-new annotation, ultimately failing at the kubelet with UnexpectedAdmissionError. Root cause was that NodeInfo.CloneOthers called DeepCopy() on typed-nil pointers stored in NodeInfo.Others; each Devices implementation's DeepCopy returns plain nil for a nil receiver, which broke the downstream `Others[val].(api.Devices)` type assertion. CloneOthers now preserves the typed-nil interface value, and the predicates plugin's Allocate / Release / SimulatePredicate loops gain the same IsNil guard already present in the deviceshare plugin (extracted into a shared api.IsNilDevice helper).
```