### PR TITLE
ci: set read-only default GitHub Actions permissions

### DIFF
--- a/.github/workflows/code_verify.yaml
+++ b/.github/workflows/code_verify.yaml
@@ -7,6 +7,8 @@ on:
     tags:
   pull_request:
 
+permissions: read-all
+
 jobs:
   verify:
     runs-on: ubuntu-24.04

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -20,10 +20,16 @@ on:
   schedule:
     - cron: '15 16 * * 3'
 
+permissions: read-all
+
 jobs:
   analyze:
     name: Analyze
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
+      security-events: write
 
     strategy:
       fail-fast: false

--- a/.github/workflows/docker_images.yaml
+++ b/.github/workflows/docker_images.yaml
@@ -3,8 +3,12 @@ name: Build Images
 on:
   workflow_call:
 
+
 jobs:
   build-images:
+    permissions:
+      contents: read
+      actions: write
     runs-on: ubuntu-24.04
     steps:
       - name: Free Disk Space

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -11,58 +11,102 @@ on:
     tags:
   pull_request:
 
+permissions: read-all
+
 jobs:
   build-images:
+    permissions:
+      contents: read
+      actions: write
     uses: ./.github/workflows/docker_images.yaml
 
   e2e-admission:
     needs: build-images
+    permissions:
+      contents: read
+      actions: write
     uses: ./.github/workflows/e2e_admission.yaml
 
   e2e-cronjob:
     needs: build-images
+    permissions:
+      contents: read
+      actions: write
     uses: ./.github/workflows/e2e_cronjob.yaml
 
   e2e-dra:
     needs: build-images
+    permissions:
+      contents: read
+      actions: write
     uses: ./.github/workflows/e2e_dra.yml
 
   e2e-gangevict:
     needs: build-images
+    permissions:
+      contents: read
+      actions: write
     uses: ./.github/workflows/e2e_gangevict.yaml
 
   e2e-hypernode:
     needs: build-images
+    permissions:
+      contents: read
+      actions: write
     uses: ./.github/workflows/e2e_hypernode.yaml
 
   e2e-parallel-jobs:
     needs: build-images
+    permissions:
+      contents: read
+      actions: write
     uses: ./.github/workflows/e2e_parallel_jobs.yaml
 
   e2e-scheduling-actions:
     needs: build-images
+    permissions:
+      contents: read
+      actions: write
     uses: ./.github/workflows/e2e_scheduling_actions.yaml
 
   e2e-scheduling-gates:
     needs: build-images
+    permissions:
+      contents: read
+      actions: write
     uses: ./.github/workflows/e2e_scheduling_gates.yaml
 
   e2e-scheduling-basic:
     needs: build-images
+    permissions:
+      contents: read
+      actions: write
     uses: ./.github/workflows/e2e_scheduling_basic.yaml
 
   e2e-sequence:
     needs: build-images
+    permissions:
+      contents: read
+      actions: write
     uses: ./.github/workflows/e2e_sequence.yaml
 
   e2e-spark:
     needs: build-images
+    permissions:
+      contents: read
+      actions: write
     uses: ./.github/workflows/e2e_spark.yaml
 
   e2e-vcctl:
     needs: build-images
+    permissions:
+      contents: read
+      actions: write
     uses: ./.github/workflows/e2e_vcctl.yaml
 
   e2e-shard:
     needs: build-images
+    permissions:
+      contents: read
+      actions: write
     uses: ./.github/workflows/e2e_shard.yaml

--- a/.github/workflows/e2e_admission.yaml
+++ b/.github/workflows/e2e_admission.yaml
@@ -3,8 +3,12 @@ name: E2E Admission
 on:
   workflow_call:
 
+
 jobs:
   e2e_admission_policy:
+    permissions:
+      contents: read
+      actions: write
     runs-on: ubuntu-24.04
     name: E2E about Admission Policy
     timeout-minutes: 50
@@ -60,6 +64,9 @@ jobs:
           path: ${{ github.workspace }}/e2e-admission-logs
 
   e2e_admission_webhook:
+    permissions:
+      contents: read
+      actions: write
     runs-on: ubuntu-24.04
     name: E2E about Admission Webhook
     timeout-minutes: 50

