### PR TITLE
test(queue): add coverage for hierarchical queue controller propagation logic

### DIFF
--- a/pkg/controllers/queue/queue_controller_test.go
+++ b/pkg/controllers/queue/queue_controller_test.go
@@ -52,6 +52,12 @@ func newFakeController() *queuecontroller {
 	return controller
 }
 
+// addQueueToStore adds a Queue to the controller's informer cache so that
+// queueLister.Get / queueLister.List return it without needing a running informer.
+func addQueueToStore(c *queuecontroller, q *schedulingv1beta1.Queue) {
+	_ = c.queueInformer.Informer().GetStore().Add(q)
+}
+
 func TestAddQueue(t *testing.T) {
 	testCases := []struct {
 		Name        string
@@ -321,5 +327,471 @@ func TestProcessNextWorkItem(t *testing.T) {
 		if c.queue.Len() != 0 {
 			t.Errorf("case %d (%s): expected: %v, got %v ", i, testcase.Name, testcase.ExpectValue, c.queue.Len())
 		}
+	}
+}
+
+func TestUpdateQueueParent(t *testing.T) {
+	testCases := []struct {
+		Name         string
+		queue        *schedulingv1beta1.Queue
+		needsCreate  bool
+		expectParent string
+	}{
+		{
+			Name: "root queue is not patched",
+			queue: &schedulingv1beta1.Queue{
+				ObjectMeta: metav1.ObjectMeta{Name: "root"},
+				Spec:       schedulingv1beta1.QueueSpec{Weight: 1},
+			},
+			needsCreate:  false,
+			expectParent: "",
+		},
+		{
+			Name: "queue with parent already set is not patched",
+			queue: &schedulingv1beta1.Queue{
+				ObjectMeta: metav1.ObjectMeta{Name: "child"},
+				Spec:       schedulingv1beta1.QueueSpec{Weight: 1, Parent: "custom-parent"},
+			},
+			needsCreate:  false,
+			expectParent: "custom-parent",
+		},
+		{
+			Name: "queue without parent gets parent set to root",
+			queue: &schedulingv1beta1.Queue{
+				ObjectMeta: metav1.ObjectMeta{Name: "orphan"},
+				Spec:       schedulingv1beta1.QueueSpec{Weight: 1},
+			},
+			needsCreate:  true,
+			expectParent: "root",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			c := newFakeController()
+			if tc.needsCreate {
+				_, err := c.vcClient.SchedulingV1beta1().Queues().Create(context.TODO(), tc.queue, metav1.CreateOptions{})
+				assert.NoError(t, err)
+			}
+			result, err := c.updateQueueParent(tc.queue)
+			assert.NoError(t, err)
+			assert.Equal(t, tc.expectParent, result.Spec.Parent)
+		})
+	}
+}
+
+func TestUpdateQueueAnnotation(t *testing.T) {
+	testCases := []struct {
+		Name            string
+		queue           *schedulingv1beta1.Queue
+		annotationKey   string
+		annotationValue string
+		expectValue     string
+		// needsCreate controls whether the queue must pre-exist in vcClient (i.e. a patch will be issued).
+		needsCreate bool
+	}{
+		{
+			Name: "annotation already set to same value is a no-op",
+			queue: &schedulingv1beta1.Queue{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "q1",
+					Annotations: map[string]string{
+						ClosedByParentAnnotationKey: ClosedByParentAnnotationTrueValue,
+					},
+				},
+			},
+			annotationKey:   ClosedByParentAnnotationKey,
+			annotationValue: ClosedByParentAnnotationTrueValue,
+			expectValue:     ClosedByParentAnnotationTrueValue,
+			needsCreate:     false,
+		},
+		{
+			Name: "nil annotations map gets created with the new key",
+			queue: &schedulingv1beta1.Queue{
+				ObjectMeta: metav1.ObjectMeta{Name: "q2"},
+			},
+			annotationKey:   ClosedByParentAnnotationKey,
+			annotationValue: ClosedByParentAnnotationTrueValue,
+			expectValue:     ClosedByParentAnnotationTrueValue,
+			needsCreate:     true,
+		},
+		{
+			Name: "existing annotations get new key appended",
+			queue: &schedulingv1beta1.Queue{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "q3",
+					Annotations: map[string]string{"unrelated-key": "unrelated-value"},
+				},
+			},
+			annotationKey:   ClosedByParentAnnotationKey,
+			annotationValue: ClosedByParentAnnotationFalseValue,
+			expectValue:     ClosedByParentAnnotationFalseValue,
+			needsCreate:     true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			c := newFakeController()
+			if tc.needsCreate {
+				_, err := c.vcClient.SchedulingV1beta1().Queues().Create(context.TODO(), tc.queue, metav1.CreateOptions{})
+				assert.NoError(t, err)
+			}
+			result, err := c.updateQueueAnnotation(tc.queue, tc.annotationKey, tc.annotationValue)
+			assert.NoError(t, err)
+			assert.Equal(t, tc.expectValue, result.Annotations[tc.annotationKey])
+		})
+	}
+}
+
+func TestUpdateQueueHandler(t *testing.T) {
+	testCases := []struct {
+		Name               string
+		oldQueue           *schedulingv1beta1.Queue
+		newQueue           *schedulingv1beta1.Queue
+		expectEnqueueCount int
+	}{
+		{
+			Name: "weight change with same parent does not enqueue",
+			oldQueue: &schedulingv1beta1.Queue{
+				ObjectMeta: metav1.ObjectMeta{Name: "child"},
+				Spec:       schedulingv1beta1.QueueSpec{Weight: 1, Parent: "parent"},
+			},
+			newQueue: &schedulingv1beta1.Queue{
+				ObjectMeta: metav1.ObjectMeta{Name: "child"},
+				Spec:       schedulingv1beta1.QueueSpec{Weight: 5, Parent: "parent"},
+			},
+			expectEnqueueCount: 0,
+		},
+		{
+			Name: "parent change triggers a sync work item",
+			oldQueue: &schedulingv1beta1.Queue{
+				ObjectMeta: metav1.ObjectMeta{Name: "child"},
+				Spec:       schedulingv1beta1.QueueSpec{Weight: 1, Parent: "old-parent"},
+			},
+			newQueue: &schedulingv1beta1.Queue{
+				ObjectMeta: metav1.ObjectMeta{Name: "child"},
+				Spec:       schedulingv1beta1.QueueSpec{Weight: 1, Parent: "new-parent"},
+			},
+			expectEnqueueCount: 1,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			c := newFakeController()
+			c.updateQueue(tc.oldQueue, tc.newQueue)
+			assert.Equal(t, tc.expectEnqueueCount, c.queue.Len())
+		})
+	}
+}
+
+func TestSyncHierarchicalQueue(t *testing.T) {
+	testCases := []struct {
+		Name               string
+		child              *schedulingv1beta1.Queue
+		parent             *schedulingv1beta1.Queue
+		// childInVCClient indicates the child must pre-exist in vcClient so that the
+		// annotation patch inside syncHierarchicalQueue can succeed.
+		childInVCClient    bool
+		expectEnqueueCount int
+		expectAnnotation   string
+	}{
+		{
+			Name: "root queue returns immediately without action",
+			child: &schedulingv1beta1.Queue{
+				ObjectMeta: metav1.ObjectMeta{Name: "root"},
+				Status:     schedulingv1beta1.QueueStatus{State: schedulingv1beta1.QueueStateOpen},
+			},
+			parent:             nil,
+			expectEnqueueCount: 0,
+		},
+		{
+			Name: "parent closed - open child gets close action enqueued and ClosedByParent set",
+			child: &schedulingv1beta1.Queue{
+				ObjectMeta: metav1.ObjectMeta{Name: "child-a"},
+				Spec:       schedulingv1beta1.QueueSpec{Weight: 1, Parent: "par-a"},
+				Status:     schedulingv1beta1.QueueStatus{State: schedulingv1beta1.QueueStateOpen},
+			},
+			parent: &schedulingv1beta1.Queue{
+				ObjectMeta: metav1.ObjectMeta{Name: "par-a"},
+				Status:     schedulingv1beta1.QueueStatus{State: schedulingv1beta1.QueueStateClosed},
+			},
+			childInVCClient:    true,
+			expectEnqueueCount: 1,
+			expectAnnotation:   ClosedByParentAnnotationTrueValue,
+		},
+		{
+			Name: "parent closing - open child gets close action enqueued and ClosedByParent set",
+			child: &schedulingv1beta1.Queue{
+				ObjectMeta: metav1.ObjectMeta{Name: "child-b"},
+				Spec:       schedulingv1beta1.QueueSpec{Weight: 1, Parent: "par-b"},
+				Status:     schedulingv1beta1.QueueStatus{State: schedulingv1beta1.QueueStateOpen},
+			},
+			parent: &schedulingv1beta1.Queue{
+				ObjectMeta: metav1.ObjectMeta{Name: "par-b"},
+				Status:     schedulingv1beta1.QueueStatus{State: schedulingv1beta1.QueueStateClosing},
+			},
+			childInVCClient:    true,
+			expectEnqueueCount: 1,
+			expectAnnotation:   ClosedByParentAnnotationTrueValue,
+		},
+		{
+			Name: "parent closed - child already closed - no action taken",
+			child: &schedulingv1beta1.Queue{
+				ObjectMeta: metav1.ObjectMeta{Name: "child-c"},
+				Spec:       schedulingv1beta1.QueueSpec{Weight: 1, Parent: "par-c"},
+				Status:     schedulingv1beta1.QueueStatus{State: schedulingv1beta1.QueueStateClosed},
+			},
+			parent: &schedulingv1beta1.Queue{
+				ObjectMeta: metav1.ObjectMeta{Name: "par-c"},
+				Status:     schedulingv1beta1.QueueStatus{State: schedulingv1beta1.QueueStateClosed},
+			},
+			expectEnqueueCount: 0,
+		},
+		{
+			Name: "parent open - child closed-by-parent - open action enqueued",
+			child: &schedulingv1beta1.Queue{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "child-d",
+					Annotations: map[string]string{
+						ClosedByParentAnnotationKey: ClosedByParentAnnotationTrueValue,
+					},
+				},
+				Spec:   schedulingv1beta1.QueueSpec{Weight: 1, Parent: "par-d"},
+				Status: schedulingv1beta1.QueueStatus{State: schedulingv1beta1.QueueStateClosed},
+			},
+			parent: &schedulingv1beta1.Queue{
+				ObjectMeta: metav1.ObjectMeta{Name: "par-d"},
+				Status:     schedulingv1beta1.QueueStatus{State: schedulingv1beta1.QueueStateOpen},
+			},
+			expectEnqueueCount: 1,
+		},
+		{
+			Name: "parent open - child closed but NOT by parent - no action taken",
+			child: &schedulingv1beta1.Queue{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "child-e",
+					Annotations: map[string]string{
+						ClosedByParentAnnotationKey: ClosedByParentAnnotationFalseValue,
+					},
+				},
+				Spec:   schedulingv1beta1.QueueSpec{Weight: 1, Parent: "par-e"},
+				Status: schedulingv1beta1.QueueStatus{State: schedulingv1beta1.QueueStateClosed},
+			},
+			parent: &schedulingv1beta1.Queue{
+				ObjectMeta: metav1.ObjectMeta{Name: "par-e"},
+				Status:     schedulingv1beta1.QueueStatus{State: schedulingv1beta1.QueueStateOpen},
+			},
+			expectEnqueueCount: 0,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			c := newFakeController()
+			if tc.parent != nil {
+				addQueueToStore(c, tc.parent)
+			}
+			if tc.childInVCClient {
+				_, err := c.vcClient.SchedulingV1beta1().Queues().Create(context.TODO(), tc.child, metav1.CreateOptions{})
+				assert.NoError(t, err)
+			}
+
+			err := c.syncHierarchicalQueue(tc.child)
+			assert.NoError(t, err)
+			assert.Equal(t, tc.expectEnqueueCount, c.queue.Len())
+
+			if tc.expectAnnotation != "" {
+				updated, err := c.vcClient.SchedulingV1beta1().Queues().Get(context.TODO(), tc.child.Name, metav1.GetOptions{})
+				assert.NoError(t, err)
+				assert.Equal(t, tc.expectAnnotation, updated.Annotations[ClosedByParentAnnotationKey])
+			}
+		})
+	}
+}
+
+func TestOpenHierarchicalQueue(t *testing.T) {
+	testCases := []struct {
+		Name               string
+		queue              *schedulingv1beta1.Queue
+		parent             *schedulingv1beta1.Queue
+		children           []*schedulingv1beta1.Queue
+		expectError        bool
+		expectEnqueueCount int
+	}{
+		{
+			Name: "root-parented queue with no children enqueues nothing",
+			queue: &schedulingv1beta1.Queue{
+				ObjectMeta: metav1.ObjectMeta{Name: "q1"},
+				Spec:       schedulingv1beta1.QueueSpec{Weight: 1, Parent: "root"},
+			},
+			expectError:        false,
+			expectEnqueueCount: 0,
+		},
+		{
+			Name: "parent is closing - returns error and does not open",
+			queue: &schedulingv1beta1.Queue{
+				ObjectMeta: metav1.ObjectMeta{Name: "child"},
+				Spec:       schedulingv1beta1.QueueSpec{Weight: 1, Parent: "par"},
+			},
+			parent: &schedulingv1beta1.Queue{
+				ObjectMeta: metav1.ObjectMeta{Name: "par"},
+				Status:     schedulingv1beta1.QueueStatus{State: schedulingv1beta1.QueueStateClosing},
+			},
+			expectError:        true,
+			expectEnqueueCount: 0,
+		},
+		{
+			Name: "parent is closed - returns error and does not open",
+			queue: &schedulingv1beta1.Queue{
+				ObjectMeta: metav1.ObjectMeta{Name: "child2"},
+				Spec:       schedulingv1beta1.QueueSpec{Weight: 1, Parent: "par2"},
+			},
+			parent: &schedulingv1beta1.Queue{
+				ObjectMeta: metav1.ObjectMeta{Name: "par2"},
+				Status:     schedulingv1beta1.QueueStatus{State: schedulingv1beta1.QueueStateClosed},
+			},
+			expectError:        true,
+			expectEnqueueCount: 0,
+		},
+		{
+			Name: "children with ClosedByParent annotation get open action enqueued",
+			queue: &schedulingv1beta1.Queue{
+				ObjectMeta: metav1.ObjectMeta{Name: "parent"},
+				Spec:       schedulingv1beta1.QueueSpec{Weight: 1, Parent: "root"},
+			},
+			children: []*schedulingv1beta1.Queue{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "c1",
+						Annotations: map[string]string{
+							ClosedByParentAnnotationKey: ClosedByParentAnnotationTrueValue,
+						},
+					},
+					Spec: schedulingv1beta1.QueueSpec{Parent: "parent"},
+				},
+				{
+					// no ClosedByParent annotation — should not be re-opened
+					ObjectMeta: metav1.ObjectMeta{Name: "c2"},
+					Spec:       schedulingv1beta1.QueueSpec{Parent: "parent"},
+				},
+			},
+			expectError:        false,
+			expectEnqueueCount: 1,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			c := newFakeController()
+			if tc.parent != nil {
+				addQueueToStore(c, tc.parent)
+			}
+			for _, child := range tc.children {
+				addQueueToStore(c, child)
+			}
+
+			err := c.openHierarchicalQueue(tc.queue)
+			if tc.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, tc.expectEnqueueCount, c.queue.Len())
+		})
+	}
+}
+
+func TestCloseHierarchicalQueue(t *testing.T) {
+	testCases := []struct {
+		Name                    string
+		queue                   *schedulingv1beta1.Queue
+		children                []*schedulingv1beta1.Queue
+		expectContinue          bool
+		expectEnqueueCount      int
+		expectAnnotatedChildren []string
+	}{
+		{
+			Name: "root queue cannot be closed - returns false",
+			queue: &schedulingv1beta1.Queue{
+				ObjectMeta: metav1.ObjectMeta{Name: "root"},
+			},
+			expectContinue:     false,
+			expectEnqueueCount: 0,
+		},
+		{
+			Name: "leaf queue with no children returns true with no work",
+			queue: &schedulingv1beta1.Queue{
+				ObjectMeta: metav1.ObjectMeta{Name: "leaf"},
+				Spec:       schedulingv1beta1.QueueSpec{Parent: "root"},
+			},
+			expectContinue:     true,
+			expectEnqueueCount: 0,
+		},
+		{
+			Name: "open children get ClosedByParent annotation and close action enqueued",
+			queue: &schedulingv1beta1.Queue{
+				ObjectMeta: metav1.ObjectMeta{Name: "par"},
+				Spec:       schedulingv1beta1.QueueSpec{Parent: "root"},
+			},
+			children: []*schedulingv1beta1.Queue{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "open-child"},
+					Spec:       schedulingv1beta1.QueueSpec{Parent: "par"},
+					Status:     schedulingv1beta1.QueueStatus{State: schedulingv1beta1.QueueStateOpen},
+				},
+			},
+			expectContinue:          true,
+			expectEnqueueCount:      1,
+			expectAnnotatedChildren: []string{"open-child"},
+		},
+		{
+			Name: "already closed and closing children are skipped entirely",
+			queue: &schedulingv1beta1.Queue{
+				ObjectMeta: metav1.ObjectMeta{Name: "par2"},
+				Spec:       schedulingv1beta1.QueueSpec{Parent: "root"},
+			},
+			children: []*schedulingv1beta1.Queue{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "closed-child"},
+					Spec:       schedulingv1beta1.QueueSpec{Parent: "par2"},
+					Status:     schedulingv1beta1.QueueStatus{State: schedulingv1beta1.QueueStateClosed},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "closing-child"},
+					Spec:       schedulingv1beta1.QueueSpec{Parent: "par2"},
+					Status:     schedulingv1beta1.QueueStatus{State: schedulingv1beta1.QueueStateClosing},
+				},
+			},
+			expectContinue:     true,
+			expectEnqueueCount: 0,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			c := newFakeController()
+			for _, child := range tc.children {
+				addQueueToStore(c, child)
+				// Children that will be annotated must also exist in vcClient so the patch succeeds.
+				if child.Status.State != schedulingv1beta1.QueueStateClosed &&
+					child.Status.State != schedulingv1beta1.QueueStateClosing {
+					_, err := c.vcClient.SchedulingV1beta1().Queues().Create(context.TODO(), child, metav1.CreateOptions{})
+					assert.NoError(t, err)
+				}
+			}
+
+			continued, err := c.closeHierarchicalQueue(tc.queue)
+			assert.NoError(t, err)
+			assert.Equal(t, tc.expectContinue, continued)
+			assert.Equal(t, tc.expectEnqueueCount, c.queue.Len())
+
+			for _, childName := range tc.expectAnnotatedChildren {
+				updated, err := c.vcClient.SchedulingV1beta1().Queues().Get(context.TODO(), childName, metav1.GetOptions{})
+				assert.NoError(t, err)
+				assert.Equal(t, ClosedByParentAnnotationTrueValue, updated.Annotations[ClosedByParentAnnotationKey])
+			}
+		})
 	}
 }


