### PR TITLE
fix: add AddFunc handler to pgInformer to prevent VCJob stuck in Pending

### DIFF
--- a/pkg/controllers/job/job_controller.go
+++ b/pkg/controllers/job/job_controller.go
@@ -246,6 +246,7 @@ func (cc *jobcontroller) Initialize(opt *framework.ControllerOption) error {
 
 	cc.pgInformer = factory.Scheduling().V1beta1().PodGroups()
 	cc.pgInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    cc.addPodGroup,
 		UpdateFunc: cc.updatePodGroup,
 	})
 	cc.pgLister = cc.pgInformer.Lister()

--- a/pkg/controllers/job/job_controller_handler.go
+++ b/pkg/controllers/job/job_controller_handler.go
@@ -449,6 +449,31 @@ func (cc *jobcontroller) processNextCommand() bool {
 	return true
 }
 
+func (cc *jobcontroller) addPodGroup(obj interface{}) {
+	pg, ok := obj.(*scheduling.PodGroup)
+	if !ok {
+		klog.Errorf("Failed to convert %v to PodGroup", obj)
+		return
+	}
+
+	jobNameKey := pg.Name
+	for _, or := range pg.OwnerReferences {
+		if or.Kind == helpers.JobKind.Kind {
+			jobNameKey = or.Name
+			break
+		}
+	}
+
+	req := apis.Request{
+		Namespace: pg.Namespace,
+		JobName:   jobNameKey,
+		Event:     bus.OutOfSyncEvent,
+	}
+	key := jobhelpers.GetJobKeyByReq(&req)
+	queue := cc.getWorkerQueue(key)
+	queue.Add(req)
+}
+
 func (cc *jobcontroller) updatePodGroup(oldObj, newObj interface{}) {
 	oldPG, ok := oldObj.(*scheduling.PodGroup)
 	if !ok {

--- a/pkg/controllers/job/job_controller_handler_test.go
+++ b/pkg/controllers/job/job_controller_handler_test.go
@@ -569,6 +569,67 @@ func TestDeletePodFunc(t *testing.T) {
 	}
 }
 
+func TestAddPodGroupFunc(t *testing.T) {
+	namespace := "test"
+	boolTrue := true
+
+	testCases := []struct {
+		Name        string
+		PodGroup    *scheduling.PodGroup
+		ExpectValue int
+		ExpectKey   string
+	}{
+		{
+			Name: "PodGroup with Job OwnerReference re-queues job",
+			PodGroup: &scheduling.PodGroup{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pg1-uid",
+					Namespace: namespace,
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion: helpers.JobKind.GroupVersion().String(),
+							Kind:       helpers.JobKind.Kind,
+							Name:       "job1",
+							Controller: &boolTrue,
+						},
+					},
+				},
+				Status: scheduling.PodGroupStatus{
+					Phase: scheduling.PodGroupInqueue,
+				},
+			},
+			ExpectValue: 1,
+			ExpectKey:   "test/job1",
+		},
+		{
+			Name: "PodGroup without OwnerReference uses PodGroup name",
+			PodGroup: &scheduling.PodGroup{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "legacy-pg",
+					Namespace: namespace,
+				},
+				Status: scheduling.PodGroupStatus{
+					Phase: scheduling.PodGroupPending,
+				},
+			},
+			ExpectValue: 1,
+			ExpectKey:   "test/legacy-pg",
+		},
+	}
+
+	for i, testcase := range testCases {
+		t.Run(testcase.Name, func(t *testing.T) {
+			controller := newController()
+			controller.addPodGroup(testcase.PodGroup)
+			queue := controller.getWorkerQueue(testcase.ExpectKey)
+			qLen := queue.Len()
+			if testcase.ExpectValue != qLen {
+				t.Errorf("case %d (%s): expected queue length: %v, got %v", i, testcase.Name, testcase.ExpectValue, qLen)
+			}
+		})
+	}
+}
+
 func TestUpdatePodGroupFunc(t *testing.T) {
 
 	namespace := "test"

--- a/pkg/controllers/job/job_controller_handler_test.go
+++ b/pkg/controllers/job/job_controller_handler_test.go
@@ -602,10 +602,10 @@ func TestAddPodGroupFunc(t *testing.T) {
 			ExpectKey:   "test/job1",
 		},
 		{
-			Name: "PodGroup without OwnerReference uses PodGroup name",
+			Name: "PodGroup without Job OwnerReference falls back to PodGroup name",
 			PodGroup: &scheduling.PodGroup{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "legacy-pg",
+					Name:      "deploy-pg",
 					Namespace: namespace,
 				},
 				Status: scheduling.PodGroupStatus{
@@ -613,7 +613,7 @@ func TestAddPodGroupFunc(t *testing.T) {
 				},
 			},
 			ExpectValue: 1,
-			ExpectKey:   "test/legacy-pg",
+			ExpectKey:   "test/deploy-pg",
 		},
 	}
 
