### PR TITLE
Support vnpus.configs wrapper format for HAMi vNPU device config

### DIFF
--- a/pkg/scheduler/api/devices/ascend/hami/device_info.go
+++ b/pkg/scheduler/api/devices/ascend/hami/device_info.go
@@ -90,7 +90,7 @@ func NewAscendDevices(name string, node *v1.Node) map[string]*AscendDevices {
 		klog.V(5).InfoS("cur config is null. call GetDefaultDevicesConfig")
 		curConfig = config.GetDefaultDevicesConfig()
 	}
-	devs := InitDevices(curConfig.VNPUs.Configs)
+	devs := InitDevices(curConfig.VNPUConfigs())
 	if node.Status.Allocatable == nil {
 		klog.V(3).Infof("Node %s does not have allocatable resources information", node.Name)
 		return ascendDevices
@@ -140,8 +140,8 @@ func GetAscendDeviceNames() []string {
 		klog.V(5).InfoS("cur config is null. call GetDefaultDevicesConfig")
 		curConfig = config.GetDefaultDevicesConfig()
 	}
-	deviceNames := make([]string, 0, len(curConfig.VNPUs.Configs))
-	for _, vnpu := range curConfig.VNPUs.Configs {
+	deviceNames := make([]string, 0, len(curConfig.VNPUConfigs()))
+	for _, vnpu := range curConfig.VNPUConfigs() {
 		deviceNames = append(deviceNames, vnpu.CommonWord)
 	}
 	return deviceNames

--- a/pkg/scheduler/api/devices/ascend/hami/device_info.go
+++ b/pkg/scheduler/api/devices/ascend/hami/device_info.go
@@ -90,7 +90,7 @@ func NewAscendDevices(name string, node *v1.Node) map[string]*AscendDevices {
 		klog.V(5).InfoS("cur config is null. call GetDefaultDevicesConfig")
 		curConfig = config.GetDefaultDevicesConfig()
 	}
-	devs := InitDevices(curConfig.VNPUs)
+	devs := InitDevices(curConfig.VNPUs.Configs)
 	if node.Status.Allocatable == nil {
 		klog.V(3).Infof("Node %s does not have allocatable resources information", node.Name)
 		return ascendDevices
@@ -140,8 +140,8 @@ func GetAscendDeviceNames() []string {
 		klog.V(5).InfoS("cur config is null. call GetDefaultDevicesConfig")
 		curConfig = config.GetDefaultDevicesConfig()
 	}
-	deviceNames := make([]string, 0, len(curConfig.VNPUs))
-	for _, vnpu := range curConfig.VNPUs {
+	deviceNames := make([]string, 0, len(curConfig.VNPUs.Configs))
+	for _, vnpu := range curConfig.VNPUs.Configs {
 		deviceNames = append(deviceNames, vnpu.CommonWord)
 	}
 	return deviceNames

--- a/pkg/scheduler/api/devices/ascend/hami/device_info_test.go
+++ b/pkg/scheduler/api/devices/ascend/hami/device_info_test.go
@@ -194,7 +194,7 @@ func Test_trimMemory(t *testing.T) {
 	conf, err := yamlStringToConfig(config_yaml)
 	assert.Nil(t, err)
 	dev := AscendDevice{
-		config: conf.VNPUs[len(conf.VNPUs)-1],
+		config: conf.VNPUs.Configs[len(conf.VNPUs.Configs)-1],
 	}
 	tests := []struct {
 		name     string
@@ -229,7 +229,7 @@ func Test_trimMemory(t *testing.T) {
 func Test_fit(t *testing.T) {
 	conf, err := yamlStringToConfig(config_yaml)
 	assert.Nil(t, err)
-	ascend310PConfig := conf.VNPUs[len(conf.VNPUs)-1]
+	ascend310PConfig := conf.VNPUs.Configs[len(conf.VNPUs.Configs)-1]
 	device_info := &devices.DeviceInfo{
 		ID:      "68496E64-20E05477-92C31323-6E78030A-BD003019",
 		Index:   0,
@@ -343,7 +343,7 @@ func Test_verifyReq(t *testing.T) {
 	conf, err := yamlStringToConfig(config_yaml)
 	assert.Nil(t, err)
 	dev := AscendDevice{
-		config: conf.VNPUs[len(conf.VNPUs)-1],
+		config: conf.VNPUs.Configs[len(conf.VNPUs.Configs)-1],
 	}
 	tests := []struct {
 		name string

--- a/pkg/scheduler/api/devices/ascend/hami/device_info_test.go
+++ b/pkg/scheduler/api/devices/ascend/hami/device_info_test.go
@@ -194,7 +194,7 @@ func Test_trimMemory(t *testing.T) {
 	conf, err := yamlStringToConfig(config_yaml)
 	assert.Nil(t, err)
 	dev := AscendDevice{
-		config: conf.VNPUs.Configs[len(conf.VNPUs.Configs)-1],
+		config: conf.VNPUConfigs()[len(conf.VNPUConfigs())-1],
 	}
 	tests := []struct {
 		name     string
@@ -229,7 +229,7 @@ func Test_trimMemory(t *testing.T) {
 func Test_fit(t *testing.T) {
 	conf, err := yamlStringToConfig(config_yaml)
 	assert.Nil(t, err)
-	ascend310PConfig := conf.VNPUs.Configs[len(conf.VNPUs.Configs)-1]
+	ascend310PConfig := conf.VNPUConfigs()[len(conf.VNPUConfigs())-1]
 	device_info := &devices.DeviceInfo{
 		ID:      "68496E64-20E05477-92C31323-6E78030A-BD003019",
 		Index:   0,
@@ -343,7 +343,7 @@ func Test_verifyReq(t *testing.T) {
 	conf, err := yamlStringToConfig(config_yaml)
 	assert.Nil(t, err)
 	dev := AscendDevice{
-		config: conf.VNPUs.Configs[len(conf.VNPUs.Configs)-1],
+		config: conf.VNPUConfigs()[len(conf.VNPUConfigs())-1],
 	}
 	tests := []struct {
 		name string

--- a/pkg/scheduler/api/devices/config/config.go
+++ b/pkg/scheduler/api/devices/config/config.go
@@ -35,39 +35,26 @@ const (
 )
 
 /* Config Examples:
-   nvidia:
-     resourceCountName: "volcano.sh/vgpu"
-     ...
-   cambricon:
-     resourceCountName: "volcano.sh/vmlu"
-     ...
-   hygon:
-     resourceCountName: "volcano.sh/vdcu"
-     ...
+
+   New HAMi wrapper format (recommended):
+   vnpus:
+     hamiVnpuCore: false
+     configs:
+     - chipName: 910B3
+       commonWord: Ascend910B3
+       ...
+
+   Legacy direct array format (still supported):
    vnpus:
    - chipName: 910B3
-      commonWord: Ascend910B3
-      resourceName: huawei.com/Ascend910B3
-      resourceMemoryName: huawei.com/Ascend910B3-memory
-      memoryAllocatable: 65536
-      memoryCapacity: 65536
-      aiCore: 20
-      aiCPU: 7
-      templates:
-        - name: vir05_1c_16g
-          memory: 16384
-          aiCore: 5
-          aiCPU: 1
-        - name: vir10_3c_32g
-          memory: 32768
-          aiCore: 10
-          aiCPU: 3
+     commonWord: Ascend910B3
+     ...
 */
 
 type Config struct {
 	//NvidiaConfig is used for vGPU feature for nvidia, gpushare is not using this config
 	NvidiaConfig NvidiaConfig `yaml:"nvidia"`
-	VNPUs        []VNPUConfig `yaml:"vnpus"`
+	VNPUs        VNPUsConfig  `yaml:"vnpus"`
 }
 
 var (
@@ -116,34 +103,36 @@ func GetDefaultDevicesConfig() *Config {
 			DeviceCoreScaling:   1,
 			DisableCoreLimit:    false,
 		},
-		VNPUs: []VNPUConfig{
-			{
-				CommonWord:         "Ascend310P",
-				ChipName:           "310P3",
-				ResourceName:       "huawei.com/Ascend310P",
-				ResourceMemoryName: "huawei.com/Ascend310P-memory",
-				MemoryAllocatable:  21527,
-				MemoryCapacity:     24576,
-				AICore:             8,
-				AICPU:              7,
-				Templates: []Template{
-					{
-						Name:   "vir01",
-						Memory: 3072,
-						AICore: 1,
-						AICPU:  1,
-					},
-					{
-						Name:   "vir02",
-						Memory: 6144,
-						AICore: 2,
-						AICPU:  2,
-					},
-					{
-						Name:   "vir04",
-						Memory: 12288,
-						AICore: 4,
-						AICPU:  4,
+		VNPUs: VNPUsConfig{
+			Configs: []VNPUConfig{
+				{
+					CommonWord:         "Ascend310P",
+					ChipName:           "310P3",
+					ResourceName:       "huawei.com/Ascend310P",
+					ResourceMemoryName: "huawei.com/Ascend310P-memory",
+					MemoryAllocatable:  21527,
+					MemoryCapacity:     24576,
+					AICore:             8,
+					AICPU:              7,
+					Templates: []Template{
+						{
+							Name:   "vir01",
+							Memory: 3072,
+							AICore: 1,
+							AICPU:  1,
+						},
+						{
+							Name:   "vir02",
+							Memory: 6144,
+							AICore: 2,
+							AICPU:  2,
+						},
+						{
+							Name:   "vir04",
+							Memory: 12288,
+							AICore: 4,
+							AICPU:  4,
+						},
 					},
 				},
 			},

--- a/pkg/scheduler/api/devices/config/config.go
+++ b/pkg/scheduler/api/devices/config/config.go
@@ -57,6 +57,11 @@ type Config struct {
 	VNPUs        VNPUsConfig  `yaml:"vnpus"`
 }
 
+// VNPUConfigs is a compatibility accessor for external consumers that used to access Config.VNPUs as a slice.
+func (c *Config) VNPUConfigs() []VNPUConfig {
+	return c.VNPUs.Configs
+}
+
 var (
 	configs *Config
 	once    sync.Once

--- a/pkg/scheduler/api/devices/config/config_test.go
+++ b/pkg/scheduler/api/devices/config/config_test.go
@@ -277,3 +277,85 @@ func TestParseDeviceConfig(t *testing.T) {
 		})
 	}
 }
+
+func TestParseVNPUsNewWrapperFormat(t *testing.T) {
+	yamlStr := `
+vnpus:
+  hamiVnpuCore: false
+  configs:
+  - chipName: 910A
+    commonWord: Ascend910A
+    resourceName: huawei.com/Ascend910A
+    resourceMemoryName: huawei.com/Ascend910A-memory
+    memoryAllocatable: 32768
+    memoryCapacity: 32768
+    aiCore: 30
+    templates:
+      - name: vir02
+        memory: 2184
+        aiCore: 2
+`
+	var config Config
+	err := yaml.Unmarshal([]byte(yamlStr), &config)
+	assert.Nil(t, err)
+	assert.Equal(t, false, config.VNPUs.HamiVnpuCore)
+	assert.Equal(t, 1, len(config.VNPUs.Configs))
+	assert.Equal(t, "910A", config.VNPUs.Configs[0].ChipName)
+	assert.Equal(t, "Ascend910A", config.VNPUs.Configs[0].CommonWord)
+	assert.Equal(t, int64(32768), config.VNPUs.Configs[0].MemoryAllocatable)
+	assert.Equal(t, 1, len(config.VNPUs.Configs[0].Templates))
+	assert.Equal(t, "vir02", config.VNPUs.Configs[0].Templates[0].Name)
+}
+
+func TestParseVNPUsLegacyArrayFormat(t *testing.T) {
+	yamlStr := `
+vnpus:
+- chipName: 910A
+  commonWord: Ascend910A
+  resourceName: huawei.com/Ascend910A
+  resourceMemoryName: huawei.com/Ascend910A-memory
+  memoryAllocatable: 32768
+  memoryCapacity: 32768
+  aiCore: 30
+  templates:
+    - name: vir02
+      memory: 2184
+      aiCore: 2
+- chipName: 310P3
+  commonWord: Ascend310P
+  resourceName: huawei.com/Ascend310P
+  resourceMemoryName: huawei.com/Ascend310P-memory
+  memoryAllocatable: 21527
+  memoryCapacity: 24576
+  aiCore: 8
+  aiCPU: 7
+  templates:
+    - name: vir01
+      memory: 3072
+      aiCore: 1
+      aiCPU: 1
+`
+	var config Config
+	err := yaml.Unmarshal([]byte(yamlStr), &config)
+	assert.Nil(t, err)
+	assert.Equal(t, false, config.VNPUs.HamiVnpuCore)
+	assert.Equal(t, 2, len(config.VNPUs.Configs))
+	assert.Equal(t, "910A", config.VNPUs.Configs[0].ChipName)
+	assert.Equal(t, "Ascend910A", config.VNPUs.Configs[0].CommonWord)
+	assert.Equal(t, "310P3", config.VNPUs.Configs[1].ChipName)
+	assert.Equal(t, "Ascend310P", config.VNPUs.Configs[1].CommonWord)
+	assert.Equal(t, int64(21527), config.VNPUs.Configs[1].MemoryAllocatable)
+}
+
+func TestParseVNPUsWrapperWithEmptyConfigs(t *testing.T) {
+	yamlStr := `
+vnpus:
+  hamiVnpuCore: true
+  configs: []
+`
+	var config Config
+	err := yaml.Unmarshal([]byte(yamlStr), &config)
+	assert.Nil(t, err)
+	assert.Equal(t, true, config.VNPUs.HamiVnpuCore)
+	assert.Equal(t, 0, len(config.VNPUs.Configs))
+}

--- a/pkg/scheduler/api/devices/config/vnpu.go
+++ b/pkg/scheduler/api/devices/config/vnpu.go
@@ -26,9 +26,6 @@ type VNPUsConfig struct {
 	Configs      []VNPUConfig `yaml:"configs"`
 }
 
-// UnmarshalYAML implements custom YAML unmarshaling for VNPUsConfig.
-// It probes the YAML node type to disambiguate between the two formats:
-// a map indicates the new wrapper format, an array indicates the legacy format.
 func (v *VNPUsConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	// Probe whether the YAML node is a map (new wrapper format) or array (legacy format).
 	var raw map[string]interface{}

--- a/pkg/scheduler/api/devices/config/vnpu.go
+++ b/pkg/scheduler/api/devices/config/vnpu.go
@@ -18,19 +18,14 @@ package config
 
 import "fmt"
 
-// VNPUsConfig wraps VNPUConfig entries and supports both the new HAMi wrapper
-// format (vnpus: {hamiVnpuCore: ..., configs: [...]}) and the legacy direct
-// array format (vnpus: [{chipName: ...}]).
 type VNPUsConfig struct {
 	HamiVnpuCore bool         `yaml:"hamiVnpuCore,omitempty"`
 	Configs      []VNPUConfig `yaml:"configs"`
 }
 
 func (v *VNPUsConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
-	// Probe whether the YAML node is a map (new wrapper format) or array (legacy format).
 	var raw map[string]interface{}
 	if err := unmarshal(&raw); err == nil {
-		// YAML node is a map — parse as the new wrapper format.
 		type vnpusConfigAlias VNPUsConfig // alias prevents infinite recursion
 		var wrapper vnpusConfigAlias
 		if err := unmarshal(&wrapper); err != nil {

--- a/pkg/scheduler/api/devices/config/vnpu.go
+++ b/pkg/scheduler/api/devices/config/vnpu.go
@@ -16,6 +16,43 @@ limitations under the License.
 
 package config
 
+import "fmt"
+
+// VNPUsConfig wraps VNPUConfig entries and supports both the new HAMi wrapper
+// format (vnpus: {hamiVnpuCore: ..., configs: [...]}) and the legacy direct
+// array format (vnpus: [{chipName: ...}]).
+type VNPUsConfig struct {
+	HamiVnpuCore bool         `yaml:"hamiVnpuCore,omitempty"`
+	Configs      []VNPUConfig `yaml:"configs"`
+}
+
+// UnmarshalYAML implements custom YAML unmarshaling for VNPUsConfig.
+// It probes the YAML node type to disambiguate between the two formats:
+// a map indicates the new wrapper format, an array indicates the legacy format.
+func (v *VNPUsConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	// Probe whether the YAML node is a map (new wrapper format) or array (legacy format).
+	var raw map[string]interface{}
+	if err := unmarshal(&raw); err == nil {
+		// YAML node is a map — parse as the new wrapper format.
+		type vnpusConfigAlias VNPUsConfig // alias prevents infinite recursion
+		var wrapper vnpusConfigAlias
+		if err := unmarshal(&wrapper); err != nil {
+			return fmt.Errorf("vnpus: failed to parse wrapper struct: %w", err)
+		}
+		*v = VNPUsConfig(wrapper)
+		return nil
+	}
+
+	// Fallback: YAML node is an array — parse as legacy direct array format.
+	var configs []VNPUConfig
+	if err := unmarshal(&configs); err != nil {
+		return fmt.Errorf("vnpus: failed to parse as either wrapper struct or direct array: %w", err)
+	}
+	v.Configs = configs
+	v.HamiVnpuCore = false
+	return nil
+}
+
 type Template struct {
 	Name   string `yaml:"name"`
 	Memory int64  `yaml:"memory"`

--- a/pkg/scheduler/plugins/deviceshare/deviceshare.go
+++ b/pkg/scheduler/plugins/deviceshare/deviceshare.go
@@ -139,7 +139,7 @@ func registerDevices() {
 			api.RegisterDevice(vnpu.DeviceName)
 		}
 		if hami.AscendHAMiVNPUEnable {
-			for _, vnpu := range config.GetConfig().VNPUs {
+			for _, vnpu := range config.GetConfig().VNPUs.Configs {
 				klog.V(3).Infof("register device %s", vnpu.CommonWord)
 				api.RegisterDevice(vnpu.CommonWord)
 			}

--- a/pkg/scheduler/plugins/deviceshare/deviceshare.go
+++ b/pkg/scheduler/plugins/deviceshare/deviceshare.go
@@ -139,9 +139,12 @@ func registerDevices() {
 			api.RegisterDevice(vnpu.DeviceName)
 		}
 		if hami.AscendHAMiVNPUEnable {
-			for _, vnpu := range config.GetConfig().VNPUs.Configs {
-				klog.V(3).Infof("register device %s", vnpu.CommonWord)
-				api.RegisterDevice(vnpu.CommonWord)
+			cfg := config.GetConfig()
+			if cfg != nil {
+				for _, vnpu := range cfg.VNPUConfigs() {
+					klog.V(3).Infof("register device %s", vnpu.CommonWord)
+					api.RegisterDevice(vnpu.CommonWord)
+				}
 			}
 		}
 	})


### PR DESCRIPTION
## What type of PR is this?

/kind bug

## What this PR does / why we need it

The HAMi / ascend-device-plugin shared ConfigMap (`hami-scheduler-device`) has moved to a new `vnpus` structure:

```yaml
vnpus:
  hamiVnpuCore: false
  configs:
    - chipName: 910A
      commonWord: Ascend910A
      ...
```

But Volcano currently parses `vnpus` as a direct array:

```go
type Config struct {
    VNPUs []VNPUConfig `yaml:"vnpus"`
}
```

This means users following the [HAMi vNPU guide](https://raw.githubusercontent.com/Project-HAMi/ascend-device-plugin/refs/heads/main/ascend-device-configmap.yaml) will deploy the new format, but Volcano silently fails to parse the vNPU configs — resulting in zero configs being loaded.

This PR adds a `VNPUsConfig` wrapper struct with a **custom `UnmarshalYAML`** that auto-detects the YAML shape:
1. First tries the **new wrapper format**: `vnpus: { hamiVnpuCore: ..., configs: [...] }`
2. Falls back to the **legacy array format**: `vnpus: [{ chipName: ... }]`

This ensures **full backward compatibility** — existing deployments using the old array format continue to work, while new deployments following HAMi docs also parse correctly.

## Which issue(s) this PR fixes

Fixes #5372

## Changes

### Core: Config Package
- **`config/vnpu.go`**: Added `VNPUsConfig` wrapper struct with `HamiVnpuCore` bool + `Configs []VNPUConfig`, and a custom `UnmarshalYAML` method for dual-format parsing
- **`config/config.go`**: Changed `Config.VNPUs` field type from `[]VNPUConfig` to `VNPUsConfig`; updated `GetDefaultDevicesConfig()` and inline YAML documentation
- **`config/config_test.go`**: Added `TestParseVNPUsNewWrapperFormat` and `TestParseVNPUsLegacyArrayFormat`

### Consumers
- **`deviceshare/deviceshare.go`**: Updated `.VNPUs` → `.VNPUs.Configs` (1 site)
- **`ascend/hami/device_info.go`**: Updated `.VNPUs` → `.VNPUs.Configs` (3 sites)
- **`ascend/hami/device_info_test.go`**: Updated `.VNPUs` → `.VNPUs.Configs` (3 sites)

## Special notes for your reviewer

- The custom `UnmarshalYAML` uses a type alias (`vnpusConfigAlias`) to prevent infinite recursion when unmarshaling the wrapper format
- The `HamiVnpuCore` field is parsed and stored but not yet consumed by Volcano — included for forward compatibility with HAMi
- No external APIs or CLI flags are affected; this is a purely internal config parsing change

## Does this PR introduce a user-facing change?

```release-note
Support both the new HAMi vnpus.configs wrapper format and the legacy vnpus direct array format in device config parsing for Ascend vNPU.
```