### PR TITLE
fix(enqueue): move inqueue mutation from JobEnqueueableFn to JobEnque…

### DIFF
--- a/pkg/scheduler/plugins/capacity/capacity.go
+++ b/pkg/scheduler/plugins/capacity/capacity.go
@@ -775,7 +775,22 @@ func (cp *capacityPlugin) OnSessionOpen(ssn *framework.Session) {
 			return util.Reject
 		}
 
-		// job enqueued
+		return util.Permit
+	})
+
+	ssn.AddJobEnqueuedFn(cp.Name(), func(obj interface{}) {
+		job, ok := obj.(*api.JobInfo)
+		if !ok || job == nil || job.PodGroup == nil {
+			return
+		}
+		queueID := job.Queue
+		attr := cp.queueOpts[queueID]
+		if attr == nil {
+			return
+		}
+		if job.PodGroup.Spec.MinResources == nil && !(cp.dynamicResourceAllocationEnable && attr.dra != nil && job.GetMinDRAResources() != nil) {
+			return
+		}
 		deductedResources := job.DeductSchGatedResources(job.GetMinResources())
 		attr.inqueue.Add(deductedResources)
 		var minDRAReq map[string]*api.DRAResource
@@ -796,7 +811,6 @@ func (cp *capacityPlugin) OnSessionOpen(ssn *framework.Session) {
 			}
 		}
 		klog.V(5).Infof("job <%s/%s> enqueued", job.Namespace, job.Name)
-		return util.Permit
 	})
 
 	ssn.AddPrePredicateFn(cp.Name(), func(task *api.TaskInfo) error {

--- a/pkg/scheduler/plugins/capacity/capacity_test.go
+++ b/pkg/scheduler/plugins/capacity/capacity_test.go
@@ -1959,3 +1959,123 @@ func TestDRAAllocatableIgnoresInqueue(t *testing.T) {
 		t.Fatalf("expected enqueueable DRA check to account inqueue resources")
 	}
 }
+
+// TestJobEnqueuedOnOtherPluginsReject verifies that the capacity plugin updates
+// a queue's inqueue accounting only when a job is fully admitted by all plugins in
+// the tier. A job rejected by a co-tier plugin must not consume queue capacity,
+// leaving room for subsequent jobs that fit within the queue's limit.
+func TestJobEnqueuedOnOtherPluginsReject(t *testing.T) {
+	trueValue := true
+	res1CPU := api.BuildResourceList("1", "1G")
+
+	n1 := util.BuildNode("n1", api.BuildResourceList("4", "4G", []api.ScalarResource{{Name: "pods", Value: "10"}}...), nil)
+	podA := util.BuildPod("ns1", "podA", "", corev1.PodPending, res1CPU, "pgA", nil, nil)
+	podB := util.BuildPod("ns1", "podB", "", corev1.PodPending, res1CPU, "pgB", nil, nil)
+
+	pgA := util.BuildPodGroup("pgA", "ns1", "q1", 1, nil, schedulingv1beta1.PodGroupPending)
+	pgB := util.BuildPodGroup("pgB", "ns1", "q1", 1, nil, schedulingv1beta1.PodGroupPending)
+	pgA.Spec.MinResources = &res1CPU
+	pgB.Spec.MinResources = &res1CPU
+
+	// Queue with exactly 1 CPU capability — only one job can be admitted per session.
+	queue1 := util.BuildQueueWithResourcesQuantity("q1", api.BuildResourceList("1", "4G"), api.BuildResourceList("1", "4G"))
+
+	const rejecterName = "test-rejecter"
+	plugins := map[string]framework.PluginBuilder{
+		PluginName:   New,
+		rejecterName: func(_ framework.Arguments) framework.Plugin { return &uthelper.RejecterPlugin{RejectJob: "pgA"} },
+	}
+	tiers := []conf.Tier{
+		{
+			Plugins: []conf.PluginOption{
+				{Name: PluginName, EnabledJobEnqueued: &trueValue},
+				{Name: rejecterName, EnabledJobEnqueued: &trueValue},
+			},
+		},
+	}
+
+	test := uthelper.TestCommonStruct{
+		Name:      "pgA rejected by co-tier plugin must not consume q1 capacity; pgB must be admitted",
+		Plugins:   plugins,
+		Pods:      []*corev1.Pod{podA, podB},
+		Nodes:     []*corev1.Node{n1},
+		PodGroups: []*schedulingv1beta1.PodGroup{pgA, pgB},
+		Queues:    []*schedulingv1beta1.Queue{queue1},
+		ExpectStatus: map[api.JobID]scheduling.PodGroupPhase{
+			"ns1/pgB": scheduling.PodGroupInqueue,
+		},
+	}
+	test.RegisterSession(tiers, nil)
+	defer test.Close()
+	test.Run([]framework.Action{enqueue.New()})
+	if err := test.CheckAll(0); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestJobEnqueuedUpdatesDRAInqueueForDRAOnlyJob verifies that JobEnqueuedFn correctly
+// updates DRA inqueue accounting for jobs that have no scalar MinResources but do have
+// DRA resource requests. The early return guard must not skip DRA-only jobs.
+func TestJobEnqueuedUpdatesDRAInqueueForDRAOnlyJob(t *testing.T) {
+	if err := utilfeature.DefaultMutableFeatureGate.Set(fmt.Sprintf("%s=true", kubefeatures.DynamicResourceAllocation)); err != nil {
+		t.Fatal(err)
+	}
+
+	const deviceClass = "gpu.com"
+	const claimName = "dra-job-claim"
+
+	// Queue: DRA capability 4 GPUs, no scalar capability.
+	queue1 := util.BuildQueueWithResourcesQuantity("q1", nil, nil)
+	queue1.Spec.Capability = corev1.ResourceList{
+		corev1.ResourceName(DeviceClassCountPrefix + deviceClass): resource.MustParse("4"),
+	}
+
+	// DRA-only job: MinResources == nil, requests 2 GPUs via ResourceClaim.
+	claim := &resourcev1.ResourceClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: claimName, Namespace: "ns1"},
+		Spec: resourcev1.ResourceClaimSpec{
+			Devices: resourcev1.DeviceClaim{
+				Requests: []resourcev1.DeviceRequest{{
+					Name: "req-1",
+					Exactly: &resourcev1.ExactDeviceRequest{
+						DeviceClassName: deviceClass,
+						Count:           2,
+					},
+				}},
+			},
+		},
+	}
+	pod := util.BuildPod("ns1", "dra-pod", "", corev1.PodPending, api.BuildResourceList("0", "0"), "dra-pg", nil, nil)
+	pod.Spec.ResourceClaims = []corev1.PodResourceClaim{{
+		Name:              "claim-1",
+		ResourceClaimName: &[]string{claimName}[0],
+	}}
+	pod.Annotations[batchv1alpha1.TaskSpecKey] = "worker"
+
+	pg := util.BuildPodGroup("dra-pg", "ns1", "q1", 1, nil, schedulingv1beta1.PodGroupPending)
+	pg.Spec.MinTaskMember = map[string]int32{"worker": 1}
+	// MinResources intentionally left nil — DRA-only job.
+
+	trueValue := true
+	tiers := []conf.Tier{{Plugins: []conf.PluginOption{{
+		Name: PluginName, EnabledJobEnqueued: &trueValue,
+	}}}}
+
+	test := uthelper.TestCommonStruct{
+		Name:           "DRA-only job (MinResources==nil) must update DRA inqueue accounting on enqueue",
+		Plugins:        map[string]framework.PluginBuilder{PluginName: New},
+		Pods:           []*corev1.Pod{pod},
+		PodGroups:      []*schedulingv1beta1.PodGroup{pg},
+		Queues:         []*schedulingv1beta1.Queue{queue1},
+		ResourceClaims: []*resourcev1.ResourceClaim{claim},
+		ExpectStatus: map[api.JobID]scheduling.PodGroupPhase{
+			"ns1/dra-pg": scheduling.PodGroupInqueue,
+		},
+	}
+	test.RegisterSession(tiers, nil)
+	defer test.Close()
+	test.Run([]framework.Action{enqueue.New()})
+	if err := test.CheckAll(0); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/pkg/scheduler/plugins/extender/argument.go
+++ b/pkg/scheduler/plugins/extender/argument.go
@@ -73,6 +73,12 @@ type JobEnqueueableResponse struct {
 	Status int `json:"status"`
 }
 
+type JobEnqueuedRequest struct {
+	Job *api.JobInfo `json:"job"`
+}
+
+type JobEnqueuedResponse struct{}
+
 type QueueOverusedRequest struct {
 	Queue *api.QueueInfo `json:"queue"`
 }

--- a/pkg/scheduler/plugins/extender/extender.go
+++ b/pkg/scheduler/plugins/extender/extender.go
@@ -58,6 +58,8 @@ const (
 	ExtenderQueueOverusedVerb = "extender.queueOverusedVerb"
 	// ExtenderJobEnqueueableVerb is the verb of JobEnqueueable method
 	ExtenderJobEnqueueableVerb = "extender.jobEnqueueableVerb"
+	// ExtenderJobEnqueuedVerb is the verb of JobEnqueued method
+	ExtenderJobEnqueuedVerb = "extender.jobEnqueuedVerb"
 	// ExtenderJobReadyVerb is the verb of JobReady method
 	ExtenderJobReadyVerb = "extender.jobReadyVerb"
 	// ExtenderAllocateFuncVerb is the verb of AllocateFunc method
@@ -84,6 +86,7 @@ type extenderConfig struct {
 	reclaimableVerb    string
 	queueOverusedVerb  string
 	jobEnqueueableVerb string
+	jobEnqueuedVerb    string
 	jobReadyVerb       string
 	allocateFuncVerb   string
 	deallocateFuncVerb string
@@ -136,6 +139,7 @@ func parseExtenderConfig(arguments framework.Arguments) *extenderConfig {
 	ec.reclaimableVerb, _ = arguments[ExtenderReclaimableVerb].(string)
 	ec.queueOverusedVerb, _ = arguments[ExtenderQueueOverusedVerb].(string)
 	ec.jobEnqueueableVerb, _ = arguments[ExtenderJobEnqueueableVerb].(string)
+	ec.jobEnqueuedVerb, _ = arguments[ExtenderJobEnqueuedVerb].(string)
 	ec.jobReadyVerb, _ = arguments[ExtenderJobReadyVerb].(string)
 	ec.allocateFuncVerb, _ = arguments[ExtenderAllocateFuncVerb].(string)
 	ec.deallocateFuncVerb, _ = arguments[ExtenderDeallocateFuncVerb].(string)
@@ -293,6 +297,16 @@ func (ep *extenderPlugin) OnSessionOpen(ssn *framework.Session) {
 			}
 
 			return resp.Status
+		})
+	}
+
+	if ep.config.jobEnqueuedVerb != "" {
+		ssn.AddJobEnqueuedFn(ep.Name(), func(obj interface{}) {
+			job := obj.(*api.JobInfo)
+			resp := &JobEnqueuedResponse{}
+			if err := ep.send(ep.config.jobEnqueuedVerb, &JobEnqueuedRequest{Job: job}, resp); err != nil {
+				klog.Warningf("JobEnqueued failed with error %v", err)
+			}
 		})
 	}
 

--- a/pkg/scheduler/plugins/proportion/proportion.go
+++ b/pkg/scheduler/plugins/proportion/proportion.go
@@ -432,13 +432,24 @@ func (pp *proportionPlugin) OnSessionOpen(ssn *framework.Session) {
 		inqueue, resourceNames := r.LessEqualWithDimensionAndResourcesName(attr.realCapability, minReq)
 		klog.V(5).Infof("job %s inqueue %v", job.Name, inqueue)
 		if inqueue {
-			// deduct the resources of scheduling gated tasks in a job when calculating inqueued resources
-			// so that it will not block other jobs from being inqueued.
-			attr.inqueue.Add(job.DeductSchGatedResources(minReq))
 			return util.Permit
 		}
 		ssn.RecordPodGroupEvent(job.PodGroup, v1.EventTypeNormal, string(scheduling.PodGroupUnschedulableType), util.FormatResourceNames("queue resource quota insufficient", "insufficient", resourceNames))
 		return util.Reject
+	})
+
+	ssn.AddJobEnqueuedFn(pp.Name(), func(obj interface{}) {
+		job := obj.(*api.JobInfo)
+		if job.PodGroup.Spec.MinResources == nil {
+			return
+		}
+		attr := pp.queueOpts[job.Queue]
+		if attr == nil {
+			return
+		}
+		// deduct the resources of scheduling gated tasks in a job when calculating inqueued resources
+		// so that it will not block other jobs from being inqueued.
+		attr.inqueue.Add(job.DeductSchGatedResources(job.GetMinResources()))
 	})
 
 	ssn.AddSimulateAddTaskFn(pp.Name(), func(ctx context.Context, cycleState fwk.CycleState, taskToSchedule *api.TaskInfo, taskToAdd *api.TaskInfo, nodeInfo *api.NodeInfo) error {

--- a/pkg/scheduler/plugins/proportion/proportion_test.go
+++ b/pkg/scheduler/plugins/proportion/proportion_test.go
@@ -32,6 +32,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/record"
 
+	"volcano.sh/apis/pkg/apis/scheduling"
 	schedulingv1beta1 "volcano.sh/apis/pkg/apis/scheduling/v1beta1"
 	"volcano.sh/volcano/cmd/scheduler/app/options"
 	"volcano.sh/volcano/pkg/scheduler/actions/allocate"
@@ -625,5 +626,62 @@ func TestNoDoubleCountingForInqueueJobWithBindingTasks(t *testing.T) {
 	if !cycle2["ns1/pB1"] {
 		t.Errorf("regression: pB1 was not bound in cycle 2 (got %v) — proportion plugin "+
 			"is double-counting inqueue resources for pgA whose tasks are in Binding state", cycle2)
+	}
+}
+
+// TestJobEnqueuedOnOtherPluginsReject verifies that proportion's inqueue
+// accounting is updated only after all plugins in the tier admit a job. A job
+// rejected by a co-tier plugin must not consume queue capacity, leaving room for
+// subsequent jobs that fit within the queue's limit.
+func TestJobEnqueuedOnOtherPluginsReject(t *testing.T) {
+	trueValue := true
+
+	// Queue q1 holds 1 CPU. The rejecter blocks pgA while proportion sees it as
+	// fitting; pgB must still be admitted because pgA never consumed any capacity.
+	n1 := util.BuildNode("n1", api.BuildResourceList("4", "4G", []api.ScalarResource{{Name: "pods", Value: "10"}}...), nil)
+
+	res1CPU := api.BuildResourceList("1", "1G")
+	podA := util.BuildPod("ns1", "podA", "", apiv1.PodPending, res1CPU, "pgA", nil, nil)
+	podB := util.BuildPod("ns1", "podB", "", apiv1.PodPending, res1CPU, "pgB", nil, nil)
+
+	pgA := util.BuildPodGroup("pgA", "ns1", "q1", 1, nil, schedulingv1beta1.PodGroupPending)
+	pgB := util.BuildPodGroup("pgB", "ns1", "q1", 1, nil, schedulingv1beta1.PodGroupPending)
+	pgA.Spec.MinResources = &res1CPU
+	pgB.Spec.MinResources = &res1CPU
+
+	// Queue capacity: exactly 1 CPU — only one job can be admitted per session.
+	queue1 := util.BuildQueue("q1", 1, api.BuildResourceList("1", "4G"))
+
+	const rejecterName = "test-rejecter"
+	plugins := map[string]framework.PluginBuilder{
+		PluginName:   New,
+		rejecterName: func(_ framework.Arguments) framework.Plugin { return &uthelper.RejecterPlugin{RejectJob: "pgA"} },
+	}
+	tiers := []conf.Tier{
+		{
+			Plugins: []conf.PluginOption{
+				{Name: PluginName, EnabledJobEnqueued: &trueValue},
+				{Name: rejecterName, EnabledJobEnqueued: &trueValue},
+			},
+		},
+	}
+
+	test := uthelper.TestCommonStruct{
+		Name:      "phantom inqueue reservation: rejecter blocks pgA, pgB must still be admitted",
+		Plugins:   plugins,
+		Pods:      []*apiv1.Pod{podA, podB},
+		Nodes:     []*apiv1.Node{n1},
+		PodGroups: []*schedulingv1beta1.PodGroup{pgA, pgB},
+		Queues:    []*schedulingv1beta1.Queue{queue1},
+		// pgB must be enqueued; pgA stays Pending (blocked by the rejecter, not proportion).
+		ExpectStatus: map[api.JobID]scheduling.PodGroupPhase{
+			"ns1/pgB": scheduling.PodGroupInqueue,
+		},
+	}
+	test.RegisterSession(tiers, nil)
+	defer test.Close()
+	test.Run([]framework.Action{enqueue.New()})
+	if err := test.CheckAll(0); err != nil {
+		t.Fatal(err)
 	}
 }

--- a/pkg/scheduler/plugins/resourcequota/resourcequota.go
+++ b/pkg/scheduler/plugins/resourcequota/resourcequota.go
@@ -91,11 +91,21 @@ func (rq *resourceQuotaPlugin) OnSessionOpen(ssn *framework.Session) {
 				return util.Reject
 			}
 		}
+		return util.Permit
+	})
+
+	ssn.AddJobEnqueuedFn(rq.Name(), func(obj interface{}) {
+		job, ok := obj.(*api.JobInfo)
+		if !ok || job == nil || job.PodGroup == nil || job.PodGroup.Spec.MinResources == nil {
+			return
+		}
+		if ssn.NamespaceInfo[api.NamespaceName(job.Namespace)] == nil {
+			return
+		}
 		if _, found := pendingResources[job.Namespace]; !found {
 			pendingResources[job.Namespace] = v1.ResourceList{}
 		}
-		pendingResources[job.Namespace] = quotav1.Add(pendingResources[job.Namespace], *resourcesRequests)
-		return util.Permit
+		pendingResources[job.Namespace] = quotav1.Add(pendingResources[job.Namespace], *job.PodGroup.Spec.MinResources)
 	})
 }
 

