### PR TITLE
Publish signed vcctl release artifacts and provenance

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -92,6 +92,7 @@ jobs:
           docker logout ghcr.io
 
   sbom:
+    needs: release
     if: startsWith(github.ref, 'refs/tags/v')
     name: Release SBOM
     runs-on: ubuntu-latest
@@ -117,3 +118,99 @@ jobs:
         with:
           files: |
             sbom.tar.gz
+
+  release-assets:
+    if: startsWith(github.ref, 'refs/tags/v')
+    name: Release vcctl CLI Assets
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    strategy:
+      matrix:
+        include:
+          - goos: linux
+            goarch: amd64
+          - goos: linux
+            goarch: arm64
+          - goos: darwin
+            goarch: amd64
+          - goos: darwin
+            goarch: arm64
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: 1.25.x
+
+      - name: Build vcctl
+        env:
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
+          RELEASE_VER: ${{ github.ref_name }}
+        run: make vcctl
+
+      - name: Package vcctl
+        run: |
+          PKG="vcctl-${{ github.ref_name }}-${{ matrix.goos }}-${{ matrix.goarch }}"
+          mkdir -p "_output/release/${PKG}"
+          cp "_output/bin/vcctl" "_output/release/${PKG}/"
+          cp LICENSE "_output/release/${PKG}/"
+          cd _output/release
+          tar -czf "${PKG}.tar.gz" "${PKG}/"
+          sha256sum "${PKG}.tar.gz" > "${PKG}.tar.gz.sha256"
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: vcctl-${{ matrix.goos }}-${{ matrix.goarch }}
+          path: _output/release/vcctl-*.tar.gz*
+
+  release:
+    needs: release-assets
+    if: startsWith(github.ref, 'refs/tags/v')
+    name: Upload Release Assets
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    outputs:
+      hashes: ${{ steps.hash.outputs.hashes }}
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          pattern: vcctl-*
+
+      - name: Generate hashes for SLSA provenance
+        id: hash
+        run: |
+          mkdir -p _flat
+          cp artifacts/vcctl-*/*.tar.gz _flat/
+          cd _flat
+          echo "hashes=$(sha256sum *.tar.gz | base64 -w0)" >> "$GITHUB_OUTPUT"
+
+      - name: Upload to GitHub Release
+        uses: softprops/action-gh-release@v3
+        with:
+          files: artifacts/vcctl-*/*
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  provenance:
+    needs: release
+    if: startsWith(github.ref, 'refs/tags/v')
+    name: Generate SLSA Provenance
+    permissions:
+      actions: read
+      id-token: write
+      contents: write
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
+    with:
+      base64-subjects: "${{ needs.release.outputs.hashes }}"
+      upload-assets: true
+      upload-tag-name: "${{ github.ref_name }}"

--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,7 @@ vc-agent: init
 	CC=${CC} CGO_ENABLED=0 go build -ldflags ${LD_FLAGS} -o ${BIN_DIR}/network-qos ./cmd/network-qos
 
 vcctl: init
-	CC=${CC} CGO_ENABLED=0 GOOS=${OS} go build -ldflags ${LD_FLAGS} -o ${BIN_DIR}/vcctl ./cmd/cli
+	CC=${CC} CGO_ENABLED=0 GOOS=$(if $(filter file,$(origin GOOS)),$(OS),$(GOOS)) GOARCH=$(GOARCH) go build -ldflags ${LD_FLAGS} -o ${BIN_DIR}/vcctl ./cmd/cli
 
 image_bins: vc-scheduler vc-agent-scheduler vc-controller-manager vc-webhook-manager vc-agent
 


### PR DESCRIPTION
### What this PR does

Fixes [volcano-sh/volcano#5376](https://github.com/volcano-sh/volcano/issues/5376)

This PR adds release workflow support for publishing signed Volcano release artifacts, starting with `vcctl` CLI binaries.

### Changes

- **Makefile**: `vcctl` target now supports cross-compilation via `GOOS`/`GOARCH` environment variables while preserving backward compatibility (macOS developers still get Darwin binary by default). Uses `$(origin GOOS)` to distinguish between Makefile-default and user-provided values.
- **`.github/workflows/release.yaml`**: adds three new jobs and fixes a race condition:
  - `release-assets`: builds `vcctl` for `linux/amd64`, `linux/arm64`, `darwin/amd64`, `darwin/arm64`, packages each with `LICENSE` and `.sha256`.
  - `release`: uploads artifacts to GitHub Release and generates base64-encoded hashes for SLSA provenance.
  - `provenance`: uses `slsa-framework/slsa-github-generator` to generate and upload `.intoto.jsonl` provenance files.
  - `sbom`: added `needs: release` to avoid race condition when multiple jobs upload to the same GitHub Release; unified `softprops/action-gh-release` to `@v3` across all jobs.

### Validation

#### 1. Workflow & Release (fork test tag `v0.0.0-test2`)

- **Workflow run**: https://github.com/xuezhaojun/volcano/actions/runs/27003782557
- **Test release**: https://github.com/xuezhaojun/volcano/releases/tag/v0.0.0-test2

Evidence:
- [x] 4 platform archives uploaded: `vcctl-v0.0.0-test2-{linux,darwin}-{amd64,arm64}.tar.gz`
- [x] `.sha256` files match the uploaded archives
- [x] SLSA provenance (`multiple.intoto.jsonl`) uploaded
- [x] SBOM (`sbom.tar.gz`) uploaded after `release` job completes (no race condition)
- [x] Downloaded binary runs:

```
$ ./vcctl version
API Version: v1alpha1
Version: v0.0.0-test2
Git SHA: eeb7dd3ac985a19bf56b5d080f7e164fa34d3afb
Built At: 2026-06-05 08:16:38
Go Version: go1.25.10
Go OS/Arch: linux/amd64

$ ./vcctl --help
Usage:
  vcctl [command]

Available Commands:
  help        Help about any command
  job         vcctl command line operation job
  jobflow     vcctl command line operation jobflow
  jobtemplate vcctl command line operation jobtemplate
  pod         vcctl command line operation pod
  queue       Queue Operations
  version     Print the version information
```

#### 2. Local `make vcctl` tests

| Scenario | Command | Expected GOOS | Result |
|---|---|---|---|
| Default (Linux host) | `make vcctl` | `linux` | ✅ ELF x86-64, runs correctly |
| Explicit Linux | `GOOS=linux GOARCH=amd64 make vcctl` | `linux` | ✅ ELF x86-64 |
| Cross-compile macOS | `GOOS=darwin GOARCH=arm64 make vcctl` | `darwin` | ✅ Mach-O arm64 |

#### 3. Action version consistency check

All newly introduced actions use versions already present in the repository:
- `actions/setup-go@v5` ✅
- `actions/upload-artifact@v4` ✅
- `actions/download-artifact@v4` ✅
- `softprops/action-gh-release@v3` ✅ (unified with existing `sbom` job)

### Out of scope (as per issue)

- Backfilling historical releases
- Publishing install manifests or CRD bundles as release assets
- Moving Helm chart publishing