### PR TITLE
e2e(agentscheduler): fix flaky batch scheduling test in hard mode

### DIFF
--- a/test/e2e/agentscheduler/agent_scheduler_test.go
+++ b/test/e2e/agentscheduler/agent_scheduler_test.go
@@ -447,7 +447,9 @@ var _ = Describe("Agent Scheduler E2E Test", func() {
 		})
 	})
 
-	Describe("Batch Scheduling", Label("hard", "soft", "none"), func() {
+	// Batch throughput is validated in soft/none modes, where pods can spread
+	// across the volcano shard nodes in addition to the agent shard.
+	Describe("Batch Scheduling", Label("soft", "none"), func() {
 		It("should schedule a batch of pods", func() {
 			podCount := 10
 


### PR DESCRIPTION
### What this PR does

Fixes the intermittently failing **Agent Scheduler E2E → Batch Scheduling → should schedule a batch of pods** spec in `hard` sharding mode.

### Why

The spec was labeled `Label("hard", "soft", "none")`, so it runs in all three sharding modes. The default agent shard is capped to a single node (`node-limit maxNodes=1`). In **hard** mode there is no fallback to the volcano shard, so all 10 pods are forced onto that single node. When the node's remaining capacity (after system + volcano-system pods) cannot hold the full batch, one pod stays pending until the timeout — observed as `9/10 scheduled` and a failed run.

`soft`/`none` modes allow fallback onto the volcano shard's worker nodes, so the batch spreads and the throughput assertion is deterministic.

### Change

Restrict the throughput spec to `Label("soft", "none")`. Hard-mode shard semantics remain covered by the dedicated **Agent Scheduler Sharding Modes** specs (hard-no-fallback, etc.).

### Evidence

Failing run: `e2e-shard / E2E Agent Scheduler Hard`
```
Scheduled 9/10 pods
[FAILED] all pods should be scheduled
Expected <int>: 9 to equal <int>: 10
NodeShard: agent-scheduler, NodesDesired: 1, NodesInUse: 1
```