--- a/pkg/scheduler/plugins/resourcequota/resourcequota_test.go
+++ b/pkg/scheduler/plugins/resourcequota/resourcequota_test.go
@@ -24,6 +24,7 @@ import (
 
 	"volcano.sh/apis/pkg/apis/scheduling"
 	schedulingv1 "volcano.sh/apis/pkg/apis/scheduling/v1beta1"
+	"volcano.sh/volcano/pkg/scheduler/actions/enqueue"
 	"volcano.sh/volcano/pkg/scheduler/api"
 	"volcano.sh/volcano/pkg/scheduler/conf"
 	"volcano.sh/volcano/pkg/scheduler/framework"
@@ -114,5 +115,62 @@ func TestResourceQuotaPlugin(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// TestJobEnqueuedOnOtherPluginsReject verifies that the resourcequota plugin
+// adds to a namespace's pending usage only when a job is fully admitted by all plugins
+// in the tier. A job rejected by a co-tier plugin must not consume namespace quota,
+// leaving room for subsequent jobs that fit within the hard limit.
+func TestJobEnqueuedOnOtherPluginsReject(t *testing.T) {
+	trueValue := true
+	res1CPU := api.BuildResourceList("1", "1G")
+
+	n1 := util.BuildNode("n1", api.BuildResourceList("4", "4G", []api.ScalarResource{{Name: "pods", Value: "10"}}...), nil)
+
+	// Namespace quota: exactly 1 CPU — only one job can be admitted per session.
+	rq1 := util.BuildResourceQuota("rq1", "ns1", res1CPU)
+
+	podA := util.BuildPod("ns1", "podA", "", v1.PodPending, res1CPU, "pgA", nil, nil)
+	podB := util.BuildPod("ns1", "podB", "", v1.PodPending, res1CPU, "pgB", nil, nil)
+
+	pgA := util.BuildPodGroup("pgA", "ns1", "q1", 1, nil, schedulingv1.PodGroupPending)
+	pgB := util.BuildPodGroup("pgB", "ns1", "q1", 1, nil, schedulingv1.PodGroupPending)
+	pgA.Spec.MinResources = &res1CPU
+	pgB.Spec.MinResources = &res1CPU
+
+	queue1 := util.BuildQueue("q1", 1, nil)
+
+	const rejecterName = "test-rejecter"
+	plugins := map[string]framework.PluginBuilder{
+		PluginName:   New,
+		rejecterName: func(_ framework.Arguments) framework.Plugin { return &uthelper.RejecterPlugin{RejectJob: "pgA"} },
+	}
+	tiers := []conf.Tier{
+		{
+			Plugins: []conf.PluginOption{
+				{Name: PluginName, EnabledJobEnqueued: &trueValue},
+				{Name: rejecterName, EnabledJobEnqueued: &trueValue},
+			},
+		},
+	}
+
+	test := uthelper.TestCommonStruct{
+		Name:           "pgA rejected by co-tier plugin must not consume ns1 quota; pgB must be admitted",
+		Plugins:        plugins,
+		Pods:           []*v1.Pod{podA, podB},
+		Nodes:          []*v1.Node{n1},
+		PodGroups:      []*schedulingv1.PodGroup{pgA, pgB},
+		Queues:         []*schedulingv1.Queue{queue1},
+		ResourceQuotas: []*v1.ResourceQuota{rq1},
+		ExpectStatus: map[api.JobID]scheduling.PodGroupPhase{
+			"ns1/pgB": scheduling.PodGroupInqueue,
+		},
+	}
+	test.RegisterSession(tiers, nil)
+	defer test.Close()
+	test.Run([]framework.Action{enqueue.New()})
+	if err := test.CheckAll(0); err != nil {
+		t.Fatal(err)
 	}
 }

--- a/pkg/scheduler/uthelper/rejecter_plugin.go
+++ b/pkg/scheduler/uthelper/rejecter_plugin.go
@@ -1,0 +1,39 @@
+/*
+Copyright 2024 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package uthelper
+
+import (
+	"volcano.sh/volcano/pkg/scheduler/api"
+	"volcano.sh/volcano/pkg/scheduler/framework"
+)
+
+// RejecterPlugin is a test helper plugin that rejects the job whose PodGroup
+// name matches RejectJob and permits everything else. Used in multi-plugin
+// enqueue tests to verify that a co-tier rejection leaves no phantom reservation.
+type RejecterPlugin struct{ RejectJob string }
+
+func (r *RejecterPlugin) Name() string { return "test-rejecter" }
+func (r *RejecterPlugin) OnSessionOpen(ssn *framework.Session) {
+	ssn.AddJobEnqueueableFn(r.Name(), func(obj interface{}) int {
+		job := obj.(*api.JobInfo)
+		if job.PodGroup != nil && job.PodGroup.Name == r.RejectJob {
+			return -1 // Reject
+		}
+		return 1 // Permit
+	})
+}
+func (r *RejecterPlugin) OnSessionClose(_ *framework.Session) {}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it:**

After #5091 and #5100 fixed the double-counting in the inqueue initialization path, I kept staring at `attr.inqueue` and noticed a second class of incorrectness hiding in the same area.

Both proportion and capacity mutate `attr.inqueue` inside `JobEnqueueableFn` ; before the overall `ssn.JobEnqueueable()` verdict is even in. The dispatcher calls plugins in tier order and short-circuits on the first `Reject`, so if proportion/capacity says "fits, bumping inqueue" and a downstream plugin like `resourcequota` or `sla` says "actually no" ; the bump sticks for the rest of the session. The next job from the same queue walks in and sees inflated quota it has no business seeing.

For capacity with hierarchy it compounds: the phantom reservation propagates up to every ancestor queue, so sibling queues under the same parent end up throttled for a job that was never enqueued.

The fix is just following the pattern `overcommit` already gets right, `JobEnqueueableFn` is a pure vote (no side effects), and the actual `attr.inqueue.Add()` fires in a new `JobEnqueuedFn` callback that only runs once the full decision is confirmed as `Permit`.

**Which issue(s) this PR fixes:**
Fixes #5387 

**Special notes for your reviewer:**

`overcommit` already implements the correct two-phase pattern (vote in `JobEnqueueableFn`, mutate in `JobEnqueuedFn`) ; the new callbacks in both plugins mirror it exactly. This only manifests when a plugin registered after proportion/capacity in the same tier returns `Reject`; single-plugin configs are unaffected.

**AI Disclosure**: This change was developed with AI assistance (Claude). The author has reviewed and understands all changes.

**Does this PR introduce a user-facing change?**

Fixed phantom inqueue quota inflation in proportion and capacity plugins when multiple `JobEnqueueableFn` plugins are configured in the same tier. Jobs were being incorrectly rejected for enqueue due to a reservation left by a previously rejected job. In hierarchical queue mode, the inflation also propagated to ancestor queues, throttling sibling queues unnecessarily.