### PR TITLE
poc(namespacequeue): NamespaceQueue CRD + shadow Queue controller

### DIFF
--- a/pkg/controllers/namespacequeue/namespacequeue_controller.go
+++ b/pkg/controllers/namespacequeue/namespacequeue_controller.go
@@ -1,0 +1,328 @@
+/*
+Copyright 2025 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package namespacequeue implements the NamespaceQueue controller.
+//
+// Design: each NamespaceQueue object is reconciled into a cluster-scoped shadow Queue
+// (via buildShadowQueue in shadow_queue.go) so the Volcano scheduler can pick it up
+// through the existing Queue informer without any scheduler-side changes. The shadow
+// Queue name is deterministic (shadowQueueName), enabling idempotent reconciliation.
+//
+// Pre-codegen note: the controller uses a dynamic informer for NamespaceQueue objects
+// because the generated lister/informer for this new type does not exist yet. After
+// running `make generate-code`, replace the dynamic informer with the generated one:
+//
+//	factory.Scheduling().V1beta1().NamespaceQueues()
+package namespacequeue
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/dynamic/dynamicinformer"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+	"k8s.io/klog/v2"
+
+	schedulingv1beta1 "volcano.sh/apis/pkg/apis/scheduling/v1beta1"
+	vcclientset "volcano.sh/apis/pkg/client/clientset/versioned"
+	"volcano.sh/volcano/pkg/controllers/framework"
+)
+
+const (
+	controllerName = "namespacequeue-controller"
+	workers        = 2
+)
+
+// namespaceQueueGVR is the GroupVersionResource used with the dynamic client.
+// It is replaced by the generated typed informer after `make generate-code`.
+var namespaceQueueGVR = schema.GroupVersionResource{
+	Group:    schedulingv1beta1.GroupName,
+	Version:  schedulingv1beta1.GroupVersion,
+	Resource: "namespacequeues",
+}
+
+func init() {
+	// Registers the controller with the volcano controller-manager framework.
+	// The manager will call Initialize then Run when it starts.
+	// To activate, add a blank import of this package in cmd/controller-manager/main.go.
+	if err := framework.RegisterController(&namespaceQueueController{}); err != nil {
+		klog.Fatalf("Failed to register %s: %v", controllerName, err)
+	}
+}
+
+// namespaceQueueController watches NamespaceQueue objects (via dynamic informer,
+// pre-codegen) and reconciles each one into a cluster-scoped shadow Queue so that
+// the Volcano scheduler can schedule PodGroups against it without modification.
+type namespaceQueueController struct {
+	vcClient      vcclientset.Interface
+	dynamicClient dynamic.Interface
+
+	dynInformerFactory dynamicinformer.DynamicSharedInformerFactory
+	nsqSynced          cache.InformerSynced
+
+	queue workqueue.TypedRateLimitingInterface[string]
+}
+
+// Name implements framework.Controller.
+func (c *namespaceQueueController) Name() string { return controllerName }
+
+// Initialize implements framework.Controller. It wires up informers and the work queue.
+func (c *namespaceQueueController) Initialize(opt *framework.ControllerOption) error {
+	if opt.Config == nil {
+		return fmt.Errorf("%s: ControllerOption.Config is nil; cannot build dynamic client", controllerName)
+	}
+
+	dynamicClient, err := dynamic.NewForConfig(opt.Config)
+	if err != nil {
+		return fmt.Errorf("%s: failed to create dynamic client: %w", controllerName, err)
+	}
+	c.dynamicClient = dynamicClient
+	c.vcClient = opt.VolcanoClient
+
+	// Dynamic informer for NamespaceQueue.
+	// TODO(lfx): replace with factory.Scheduling().V1beta1().NamespaceQueues() after
+	//            running `make generate-code` to produce the typed lister/informer.
+	c.dynInformerFactory = dynamicinformer.NewDynamicSharedInformerFactory(dynamicClient, 0)
+	nsqInformer := c.dynInformerFactory.ForResource(namespaceQueueGVR)
+
+	_, err = nsqInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			key, err := cache.MetaNamespaceKeyFunc(obj)
+			if err == nil {
+				c.queue.Add(key)
+			}
+		},
+		UpdateFunc: func(_, newObj interface{}) {
+			key, err := cache.MetaNamespaceKeyFunc(newObj)
+			if err == nil {
+				c.queue.Add(key)
+			}
+		},
+		DeleteFunc: func(obj interface{}) {
+			// DeletionHandlingMetaNamespaceKeyFunc handles tombstone objects correctly.
+			key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
+			if err == nil {
+				c.queue.Add(key)
+			}
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("%s: failed to add event handler: %w", controllerName, err)
+	}
+
+	c.nsqSynced = nsqInformer.Informer().HasSynced
+	c.queue = workqueue.NewTypedRateLimitingQueue(
+		workqueue.DefaultTypedControllerRateLimiter[string](),
+	)
+	return nil
+}
+
+// Run implements framework.Controller. It blocks until stopCh is closed.
+func (c *namespaceQueueController) Run(stopCh <-chan struct{}) {
+	defer utilruntime.HandleCrash()
+	defer c.queue.ShutDown()
+
+	klog.Infof("Starting %s", controllerName)
+	defer klog.Infof("Shutting down %s", controllerName)
+
+	c.dynInformerFactory.Start(stopCh)
+
+	if !cache.WaitForCacheSync(stopCh, c.nsqSynced) {
+		klog.Errorf("%s: timed out waiting for caches to sync", controllerName)
+		return
+	}
+
+	for i := 0; i < workers; i++ {
+		go wait.Until(c.runWorker, time.Second, stopCh)
+	}
+
+	<-stopCh
+}
+
+func (c *namespaceQueueController) runWorker() {
+	for c.processNextItem() {
+	}
+}
+
+func (c *namespaceQueueController) processNextItem() bool {
+	key, shutdown := c.queue.Get()
+	if shutdown {
+		return false
+	}
+	defer c.queue.Done(key)
+
+	if err := c.reconcile(key); err != nil {
+		klog.Errorf("%s: error reconciling %q: %v", controllerName, key, err)
+		c.queue.AddRateLimited(key)
+		return true
+	}
+	c.queue.Forget(key)
+	return true
+}
+
+// reconcile is the core reconciliation function. For a given namespace/name key it:
+//  1. Fetches the NamespaceQueue via the dynamic client.
+//  2. If not found, deletes the corresponding shadow Queue (GC path).
+//  3. Otherwise, constructs the desired shadow Queue via buildShadowQueue and
+//     creates or updates it in the cluster so the scheduler can see it.
+//
+// The shadow Queue name is derived by shadowQueueName, which is deterministic and
+// based on a hash of namespace+name, guaranteeing idempotency.
+func (c *namespaceQueueController) reconcile(key string) error {
+	ctx := context.TODO()
+	namespace, name, err := cache.SplitMetaNamespaceKey(key)
+	if err != nil {
+		return fmt.Errorf("invalid key %q: %w", key, err)
+	}
+
+	// 1. Fetch NamespaceQueue via dynamic client.
+	unstrObj, err := c.dynamicClient.Resource(namespaceQueueGVR).Namespace(namespace).Get(ctx, name, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		// NamespaceQueue was deleted — clean up the shadow Queue.
+		return c.deleteShadowQueue(ctx, namespace, name)
+	}
+	if err != nil {
+		return fmt.Errorf("get NamespaceQueue %s: %w", key, err)
+	}
+
+	// 2. Convert unstructured → typed NamespaceQueue.
+	nsq := &schedulingv1beta1.NamespaceQueue{}
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(unstrObj.Object, nsq); err != nil {
+		return fmt.Errorf("convert NamespaceQueue %s: %w", key, err)
+	}
+
+	// 3. Build the desired shadow Queue from the NamespaceQueue spec.
+	desired := buildShadowQueue(nsq)
+
+	// 4. Create or update the shadow Queue.
+	existing, err := c.vcClient.SchedulingV1beta1().Queues().Get(ctx, desired.Name, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		klog.V(4).Infof("%s: creating shadow Queue %q for NamespaceQueue %s", controllerName, desired.Name, key)
+		if _, err := c.vcClient.SchedulingV1beta1().Queues().Create(ctx, desired, metav1.CreateOptions{
+			FieldManager: controllerName,
+		}); err != nil {
+			return fmt.Errorf("create shadow Queue %q: %w", desired.Name, err)
+		}
+		return c.updateStatus(ctx, nsq, desired.Name)
+	}
+	if err != nil {
+		return fmt.Errorf("get shadow Queue %q: %w", desired.Name, err)
+	}
+
+	// 5. Update only when spec has drifted (e.g. tenant changed Capability).
+	if shadowQueueSpecChanged(existing, desired) {
+		klog.V(4).Infof("%s: updating shadow Queue %q for NamespaceQueue %s", controllerName, desired.Name, key)
+		updated := existing.DeepCopy()
+		updated.Spec = desired.Spec
+		if _, err := c.vcClient.SchedulingV1beta1().Queues().Update(ctx, updated, metav1.UpdateOptions{
+			FieldManager: controllerName,
+		}); err != nil {
+			return fmt.Errorf("update shadow Queue %q: %w", desired.Name, err)
+		}
+	}
+
+	return c.updateStatus(ctx, nsq, desired.Name)
+}
+
+// deleteShadowQueue removes the cluster-scoped shadow Queue when the NamespaceQueue
+// that owns it has been deleted. We cannot use an OwnerReference for automatic GC
+// because Kubernetes forbids cross-namespace ownership (namespaced → cluster-scoped).
+// Instead, the controller explicitly deletes by the deterministic shadow Queue name.
+func (c *namespaceQueueController) deleteShadowQueue(ctx context.Context, namespace, name string) error {
+	shadowName := shadowQueueName(namespace, name)
+	klog.V(4).Infof("%s: deleting shadow Queue %q (NamespaceQueue %s/%s deleted)", controllerName, shadowName, namespace, name)
+	err := c.vcClient.SchedulingV1beta1().Queues().Delete(ctx, shadowName, metav1.DeleteOptions{})
+	if apierrors.IsNotFound(err) {
+		return nil // already gone
+	}
+	return err
+}
+
+// updateStatus patches the NamespaceQueue status with the shadow Queue name and
+// mirrors the shadow Queue's current state (Open/Closed/Closing) back to the tenant.
+// This gives tenants full observability without requiring access to cluster resources.
+func (c *namespaceQueueController) updateStatus(ctx context.Context, nsq *schedulingv1beta1.NamespaceQueue, shadowName string) error {
+	shadowQueue, err := c.vcClient.SchedulingV1beta1().Queues().Get(ctx, shadowName, metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		return err
+	}
+
+	patch := map[string]interface{}{
+		"status": map[string]interface{}{
+			"shadowQueueName": shadowName,
+			"state":           string(shadowQueue.Status.State),
+			"pending":         shadowQueue.Status.Pending,
+			"running":         shadowQueue.Status.Running,
+			"inqueue":         shadowQueue.Status.Inqueue,
+			"completed":       shadowQueue.Status.Completed,
+			"unknown":         shadowQueue.Status.Unknown,
+		},
+	}
+	patchBytes, err := json.Marshal(patch)
+	if err != nil {
+		return err
+	}
+
+	_, err = c.dynamicClient.Resource(namespaceQueueGVR).Namespace(nsq.Namespace).
+		Patch(ctx, nsq.Name, "application/merge-patch+json", patchBytes,
+			metav1.PatchOptions{FieldManager: controllerName}, "status")
+	return err
+}
+
+// OrphanedShadowQueues returns shadow Queues whose owning NamespaceQueue no longer
+// exists. This is a diagnostic helper; the reconciler's delete path handles normal GC.
+// Call this from a maintenance routine if orphans accumulate (e.g., after a controller restart).
+func (c *namespaceQueueController) OrphanedShadowQueues(ctx context.Context) ([]*schedulingv1beta1.Queue, error) {
+	allShadow, err := c.vcClient.SchedulingV1beta1().Queues().List(ctx, metav1.ListOptions{
+		LabelSelector: labels.SelectorFromSet(labels.Set{ManagedByLabelKey: ManagedByLabelVal}).String(),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var orphans []*schedulingv1beta1.Queue
+	for i := range allShadow.Items {
+		q := &allShadow.Items[i]
+		ref, ok := q.Annotations[NSQRefAnnotationKey]
+		if !ok {
+			continue
+		}
+		// ref = "namespace/name"
+		ns, name, err := cache.SplitMetaNamespaceKey(ref)
+		if err != nil {
+			continue
+		}
+		_, err = c.dynamicClient.Resource(namespaceQueueGVR).Namespace(ns).Get(ctx, name, metav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			orphans = append(orphans, q)
+		}
+	}
+	return orphans, nil
+}

--- a/pkg/controllers/namespacequeue/namespacequeue_controller.go
+++ b/pkg/controllers/namespacequeue/namespacequeue_controller.go
@@ -85,6 +85,11 @@ type namespaceQueueController struct {
 	nsqSynced          cache.InformerSynced
 
 	queue workqueue.TypedRateLimitingInterface[string]
+
+	// ctx is derived from the stopCh passed to Run so that all API calls respect
+	// the controller lifecycle and are cancelled cleanly on shutdown.
+	ctx    context.Context
+	cancel context.CancelFunc
 }
 
 // Name implements framework.Controller.
@@ -149,6 +154,14 @@ func (c *namespaceQueueController) Run(stopCh <-chan struct{}) {
 	klog.Infof("Starting %s", controllerName)
 	defer klog.Infof("Shutting down %s", controllerName)
 
+	// Derive a context that is cancelled when the controller stops, so all
+	// in-flight API calls are cleaned up properly on shutdown.
+	c.ctx, c.cancel = context.WithCancel(context.Background())
+	go func() {
+		<-stopCh
+		c.cancel()
+	}()
+
 	c.dynInformerFactory.Start(stopCh)
 
 	if !cache.WaitForCacheSync(stopCh, c.nsqSynced) {
@@ -193,7 +206,7 @@ func (c *namespaceQueueController) processNextItem() bool {
 // The shadow Queue name is derived by shadowQueueName, which is deterministic and
 // based on a hash of namespace+name, guaranteeing idempotency.
 func (c *namespaceQueueController) reconcile(key string) error {
-	ctx := context.TODO()
+	ctx := c.ctx
 	namespace, name, err := cache.SplitMetaNamespaceKey(key)
 	if err != nil {
 		return fmt.Errorf("invalid key %q: %w", key, err)
@@ -278,6 +291,7 @@ func (c *namespaceQueueController) updateStatus(ctx context.Context, nsq *schedu
 		"status": map[string]interface{}{
 			"shadowQueueName": shadowName,
 			"state":           string(shadowQueue.Status.State),
+			"allocated":       shadowQueue.Status.Allocated,
 			"pending":         shadowQueue.Status.Pending,
 			"running":         shadowQueue.Status.Running,
 			"inqueue":         shadowQueue.Status.Inqueue,

--- a/pkg/controllers/namespacequeue/shadow_queue.go
+++ b/pkg/controllers/namespacequeue/shadow_queue.go
@@ -203,4 +203,3 @@ func reclaimableEqual(a, b *bool) bool {
 	}
 	return *a == *b
 }
-

--- a/pkg/controllers/namespacequeue/shadow_queue.go
+++ b/pkg/controllers/namespacequeue/shadow_queue.go
@@ -19,8 +19,8 @@ package namespacequeue
 import (
 	"crypto/sha256"
 	"fmt"
-	"reflect"
 
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	schedulingv1beta1 "volcano.sh/apis/pkg/apis/scheduling/v1beta1"
@@ -144,8 +144,63 @@ func buildShadowQueue(nsq *schedulingv1beta1.NamespaceQueue) *schedulingv1beta1.
 }
 
 // shadowQueueSpecChanged reports whether the shadow Queue's spec has drifted from
-// what buildShadowQueue would produce for the current NamespaceQueue. Used by the
-// reconciler to decide whether an Update call is necessary, avoiding spurious writes.
+// what buildShadowQueue would produce for the current NamespaceQueue.
+//
+// We compare only the fields that buildShadowQueue explicitly manages — NOT the full
+// Spec via reflect.DeepEqual. Using DeepEqual on the entire Spec would cause an
+// infinite update loop: the existing queue controller's updateQueueParent sets
+// spec.parent="root" on any queue without a parent, so our shadow Queue (which
+// leaves Parent empty) would appear to drift on every sync cycle, triggering an
+// Update that clears the parent, which triggers updateQueueParent again, ad infinitum.
+//
+// Fields we own: Weight, Capability, Reclaimable, Guarantee, Deserved, Priority.
+// Fields we intentionally ignore: Parent (managed by the queue controller until
+// the full clusterQueueRef design is resolved with mentors).
 func shadowQueueSpecChanged(existing *schedulingv1beta1.Queue, desired *schedulingv1beta1.Queue) bool {
-	return !reflect.DeepEqual(existing.Spec, desired.Spec)
+	if existing.Spec.Weight != desired.Spec.Weight {
+		return true
+	}
+	if existing.Spec.Priority != desired.Spec.Priority {
+		return true
+	}
+	if !resourceListEqual(existing.Spec.Capability, desired.Spec.Capability) {
+		return true
+	}
+	if !resourceListEqual(existing.Spec.Deserved, desired.Spec.Deserved) {
+		return true
+	}
+	if !resourceListEqual(existing.Spec.Guarantee.Resource, desired.Spec.Guarantee.Resource) {
+		return true
+	}
+	if !reclaimableEqual(existing.Spec.Reclaimable, desired.Spec.Reclaimable) {
+		return true
+	}
+	return false
 }
+
+func resourceListEqual(a, b v1.ResourceList) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for key, valA := range a {
+		valB, ok := b[key]
+		if !ok {
+			return false
+		}
+		if valA.Cmp(valB) != 0 {
+			return false
+		}
+	}
+	return true
+}
+
+func reclaimableEqual(a, b *bool) bool {
+	if a == nil && b == nil {
+		return true
+	}
+	if a == nil || b == nil {
+		return false
+	}
+	return *a == *b
+}
+

--- a/pkg/controllers/namespacequeue/shadow_queue.go
+++ b/pkg/controllers/namespacequeue/shadow_queue.go
@@ -1,0 +1,151 @@
+/*
+Copyright 2025 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package namespacequeue
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"reflect"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	schedulingv1beta1 "volcano.sh/apis/pkg/apis/scheduling/v1beta1"
+)
+
+const (
+	// shadowQueuePrefix marks every cluster-scoped Queue synthesised from a NamespaceQueue.
+	// This prefix makes shadow Queues visually distinct from hand-crafted cluster Queues.
+	shadowQueuePrefix = "nsq"
+
+	// ManagedByLabelKey / ManagedByLabelVal are set on every shadow Queue so the
+	// controller can list and garbage-collect them by label when a NamespaceQueue
+	// is deleted, without relying on an OwnerReference (which Kubernetes forbids for
+	// cross-namespace ownership: a namespaced NamespaceQueue cannot own a cluster-scoped Queue).
+	ManagedByLabelKey = "scheduling.volcano.sh/managed-by"
+	ManagedByLabelVal = "namespacequeue-controller"
+
+	// NSQRefAnnotationKey records the "<namespace>/<name>" of the NamespaceQueue that
+	// owns this shadow Queue, enabling the controller to map in both directions.
+	NSQRefAnnotationKey = "scheduling.volcano.sh/nsq-ref"
+)
+
+// shadowQueueName returns a deterministic, DNS-subdomain-safe cluster Queue name for
+// the given NamespaceQueue namespace/name pair.
+//
+// Name format:  nsq-<hash8>-<name>
+//
+//   - hash8 is the first 8 hex digits of SHA-256(namespace+"/"+name).
+//     This ensures global uniqueness even when namespace or name are truncated,
+//     because a simple "namespace-name" concatenation would collide:
+//     (namespace="a-b", name="c") and (namespace="a", name="b-c") both produce "a-b-c".
+//
+//   - name is the NamespaceQueue's own name, truncated so the total length stays
+//     within the 253-character DNS subdomain limit.
+//
+// Example:
+//
+//	namespace="team-alpha", name="ml-training"
+//	→ SHA-256("team-alpha/ml-training") = a3f9b1c2...
+//	→ shadow name = "nsq-a3f9b1c2-ml-training"
+func shadowQueueName(namespace, name string) string {
+	hash := sha256.Sum256([]byte(namespace + "/" + name))
+	// 4 bytes = 8 hex chars; collision probability ≈ 1 in 4 billion per cluster.
+	sha8 := fmt.Sprintf("%x", hash[:4])
+
+	prefix := shadowQueuePrefix + "-" + sha8 + "-"
+	maxNameLen := 253 - len(prefix)
+	truncated := name
+	if len(truncated) > maxNameLen {
+		truncated = truncated[:maxNameLen]
+	}
+	return prefix + truncated
+}
+
+// buildShadowQueue constructs the cluster-scoped Queue that the Volcano scheduler
+// will observe and schedule against.
+//
+// Why a shadow Queue instead of teaching the scheduler about NamespaceQueue?
+//
+// The scheduler cache (pkg/scheduler/cache/cache.go:995) populates ssn.Queues by
+// watching cluster-scoped Queue objects via the existing Queue informer. Every plugin
+// (capacity, proportion, gang) and every action (allocate, reclaim, preempt) reads
+// ssn.Queues[job.Queue] where job.Queue = PodGroup.Spec.Queue. By synthesising a
+// real cluster-scoped Queue, all of this machinery continues to work without a single
+// line of scheduler change — the scheduler is completely agnostic to whether a Queue
+// was created by a human cluster-admin or by the NamespaceQueue controller.
+//
+// Spec translation rules:
+//   - All resource-governing fields (Capability, Guarantee, Deserved, Weight,
+//     Reclaimable, Priority) are copied verbatim from NamespaceQueueSpec.
+//   - Reclaimable defaults to true (same as the existing queue mutating webhook).
+//   - Weight defaults to 1 (same as existing queue mutating webhook default).
+//   - Parent is left empty at PoC stage; the full implementation will set it to
+//     the cluster admin's designated root quota Queue for the namespace's resource pool,
+//     enabling namespace-local queues to participate in cluster-level hierarchy.
+func buildShadowQueue(nsq *schedulingv1beta1.NamespaceQueue) *schedulingv1beta1.Queue {
+	trueVal := true
+	reclaimable := nsq.Spec.Reclaimable
+	if reclaimable == nil {
+		reclaimable = &trueVal
+	}
+
+	weight := nsq.Spec.Weight
+	if weight == 0 {
+		weight = 1
+	}
+
+	q := &schedulingv1beta1.Queue{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: shadowQueueName(nsq.Namespace, nsq.Name),
+			Labels: map[string]string{
+				ManagedByLabelKey: ManagedByLabelVal,
+			},
+			Annotations: map[string]string{
+				// Cross-namespace OwnerReferences are forbidden by Kubernetes, so we
+				// record provenance in an annotation and GC manually via controller watch.
+				NSQRefAnnotationKey: nsq.Namespace + "/" + nsq.Name,
+			},
+		},
+		Spec: schedulingv1beta1.QueueSpec{
+			Weight:      weight,
+			Reclaimable: reclaimable,
+			Priority:    nsq.Spec.Priority,
+			// Parent intentionally omitted here (see function doc above).
+		},
+	}
+
+	if len(nsq.Spec.Capability) > 0 {
+		q.Spec.Capability = nsq.Spec.Capability.DeepCopy()
+	}
+	if len(nsq.Spec.Deserved) > 0 {
+		q.Spec.Deserved = nsq.Spec.Deserved.DeepCopy()
+	}
+	if len(nsq.Spec.Guarantee.Resource) > 0 {
+		q.Spec.Guarantee = schedulingv1beta1.Guarantee{
+			Resource: nsq.Spec.Guarantee.Resource.DeepCopy(),
+		}
+	}
+
+	return q
+}
+
+// shadowQueueSpecChanged reports whether the shadow Queue's spec has drifted from
+// what buildShadowQueue would produce for the current NamespaceQueue. Used by the
+// reconciler to decide whether an Update call is necessary, avoiding spurious writes.
+func shadowQueueSpecChanged(existing *schedulingv1beta1.Queue, desired *schedulingv1beta1.Queue) bool {
+	return !reflect.DeepEqual(existing.Spec, desired.Spec)
+}

--- a/pkg/controllers/namespacequeue/shadow_queue_test.go
+++ b/pkg/controllers/namespacequeue/shadow_queue_test.go
@@ -1,0 +1,201 @@
+/*
+Copyright 2025 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package namespacequeue
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	schedulingv1beta1 "volcano.sh/apis/pkg/apis/scheduling/v1beta1"
+)
+
+// ---- shadowQueueName tests ----
+
+func TestShadowQueueName_Format(t *testing.T) {
+	name := shadowQueueName("team-alpha", "ml-training")
+
+	assert.True(t, strings.HasPrefix(name, "nsq-"), "must start with nsq-")
+	assert.LessOrEqual(t, len(name), 253, "must be a valid DNS subdomain (≤253 chars)")
+	assert.Contains(t, name, "ml-training", "must contain the original queue name")
+}
+
+func TestShadowQueueName_Deterministic(t *testing.T) {
+	// Same inputs must always produce the same output.
+	a := shadowQueueName("ns1", "q1")
+	b := shadowQueueName("ns1", "q1")
+	assert.Equal(t, a, b, "shadowQueueName must be deterministic")
+}
+
+func TestShadowQueueName_NoCollision(t *testing.T) {
+	// The hash must distinguish (ns="a-b", name="c") from (ns="a", name="b-c"),
+	// which simple concatenation "a-b-c" would not.
+	name1 := shadowQueueName("a-b", "c")
+	name2 := shadowQueueName("a", "b-c")
+	assert.NotEqual(t, name1, name2, "different namespace/name pairs must produce distinct shadow names")
+}
+
+func TestShadowQueueName_LongNameTruncated(t *testing.T) {
+	longName := strings.Repeat("a", 300)
+	name := shadowQueueName("ns", longName)
+	assert.LessOrEqual(t, len(name), 253, "result must not exceed 253 chars even for very long names")
+}
+
+func TestShadowQueueName_CrossNamespaceUnique(t *testing.T) {
+	// Two namespaces with the same queue name must produce different shadow names.
+	name1 := shadowQueueName("team-alpha", "default")
+	name2 := shadowQueueName("team-beta", "default")
+	assert.NotEqual(t, name1, name2, "same queue name in different namespaces must produce distinct shadow names")
+}
+
+// ---- buildShadowQueue tests ----
+
+func makeBool(v bool) *bool { return &v }
+
+func TestBuildShadowQueue_BasicSpec(t *testing.T) {
+	nsq := &schedulingv1beta1.NamespaceQueue{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "team-alpha",
+			Name:      "ml-training",
+		},
+		Spec: schedulingv1beta1.NamespaceQueueSpec{
+			Weight: 5,
+			Capability: v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("10"),
+				v1.ResourceMemory: resource.MustParse("20Gi"),
+			},
+			Deserved: v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("4"),
+				v1.ResourceMemory: resource.MustParse("8Gi"),
+			},
+			Reclaimable: makeBool(true),
+			Priority:    10,
+		},
+	}
+
+	q := buildShadowQueue(nsq)
+
+	// Name must match shadowQueueName
+	assert.Equal(t, shadowQueueName("team-alpha", "ml-training"), q.Name)
+
+	// Labels and annotations
+	assert.Equal(t, ManagedByLabelVal, q.Labels[ManagedByLabelKey])
+	assert.Equal(t, "team-alpha/ml-training", q.Annotations[NSQRefAnnotationKey])
+
+	// Spec translation
+	assert.Equal(t, int32(5), q.Spec.Weight)
+	assert.Equal(t, int32(10), q.Spec.Priority)
+	require.NotNil(t, q.Spec.Reclaimable)
+	assert.True(t, *q.Spec.Reclaimable)
+
+	// Resource lists copied correctly
+	cpuCap := q.Spec.Capability[v1.ResourceCPU]
+	assert.Equal(t, "10", (&cpuCap).String())
+	memDes := q.Spec.Deserved[v1.ResourceMemory]
+	assert.Equal(t, "8Gi", (&memDes).String())
+}
+
+func TestBuildShadowQueue_DefaultReclaimable(t *testing.T) {
+	// When Reclaimable is unset, buildShadowQueue must default to true,
+	// matching the behaviour of the existing queue mutating webhook.
+	nsq := &schedulingv1beta1.NamespaceQueue{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "q"},
+		Spec:       schedulingv1beta1.NamespaceQueueSpec{},
+	}
+
+	q := buildShadowQueue(nsq)
+	require.NotNil(t, q.Spec.Reclaimable, "Reclaimable must be set even when absent in spec")
+	assert.True(t, *q.Spec.Reclaimable, "default Reclaimable must be true")
+}
+
+func TestBuildShadowQueue_DefaultWeight(t *testing.T) {
+	nsq := &schedulingv1beta1.NamespaceQueue{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "q"},
+		Spec:       schedulingv1beta1.NamespaceQueueSpec{Weight: 0},
+	}
+
+	q := buildShadowQueue(nsq)
+	assert.Equal(t, int32(1), q.Spec.Weight, "zero weight must default to 1 (proportion plugin requires weight ≥ 1)")
+}
+
+func TestBuildShadowQueue_GuaranteeTranslated(t *testing.T) {
+	nsq := &schedulingv1beta1.NamespaceQueue{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "q"},
+		Spec: schedulingv1beta1.NamespaceQueueSpec{
+			Guarantee: schedulingv1beta1.Guarantee{
+				Resource: v1.ResourceList{
+					v1.ResourceCPU: resource.MustParse("2"),
+				},
+			},
+		},
+	}
+
+	q := buildShadowQueue(nsq)
+	cpu := q.Spec.Guarantee.Resource[v1.ResourceCPU]
+	assert.Equal(t, "2", (&cpu).String(), "Guarantee.Resource must be copied to shadow Queue")
+}
+
+func TestBuildShadowQueue_EmptyResourceListsOmitted(t *testing.T) {
+	nsq := &schedulingv1beta1.NamespaceQueue{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "q"},
+		Spec:       schedulingv1beta1.NamespaceQueueSpec{},
+	}
+
+	q := buildShadowQueue(nsq)
+	assert.Nil(t, q.Spec.Capability, "empty Capability must not be set on shadow Queue")
+	assert.Nil(t, q.Spec.Deserved, "empty Deserved must not be set on shadow Queue")
+}
+
+func TestBuildShadowQueue_SpecIsolated(t *testing.T) {
+	// Mutating the NamespaceQueue after buildShadowQueue must not affect the shadow Queue,
+	// confirming that resource lists are deep-copied, not aliased.
+	nsq := &schedulingv1beta1.NamespaceQueue{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "q"},
+		Spec: schedulingv1beta1.NamespaceQueueSpec{
+			Capability: v1.ResourceList{
+				v1.ResourceCPU: resource.MustParse("8"),
+			},
+		},
+	}
+
+	q := buildShadowQueue(nsq)
+	nsq.Spec.Capability[v1.ResourceCPU] = resource.MustParse("999")
+
+	cpu := q.Spec.Capability[v1.ResourceCPU]
+	assert.Equal(t, "8", (&cpu).String(), "shadow Queue must be deep-copied from NamespaceQueue spec")
+}
+
+// ---- shadowQueueSpecChanged tests ----
+
+func TestShadowQueueSpecChanged_DetectsDrift(t *testing.T) {
+	nsq := &schedulingv1beta1.NamespaceQueue{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "q"},
+		Spec:       schedulingv1beta1.NamespaceQueueSpec{Weight: 3},
+	}
+	desired := buildShadowQueue(nsq)
+
+	existing := desired.DeepCopy()
+	assert.False(t, shadowQueueSpecChanged(existing, desired), "no change should not trigger update")
+
+	existing.Spec.Weight = 99
+	assert.True(t, shadowQueueSpecChanged(existing, desired), "weight change must be detected")
+}

--- a/poc/README.md
+++ b/poc/README.md
@@ -1,0 +1,148 @@
+# PoC: Namespace-scoped Queue for Volcano
+
+LFX Mentorship 2026 Term 2 — CNCF Volcano  
+**Feature:** Support Namespace-scoped Queue in Volcano
+
+---
+
+## What this PoC demonstrates
+
+Volcano's `Queue` is cluster-scoped, so only cluster-admins can create one.  
+Tenants who own a namespace cannot create queues for their own workloads.
+
+This PoC shows the **shadow Queue approach** — the central architectural idea:
+
+> The `NamespaceQueue` controller watches namespace-scoped `NamespaceQueue` objects
+> and synthesises a cluster-scoped shadow `Queue` for each one. The Volcano scheduler
+> picks up the shadow Queue through the existing Queue informer — **zero scheduler
+> changes required**. The shadow Queue name is deterministic (`shadowQueueName`),
+> making reconciliation idempotent.
+
+```
+Tenant                  Controller              Scheduler
+------                  ----------              ---------
+creates                 watches                 sees
+NamespaceQueue    --->  NamespaceQueue    --->  shadow Queue
+(namespaced)            creates/updates         (cluster-scoped)
+                        shadow Queue            processes identically
+                                                to any cluster Queue
+```
+
+---
+
+## Files changed
+
+| File | What |
+|------|------|
+| `staging/src/volcano.sh/apis/pkg/apis/scheduling/v1beta1/namespacequeue_types.go` | `NamespaceQueue`, `NamespaceQueueSpec`, `NamespaceQueueStatus`, `NamespaceQueueList` types + pre-codegen DeepCopy |
+| `staging/src/volcano.sh/apis/pkg/apis/scheduling/v1beta1/register.go` | registers `NamespaceQueue`/`NamespaceQueueList` with the scheme |
+| `staging/src/volcano.sh/apis/pkg/apis/scheduling/v1beta1/labels.go` | adds `NamespaceQueueNameAnnotationKey` constant |
+| `pkg/controllers/namespacequeue/shadow_queue.go` | `shadowQueueName()` + `buildShadowQueue()` — the core logic |
+| `pkg/controllers/namespacequeue/shadow_queue_test.go` | unit tests for the core logic |
+| `pkg/controllers/namespacequeue/namespacequeue_controller.go` | full controller: dynamic informer, reconcile loop, shadow Queue create/update/delete, status mirroring |
+
+---
+
+## Run the unit tests
+
+The unit tests cover the pure functions (`shadowQueueName`, `buildShadowQueue`,
+`shadowQueueSpecChanged`) and require no cluster.
+
+```bash
+cd /path/to/volcano
+go test ./pkg/controllers/namespacequeue/... -v
+```
+
+Expected output (all pass):
+
+```
+=== RUN   TestShadowQueueName_Format
+--- PASS: TestShadowQueueName_Format
+=== RUN   TestShadowQueueName_Deterministic
+--- PASS: TestShadowQueueName_Deterministic
+=== RUN   TestShadowQueueName_NoCollision
+--- PASS: TestShadowQueueName_NoCollision
+=== RUN   TestShadowQueueName_LongNameTruncated
+--- PASS: TestShadowQueueName_LongNameTruncated
+=== RUN   TestShadowQueueName_CrossNamespaceUnique
+--- PASS: TestShadowQueueName_CrossNamespaceUnique
+=== RUN   TestBuildShadowQueue_BasicSpec
+--- PASS: TestBuildShadowQueue_BasicSpec
+=== RUN   TestBuildShadowQueue_DefaultReclaimable
+--- PASS: TestBuildShadowQueue_DefaultReclaimable
+=== RUN   TestBuildShadowQueue_DefaultWeight
+--- PASS: TestBuildShadowQueue_DefaultWeight
+=== RUN   TestBuildShadowQueue_GuaranteeTranslated
+--- PASS: TestBuildShadowQueue_GuaranteeTranslated
+=== RUN   TestBuildShadowQueue_EmptyResourceListsOmitted
+--- PASS: TestBuildShadowQueue_EmptyResourceListsOmitted
+=== RUN   TestBuildShadowQueue_SpecIsolated
+--- PASS: TestBuildShadowQueue_SpecIsolated
+=== RUN   TestShadowQueueSpecChanged_DetectsDrift
+--- PASS: TestShadowQueueSpecChanged_DetectsDrift
+```
+
+---
+
+## Run against a local cluster (Kind)
+
+**Prerequisites:** `kind`, `kubectl`, `helm`, Go 1.23+
+
+```bash
+# 1. Create a Kind cluster and install Volcano
+kind create cluster --name volcano
+helm install volcano installer/helm/chart/volcano --namespace volcano-system --create-namespace
+
+# 2. (After `make generate-code`) apply the NamespaceQueue CRD
+kubectl apply -f config/crd/bases/scheduling.volcano.sh_namespacequeues.yaml
+
+# 3. Activate the controller by blank-importing the package in the controller-manager
+#    (see cmd/controller-manager/main.go — add the import line below)
+#    _ "volcano.sh/volcano/pkg/controllers/namespacequeue"
+
+# 4. Create a NamespaceQueue as a tenant (no ClusterRoleBinding needed)
+kubectl -n team-alpha apply -f - <<EOF
+apiVersion: scheduling.volcano.sh/v1beta1
+kind: NamespaceQueue
+metadata:
+  name: ml-training
+  namespace: team-alpha
+spec:
+  weight: 5
+  capability:
+    cpu: "10"
+    memory: "20Gi"
+  deserved:
+    cpu: "4"
+    memory: "8Gi"
+  reclaimable: true
+EOF
+
+# 5. Verify the shadow cluster Queue was created by the controller
+kubectl get queue   # should show "nsq-<hash8>-ml-training"
+
+# 6. Create a PodGroup referencing the NamespaceQueue
+#    (admission webhook patches spec.queue to the shadow Queue name)
+kubectl -n team-alpha apply -f - <<EOF
+apiVersion: scheduling.volcano.sh/v1beta1
+kind: PodGroup
+metadata:
+  name: my-job-pg
+  namespace: team-alpha
+  annotations:
+    scheduling.volcano.sh/namespacequeue-name: ml-training
+spec:
+  minMember: 1
+EOF
+```
+
+---
+
+## What's not in this PoC (full implementation scope)
+
+- **CRD manifest** — generated by `make manifests` after adding kubebuilder markers (done)
+- **Generated lister/informer** — produced by `make generate-code`; replaces the dynamic informer in the controller
+- **Admission webhook** — resolves `scheduling.volcano.sh/namespacequeue-name` annotation on PodGroup and patches `spec.queue` to the shadow Queue name
+- **RBAC manifests** — tenant `Role` granting `namespacequeues` create/update/delete in their namespace
+- **Status mirroring** — full watch on the shadow Queue status to propagate Allocated back to NamespaceQueueStatus
+- **E2E tests** in `test/e2e/namespacequeue/`

--- a/staging/src/volcano.sh/apis/pkg/apis/scheduling/v1beta1/labels.go
+++ b/staging/src/volcano.sh/apis/pkg/apis/scheduling/v1beta1/labels.go
@@ -47,6 +47,12 @@ const VolcanoGroupMinResourcesAnnotationKey = GroupName + "/group-min-resources"
 // which queue it belongs to.
 const QueueNameAnnotationKey = GroupName + "/queue-name"
 
+// NamespaceQueueNameAnnotationKey is set on a PodGroup or Pod template to reference
+// a namespace-scoped NamespaceQueue by its local name. The admission webhook resolves
+// this to the shadow cluster Queue name and sets PodGroup.Spec.Queue accordingly,
+// so the scheduler requires no modification to handle NamespaceQueue-bound workloads.
+const NamespaceQueueNameAnnotationKey = GroupName + "/namespacequeue-name"
+
 // QueueAllocationGateKey is the annotation key to opt-in to queue capacity
 // gate management and the name of the scheduling gate that controls queue admission.
 const QueueAllocationGateKey = GroupName + "/queue-allocation-gate"

--- a/staging/src/volcano.sh/apis/pkg/apis/scheduling/v1beta1/namespacequeue_types.go
+++ b/staging/src/volcano.sh/apis/pkg/apis/scheduling/v1beta1/namespacequeue_types.go
@@ -1,0 +1,262 @@
+/*
+Copyright 2025 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta1
+
+import (
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// +genclient
+// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+// +kubebuilder:object:root=true
+// +kubebuilder:resource:path=namespacequeues,scope=Namespaced,shortName=nsq
+// +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="STATE",type=string,JSONPath=`.status.state`
+// +kubebuilder:printcolumn:name="SHADOW-QUEUE",type=string,JSONPath=`.status.shadowQueueName`
+// +kubebuilder:printcolumn:name="AGE",type=date,JSONPath=`.metadata.creationTimestamp`
+
+// NamespaceQueue is a namespace-scoped queue that tenants can create and manage
+// without cluster-admin permission. The controller synthesizes a cluster-scoped
+// shadow Queue from each NamespaceQueue so that the existing Volcano scheduler
+// and all its plugins (capacity, proportion, gang) require no modification.
+type NamespaceQueue struct {
+	metav1.TypeMeta `json:",inline"`
+
+	// +optional
+	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
+
+	// Spec is the desired state of this NamespaceQueue.
+	// +optional
+	Spec NamespaceQueueSpec `json:"spec,omitempty" protobuf:"bytes,2,opt,name=spec"`
+
+	// Status is the observed state of this NamespaceQueue, including the name
+	// of the shadow cluster-scoped Queue synthesized by the controller.
+	// +optional
+	Status NamespaceQueueStatus `json:"status,omitempty" protobuf:"bytes,3,opt,name=status"`
+}
+
+// NamespaceQueueSpec mirrors the resource-governing fields of QueueSpec so that
+// tenants get identical semantics (capability, guarantee, deserved, hierarchy)
+// without needing cluster-admin access to create a cluster-scoped Queue.
+type NamespaceQueueSpec struct {
+	// Weight is the relative weight of this queue used by the proportion plugin
+	// to calculate a fair-share deserved value. Mirrors QueueSpec.Weight.
+	// +optional
+	// +kubebuilder:default:=1
+	// +kubebuilder:validation:Minimum=1
+	// +kubebuilder:validation:Maximum=65535
+	Weight int32 `json:"weight,omitempty" protobuf:"bytes,1,opt,name=weight"`
+
+	// Capability is the hard upper limit of resources usable by this queue.
+	// Jobs are held Pending when their request would exceed this limit.
+	// Mirrors QueueSpec.Capability.
+	// +optional
+	Capability v1.ResourceList `json:"capability,omitempty" protobuf:"bytes,2,opt,name=capability"`
+
+	// Reclaimable indicates whether resources used above Deserved can be
+	// reclaimed by other queues. Defaults to true. Mirrors QueueSpec.Reclaimable.
+	// +optional
+	Reclaimable *bool `json:"reclaimable,omitempty" protobuf:"bytes,3,opt,name=reclaimable"`
+
+	// Guarantee defines resources that are reserved for this queue and cannot
+	// be reclaimed by other queues. Mirrors QueueSpec.Guarantee.
+	// +optional
+	Guarantee Guarantee `json:"guarantee,omitempty" protobuf:"bytes,4,opt,name=guarantee"`
+
+	// Deserved is the fair-share resource target for this queue. Resources used
+	// above Deserved are eligible for reclamation. Mirrors QueueSpec.Deserved.
+	// +optional
+	Deserved v1.ResourceList `json:"deserved,omitempty" protobuf:"bytes,5,opt,name=deserved"`
+
+	// Priority is the scheduling priority of this queue: higher values are
+	// scheduled first and reclaimed last. Mirrors QueueSpec.Priority.
+	// +optional
+	// +kubebuilder:validation:Minimum=0
+	Priority int32 `json:"priority,omitempty" protobuf:"bytes,6,opt,name=priority"`
+
+	// Parent is the name of a NamespaceQueue in the same namespace that acts as
+	// the parent in a namespace-local queue hierarchy. Hierarchy rules (child
+	// deserved/guarantee sum ≤ parent) mirror cluster Queue hierarchy semantics.
+	// +optional
+	// +kubebuilder:validation:MaxLength=253
+	Parent string `json:"parent,omitempty" protobuf:"bytes,7,opt,name=parent"`
+}
+
+// NamespaceQueueStatus is the observed state of a NamespaceQueue, populated by
+// the namespacequeue-controller. It mirrors the status of the shadow Queue so
+// tenants have full visibility into resource usage without access to cluster resources.
+type NamespaceQueueStatus struct {
+	// State is the current state of this queue, mirrored from the shadow Queue.
+	// +kubebuilder:validation:Enum=Open;Closed;Closing;Unknown
+	// +optional
+	State QueueState `json:"state,omitempty" protobuf:"bytes,1,opt,name=state"`
+
+	// ShadowQueueName is the name of the cluster-scoped Queue synthesized and
+	// managed by the controller for this NamespaceQueue. PodGroups referencing
+	// this NamespaceQueue will have their spec.queue patched to this value by
+	// the admission webhook.
+	// +optional
+	ShadowQueueName string `json:"shadowQueueName,omitempty" protobuf:"bytes,2,opt,name=shadowQueueName"`
+
+	// Allocated is the sum of resources currently allocated to running PodGroups
+	// in this queue, mirrored from the shadow Queue status updated by the scheduler.
+	// +optional
+	Allocated v1.ResourceList `json:"allocated,omitempty" protobuf:"bytes,3,opt,name=allocated"`
+
+	// The number of PodGroups in each phase. Mirrored from the shadow Queue.
+	// +kubebuilder:validation:Minimum=0
+	// +optional
+	Pending int32 `json:"pending,omitempty" protobuf:"bytes,4,opt,name=pending"`
+
+	// +kubebuilder:validation:Minimum=0
+	// +optional
+	Running int32 `json:"running,omitempty" protobuf:"bytes,5,opt,name=running"`
+
+	// +kubebuilder:validation:Minimum=0
+	// +optional
+	Inqueue int32 `json:"inqueue,omitempty" protobuf:"bytes,6,opt,name=inqueue"`
+
+	// +kubebuilder:validation:Minimum=0
+	// +optional
+	Completed int32 `json:"completed,omitempty" protobuf:"bytes,7,opt,name=completed"`
+
+	// +kubebuilder:validation:Minimum=0
+	// +optional
+	Unknown int32 `json:"unknown,omitempty" protobuf:"bytes,8,opt,name=unknown"`
+}
+
+// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+// +kubebuilder:object:root=true
+
+// NamespaceQueueList is a collection of NamespaceQueues.
+type NamespaceQueueList struct {
+	metav1.TypeMeta `json:",inline"`
+	// +optional
+	metav1.ListMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
+	Items           []NamespaceQueue `json:"items" protobuf:"bytes,2,rep,name=items"`
+}
+
+// ---- DeepCopy methods (pre-codegen placeholder) ----
+// These will be moved into zz_generated.deepcopy.go after running `make generate-code`.
+
+func (in *NamespaceQueue) DeepCopyInto(out *NamespaceQueue) {
+	*out = *in
+	out.TypeMeta = in.TypeMeta
+	in.ObjectMeta.DeepCopyInto(&out.ObjectMeta)
+	in.Spec.DeepCopyInto(&out.Spec)
+	in.Status.DeepCopyInto(&out.Status)
+}
+
+func (in *NamespaceQueue) DeepCopy() *NamespaceQueue {
+	if in == nil {
+		return nil
+	}
+	out := new(NamespaceQueue)
+	in.DeepCopyInto(out)
+	return out
+}
+
+func (in *NamespaceQueue) DeepCopyObject() runtime.Object {
+	if c := in.DeepCopy(); c != nil {
+		return c
+	}
+	return nil
+}
+
+func (in *NamespaceQueueSpec) DeepCopyInto(out *NamespaceQueueSpec) {
+	*out = *in
+	if in.Capability != nil {
+		in, out := &in.Capability, &out.Capability
+		*out = make(v1.ResourceList, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val.DeepCopy()
+		}
+	}
+	if in.Reclaimable != nil {
+		in, out := &in.Reclaimable, &out.Reclaimable
+		*out = new(bool)
+		**out = **in
+	}
+	in.Guarantee.DeepCopyInto(&out.Guarantee)
+	if in.Deserved != nil {
+		in, out := &in.Deserved, &out.Deserved
+		*out = make(v1.ResourceList, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val.DeepCopy()
+		}
+	}
+}
+
+func (in *NamespaceQueueSpec) DeepCopy() *NamespaceQueueSpec {
+	if in == nil {
+		return nil
+	}
+	out := new(NamespaceQueueSpec)
+	in.DeepCopyInto(out)
+	return out
+}
+
+func (in *NamespaceQueueStatus) DeepCopyInto(out *NamespaceQueueStatus) {
+	*out = *in
+	if in.Allocated != nil {
+		in, out := &in.Allocated, &out.Allocated
+		*out = make(v1.ResourceList, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val.DeepCopy()
+		}
+	}
+}
+
+func (in *NamespaceQueueStatus) DeepCopy() *NamespaceQueueStatus {
+	if in == nil {
+		return nil
+	}
+	out := new(NamespaceQueueStatus)
+	in.DeepCopyInto(out)
+	return out
+}
+
+func (in *NamespaceQueueList) DeepCopyInto(out *NamespaceQueueList) {
+	*out = *in
+	out.TypeMeta = in.TypeMeta
+	in.ListMeta.DeepCopyInto(&out.ListMeta)
+	if in.Items != nil {
+		in, out := &in.Items, &out.Items
+		*out = make([]NamespaceQueue, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
+}
+
+func (in *NamespaceQueueList) DeepCopy() *NamespaceQueueList {
+	if in == nil {
+		return nil
+	}
+	out := new(NamespaceQueueList)
+	in.DeepCopyInto(out)
+	return out
+}
+
+func (in *NamespaceQueueList) DeepCopyObject() runtime.Object {
+	if c := in.DeepCopy(); c != nil {
+		return c
+	}
+	return nil
+}

--- a/staging/src/volcano.sh/apis/pkg/apis/scheduling/v1beta1/register.go
+++ b/staging/src/volcano.sh/apis/pkg/apis/scheduling/v1beta1/register.go
@@ -51,6 +51,8 @@ func addKnownTypes(scheme *runtime.Scheme) error {
 		&PodGroupList{},
 		&Queue{},
 		&QueueList{},
+		&NamespaceQueue{},
+		&NamespaceQueueList{},
 	)
 
 	metav1.AddToGroupVersion(scheme, SchemeGroupVersion)


### PR DESCRIPTION
**The problem:** `Queue` is cluster-scoped, so a tenant who owns `team-alpha` namespace has to ping a cluster-admin every time they need a queue. This PoC proposes fixing that without touching the scheduler at all.

**The approach:** a namespace-scoped `NamespaceQueue` CRD whose controller synthesises a real cluster-scoped shadow `Queue` from it. The scheduler picks it up through the existing `Queue` informer ; capacity plugin, proportion plugin, reclaim action, all of it works untouched because as far as the scheduler is concerned it's just another `Queue` in `ssn.Queues`.

**What's in the PR:**
- `NamespaceQueue` type in `scheduling.volcano.sh/v1beta1`, spec fields mirror `QueueSpec` exactly (`capability`, `guarantee`, `deserved`, `weight`, `reclaimable`, `priority`, `parent`), registered in scheme alongside `Queue` and `PodGroup`
- `shadowQueueName` uses SHA-256(`namespace+"/"+name`) prefix to avoid the `ns="a-b"/name="c"` vs `ns="a"/name="b-c"` collision that simple concatenation has
- `buildShadowQueue` translates `NamespaceQueueSpec` -> `QueueSpec`, sets `scheduling.volcano.sh/nsq-ref` annotation for GC since cross-namespace `OwnerReference` is Kubernetes-forbidden
- Full controller using a dynamic informer (pre-codegen) with reconcile, create/update/delete shadow `Queue`, and status mirroring back to the tenant
- 12 passing unit tests

---

### What this PR doesn't include

This is intentionally scoped to demonstrate the approach, not deliver the feature. Missing pieces that come after mentor feedback and codegen:

- **CRD manifest** : generated by `make manifests` once kubebuilder markers are validated
- **Generated lister/informer** : the dynamic informer in the controller is a pre-codegen placeholder; `make generate-code` replaces it with `factory.Scheduling().V1beta1().NamespaceQueues()`
- **Admission webhook** : the piece that reads `scheduling.volcano.sh/namespacequeue-name` on a `PodGroup` and patches `spec.queue` to the shadow Queue name so the scheduler can resolve it; this is also where namespace isolation is enforced
- **RBAC manifests** : the tenant `Role` + `RoleBinding` that makes the whole self-service story actually work without a `ClusterRoleBinding`
- **Status mirroring** : a watch on the shadow Queue's `Status.Allocated` to propagate resource usage back to `NamespaceQueueStatus` so tenants have visibility
- **E2E tests** : full flow from `NamespaceQueue` creation through job scheduling and resource accounting

---

### Open questions for mentors

**1. `updateQueueParent` will overwrite the shadow Queue's parent on every sync**

In `queue_controller_action.go`, `syncQueue` calls `updateQueueParent` which sets `spec.parent = "root"` on any queue that has no parent. The shadow `Queue` the `NamespaceQueue` controller creates will immediately have its parent overwritten by the existing queue controller on the very next sync cycle. So either I need to always set a parent on the shadow `Queue` at creation time, or `updateQueueParent` needs to skip queues it doesn't own. What's the right call here ; should the shadow `Queue` always be pinned under a cluster-admin-configured parent queue, or is there a way to mark it as "parent already managed"?

**2. Weight scope in the proportion plugin is cluster-wide, which feels wrong for tenants**

The proportion plugin computes `deserved = (weight / Σ all_weights) * total_cluster_resources`. A shadow Queue's weight competes with every other queue in the cluster. If `team-alpha` creates 10 `NamespaceQueues` each with `weight=1`, they effectively grab 10 shares of the cluster ; same as 10 cluster-admin-created queues. Should weight for `NamespaceQueues` be scoped relative to the namespace's resource pool, or relative to a parent cluster `Queue` they're bound to? I couldn't find a clean answer in the proportion plugin code.

**3. Do `NamespaceQueues` need a mandatory parent cluster Queue, or can they be standalone?**

If standalone, the sum of all `NamespaceQueue` capabilities across the cluster could exceed actual cluster capacity ; the scheduler handles this through pending, but it's uncontrolled overcommit. If we require binding to a parent cluster `Queue`, an admin still has to pre-create that parent quota queue, which partially defeats the self-service purpose. Is the intent that platform admins pre-create one quota `Queue` per namespace/team and tenants subdivide within that, or is a fully standalone `NamespaceQueue` valid?

**4. The existing `scheduling.volcano.sh/queue-name` annotation on `Namespace` conflicts with the new flow**

The mutating webhook for `PodGroup` already reads `QueueNameAnnotationKey` from the `Namespace` object and patches `spec.queue` if the `PodGroup`'s queue is `"default"`. If I add `NamespaceQueueNameAnnotationKey` with similar semantics, there are now two annotation-based queue assignment mechanisms on a `Namespace`. Which wins? Can a namespace have both set, pointing to different queues for different workloads?