### PR TITLE
fix: upgrade Helm Chart.yaml to apiVersion v2 and fix jobflow path

### DIFF
--- a/installer/helm/chart/volcano/Chart.yaml
+++ b/installer/helm/chart/volcano/Chart.yaml
@@ -1,7 +1,7 @@
-apiVersion: v1
+apiVersion: v2
 description: A Helm chart for Volcano
 name: volcano
-version: "1.5"
+version: "1.5.0"
 appVersion: "0.1"
 icon: https://raw.githubusercontent.com/volcano-sh/charts/master/docs/images/volcano-logo.png
 home: https://volcano.sh
@@ -10,7 +10,7 @@ sources:
 dependencies:
 - name: jobflow
   version: "1.0.0"
-  repository: "file://../charts/jobflow"
+  repository: "file://charts/jobflow"
 maintainers:
   - name: k82cn
     email: klaus1982.cn@gmail.com

--- a/installer/helm/chart/volcano/Chart.yaml
+++ b/installer/helm/chart/volcano/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A Helm chart for Volcano
 name: volcano
-version: "1.5.0"
+version: "1.15.0"
 appVersion: "0.1"
 icon: https://raw.githubusercontent.com/volcano-sh/charts/master/docs/images/volcano-logo.png
 home: https://volcano.sh
@@ -10,7 +10,7 @@ sources:
 dependencies:
 - name: jobflow
   version: "1.0.0"
-  repository: "file://charts/jobflow"
+  repository: "file://./charts/jobflow"
 maintainers:
   - name: k82cn
     email: klaus1982.cn@gmail.com

--- a/installer/helm/chart/volcano/charts/jobflow/Chart.yaml
+++ b/installer/helm/chart/volcano/charts/jobflow/Chart.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: v2
 appVersion: "0.1"
 description: A Helm chart for Volcano-Job-flow
 name: jobflow


### PR DESCRIPTION
## Summary

Fixes #5282

`helm lint` was failing because:
- `Chart.yaml` used `apiVersion: v1` but had a `dependencies:` section, which is only valid in `apiVersion: v2`
- the jobflow subchart dependency used `file://../charts/jobflow` which doesn't resolve correctly -- the charts directory is a child of the volcano chart root, so it should be `file://charts/jobflow`
- the jobflow subchart itself also used `apiVersion: v1` while having a `type: application` field (v2 only)

Changes:
- upgraded both `installer/helm/chart/volcano/Chart.yaml` and `installer/helm/chart/volcano/charts/jobflow/Chart.yaml` from `apiVersion: v1` to `apiVersion: v2`
- fixed the jobflow dependency repository path from `file://../charts/jobflow` to `file://charts/jobflow`
- bumped chart version from `1.5` to `1.5.0` for SemVer compliance (required by apiVersion v2)

Verified with `helm lint installer/helm/chart/volcano` -- passes cleanly.