### PR TITLE
fix(jobcontroller): skip PodGroup deletion for targeted pod restarts

### DIFF
--- a/pkg/controllers/job/job_controller_actions.go
+++ b/pkg/controllers/job/job_controller_actions.go
@@ -263,17 +263,21 @@ func (cc *jobcontroller) killPods(jobInfo *apis.JobInfo, podRetainPhase state.Ph
 		return e
 	}
 
-	// Delete PodGroup
-	pg, err := cc.getPodGroupByJob(job)
-	if err != nil && !apierrors.IsNotFound(err) {
-		klog.Errorf("Failed to find PodGroup of Job: %s/%s, error: %s", job.Namespace, job.Name, err.Error())
-		return err
-	}
-	if pg != nil {
-		if err := cc.vcClient.SchedulingV1beta1().PodGroups(job.Namespace).Delete(context.TODO(), pg.Name, metav1.DeleteOptions{}); err != nil {
-			if !apierrors.IsNotFound(err) {
-				klog.Errorf("Failed to delete PodGroup of Job %s/%s: %v", job.Namespace, job.Name, err)
-				return err
+	// Delete PodGroup only on full job kills; targeted pod restarts (RestartPodAction)
+	// must keep the PodGroup alive so the scheduler does not need to re-enqueue and
+	// re-schedule the job from scratch on every individual pod failure.
+	if target == nil {
+		pg, err := cc.getPodGroupByJob(job)
+		if err != nil && !apierrors.IsNotFound(err) {
+			klog.Errorf("Failed to find PodGroup of Job: %s/%s, error: %s", job.Namespace, job.Name, err.Error())
+			return err
+		}
+		if pg != nil {
+			if err := cc.vcClient.SchedulingV1beta1().PodGroups(job.Namespace).Delete(context.TODO(), pg.Name, metav1.DeleteOptions{}); err != nil {
+				if !apierrors.IsNotFound(err) {
+					klog.Errorf("Failed to delete PodGroup of Job %s/%s: %v", job.Namespace, job.Name, err)
+					return err
+				}
 			}
 		}
 	}

--- a/pkg/controllers/job/job_controller_actions_test.go
+++ b/pkg/controllers/job/job_controller_actions_test.go
@@ -26,7 +26,9 @@ import (
 
 	"github.com/agiledragon/gomonkey/v2"
 	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/ptr"
 
@@ -1356,6 +1358,98 @@ func TestPodsToKill(t *testing.T) {
 					t.Errorf("Test case %d (%s): expected pod %s to exist, but got error %v", i, testcase.Name, podName, err)
 				} else if !shouldExist && err == nil {
 					t.Errorf("Test case %d (%s): expected pod %s to be deleted, but still exists", i, testcase.Name, podName)
+				}
+			}
+		})
+	}
+}
+
+func TestKillPodsPodGroupDeletion(t *testing.T) {
+	namespace := "test"
+	jobUID := "e7f18111-1cec-11ea-b688-fa163ec79500"
+
+	testcases := []struct {
+		Name               string
+		Target             *state.Target
+		ExpectPodGroupGone bool
+	}{
+		{
+			Name:               "full job kill (target=nil) deletes PodGroup",
+			Target:             nil,
+			ExpectPodGroupGone: true,
+		},
+		{
+			Name: "targeted pod restart (target!=nil) keeps PodGroup",
+			Target: &state.Target{
+				Type:     state.TargetTypePod,
+				TaskName: "task1",
+				PodName:  "pod1",
+			},
+			ExpectPodGroupGone: false,
+		},
+	}
+
+	for _, testcase := range testcases {
+		t.Run(testcase.Name, func(t *testing.T) {
+			job := &v1alpha1.Job{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            "job1",
+					Namespace:       namespace,
+					UID:             types.UID(jobUID),
+					ResourceVersion: "100",
+				},
+			}
+			pgName := fmt.Sprintf("%s-%s", job.Name, jobUID)
+			pg := &schedulingapi.PodGroup{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      pgName,
+					Namespace: namespace,
+				},
+			}
+			jobInfo := &apis.JobInfo{
+				Namespace: namespace,
+				Name:      job.Name,
+				Job:       job,
+				Pods: map[string]map[string]*v1.Pod{
+					"task1": {
+						"pod1": buildPod(namespace, "pod1", v1.PodRunning, nil),
+					},
+				},
+			}
+
+			fakeController := newFakeController()
+
+			fakeController.pgInformer.Informer().GetIndexer().Add(pg)
+			_, err := fakeController.vcClient.SchedulingV1beta1().PodGroups(namespace).Create(context.TODO(), pg, metav1.CreateOptions{})
+			if err != nil {
+				t.Fatalf("Error creating PodGroup: %v", err)
+			}
+
+			_, err = fakeController.kubeClient.CoreV1().Pods(namespace).Create(context.TODO(), jobInfo.Pods["task1"]["pod1"], metav1.CreateOptions{})
+			if err != nil {
+				t.Fatalf("Error creating pod: %v", err)
+			}
+
+			_, err = fakeController.vcClient.BatchV1alpha1().Jobs(namespace).Create(context.TODO(), job, metav1.CreateOptions{})
+			if err != nil {
+				t.Fatalf("Error creating job: %v", err)
+			}
+			if err = fakeController.cache.Add(job); err != nil {
+				t.Fatalf("Error adding job to cache: %v", err)
+			}
+
+			err = fakeController.killPods(jobInfo, state.PodRetainPhaseNone, testcase.Target, nil)
+			if err != nil {
+				t.Fatalf("killPods returned unexpected error: %v", err)
+			}
+
+			_, pgErr := fakeController.vcClient.SchedulingV1beta1().PodGroups(namespace).Get(context.TODO(), pgName, metav1.GetOptions{})
+			pgGone := pgErr != nil && apierrors.IsNotFound(pgErr)
+			if pgGone != testcase.ExpectPodGroupGone {
+				if testcase.ExpectPodGroupGone {
+					t.Errorf("expected PodGroup to be deleted, but it still exists")
+				} else {
+					t.Errorf("expected PodGroup to be kept, but it was deleted")
 				}
 			}
 		})


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it:**

