### PR TITLE
fix: guard podgroup annotation patch by pod UID

### DIFF
--- a/pkg/controllers/podgroup/pg_controller.go
+++ b/pkg/controllers/podgroup/pg_controller.go
@@ -158,6 +158,10 @@ func (pg *pgcontroller) processNextReq() bool {
 		klog.Errorf("Failed to get pod by <%v> from cache: %v", req, err)
 		return true
 	}
+	if pod.UID != req.podUID {
+		klog.V(5).Infof("pod %v/%v UID is not matched, maybe pod has been recreated, skip it", pod.Namespace, pod.Name)
+		return true
+	}
 
 	if !slices.Contains(pg.schedulerNames, pod.Spec.SchedulerName) {
 		klog.V(5).Infof("pod %v/%v field SchedulerName is not matched", pod.Namespace, pod.Name)

--- a/pkg/controllers/podgroup/pg_controller_handler.go
+++ b/pkg/controllers/podgroup/pg_controller_handler.go
@@ -46,14 +46,7 @@ const (
 type podRequest struct {
 	podName      string
 	podNamespace string
-}
-
-type metadataForMergePatch struct {
-	Metadata annotationForMergePatch `json:"metadata"`
-}
-
-type annotationForMergePatch struct {
-	Annotations map[string]string `json:"annotations"`
+	podUID       types.UID
 }
 
 func (pg *pgcontroller) addPod(obj interface{}) {
@@ -66,6 +59,7 @@ func (pg *pgcontroller) addPod(obj interface{}) {
 	req := podRequest{
 		podName:      pod.Name,
 		podNamespace: pod.Namespace,
+		podUID:       pod.UID,
 	}
 
 	pg.queue.Add(req)
@@ -187,36 +181,60 @@ func (pg *pgcontroller) updateStatefulSet(oldObj, newObj interface{}) {
 }
 
 func (pg *pgcontroller) updatePodAnnotations(pod *v1.Pod, pgName string) error {
-	if pod.Annotations == nil {
-		pod.Annotations = make(map[string]string)
+	// UID test keeps this patch from hitting a recreated pod with the same namespace/name.
+	patch := []map[string]any{
+		{
+			"op":    "test",
+			"path":  "/metadata/uid",
+			"value": string(pod.UID),
+		},
 	}
-	if pod.Annotations[scheduling.KubeGroupNameAnnotationKey] == "" {
-		patch := metadataForMergePatch{
-			Metadata: annotationForMergePatch{
-				Annotations: map[string]string{
-					scheduling.KubeGroupNameAnnotationKey: pgName,
-				},
+	if len(pod.Annotations) == 0 {
+		if pod.ResourceVersion != "" {
+			patch = append(patch, map[string]any{
+				"op":    "test",
+				"path":  "/metadata/resourceVersion",
+				"value": pod.ResourceVersion,
+			})
+		}
+		patch = append(patch, map[string]any{
+			"op":   "add",
+			"path": "/metadata/annotations",
+			"value": map[string]string{
+				scheduling.KubeGroupNameAnnotationKey: pgName,
 			},
-		}
-
-		patchBytes, err := json.Marshal(&patch)
-		if err != nil {
-			klog.Errorf("Failed to json.Marshal pod annotation: %v", err)
-			return err
-		}
-
-		if _, err := pg.kubeClient.CoreV1().Pods(pod.Namespace).Patch(context.TODO(), pod.Name, types.StrategicMergePatchType, patchBytes, metav1.PatchOptions{}); err != nil {
-			klog.Errorf("Failed to update pod <%s/%s>: %v", pod.Namespace, pod.Name, err)
-			return err
-		}
-		klog.V(4).Infof("Bound Pod <%s/%s> to PodGroup <%s/%s>", pod.Namespace, pod.Name, pod.Namespace, pgName)
+		})
+	} else if pod.Annotations[scheduling.KubeGroupNameAnnotationKey] == "" {
+		patch = append(patch, map[string]any{
+			"op":    "add",
+			"path":  "/metadata/annotations/" + escapeJSONPointer(scheduling.KubeGroupNameAnnotationKey),
+			"value": pgName,
+		})
 	} else {
 		if pod.Annotations[scheduling.KubeGroupNameAnnotationKey] != pgName {
 			klog.Errorf("normal pod %s/%s annotations %s value is not %s, but %s", pod.Namespace, pod.Name,
 				scheduling.KubeGroupNameAnnotationKey, pgName, pod.Annotations[scheduling.KubeGroupNameAnnotationKey])
 		}
+		return nil
 	}
+	patchBytes, err := json.Marshal(&patch)
+	if err != nil {
+		klog.Errorf("Failed to json.Marshal pod annotation: %v", err)
+		return err
+	}
+
+	if _, err := pg.kubeClient.CoreV1().Pods(pod.Namespace).Patch(context.TODO(), pod.Name, types.JSONPatchType, patchBytes, metav1.PatchOptions{}); err != nil {
+		klog.Errorf("Failed to update pod <%s/%s>: %v", pod.Namespace, pod.Name, err)
+		return err
+	}
+	klog.V(4).Infof("Bound Pod <%s/%s> to PodGroup <%s/%s>", pod.Namespace, pod.Name, pod.Namespace, pgName)
 	return nil
+}
+
+func escapeJSONPointer(s string) string {
+	s = strings.ReplaceAll(s, "~", "~0")
+	s = strings.ReplaceAll(s, "/", "~1")
+	return s
 }
 
 func (pg *pgcontroller) getAnnotationsFromUpperRes(pod *v1.Pod) map[string]string {

--- a/pkg/controllers/podgroup/pg_controller_test.go
+++ b/pkg/controllers/podgroup/pg_controller_test.go
@@ -18,6 +18,7 @@ package podgroup
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"reflect"
 	"testing"
@@ -29,9 +30,11 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/informers"
 	kubeclient "k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/utils/ptr"
 
@@ -91,6 +94,7 @@ func TestAddPodGroup(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "pod1",
 						Namespace: namespace,
+						UID:       types.UID("pod-uid-1"),
 						OwnerReferences: []metav1.OwnerReference{
 							{
 								APIVersion: "app/v1",
@@ -216,6 +220,7 @@ func TestAddPodGroup(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "pod1",
 						Namespace: namespace,
+						UID:       types.UID("pod-uid-1"),
 						Labels: map[string]string{
 							"app": "rs1",
 						},
@@ -250,6 +255,7 @@ func TestAddPodGroup(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "pod2",
 						Namespace: namespace,
+						UID:       types.UID("pod-uid-2"),
 						Labels: map[string]string{
 							"app": "rs1",
 						},
@@ -512,6 +518,7 @@ func Test_createOrUpdateNormalPodPG(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "pod1",
 				Namespace: namespace,
+				UID:       types.UID("pod-uid-1"),
 				Labels: map[string]string{
 					"app": "sts1",
 				},
@@ -651,6 +658,7 @@ func Test_createOrUpdateNormalPodPG(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "pod1",
 				Namespace: namespace,
+				UID:       types.UID("pod-uid-1"),
 				Labels: map[string]string{
 					"app": "sts1",
 				},
@@ -1414,4 +1422,103 @@ func TestNoPodGroupCreatedForWhenKubeGroupNameAnnotationExists(t *testing.T) {
 		}
 		assert.Equal(t, 1, len(pgList.Items), "Expected 1 PodGroup, found %d: %v", len(pgList.Items), names)
 	})
+}
+
+func TestProcessNextReqSkipsRecreatedPod(t *testing.T) {
+	c := newFakeController()
+	namespace := "test"
+	podName := "recreated-pod"
+
+	oldPod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      podName,
+			Namespace: namespace,
+			UID:       types.UID("old-pod-uid"),
+		},
+		Spec: v1.PodSpec{
+			SchedulerName: "volcano",
+		},
+	}
+	newPod := oldPod.DeepCopy()
+	newPod.UID = types.UID("new-pod-uid")
+
+	c.addPod(oldPod)
+	err := c.podInformer.Informer().GetIndexer().Add(newPod)
+	assert.NoError(t, err)
+
+	c.processNextReq()
+
+	pgList, err := c.vcClient.SchedulingV1beta1().PodGroups(namespace).List(context.TODO(), metav1.ListOptions{})
+	assert.NoError(t, err)
+	assert.Empty(t, pgList.Items)
+	assert.Equal(t, 0, c.queue.Len())
+
+	for _, action := range c.kubeClient.(*kubeclient.Clientset).Actions() {
+		assert.False(t, action.Matches("patch", "pods"))
+	}
+}
+
+func TestUpdatePodAnnotationsUsesUIDTest(t *testing.T) {
+	c := newFakeController()
+	namespace := "test"
+	pgName := "podgroup-test"
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "pod1",
+			Namespace:       namespace,
+			UID:             types.UID("pod-uid"),
+			ResourceVersion: "123",
+			Annotations:     map[string]string{},
+		},
+	}
+
+	_, err := c.kubeClient.CoreV1().Pods(namespace).Create(context.TODO(), pod, metav1.CreateOptions{})
+	assert.NoError(t, err)
+	c.kubeClient.(*kubeclient.Clientset).Fake.PrependReactor("patch", "pods",
+		func(action k8stesting.Action) (bool, runtime.Object, error) {
+			return true, pod, nil
+		})
+
+	err = c.updatePodAnnotations(pod, pgName)
+	assert.NoError(t, err)
+
+	var patchAction k8stesting.PatchAction
+	found := false
+	for _, action := range c.kubeClient.(*kubeclient.Clientset).Actions() {
+		if action.Matches("patch", "pods") {
+			patchAction = action.(k8stesting.PatchAction)
+			found = true
+			break
+		}
+	}
+	if !assert.True(t, found) {
+		return
+	}
+	assert.Equal(t, types.JSONPatchType, patchAction.GetPatchType())
+
+	var patch []map[string]any
+	err = json.Unmarshal(patchAction.GetPatch(), &patch)
+	assert.NoError(t, err)
+	assert.Len(t, patch, 3)
+	assert.Equal(t, map[string]any{
+		"op":    "test",
+		"path":  "/metadata/uid",
+		"value": string(pod.UID),
+	}, patch[0])
+	assert.Equal(t, map[string]any{
+		"op":    "test",
+		"path":  "/metadata/resourceVersion",
+		"value": pod.ResourceVersion,
+	}, patch[1])
+	assert.Equal(t, "add", patch[2]["op"])
+	assert.Equal(t, "/metadata/annotations", patch[2]["path"])
+
+	annotations, ok := patch[2]["value"].(map[string]any)
+	assert.True(t, ok)
+	assert.Equal(t, pgName, annotations[scheduling.KubeGroupNameAnnotationKey])
+}
+
+func TestEscapeJSONPointer(t *testing.T) {
+	assert.Equal(t, "scheduling.k8s.io~1group-name", escapeJSONPointer(scheduling.KubeGroupNameAnnotationKey))
+	assert.Equal(t, "a~0b~1c", escapeJSONPointer("a~b/c"))
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

When a StatefulSet in Volcano is deleted and then recreated with the same namespace/name, the PodGroup controller may still have an old Pod request in the queue.

The `podRequest` only contains namespace and name. If the worker handles it after the Pod is recreated, the cache lookup can return the new Pod. Then the old PodGroup name may be patched into the new Pod's `scheduling.k8s.io/group-name`.

If that old PodGroup is garbage-collected, the new Pod keeps a annotation pointing to a missing PodGroup and can stay Pending.

This PR adds the Pod UID field in `podRequest` and skips queued work when the cached Pod UID mismatches the request. And it changes the annotation update to a JSON Patch with a `/metadata/uid` test, so the API server should reject the patch if the Pod was recreated after the controller read it from cache.

#### Which issue this PR fixes:

Fixes #5331

#### Special notes for your reviewer:

The original issue was reproduced with StatefulSet delete/recreate loops on Volcano v1.11.0. Details are shown in the original issue page.

#### Does this PR introduce a user-facing change?

NONE
