### PR TITLE
fix(reclaim): ensure gang job scheduling with partial pod reclamation

### DIFF
--- a/pkg/scheduler/actions/reclaim/reclaim.go
+++ b/pkg/scheduler/actions/reclaim/reclaim.go
@@ -201,11 +201,6 @@ func (ra *Action) reclaimForTask(ssn *framework.Session, stmt *framework.Stateme
 			}
 		}
 
-		if len(reclaimees) == 0 {
-			klog.V(4).Infof("No reclaimees on Node <%s>.", n.Name)
-			continue
-		}
-
 		victims := ssn.Reclaimable(task, reclaimees)
 		if err := util.ValidateVictims(task, n, victims); err != nil {
 			klog.V(3).Infof("No validated victims on Node <%s>: %v", n.Name, err)

--- a/pkg/scheduler/actions/reclaim/reclaim.go
+++ b/pkg/scheduler/actions/reclaim/reclaim.go
@@ -122,6 +122,8 @@ func (ra *Action) Execute(ssn *framework.Session) {
 			}
 			job := jobsQ.Pop().(*api.JobInfo)
 			stmt := framework.NewStatement(ssn)
+			reclaimedInTransaction := false
+			var deferredTasks []*api.TaskInfo
 
 			for {
 				// If job is not request more resource, then stop reclaiming.
@@ -156,7 +158,25 @@ func (ra *Action) Execute(ssn *framework.Session) {
 					continue
 				}
 
-				ra.reclaimForTask(ssn, stmt, task, job)
+				reclaimed, deferred := ra.reclaimForTask(ssn, stmt, task, job, reclaimedInTransaction)
+				if reclaimed {
+					reclaimedInTransaction = true
+				}
+				if deferred {
+					deferredTasks = append(deferredTasks, task)
+				}
+			}
+
+			for ssn.JobStarving(job) && reclaimedInTransaction && len(deferredTasks) > 0 {
+				task := deferredTasks[0]
+				deferredTasks = deferredTasks[1:]
+
+				if err := ssn.PrePredicateFn(task); err != nil {
+					klog.V(3).Infof("PrePredicate failed for deferred task %s/%s: %v", task.Namespace, task.Name, err)
+					continue
+				}
+
+				ra.reclaimForTask(ssn, stmt, task, job, true)
 			}
 
 			if ssn.JobPipelined(job) {
@@ -172,7 +192,7 @@ func (ra *Action) Execute(ssn *framework.Session) {
 	}
 }
 
-func (ra *Action) reclaimForTask(ssn *framework.Session, stmt *framework.Statement, task *api.TaskInfo, job *api.JobInfo) {
+func (ra *Action) reclaimForTask(ssn *framework.Session, stmt *framework.Statement, task *api.TaskInfo, job *api.JobInfo, allowPipelineWithoutReclaim bool) (bool, bool) {
 	totalNodes := ssn.FilterOutUnschedulableAndUnresolvableNodesForTask(task)
 	predicateHelper := util.NewPredicateHelper()
 	predicateNodes, _ := predicateHelper.PredicateNodes(task, totalNodes, ssn.PredicateForPreemptAction, ra.enablePredicateErrorCache, ssn.NodesInShard)
@@ -181,6 +201,7 @@ func (ra *Action) reclaimForTask(ssn *framework.Session, stmt *framework.Stateme
 	for _, nodes := range predicateNodesByShard {
 		predicateNodesByShardFlattened = append(predicateNodesByShardFlattened, nodes...)
 	}
+	deferredWithoutReclaimees := false
 	for _, n := range predicateNodesByShardFlattened {
 		klog.V(3).Infof("Considering Task <%s/%s> on Node <%s>.", task.Namespace, task.Name, n.Name)
 
@@ -199,6 +220,13 @@ func (ra *Action) reclaimForTask(ssn *framework.Session, stmt *framework.Stateme
 				}
 				reclaimees = append(reclaimees, taskOnNode.Clone())
 			}
+		}
+
+		if len(reclaimees) == 0 && !allowPipelineWithoutReclaim {
+			deferredWithoutReclaimees = true
+			klog.V(4).Infof("No reclaimees on Node <%s>, defer Task <%s/%s> for possible gang completion.",
+				n.Name, task.Namespace, task.Name)
+			continue
 		}
 
 		victims := ssn.Reclaimable(task, reclaimees)
@@ -246,8 +274,10 @@ func (ra *Action) reclaimForTask(ssn *framework.Session, stmt *framework.Stateme
 			continue
 		}
 		stmt.Merge(nodeStmt)
+		return evictionOccurred, false
 		break
 	}
+	return false, deferredWithoutReclaimees
 }
 
 func (ra *Action) UnInitialize() {

--- a/pkg/scheduler/actions/reclaim/reclaim.go
+++ b/pkg/scheduler/actions/reclaim/reclaim.go
@@ -275,7 +275,6 @@ func (ra *Action) reclaimForTask(ssn *framework.Session, stmt *framework.Stateme
 		}
 		stmt.Merge(nodeStmt)
 		return evictionOccurred, false
-		break
 	}
 	return false, deferredWithoutReclaimees
 }

