### PR TITLE
fix: use milli-units for scalar in-queue resources

### DIFF
--- a/pkg/scheduler/plugins/util/util.go
+++ b/pkg/scheduler/plugins/util/util.go
@@ -127,9 +127,9 @@ func GetInqueueResource(job *api.JobInfo, allocated *api.Resource) *api.Resource
 				inqueue.ScalarResources = make(map[v1.ResourceName]float64)
 			}
 			if allocatedMount, ok := allocated.ScalarResources[rName]; !ok {
-				inqueue.ScalarResources[rName] = float64(rQuantity.Value())
+				inqueue.ScalarResources[rName] = float64(rQuantity.MilliValue())
 			} else {
-				reservedScalarRes := float64(rQuantity.Value()) - allocatedMount
+				reservedScalarRes := float64(rQuantity.MilliValue()) - allocatedMount
 				if reservedScalarRes > 0 {
 					inqueue.ScalarResources[rName] = reservedScalarRes
 				}

--- a/pkg/scheduler/plugins/util/util.go
+++ b/pkg/scheduler/plugins/util/util.go
@@ -95,16 +95,22 @@ func CalculateAllocatedTaskNum(job *api.JobInfo) int {
 
 // GetInqueueResource returns reserved resource for running job whose part of pods have not been allocated resource.
 func GetInqueueResource(job *api.JobInfo, allocated *api.Resource) *api.Resource {
+	// Convert MinResources through api.NewResource so it shares the exact unit
+	// model of job.Allocated (also built via api.NewResource): CPU/ephemeral in
+	// milli, memory in bytes, extended/scalar resources (e.g. GPUs) in milli.
+	// This replaces hand-written Value()/MilliValue() conversions that previously
+	// mixed whole-unit MinResources with milli-unit allocated for scalars.
+	minResources := api.NewResource(*job.PodGroup.Spec.MinResources)
 	inqueue := &api.Resource{}
-	for rName, rQuantity := range *job.PodGroup.Spec.MinResources {
+	for rName := range *job.PodGroup.Spec.MinResources {
 		switch rName {
 		case v1.ResourceCPU:
-			reservedCPU := float64(rQuantity.MilliValue()) - allocated.MilliCPU
+			reservedCPU := minResources.MilliCPU - allocated.MilliCPU
 			if reservedCPU > 0 {
 				inqueue.MilliCPU = reservedCPU
 			}
 		case v1.ResourceMemory:
-			reservedMemory := float64(rQuantity.Value()) - allocated.Memory
+			reservedMemory := minResources.Memory - allocated.Memory
 			if reservedMemory > 0 {
 				inqueue.Memory = reservedMemory
 			}
@@ -126,10 +132,11 @@ func GetInqueueResource(job *api.JobInfo, allocated *api.Resource) *api.Resource
 			if inqueue.ScalarResources == nil {
 				inqueue.ScalarResources = make(map[v1.ResourceName]float64)
 			}
+			reservedScalar := minResources.ScalarResources[rName]
 			if allocatedMount, ok := allocated.ScalarResources[rName]; !ok {
-				inqueue.ScalarResources[rName] = float64(rQuantity.MilliValue())
+				inqueue.ScalarResources[rName] = reservedScalar
 			} else {
-				reservedScalarRes := float64(rQuantity.MilliValue()) - allocatedMount
+				reservedScalarRes := reservedScalar - allocatedMount
 				if reservedScalarRes > 0 {
 					inqueue.ScalarResources[rName] = reservedScalarRes
 				}

--- a/pkg/scheduler/plugins/util/util.go
+++ b/pkg/scheduler/plugins/util/util.go
@@ -109,6 +109,18 @@ func GetInqueueResource(job *api.JobInfo, allocated *api.Resource) *api.Resource
 			if reservedMemory > 0 {
 				inqueue.Memory = reservedMemory
 			}
+		case v1.ResourcePods:
+			// pods is stored in ScalarResources in whole units (see api.NewResource),
+			// unlike other scalars which are milli-units, so reserve it without conversion.
+			// It is also excluded from the generic scalar branch below because
+			// v1helper.IsScalarResourceName(pods) is false.
+			reservedPods := minResources.ScalarResources[rName] - allocated.ScalarResources[rName]
+			if reservedPods > 0 {
+				if inqueue.ScalarResources == nil {
+					inqueue.ScalarResources = make(map[v1.ResourceName]float64)
+				}
+				inqueue.ScalarResources[rName] = reservedPods
+			}
 		default:
 			if api.IsCountQuota(rName) || !v1helper.IsScalarResourceName(rName) {
 				continue

--- a/pkg/scheduler/plugins/util/util.go
+++ b/pkg/scheduler/plugins/util/util.go
@@ -95,11 +95,6 @@ func CalculateAllocatedTaskNum(job *api.JobInfo) int {
 
 // GetInqueueResource returns reserved resource for running job whose part of pods have not been allocated resource.
 func GetInqueueResource(job *api.JobInfo, allocated *api.Resource) *api.Resource {
-	// Convert MinResources through api.NewResource so it shares the exact unit
-	// model of job.Allocated (also built via api.NewResource): CPU/ephemeral in
-	// milli, memory in bytes, extended/scalar resources (e.g. GPUs) in milli.
-	// This replaces hand-written Value()/MilliValue() conversions that previously
-	// mixed whole-unit MinResources with milli-unit allocated for scalars.
 	minResources := api.NewResource(*job.PodGroup.Spec.MinResources)
 	inqueue := &api.Resource{}
 	for rName := range *job.PodGroup.Spec.MinResources {

--- a/pkg/scheduler/plugins/util/util_test.go
+++ b/pkg/scheduler/plugins/util/util_test.go
@@ -52,6 +52,8 @@ func TestGetInqueueResource(t *testing.T) {
 		minRes    v1.ResourceList
 		allocated *api.Resource
 		expected  *api.Resource
+		// absentScalars lists scalar resources that must NOT appear in the result.
+		absentScalars []v1.ResourceName
 	}{
 		{
 			name: "nothing allocated yet: full request reserved",
@@ -100,6 +102,25 @@ func TestGetInqueueResource(t *testing.T) {
 				ScalarResources: map[v1.ResourceName]float64{},
 			},
 		},
+		{
+			// "pods" is neither a count quota nor a scalar resource, so it is
+			// intentionally skipped (every pod implicitly requests one "pods").
+			// The remaining CPU must still be computed correctly, and "pods" must
+			// not leak into the reserved scalar resources.
+			name: "partial pods allocation: pods skipped, CPU remainder reserved",
+			minRes: v1.ResourceList{
+				v1.ResourceCPU:  resource.MustParse("4"),
+				v1.ResourcePods: resource.MustParse("10"),
+			},
+			allocated: &api.Resource{
+				MilliCPU:        1000,
+				ScalarResources: map[v1.ResourceName]float64{v1.ResourcePods: 4},
+			},
+			expected: &api.Resource{
+				MilliCPU: 3000,
+			},
+			absentScalars: []v1.ResourceName{v1.ResourcePods},
+		},
 	}
 
 	for _, test := range tests {
@@ -116,6 +137,11 @@ func TestGetInqueueResource(t *testing.T) {
 			for name, want := range test.expected.ScalarResources {
 				if got.ScalarResources[name] != want {
 					t.Errorf("ScalarResources[%s] = %v, expected %v", name, got.ScalarResources[name], want)
+				}
+			}
+			for _, name := range test.absentScalars {
+				if _, ok := got.ScalarResources[name]; ok {
+					t.Errorf("ScalarResources[%s] = %v, expected to be absent", name, got.ScalarResources[name])
 				}
 			}
 		})

--- a/pkg/scheduler/plugins/util/util_test.go
+++ b/pkg/scheduler/plugins/util/util_test.go
@@ -52,8 +52,6 @@ func TestGetInqueueResource(t *testing.T) {
 		minRes    v1.ResourceList
 		allocated *api.Resource
 		expected  *api.Resource
-		// absentScalars lists scalar resources that must NOT appear in the result.
-		absentScalars []v1.ResourceName
 	}{
 		{
 			name: "nothing allocated yet: full request reserved",
@@ -103,11 +101,10 @@ func TestGetInqueueResource(t *testing.T) {
 			},
 		},
 		{
-			// "pods" is neither a count quota nor a scalar resource, so it is
-			// intentionally skipped (every pod implicitly requests one "pods").
-			// The remaining CPU must still be computed correctly, and "pods" must
-			// not leak into the reserved scalar resources.
-			name: "partial pods allocation: pods skipped, CPU remainder reserved",
+			// "pods" is a scalar resource stored in whole units (not milli-units),
+			// so its reservation must be computed without any 1000x conversion:
+			// 10 requested - 4 allocated == 6 reserved.
+			name: "partial pods allocation: remainder reserved in whole units",
 			minRes: v1.ResourceList{
 				v1.ResourceCPU:  resource.MustParse("4"),
 				v1.ResourcePods: resource.MustParse("10"),
@@ -117,9 +114,9 @@ func TestGetInqueueResource(t *testing.T) {
 				ScalarResources: map[v1.ResourceName]float64{v1.ResourcePods: 4},
 			},
 			expected: &api.Resource{
-				MilliCPU: 3000,
+				MilliCPU:        3000,
+				ScalarResources: map[v1.ResourceName]float64{v1.ResourcePods: 6},
 			},
-			absentScalars: []v1.ResourceName{v1.ResourcePods},
 		},
 	}
 
@@ -137,11 +134,6 @@ func TestGetInqueueResource(t *testing.T) {
 			for name, want := range test.expected.ScalarResources {
 				if got.ScalarResources[name] != want {
 					t.Errorf("ScalarResources[%s] = %v, expected %v", name, got.ScalarResources[name], want)
-				}
-			}
-			for _, name := range test.absentScalars {
-				if _, ok := got.ScalarResources[name]; ok {
-					t.Errorf("ScalarResources[%s] = %v, expected to be absent", name, got.ScalarResources[name])
 				}
 			}
 		})

--- a/pkg/scheduler/plugins/util/util_test.go
+++ b/pkg/scheduler/plugins/util/util_test.go
@@ -1,0 +1,123 @@
+/*
+Copyright 2024 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+
+	"volcano.sh/apis/pkg/apis/scheduling"
+	"volcano.sh/volcano/pkg/scheduler/api"
+)
+
+const gpuResource = v1.ResourceName("nvidia.com/gpu")
+
+func newJobWithMinResources(minResources v1.ResourceList) *api.JobInfo {
+	return &api.JobInfo{
+		PodGroup: &api.PodGroup{
+			PodGroup: scheduling.PodGroup{
+				Spec: scheduling.PodGroupSpec{
+					MinResources: &minResources,
+				},
+			},
+		},
+	}
+}
+
+// TestGetInqueueResource verifies that reserved (in-queue) resources are computed
+// using the canonical unit model. In particular, extended/scalar resources such as
+// GPUs are stored in milli-units (see api.NewResource), so MinResources for those
+// must be converted to milli-units to be consistent with job.Allocated. The
+// previous implementation used Quantity.Value() for scalars, which under-counted
+// reserved GPUs by a factor of 1000 once any pod had been allocated.
+func TestGetInqueueResource(t *testing.T) {
+	tests := []struct {
+		name      string
+		minRes    v1.ResourceList
+		allocated *api.Resource
+		expected  *api.Resource
+	}{
+		{
+			name: "nothing allocated yet: full request reserved",
+			minRes: v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("4"),
+				v1.ResourceMemory: resource.MustParse("4096"),
+				gpuResource:       resource.MustParse("8"),
+			},
+			allocated: api.EmptyResource(),
+			expected: &api.Resource{
+				MilliCPU: 4000,
+				Memory:   4096,
+				// 8 GPUs == 8000 milli-units, matching NewResource.
+				ScalarResources: map[v1.ResourceName]float64{gpuResource: 8000},
+			},
+		},
+		{
+			name: "partial GPU allocation: remainder reserved in milli-units",
+			minRes: v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("4"),
+				v1.ResourceMemory: resource.MustParse("4096"),
+				gpuResource:       resource.MustParse("8"),
+			},
+			// allocated is built like job.Allocated (via NewResource), i.e. milli-units.
+			allocated: &api.Resource{
+				MilliCPU:        1000,
+				Memory:          1024,
+				ScalarResources: map[v1.ResourceName]float64{gpuResource: 4000},
+			},
+			expected: &api.Resource{
+				MilliCPU: 3000,
+				Memory:   3072,
+				// 8000 - 4000 == 4000 milli (4 GPUs) still reserved.
+				ScalarResources: map[v1.ResourceName]float64{gpuResource: 4000},
+			},
+		},
+		{
+			name: "GPU fully allocated: no scalar reserved",
+			minRes: v1.ResourceList{
+				gpuResource: resource.MustParse("2"),
+			},
+			allocated: &api.Resource{
+				ScalarResources: map[v1.ResourceName]float64{gpuResource: 2000},
+			},
+			expected: &api.Resource{
+				ScalarResources: map[v1.ResourceName]float64{},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			job := newJobWithMinResources(test.minRes)
+			got := GetInqueueResource(job, test.allocated)
+
+			if got.MilliCPU != test.expected.MilliCPU {
+				t.Errorf("MilliCPU = %v, expected %v", got.MilliCPU, test.expected.MilliCPU)
+			}
+			if got.Memory != test.expected.Memory {
+				t.Errorf("Memory = %v, expected %v", got.Memory, test.expected.Memory)
+			}
+			for name, want := range test.expected.ScalarResources {
+				if got.ScalarResources[name] != want {
+					t.Errorf("ScalarResources[%s] = %v, expected %v", name, got.ScalarResources[name], want)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Summary

Fix a scalar resource accounting inconsistency in GetInqueueResource by replacing Value() with MilliValue() for scalar resource calculations.

Previously, scalar resources such as GPUs were recorded in whole units while the rest of the scheduler stored and compared them in milli-units. This caused in-queue GPU reservations to be undercounted and could allow jobs to be admitted beyond a queue's configured GPU quota.

This change aligns in-queue scalar resource accounting with the scheduler's internal resource representation, ensuring accurate quota enforcement across proportion, capacity, and overcommit plugins.

Fixes:
- Consistent milli-unit accounting for scalar resources.
- Correct reservation calculation when allocated resources are present.
- Prevents GPU/scalar quota over-admission caused by unit mismatches.