### PR TITLE
Add Security Insights metadata and release SBOM

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -90,3 +90,30 @@ jobs:
         run: |
           docker logout
           docker logout ghcr.io
+
+  sbom:
+    if: startsWith(github.ref, 'refs/tags/v')
+    name: Release SBOM
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Generate SBOM
+        uses: aquasecurity/trivy-action@v0.36.0
+        with:
+          scan-type: 'fs'
+          format: 'spdx'
+          output: 'sbom-volcano.spdx'
+          scan-ref: "${{ github.workspace }}/"
+
+      - name: Package SBOM
+        run: |
+          tar -zcf sbom.tar.gz *.spdx
+
+      - name: Upload SBOM
+        uses: softprops/action-gh-release@v3
+        with:
+          files: |
+            sbom.tar.gz

--- a/SECURITY-INSIGHTS.yml
+++ b/SECURITY-INSIGHTS.yml
@@ -1,0 +1,76 @@
+header:
+  expiration-date: '2027-06-03T00:00:00.000Z'
+  project-url: 'https://github.com/volcano-sh/volcano'
+  schema-version: '1.0.0'
+  last-updated: '2026-06-03'
+  last-reviewed: '2026-06-03'
+  changelog: 'https://github.com/volcano-sh/volcano/blob/master/CHANGELOG.md'
+  license: 'https://github.com/volcano-sh/volcano/blob/master/LICENSE'
+
+project-lifecycle:
+  status: 'active'
+  bug-fixes-only: false
+  core-maintainers:
+    - 'https://github.com/volcano-sh/community/blob/master/MAINTAINERS.md'
+  roadmap: 'https://github.com/volcano-sh/community/blob/master/roadmap.md'
+  release-process: 'https://github.com/volcano-sh/community/blob/master/version-release.md'
+
+contribution-policy:
+  accepts-pull-requests: true
+  accepts-automated-pull-requests: true
+  automated-tools-list:
+    - automated-tool: 'dependabot'
+      action: 'allowed'
+      path:
+        - /
+  contributing-policy: 'https://github.com/volcano-sh/community/blob/master/contribute.md'
+  code-of-conduct: 'https://github.com/volcano-sh/community/blob/master/CODE_OF_CONDUCT.md'
+
+documentation:
+  - 'https://volcano.sh/'
+
+distribution-points:
+  - 'https://github.com/volcano-sh/volcano/releases'
+  - 'https://hub.docker.com/u/volcanosh'
+  - 'https://github.com/volcano-sh/helm-charts'
+
+security-testing:
+  - tool-type: 'sca'
+    tool-name: 'Dependabot'
+    tool-version: '2'
+    integration:
+      ad-hoc: false
+      ci: false
+      before-release: false
+    tool-rulesets:
+      - 'https://github.com/volcano-sh/volcano/blob/master/.github/dependabot.yml'
+    tool-url: 'https://github.com/dependabot'
+  - tool-type: 'sca'
+    tool-name: 'OpenSSF Scorecard'
+    integration:
+      ad-hoc: false
+      ci: true
+      before-release: false
+    tool-rulesets:
+      - 'https://github.com/volcano-sh/volcano/blob/master/.github/workflows/scorecards.yml'
+    tool-url: 'https://github.com/ossf/scorecard'
+
+security-contacts:
+  - type: 'email'
+    value: 'volcano-security@googlegroups.com'
+
+vulnerability-reporting:
+  accepts-vulnerability-reports: true
+  email-contact: 'volcano-security@googlegroups.com'
+  security-policy: 'https://github.com/volcano-sh/community/blob/master/SECURITY.md'
+
+dependencies:
+  dependencies-lists:
+    - 'https://github.com/volcano-sh/volcano/blob/master/go.mod'
+    - 'https://github.com/volcano-sh/volcano/blob/master/go.sum'
+    - 'https://github.com/volcano-sh/volcano/blob/master/staging/src/volcano.sh/apis/go.mod'
+    - 'https://github.com/volcano-sh/volcano/blob/master/staging/src/volcano.sh/apis/go.sum'
+  third-party-packages: true
+  sbom:
+    - sbom-file: 'https://github.com/volcano-sh/volcano/releases'
+      sbom-format: 'SPDX'


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

Adds `SECURITY-INSIGHTS.yml` for Volcano. It points security reporting and policy information to the community repository, and records where release SBOMs are published.

This also adds a release SBOM asset. When a version tag is released, the release workflow generates an SPDX SBOM with Trivy and uploads it as `sbom.tar.gz`.

These two files are required in the CLOMonitor Security Section: 
<img width="1587" height="830" alt="image" src="https://github.com/user-attachments/assets/5d5d5c28-d73b-4848-aaf5-6a1ba8a717bd" />

**Validation**:
I ran the workflow in my own repo, check this action: https://github.com/JesseStutler/volcano/actions/runs/26873414950/job/79254292467, then we will get the sbom artifact, followed these commands:
```
mkdir -p /tmp/volcano-sbom-check

gh release download v0.0.0-sbom-test-20260603084200 \
  --repo JesseStutler/volcano \
  --pattern sbom.tar.gz \
  --dir /tmp/volcano-sbom-check

cd /tmp/volcano-sbom-check
tar -xzf sbom.tar.gz

trivy sbom sbom-volcano.spdx
```
By using `trivy sbom`, we will get:
<img width="2277" height="847" alt="image" src="https://github.com/user-attachments/assets/029d1c00-41a4-4765-81b5-1863a3b47ff6" />


#### Which issue(s) this PR fixes:

Part of #5366

#### Special notes for your reviewer:

AI Disclosure: This content wouldn't be possible without the help of Codex. But all of the contents has been reviewed carefully

Notice: Please note that the sbom artifact does not imply that Volcano has security risks, it only indicates what dependencies Volcano has. If these dependencies contain CVEs, tools such as Trivy can help users assess which version of the dependencies needs to be upgraded to.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