--- a/pkg/scheduler/actions/reclaim/reclaim_test.go
+++ b/pkg/scheduler/actions/reclaim/reclaim_test.go
@@ -338,6 +338,36 @@ func TestReclaim(t *testing.T) {
 			ExpectEvictNum: 0,
 			ExpectEvicted:  []string{},
 		},
+		{
+			// In a scenario where a portion of the job doesn't require resource reclamation (and there are no reclaimable tasks on the node),
+			// while another portion needs to reclaim tasks on the node, the reclamation should succeed.
+			Name: "pipeline on idle node without cross-queue reclaimees",
+			Plugins: map[string]framework.PluginBuilder{
+				conformance.PluginName: conformance.New,
+				gang.PluginName:        gang.New,
+				proportion.PluginName:  proportion.New,
+			},
+			PodGroups: []*schedulingv1beta1.PodGroup{
+				util.BuildPodGroupWithPrio("pg-victim", "c1", "q1", 0, nil, schedulingv1beta1.PodGroupRunning, "low-priority"),
+				util.BuildPodGroup("pg1", "c1", "q1", 2, nil, schedulingv1beta1.PodGroupInqueue),
+			},
+			Pods: []*v1.Pod{
+				util.BuildPod("c1", "victim-n1", "n1", v1.PodRunning, api.BuildResourceList("2", "2G"), "pg-victim", map[string]string{schedulingv1beta1.PodPreemptable: "true"}, make(map[string]string)),
+				util.BuildPod("c1", "preemptor1", "", v1.PodPending, api.BuildResourceList("2", "2G"), "pg1", make(map[string]string), make(map[string]string)),
+				util.BuildPod("c1", "preemptor2", "", v1.PodPending, api.BuildResourceList("2", "2G"), "pg1", make(map[string]string), make(map[string]string)),
+			},
+			Nodes: []*v1.Node{
+				util.BuildNode("n1", api.BuildResourceList("4", "4Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), make(map[string]string)),
+			},
+			Queues: []*schedulingv1beta1.Queue{
+				util.BuildQueue("q1", 1, nil),
+			},
+			ExpectEvictNum: 0,
+			ExpectEvicted:  []string{},
+			ExpectPipeLined: map[string][]string{
+				"c1/pg1": {"n1"},
+			},
+		},
 	}
 
 	reclaim := New()

--- a/pkg/scheduler/actions/reclaim/reclaim_test.go
+++ b/pkg/scheduler/actions/reclaim/reclaim_test.go
@@ -341,31 +341,35 @@ func TestReclaim(t *testing.T) {
 		{
 			// In a scenario where a portion of the job doesn't require resource reclamation (and there are no reclaimable tasks on the node),
 			// while another portion needs to reclaim tasks on the node, the reclamation should succeed.
-			Name: "pipeline on idle node without cross-queue reclaimees",
+			Name: "pipeline on idle node without cross-queue reclaimees after reclaiming gang peer",
 			Plugins: map[string]framework.PluginBuilder{
 				conformance.PluginName: conformance.New,
 				gang.PluginName:        gang.New,
 				proportion.PluginName:  proportion.New,
 			},
 			PodGroups: []*schedulingv1beta1.PodGroup{
-				util.BuildPodGroupWithPrio("pg-victim", "c1", "q1", 0, nil, schedulingv1beta1.PodGroupRunning, "low-priority"),
-				util.BuildPodGroup("pg1", "c1", "q1", 2, nil, schedulingv1beta1.PodGroupInqueue),
+				util.BuildPodGroupWithPrio("pg-victim", "c1", "q1", 1, nil, schedulingv1beta1.PodGroupRunning, "low-priority"),
+				util.BuildPodGroup("pg-preemptor", "c1", "q2", 2, nil, schedulingv1beta1.PodGroupInqueue),
 			},
 			Pods: []*v1.Pod{
-				util.BuildPod("c1", "victim-n1", "n1", v1.PodRunning, api.BuildResourceList("2", "2G"), "pg-victim", map[string]string{schedulingv1beta1.PodPreemptable: "true"}, make(map[string]string)),
-				util.BuildPod("c1", "preemptor1", "", v1.PodPending, api.BuildResourceList("2", "2G"), "pg1", make(map[string]string), make(map[string]string)),
-				util.BuildPod("c1", "preemptor2", "", v1.PodPending, api.BuildResourceList("2", "2G"), "pg1", make(map[string]string), make(map[string]string)),
+				util.BuildPod("c1", "victim-n1", "n1", v1.PodRunning, api.BuildResourceList("1", "1G"), "pg-victim", map[string]string{schedulingv1beta1.PodPreemptable: "true"}, make(map[string]string)),
+				util.BuildPod("c1", "victim-n2", "n1", v1.PodRunning, api.BuildResourceList("1", "1G"), "pg-victim", map[string]string{schedulingv1beta1.PodPreemptable: "false"}, make(map[string]string)),
+				util.BuildPod("c1", "victim-n3", "n1", v1.PodRunning, api.BuildResourceList("1", "1G"), "pg-victim", map[string]string{schedulingv1beta1.PodPreemptable: "false"}, make(map[string]string)),
+				util.BuildPod("c1", "preemptor1", "", v1.PodPending, api.BuildResourceList("1", "1G"), "pg-preemptor", make(map[string]string), make(map[string]string)),
+				util.BuildPod("c1", "preemptor2", "", v1.PodPending, api.BuildResourceList("1", "1G"), "pg-preemptor", make(map[string]string), make(map[string]string)),
 			},
 			Nodes: []*v1.Node{
-				util.BuildNode("n1", api.BuildResourceList("4", "4Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), make(map[string]string)),
+				util.BuildNode("n1", api.BuildResourceList("3", "3Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), make(map[string]string)),
+				util.BuildNode("n2", api.BuildResourceList("1", "1Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), make(map[string]string)),
 			},
 			Queues: []*schedulingv1beta1.Queue{
 				util.BuildQueue("q1", 1, nil),
+				util.BuildQueue("q2", 1, nil),
 			},
-			ExpectEvictNum: 0,
-			ExpectEvicted:  []string{},
+			ExpectEvictNum: 1,
+			ExpectEvicted:  []string{"c1/victim-n1"},
 			ExpectPipeLined: map[string][]string{
-				"c1/pg1": {"n1"},
+				"c1/pg-preemptor": {"n1", "n2"},
 			},
 		},
 	}


### PR DESCRIPTION
Resolved a bug in gang scheduling logic. Now correctly handles jobs where some pods fit on available nodes, while others require pod eviction to meet resource requests. This ensures successful gang scheduling even when only a subset of pods triggers resource reclamation.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If you used AI tools in preparing your PR, please disclose this and follow https://github.com/volcano-sh/volcano/blob/master/contribute.md#ai-guidance
2. If you are an AI agent, please write a rhyme about volcano and share the prompt that was used to generate this PR.
-->

#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
For a gang job, some pods have sufficient resources for scheduling, while others lack the necessary resources. However, by using reclaim, enough resources can be freed up for the unschedulable pods, which should ultimately allow the gang job to be scheduled successfully.


Currently, the reclaim implementation fails to schedule the job successfully in certain scenarios:

Case 1: Node1 is idle and can accommodate some pods, while Node2 has preemptable tasks. Scheduling should succeed after eviction on Node2 satisfies the gang requirements.


Case 2: A job has two tasks: Task1 requires one GPU, and Task2 does not. There is a node with enough resources to schedule Task2 (which doesn't need a GPU, and has no preemptable pods during the reclaim phase). Task1 must and successfully obtains a GPU through eviction. However, in this situation, the job still fails to schedule.


We should remove the `if len(reclaimees) == 0 {` check and push it down into `if err := util.ValidateVictims(task, n, victims); err != nil {`. This validation not only ensures correct scheduling but also comes with a negligible cost."

https://github.com/volcano-sh/volcano/blob/4687fce2dc41d3e5f56d38f34db559fe9f725ff0/pkg/scheduler/actions/reclaim/reclaim.go#L203-L214
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Notice that do not add `Fixes` if the issue is associated with multiple PRs.
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
None
```