--- a/.github/workflows/e2e_cronjob.yaml
+++ b/.github/workflows/e2e_cronjob.yaml
@@ -3,12 +3,12 @@ name: E2E CRONJOB
 on:
   workflow_call:
 
-permissions:
-  contents: read
-  actions: write
 
 jobs:
   cronjob:
+    permissions:
+      contents: read
+      actions: write
     runs-on: ubuntu-24.04
     name: E2E about CRONJOB
     timeout-minutes: 70

--- a/.github/workflows/e2e_dra.yml
+++ b/.github/workflows/e2e_dra.yml
@@ -3,8 +3,12 @@ name: E2E DRA
 on:
   workflow_call:
 
+
 jobs:
   e2e_dra:
+    permissions:
+      contents: read
+      actions: write
     runs-on: ubuntu-24.04
     name: E2E about DRA
     timeout-minutes: 40

--- a/.github/workflows/e2e_gangevict.yaml
+++ b/.github/workflows/e2e_gangevict.yaml
@@ -3,8 +3,12 @@ name: E2E Gang Eviction
 on:
   workflow_call:
 
+
 jobs:
   e2e_gangevict:
+    permissions:
+      contents: read
+      actions: write
     runs-on: ubuntu-24.04
     name: E2E about Gang Eviction
     timeout-minutes: 40

--- a/.github/workflows/e2e_hypernode.yaml
+++ b/.github/workflows/e2e_hypernode.yaml
@@ -3,8 +3,12 @@ name: E2E Hypernode
 on:
   workflow_call:
 
+
 jobs:
   e2e_hypernode:
+    permissions:
+      contents: read
+      actions: write
     runs-on: ubuntu-24.04
     name: E2E about Hypernode
     timeout-minutes: 40

--- a/.github/workflows/e2e_parallel_jobs.yaml
+++ b/.github/workflows/e2e_parallel_jobs.yaml
@@ -3,12 +3,12 @@ name: E2E Parallel Jobs
 on:
   workflow_call:
 
-permissions:
-  contents: read
-  actions: write
 
 jobs:
   e2e_parallel_jobs:
+    permissions:
+      contents: read
+      actions: write
     runs-on: ubuntu-24.04
     name: E2E about Parallel Jobs
     timeout-minutes: 40

--- a/.github/workflows/e2e_scheduling_actions.yaml
+++ b/.github/workflows/e2e_scheduling_actions.yaml
@@ -3,8 +3,12 @@ name: Scheduling Actions
 on:
   workflow_call:
 
+
 jobs:
   e2e_scheduling_actions:
+    permissions:
+      contents: read
+      actions: write
     runs-on: ubuntu-24.04
     name: E2E about Scheduling Actions
     timeout-minutes: 50

--- a/.github/workflows/e2e_scheduling_basic.yaml
+++ b/.github/workflows/e2e_scheduling_basic.yaml
@@ -3,8 +3,12 @@ name: Basic scheduling Jobs
 on:
   workflow_call:
 
+
 jobs:
   e2e_scheduling_basic:
+    permissions:
+      contents: read
+      actions: write
     runs-on: ubuntu-24.04
     name: E2E about Basic Scheduling
     timeout-minutes: 50

--- a/.github/workflows/e2e_scheduling_gates.yaml
+++ b/.github/workflows/e2e_scheduling_gates.yaml
@@ -3,8 +3,12 @@ name: Scheduling Gates
 on:
   workflow_call:
 
+
 jobs:
   e2e_scheduling_gates:
+    permissions:
+      contents: read
+      actions: write
     runs-on: ubuntu-24.04
     name: E2E about Scheduling Gates
     timeout-minutes: 40

--- a/.github/workflows/e2e_sequence.yaml
+++ b/.github/workflows/e2e_sequence.yaml
@@ -3,8 +3,12 @@ name: E2E Sequence Jobs
 on:
   workflow_call:
 
+
 jobs:
   e2e_sequence:
+    permissions:
+      contents: read
+      actions: write
     runs-on: ubuntu-24.04
     name: E2E about Sequence
     timeout-minutes: 50

--- a/.github/workflows/e2e_shard.yaml
+++ b/.github/workflows/e2e_shard.yaml
@@ -3,8 +3,12 @@ name: E2E Shard
 on:
   workflow_call:
 
