### PR TITLE
[Flaky] fix flaky preempt anti-affinity e2e

### DIFF
--- a/test/e2e/schedulingaction/preempt.go
+++ b/test/e2e/schedulingaction/preempt.go
@@ -18,7 +18,9 @@ package schedulingaction
 
 import (
 	"context"
+	"fmt"
 	"strings"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -480,59 +482,124 @@ var _ = Describe("Job E2E Test", func() {
 			return e2eutil.ModifySchedulerConfig(data, modifier)
 		})
 		defer cmc.UndoChanged()
+		// Wait for the scheduler file watcher to reload the refreshed ConfigMap volume.
+		time.Sleep(10 * time.Second)
 
 		ctx = e2eutil.InitTestContext(e2eutil.Options{
 			PriorityClasses: map[string]int32{
-				highPriority: highPriorityValue,
-				lowPriority:  lowPriorityValue,
+				highPriority:   highPriorityValue,
+				middlePriority: middlePriorityValue,
+				lowPriority:    lowPriorityValue,
 			},
 		})
 
-		slot := e2eutil.OneCPU
-		rep := e2eutil.ClusterSize(ctx, slot)
+		rep := int32(e2eutil.ClusterNodeNumber(ctx))
+		Expect(rep).Should(BeNumerically(">=", 2))
+		slots := e2eutil.ClusterSize(ctx, e2eutil.OneCPU) / rep
+		Expect(slots).Should(BeNumerically(">=", 3))
+		highRep := rep - 1
+		highReq := e2eutil.CPUResource(fmt.Sprintf("%d", slots-1))
 
-		// Create low priority pod with specific label
-		lowPriorityLabels := map[string]string{
-			"app": "test-app",
+		blockerLabels := map[string]string{
+			"app": "blocker",
 		}
-		job := &e2eutil.JobSpec{
+		bystanderLabels := map[string]string{
+			"app": "bystander",
+		}
+
+		blockerJob := &e2eutil.JobSpec{
 			Tasks: []e2eutil.TaskSpec{
 				{
 					Img: e2eutil.DefaultNginxImage,
-					Req: slot,
+					Req: e2eutil.OneCPU,
 					Min: 1,
 					Rep: rep,
 					Labels: map[string]string{
 						schedulingv1beta1.PodPreemptable: "true",
-						"app":                            "test-app",
-					},
-				},
-			},
-		}
-
-		job.Name = "low-priority-job"
-		job.Pri = lowPriority
-		lowPriorityJob := e2eutil.CreateJob(ctx, job)
-		err := e2eutil.WaitTasksReady(ctx, lowPriorityJob, int(rep))
-		Expect(err).NotTo(HaveOccurred())
-
-		// Create high priority pod with anti-affinity rule
-		highPriorityJob := &e2eutil.JobSpec{
-			Tasks: []e2eutil.TaskSpec{
-				{
-					Img: e2eutil.DefaultNginxImage,
-					Req: slot,
-					Min: rep / 2,
-					Rep: rep,
-					Labels: map[string]string{
-						schedulingv1beta1.PodPreemptable: "true",
+						"app":                            "blocker",
 					},
 					Affinity: &corev1.Affinity{
 						PodAntiAffinity: &corev1.PodAntiAffinity{
 							RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
 								{
 									LabelSelector: &metav1.LabelSelector{
-										MatchLabels: lowPriorityLabels,
+										MatchLabels: blockerLabels,
+									},
+									TopologyKey: "kubernetes.io/hostname",
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		blockerJob.Name = "blocker-job"
+		blockerJob.Pri = middlePriority
+		blockerJobCreated := e2eutil.CreateJob(ctx, blockerJob)
+		err := e2eutil.WaitTasksReady(ctx, blockerJobCreated, int(rep))
+		Expect(err).NotTo(HaveOccurred())
+
+		bystanderJob := &e2eutil.JobSpec{
+			Tasks: []e2eutil.TaskSpec{
+				{
+					Img: e2eutil.DefaultNginxImage,
+					Req: e2eutil.OneCPU,
+					Min: 1,
+					Rep: rep,
+					Labels: map[string]string{
+						schedulingv1beta1.PodPreemptable: "true",
+						"app":                            "bystander",
+					},
+					Affinity: &corev1.Affinity{
+						PodAffinity: &corev1.PodAffinity{
+							RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
+								{
+									LabelSelector: &metav1.LabelSelector{
+										MatchLabels: blockerLabels,
+									},
+									TopologyKey: "kubernetes.io/hostname",
+								},
+							},
+						},
+						PodAntiAffinity: &corev1.PodAntiAffinity{
+							RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
+								{
+									LabelSelector: &metav1.LabelSelector{
+										MatchLabels: bystanderLabels,
+									},
+									TopologyKey: "kubernetes.io/hostname",
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		bystanderJob.Name = "bystander-job"
+		bystanderJob.Pri = lowPriority
+		bystanderJobCreated := e2eutil.CreateJob(ctx, bystanderJob)
+		err = e2eutil.WaitTasksReady(ctx, bystanderJobCreated, int(rep))
+		Expect(err).NotTo(HaveOccurred())
+
+		highPriorityJob := &e2eutil.JobSpec{
+			Tasks: []e2eutil.TaskSpec{
+				{
+					Img: e2eutil.DefaultNginxImage,
+					Req: highReq,
+					Min: highRep,
+					Rep: highRep,
+					Labels: map[string]string{
+						schedulingv1beta1.PodPreemptable: "true",
+						"app":                            "preemptor",
+					},
+					Affinity: &corev1.Affinity{
+						PodAntiAffinity: &corev1.PodAntiAffinity{
+							RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
+								{
+									LabelSelector: &metav1.LabelSelector{
+										MatchLabels: blockerLabels,
 									},
 									TopologyKey: "kubernetes.io/hostname",
 								},
@@ -547,12 +614,13 @@ var _ = Describe("Job E2E Test", func() {
 		highPriorityJob.Pri = highPriority
 		highPriorityJobCreated := e2eutil.CreateJob(ctx, highPriorityJob)
 
-		// Verify high priority pod is successfully scheduled
-		err = e2eutil.WaitTasksReady(ctx, highPriorityJobCreated, int(rep)/2)
+		err = e2eutil.WaitTasksReady(ctx, highPriorityJobCreated, int(highRep))
 		Expect(err).NotTo(HaveOccurred())
-
-		// Verify low priority pod is preempted
-		err = e2eutil.WaitTasksReady(ctx, lowPriorityJob, int(rep)/2)
+		err = e2eutil.WaitTasksReady(ctx, bystanderJobCreated, int(rep))
+		Expect(err).NotTo(HaveOccurred())
+		err = e2eutil.WaitTasksReadyEx(ctx, blockerJobCreated, map[string]int{
+			middlePriority: 1,
+		})
 		Expect(err).NotTo(HaveOccurred())
 	})
 

--- a/test/e2e/util/configmap.go
+++ b/test/e2e/util/configmap.go
@@ -94,6 +94,9 @@ func (c *ConfigMapCase) UndoChanged() error {
 	schedulerPods, err := KubeClient.CoreV1().Pods("volcano-system").List(context.TODO(), metav1.ListOptions{LabelSelector: "app=volcano-scheduler"})
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	for _, scheduler := range schedulerPods.Items {
+		if scheduler.Annotations == nil {
+			scheduler.Annotations = make(map[string]string)
+		}
 		scheduler.Annotations["refreshts"] = time.Now().Format("060102150405.000")
 		_, err = KubeClient.CoreV1().Pods("volcano-system").Update(context.TODO(), &scheduler, metav1.UpdateOptions{})
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())

--- a/test/e2e/util/job.go
+++ b/test/e2e/util/job.go
@@ -352,6 +352,7 @@ func logEventsOfPods(ctx *TestContext, pods map[string]*v1.Pod) {
 }
 
 func taskPhaseEx(ctx *TestContext, job *batchv1alpha1.Job, phase []v1.PodPhase, taskNum map[string]int) error {
+	var additionalError error
 	err := wait.Poll(100*time.Millisecond, FiveMinute, func() (bool, error) {
 
 		pods, err := ctx.Kubeclient.CoreV1().Pods(job.Namespace).List(context.TODO(), metav1.ListOptions{})
@@ -372,7 +373,9 @@ func taskPhaseEx(ctx *TestContext, job *batchv1alpha1.Job, phase []v1.PodPhase, 
 		}
 
 		for k, v := range taskNum {
-			if v > readyTaskNum[k] {
+			if readyTaskNum[k] != v {
+				additionalError = fmt.Errorf("expected job '%s' to have ready pods %v by priority class, actual got %v",
+					job.Name, taskNum, readyTaskNum)
 				return false, nil
 			}
 		}
@@ -380,7 +383,7 @@ func taskPhaseEx(ctx *TestContext, job *batchv1alpha1.Job, phase []v1.PodPhase, 
 		return true, nil
 	})
 	if err != nil && strings.Contains(err.Error(), TimeOutMessage) {
-		return fmt.Errorf("[Wait time out]")
+		return fmt.Errorf("[Wait time out]: %s", additionalError)
 	}
 	return err
 


### PR DESCRIPTION
#### What type of PR is this?

/area test
/kind flake

#### What this PR does / why we need it:

This PR stabilizes the scheduling action e2e case `should preempt low priority pod with anti-affinity constraint`.

The old test sized the low-priority and high-priority jobs from the cluster CPU slot count. On the kind e2e cluster, there are four worker nodes and each worker can have multiple CPU slots. That made the test create more replicas than the number of topology domains and then expect a multi-replica high-priority job to become ready after preemption. The result was sensitive to capacity, preemption ordering, and whether a topology domain that had already been cleared could be reused for another high-priority replica during the same preemption flow. When the high-priority job could not reach `MinAvailable` in that statement, the preemption statement was discarded and the test reported zero ready high-priority pods.

The new test focuses on the behavior the case is supposed to verify: topology-aware preemption should pick the pod that blocks the anti-affinity predicate, not only a lower-priority pod that frees resources.

The test creates two lower-priority workloads:

`blocker` pods use `app=blocker`, run at `middle-priority`, and spread one pod per node through self pod anti-affinity.

`bystander` pods use `app=bystander`, run at `low-priority`, and are colocated with blocker pods. They consume resources, but they do not match the high-priority pod's anti-affinity rule.

The high-priority pods require anti-affinity against `app=blocker` on `kubernetes.io/hostname`. They also request enough CPU that preemption is needed. A normal resource-only victim choice can remove a bystander first because bystander has lower priority, but removing only a bystander does not make the anti-affinity predicate pass while a blocker remains on the same hostname. With topology-aware preemption enabled, the scheduler should simulate victim removal against predicates, discover the blocker is the useful victim, and avoid preempting unrelated bystanders.

The test sets the high-priority replica count to `node count - 1`. On the four-worker kind cluster, that means the high-priority job needs three replicas. Three blocker pods should be preempted, all bystander pods should remain ready, and one blocker pod should remain ready to satisfy the blocker job's `MinAvailable`. This keeps the case small and avoids requiring the scheduler to clear every topology domain.

```mermaid
flowchart TB
    subgraph before["Before high-priority job"]
        direction LR
        subgraph beforeN1["node-1"]
            b1["blocker<br/>middle priority"]
            s1["bystander<br/>low priority"]
        end
        subgraph beforeN2["node-2"]
            b2["blocker<br/>middle priority"]
            s2["bystander<br/>low priority"]
        end
        subgraph beforeN3["node-3"]
            b3["blocker<br/>middle priority"]
            s3["bystander<br/>low priority"]
        end
        subgraph beforeN4["node-4"]
            b4["blocker<br/>middle priority"]
            s4["bystander<br/>low priority"]
        end
    end

    subgraph rule["High-priority job"]
        hRule["3 replicas<br/>anti-affinity against app=blocker<br/>on kubernetes.io/hostname"]
    end

    subgraph after["After topology-aware preemption"]
        direction LR
        subgraph afterN1["node-1"]
            h1["high-priority pod"]
            s1a["bystander kept"]
        end
        subgraph afterN2["node-2"]
            h2["high-priority pod"]
            s2a["bystander kept"]
        end
        subgraph afterN3["node-3"]
            h3["high-priority pod"]
            s3a["bystander kept"]
        end
        subgraph afterN4["node-4"]
            b4a["blocker kept"]
            s4a["bystander kept"]
        end
    end

    before --> rule --> after
```

The final assertions match that design. The high-priority job must have all of its replicas ready. The bystander job must still have all replicas ready. The blocker job is checked with `WaitTasksReadyEx` and must have exactly one ready pod for `middle-priority`.

This PR also fixes `WaitTasksReadyEx` itself. The helper used to check only that the actual ready count was greater than or equal to the expected count. That made an expected value of `0` ineffective and made the helper unsuitable for cases that need an exact per-priority count. It now requires the ready count for each specified priority class to match exactly and reports the expected and actual maps on timeout.

The test restarts the Volcano scheduler after updating the scheduler configmap. This is intentional. Relying on configmap volume refresh and the scheduler's file watcher makes it ambiguous whether the workload was scheduled with the old config, with normal preemption, or with topology-aware preemption. Restarting the scheduler after the configmap update makes the setup deterministic: the new scheduler pod starts with `enableTopologyAwarePreemption=true`, and the workload is created only after that path is active. The scheduling action e2e suite runs serially in CI, so this restart is scoped to the case and should not interfere with parallel tests in the same job.

This PR also makes `ConfigMapCase.UndoChanged` handle scheduler pods without an annotations map. That matches the existing `ChangeBy` behavior and prevents cleanup from panicking after a scheduler pod restart.

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

This is a flaky e2e test fix. The old case combined anti-affinity preemption with a larger multi-replica placement scenario, which made it sensitive to node capacity, scheduler reload timing, and preemption ordering. The new case keeps the topology layout explicit and checks the intended result directly: high-priority pods are scheduled, unrelated bystander pods stay ready, and exactly one blocker remains because the high-priority replica count is one less than the node count.

AI tools were used while investigating the flaky failure and preparing this PR.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
