### PR TITLE
webhook/job: handle error returned by createPatch

### DIFF
--- a/pkg/webhooks/admission/jobs/mutate/mutate_job.go
+++ b/pkg/webhooks/admission/jobs/mutate/mutate_job.go
@@ -93,7 +93,10 @@ func Jobs(ar admissionv1.AdmissionReview) *admissionv1.AdmissionResponse {
 	var patchBytes []byte
 	switch ar.Request.Operation {
 	case admissionv1.Create:
-		patchBytes, _ = createPatch(job)
+		patchBytes, err = createPatch(job)
+		if err != nil {
+			return util.ToAdmissionResponse(err)
+		}
 	default:
 		err = fmt.Errorf("expect operation to be 'CREATE' ")
 		return util.ToAdmissionResponse(err)


### PR DESCRIPTION
This PR fixes a bug in the job mutation webhook.

When Volcano creates a job, the webhook automatically sets default values (like default queue name, scheduler name, max retry count). The function `createPatch()` does this work and can return an error. But the code was ignoring that error silently with _.

If that error ever happened, the job would be created without any default values being applied, and the webhook would still say "OK, approved" — which is wrong behavior.

This fix makes it properly return an error response instead of silently approving a broken job.