### PR TITLE
clomonitor: expose license scanning for CLOMonitor

### DIFF
--- a/.clomonitor.yml
+++ b/.clomonitor.yml
@@ -1,0 +1,6 @@
+# CLOMonitor metadata
+# https://github.com/cncf/clomonitor/blob/main/docs/metadata/.clomonitor.yml
+
+licenseScanning:
+  # FOSSA analysis runs on PRs and master via .github/workflows/fossa.yml
+  url: https://github.com/volcano-sh/volcano/actions/workflows/fossa.yml?query=branch%3Amaster


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

This PR is part of the work for [#5366](https://github.com/volcano-sh/volcano/issues/5366) (improve CLOMonitor score). It addresses **license scanning detection** on the issue.

Volcano already runs FOSSA in [`.github/workflows/fossa.yml`](.github/workflows/fossa.yml). CLOMonitor does not infer CI workflows automatically. This adds root [`.clomonitor.yml`](.clomonitor.yml) with `licenseScanning.url` pointing at that workflow on `master`, per [CLOMonitor metadata](https://github.com/cncf/clomonitor/blob/main/docs/metadata/.clomonitor.yml).

No workflow, Go, or runtime changes.

Does not overlap with [#5367](https://github.com/volcano-sh/volcano/pull/5367) (Security Insights + SBOM) or [#5369](https://github.com/volcano-sh/volcano/pull/5369) (contributing guide and workflow permissions).

#### Which issue(s) this PR fixes:

Part of #5366

#### Special notes for your reviewer:

- Tested: `.clomonitor.yml` YAML parse; `make verify` passed locally (macOS).
- No Go/runtime behavior changes. FOSSA CI is unchanged.
- After merge, `license_scanning` on clomonitor.io may take up to about an hour to refresh. If the check still fails, we can add a FOSSA README badge when a project URL is available.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```