### PR TITLE
Fix FOSSA license scanning workflow

### DIFF
--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -5,6 +5,9 @@ on:
   pull_request:
     branches: [master]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -14,15 +17,14 @@ jobs:
         with:
           go-version: 1.25.x
       - run: go version
-      # Runs a set of commands to initialize and analyze with FOSSA
       - name: run FOSSA analysis
-        env:
-          # FOSSA Push-Only API Token
-          FOSSA_API_KEY: '1a92b8d8ee4304c0ad85a726b9e9acab'
-          BINDIR: /home/runner/work/volcano/volcano
-        run: |
-          export GOPATH=$HOME/go
-          export PATH=$PATH:$(go env GOPATH)/bin
-          curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/fossa-cli/master/install.sh | bash -s -- -b /home/runner/work/volcano/volcano 
-          /home/runner/work/volcano/volcano/fossa init
-          /home/runner/work/volcano/volcano/fossa analyze
+        uses: fossas/fossa-action@v1.9.0
+        with:
+          api-key: ${{ secrets.FOSSA_API_KEY }}
+
+      - name: run FOSSA policy test
+        uses: fossas/fossa-action@v1.9.0
+        with:
+          api-key: ${{ secrets.FOSSA_API_KEY }}
+          run-tests: true
+          test-diff-revision: ${{ github.event.pull_request.base.sha }}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Updates the FOSSA workflow to use the supported FOSSA GitHub Action and `secrets.FOSSA_API_KEY` instead of a hard-coded API key.

This updates the workflow from only uploading FOSSA analysis results with a hard-coded push-only key to using the official FOSSA action with a repository secret and running a policy diff test, so PRs can fail when they introduce new license policy issues.

#### Which issue(s) this PR fixes:

Fixes #5374 #5312

#### Special notes for your reviewer:

NONE

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