### PR DESCRIPTION
## PR Description

## What this PR does

Adds unit test coverage for hierarchical queue controller actions in:

- `pkg/controllers/queue/queue_controller_action.go`
- `pkg/controllers/queue/queue_controller_handler.go`

These paths previously had effectively no direct test coverage.

## Why this PR is needed

The hierarchical queue controller logic is responsible for propagating
parent queue state changes to child queues and will be relied upon by the
upcoming `NamespaceQueue` functionality.

The covered functions include:

- `syncHierarchicalQueue`
- `openHierarchicalQueue`
- `closeHierarchicalQueue`
- `updateQueueParent`
- `updateQueueAnnotation`
- `updateQueue` event handler

Before this PR, the only indirect coverage came from `TestSyncQueue`,
which used a `"root"` queue and bypassed most hierarchical logic paths.

## Changes made

- Added `addQueueToStore` helper to populate informer cache state during tests
  without requiring a running informer.
- Added 20 new sub-tests across 6 table-driven test suites:
  - `TestUpdateQueueParent`
  - `TestUpdateQueueAnnotation`
  - `TestUpdateQueueHandler`
  - `TestSyncHierarchicalQueue`
  - `TestOpenHierarchicalQueue`
  - `TestCloseHierarchicalQueue`
- Verified propagation behavior for:
  - parent close/open state transitions
  - child queue reopening
  - annotation updates
  - default parent assignment
  - queue hierarchy synchronization edge cases

## Test plan

```bash
go test ./pkg/controllers/queue/... -v
````

## What type of PR is this?

/kind test

## Which issue(s) this PR fixes

Fixes N/A

## Special notes for reviewers

* No production code changes are included.
* Tests use the existing `newFakeController()` pattern and fake clients.
* Informer cache state is injected directly through the added helper to keep
  tests lightweight and deterministic.

## AI disclosure

Claude Code (claude-sonnet-4-6) was used only for initial assistance in identifying uncovered paths and generating a rough test scaffold.

The actual test scenarios, assertions, informer-store setup, edge-case handling, and final implementation were manually reviewed, expanded, modified, and validated locally. Significant manual work was done to refine the test logic, ensure realistic controller behavior coverage, and verify all cases with local test runs before submission.

## Does this PR introduce a user-facing change?

```release-note
NONE
```

```
```
