### PR TITLE
feature: refactor job controller to use shared queue

### DIFF
--- a/pkg/controllers/job/job_controller.go
+++ b/pkg/controllers/job/job_controller.go
@@ -18,8 +18,8 @@ package job
 
 import (
 	"context"
+	"errors"
 	"fmt"
-	"hash/fnv"
 	"sync"
 	"time"
 
@@ -90,6 +90,32 @@ type delayAction struct {
 	cancel context.CancelFunc
 }
 
+type retryKey struct {
+	// retryKey identifies one retry budget bucket for a request/action pair under the same job.
+	// It separates retries across pod/task/partition/event/action to avoid cross-request interference.
+	jobKey      string
+	podName     string
+	taskName    string
+	partitionID string
+	event       busv1alpha1.Event
+	action      busv1alpha1.Action
+}
+
+// jobRetryError wraps a request processing error with the action that failed so retry logic
+// can apply limits and terminal handling on the exact failed action.
+type jobRetryError struct {
+	err    error
+	action busv1alpha1.Action
+}
+
+func (e *jobRetryError) Error() string {
+	return e.err.Error()
+}
+
+func (e *jobRetryError) Unwrap() error {
+	return e.err
+}
+
 // jobcontroller the Job jobcontroller type.
 type jobcontroller struct {
 	kubeClient kubernetes.Interface
@@ -135,8 +161,9 @@ type jobcontroller struct {
 	queueLister schedulinglisters.QueueLister
 	queueSynced func() bool
 
-	// queue that need to sync up
-	queueList    []workqueue.TypedRateLimitingInterface[any]
+	// queue that need to sync up.
+	queue workqueue.TypedRateLimitingInterface[string]
+	// commandQueue is a dedicated pre-delete queue for Command CRs and still stores *busv1alpha1.Command.
 	commandQueue workqueue.TypedRateLimitingInterface[any]
 	cache        jobcache.Cache
 	// Job Event recorder
@@ -145,6 +172,12 @@ type jobcontroller struct {
 	errTasks      workqueue.TypedRateLimitingInterface[any]
 	workers       uint32
 	maxRequeueNum int
+
+	pendingMu       sync.Mutex
+	pendingRequests map[string][]apis.Request
+
+	requestRetryMu      sync.Mutex
+	requestRetryCounter map[retryKey]int
 
 	delayActionMapLock sync.RWMutex
 	// delayActionMap stores delayed actions for jobs, where outer map key is job key (namespace/name),
@@ -170,7 +203,7 @@ func (cc *jobcontroller) Initialize(opt *framework.ControllerOption) error {
 	recorder := eventBroadcaster.NewRecorder(vcscheme.Scheme, v1.EventSource{Component: "vc-controller-manager"})
 
 	cc.informerFactory = sharedInformers
-	cc.queueList = make([]workqueue.TypedRateLimitingInterface[any], workers)
+	cc.queue = workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[string]())
 	cc.commandQueue = workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[any]())
 	cc.cache = jobcache.New()
 	cc.errTasks = newRateLimitingQueue()
@@ -181,10 +214,8 @@ func (cc *jobcontroller) Initialize(opt *framework.ControllerOption) error {
 		cc.maxRequeueNum = -1
 	}
 
-	var i uint32
-	for i = 0; i < workers; i++ {
-		cc.queueList[i] = workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[any]())
-	}
+	cc.pendingRequests = make(map[string][]apis.Request)
+	cc.requestRetryCounter = make(map[retryKey]int)
 
 	factory := opt.VCSharedInformerFactory
 	cc.vcInformerFactory = factory
@@ -313,46 +344,62 @@ func (cc *jobcontroller) Run(stopCh <-chan struct{}) {
 func (cc *jobcontroller) worker(i uint32) {
 	klog.Infof("worker %d start ...... ", i)
 
-	for cc.processNextReq(i) {
+	for cc.processNextJob() {
 	}
 }
 
-func (cc *jobcontroller) belongsToThisRoutine(key string, count uint32) bool {
-	val := cc.genHash(key)
-	return val%cc.workers == count
-}
-
-func (cc *jobcontroller) getWorkerQueue(key string) workqueue.TypedRateLimitingInterface[any] {
-	val := cc.genHash(key)
-	queue := cc.queueList[val%cc.workers]
-	return queue
-}
-
-func (cc *jobcontroller) genHash(key string) uint32 {
-	hashVal := fnv.New32()
-	hashVal.Write([]byte(key))
-	return hashVal.Sum32()
-}
-
-func (cc *jobcontroller) processNextReq(count uint32) bool {
-	queue := cc.queueList[count]
-	obj, shutdown := queue.Get()
-	if shutdown {
-		klog.Errorf("Fail to pop item from queue")
-		return false
+func (cc *jobcontroller) retryKeyByRequest(jobKey string, req apis.Request, action busv1alpha1.Action) retryKey {
+	return retryKey{
+		jobKey:      jobKey,
+		podName:     req.PodName,
+		taskName:    req.TaskName,
+		partitionID: req.PartitionID,
+		event:       req.Event,
+		action:      action,
 	}
+}
 
-	req := obj.(apis.Request)
-	defer queue.Done(req)
-
+func (cc *jobcontroller) pushRequest(req apis.Request) {
 	key := jobcache.JobKeyByReq(&req)
-	if !cc.belongsToThisRoutine(key, count) {
-		klog.Errorf("should not occur The job does not belongs to this routine key:%s, worker:%d...... ", key, count)
-		queueLocal := cc.getWorkerQueue(key)
-		queueLocal.Add(req)
-		return true
-	}
+	cc.pendingMu.Lock()
+	cc.pendingRequests[key] = append(cc.pendingRequests[key], req)
+	cc.pendingMu.Unlock()
+	cc.queue.Add(key)
+}
 
+func (cc *jobcontroller) popAllRequests(key string) []apis.Request {
+	cc.pendingMu.Lock()
+	defer cc.pendingMu.Unlock()
+
+	reqs := cc.pendingRequests[key]
+	delete(cc.pendingRequests, key)
+	return reqs
+}
+
+func (cc *jobcontroller) requeueToHead(key string, reqs []apis.Request) {
+	if len(reqs) == 0 {
+		return
+	}
+	cc.pendingMu.Lock()
+	cc.pendingRequests[key] = append(reqs, cc.pendingRequests[key]...)
+	cc.pendingMu.Unlock()
+}
+
+func (cc *jobcontroller) clearPendingAndRetryByJobKey(key string) {
+	cc.pendingMu.Lock()
+	delete(cc.pendingRequests, key)
+	cc.pendingMu.Unlock()
+
+	cc.requestRetryMu.Lock()
+	for currentKey := range cc.requestRetryCounter {
+		if currentKey.jobKey == key {
+			delete(cc.requestRetryCounter, currentKey)
+		}
+	}
+	cc.requestRetryMu.Unlock()
+}
+
+func (cc *jobcontroller) processOneRequest(req apis.Request, key string) error {
 	klog.V(3).Infof("Try to handle request <%v>", req)
 
 	cc.CleanPodDelayActionsIfNeed(req)
@@ -360,15 +407,14 @@ func (cc *jobcontroller) processNextReq(count uint32) bool {
 	jobInfo, err := cc.cache.Get(key)
 	if err != nil {
 		// TODO(k82cn): ignore not-ready error.
-		klog.Errorf("Failed to get job by <%v> from cache: %v", req, err)
-		return true
+		return err
 	}
 
 	st := state.NewState(jobInfo)
 	if st == nil {
 		klog.Errorf("Invalid state <%s> of Job <%v/%v>",
 			jobInfo.Job.Status.State, jobInfo.Job.Namespace, jobInfo.Job.Name)
-		return true
+		return nil
 	}
 
 	delayAct := applyPolicies(jobInfo.Job, &req)
@@ -379,7 +425,7 @@ func (cc *jobcontroller) processNextReq(count uint32) bool {
 		cc.recordJobEvent(jobInfo.Job.Namespace, jobInfo.Job.Name, batchv1alpha1.ExecuteAction, fmt.Sprintf(
 			"Execute action %s after %s", delayAct.action, delayAct.delay.String()))
 		cc.AddDelayActionForJob(req, delayAct)
-		return true
+		return nil
 	}
 
 	klog.V(3).Infof("Execute <%v> on Job <%s/%s> in <%s> by <%T>.",
@@ -393,18 +439,82 @@ func (cc *jobcontroller) processNextReq(count uint32) bool {
 	action := GetStateAction(delayAct)
 
 	if err := st.Execute(action); err != nil {
-		cc.handleJobError(queue, req, st, err, delayAct.action)
-		return true
+		return &jobRetryError{
+			err:    err,
+			action: delayAct.action,
+		}
 	}
 
-	// If no error, forget it.
-	queue.Forget(req)
+	cc.requestRetryMu.Lock()
+	delete(cc.requestRetryCounter, cc.retryKeyByRequest(key, req, delayAct.action))
+	cc.requestRetryMu.Unlock()
 
 	// If the action is not an internal action, cancel all delayed actions
 	if !isInternalAction(delayAct.action) {
 		cc.cleanupDelayActions(delayAct)
 	}
 
+	return nil
+}
+
+func (cc *jobcontroller) processNextJob() bool {
+	key, shutdown := cc.queue.Get()
+	if shutdown {
+		klog.Errorf("Fail to pop item from queue.")
+		return false
+	}
+	defer cc.queue.Done(key)
+
+	reqs := cc.popAllRequests(key)
+	if len(reqs) == 0 {
+		cc.queue.Forget(key)
+		return true
+	}
+
+	if _, err := cc.cache.Get(key); err != nil {
+		klog.Errorf("Failed to get job by <%v> from cache: %v", key, err)
+		cc.clearPendingAndRetryByJobKey(key)
+		cc.queue.Forget(key)
+		return true
+	}
+
+	for reqIdx, req := range reqs {
+		if err := cc.processOneRequest(req, key); err != nil {
+			var retryErr *jobRetryError
+			if errors.As(err, &retryErr) {
+				jobInfo, getErr := cc.cache.Get(key)
+				if getErr != nil {
+					klog.Errorf("Failed to get job by <%v> from cache while handling request error: %v", key, getErr)
+					cc.clearPendingAndRetryByJobKey(key)
+					cc.queue.Forget(key)
+					return true
+				}
+				st := state.NewState(jobInfo)
+				if st == nil {
+					klog.Errorf("Invalid state <%s> of Job <%v/%v> while handling request error",
+						jobInfo.Job.Status.State, jobInfo.Job.Namespace, jobInfo.Job.Name)
+					cc.clearPendingAndRetryByJobKey(key)
+					cc.queue.Forget(key)
+					return true
+				}
+				if cc.handleJobError(key, req, st, retryErr.Unwrap(), retryErr.action) {
+					cc.requeueToHead(key, reqs[reqIdx:])
+					// In dense event storms, pushRequest's immediate Add(key) can mark this key dirty
+					// while in-flight and effectively short-circuit this retry rate-limit delay.
+					// This is a known workqueue behavior and accepted for this cleanup scope.
+					cc.queue.AddRateLimited(key)
+				} else {
+					cc.clearPendingAndRetryByJobKey(key)
+					cc.queue.Forget(key)
+				}
+				return true
+			}
+
+			klog.Errorf("Failed to process request <%v>: %v", req, err)
+		}
+	}
+
+	cc.queue.Forget(key)
 	return true
 }
 
@@ -483,38 +593,26 @@ func (cc *jobcontroller) AddDelayActionForJob(req apis.Request, delayAct *delayA
 		}
 
 		klog.V(4).Infof("Job<%s/%s>'s delayed action %s is expired, execute it", req.Namespace, req.JobName, delayAct.action)
-
-		jobInfo, err := cc.cache.Get(delayAct.jobKey)
-		if err != nil {
-			klog.Errorf("Failed to get job by <%v> from cache: %v", req, err)
-			return
-		}
-
-		st := state.NewState(jobInfo)
-		if st == nil {
-			klog.Errorf("Invalid state <%s> of Job <%v/%v>",
-				jobInfo.Job.Status.State, jobInfo.Job.Namespace, jobInfo.Job.Name)
-			return
-		}
-		queue := cc.getWorkerQueue(delayAct.jobKey)
-
-		if err := st.Execute(GetStateAction(delayAct)); err != nil {
-			cc.handleJobError(queue, req, st, err, delayAct.action)
-		}
-
-		queue.Forget(req)
-
 		cc.cleanupDelayActions(delayAct)
+		replayedReq := req
+		replayedReq.Action = delayAct.action
+		cc.pushRequest(replayedReq)
 	}()
 }
 
-func (cc *jobcontroller) handleJobError(queue workqueue.TypedRateLimitingInterface[any], req apis.Request, st state.State, err error, action busv1alpha1.Action) {
-	if cc.maxRequeueNum == -1 || queue.NumRequeues(req) < cc.maxRequeueNum {
+func (cc *jobcontroller) handleJobError(jobKey string, req apis.Request, st state.State, err error, action busv1alpha1.Action) bool {
+	retryCounterKey := cc.retryKeyByRequest(jobKey, req, action)
+	cc.requestRetryMu.Lock()
+	retryCount := cc.requestRetryCounter[retryCounterKey]
+	if cc.maxRequeueNum == -1 || retryCount < cc.maxRequeueNum {
+		cc.requestRetryCounter[retryCounterKey] = retryCount + 1
+		cc.requestRetryMu.Unlock()
 		klog.V(2).Infof("Failed to handle Job <%s/%s>: %v",
 			req.Namespace, req.JobName, err)
-		queue.AddRateLimited(req)
-		return
+		return true
 	}
+	delete(cc.requestRetryCounter, retryCounterKey)
+	cc.requestRetryMu.Unlock()
 
 	cc.recordJobEvent(req.Namespace, req.JobName, batchv1alpha1.ExecuteAction,
 		fmt.Sprintf("Job failed on action %s for retry limit reached", action))
@@ -525,6 +623,7 @@ func (cc *jobcontroller) handleJobError(queue workqueue.TypedRateLimitingInterfa
 	}
 	klog.Warningf("Dropping job<%s/%s> out of the queue: %v because max retries has reached",
 		req.Namespace, req.JobName, err)
+	return false
 }
 
 // cleanupDelayActions cleans up delayed actions

--- a/pkg/controllers/job/job_controller_handler.go
+++ b/pkg/controllers/job/job_controller_handler.go
@@ -68,9 +68,7 @@ func (cc *jobcontroller) addJob(obj interface{}) {
 		klog.Errorf("Failed to add job <%s/%s>: %v in cache",
 			job.Namespace, job.Name, err)
 	}
-	key := jobhelpers.GetJobKeyByReq(&req)
-	queue := cc.getWorkerQueue(key)
-	queue.Add(req)
+	cc.pushRequest(req)
 }
 
 func (cc *jobcontroller) updateJob(oldObj, newObj interface{}) {
@@ -109,9 +107,7 @@ func (cc *jobcontroller) updateJob(oldObj, newObj interface{}) {
 		JobName:   newJob.Name,
 		Event:     bus.OutOfSyncEvent,
 	}
-	key := jobhelpers.GetJobKeyByReq(&req)
-	queue := cc.getWorkerQueue(key)
-	queue.Add(req)
+	cc.pushRequest(req)
 }
 
 func (cc *jobcontroller) deleteJob(obj interface{}) {
@@ -134,6 +130,7 @@ func (cc *jobcontroller) deleteJob(obj interface{}) {
 		klog.Errorf("Failed to delete job <%s/%s>: %v in cache",
 			job.Namespace, job.Name, err)
 	}
+	cc.clearPendingAndRetryByJobKey(jobcache.JobKeyByName(job.Namespace, job.Name))
 
 	// Delete job metrics
 	state.DeleteJobMetrics(fmt.Sprintf("%s/%s", job.Namespace, job.Name), job.Spec.Queue)
@@ -203,9 +200,7 @@ func (cc *jobcontroller) addPod(obj interface{}) {
 		klog.Errorf("Failed to add Pod <%s/%s>: %v to cache",
 			pod.Namespace, pod.Name, err)
 	}
-	key := jobhelpers.GetJobKeyByReq(&req)
-	queue := cc.getWorkerQueue(key)
-	queue.Add(req)
+	cc.pushRequest(req)
 }
 
 func (cc *jobcontroller) updatePod(oldObj, newObj interface{}) {
@@ -317,9 +312,7 @@ func (cc *jobcontroller) updatePod(oldObj, newObj interface{}) {
 		JobVersion:  int32(dVersion),
 	}
 
-	key := jobhelpers.GetJobKeyByReq(&req)
-	queue := cc.getWorkerQueue(key)
-	queue.Add(req)
+	cc.pushRequest(req)
 }
 
 func (cc *jobcontroller) deletePod(obj interface{}) {
@@ -396,9 +389,7 @@ func (cc *jobcontroller) deletePod(obj interface{}) {
 			pod.Namespace, pod.Name, err)
 	}
 
-	key := jobhelpers.GetJobKeyByReq(&req)
-	queue := cc.getWorkerQueue(key)
-	queue.Add(req)
+	cc.pushRequest(req)
 }
 
 func (cc *jobcontroller) recordJobEvent(namespace, name string, event batch.JobEvent, message string) {
@@ -442,9 +433,7 @@ func (cc *jobcontroller) processNextCommand() bool {
 		Action:    bus.Action(cmd.Action),
 	}
 
-	key := jobhelpers.GetJobKeyByReq(&req)
-	queue := cc.getWorkerQueue(key)
-	queue.Add(req)
+	cc.pushRequest(req)
 
 	return true
 }
@@ -485,9 +474,7 @@ func (cc *jobcontroller) updatePodGroup(oldObj, newObj interface{}) {
 		case scheduling.PodGroupUnknown:
 			req.Event = bus.JobUnknownEvent
 		}
-		key := jobhelpers.GetJobKeyByReq(&req)
-		queue := cc.getWorkerQueue(key)
-		queue.Add(req)
+		cc.pushRequest(req)
 	}
 }
 

--- a/pkg/controllers/job/job_controller_handler_test.go
+++ b/pkg/controllers/job/job_controller_handler_test.go
@@ -180,10 +180,9 @@ func TestJobAddFunc(t *testing.T) {
 			if job == nil || err != nil {
 				t.Errorf("Error while Adding Job in case %d with error %s", i, err)
 			}
-			queue := controller.getWorkerQueue(key)
-			len := queue.Len()
-			if testcase.ExpectValue != len {
-				t.Errorf("case %d (%s): expected: %v, got %v ", i, testcase.Name, testcase.ExpectValue, len)
+			pendingLen := len(controller.pendingRequests[key])
+			if testcase.ExpectValue != pendingLen {
+				t.Errorf("case %d (%s): expected: %v, got %v ", i, testcase.Name, testcase.ExpectValue, pendingLen)
 			}
 		})
 	}
@@ -615,10 +614,9 @@ func TestUpdatePodGroupFunc(t *testing.T) {
 			controller := newController()
 			controller.updatePodGroup(testcase.oldPodGroup, testcase.newPodGroup)
 			key := fmt.Sprintf("%s/%s", testcase.oldPodGroup.Namespace, testcase.oldPodGroup.Name)
-			queue := controller.getWorkerQueue(key)
-			len := queue.Len()
-			if testcase.ExpectValue != len {
-				t.Errorf("case %d (%s): expected: %v, got %v ", i, testcase.Name, testcase.ExpectValue, len)
+			pendingLen := len(controller.pendingRequests[key])
+			if testcase.ExpectValue != pendingLen {
+				t.Errorf("case %d (%s): expected: %v, got %v ", i, testcase.Name, testcase.ExpectValue, pendingLen)
 			}
 		})
 	}

--- a/pkg/controllers/job/job_controller_queue_test.go
+++ b/pkg/controllers/job/job_controller_queue_test.go
@@ -1,0 +1,302 @@
+/*
+Copyright 2026 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package job
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/agiledragon/gomonkey/v2"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	batch "volcano.sh/apis/pkg/apis/batch/v1alpha1"
+	bus "volcano.sh/apis/pkg/apis/bus/v1alpha1"
+	"volcano.sh/volcano/pkg/controllers/apis"
+	"volcano.sh/volcano/pkg/controllers/job/state"
+)
+
+type fakeState struct {
+	lastAction state.Action
+	executeErr error
+}
+
+func (f *fakeState) Execute(act state.Action) error {
+	f.lastAction = act
+	return f.executeErr
+}
+
+func TestPushRequest_NoDedup(t *testing.T) {
+	controller := newController()
+
+	req := apis.Request{
+		Namespace: "default",
+		JobName:   "job-a",
+		Event:     bus.OutOfSyncEvent,
+	}
+	key := "default/job-a"
+
+	controller.pushRequest(req)
+	controller.pushRequest(req)
+
+	if got := len(controller.pendingRequests[key]); got != 2 {
+		t.Fatalf("expected pending len 2, got %d", got)
+	}
+}
+
+func TestRequeueToHead_KeepsHeadBeforeNewTail(t *testing.T) {
+	controller := newController()
+	key := "default/job-a"
+
+	r2 := apis.Request{Namespace: "default", JobName: "job-a", PodName: "pod-2"}
+	r3 := apis.Request{Namespace: "default", JobName: "job-a", PodName: "pod-3"}
+	r4 := apis.Request{Namespace: "default", JobName: "job-a", PodName: "pod-4"}
+
+	controller.pushRequest(r4)
+	controller.requeueToHead(key, []apis.Request{r2, r3})
+
+	got := controller.pendingRequests[key]
+	if len(got) != 3 {
+		t.Fatalf("expected 3 pending requests, got %d", len(got))
+	}
+	if got[0].PodName != "pod-2" || got[1].PodName != "pod-3" || got[2].PodName != "pod-4" {
+		t.Fatalf("unexpected pending order: %+v", got)
+	}
+}
+
+func TestHandleJobError_RetryKeySeparatesTaskAndPartition(t *testing.T) {
+	controller := newController()
+	controller.maxRequeueNum = 1
+	st := &fakeState{}
+	jobKey := "default/job-a"
+
+	err1 := controller.handleJobError(jobKey, apis.Request{
+		Namespace:   "default",
+		JobName:     "job-a",
+		PodName:     "pod-a",
+		TaskName:    "task-a",
+		PartitionID: "p0",
+		Event:       bus.PodPendingEvent,
+	}, st, errors.New("boom"), bus.RestartJobAction)
+
+	err2 := controller.handleJobError(jobKey, apis.Request{
+		Namespace:   "default",
+		JobName:     "job-a",
+		PodName:     "pod-a",
+		TaskName:    "task-a",
+		PartitionID: "p1",
+		Event:       bus.PodPendingEvent,
+	}, st, errors.New("boom"), bus.RestartJobAction)
+
+	if !err1 || !err2 {
+		t.Fatalf("expected both requests to keep retry budget independently")
+	}
+}
+
+func TestHandleJobError_OverBudgetTerminatesWholeJob(t *testing.T) {
+	controller := newController()
+	controller.maxRequeueNum = 0
+	st := &fakeState{}
+	jobKey := "default/job-a"
+
+	shouldRetry := controller.handleJobError(jobKey, apis.Request{
+		Namespace: "default",
+		JobName:   "job-a",
+		Event:     bus.PodFailedEvent,
+	}, st, errors.New("boom"), bus.RestartJobAction)
+
+	if shouldRetry {
+		t.Fatalf("expected no retry when maxRequeueNum is exceeded")
+	}
+	if st.lastAction.Action != bus.TerminateJobAction {
+		t.Fatalf("expected terminate action, got %s", st.lastAction.Action)
+	}
+}
+
+func TestJobRetryError_Unwrap(t *testing.T) {
+	baseErr := errors.New("boom")
+	err := &jobRetryError{
+		err:    baseErr,
+		action: bus.RestartJobAction,
+	}
+
+	if !errors.Is(err, baseErr) {
+		t.Fatalf("expected errors.Is to match wrapped error")
+	}
+	if errors.Unwrap(err) != baseErr {
+		t.Fatalf("expected errors.Unwrap to return wrapped error")
+	}
+}
+
+func TestDeleteJob_ClearsPendingAndRetryState(t *testing.T) {
+	controller := newController()
+	job := &batch.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "job-a",
+		},
+	}
+	req := apis.Request{
+		Namespace: "default",
+		JobName:   "job-a",
+		PodName:   "pod-a",
+		TaskName:  "task-a",
+		Event:     bus.PodFailedEvent,
+	}
+	key := "default/job-a"
+
+	controller.addJob(job)
+	controller.pushRequest(req)
+	controller.requestRetryCounter[controller.retryKeyByRequest(key, req, bus.RestartJobAction)] = 1
+
+	controller.deleteJob(job)
+
+	if _, found := controller.pendingRequests[key]; found {
+		t.Fatalf("expected pending requests to be cleared for %s", key)
+	}
+	for retryKey := range controller.requestRetryCounter {
+		if retryKey.jobKey == key {
+			t.Fatalf("expected retry counter entries to be cleared for %s", key)
+		}
+	}
+}
+
+func TestProcessNextJob_CacheMissClearsPendingAndRetryState(t *testing.T) {
+	controller := newController()
+	key := "default/job-missing"
+	req := apis.Request{
+		Namespace: "default",
+		JobName:   "job-missing",
+		PodName:   "pod-a",
+		TaskName:  "task-a",
+		Event:     bus.PodFailedEvent,
+	}
+
+	controller.pendingRequests[key] = []apis.Request{req}
+	controller.requestRetryCounter[controller.retryKeyByRequest(key, req, bus.RestartJobAction)] = 1
+	controller.queue.Add(key)
+
+	if !controller.processNextJob() {
+		t.Fatalf("expected processNextJob to keep worker loop running")
+	}
+	if _, found := controller.pendingRequests[key]; found {
+		t.Fatalf("expected pending requests to be cleared for cache miss key %s", key)
+	}
+	for retryKey := range controller.requestRetryCounter {
+		if retryKey.jobKey == key {
+			t.Fatalf("expected retry counter entries to be cleared for cache miss key %s", key)
+		}
+	}
+}
+
+func TestAddDelayActionForJob_ReplayRequestWithMaterializedAction(t *testing.T) {
+	controller := newController()
+	req := apis.Request{
+		Namespace:   "default",
+		JobName:     "job-a",
+		TaskName:    "task-a",
+		PodName:     "pod-a",
+		PartitionID: "p0",
+		Event:       bus.PodPendingEvent,
+	}
+	key := "default/job-a"
+	replayedKeyCh := make(chan string, 1)
+
+	go func() {
+		gotKey, shutdown := controller.queue.Get()
+		if shutdown {
+			return
+		}
+		replayedKeyCh <- gotKey
+	}()
+
+	controller.AddDelayActionForJob(req, &delayAction{
+		jobKey:    key,
+		taskName:  req.TaskName,
+		podName:   req.PodName,
+		partition: req.PartitionID,
+		event:     req.Event,
+		action:    bus.RestartTaskAction,
+		delay:     0,
+	})
+
+	select {
+	case replayedKey := <-replayedKeyCh:
+		controller.queue.Done(replayedKey)
+		if replayedKey != key {
+			t.Fatalf("expected replayed key %s, got %s", key, replayedKey)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatalf("timed out waiting for replayed delayed action")
+	}
+
+	controller.pendingMu.Lock()
+	got := append([]apis.Request(nil), controller.pendingRequests[key]...)
+	controller.pendingMu.Unlock()
+	if len(got) == 0 {
+		t.Fatalf("expected replayed request to be enqueued")
+	}
+
+	replayed := got[len(got)-1]
+	if replayed.Action != bus.RestartTaskAction {
+		t.Fatalf("expected replayed action %s, got %s", bus.RestartTaskAction, replayed.Action)
+	}
+	if replayed.TaskName != req.TaskName || replayed.PodName != req.PodName || replayed.PartitionID != req.PartitionID {
+		t.Fatalf("expected replayed request to preserve task/pod/partition, got %+v", replayed)
+	}
+}
+
+func TestProcessNextJob_CreatesStatePerRequest(t *testing.T) {
+	controller := newController()
+	job := &batch.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "job-a",
+		},
+	}
+
+	if err := controller.cache.Add(job); err != nil {
+		t.Fatalf("failed to add job into cache: %v", err)
+	}
+
+	controller.pushRequest(apis.Request{
+		Namespace: "default",
+		JobName:   "job-a",
+		PodName:   "pod-a",
+		Action:    bus.SyncJobAction,
+	})
+	controller.pushRequest(apis.Request{
+		Namespace: "default",
+		JobName:   "job-a",
+		PodName:   "pod-b",
+		Action:    bus.SyncJobAction,
+	})
+
+	newStateCount := 0
+	patches := gomonkey.ApplyFunc(state.NewState, func(*apis.JobInfo) state.State {
+		newStateCount++
+		return &fakeState{}
+	})
+	defer patches.Reset()
+
+	if !controller.processNextJob() {
+		t.Fatalf("expected processNextJob to keep worker loop running")
+	}
+	if newStateCount != 2 {
+		t.Fatalf("expected NewState to be called per request, got %d", newStateCount)
+	}
+}

--- a/pkg/controllers/job/job_controller_queue_test.go
+++ b/pkg/controllers/job/job_controller_queue_test.go
@@ -237,6 +237,7 @@ func TestAddDelayActionForJob_ReplayRequestWithMaterializedAction(t *testing.T) 
 	select {
 	case replayedKey := <-replayedKeyCh:
 		controller.queue.Done(replayedKey)
+		controller.queue.Forget(replayedKey)
 		if replayedKey != key {
 			t.Fatalf("expected replayed key %s, got %s", key, replayedKey)
 		}
@@ -298,5 +299,42 @@ func TestProcessNextJob_CreatesStatePerRequest(t *testing.T) {
 	}
 	if newStateCount != 2 {
 		t.Fatalf("expected NewState to be called per request, got %d", newStateCount)
+	}
+}
+
+func TestProcessOneRequest_SuccessClearsRetryCounter(t *testing.T) {
+	controller := newController()
+	job := &batch.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "job-a",
+		},
+	}
+	req := apis.Request{
+		Namespace: "default",
+		JobName:   "job-a",
+		PodName:   "pod-a",
+		Action:    bus.RestartJobAction,
+		Event:     bus.PodFailedEvent,
+	}
+	key := "default/job-a"
+
+	if err := controller.cache.Add(job); err != nil {
+		t.Fatalf("failed to add job into cache: %v", err)
+	}
+
+	controller.requestRetryCounter[controller.retryKeyByRequest(key, req, req.Action)] = 1
+
+	patches := gomonkey.ApplyFunc(state.NewState, func(*apis.JobInfo) state.State {
+		return &fakeState{}
+	})
+	defer patches.Reset()
+
+	if err := controller.processOneRequest(req, key); err != nil {
+		t.Fatalf("expected request to succeed, got %v", err)
+	}
+
+	if _, exists := controller.requestRetryCounter[controller.retryKeyByRequest(key, req, req.Action)]; exists {
+		t.Fatalf("expected retry counter to be cleared after successful processing")
 	}
 }

--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -223,14 +223,16 @@ func CleanupTestContext(ctx *TestContext) {
 	err := CleanupHyperNodes(ctx)
 	Expect(err).NotTo(HaveOccurred(), "failed to clean up hypernodes")
 
+	// Delete queues before the namespace enters Terminating so queue status can
+	// observe workload cleanup and allocated pods can drain to zero reliably.
+	deleteQueues(ctx)
+	deletePriorityClasses(ctx)
+
 	foreground := metav1.DeletePropagationForeground
 	err = ctx.Kubeclient.CoreV1().Namespaces().Delete(context.TODO(), ctx.Namespace, metav1.DeleteOptions{
 		PropagationPolicy: &foreground,
 	})
 	Expect(err).NotTo(HaveOccurred(), "failed to delete namespace")
-
-	deleteQueues(ctx)
-	deletePriorityClasses(ctx)
 
 	if ctx.UsingPlaceHolder {
 		deletePlaceHolder(ctx)


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Collapses the per-worker queues in `job-controller` into a single shared workqueue.

Naively switching the queue element to `apis.Request` (as in #4844) breaks the existing "same-Job serial" invariant: different workers can pull different `Request`s of the same Job concurrently and race on `state.Execute` / `syncJob` / `killJob`.

This PR keeps that invariant by changing the scheduling unit:

- Shared `workqueue` holds `jobKey` strings.
- Per-Job pending requests buffered in `pendingRequests map[string][]apis.Request`, FIFO preserved; failure replays via `requeueToHead`.
- Same-Job serialization comes from workqueue's `Get..Done` in-flight + dirty semantics — no extra keyed mutex.
- `delayAction` timeout no longer calls `state.Execute` directly; it now re-enters via `pushRequest`, fixing a pre-existing race between the timeout goroutine and the worker.
- Retry budget stays at per-Request granularity (`requestRetryCounter map[retryKey]int`); workqueue rate-limits at `jobKey` granularity.
- `commandQueue` and `errTasks` are intentionally untouched; only the final enqueue point in `processNextCommand` is rerouted through `pushRequest`.
- `deleteJob` clears `pendingRequests[jobKey]` and matching `requestRetryCounter` entries.

Design doc: `docs/design/job-controller-single-queue-keyed-mutex.md`.

#### Which issue(s) this PR fixes:

Fixes #4835

#### Special notes for your reviewer:

- Queue element type changes from `apis.Request` to `jobKey (string)`. Confirm every old `getWorkerQueue(key).Add(req)` call site is rerouted to `pushRequest(req)`, including `processNextCommand`.
- Why not enqueue `apis.Request` directly: would break same-Job serial dispatch. See §3 / §9 of the design doc.
- Why no keyed mutex: workqueue already serializes the same key between `Get` and `Done`. See §10.
- Retry budget remains per-Request to preserve `--max-requeue-num` user-visible semantics. See §5.3 / §5.4.
- `delayAction.cleanupDelayActions` is now invoked at timeout time (before `pushRequest`) instead of after `state.Execute`, since execution is async after this PR.
- Out of scope: `commandQueue`, `errTasks` / `processResyncTask`, and reconcile-style migration.
- Tests added: same-Job FIFO, cross-Job parallel dispatch, failure replay ordering, per-Request retry budget independence, `delayAction` re-entry via `pushRequest`, `processNextCommand` end-to-end, `deleteJob` cleanup.

#### Does this PR introduce a user-facing change?

```release-note
job-controller: per-worker queues are collapsed into a single shared queue keyed by jobKey. Same-Job serial processing and per-Request retry budget (`--max-requeue-num`) are preserved. `delayAction` timeout now goes through the main worker pipeline instead of executing the state machine directly. Workqueue metrics collapse from N per-worker series to one.
```
````