### PR TITLE
fix(queue): use JSON Patch add instead of replace in updateQueueAnnotation

### DIFF
--- a/pkg/controllers/queue/queue_controller_action.go
+++ b/pkg/controllers/queue/queue_controller_action.go
@@ -313,7 +313,7 @@ func (c *queuecontroller) updateQueueAnnotation(queue *schedulingv1beta1.Queue, 
 	var patch []patchOperation
 	if len(queue.Annotations) == 0 {
 		patch = append(patch, patchOperation{
-			Op:   "replace",
+			Op:   "add",
 			Path: "/metadata/annotations",
 			Value: map[string]string{
 				key: value,
@@ -321,7 +321,7 @@ func (c *queuecontroller) updateQueueAnnotation(queue *schedulingv1beta1.Queue, 
 		})
 	} else {
 		patch = append(patch, patchOperation{
-			Op:    "replace",
+			Op:    "add",
 			Path:  fmt.Sprintf("/metadata/annotations/%s", strings.ReplaceAll(key, "/", "~1")),
 			Value: value,
 		})

--- a/pkg/controllers/queue/queue_controller_action.go
+++ b/pkg/controllers/queue/queue_controller_action.go
@@ -311,7 +311,7 @@ func (c *queuecontroller) updateQueueAnnotation(queue *schedulingv1beta1.Queue, 
 	}
 
 	var patch []patchOperation
-	if len(queue.Annotations) == 0 {
+	if queue.Annotations == nil {
 		patch = append(patch, patchOperation{
 			Op:   "add",
 			Path: "/metadata/annotations",

--- a/pkg/controllers/queue/queue_controller_util.go
+++ b/pkg/controllers/queue/queue_controller_util.go
@@ -29,7 +29,7 @@ const (
 type patchOperation struct {
 	Op    string      `json:"op"`
 	Path  string      `json:"path"`
-	Value interface{} `json:"value,omitempty"`
+	Value interface{} `json:"value"`
 }
 
 // IsQueueReference return if ownerReference is Queue Kind.


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:

`updateQueueAnnotation` uses `op: replace` in both branches of its JSON patch ; when the annotations map doesn't exist yet, and when the specific key doesn't exist yet. RFC 6902 requires the target path to already exist for `replace`; on a freshly created queue with no annotations, the API server returns 422 and the patch fails.

This silently breaks the hierarchical queue close cascade: `closeHierarchicalQueue` calls `updateQueueAnnotation` to stamp `volcano.sh/closed-by-parent: "true"` on each child before enqueuing the close action. If that patch fails, the function returns early, the close action is never enqueued, and the child queue stays `Open` while its parent is `Closed` ; permanently, since every retry hits the same failure.

Fix is to use `op: add` instead, which creates the key if absent or replaces it if present. `updateQueueParent` in the same file already does this correctly.

#### Special notes for your reviewer:

The two branches behave differently but have the same root problem:
- Branch 1 (`len(annotations) == 0`): tries to `replace` `/metadata/annotations` which doesn't exist in the stored object -> 422
- Branch 2 (annotations exist, key absent): tries to `replace` the specific key path which doesn't exist -> 422

`op: add` is safe for both ; it's a strict superset of `replace` for object members.

#### Does this PR introduce a user-facing change?
```release-note
Fixed hierarchical queue close not propagating to child queues that have no annotations set.
```