### PR TITLE
fix: correct typos in scheduler comments

### DIFF
--- a/pkg/agentscheduler/cache/cache.go
+++ b/pkg/agentscheduler/cache/cache.go
@@ -118,7 +118,7 @@ type SchedulerCache struct {
 
 	Recorder record.EventRecorder
 
-	Nodes         map[string]*nodeInfoListItem // TODO: do we need to also add a seperate lock for Nodes cache?
+	Nodes         map[string]*nodeInfoListItem // TODO: do we need to also add a separate lock for Nodes cache?
 	headNode      *nodeInfoListItem
 	NodeList      []string
 	NodeShards    map[string]*schedulingapi.NodeShardInfo
@@ -167,7 +167,7 @@ type SchedulerCache struct {
 	resourceSyncTimeout time.Duration
 }
 
-// TaskCache encapsulates the task map with a seperate lock
+// TaskCache encapsulates the task map with a separate lock
 type TaskCache struct {
 	sync.RWMutex
 	tasks map[schedulingapi.TaskID]*schedulingapi.TaskInfo

--- a/pkg/scheduler/api/devices/ascend/mindcluster/ascend310p/vnpu/type.go
+++ b/pkg/scheduler/api/devices/ascend/mindcluster/ascend310p/vnpu/type.go
@@ -345,7 +345,7 @@ const (
 	// NodedNodeHealtyStatuskey  is the key of node healthy status from configmap data of noded
 	NodedNodeHealtyStatuskey = "nodedNodeHealtyStatus"
 	// NodeSubHealthy means there is some fault on the node which is reported by nodeD, but will not immediately
-	// make node unhealthy, this status will prevent new task schduled on this node and reschedule will not consider
+	// make node unhealthy, this status will prevent new tasks from being scheduled on this node and rescheduling will not consider
 	// this node
 	NodeSubHealthy = "SubHealthy"
 	// NodeUnHealthyByNodeD is the node unhealthy status reported by nodeD configmap,

--- a/pkg/scheduler/plugins/deviceshare/deviceshare.go
+++ b/pkg/scheduler/plugins/deviceshare/deviceshare.go
@@ -273,7 +273,7 @@ func (dp *deviceSharePlugin) OnSessionOpen(ssn *framework.Session) {
 				return 0, status.AsError()
 			}
 
-			// TODO: we should use a seperate plugin for devices, and seperate them from predicates and nodeOrder plugin.
+			// TODO: we should use a separate plugin for devices, and separate them from predicates and nodeOrder plugin.
 			nodeScore = float64(score) * float64(dp.scheduleWeight)
 			klog.V(5).Infof("Node: %s, task<%s/%s> Device Score weight %d, score: %f", node.Name, task.Namespace, task.Name, dp.scheduleWeight, nodeScore)
 		}

--- a/pkg/scheduler/plugins/numaaware/provider/cpumanager/cpu_mng.go
+++ b/pkg/scheduler/plugins/numaaware/provider/cpumanager/cpu_mng.go
@@ -104,7 +104,7 @@ func generateCPUTopologyHints(availableCPUs cpuset.CPUSet, CPUDetails topology.C
 }
 
 // getPhysicalCoresNum return the number of physical cores.
-// The resourc-exporter reports core ids only unique in each socket,
+// The resource-exporter reports core IDs only unique in each socket,
 // we use the platform unique form to get all physical cores.
 func getPhysicalCoresNum(CPUDetails topology.CPUDetails) int {
 	uniques := make(map[string]struct{})


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it:**
Fixes a few typos I noticed while reading through the scheduler code:
- `seperate` → `separate` in deviceshare and agentscheduler cache
- `resourc-exporter` → `resource-exporter` in cpu_mng.go
- `schduled` → `scheduled` in vnpu type.go

**Which issue(s) this PR fixes:**
N/A

**Special notes for your reviewer:**
Comment-only changes, no logic changes.

**Does this PR introduce a user-facing change?**
NONE