### PR TITLE
fix: discard partial operations when RecoverOperations fails (#5362)

### DIFF
--- a/pkg/scheduler/actions/allocate/allocate.go
+++ b/pkg/scheduler/actions/allocate/allocate.go
@@ -426,6 +426,10 @@ func (alloc *Action) allocateForJob(job *api.JobInfo, jobWorksheet *JobWorksheet
 		finalStmt := framework.NewStatement(ssn)
 		if err = finalStmt.RecoverOperations(bestStmt); err != nil {
 			klog.ErrorS(err, "Failed to recover operations", "job", job.UID, "hyperNode", bestHyperNode)
+			// Discard partially-recovered operations so they don't leak into
+			// the session and corrupt resource accounting for the rest of the
+			// scheduling cycle.
+			finalStmt.Discard()
 			return nil
 		}
 
@@ -499,6 +503,10 @@ func (alloc *Action) allocateForSubJob(subJob *api.SubJobInfo, subJobWorksheet *
 		finalStmt := framework.NewStatement(ssn)
 		if err = finalStmt.RecoverOperations(bestStmt); err != nil {
 			klog.ErrorS(err, "Failed to recover operations", "subJob", subJob.UID, "hyperNode", bestHyperNode)
+			// Discard partially-recovered operations so they don't leak into
+			// the session and corrupt resource accounting for the rest of the
+			// scheduling cycle.
+			finalStmt.Discard()
 			return nil, 0
 		}
 		newAllocatedHyperNode := ssn.HyperNodes.GetLCAHyperNode(subJob.AllocatedHyperNode, bestHyperNode)

--- a/pkg/scheduler/framework/statement_recover_test.go
+++ b/pkg/scheduler/framework/statement_recover_test.go
@@ -77,3 +77,66 @@ func TestRecoverOperations_PipelinePreservesEvictionFlag(t *testing.T) {
 		assert.True(t, recoveredTask.EvictionOccurred)
 	}
 }
+
+// TestRecoverOperations_DiscardRollsBackPartialRecovery verifies that when
+// RecoverOperations fails partway through, the operations it already applied
+// remain in the statement and mutate session state, and that Discard rolls
+// them back. This is the contract the allocate action relies on: it must call
+// Discard on the finalStmt when RecoverOperations returns an error, otherwise
+// the partially-applied operations leak into the session.
+func TestRecoverOperations_DiscardRollsBackPartialRecovery(t *testing.T) {
+	newTask := func(uid, job string) *api.TaskInfo {
+		return &api.TaskInfo{
+			UID:        api.TaskID(uid),
+			Job:        api.JobID(job),
+			Name:       uid,
+			Namespace:  "ns",
+			Resreq:     (&api.Resource{MilliCPU: 1000}).Clone(),
+			InitResreq: (&api.Resource{MilliCPU: 1000}).Clone(),
+			Pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: uid, Namespace: "ns", UID: types.UID(uid)},
+			},
+			NumaInfo:           &api.TopologyInfo{ResMap: map[int]v1.ResourceList{}},
+			TransactionContext: api.TransactionContext{Status: api.Pending},
+		}
+	}
+
+	const nodeIdle = float64(4000)
+
+	jobAID, jobBID := api.JobID("ns/jobA"), api.JobID("ns/jobB")
+	taskA, taskB := newTask("a", string(jobAID)), newTask("b", string(jobBID))
+	node := api.NewNodeInfo(nil)
+	node.Name = "n1"
+	node.Idle = (&api.Resource{MilliCPU: nodeIdle}).Clone()
+	node.Releasing = api.EmptyResource()
+	node.Pipelined = api.EmptyResource()
+
+	ssn := &Session{
+		Jobs:  map[api.JobID]*api.JobInfo{jobAID: api.NewJobInfo(jobAID, taskA), jobBID: api.NewJobInfo(jobBID, taskB)},
+		Nodes: map[string]*api.NodeInfo{node.Name: node},
+	}
+
+	// Build a plan that allocates both tasks, then discard the source statement.
+	sourceStmt := NewStatement(ssn)
+	assert.NoError(t, sourceStmt.Allocate(taskA, node))
+	assert.NoError(t, sourceStmt.Allocate(taskB, node))
+	plan := SaveOperations(sourceStmt)
+	sourceStmt.Discard()
+
+	// Remove jobB so recovering its allocation fails after taskA is recovered.
+	delete(ssn.Jobs, jobBID)
+
+	finalStmt := NewStatement(ssn)
+	err := finalStmt.RecoverOperations(plan)
+	assert.Error(t, err, "RecoverOperations should fail when a task's job is missing")
+
+	// taskA was recovered before the failure, so it is left allocated in the
+	// session: the partially-applied operation is still live.
+	assert.NotNil(t, ssn.Jobs[jobAID].TaskStatusIndex[api.Allocated][taskA.UID],
+		"partial recovery should leave taskA allocated in the session")
+
+	// Discarding rolls the partial recovery back, restoring taskA to Pending.
+	finalStmt.Discard()
+	assert.Nil(t, ssn.Jobs[jobAID].TaskStatusIndex[api.Allocated][taskA.UID],
+		"Discard should roll back the partially-recovered allocation")
+}


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
In `pkg/scheduler/actions/allocate/allocate.go`, both `allocateForJob` and `allocateForSubJob` did not call `finalStmt.Discard()` when `RecoverOperations` returned an error.

`RecoverOperations` applies the saved operations (Evict, Pipeline, Allocate) one by one and mutates session state as it goes (node resource accounting, task statuses, event handler callbacks). If it fails partway, the operations already applied stay live in the session, corrupting accounting and task statuses for the rest of the scheduling cycle.

This discards the statement on the error path, matching the dry-run rollback already performed elsewhere in these same functions. Adds a framework test verifying that a failed `RecoverOperations` is rolled back by `Discard`.

#### Which issue(s) this PR fixes:
Fixes #5362