### PR TITLE
fix(scheduler): restore ImageStates in GenerateNodeMapAndSlice

### DIFF
--- a/pkg/scheduler/framework/util.go
+++ b/pkg/scheduler/framework/util.go
@@ -228,6 +228,7 @@ func GenerateNodeMapAndSlice(nodes map[string]*api.NodeInfo) map[string]fwk.Node
 	for _, node := range nodes {
 		nodeInfo := k8sframework.NewNodeInfo(node.Pods()...)
 		nodeInfo.SetNode(node.Node)
+		nodeInfo.ImageStates = node.CloneImageSummary()
 		nodeMap[node.Name] = nodeInfo
 	}
 	return nodeMap

--- a/pkg/scheduler/framework/util_test.go
+++ b/pkg/scheduler/framework/util_test.go
@@ -1,0 +1,85 @@
+/*
+Copyright 2025 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package framework
+
+import (
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	fwk "k8s.io/kube-scheduler/framework"
+
+	"volcano.sh/volcano/pkg/scheduler/api"
+)
+
+func TestGenerateNodeMapAndSlice_ImageStates(t *testing.T) {
+	node := &v1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "node1"},
+		Status: v1.NodeStatus{
+			Allocatable: v1.ResourceList{},
+		},
+	}
+
+	nodeInfo := api.NewNodeInfo(node)
+	nodeInfo.ImageStates = map[string]*fwk.ImageStateSummary{
+		"docker.io/library/nginx:latest": {
+			Size:     100 * 1024 * 1024,
+			NumNodes: 3,
+		},
+		"docker.io/library/redis:7": {
+			Size:     50 * 1024 * 1024,
+			NumNodes: 5,
+		},
+	}
+
+	nodes := map[string]*api.NodeInfo{
+		"node1": nodeInfo,
+	}
+
+	nodeMap := GenerateNodeMapAndSlice(nodes)
+
+	k8sNodeInfo, ok := nodeMap["node1"]
+	if !ok {
+		t.Fatalf("expected node1 in nodeMap")
+	}
+
+	if len(k8sNodeInfo.GetImageStates()) != 2 {
+		t.Fatalf("expected 2 image states, got %d", len(k8sNodeInfo.GetImageStates()))
+	}
+
+	nginxState, ok := k8sNodeInfo.GetImageStates()["docker.io/library/nginx:latest"]
+	if !ok {
+		t.Fatalf("expected nginx image state")
+	}
+	if nginxState.Size != 100*1024*1024 {
+		t.Errorf("expected nginx size 100MB, got %d", nginxState.Size)
+	}
+	if nginxState.NumNodes != 3 {
+		t.Errorf("expected nginx NumNodes 3, got %d", nginxState.NumNodes)
+	}
+
+	redisState, ok := k8sNodeInfo.GetImageStates()["docker.io/library/redis:7"]
+	if !ok {
+		t.Fatalf("expected redis image state")
+	}
+	if redisState.Size != 50*1024*1024 {
+		t.Errorf("expected redis size 50MB, got %d", redisState.Size)
+	}
+	if redisState.NumNodes != 5 {
+		t.Errorf("expected redis NumNodes 5, got %d", redisState.NumNodes)
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Restores the `ImageStates` assignment in `GenerateNodeMapAndSlice` that was accidentally dropped during a code move.

The `ImageStates` field was originally added to `GenerateNodeMapAndSlice` in commit 093d07e7 (`plugins/util/util.go`), but was accidentally lost when the function was moved to `framework/util.go` in commit 463cc4ce ("move time consuming function into framework").

Without this line, `nodeInfo.ImageStates` is always an empty map when passed to the k8s scoring plugins, causing the **ImageLocality** scoring plugin to always return 0 for every node. This effectively disables image-locality-based scheduling — nodes that already have the required container images get no scoring advantage.

**Root cause:**

```
plugins/util/util.go (commit 093d07e7, 2022-12-06):
    nodeInfo.SetNode(node.Node)
+   nodeMap[node.Name].ImageStates = node.CloneImageSumary()

framework/util.go (commit 463cc4ce, 2022-12-21, moved but dropped the line):
    nodeInfo.SetNode(node.Node)
    // ← ImageStates assignment missing
    nodeMap[node.Name] = nodeInfo
```

**Fix:** Add back `nodeInfo.ImageStates = node.CloneImageSummary()` after `SetNode`.

#### Which issue(s) this PR fixes:

Fixes the regression where ImageLocality scoring always returns 0.

#### Special notes for your reviewer:

- The data pipeline is: `kubelet → node.Status.Images → Informer → cache.AddOrUpdateNode() → addNodeImageStates() → api.NodeInfo.ImageStates ✅ → Snapshot.Clone() ✅ → Session.Nodes ✅ → GenerateNodeMapAndSlice() ❌ (was empty) → ImageLocality.Score() returns 0`
- The fix restores the last missing link in this chain.
- A unit test is added to verify ImageStates are correctly propagated through `GenerateNodeMapAndSlice`.

#### Does this PR introduce a user-facing change?

```release-note
Fix ImageLocality scoring plugin always returning 0 due to ImageStates not being propagated in GenerateNodeMapAndSlice.
```