### PR TITLE
metriccollect: use memory working set for agent eviction metrics

### DIFF
--- a/pkg/metriccollect/local/memory.go
+++ b/pkg/metriccollect/local/memory.go
@@ -32,15 +32,15 @@ import (
 	"volcano.sh/volcano/pkg/agent/utils/cgroup"
 )
 
-var memoryStatMetrics = map[string]bool{
-	"total_cache": true,
-	"total_rss":   true,
-	"total_swap":  true,
-}
-
 const (
 	defaultMemInfoPath = "/host/proc/meminfo"
 	memInfoPathEnv     = "MEM_INFO_PATH_ENV"
+
+	memoryUsageInBytesV1 = "memory.usage_in_bytes"
+	memoryCurrentV2      = "memory.current"
+
+	inactiveFileKeyV1 = "total_inactive_file"
+	inactiveFileKeyV2 = "inactive_file"
 )
 
 type MemoryResourceCollector struct {
@@ -87,47 +87,79 @@ func (c *MemoryResourceCollector) CollectLocalMetrics(metricInfo *LocalMetricInf
 	return []*prompb.TimeSeries{&sample}, nil
 }
 
+// getMemoryUsage reports cgroup memory working set, aligned with kubelet eviction:
+// total usage minus inactive file cache (reclaimable under pressure).
 func getMemoryUsage(cgroupRoot string, cgroupVersion string) (int64, error) {
-	usage := int64(0)
-
-	var memoryUsageFile string
+	var usageFile, inactiveKey string
 	if cgroupVersion == cgroup.CgroupV2 {
-		memoryUsageFile = cgroup.MemoryUsageFileV2
+		usageFile = memoryCurrentV2
+		inactiveKey = inactiveFileKeyV2
 	} else {
-		memoryUsageFile = cgroup.MemoryUsageFile
+		usageFile = memoryUsageInBytesV1
+		inactiveKey = inactiveFileKeyV1
 	}
-	cgroupMemory := filepath.Join(cgroupRoot, memoryUsageFile)
-	date, err := os.ReadFile(cgroupMemory)
+
+	usage, err := readCgroupCounter(filepath.Join(cgroupRoot, usageFile))
 	if err != nil {
 		return 0, err
 	}
-	lines := strings.Split(string(date), "\n")
-	for _, line := range lines {
-		slices := strings.Split(line, " ")
-		if len(slices) != 2 {
+
+	statFile := cgroup.MemoryUsageFile
+	if cgroupVersion == cgroup.CgroupV2 {
+		statFile = cgroup.MemoryUsageFileV2
+	}
+	inactive, err := readMemoryStatValue(filepath.Join(cgroupRoot, statFile), inactiveKey)
+	if err != nil {
+		return 0, err
+	}
+
+	return memoryWorkingSet(usage, inactive), nil
+}
+
+func memoryWorkingSet(usage, inactiveFile int64) int64 {
+	if inactiveFile >= usage {
+		return 0
+	}
+	return usage - inactiveFile
+}
+
+func readCgroupCounter(path string) (int64, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return 0, err
+	}
+	value, err := strconv.ParseInt(strings.TrimSpace(string(data)), 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("parse cgroup counter %s: %w", path, err)
+	}
+	return value, nil
+}
+
+func readMemoryStatValue(statPath, key string) (int64, error) {
+	data, err := os.ReadFile(statPath)
+	if err != nil {
+		return 0, err
+	}
+	value, ok := parseMemoryStatKey(string(data), key)
+	if !ok {
+		return 0, fmt.Errorf("memory stat key %q not found in %s", key, statPath)
+	}
+	return value, nil
+}
+
+func parseMemoryStatKey(content, key string) (int64, bool) {
+	for _, line := range strings.Split(content, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) != 2 || fields[0] != key {
 			continue
 		}
-
-		if cgroupVersion == cgroup.CgroupV2 {
-			if isMemoryStatMetricV2(slices[0]) {
-				value, err := strconv.Atoi(slices[1])
-				if err != nil {
-					continue
-				}
-				usage += int64(value)
-			}
-		} else {
-			if memoryStatMetrics[slices[0]] {
-				value, err := strconv.Atoi(slices[1])
-				if err != nil {
-					continue
-				}
-
-				usage = usage + int64(value)
-			}
+		value, err := strconv.ParseInt(fields[1], 10, 64)
+		if err != nil {
+			return 0, false
 		}
+		return value, true
 	}
-	return usage, nil
+	return 0, false
 }
 
 func nodeMemoryUsage() (int64, error) {
@@ -165,40 +197,4 @@ func nodeMemoryUsage() (int64, error) {
 	systemUsed := (total - available) * 1024
 	klog.V(4).InfoS("System used memory", "value", systemUsed)
 	return systemUsed, nil
-}
-
-// isMemoryStatMetricV2 checks if the metric is a valid memory stat metric for cgroup v2
-func isMemoryStatMetricV2(metric string) bool {
-	// In cgroup v2, memory.stat contains different field names
-	// Based on actual cgroup v2 memory.stat file content:
-	// For memory usage calculation, we focus on the main memory consumption metrics:
-	// - anon: anonymous memory (similar to total_rss in v1)
-	// - file: file-backed memory (similar to total_cache in v1)
-	// - kernel: kernel memory usage
-	// - shmem: shared memory
-	// - slab: slab memory usage
-	// - pagetables: page table memory
-	// - kernel_stack: kernel stack memory
-	// - percpu: per-CPU memory
-	// - sock: socket memory
-	// - vmalloc: vmalloc memory
-	v2MemoryStatMetrics := map[string]bool{
-		"anon":         true, // Anonymous memory (RSS equivalent)
-		"file":         true, // File-backed memory (cache equivalent)
-		"kernel":       true, // Kernel memory
-		"shmem":        true, // Shared memory
-		"slab":         true, // Slab memory
-		"pagetables":   true, // Page tables
-		"kernel_stack": true, // Kernel stack
-		"percpu":       true, // Per-CPU memory
-		"sock":         true, // Socket memory
-		"vmalloc":      true, // Vmalloc memory
-		// Note: We exclude some metrics that are subsets or derivatives:
-		// - slab_reclaimable, slab_unreclaimable (covered by slab)
-		// - active_anon, inactive_anon (covered by anon)
-		// - active_file, inactive_file (covered by file)
-		// - file_mapped, file_dirty, file_writeback (covered by file)
-		// - anon_thp, file_thp, shmem_thp (covered by anon, file, shmem)
-	}
-	return v2MemoryStatMetrics[metric]
 }

--- a/pkg/metriccollect/local/memory.go
+++ b/pkg/metriccollect/local/memory.go
@@ -17,6 +17,7 @@ limitations under the License.
 package local
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -42,6 +43,8 @@ const (
 	inactiveFileKeyV1 = "total_inactive_file"
 	inactiveFileKeyV2 = "inactive_file"
 )
+
+var errMemoryStatKeyNotFound = errors.New("memory stat key not found")
 
 type MemoryResourceCollector struct {
 	cgroupManager cgroup.CgroupManager
@@ -140,14 +143,18 @@ func readMemoryStatValue(statPath, key string) (int64, error) {
 	if err != nil {
 		return 0, err
 	}
-	value, ok := parseMemoryStatKey(string(data), key)
-	if !ok {
-		return 0, fmt.Errorf("memory stat key %q not found in %s", key, statPath)
+	value, err := parseMemoryStatKey(string(data), key)
+	if err == nil {
+		return value, nil
 	}
-	return value, nil
+	if errors.Is(err, errMemoryStatKeyNotFound) {
+		// Match kubelet/cAdvisor: missing inactive file stat means 0.
+		return 0, nil
+	}
+	return 0, fmt.Errorf("read memory stat %s: %w", statPath, err)
 }
 
-func parseMemoryStatKey(content, key string) (int64, bool) {
+func parseMemoryStatKey(content, key string) (int64, error) {
 	for _, line := range strings.Split(content, "\n") {
 		fields := strings.Fields(line)
 		if len(fields) != 2 || fields[0] != key {
@@ -155,11 +162,11 @@ func parseMemoryStatKey(content, key string) (int64, bool) {
 		}
 		value, err := strconv.ParseInt(fields[1], 10, 64)
 		if err != nil {
-			return 0, false
+			return 0, fmt.Errorf("parse value for key %q: %w", key, err)
 		}
-		return value, true
+		return value, nil
 	}
-	return 0, false
+	return 0, errMemoryStatKeyNotFound
 }
 
 func nodeMemoryUsage() (int64, error) {

--- a/pkg/metriccollect/local/memory_test.go
+++ b/pkg/metriccollect/local/memory_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package local
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -46,9 +47,54 @@ func TestMemoryWorkingSet(t *testing.T) {
 
 func TestParseMemoryStatKey(t *testing.T) {
 	content := "total_rss 100\ntotal_inactive_file 60\n"
-	got, ok := parseMemoryStatKey(content, inactiveFileKeyV1)
-	if !ok || got != 60 {
-		t.Fatalf("parseMemoryStatKey() = %d, %v, want 60, true", got, ok)
+	got, err := parseMemoryStatKey(content, inactiveFileKeyV1)
+	if err != nil || got != 60 {
+		t.Fatalf("parseMemoryStatKey() = %d, %v, want 60, nil", got, err)
+	}
+}
+
+func TestParseMemoryStatKeyNotFound(t *testing.T) {
+	_, err := parseMemoryStatKey("total_rss 100\n", inactiveFileKeyV1)
+	if !errors.Is(err, errMemoryStatKeyNotFound) {
+		t.Fatalf("parseMemoryStatKey() err = %v, want errMemoryStatKeyNotFound", err)
+	}
+}
+
+func TestGetMemoryUsageMissingInactiveFileV1(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, memoryUsageInBytesV1), []byte("500000000\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	stat := "total_cache 100\ntotal_rss 200\n"
+	if err := os.WriteFile(filepath.Join(dir, cgroup.MemoryUsageFile), []byte(stat), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := getMemoryUsage(dir, cgroup.CgroupV1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != 500_000_000 {
+		t.Fatalf("getMemoryUsage(v1) = %d, want 500000000 when inactive file key is absent", got)
+	}
+}
+
+func TestGetMemoryUsageMissingInactiveFileV2(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, memoryCurrentV2), []byte("500000000\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	stat := "anon 200000000\nfile 100000000\n"
+	if err := os.WriteFile(filepath.Join(dir, cgroup.MemoryUsageFileV2), []byte(stat), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := getMemoryUsage(dir, cgroup.CgroupV2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != 500_000_000 {
+		t.Fatalf("getMemoryUsage(v2) = %d, want 500000000 when inactive_file is absent", got)
 	}
 }
 

--- a/pkg/metriccollect/local/memory_test.go
+++ b/pkg/metriccollect/local/memory_test.go
@@ -1,0 +1,91 @@
+/*
+Copyright 2024 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package local
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"volcano.sh/volcano/pkg/agent/utils/cgroup"
+)
+
+func TestMemoryWorkingSet(t *testing.T) {
+	tests := []struct {
+		name     string
+		usage    int64
+		inactive int64
+		want     int64
+	}{
+		{name: "subtract inactive file", usage: 1_000_000_000, inactive: 600_000_000, want: 400_000_000},
+		{name: "inactive exceeds usage", usage: 100, inactive: 200, want: 0},
+		{name: "no inactive file", usage: 500, inactive: 0, want: 500},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := memoryWorkingSet(tt.usage, tt.inactive); got != tt.want {
+				t.Fatalf("memoryWorkingSet() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseMemoryStatKey(t *testing.T) {
+	content := "total_rss 100\ntotal_inactive_file 60\n"
+	got, ok := parseMemoryStatKey(content, inactiveFileKeyV1)
+	if !ok || got != 60 {
+		t.Fatalf("parseMemoryStatKey() = %d, %v, want 60, true", got, ok)
+	}
+}
+
+func TestGetMemoryUsageCgroupV1(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, memoryUsageInBytesV1), []byte("1000000000\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	stat := "total_cache 700000000\ntotal_rss 200000000\ntotal_inactive_file 600000000\n"
+	if err := os.WriteFile(filepath.Join(dir, cgroup.MemoryUsageFile), []byte(stat), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := getMemoryUsage(dir, cgroup.CgroupV1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != 400_000_000 {
+		t.Fatalf("getMemoryUsage(v1) = %d, want 400000000 (working set, not cache-inclusive sum)", got)
+	}
+}
+
+func TestGetMemoryUsageCgroupV2(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, memoryCurrentV2), []byte("900000000\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	stat := "anon 200000000\nfile 700000000\ninactive_file 550000000\n"
+	if err := os.WriteFile(filepath.Join(dir, cgroup.MemoryUsageFileV2), []byte(stat), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := getMemoryUsage(dir, cgroup.CgroupV2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != 350_000_000 {
+		t.Fatalf("getMemoryUsage(v2) = %d, want 350000000", got)
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?
Bug fix

#### What this PR does / why we need it:
`getMemoryUsage()` in the local metric collector summed cache/file-backed
memory from `memory.stat`. Agent eviction and oversubscription both use
that value, so usage looked higher than kubelet working set and could
trigger early eviction of preemptable pods and under-report oversubscription.

This change reports working set: cgroup usage (`memory.usage_in_bytes` on v1,
`memory.current` on v2) minus inactive file from `memory.stat`.

#### Which issue(s) this PR fixes:
Fixes #5333

#### Special notes for your reviewer:
- Does not change the `IncludeSystemUsed` / `nodeMemoryUsage()` path in
  `CollectLocalMetrics`; only the default cgroup `getMemoryUsage()` path.
- Unit tests use temp dirs with fake cgroup files for v1 and v2.
- Could not run `go test ./pkg/metriccollect/local/...` locally on macOS
  (linux cgroup deps); please rely on CI for package tests.
- No cluster repro on my side yet.

#### Does this PR introduce a user-facing change?
```release-note
volcano-agent memory pressure and oversubscription now use working set
(cgroup usage minus inactive file cache), consistent with kubelet eviction.
```