### PR TITLE
fix: fall back minAvailable to replicas when partition minPartitions is omitted

### DIFF
--- a/pkg/webhooks/admission/jobs/mutate/mutate_job.go
+++ b/pkg/webhooks/admission/jobs/mutate/mutate_job.go
@@ -204,7 +204,11 @@ func mutateSpec(tasks []v1alpha1.TaskSpec, basePath string, job *v1alpha1.Job) *
 
 		if tasks[index].MinAvailable == nil {
 			patched = true
-			if tasks[index].PartitionPolicy != nil {
+			// Only derive minAvailable from the partition policy when minPartitions is
+			// explicitly set (> 0). Otherwise minPartitions defaults to 0, which would
+			// make minAvailable 0 and silently drop the task's gang guarantee, so fall
+			// back to replicas just like a task without a partition policy.
+			if tasks[index].PartitionPolicy != nil && tasks[index].PartitionPolicy.MinPartitions > 0 {
 				minAvailable := tasks[index].PartitionPolicy.MinPartitions * tasks[index].PartitionPolicy.PartitionSize
 				tasks[index].MinAvailable = &minAvailable
 			} else {

--- a/pkg/webhooks/admission/jobs/mutate/mutate_job_test.go
+++ b/pkg/webhooks/admission/jobs/mutate/mutate_job_test.go
@@ -197,9 +197,10 @@ func TestCreatePatchExecution(t *testing.T) {
 					},
 				},
 				{
-					Name:         v1alpha1.DefaultTaskSpec + "3",
-					Replicas:     1,
-					MinAvailable: ptr.To(int32(0)),
+					Name:     v1alpha1.DefaultTaskSpec + "3",
+					Replicas: 1,
+					// MinPartitions omitted (0) -> minAvailable falls back to Replicas (see issue #5401)
+					MinAvailable: ptr.To(int32(1)),
 					PartitionPolicy: &v1alpha1.PartitionPolicySpec{
 						TotalPartitions: 1,
 						PartitionSize:   1,
@@ -320,6 +321,51 @@ func TestMutateSpecPartitionPolicyDefaults(t *testing.T) {
 			},
 			ShouldMutate: true,
 			Description:  "MinAvailable should be set to MinPartitions * PartitionSize",
+		},
+		{
+			// Regression test for issue #5401: PartitionPolicy is set but minPartitions
+			// is omitted (defaults to 0). MinAvailable must fall back to Replicas instead
+			// of becoming 0, otherwise the task loses its gang guarantee.
+			Name: "MinAvailable falls back to Replicas when PartitionPolicy is set but MinPartitions is omitted",
+			InputTasks: []v1alpha1.TaskSpec{
+				{
+					Name:     "task-1",
+					Replicas: 4,
+					PartitionPolicy: &v1alpha1.PartitionPolicySpec{
+						TotalPartitions: 2,
+						PartitionSize:   2,
+						// MinPartitions omitted -> 0
+					},
+					Template: v1.PodTemplateSpec{
+						Spec: v1.PodSpec{
+							Containers: []v1.Container{
+								{Name: "test", Image: "busybox:1.24"},
+							},
+						},
+					},
+				},
+			},
+			ExpectedTasks: []v1alpha1.TaskSpec{
+				{
+					Name:     "task-1",
+					Replicas: 4,
+					PartitionPolicy: &v1alpha1.PartitionPolicySpec{
+						TotalPartitions: 2,
+						PartitionSize:   2,
+					},
+					MinAvailable: ptr.To(int32(4)), // Should equal Replicas, not 0
+					MaxRetry:     defaultMaxRetry,
+					Template: v1.PodTemplateSpec{
+						Spec: v1.PodSpec{
+							Containers: []v1.Container{
+								{Name: "test", Image: "busybox:1.24"},
+							},
+						},
+					},
+				},
+			},
+			ShouldMutate: true,
+			Description:  "MinAvailable should fall back to Replicas when MinPartitions is omitted",
 		},
 		{
 			Name: "MinAvailable is set to Replicas when no PartitionPolicy",

--- a/pkg/webhooks/admission/jobs/validate/admit_job.go
+++ b/pkg/webhooks/admission/jobs/validate/admit_job.go
@@ -317,7 +317,10 @@ func validatePartitionPolicy(task v1alpha1.TaskSpec, job *v1alpha1.Job) string {
 			msg += fmt.Sprintf("'PartitionSize' must be greater than 0 in task: %s, job: %s", task.Name, job.Name)
 		} else if task.Replicas != task.PartitionPolicy.TotalPartitions*task.PartitionPolicy.PartitionSize {
 			msg += fmt.Sprintf("'Replicas' are not equal to TotalPartitions*PartitionSize in task: %s, job: %s", task.Name, job.Name)
-		} else if task.MinAvailable != nil && task.PartitionPolicy.MinPartitions*task.PartitionPolicy.PartitionSize != *task.MinAvailable {
+		} else if task.MinAvailable != nil && task.PartitionPolicy.MinPartitions > 0 && task.PartitionPolicy.MinPartitions*task.PartitionPolicy.PartitionSize != *task.MinAvailable {
+			// Only enforce the minAvailable == minPartitions*partitionSize relationship
+			// when minPartitions is explicitly set (> 0). When minPartitions is omitted
+			// (defaults to 0), minAvailable falls back to replicas, so skip this check.
 			msg += fmt.Sprintf("'MinAvailable' is not equal to MinPartitions*PartitionSize in task: %s, job: %s", task.Name, job.Name)
 		}
 		msg += validateNetworkTopology(task.PartitionPolicy.NetworkTopology)

--- a/pkg/webhooks/admission/jobs/validate/admit_job_test.go
+++ b/pkg/webhooks/admission/jobs/validate/admit_job_test.go
@@ -39,6 +39,7 @@ import (
 func TestValidateJobCreate(t *testing.T) {
 	var policyExitCode int32 = -1
 	var minAvailable int32 = 4
+	var minAvailableReplicas int32 = 4
 	namespace := "test"
 	privileged := true
 	highestTierAllowed := 1
@@ -1622,6 +1623,51 @@ func TestValidateJobCreate(t *testing.T) {
 								PartitionSize:   2,
 								TotalPartitions: 4,
 								MinPartitions:   2,
+							},
+							Template: v1.PodTemplateSpec{
+								ObjectMeta: metav1.ObjectMeta{
+									Labels: map[string]string{"name": "test"},
+								},
+								Spec: v1.PodSpec{
+									Containers: []v1.Container{
+										{
+											Name:  "fake-name",
+											Image: "busybox:1.24",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			reviewResponse: admissionv1.AdmissionResponse{Allowed: true},
+			ret:            "",
+			ExpectErr:      false,
+		},
+		// Regression test for issue #5401: PartitionPolicy set with MinPartitions omitted (0).
+		// The mutate webhook defaults MinAvailable to Replicas, so validation must accept it and
+		// must NOT enforce MinAvailable == MinPartitions*PartitionSize (which would be 0 != 4).
+		{
+			Name:                     "task-with-PartitionPolicy-MinPartitions-omitted",
+			PodLevelResourcesEnabled: false,
+			Job: v1alpha1.Job{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "task-with-PartitionPolicy-MinPartitions-omitted",
+					Namespace: namespace,
+				},
+				Spec: v1alpha1.JobSpec{
+					MinAvailable: 4,
+					Queue:        "default",
+					Tasks: []v1alpha1.TaskSpec{
+						{
+							Name:         "task-1",
+							MinAvailable: &minAvailableReplicas, // defaulted to Replicas by mutate webhook
+							Replicas:     4,
+							PartitionPolicy: &v1alpha1.PartitionPolicySpec{
+								PartitionSize:   2,
+								TotalPartitions: 2,
+								// MinPartitions omitted -> 0
 							},
 							Template: v1.PodTemplateSpec{
 								ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

When a task specifies a `partitionPolicy` but omits both `minAvailable` and `minPartitions`, `minPartitions` defaults to
`0`. The job mutate webhook then defaulted the task's `minAvailable` to `minPartitions * partitionSize = 0`, and
`patchDefaultMinAvailable` summed that into a job-level `minAvailable` of `0`.

A zero `minAvailable` removes the gang lower bound entirely, so the state machine condition
`minAvailable <= running+succeeded+failed` (`0 <= 0`) is immediately satisfied. As a result the Job is reported as
`Running` and the PodGroup as `Completed` while the pods are still `Pending`.

#### Which issue(s) this PR fixes:

Fixes #5401

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```