When a pod fails and `RestartPodAction` fires, the controller calls `killTarget` -> `killPods` to delete just that one pod. The problem: `killPods` unconditionally deleted the entire `PodGroup` at the end, even for single-pod targeted kills.

That triggered a full delete→recreate→re-enqueue→re-schedule cycle. While the new `PodGroup` was sitting in `Pending`, `syncJob` would see `pg.Status.Phase == Pending`, set `syncTask = false`, and skip pod creation entirely. The job status was stuck with `Terminating > 0` from the killed pod, so `restartingUpdateStatus` kept computing `total − Terminating < MinAvailable` and refused to leave `Restarting`. The job just sat there until the scheduler eventually picked up the new `PodGroup`, which in CI could take long enough to blow the 10-minute e2e timeout.

Fix: guard the `PodGroup` deletion with `if target == nil` so only full `KillJob` calls remove it. `KillTarget` (`RestartPodAction`) keeps the `PodGroup` alive, `syncTask` stays `true`, the replacement pod is created immediately, and the job exits `Restarting` in seconds.

**Which issue(s) this PR fixes:**
Fixes #5385 

**Special notes for your reviewer:**

The change is a single `if target == nil` guard around the existing `PodGroup` deletion block in `killPods`. Full job kills pass `target == nil` and behave exactly as before. Only targeted kills (`RestartPodAction`, `RestartTaskAction`, `RestartPartitionAction`) are affected, they now preserve the `PodGroup` instead of deleting it.

A unit test for this regression would be good, happy to add one here if preferred.

**Does this PR introduce a user-facing change?**

Fix jobs using `RestartPodAction` getting stuck in `Restarting` state after a pod failure due to unnecessary `PodGroup` deletion in `killTarget`.