### PR TITLE
docs: add Artifact Hub badge for CLOMonitor

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 [![LICENSE](https://img.shields.io/github/license/volcano-sh/volcano.svg)](https://github.com/volcano-sh/volcano/blob/master/LICENSE)
 [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/3012/badge)](https://bestpractices.coreinfrastructure.org/projects/3012)
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/volcano-sh/volcano/badge)](https://scorecard.dev/viewer/?uri=github.com/volcano-sh/volcano)
+[![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/volcano-sh)](https://artifacthub.io/packages/helm/volcano-sh/volcano)
 [![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20Volcano%20Guru-006BFF)](https://gurubase.io/g/volcano)
 
 


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

This PR is part of the work for [#5366](https://github.com/volcano-sh/volcano/issues/5366) (improve CLOMonitor score). It addresses **Artifact Hub badge** on the issue.

Adds a README badge linking to `https://artifacthub.io/packages/helm/volcano-sh/volcano`. That listing uses the official Helm repository URL (`https://volcano-sh.github.io/helm-charts`) already documented in the install section.

Does not overlap with [#5367](https://github.com/volcano-sh/volcano/pull/5367) (Security Insights + SBOM), [#5369](https://github.com/volcano-sh/volcano/pull/5369) (contributing guide and workflow permissions), or [#5370](https://github.com/volcano-sh/volcano/pull/5370) (license scanning metadata). README-only change.

#### Which issue(s) this PR fixes:

Part of #5366

#### Special notes for your reviewer:

- Tested: `make verify` passed locally (macOS).
- No Go/runtime or workflow changes.
- Please confirm `helm/volcano-sh/volcano` is the correct Artifact Hub package for the official chart (listing is not marked verified publisher on Artifact Hub).
- After merge, `artifacthub_badge` on clomonitor.io may take up to about an hour to refresh.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```