+
 jobs:
   e2e:
+    permissions:
+      contents: read
+      actions: write
     runs-on: ubuntu-24.04
     name: ${{ matrix.name }}
     timeout-minutes: 50

--- a/.github/workflows/e2e_spark.yaml
+++ b/.github/workflows/e2e_spark.yaml
@@ -3,8 +3,12 @@ name: E2E Spark Integration Test
 on:
   workflow_call:
 
+
 jobs:
   k8s-integration-tests:
+    permissions:
+      contents: read
+      actions: write
     name: "E2E about Spark Integration test"
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/e2e_vcctl.yaml
+++ b/.github/workflows/e2e_vcctl.yaml
@@ -3,8 +3,12 @@ name: Vcctl Test
 on:
   workflow_call:
 
+
 jobs:
   e2e_vcctl:
+    permissions:
+      contents: read
+      actions: write
     runs-on: ubuntu-24.04
     name: E2E about Volcano CLI
     timeout-minutes: 50

--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -5,8 +5,7 @@ on:
   pull_request:
     branches: [master]
 
-permissions:
-  contents: read
+permissions: read-all
 
 jobs:
   build:

--- a/.github/workflows/licenses_lint.yaml
+++ b/.github/workflows/licenses_lint.yaml
@@ -7,6 +7,8 @@ on:
     tags:
   pull_request:
 
+permissions: read-all
+
 jobs:
   licenses-lint:
     name: Licenses Lint

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,12 +9,13 @@ on:
       - "v*.*.*"
 
 
-permissions:
-  contents: read
-  packages: write
+permissions: read-all
 
 jobs:
   docker:
+    permissions:
+      contents: read
+      packages: write
     runs-on: ubuntu-latest
     env:
       GOPATH: /home/runner/work/${{ github.repository }}
@@ -125,6 +126,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      actions: write
     strategy:
       matrix:
         include:
@@ -177,6 +179,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      actions: read
     outputs:
       hashes: ${{ steps.hash.outputs.hashes }}
     steps:

--- a/.github/workflows/release_chart.yaml
+++ b/.github/workflows/release_chart.yaml
@@ -5,6 +5,8 @@ on:
     tags:
       - "v*.*.*"
 
+permissions: read-all
+
 jobs:
   release-charts:
     runs-on: ubuntu-latest

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -4,6 +4,8 @@ on:
   schedule:
     - cron: '0 0 * * *' # runs every day at midnight UTC
 
+permissions: read-all
+
 jobs:
   stale:
     runs-on: ubuntu-latest

--- a/.github/workflows/sync-apis.yaml
+++ b/.github/workflows/sync-apis.yaml
@@ -17,6 +17,8 @@ on:
 env:
   APIS_REPO: volcano-sh/apis
 
+permissions: read-all
+
 jobs:
   sync-apis:
     runs-on: ubuntu-latest

--- a/.github/workflows/workflows-approve.yaml
+++ b/.github/workflows/workflows-approve.yaml
@@ -9,8 +9,7 @@ on:
       - master
       - release-**
 
-permissions:
-  contents: read
+permissions: read-all
 
 jobs:
   approve:


### PR DESCRIPTION
## What type of PR is this?
/kind documentation

## What this PR does / why we need it
Part of #5366 (improve CLOMonitor score). Sets explicit GitHub Actions
token permissions:

- `permissions: read-all` at workflow scope on top-level CI workflows
  (unchanged: `scorecards.yml`)
- Job-level write scopes only where required (release image push, CodeQL
  security-events, e2e artifacts, sync-apis, stale, workflows-approve)
- Caller job permissions in `e2e.yaml` pass `contents: read` and
  `actions: write` to reusable workflows
- Reusable `workflow_call` files use minimal job permissions only (no
  workflow-level `read-all`) so GitHub validates caller/called permission
  scopes correctly

Contributing guide detection is tracked separately in #5390.

## Which issue(s) this PR fixes
Part of #5366

## Special notes for your reviewer
Rebased onto current master. Permissions-only scope per review; no README
or CONTRIBUTING changes.

Reusable workflows no longer declare workflow-level `read-all`, which
was causing E2E Tests startup failure when combined with caller job
permissions.

## Does this PR introduce a user-facing change?
NONE