### PR TITLE
test: fix restart pod lifecycle flake

### DIFF
--- a/test/e2e/jobseq/job_error_handling.go
+++ b/test/e2e/jobseq/job_error_handling.go
@@ -180,8 +180,8 @@ var _ = Describe("Job Error Handling", func() {
 			},
 		})
 
-		// job phase: pending -> running -> restarting -> running
-		err := e2eutil.WaitJobPhases(testCtx, job, []vcbatch.JobPhase{vcbatch.Pending, vcbatch.Running, vcbatch.Restarting, vcbatch.Running})
+		// The failed task keeps failing after RestartPod, so the stable signal is the transition to Restarting.
+		err := e2eutil.WaitJobPhases(testCtx, job, []vcbatch.JobPhase{vcbatch.Pending, vcbatch.Running, vcbatch.Restarting})
 		Expect(err).NotTo(HaveOccurred())
 	})
 


### PR DESCRIPTION
#### What type of PR is this?

/area test
/kind flake

#### What this PR does / why we need it:

This PR fixes the flaky jobseq e2e case `job level LifecyclePolicy, Event: PodFailed, Action: RestartPod; Event PodEvicted, Action: TerminateJob, Timeout: 5m`.

The test creates a task whose command is `sleep 10s && xxx`. That command fails every time the pod is recreated. The existing assertion waits for the job to transition through `Pending -> Running -> Restarting -> Running`, but the last `Running` phase is not a stable expectation for this workload. After `RestartPodAction` recreates the failed pod, the replacement pod runs the same failing command and can put the job back into `Restarting` again.

The stable behavior this case can verify is that `PodFailed` triggers `RestartPodAction` and moves the job into `Restarting`. The assertion now stops at that phase instead of waiting for a later `Running` window that depends on timing.

#### Which issue(s) this PR fixes:

Related to #5015

#### Special notes for your reviewer:

This keeps the workload unchanged and narrows the expected job phase sequence to the lifecycle behavior the workload can reliably prove.

AI tools were used while investigating the flaky failure and preparing this PR.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
