### PR TITLE
fix(scheduler): avoid false PodGroup Unschedulable on first gang scheduling cycle

### DIFF
--- a/pkg/scheduler/api/job_info.go
+++ b/pkg/scheduler/api/job_info.go
@@ -1178,6 +1178,23 @@ func (ji *JobInfo) IsStarving() bool {
 	return ji.WaitingTaskNum()+ji.ReadyTaskNum() < ji.MinAvailable
 }
 
+// IsGenuinelyUnschedulable returns true if the job has real scheduling failures,
+// as opposed to temporarily not meeting gang scheduling minAvailable requirements.
+func (ji *JobInfo) IsGenuinelyUnschedulable() bool {
+	if ji.JobFitErrors != "" {
+		return true
+	}
+	if ji.IsPipelined() {
+		return false
+	}
+	for uid := range ji.TaskStatusIndex[Pending] {
+		if fe := ji.NodesFitErrors[uid]; fe != nil && (len(fe.nodes) > 0 || fe.err != "") {
+			return true
+		}
+	}
+	return false
+}
+
 // IsPending returns whether job is in pending status
 func (ji *JobInfo) IsPending() bool {
 	return ji.PodGroup == nil ||

--- a/pkg/scheduler/api/job_info.go
+++ b/pkg/scheduler/api/job_info.go
@@ -1188,6 +1188,10 @@ func (ji *JobInfo) IsGenuinelyUnschedulable() bool {
 		return false
 	}
 	for uid := range ji.TaskStatusIndex[Pending] {
+		task := ji.Tasks[uid]
+		if task != nil && task.SchGated && task.Pod != nil && !HasOnlyVolcanoSchedulingGate(task.Pod) {
+			return true
+		}
 		if fe := ji.NodesFitErrors[uid]; fe != nil && fe.HasErrors() {
 			return true
 		}

--- a/pkg/scheduler/api/job_info.go
+++ b/pkg/scheduler/api/job_info.go
@@ -1188,7 +1188,7 @@ func (ji *JobInfo) IsGenuinelyUnschedulable() bool {
 		return false
 	}
 	for uid := range ji.TaskStatusIndex[Pending] {
-		if fe := ji.NodesFitErrors[uid]; fe != nil && (len(fe.nodes) > 0 || fe.err != "") {
+		if fe := ji.NodesFitErrors[uid]; fe != nil && fe.HasErrors() {
 			return true
 		}
 	}

--- a/pkg/scheduler/api/job_info_test.go
+++ b/pkg/scheduler/api/job_info_test.go
@@ -771,7 +771,7 @@ func TestIsGenuinelyUnschedulable(t *testing.T) {
 				job := NewJobInfo("job-1",
 					newPendingTask("task-1"),
 					&TaskInfo{
-						UID:  "task-2",
+						UID:  TaskID("task-2"),
 						Name: "task-2",
 						TransactionContext: TransactionContext{
 							Status: Pipelined,
@@ -780,7 +780,7 @@ func TestIsGenuinelyUnschedulable(t *testing.T) {
 						InitResreq: res,
 					},
 					&TaskInfo{
-						UID:  "task-3",
+						UID:  TaskID("task-3"),
 						Name: "task-3",
 						TransactionContext: TransactionContext{
 							Status: Running,

--- a/pkg/scheduler/api/job_info_test.go
+++ b/pkg/scheduler/api/job_info_test.go
@@ -804,6 +804,38 @@ func TestIsGenuinelyUnschedulable(t *testing.T) {
 			},
 			expected: true,
 		},
+		{
+			name: "pending task blocked by external scheduling gate",
+			job: func() *JobInfo {
+				task := newPendingTask("task-1")
+				task.SchGated = true
+				task.Pod = &v1.Pod{
+					Spec: v1.PodSpec{
+						SchedulingGates: []v1.PodSchedulingGate{{Name: "example.com/g1"}},
+					},
+				}
+				job := NewJobInfo("job-1", task, newPendingTask("task-2"))
+				job.MinAvailable = 2
+				return job
+			},
+			expected: true,
+		},
+		{
+			name: "pending task with only volcano scheduling gate is not genuinely unschedulable",
+			job: func() *JobInfo {
+				task := newPendingTask("task-1")
+				task.SchGated = true
+				task.Pod = &v1.Pod{
+					Spec: v1.PodSpec{
+						SchedulingGates: []v1.PodSchedulingGate{{Name: schedulingv2.QueueAllocationGateKey}},
+					},
+				}
+				job := NewJobInfo("job-1", task, newPendingTask("task-2"))
+				job.MinAvailable = 2
+				return job
+			},
+			expected: false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/scheduler/api/job_info_test.go
+++ b/pkg/scheduler/api/job_info_test.go
@@ -718,3 +718,97 @@ func TestParseMinMemberInfoChanged(t *testing.T) {
 		})
 	}
 }
+
+func TestIsGenuinelyUnschedulable(t *testing.T) {
+	newPendingTask := func(uid types.UID) *TaskInfo {
+		res := NewResource(v1.ResourceList{"cpu": resource.MustParse("100m")})
+		return &TaskInfo{
+			UID:  TaskID(uid),
+			Name: string(uid),
+			TransactionContext: TransactionContext{
+				Status: Pending,
+			},
+			Resreq:     res,
+			InitResreq: res,
+		}
+	}
+
+	tests := []struct {
+		name     string
+		job      func() *JobInfo
+		expected bool
+	}{
+		{
+			name: "all pending without fit errors",
+			job: func() *JobInfo {
+				job := NewJobInfo("job-1",
+					newPendingTask("task-1"),
+					newPendingTask("task-2"),
+					newPendingTask("task-3"),
+				)
+				job.MinAvailable = 3
+				return job
+			},
+			expected: false,
+		},
+		{
+			name: "pending task with node fit errors",
+			job: func() *JobInfo {
+				task := newPendingTask("task-1")
+				job := NewJobInfo("job-1", task)
+				job.MinAvailable = 1
+				fe := NewFitErrors()
+				fe.SetNodeError("node-1", NewFitError(task, &NodeInfo{Name: "node-1"}, "resource fit failed"))
+				job.NodesFitErrors[task.UID] = fe
+				return job
+			},
+			expected: true,
+		},
+		{
+			name: "pipelined job is not genuinely unschedulable",
+			job: func() *JobInfo {
+				res := NewResource(v1.ResourceList{"cpu": resource.MustParse("100m")})
+				job := NewJobInfo("job-1",
+					newPendingTask("task-1"),
+					&TaskInfo{
+						UID:  "task-2",
+						Name: "task-2",
+						TransactionContext: TransactionContext{
+							Status: Pipelined,
+						},
+						Resreq:     res,
+						InitResreq: res,
+					},
+					&TaskInfo{
+						UID:  "task-3",
+						Name: "task-3",
+						TransactionContext: TransactionContext{
+							Status: Running,
+						},
+						Resreq:     res,
+						InitResreq: res,
+					},
+				)
+				job.MinAvailable = 3
+				return job
+			},
+			expected: false,
+		},
+		{
+			name: "job fit errors indicate unschedulable",
+			job: func() *JobInfo {
+				job := NewJobInfo("job-1", newPendingTask("task-1"))
+				job.MinAvailable = 1
+				job.JobFitErrors = "queue resource quota insufficient"
+				return job
+			},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, tt.job().IsGenuinelyUnschedulable())
+		})
+	}
+}

--- a/pkg/scheduler/api/unschedule_info.go
+++ b/pkg/scheduler/api/unschedule_info.go
@@ -91,6 +91,14 @@ func (f *FitErrors) SetNodeError(nodeName string, err error) {
 	f.nodes[nodeName] = fe
 }
 
+// HasErrors returns whether FitErrors contains node-level or common errors.
+func (f *FitErrors) HasErrors() bool {
+	if f == nil {
+		return false
+	}
+	return len(f.nodes) > 0 || f.err != ""
+}
+
 // GetUnschedulableAndUnresolvableNodes returns the set of nodes that has no help from preempting pods from it
 func (f *FitErrors) GetUnschedulableAndUnresolvableNodes() map[string]sets.Empty {
 	ret := make(map[string]sets.Empty)

--- a/pkg/scheduler/api/unschedule_info_test.go
+++ b/pkg/scheduler/api/unschedule_info_test.go
@@ -78,6 +78,19 @@ func TestFitError(t *testing.T) {
 	}
 }
 
+func TestFitErrorsHasErrors(t *testing.T) {
+	assert.False(t, (*FitErrors)(nil).HasErrors())
+	assert.False(t, NewFitErrors().HasErrors())
+
+	errOnly := NewFitErrors()
+	errOnly.SetError("resource fit failed")
+	assert.True(t, errOnly.HasErrors())
+
+	nodeErr := NewFitErrors()
+	nodeErr.SetNodeError("node1", errors.New(NodeResourceFitFailed))
+	assert.True(t, nodeErr.HasErrors())
+}
+
 func TestFitErrors(t *testing.T) {
 	tests := []struct {
 		node      string

--- a/pkg/scheduler/cache/cache.go
+++ b/pkg/scheduler/cache/cache.go
@@ -1622,23 +1622,32 @@ func (sc *SchedulerCache) String() string {
 	return str
 }
 
+func podGroupHasCondition(pg *schedulingapi.PodGroup, condType scheduling.PodGroupConditionType) bool {
+	if pg == nil {
+		return false
+	}
+	for _, c := range pg.Status.Conditions {
+		if c.Type == condType && c.Status == v1.ConditionTrue {
+			return true
+		}
+	}
+	return false
+}
+
 // RecordJobStatusEvent records related events according to job status.
 func (sc *SchedulerCache) RecordJobStatusEvent(job *schedulingapi.JobInfo, updatePG bool) {
-	pgUnschedulable := job.PodGroup != nil &&
-		(job.PodGroup.Status.Phase == scheduling.PodGroupUnknown ||
-			job.PodGroup.Status.Phase == scheduling.PodGroupPending ||
-			job.PodGroup.Status.Phase == scheduling.PodGroupInqueue)
+	hasUnschedulable := podGroupHasCondition(job.PodGroup, scheduling.PodGroupUnschedulableType)
+	hasScheduled := podGroupHasCondition(job.PodGroup, scheduling.PodGroupScheduled)
 
 	fitErrStr := job.FitError()
-	// If pending or unschedulable, record unschedulable event.
-	if pgUnschedulable {
+	if updatePG && hasUnschedulable {
 		msg := fmt.Sprintf("%v/%v tasks in gang unschedulable: %v",
 			len(job.TaskStatusIndex[schedulingapi.Pending]),
 			len(job.Tasks),
 			fitErrStr)
 		// TODO: should we skip pod unschedulable event if pod group is unschedulable due to gates to avoid printing too many messages?
 		sc.recordPodGroupEvent(job.PodGroup, v1.EventTypeWarning, string(scheduling.PodGroupUnschedulableType), msg)
-	} else if updatePG {
+	} else if updatePG && hasScheduled {
 		sc.recordPodGroupEvent(job.PodGroup, v1.EventTypeNormal, string(scheduling.PodGroupScheduled), string(scheduling.PodGroupReady))
 	}
 

--- a/pkg/scheduler/plugins/gang/gang.go
+++ b/pkg/scheduler/plugins/gang/gang.go
@@ -227,6 +227,12 @@ func (gp *gangPlugin) OnSessionClose(ssn *framework.Session) {
 			continue
 		}
 		if !job.IsReady() {
+			markUnschedulable := job.IsGenuinelyUnschedulable() ||
+				job.PodGroup.Status.Phase != scheduling.PodGroupInqueue
+			if !markUnschedulable {
+				continue
+			}
+
 			schedulableTaskNum := func() (num int32) {
 				for _, task := range job.TaskStatusIndex[api.Pending] {
 					ctx := task.GetTransactionContext()

--- a/pkg/scheduler/plugins/gang/gang_test.go
+++ b/pkg/scheduler/plugins/gang/gang_test.go
@@ -93,6 +93,22 @@ func TestOnSessionCloseConditions(t *testing.T) {
 			expectScheduled:     false,
 		},
 		{
+			name:     "inqueue job blocked by external scheduling gates should set unschedulable",
+			podGroup: util.BuildPodGroup("pg1", "c1", "c1", 2, nil, schedulingv1.PodGroupInqueue),
+			pods: []*v1.Pod{
+				util.BuildPod("c1", "p1", "", v1.PodPending, resource, "pg1", nil, nil),
+				util.BuildPod("c1", "p2", "", v1.PodPending, resource, "pg1", nil, nil),
+			},
+			setupJob: func(job *api.JobInfo) {
+				for _, task := range job.TaskStatusIndex[api.Pending] {
+					task.SchGated = true
+					task.Pod.Spec.SchedulingGates = []v1.PodSchedulingGate{{Name: "example.com/g1"}}
+				}
+			},
+			expectUnschedulable: true,
+			expectScheduled:     false,
+		},
+		{
 			name:     "pending job should set unschedulable",
 			podGroup: util.BuildPodGroup("pg1", "c1", "c1", 2, nil, schedulingv1.PodGroupPending),
 			pods: []*v1.Pod{

--- a/pkg/scheduler/plugins/gang/gang_test.go
+++ b/pkg/scheduler/plugins/gang/gang_test.go
@@ -1,0 +1,155 @@
+/*
+Copyright 2025 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gang
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+
+	"volcano.sh/apis/pkg/apis/scheduling"
+	schedulingv1 "volcano.sh/apis/pkg/apis/scheduling/v1beta1"
+	"volcano.sh/volcano/pkg/scheduler/api"
+	"volcano.sh/volcano/pkg/scheduler/conf"
+	"volcano.sh/volcano/pkg/scheduler/framework"
+	"volcano.sh/volcano/pkg/scheduler/uthelper"
+	"volcano.sh/volcano/pkg/scheduler/util"
+)
+
+func gangTier() []conf.Tier {
+	trueVal := true
+	return []conf.Tier{{
+		Plugins: []conf.PluginOption{{
+			Name:                   PluginName,
+			EnabledJobReady:        &trueVal,
+			EnabledJobPipelined:    &trueVal,
+			EnabledSubJobReady:     &trueVal,
+			EnabledSubJobPipelined: &trueVal,
+		}},
+	}}
+}
+
+func hasCondition(conditions []scheduling.PodGroupCondition, condType scheduling.PodGroupConditionType) bool {
+	for _, c := range conditions {
+		if c.Type == condType && c.Status == v1.ConditionTrue {
+			return true
+		}
+	}
+	return false
+}
+
+func TestOnSessionCloseConditions(t *testing.T) {
+	resource := api.BuildResourceList("1", "1G")
+
+	tests := []struct {
+		name                string
+		podGroup            *schedulingv1.PodGroup
+		pods                []*v1.Pod
+		setupJob            func(*api.JobInfo)
+		expectUnschedulable bool
+		expectScheduled     bool
+	}{
+		{
+			name:     "inqueue job waiting for gang should not set unschedulable",
+			podGroup: util.BuildPodGroup("pg1", "c1", "c1", 2, nil, schedulingv1.PodGroupInqueue),
+			pods: []*v1.Pod{
+				util.BuildPod("c1", "p1", "", v1.PodPending, resource, "pg1", nil, nil),
+				util.BuildPod("c1", "p2", "", v1.PodPending, resource, "pg1", nil, nil),
+			},
+			expectUnschedulable: false,
+			expectScheduled:     false,
+		},
+		{
+			name:     "inqueue job with fit errors should set unschedulable",
+			podGroup: util.BuildPodGroup("pg1", "c1", "c1", 2, nil, schedulingv1.PodGroupInqueue),
+			pods: []*v1.Pod{
+				util.BuildPod("c1", "p1", "", v1.PodPending, resource, "pg1", nil, nil),
+				util.BuildPod("c1", "p2", "", v1.PodPending, resource, "pg1", nil, nil),
+			},
+			setupJob: func(job *api.JobInfo) {
+				for _, task := range job.TaskStatusIndex[api.Pending] {
+					fe := api.NewFitErrors()
+					fe.SetNodeError("n1", api.NewFitError(task, &api.NodeInfo{Name: "n1"}, "resource fit failed"))
+					job.NodesFitErrors[task.UID] = fe
+					break
+				}
+			},
+			expectUnschedulable: true,
+			expectScheduled:     false,
+		},
+		{
+			name:     "pending job should set unschedulable",
+			podGroup: util.BuildPodGroup("pg1", "c1", "c1", 2, nil, schedulingv1.PodGroupPending),
+			pods: []*v1.Pod{
+				util.BuildPod("c1", "p1", "", v1.PodPending, resource, "pg1", nil, nil),
+				util.BuildPod("c1", "p2", "", v1.PodPending, resource, "pg1", nil, nil),
+			},
+			expectUnschedulable: true,
+			expectScheduled:     false,
+		},
+		{
+			name:     "ready job should set scheduled",
+			podGroup: util.BuildPodGroup("pg1", "c1", "c1", 2, nil, schedulingv1.PodGroupInqueue),
+			pods: []*v1.Pod{
+				util.BuildPod("c1", "p1", "n1", v1.PodRunning, resource, "pg1", nil, nil),
+				util.BuildPod("c1", "p2", "n1", v1.PodRunning, resource, "pg1", nil, nil),
+			},
+			expectUnschedulable: false,
+			expectScheduled:     true,
+		},
+	}
+
+	for i, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			test := &uthelper.TestCommonStruct{
+				Name:      tt.name,
+				Plugins:   map[string]framework.PluginBuilder{PluginName: New},
+				PodGroups: []*schedulingv1.PodGroup{tt.podGroup},
+				Pods:      tt.pods,
+				Queues:    []*schedulingv1.Queue{util.BuildQueue("c1", 1, nil)},
+				Nodes: []*v1.Node{
+					util.BuildNode("n1", api.BuildResourceList("10", "10G", []api.ScalarResource{{Name: "pods", Value: "10"}}...), nil),
+				},
+			}
+
+			ssn := test.RegisterSession(gangTier(), nil)
+			defer test.Close()
+
+			for _, job := range ssn.Jobs {
+				if tt.setupJob != nil {
+					tt.setupJob(job)
+				}
+			}
+
+			plugin := New(nil)
+			plugin.OnSessionClose(ssn)
+
+			var checked bool
+			for _, job := range ssn.Jobs {
+				checked = true
+				assert.Equal(t, tt.expectUnschedulable, hasCondition(job.PodGroup.Status.Conditions, scheduling.PodGroupUnschedulableType),
+					"case %d(%s) unschedulable condition mismatch for job %s", i, tt.name, job.Name)
+				assert.Equal(t, tt.expectScheduled, hasCondition(job.PodGroup.Status.Conditions, scheduling.PodGroupScheduled),
+					"case %d(%s) scheduled condition mismatch for job %s", i, tt.name, job.Name)
+			}
+			if !checked {
+				t.Fatalf("case %d(%s): no jobs found in session", i, tt.name)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Skip writing PodGroup `Unschedulable` conditions while an Inqueue job is still collecting gang-ready tasks without real fit errors, preventing the first scheduling cycle from falsely reporting failure when resources are sufficient.
- Align PodGroup events with actual condition state instead of inferring unschedulability from `Inqueue`/`Pending` phase alone, reducing noisy Warning events during normal gang scheduling.

Fixes #4503

## Test plan

- [x] `go test ./pkg/scheduler/api/... ./pkg/scheduler/plugins/gang/... -count=1 -run 'TestIsGenuinelyUnschedulable|TestOnSessionCloseConditions'`
- [x] Create a vcjob with sufficient cluster resources and verify PodGroup conditions go directly to `Scheduled` without an initial `Unschedulable` condition/event
- [x] Verify jobs with real predicate failures still get `Unschedulable` conditions and Warning events
- [x] Verify Pending jobs blocked from enqueue (e.g. queue quota) still get `Unschedulable` conditions


Made with [Cursor](https://cursor.com)