@@ -628,6 +628,57 @@ func TestAddPodGroupFunc(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestAddPodGroupRequiredForPreSetPhase proves that AddFunc is the only
+// enqueue path when the informer first observes a PodGroup whose phase is
+// already set (e.g. Inqueue). updatePodGroup only enqueues on phase
+// transitions, so without AddFunc the job would never be reconciled.
+func TestAddPodGroupRequiredForPreSetPhase(t *testing.T) {
+	namespace := "test"
+	boolTrue := true
+
+	pg := &scheduling.PodGroup{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pg-preset",
+			Namespace: namespace,
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: helpers.JobKind.GroupVersion().String(),
+					Kind:       helpers.JobKind.Kind,
+					Name:       "job-preset",
+					Controller: &boolTrue,
+				},
+			},
+		},
+		Status: scheduling.PodGroupStatus{
+			Phase: scheduling.PodGroupInqueue,
+		},
+	}
+
+	controller := newController()
+	key := "test/job-preset"
+
+	// Step 1: addPodGroup enqueues OutOfSyncEvent for the owning job.
+	controller.addPodGroup(pg)
+	queue := controller.getWorkerQueue(key)
+	if queue.Len() != 1 {
+		t.Fatalf("step 1: expected queue length 1 after addPodGroup, got %d", queue.Len())
+	}
+
+	// Drain the queue so we can observe step 2 cleanly.
+	item, _ := queue.Get()
+	queue.Done(item)
+
+	// Step 2: updatePodGroup with identical phase does NOT enqueue.
+	controller.updatePodGroup(pg, pg)
+	if queue.Len() != 0 {
+		t.Fatalf("step 2: expected queue length 0 after same-phase updatePodGroup, got %d", queue.Len())
+	}
+
+	// Step 3 (assertion): without AddFunc, step 1 would not exist and step 2
+	// produces nothing, so the job would never be reconciled. The fact that
+	// step 1 enqueued proves AddFunc is the required trigger.
 }
 
 func TestUpdatePodGroupFunc(t *testing.T) {


### PR DESCRIPTION
## Summary

- Register `AddFunc` on the pgInformer in the job controller so PodGroup creation events trigger a job re-sync
- Without this handler, when the scheduler updates PodGroup phase before the informer caches it, the Add event is silently dropped and the VCJob permanently leaves the work queue with 0 pods created
- The handler extracts the owning job name from OwnerReferences (falling back to PodGroup name for PodGroups not owned by a Volcano Job) and re-queues the job with `OutOfSyncEvent`

Related: #5325

## Test plan

- `TestAddPodGroupFunc`: name resolution for PodGroups with and without Job OwnerReferences
- `TestAddPodGroupRequiredForPreSetPhase`: deterministic test proving AddFunc is required when the informer first observes a PodGroup with phase already set (Inqueue). Validates that addPodGroup enqueues while updatePodGroup with same phase does not, confirming AddFunc is the only enqueue path in this scenario
- All 243 tests pass