### PR TITLE
test(controllers/job/state): add unit tests for job state machine

### DIFF
--- a/pkg/controllers/job/state/aborted_test.go
+++ b/pkg/controllers/job/state/aborted_test.go
@@ -1,0 +1,101 @@
+/*
+Copyright 2024 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package state
+
+import (
+	"errors"
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+
+	vcbatch "volcano.sh/apis/pkg/apis/batch/v1alpha1"
+	busv1alpha1 "volcano.sh/apis/pkg/apis/bus/v1alpha1"
+)
+
+func TestAbortedState_Execute_ResumeTransitionsToRestarting(t *testing.T) {
+	m, cleanup := newMock()
+	defer cleanup()
+
+	job := makeJob(vcbatch.Aborted)
+	job.Job.Status.RetryCount = 2
+
+	st := NewState(job)
+	if err := st.Execute(Action{Action: busv1alpha1.ResumeJobAction}); err != nil {
+		t.Fatalf("Execute err: %v", err)
+	}
+
+	if len(m.KillJobCalls) != 1 {
+		t.Fatalf("KillJob calls = %d, want 1", len(m.KillJobCalls))
+	}
+	call := m.KillJobCalls[0]
+	if _, ok := call.RetainPhase[v1.PodSucceeded]; !ok {
+		t.Errorf("RetainPhase should be PodRetainPhaseSoft")
+	}
+	if !call.PhaseChanged {
+		t.Errorf("PhaseChanged = false, want true")
+	}
+	if job.Job.Status.State.Phase != vcbatch.Restarting {
+		t.Errorf("Phase = %q, want Restarting", job.Job.Status.State.Phase)
+	}
+	if job.Job.Status.RetryCount != 3 {
+		t.Errorf("RetryCount = %d, want 3 (incremented from 2)", job.Job.Status.RetryCount)
+	}
+}
+
+func TestAbortedState_Execute_OtherActionsKeepAborted(t *testing.T) {
+	actions := []busv1alpha1.Action{
+		busv1alpha1.SyncJobAction,
+		busv1alpha1.RestartJobAction,
+		busv1alpha1.AbortJobAction,
+		busv1alpha1.CompleteJobAction,
+		busv1alpha1.TerminateJobAction,
+	}
+	for _, action := range actions {
+		t.Run(string(action), func(t *testing.T) {
+			m, cleanup := newMock()
+			defer cleanup()
+
+			job := makeJob(vcbatch.Aborted)
+			st := NewState(job)
+			if err := st.Execute(Action{Action: action}); err != nil {
+				t.Fatalf("Execute err: %v", err)
+			}
+
+			if len(m.KillJobCalls) != 1 {
+				t.Fatalf("KillJob calls = %d, want 1", len(m.KillJobCalls))
+			}
+			call := m.KillJobCalls[0]
+			if call.HadStatusFn {
+				t.Errorf("non-Resume action should pass nil UpdateStatusFn")
+			}
+			if job.Job.Status.State.Phase != vcbatch.Aborted {
+				t.Errorf("Phase = %q, want unchanged (Aborted)", job.Job.Status.State.Phase)
+			}
+		})
+	}
+}
+
+func TestAbortedState_Execute_PropagatesError(t *testing.T) {
+	m, cleanup := newMock()
+	defer cleanup()
+	m.KillJobErr = errors.New("kill failed")
+
+	st := NewState(makeJob(vcbatch.Aborted))
+	if err := st.Execute(Action{Action: busv1alpha1.ResumeJobAction}); err == nil || err.Error() != "kill failed" {
+		t.Errorf("err = %v, want \"kill failed\"", err)
+	}
+}

--- a/pkg/controllers/job/state/aborting_test.go
+++ b/pkg/controllers/job/state/aborting_test.go
@@ -1,0 +1,171 @@
+/*
+Copyright 2024 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package state
+
+import (
+	"errors"
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+
+	vcbatch "volcano.sh/apis/pkg/apis/batch/v1alpha1"
+	busv1alpha1 "volcano.sh/apis/pkg/apis/bus/v1alpha1"
+)
+
+func TestAbortingState_Execute_ResumeTransitionsToRestarting(t *testing.T) {
+	m, cleanup := newMock()
+	defer cleanup()
+
+	job := makeJob(vcbatch.Aborting)
+	job.Job.Status.RetryCount = 1
+
+	st := NewState(job)
+	if err := st.Execute(Action{Action: busv1alpha1.ResumeJobAction}); err != nil {
+		t.Fatalf("Execute err: %v", err)
+	}
+
+	if len(m.KillJobCalls) != 1 {
+		t.Fatalf("KillJob calls = %d, want 1", len(m.KillJobCalls))
+	}
+	call := m.KillJobCalls[0]
+	if _, ok := call.RetainPhase[v1.PodSucceeded]; !ok {
+		t.Errorf("RetainPhase should be PodRetainPhaseSoft")
+	}
+	if !call.PhaseChanged {
+		t.Errorf("PhaseChanged = false, want true")
+	}
+	if job.Job.Status.State.Phase != vcbatch.Restarting {
+		t.Errorf("Phase = %q, want Restarting", job.Job.Status.State.Phase)
+	}
+	if job.Job.Status.RetryCount != 2 {
+		t.Errorf("RetryCount = %d, want 2", job.Job.Status.RetryCount)
+	}
+}
+
+func TestAbortingState_Execute_DefaultDrainTransitions(t *testing.T) {
+	tests := []struct {
+		name          string
+		initialStatus vcbatch.JobStatus
+		wantPhase     vcbatch.JobPhase
+		wantChanged   bool
+	}{
+		{
+			name: "all pods drained -> Aborted",
+			initialStatus: vcbatch.JobStatus{
+				State: vcbatch.JobState{Phase: vcbatch.Aborting},
+			},
+			wantPhase:   vcbatch.Aborted,
+			wantChanged: true,
+		},
+		{
+			name: "Terminating != 0 -> stays Aborting",
+			initialStatus: vcbatch.JobStatus{
+				Terminating: 1,
+				State:       vcbatch.JobState{Phase: vcbatch.Aborting},
+			},
+			wantPhase:   vcbatch.Aborting,
+			wantChanged: false,
+		},
+		{
+			name: "Pending != 0 -> stays Aborting",
+			initialStatus: vcbatch.JobStatus{
+				Pending: 1,
+				State:   vcbatch.JobState{Phase: vcbatch.Aborting},
+			},
+			wantPhase:   vcbatch.Aborting,
+			wantChanged: false,
+		},
+		{
+			name: "Running != 0 -> stays Aborting",
+			initialStatus: vcbatch.JobStatus{
+				Running: 2,
+				State:   vcbatch.JobState{Phase: vcbatch.Aborting},
+			},
+			wantPhase:   vcbatch.Aborting,
+			wantChanged: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m, cleanup := newMock()
+			defer cleanup()
+
+			job := makeJob(vcbatch.Aborting)
+			job.Job.Status = tt.initialStatus
+
+			st := NewState(job)
+			if err := st.Execute(Action{Action: busv1alpha1.SyncJobAction}); err != nil {
+				t.Fatalf("Execute err: %v", err)
+			}
+
+			if len(m.KillJobCalls) != 1 {
+				t.Fatalf("KillJob calls = %d, want 1", len(m.KillJobCalls))
+			}
+			call := m.KillJobCalls[0]
+			if !call.HadStatusFn {
+				t.Errorf("default branch should pass non-nil UpdateStatusFn for drain logic")
+			}
+			if call.PhaseChanged != tt.wantChanged {
+				t.Errorf("PhaseChanged = %v, want %v", call.PhaseChanged, tt.wantChanged)
+			}
+			if job.Job.Status.State.Phase != tt.wantPhase {
+				t.Errorf("Phase = %q, want %q", job.Job.Status.State.Phase, tt.wantPhase)
+			}
+		})
+	}
+}
+
+func TestAbortingState_Execute_NonResumeActionsAllUseDefault(t *testing.T) {
+	actions := []busv1alpha1.Action{
+		busv1alpha1.SyncJobAction,
+		busv1alpha1.RestartJobAction,
+		busv1alpha1.AbortJobAction,
+		busv1alpha1.CompleteJobAction,
+		busv1alpha1.TerminateJobAction,
+	}
+	for _, action := range actions {
+		t.Run(string(action), func(t *testing.T) {
+			m, cleanup := newMock()
+			defer cleanup()
+
+			job := makeJob(vcbatch.Aborting)
+			st := NewState(job)
+			if err := st.Execute(Action{Action: action}); err != nil {
+				t.Fatalf("Execute err: %v", err)
+			}
+
+			if len(m.KillJobCalls) != 1 {
+				t.Fatalf("KillJob calls = %d, want 1", len(m.KillJobCalls))
+			}
+			if job.Job.Status.RetryCount != 0 {
+				t.Errorf("RetryCount = %d, want 0 (default branch should not increment)", job.Job.Status.RetryCount)
+			}
+		})
+	}
+}
+
+func TestAbortingState_Execute_PropagatesError(t *testing.T) {
+	m, cleanup := newMock()
+	defer cleanup()
+	m.KillJobErr = errors.New("kill failed")
+
+	st := NewState(makeJob(vcbatch.Aborting))
+	if err := st.Execute(Action{Action: busv1alpha1.SyncJobAction}); err == nil || err.Error() != "kill failed" {
+		t.Errorf("err = %v, want \"kill failed\"", err)
+	}
+}

--- a/pkg/controllers/job/state/completing_test.go
+++ b/pkg/controllers/job/state/completing_test.go
@@ -1,0 +1,152 @@
+/*
+Copyright 2024 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package state
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	v1 "k8s.io/api/core/v1"
+
+	vcbatch "volcano.sh/apis/pkg/apis/batch/v1alpha1"
+	busv1alpha1 "volcano.sh/apis/pkg/apis/bus/v1alpha1"
+)
+
+func TestCompletingState_Execute(t *testing.T) {
+	tests := []struct {
+		name          string
+		initialStatus vcbatch.JobStatus
+		wantPhase     vcbatch.JobPhase
+		wantChanged   bool
+		wantMetric    float64
+	}{
+		{
+			name: "all pods drained -> Completed and metric +1",
+			initialStatus: vcbatch.JobStatus{
+				State: vcbatch.JobState{Phase: vcbatch.Completing},
+			},
+			wantPhase:   vcbatch.Completed,
+			wantChanged: true,
+			wantMetric:  1,
+		},
+		{
+			name: "still has Running pods -> stays Completing, no metric",
+			initialStatus: vcbatch.JobStatus{
+				Running: 2,
+				State:   vcbatch.JobState{Phase: vcbatch.Completing},
+			},
+			wantPhase:   vcbatch.Completing,
+			wantChanged: false,
+			wantMetric:  0,
+		},
+		{
+			name: "still has Pending pods -> stays Completing",
+			initialStatus: vcbatch.JobStatus{
+				Pending: 1,
+				State:   vcbatch.JobState{Phase: vcbatch.Completing},
+			},
+			wantPhase:   vcbatch.Completing,
+			wantChanged: false,
+			wantMetric:  0,
+		},
+		{
+			name: "still has Terminating pods -> stays Completing",
+			initialStatus: vcbatch.JobStatus{
+				Terminating: 1,
+				State:       vcbatch.JobState{Phase: vcbatch.Completing},
+			},
+			wantPhase:   vcbatch.Completing,
+			wantChanged: false,
+			wantMetric:  0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m, cleanup := newMock()
+			defer cleanup()
+			jobCompletedPhaseCount.Reset()
+
+			job := makeJob(vcbatch.Completing)
+			job.Job.Namespace = "ns"
+			job.Job.Name = "j1"
+			job.Job.Spec.Queue = "q1"
+			job.Job.Status = tt.initialStatus
+
+			st := NewState(job)
+			if err := st.Execute(Action{Action: busv1alpha1.SyncJobAction}); err != nil {
+				t.Fatalf("Execute err: %v", err)
+			}
+
+			if len(m.KillJobCalls) != 1 {
+				t.Fatalf("KillJob calls = %d, want 1", len(m.KillJobCalls))
+			}
+			call := m.KillJobCalls[0]
+			if _, ok := call.RetainPhase[v1.PodSucceeded]; !ok {
+				t.Errorf("RetainPhase missing PodSucceeded")
+			}
+			if !call.HadStatusFn {
+				t.Errorf("UpdateStatusFn should be non-nil")
+			}
+			if call.PhaseChanged != tt.wantChanged {
+				t.Errorf("PhaseChanged = %v, want %v", call.PhaseChanged, tt.wantChanged)
+			}
+			if job.Job.Status.State.Phase != tt.wantPhase {
+				t.Errorf("Phase = %q, want %q", job.Job.Status.State.Phase, tt.wantPhase)
+			}
+			got := testutil.ToFloat64(jobCompletedPhaseCount.WithLabelValues("ns/j1", "q1"))
+			if got != tt.wantMetric {
+				t.Errorf("completed metric = %v, want %v", got, tt.wantMetric)
+			}
+		})
+	}
+}
+
+func TestCompletingState_Execute_ActionIsIgnored(t *testing.T) {
+	actions := []busv1alpha1.Action{
+		busv1alpha1.SyncJobAction,
+		busv1alpha1.ResumeJobAction,
+		busv1alpha1.RestartJobAction,
+		busv1alpha1.AbortJobAction,
+	}
+	for _, action := range actions {
+		t.Run(string(action), func(t *testing.T) {
+			m, cleanup := newMock()
+			defer cleanup()
+
+			st := NewState(makeJob(vcbatch.Completing))
+			if err := st.Execute(Action{Action: action}); err != nil {
+				t.Fatalf("Execute err: %v", err)
+			}
+			if len(m.KillJobCalls) != 1 {
+				t.Errorf("KillJob calls = %d, want 1 for %q", len(m.KillJobCalls), action)
+			}
+		})
+	}
+}
+
+func TestCompletingState_Execute_PropagatesError(t *testing.T) {
+	m, cleanup := newMock()
+	defer cleanup()
+	m.KillJobErr = errors.New("kill failed")
+
+	st := NewState(makeJob(vcbatch.Completing))
+	if err := st.Execute(Action{Action: busv1alpha1.SyncJobAction}); err == nil || err.Error() != "kill failed" {
+		t.Errorf("err = %v, want \"kill failed\"", err)
+	}
+}

--- a/pkg/controllers/job/state/factory_test.go
+++ b/pkg/controllers/job/state/factory_test.go
@@ -1,0 +1,101 @@
+/*
+Copyright 2024 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package state
+
+import (
+	"reflect"
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+
+	vcbatch "volcano.sh/apis/pkg/apis/batch/v1alpha1"
+	"volcano.sh/volcano/pkg/controllers/apis"
+)
+
+func jobInfoWithPhase(phase vcbatch.JobPhase) *apis.JobInfo {
+	return &apis.JobInfo{
+		Job: &vcbatch.Job{
+			Status: vcbatch.JobStatus{
+				State: vcbatch.JobState{Phase: phase},
+			},
+		},
+	}
+}
+
+func TestNewState_PhaseMapping(t *testing.T) {
+	tests := []struct {
+		phase    vcbatch.JobPhase
+		wantType State
+	}{
+		{vcbatch.Pending, &pendingState{}},
+		{vcbatch.Running, &runningState{}},
+		{vcbatch.Restarting, &restartingState{}},
+		{vcbatch.Terminated, &finishedState{}},
+		{vcbatch.Completed, &finishedState{}},
+		{vcbatch.Failed, &finishedState{}},
+		{vcbatch.Terminating, &terminatingState{}},
+		{vcbatch.Aborting, &abortingState{}},
+		{vcbatch.Aborted, &abortedState{}},
+		{vcbatch.Completing, &completingState{}},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.phase), func(t *testing.T) {
+			got := NewState(jobInfoWithPhase(tt.phase))
+			if reflect.TypeOf(got) != reflect.TypeOf(tt.wantType) {
+				t.Errorf("phase %q -> %T, want %T", tt.phase, got, tt.wantType)
+			}
+		})
+	}
+}
+
+func TestNewState_UnknownPhaseDefaultsToPending(t *testing.T) {
+	got := NewState(jobInfoWithPhase(vcbatch.JobPhase("totally-unknown-phase")))
+	if _, ok := got.(*pendingState); !ok {
+		t.Errorf("unknown phase -> %T, want *pendingState", got)
+	}
+}
+
+func TestNewState_EmptyPhaseDefaultsToPending(t *testing.T) {
+	got := NewState(jobInfoWithPhase(""))
+	if _, ok := got.(*pendingState); !ok {
+		t.Errorf("empty phase -> %T, want *pendingState", got)
+	}
+}
+
+func TestNewState_StateHoldsTheGivenJobInfo(t *testing.T) {
+	ji := jobInfoWithPhase(vcbatch.Running)
+	st := NewState(ji).(*runningState)
+	if st.job != ji {
+		t.Errorf("state.job not set to provided JobInfo")
+	}
+}
+
+func TestPodRetainPhaseConstants(t *testing.T) {
+	if len(PodRetainPhaseNone) != 0 {
+		t.Errorf("PodRetainPhaseNone should be empty, got %v", PodRetainPhaseNone)
+	}
+	if len(PodRetainPhaseSoft) != 2 {
+		t.Errorf("PodRetainPhaseSoft should have 2 entries, got %d", len(PodRetainPhaseSoft))
+	}
+	if _, ok := PodRetainPhaseSoft[v1.PodSucceeded]; !ok {
+		t.Errorf("PodRetainPhaseSoft missing PodSucceeded: %v", PodRetainPhaseSoft)
+	}
+	if _, ok := PodRetainPhaseSoft[v1.PodFailed]; !ok {
+		t.Errorf("PodRetainPhaseSoft missing PodFailed: %v", PodRetainPhaseSoft)
+	}
+}

--- a/pkg/controllers/job/state/finished_test.go
+++ b/pkg/controllers/job/state/finished_test.go
@@ -1,0 +1,104 @@
+/*
+Copyright 2024 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package state
+
+import (
+	"errors"
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+
+	vcbatch "volcano.sh/apis/pkg/apis/batch/v1alpha1"
+	busv1alpha1 "volcano.sh/apis/pkg/apis/bus/v1alpha1"
+)
+
+func TestFinishedState_Execute_AllPhasesCallKillJob(t *testing.T) {
+	terminalPhases := []vcbatch.JobPhase{
+		vcbatch.Completed,
+		vcbatch.Terminated,
+		vcbatch.Failed,
+	}
+
+	for _, phase := range terminalPhases {
+		t.Run(string(phase), func(t *testing.T) {
+			m, cleanup := newMock()
+			defer cleanup()
+
+			st := NewState(makeJob(phase))
+			if err := st.Execute(Action{Action: busv1alpha1.SyncJobAction}); err != nil {
+				t.Fatalf("Execute returned err: %v", err)
+			}
+
+			if len(m.KillJobCalls) != 1 {
+				t.Fatalf("KillJob calls = %d, want 1", len(m.KillJobCalls))
+			}
+			if len(m.SyncCalls) != 0 || len(m.KillTargetCalls) != 0 {
+				t.Errorf("unexpected calls: sync=%d killTarget=%d", len(m.SyncCalls), len(m.KillTargetCalls))
+			}
+
+			call := m.KillJobCalls[0]
+			if _, ok := call.RetainPhase[v1.PodSucceeded]; !ok {
+				t.Errorf("RetainPhase missing PodSucceeded: %v", call.RetainPhase)
+			}
+			if _, ok := call.RetainPhase[v1.PodFailed]; !ok {
+				t.Errorf("RetainPhase missing PodFailed: %v", call.RetainPhase)
+			}
+			if call.HadStatusFn {
+				t.Errorf("finishedState should pass nil UpdateStatusFn")
+			}
+		})
+	}
+}
+
+func TestFinishedState_Execute_AnyActionStillKillsJob(t *testing.T) {
+	actions := []busv1alpha1.Action{
+		busv1alpha1.SyncJobAction,
+		busv1alpha1.RestartJobAction,
+		busv1alpha1.AbortJobAction,
+		busv1alpha1.CompleteJobAction,
+		busv1alpha1.TerminateJobAction,
+		busv1alpha1.ResumeJobAction,
+		busv1alpha1.RestartTaskAction,
+	}
+
+	for _, action := range actions {
+		t.Run(string(action), func(t *testing.T) {
+			m, cleanup := newMock()
+			defer cleanup()
+
+			st := NewState(makeJob(vcbatch.Completed))
+			if err := st.Execute(Action{Action: action}); err != nil {
+				t.Fatalf("Execute returned err: %v", err)
+			}
+			if len(m.KillJobCalls) != 1 {
+				t.Errorf("KillJob calls = %d, want 1 for action %q", len(m.KillJobCalls), action)
+			}
+		})
+	}
+}
+
+func TestFinishedState_Execute_PropagatesError(t *testing.T) {
+	m, cleanup := newMock()
+	defer cleanup()
+	m.KillJobErr = errors.New("boom")
+
+	st := NewState(makeJob(vcbatch.Failed))
+	err := st.Execute(Action{Action: busv1alpha1.SyncJobAction})
+	if err == nil || err.Error() != "boom" {
+		t.Errorf("Execute err = %v, want \"boom\"", err)
+	}
+}

--- a/pkg/controllers/job/state/metrics_test.go
+++ b/pkg/controllers/job/state/metrics_test.go
@@ -1,0 +1,89 @@
+/*
+Copyright 2024 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package state
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+)
+
+func TestUpdateJobCompleted(t *testing.T) {
+	jobCompletedPhaseCount.Reset()
+
+	UpdateJobCompleted("ns1/job-a", "q1")
+	UpdateJobCompleted("ns1/job-a", "q1")
+	UpdateJobCompleted("ns1/job-b", "q2")
+
+	if got := testutil.ToFloat64(jobCompletedPhaseCount.WithLabelValues("ns1/job-a", "q1")); got != 2 {
+		t.Errorf("ns1/job-a@q1 = %v, want 2", got)
+	}
+	if got := testutil.ToFloat64(jobCompletedPhaseCount.WithLabelValues("ns1/job-b", "q2")); got != 1 {
+		t.Errorf("ns1/job-b@q2 = %v, want 1", got)
+	}
+	if got := testutil.ToFloat64(jobCompletedPhaseCount.WithLabelValues("ns1/unknown", "q1")); got != 0 {
+		t.Errorf("unknown label combo = %v, want 0", got)
+	}
+}
+
+func TestUpdateJobFailed(t *testing.T) {
+	jobFailedPhaseCount.Reset()
+
+	UpdateJobFailed("ns1/job-a", "q1")
+	UpdateJobFailed("ns1/job-a", "q1")
+	UpdateJobFailed("ns1/job-a", "q1")
+
+	if got := testutil.ToFloat64(jobFailedPhaseCount.WithLabelValues("ns1/job-a", "q1")); got != 3 {
+		t.Errorf("ns1/job-a@q1 = %v, want 3", got)
+	}
+}
+
+func TestDeleteJobMetrics(t *testing.T) {
+	jobCompletedPhaseCount.Reset()
+	jobFailedPhaseCount.Reset()
+
+	UpdateJobCompleted("ns1/job-a", "q1")
+	UpdateJobFailed("ns1/job-a", "q1")
+	UpdateJobCompleted("ns1/job-b", "q2")
+
+	DeleteJobMetrics("ns1/job-a", "q1")
+
+	if got := testutil.CollectAndCount(jobCompletedPhaseCount); got != 1 {
+		t.Errorf("completed series count = %d, want 1 (only job-b should remain)", got)
+	}
+	if got := testutil.CollectAndCount(jobFailedPhaseCount); got != 0 {
+		t.Errorf("failed series count = %d, want 0", got)
+	}
+	if got := testutil.ToFloat64(jobCompletedPhaseCount.WithLabelValues("ns1/job-b", "q2")); got != 1 {
+		t.Errorf("ns1/job-b@q2 = %v, want 1 (untouched)", got)
+	}
+}
+
+func TestMetricsAreIndependentAcrossLabels(t *testing.T) {
+	jobCompletedPhaseCount.Reset()
+	jobFailedPhaseCount.Reset()
+
+	UpdateJobCompleted("ns/job", "q1")
+	UpdateJobFailed("ns/job", "q1")
+
+	if got := testutil.ToFloat64(jobCompletedPhaseCount.WithLabelValues("ns/job", "q1")); got != 1 {
+		t.Errorf("completed = %v, want 1", got)
+	}
+	if got := testutil.ToFloat64(jobFailedPhaseCount.WithLabelValues("ns/job", "q1")); got != 1 {
+		t.Errorf("failed = %v, want 1", got)
+	}
+}

--- a/pkg/controllers/job/state/mock_test.go
+++ b/pkg/controllers/job/state/mock_test.go
@@ -1,0 +1,123 @@
+/*
+Copyright 2024 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package state
+
+import (
+	vcbatch "volcano.sh/apis/pkg/apis/batch/v1alpha1"
+	"volcano.sh/volcano/pkg/controllers/apis"
+)
+
+// Captured call records for the injected action functions.
+type syncCall struct {
+	Job          *apis.JobInfo
+	StatusAfter  vcbatch.JobStatus
+	PhaseChanged bool
+	HadStatusFn  bool
+}
+
+type killJobCall struct {
+	Job          *apis.JobInfo
+	RetainPhase  PhaseMap
+	StatusAfter  vcbatch.JobStatus
+	PhaseChanged bool
+	HadStatusFn  bool
+}
+
+type killTargetCall struct {
+	Job          *apis.JobInfo
+	Target       Target
+	StatusAfter  vcbatch.JobStatus
+	PhaseChanged bool
+	HadStatusFn  bool
+}
+
+// mockOps replaces the package-level action functions with capturing fakes.
+// Each fake invokes the supplied UpdateStatusFn against the Job's Status so
+// state transition logic is exercised against a real *JobStatus.
+type mockOps struct {
+	SyncCalls       []syncCall
+	KillJobCalls    []killJobCall
+	KillTargetCalls []killTargetCall
+
+	SyncErr       error
+	KillJobErr    error
+	KillTargetErr error
+
+	origSync       ActionFn
+	origKillJob    KillActionFn
+	origKillTarget KillTargetFn
+}
+
+func (m *mockOps) install() {
+	m.origSync = SyncJob
+	m.origKillJob = KillJob
+	m.origKillTarget = KillTarget
+
+	SyncJob = func(job *apis.JobInfo, fn UpdateStatusFn) error {
+		c := syncCall{Job: job, HadStatusFn: fn != nil}
+		if fn != nil {
+			c.PhaseChanged = fn(&job.Job.Status)
+		}
+		c.StatusAfter = job.Job.Status
+		m.SyncCalls = append(m.SyncCalls, c)
+		return m.SyncErr
+	}
+	KillJob = func(job *apis.JobInfo, retain PhaseMap, fn UpdateStatusFn) error {
+		c := killJobCall{Job: job, RetainPhase: retain, HadStatusFn: fn != nil}
+		if fn != nil {
+			c.PhaseChanged = fn(&job.Job.Status)
+		}
+		c.StatusAfter = job.Job.Status
+		m.KillJobCalls = append(m.KillJobCalls, c)
+		return m.KillJobErr
+	}
+	KillTarget = func(job *apis.JobInfo, target Target, fn UpdateStatusFn) error {
+		c := killTargetCall{Job: job, Target: target, HadStatusFn: fn != nil}
+		if fn != nil {
+			c.PhaseChanged = fn(&job.Job.Status)
+		}
+		c.StatusAfter = job.Job.Status
+		m.KillTargetCalls = append(m.KillTargetCalls, c)
+		return m.KillTargetErr
+	}
+}
+
+func (m *mockOps) uninstall() {
+	SyncJob = m.origSync
+	KillJob = m.origKillJob
+	KillTarget = m.origKillTarget
+}
+
+// newMock installs a fresh mockOps and returns it with its cleanup func.
+func newMock() (*mockOps, func()) {
+	m := &mockOps{}
+	m.install()
+	return m, m.uninstall
+}
+
+// makeJob builds a minimal JobInfo with the given phase and initial status.
+func makeJob(phase vcbatch.JobPhase) *apis.JobInfo {
+	return &apis.JobInfo{
+		Namespace: "ns",
+		Name:      "job-info",
+		Job: &vcbatch.Job{
+			Status: vcbatch.JobStatus{
+				State: vcbatch.JobState{Phase: phase},
+			},
+		},
+	}
+}

--- a/pkg/controllers/job/state/pending_test.go
+++ b/pkg/controllers/job/state/pending_test.go
@@ -1,0 +1,263 @@
+/*
+Copyright 2024 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package state
+
+import (
+	"errors"
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+
+	vcbatch "volcano.sh/apis/pkg/apis/batch/v1alpha1"
+	busv1alpha1 "volcano.sh/apis/pkg/apis/bus/v1alpha1"
+)
+
+func TestPendingState_Execute_RestartJob(t *testing.T) {
+	m, cleanup := newMock()
+	defer cleanup()
+
+	job := makeJob(vcbatch.Pending)
+	job.Job.Status.RetryCount = 4
+
+	st := NewState(job)
+	if err := st.Execute(Action{Action: busv1alpha1.RestartJobAction}); err != nil {
+		t.Fatalf("Execute err: %v", err)
+	}
+
+	if len(m.KillJobCalls) != 1 {
+		t.Fatalf("KillJob calls = %d, want 1", len(m.KillJobCalls))
+	}
+	call := m.KillJobCalls[0]
+	if len(call.RetainPhase) != 0 {
+		t.Errorf("RetainPhase should be PodRetainPhaseNone (empty), got %v", call.RetainPhase)
+	}
+	if job.Job.Status.State.Phase != vcbatch.Restarting {
+		t.Errorf("Phase = %q, want Restarting", job.Job.Status.State.Phase)
+	}
+	if job.Job.Status.RetryCount != 5 {
+		t.Errorf("RetryCount = %d, want 5", job.Job.Status.RetryCount)
+	}
+}
+
+func TestPendingState_Execute_RestartTargetActions(t *testing.T) {
+	targetActions := []busv1alpha1.Action{
+		busv1alpha1.RestartTaskAction,
+		busv1alpha1.RestartPodAction,
+		busv1alpha1.RestartPartitionAction,
+	}
+	for _, action := range targetActions {
+		t.Run(string(action), func(t *testing.T) {
+			m, cleanup := newMock()
+			defer cleanup()
+
+			job := makeJob(vcbatch.Pending)
+			job.Job.Status.RetryCount = 0
+			target := Target{TaskName: "task-x", Type: TargetTypeTask}
+
+			st := NewState(job)
+			if err := st.Execute(Action{Action: action, Target: target}); err != nil {
+				t.Fatalf("Execute err: %v", err)
+			}
+
+			if len(m.KillTargetCalls) != 1 {
+				t.Fatalf("KillTarget calls = %d, want 1", len(m.KillTargetCalls))
+			}
+			call := m.KillTargetCalls[0]
+			if call.Target != target {
+				t.Errorf("Target = %+v, want %+v", call.Target, target)
+			}
+			if job.Job.Status.State.Phase != vcbatch.Restarting {
+				t.Errorf("Phase = %q, want Restarting", job.Job.Status.State.Phase)
+			}
+			if job.Job.Status.RetryCount != 1 {
+				t.Errorf("RetryCount = %d, want 1", job.Job.Status.RetryCount)
+			}
+		})
+	}
+}
+
+func TestPendingState_Execute_AbortCompleteTerminate(t *testing.T) {
+	tests := []struct {
+		action    busv1alpha1.Action
+		wantPhase vcbatch.JobPhase
+	}{
+		{busv1alpha1.AbortJobAction, vcbatch.Aborting},
+		{busv1alpha1.CompleteJobAction, vcbatch.Completing},
+		{busv1alpha1.TerminateJobAction, vcbatch.Terminating},
+	}
+	for _, tt := range tests {
+		t.Run(string(tt.action), func(t *testing.T) {
+			m, cleanup := newMock()
+			defer cleanup()
+
+			job := makeJob(vcbatch.Pending)
+			job.Job.Status.RetryCount = 7
+
+			st := NewState(job)
+			if err := st.Execute(Action{Action: tt.action}); err != nil {
+				t.Fatalf("Execute err: %v", err)
+			}
+
+			if len(m.KillJobCalls) != 1 {
+				t.Fatalf("KillJob calls = %d, want 1", len(m.KillJobCalls))
+			}
+			call := m.KillJobCalls[0]
+			if _, ok := call.RetainPhase[v1.PodSucceeded]; !ok {
+				t.Errorf("RetainPhase should retain PodSucceeded")
+			}
+			if job.Job.Status.State.Phase != tt.wantPhase {
+				t.Errorf("Phase = %q, want %q", job.Job.Status.State.Phase, tt.wantPhase)
+			}
+			if job.Job.Status.RetryCount != 7 {
+				t.Errorf("RetryCount = %d, want 7 (no inc on abort/complete/terminate)", job.Job.Status.RetryCount)
+			}
+		})
+	}
+}
+
+func TestPendingState_Execute_SyncDefault(t *testing.T) {
+	tests := []struct {
+		name          string
+		spec          vcbatch.JobSpec
+		initialStatus vcbatch.JobStatus
+		wantPhase     vcbatch.JobPhase
+		wantChanged   bool
+	}{
+		{
+			name: "enough pods alive -> transition to Running",
+			spec: vcbatch.JobSpec{MinAvailable: 3},
+			initialStatus: vcbatch.JobStatus{
+				Running:   2,
+				Succeeded: 1,
+				State:     vcbatch.JobState{Phase: vcbatch.Pending},
+			},
+			wantPhase:   vcbatch.Running,
+			wantChanged: true,
+		},
+		{
+			name: "enough via failed pods too -> transition to Running",
+			spec: vcbatch.JobSpec{MinAvailable: 3},
+			initialStatus: vcbatch.JobStatus{
+				Running:   1,
+				Succeeded: 1,
+				Failed:    1,
+				State:     vcbatch.JobState{Phase: vcbatch.Pending},
+			},
+			wantPhase:   vcbatch.Running,
+			wantChanged: true,
+		},
+		{
+			name: "not enough pods alive -> stays Pending",
+			spec: vcbatch.JobSpec{MinAvailable: 3},
+			initialStatus: vcbatch.JobStatus{
+				Running: 2,
+				State:   vcbatch.JobState{Phase: vcbatch.Pending},
+			},
+			wantPhase:   vcbatch.Pending,
+			wantChanged: false,
+		},
+		{
+			name: "MinAvailable 0 with no pods -> transitions to Running (0 <= 0)",
+			spec: vcbatch.JobSpec{MinAvailable: 0},
+			initialStatus: vcbatch.JobStatus{
+				State: vcbatch.JobState{Phase: vcbatch.Pending},
+			},
+			wantPhase:   vcbatch.Running,
+			wantChanged: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m, cleanup := newMock()
+			defer cleanup()
+
+			job := makeJob(vcbatch.Pending)
+			job.Job.Spec = tt.spec
+			job.Job.Status = tt.initialStatus
+
+			st := NewState(job)
+			if err := st.Execute(Action{Action: busv1alpha1.SyncJobAction}); err != nil {
+				t.Fatalf("Execute err: %v", err)
+			}
+
+			if len(m.SyncCalls) != 1 {
+				t.Fatalf("SyncJob calls = %d, want 1", len(m.SyncCalls))
+			}
+			call := m.SyncCalls[0]
+			if call.PhaseChanged != tt.wantChanged {
+				t.Errorf("PhaseChanged = %v, want %v", call.PhaseChanged, tt.wantChanged)
+			}
+			if job.Job.Status.State.Phase != tt.wantPhase {
+				t.Errorf("Phase = %q, want %q", job.Job.Status.State.Phase, tt.wantPhase)
+			}
+		})
+	}
+}
+
+func TestPendingState_Execute_UnknownActionFallsThroughToSync(t *testing.T) {
+	m, cleanup := newMock()
+	defer cleanup()
+
+	job := makeJob(vcbatch.Pending)
+	job.Job.Spec.MinAvailable = 1
+	job.Job.Status.Running = 1
+
+	st := NewState(job)
+	if err := st.Execute(Action{Action: busv1alpha1.EnqueueAction}); err != nil {
+		t.Fatalf("Execute err: %v", err)
+	}
+
+	if len(m.SyncCalls) != 1 {
+		t.Errorf("SyncJob calls = %d, want 1 (Enqueue should hit default)", len(m.SyncCalls))
+	}
+	if len(m.KillJobCalls) != 0 {
+		t.Errorf("KillJob calls = %d, want 0", len(m.KillJobCalls))
+	}
+}
+
+func TestPendingState_Execute_ErrorPropagation(t *testing.T) {
+	t.Run("from KillJob (RestartJobAction)", func(t *testing.T) {
+		m, cleanup := newMock()
+		defer cleanup()
+		m.KillJobErr = errors.New("kj")
+
+		st := NewState(makeJob(vcbatch.Pending))
+		if err := st.Execute(Action{Action: busv1alpha1.RestartJobAction}); err == nil || err.Error() != "kj" {
+			t.Errorf("err = %v, want \"kj\"", err)
+		}
+	})
+	t.Run("from KillTarget", func(t *testing.T) {
+		m, cleanup := newMock()
+		defer cleanup()
+		m.KillTargetErr = errors.New("kt")
+
+		st := NewState(makeJob(vcbatch.Pending))
+		if err := st.Execute(Action{Action: busv1alpha1.RestartTaskAction}); err == nil || err.Error() != "kt" {
+			t.Errorf("err = %v, want \"kt\"", err)
+		}
+	})
+	t.Run("from SyncJob (default)", func(t *testing.T) {
+		m, cleanup := newMock()
+		defer cleanup()
+		m.SyncErr = errors.New("sj")
+
+		st := NewState(makeJob(vcbatch.Pending))
+		if err := st.Execute(Action{Action: busv1alpha1.SyncJobAction}); err == nil || err.Error() != "sj" {
+			t.Errorf("err = %v, want \"sj\"", err)
+		}
+	})
+}

--- a/pkg/controllers/job/state/restarting_test.go
+++ b/pkg/controllers/job/state/restarting_test.go
@@ -1,0 +1,233 @@
+/*
+Copyright 2024 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package state
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+
+	vcbatch "volcano.sh/apis/pkg/apis/batch/v1alpha1"
+	busv1alpha1 "volcano.sh/apis/pkg/apis/bus/v1alpha1"
+)
+
+func TestRestartingState_Execute_MaxRetryExceeded_FailsAndEmitsMetric(t *testing.T) {
+	m, cleanup := newMock()
+	defer cleanup()
+	jobFailedPhaseCount.Reset()
+
+	job := makeJob(vcbatch.Restarting)
+	job.Job.Namespace = "ns"
+	job.Job.Name = "j1"
+	job.Job.Spec.Queue = "q1"
+	job.Job.Spec.MaxRetry = 3
+	job.Job.Status.RetryCount = 3 // equal => exceed
+
+	st := NewState(job)
+	if err := st.Execute(Action{Action: busv1alpha1.RestartJobAction}); err != nil {
+		t.Fatalf("Execute err: %v", err)
+	}
+
+	if len(m.KillJobCalls) != 1 {
+		t.Fatalf("KillJob calls = %d, want 1 (default branch)", len(m.KillJobCalls))
+	}
+	if !m.KillJobCalls[0].PhaseChanged {
+		t.Errorf("PhaseChanged = false, want true")
+	}
+	if job.Job.Status.State.Phase != vcbatch.Failed {
+		t.Errorf("Phase = %q, want Failed", job.Job.Status.State.Phase)
+	}
+	if got := testutil.ToFloat64(jobFailedPhaseCount.WithLabelValues("ns/j1", "q1")); got != 1 {
+		t.Errorf("failed metric = %v, want 1", got)
+	}
+}
+
+func TestRestartingState_Execute_RetryCountStrictlyGreaterAlsoFails(t *testing.T) {
+	m, cleanup := newMock()
+	defer cleanup()
+	jobFailedPhaseCount.Reset()
+
+	job := makeJob(vcbatch.Restarting)
+	job.Job.Spec.MaxRetry = 2
+	job.Job.Status.RetryCount = 5
+
+	st := NewState(job)
+	if err := st.Execute(Action{Action: busv1alpha1.RestartJobAction}); err != nil {
+		t.Fatalf("Execute err: %v", err)
+	}
+	if !m.KillJobCalls[0].PhaseChanged {
+		t.Errorf("PhaseChanged = false, want true")
+	}
+	if job.Job.Status.State.Phase != vcbatch.Failed {
+		t.Errorf("Phase = %q, want Failed", job.Job.Status.State.Phase)
+	}
+}
+
+func TestRestartingState_Execute_TransitionsToPendingWhenDrained(t *testing.T) {
+	m, cleanup := newMock()
+	defer cleanup()
+
+	job := makeJob(vcbatch.Restarting)
+	job.Job.Spec.MaxRetry = 5
+	job.Job.Spec.Tasks = []vcbatch.TaskSpec{
+		{Name: "t1", Replicas: 2},
+		{Name: "t2", Replicas: 1},
+	}
+	job.Job.Status.RetryCount = 1
+	job.Job.Status.MinAvailable = 2
+	job.Job.Status.Terminating = 1 // total(3) - terminating(1) = 2 >= minAvailable(2)
+
+	st := NewState(job)
+	if err := st.Execute(Action{Action: busv1alpha1.RestartJobAction}); err != nil {
+		t.Fatalf("Execute err: %v", err)
+	}
+	call := m.KillJobCalls[0]
+	if !call.PhaseChanged {
+		t.Errorf("PhaseChanged = false, want true")
+	}
+	if job.Job.Status.State.Phase != vcbatch.Pending {
+		t.Errorf("Phase = %q, want Pending", job.Job.Status.State.Phase)
+	}
+}
+
+func TestRestartingState_Execute_StaysRestartingWhenNotDrained(t *testing.T) {
+	m, cleanup := newMock()
+	defer cleanup()
+
+	job := makeJob(vcbatch.Restarting)
+	job.Job.Spec.MaxRetry = 5
+	job.Job.Spec.Tasks = []vcbatch.TaskSpec{
+		{Name: "t1", Replicas: 3},
+	}
+	job.Job.Status.RetryCount = 1
+	job.Job.Status.MinAvailable = 2
+	job.Job.Status.Terminating = 2 // 3-2 = 1 < 2 => not yet
+
+	st := NewState(job)
+	if err := st.Execute(Action{Action: busv1alpha1.RestartJobAction}); err != nil {
+		t.Fatalf("Execute err: %v", err)
+	}
+	call := m.KillJobCalls[0]
+	if call.PhaseChanged {
+		t.Errorf("PhaseChanged = true, want false")
+	}
+	if job.Job.Status.State.Phase != vcbatch.Restarting {
+		t.Errorf("Phase = %q, want unchanged Restarting", job.Job.Status.State.Phase)
+	}
+}
+
+func TestRestartingState_Execute_SyncJobActionRoutesToSyncJob(t *testing.T) {
+	m, cleanup := newMock()
+	defer cleanup()
+
+	job := makeJob(vcbatch.Restarting)
+	job.Job.Spec.MaxRetry = 5
+	job.Job.Status.RetryCount = 1
+	job.Job.Status.MinAvailable = 0
+	// total = 0, terminating = 0 -> 0 >= 0 -> Pending
+
+	st := NewState(job)
+	if err := st.Execute(Action{Action: busv1alpha1.SyncJobAction}); err != nil {
+		t.Fatalf("Execute err: %v", err)
+	}
+	if len(m.SyncCalls) != 1 {
+		t.Errorf("SyncJob calls = %d, want 1", len(m.SyncCalls))
+	}
+	if len(m.KillJobCalls) != 0 {
+		t.Errorf("KillJob calls = %d, want 0", len(m.KillJobCalls))
+	}
+	if job.Job.Status.State.Phase != vcbatch.Pending {
+		t.Errorf("Phase = %q, want Pending", job.Job.Status.State.Phase)
+	}
+}
+
+func TestRestartingState_Execute_RestartTargetActionsRouteToKillTarget(t *testing.T) {
+	targetActions := []busv1alpha1.Action{
+		busv1alpha1.RestartTaskAction,
+		busv1alpha1.RestartPodAction,
+		busv1alpha1.RestartPartitionAction,
+	}
+	for _, action := range targetActions {
+		t.Run(string(action), func(t *testing.T) {
+			m, cleanup := newMock()
+			defer cleanup()
+
+			job := makeJob(vcbatch.Restarting)
+			job.Job.Spec.MaxRetry = 5
+			job.Job.Status.RetryCount = 0
+			target := Target{TaskName: "tx", Type: TargetTypeTask}
+
+			st := NewState(job)
+			if err := st.Execute(Action{Action: action, Target: target}); err != nil {
+				t.Fatalf("Execute err: %v", err)
+			}
+			if len(m.KillTargetCalls) != 1 {
+				t.Errorf("KillTarget calls = %d, want 1", len(m.KillTargetCalls))
+			}
+			if m.KillTargetCalls[0].Target != target {
+				t.Errorf("Target = %+v, want %+v", m.KillTargetCalls[0].Target, target)
+			}
+			if !m.KillTargetCalls[0].HadStatusFn {
+				t.Errorf("restartingUpdateStatus should be passed as UpdateStatusFn")
+			}
+		})
+	}
+}
+
+func TestRestartingState_Execute_DefaultUsesPodRetainPhaseNone(t *testing.T) {
+	m, cleanup := newMock()
+	defer cleanup()
+
+	job := makeJob(vcbatch.Restarting)
+	job.Job.Spec.MaxRetry = 5
+
+	st := NewState(job)
+	if err := st.Execute(Action{Action: busv1alpha1.AbortJobAction}); err != nil {
+		t.Fatalf("Execute err: %v", err)
+	}
+	if len(m.KillJobCalls) != 1 {
+		t.Fatalf("KillJob calls = %d, want 1", len(m.KillJobCalls))
+	}
+	if len(m.KillJobCalls[0].RetainPhase) != 0 {
+		t.Errorf("RetainPhase should be empty (PodRetainPhaseNone), got %v", m.KillJobCalls[0].RetainPhase)
+	}
+}
+
+func TestRestartingState_Execute_ErrorPropagation(t *testing.T) {
+	cases := []struct {
+		name   string
+		action busv1alpha1.Action
+		setup  func(*mockOps)
+	}{
+		{"sync err", busv1alpha1.SyncJobAction, func(m *mockOps) { m.SyncErr = errors.New("e") }},
+		{"kill target err", busv1alpha1.RestartTaskAction, func(m *mockOps) { m.KillTargetErr = errors.New("e") }},
+		{"kill job err (default)", busv1alpha1.RestartJobAction, func(m *mockOps) { m.KillJobErr = errors.New("e") }},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			m, cleanup := newMock()
+			defer cleanup()
+			c.setup(m)
+
+			st := NewState(makeJob(vcbatch.Restarting))
+			if err := st.Execute(Action{Action: c.action}); err == nil || err.Error() != "e" {
+				t.Errorf("err = %v, want \"e\"", err)
+			}
+		})
+	}
+}

--- a/pkg/controllers/job/state/running_test.go
+++ b/pkg/controllers/job/state/running_test.go
@@ -1,0 +1,350 @@
+/*
+Copyright 2024 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package state
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	v1 "k8s.io/api/core/v1"
+
+	vcbatch "volcano.sh/apis/pkg/apis/batch/v1alpha1"
+	busv1alpha1 "volcano.sh/apis/pkg/apis/bus/v1alpha1"
+)
+
+func TestRunningState_Execute_RestartJob(t *testing.T) {
+	m, cleanup := newMock()
+	defer cleanup()
+
+	job := makeJob(vcbatch.Running)
+	job.Job.Status.RetryCount = 2
+
+	st := NewState(job)
+	if err := st.Execute(Action{Action: busv1alpha1.RestartJobAction}); err != nil {
+		t.Fatalf("Execute err: %v", err)
+	}
+	if len(m.KillJobCalls) != 1 {
+		t.Fatalf("KillJob calls = %d, want 1", len(m.KillJobCalls))
+	}
+	if len(m.KillJobCalls[0].RetainPhase) != 0 {
+		t.Errorf("RetainPhase should be PodRetainPhaseNone, got %v", m.KillJobCalls[0].RetainPhase)
+	}
+	if job.Job.Status.State.Phase != vcbatch.Restarting {
+		t.Errorf("Phase = %q, want Restarting", job.Job.Status.State.Phase)
+	}
+	if job.Job.Status.RetryCount != 3 {
+		t.Errorf("RetryCount = %d, want 3", job.Job.Status.RetryCount)
+	}
+}
+
+func TestRunningState_Execute_RestartTargets(t *testing.T) {
+	targetActions := []busv1alpha1.Action{
+		busv1alpha1.RestartTaskAction,
+		busv1alpha1.RestartPodAction,
+		busv1alpha1.RestartPartitionAction,
+	}
+	for _, action := range targetActions {
+		t.Run(string(action), func(t *testing.T) {
+			m, cleanup := newMock()
+			defer cleanup()
+
+			job := makeJob(vcbatch.Running)
+			target := Target{TaskName: "tx", Type: TargetTypeTask}
+
+			st := NewState(job)
+			if err := st.Execute(Action{Action: action, Target: target}); err != nil {
+				t.Fatalf("Execute err: %v", err)
+			}
+			if len(m.KillTargetCalls) != 1 {
+				t.Errorf("KillTarget calls = %d, want 1", len(m.KillTargetCalls))
+			}
+			if job.Job.Status.State.Phase != vcbatch.Restarting {
+				t.Errorf("Phase = %q, want Restarting", job.Job.Status.State.Phase)
+			}
+			if job.Job.Status.RetryCount != 1 {
+				t.Errorf("RetryCount = %d, want 1", job.Job.Status.RetryCount)
+			}
+		})
+	}
+}
+
+func TestRunningState_Execute_AbortCompleteTerminate(t *testing.T) {
+	tests := []struct {
+		action    busv1alpha1.Action
+		wantPhase vcbatch.JobPhase
+	}{
+		{busv1alpha1.AbortJobAction, vcbatch.Aborting},
+		{busv1alpha1.TerminateJobAction, vcbatch.Terminating},
+		{busv1alpha1.CompleteJobAction, vcbatch.Completing},
+	}
+	for _, tt := range tests {
+		t.Run(string(tt.action), func(t *testing.T) {
+			m, cleanup := newMock()
+			defer cleanup()
+
+			job := makeJob(vcbatch.Running)
+			st := NewState(job)
+			if err := st.Execute(Action{Action: tt.action}); err != nil {
+				t.Fatalf("Execute err: %v", err)
+			}
+			if len(m.KillJobCalls) != 1 {
+				t.Fatalf("KillJob calls = %d, want 1", len(m.KillJobCalls))
+			}
+			if _, ok := m.KillJobCalls[0].RetainPhase[v1.PodSucceeded]; !ok {
+				t.Errorf("RetainPhase should be Soft")
+			}
+			if job.Job.Status.State.Phase != tt.wantPhase {
+				t.Errorf("Phase = %q, want %q", job.Job.Status.State.Phase, tt.wantPhase)
+			}
+		})
+	}
+}
+
+func TestRunningState_Execute_ZeroReplicasKeepsRunning(t *testing.T) {
+	m, cleanup := newMock()
+	defer cleanup()
+
+	job := makeJob(vcbatch.Running)
+	// no tasks -> TotalTasks == 0
+	st := NewState(job)
+	if err := st.Execute(Action{Action: busv1alpha1.SyncJobAction}); err != nil {
+		t.Fatalf("Execute err: %v", err)
+	}
+	if len(m.SyncCalls) != 1 {
+		t.Fatalf("SyncJob calls = %d, want 1", len(m.SyncCalls))
+	}
+	if m.SyncCalls[0].PhaseChanged {
+		t.Errorf("PhaseChanged = true, want false (zero replicas should keep phase)")
+	}
+	if job.Job.Status.State.Phase != vcbatch.Running {
+		t.Errorf("Phase = %q, want unchanged Running", job.Job.Status.State.Phase)
+	}
+}
+
+func TestRunningState_Execute_MinSuccessReachedEarly(t *testing.T) {
+	m, cleanup := newMock()
+	defer cleanup()
+	jobCompletedPhaseCount.Reset()
+
+	min := int32(2)
+	job := makeJob(vcbatch.Running)
+	job.Job.Namespace = "ns"
+	job.Job.Name = "j1"
+	job.Job.Spec.Queue = "q1"
+	job.Job.Spec.MinSuccess = &min
+	job.Job.Spec.Tasks = []vcbatch.TaskSpec{{Name: "t1", Replicas: 5}}
+	job.Job.Status.Succeeded = 3
+
+	st := NewState(job)
+	if err := st.Execute(Action{Action: busv1alpha1.SyncJobAction}); err != nil {
+		t.Fatalf("Execute err: %v", err)
+	}
+	if !m.SyncCalls[0].PhaseChanged {
+		t.Errorf("PhaseChanged = false, want true")
+	}
+	if job.Job.Status.State.Phase != vcbatch.Completed {
+		t.Errorf("Phase = %q, want Completed", job.Job.Status.State.Phase)
+	}
+	if got := testutil.ToFloat64(jobCompletedPhaseCount.WithLabelValues("ns/j1", "q1")); got != 1 {
+		t.Errorf("completed metric = %v, want 1", got)
+	}
+}
+
+func TestRunningState_Execute_AllPodsDone_CompletedBySpecMinAvailable(t *testing.T) {
+	m, cleanup := newMock()
+	defer cleanup()
+	jobCompletedPhaseCount.Reset()
+
+	job := makeJob(vcbatch.Running)
+	job.Job.Namespace = "ns"
+	job.Job.Name = "j1"
+	job.Job.Spec.Queue = "q1"
+	job.Job.Spec.MinAvailable = 2
+	job.Job.Spec.Tasks = []vcbatch.TaskSpec{{Name: "t1", Replicas: 3}}
+	job.Job.Status.Succeeded = 2
+	job.Job.Status.Failed = 1
+
+	st := NewState(job)
+	if err := st.Execute(Action{Action: busv1alpha1.SyncJobAction}); err != nil {
+		t.Fatalf("Execute err: %v", err)
+	}
+	if !m.SyncCalls[0].PhaseChanged {
+		t.Errorf("PhaseChanged = false, want true")
+	}
+	if job.Job.Status.State.Phase != vcbatch.Completed {
+		t.Errorf("Phase = %q, want Completed", job.Job.Status.State.Phase)
+	}
+	if got := testutil.ToFloat64(jobCompletedPhaseCount.WithLabelValues("ns/j1", "q1")); got != 1 {
+		t.Errorf("completed metric = %v, want 1", got)
+	}
+}
+
+func TestRunningState_Execute_AllPodsDone_FailedBecauseUnderMinAvailable(t *testing.T) {
+	_, cleanup := newMock()
+	defer cleanup()
+	jobFailedPhaseCount.Reset()
+
+	job := makeJob(vcbatch.Running)
+	job.Job.Namespace = "ns"
+	job.Job.Name = "j1"
+	job.Job.Spec.Queue = "q1"
+	job.Job.Spec.MinAvailable = 3
+	job.Job.Spec.Tasks = []vcbatch.TaskSpec{{Name: "t1", Replicas: 3}}
+	job.Job.Status.Succeeded = 1
+	job.Job.Status.Failed = 2
+
+	st := NewState(job)
+	if err := st.Execute(Action{Action: busv1alpha1.SyncJobAction}); err != nil {
+		t.Fatalf("Execute err: %v", err)
+	}
+	if job.Job.Status.State.Phase != vcbatch.Failed {
+		t.Errorf("Phase = %q, want Failed", job.Job.Status.State.Phase)
+	}
+	if got := testutil.ToFloat64(jobFailedPhaseCount.WithLabelValues("ns/j1", "q1")); got != 1 {
+		t.Errorf("failed metric = %v, want 1", got)
+	}
+}
+
+func TestRunningState_Execute_AllPodsDone_FailedBecauseTaskMinAvailableUnmet(t *testing.T) {
+	_, cleanup := newMock()
+	defer cleanup()
+	jobFailedPhaseCount.Reset()
+
+	taskMin := int32(2)
+	job := makeJob(vcbatch.Running)
+	job.Job.Namespace = "ns"
+	job.Job.Name = "j1"
+	job.Job.Spec.Queue = "q1"
+	job.Job.Spec.MinAvailable = 3
+	job.Job.Spec.Tasks = []vcbatch.TaskSpec{
+		{Name: "t1", Replicas: 3, MinAvailable: &taskMin},
+	}
+	job.Job.Status.Succeeded = 1
+	job.Job.Status.Failed = 2
+	job.Job.Status.TaskStatusCount = map[string]vcbatch.TaskState{
+		"t1": {Phase: map[v1.PodPhase]int32{v1.PodSucceeded: 1, v1.PodFailed: 2}},
+	}
+
+	st := NewState(job)
+	if err := st.Execute(Action{Action: busv1alpha1.SyncJobAction}); err != nil {
+		t.Fatalf("Execute err: %v", err)
+	}
+	if job.Job.Status.State.Phase != vcbatch.Failed {
+		t.Errorf("Phase = %q, want Failed", job.Job.Status.State.Phase)
+	}
+	if got := testutil.ToFloat64(jobFailedPhaseCount.WithLabelValues("ns/j1", "q1")); got != 1 {
+		t.Errorf("failed metric = %v, want 1", got)
+	}
+}
+
+func TestRunningState_Execute_AllPodsDone_FailedBecauseUnderMinSuccess(t *testing.T) {
+	_, cleanup := newMock()
+	defer cleanup()
+	jobFailedPhaseCount.Reset()
+
+	minSuccess := int32(3)
+	job := makeJob(vcbatch.Running)
+	job.Job.Namespace = "ns"
+	job.Job.Name = "j1"
+	job.Job.Spec.Queue = "q1"
+	job.Job.Spec.MinAvailable = 1
+	job.Job.Spec.MinSuccess = &minSuccess
+	job.Job.Spec.Tasks = []vcbatch.TaskSpec{{Name: "t1", Replicas: 3}}
+	job.Job.Status.Succeeded = 2
+	job.Job.Status.Failed = 1
+
+	st := NewState(job)
+	if err := st.Execute(Action{Action: busv1alpha1.SyncJobAction}); err != nil {
+		t.Fatalf("Execute err: %v", err)
+	}
+	if job.Job.Status.State.Phase != vcbatch.Failed {
+		t.Errorf("Phase = %q, want Failed", job.Job.Status.State.Phase)
+	}
+	if got := testutil.ToFloat64(jobFailedPhaseCount.WithLabelValues("ns/j1", "q1")); got != 1 {
+		t.Errorf("failed metric = %v, want 1", got)
+	}
+}
+
+func TestRunningState_Execute_BackToPendingWhenPendingExceedsThreshold(t *testing.T) {
+	m, cleanup := newMock()
+	defer cleanup()
+
+	job := makeJob(vcbatch.Running)
+	job.Job.Spec.MinAvailable = 3
+	job.Job.Spec.Tasks = []vcbatch.TaskSpec{{Name: "t1", Replicas: 5}}
+	// jobReplicas - MinAvailable = 5 - 3 = 2; Pending(3) > 2 => Pending
+	job.Job.Status.Pending = 3
+
+	st := NewState(job)
+	if err := st.Execute(Action{Action: busv1alpha1.SyncJobAction}); err != nil {
+		t.Fatalf("Execute err: %v", err)
+	}
+	if !m.SyncCalls[0].PhaseChanged {
+		t.Errorf("PhaseChanged = false, want true")
+	}
+	if job.Job.Status.State.Phase != vcbatch.Pending {
+		t.Errorf("Phase = %q, want Pending", job.Job.Status.State.Phase)
+	}
+}
+
+func TestRunningState_Execute_KeepsRunningWhenInFlight(t *testing.T) {
+	m, cleanup := newMock()
+	defer cleanup()
+
+	job := makeJob(vcbatch.Running)
+	job.Job.Spec.MinAvailable = 3
+	job.Job.Spec.Tasks = []vcbatch.TaskSpec{{Name: "t1", Replicas: 5}}
+	// no terminal condition met, pending threshold not crossed
+	job.Job.Status.Running = 3
+	job.Job.Status.Pending = 2 // 2 <= 5-3 = 2
+
+	st := NewState(job)
+	if err := st.Execute(Action{Action: busv1alpha1.SyncJobAction}); err != nil {
+		t.Fatalf("Execute err: %v", err)
+	}
+	if m.SyncCalls[0].PhaseChanged {
+		t.Errorf("PhaseChanged = true, want false")
+	}
+	if job.Job.Status.State.Phase != vcbatch.Running {
+		t.Errorf("Phase = %q, want unchanged Running", job.Job.Status.State.Phase)
+	}
+}
+
+func TestRunningState_Execute_ErrorPropagation(t *testing.T) {
+	cases := []struct {
+		name   string
+		action busv1alpha1.Action
+		setup  func(*mockOps)
+	}{
+		{"kill job err", busv1alpha1.RestartJobAction, func(m *mockOps) { m.KillJobErr = errors.New("e") }},
+		{"kill target err", busv1alpha1.RestartTaskAction, func(m *mockOps) { m.KillTargetErr = errors.New("e") }},
+		{"sync err (default)", busv1alpha1.SyncJobAction, func(m *mockOps) { m.SyncErr = errors.New("e") }},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			m, cleanup := newMock()
+			defer cleanup()
+			c.setup(m)
+
+			st := NewState(makeJob(vcbatch.Running))
+			if err := st.Execute(Action{Action: c.action}); err == nil || err.Error() != "e" {
+				t.Errorf("err = %v, want \"e\"", err)
+			}
+		})
+	}
+}

--- a/pkg/controllers/job/state/terminating_test.go
+++ b/pkg/controllers/job/state/terminating_test.go
@@ -1,0 +1,141 @@
+/*
+Copyright 2024 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package state
+
+import (
+	"errors"
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+
+	vcbatch "volcano.sh/apis/pkg/apis/batch/v1alpha1"
+	busv1alpha1 "volcano.sh/apis/pkg/apis/bus/v1alpha1"
+)
+
+func TestTerminatingState_Execute(t *testing.T) {
+	tests := []struct {
+		name          string
+		initialStatus vcbatch.JobStatus
+		wantPhase     vcbatch.JobPhase
+		wantChanged   bool
+	}{
+		{
+			name: "all pods drained -> Terminated",
+			initialStatus: vcbatch.JobStatus{
+				State: vcbatch.JobState{Phase: vcbatch.Terminating},
+			},
+			wantPhase:   vcbatch.Terminated,
+			wantChanged: true,
+		},
+		{
+			name: "still has Running pods -> stays Terminating",
+			initialStatus: vcbatch.JobStatus{
+				Running: 2,
+				State:   vcbatch.JobState{Phase: vcbatch.Terminating},
+			},
+			wantPhase:   vcbatch.Terminating,
+			wantChanged: false,
+		},
+		{
+			name: "still has Pending pods -> stays Terminating",
+			initialStatus: vcbatch.JobStatus{
+				Pending: 1,
+				State:   vcbatch.JobState{Phase: vcbatch.Terminating},
+			},
+			wantPhase:   vcbatch.Terminating,
+			wantChanged: false,
+		},
+		{
+			name: "still has Terminating pods -> stays Terminating",
+			initialStatus: vcbatch.JobStatus{
+				Terminating: 3,
+				State:       vcbatch.JobState{Phase: vcbatch.Terminating},
+			},
+			wantPhase:   vcbatch.Terminating,
+			wantChanged: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m, cleanup := newMock()
+			defer cleanup()
+
+			job := makeJob(vcbatch.Terminating)
+			job.Job.Status = tt.initialStatus
+
+			st := NewState(job)
+			if err := st.Execute(Action{Action: busv1alpha1.SyncJobAction}); err != nil {
+				t.Fatalf("Execute err: %v", err)
+			}
+
+			if len(m.KillJobCalls) != 1 {
+				t.Fatalf("KillJob calls = %d, want 1", len(m.KillJobCalls))
+			}
+			call := m.KillJobCalls[0]
+			if _, ok := call.RetainPhase[v1.PodSucceeded]; !ok {
+				t.Errorf("RetainPhase missing PodSucceeded")
+			}
+			if _, ok := call.RetainPhase[v1.PodFailed]; !ok {
+				t.Errorf("RetainPhase missing PodFailed")
+			}
+			if !call.HadStatusFn {
+				t.Errorf("UpdateStatusFn should be non-nil (drain logic lives in it)")
+			}
+			if call.PhaseChanged != tt.wantChanged {
+				t.Errorf("PhaseChanged = %v, want %v", call.PhaseChanged, tt.wantChanged)
+			}
+			if job.Job.Status.State.Phase != tt.wantPhase {
+				t.Errorf("Phase = %q, want %q", job.Job.Status.State.Phase, tt.wantPhase)
+			}
+		})
+	}
+}
+
+func TestTerminatingState_Execute_ActionIsIgnored(t *testing.T) {
+	actions := []busv1alpha1.Action{
+		busv1alpha1.SyncJobAction,
+		busv1alpha1.ResumeJobAction,
+		busv1alpha1.RestartJobAction,
+		busv1alpha1.AbortJobAction,
+	}
+	for _, action := range actions {
+		t.Run(string(action), func(t *testing.T) {
+			m, cleanup := newMock()
+			defer cleanup()
+
+			st := NewState(makeJob(vcbatch.Terminating))
+			if err := st.Execute(Action{Action: action}); err != nil {
+				t.Fatalf("Execute err: %v", err)
+			}
+			if len(m.KillJobCalls) != 1 {
+				t.Errorf("KillJob calls = %d, want 1 for %q", len(m.KillJobCalls), action)
+			}
+		})
+	}
+}
+
+func TestTerminatingState_Execute_PropagatesError(t *testing.T) {
+	m, cleanup := newMock()
+	defer cleanup()
+	m.KillJobErr = errors.New("kill failed")
+
+	st := NewState(makeJob(vcbatch.Terminating))
+	if err := st.Execute(Action{Action: busv1alpha1.SyncJobAction}); err == nil || err.Error() != "kill failed" {
+		t.Errorf("err = %v, want \"kill failed\"", err)
+	}
+}

--- a/pkg/controllers/job/state/util_test.go
+++ b/pkg/controllers/job/state/util_test.go
@@ -1,0 +1,116 @@
+/*
+Copyright 2024 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package state
+
+import (
+	"testing"
+
+	vcbatch "volcano.sh/apis/pkg/apis/batch/v1alpha1"
+)
+
+func int32Ptr(i int32) *int32 { return &i }
+
+func TestTotalTasks(t *testing.T) {
+	tests := []struct {
+		name string
+		job  *vcbatch.Job
+		want int32
+	}{
+		{
+			name: "no tasks",
+			job:  &vcbatch.Job{Spec: vcbatch.JobSpec{}},
+			want: 0,
+		},
+		{
+			name: "single task with replicas",
+			job: &vcbatch.Job{Spec: vcbatch.JobSpec{
+				Tasks: []vcbatch.TaskSpec{{Name: "t1", Replicas: 3}},
+			}},
+			want: 3,
+		},
+		{
+			name: "multiple tasks summed",
+			job: &vcbatch.Job{Spec: vcbatch.JobSpec{
+				Tasks: []vcbatch.TaskSpec{
+					{Name: "t1", Replicas: 2},
+					{Name: "t2", Replicas: 5},
+					{Name: "t3", Replicas: 0},
+				},
+			}},
+			want: 7,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := TotalTasks(tt.job); got != tt.want {
+				t.Errorf("TotalTasks() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTotalTaskMinAvailable(t *testing.T) {
+	tests := []struct {
+		name string
+		job  *vcbatch.Job
+		want int32
+	}{
+		{
+			name: "no tasks",
+			job:  &vcbatch.Job{Spec: vcbatch.JobSpec{}},
+			want: 0,
+		},
+		{
+			name: "all tasks have MinAvailable set",
+			job: &vcbatch.Job{Spec: vcbatch.JobSpec{
+				Tasks: []vcbatch.TaskSpec{
+					{Name: "t1", Replicas: 5, MinAvailable: int32Ptr(2)},
+					{Name: "t2", Replicas: 4, MinAvailable: int32Ptr(3)},
+				},
+			}},
+			want: 5,
+		},
+		{
+			name: "MinAvailable nil falls back to Replicas",
+			job: &vcbatch.Job{Spec: vcbatch.JobSpec{
+				Tasks: []vcbatch.TaskSpec{
+					{Name: "t1", Replicas: 4, MinAvailable: nil},
+					{Name: "t2", Replicas: 2, MinAvailable: int32Ptr(1)},
+				},
+			}},
+			want: 5,
+		},
+		{
+			name: "MinAvailable zero is respected (not Replicas fallback)",
+			job: &vcbatch.Job{Spec: vcbatch.JobSpec{
+				Tasks: []vcbatch.TaskSpec{
+					{Name: "t1", Replicas: 4, MinAvailable: int32Ptr(0)},
+				},
+			}},
+			want: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := TotalTaskMinAvailable(tt.job); got != tt.want {
+				t.Errorf("TotalTaskMinAvailable() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
  Add unit tests for `pkg/controllers/job/state/` package, which previously
  had 0% test coverage. This package implements the Volcano Job lifecycle
  state machine (Pending → Running → Completing/Terminating/Aborting/
  Restarting → terminal states).

## Changes
  | File | Test File | Coverage |
  |---|---|---|
  | util.go | util_test.go | 100% |
  | metrics.go | metrics_test.go | 100% |
  | mock.go | mock_test.go | 100% |
  | factory.go | factory_test.go | 100% |
  | finished.go | finished_test.go | 100% |
  | terminating.go | terminating_test.go | 100% |
  | completing.go | completing_test.go | 100% |
  | aborted.go | aborted_test.go | 100% |
  | aborting.go | aborting_test.go | 100% |
  | pending.go | pending_test.go | 100% |
  | restarting.go | restarting_test.go | 100% |
  | running.go | running_test.go | 100% |

## Test Coverage
  Before: `0.0%`
  After:  `100.0%` (pkg/controllers/job/state)

  ## How to Verify
  go test ./pkg/controllers/job/state/... -v -coverprofile=cover.out
  go tool cover -func=cover.out