### PR TITLE
fix(scheduler): validate vgpu device annotation usage fields

### DIFF
--- a/pkg/scheduler/api/devices/nvidia/vgpu/utils.go
+++ b/pkg/scheduler/api/devices/nvidia/vgpu/utils.go
@@ -134,11 +134,23 @@ func decodeContainerDevices(str string) ContainerDevices {
 	for _, val := range cd {
 		if strings.Contains(val, ",") {
 			tmpstr := strings.Split(val, ",")
+			if len(tmpstr) < 4 {
+				klog.Errorf("invalid container device %q: expected at least 4 fields", val)
+				continue
+			}
+			devmem, err := strconv.ParseUint(tmpstr[2], 10, 32)
+			if err != nil {
+				klog.Errorf("invalid used memory %q in container device %q: %v", tmpstr[2], val, err)
+				continue
+			}
+			devcores, err := strconv.ParseUint(tmpstr[3], 10, 32)
+			if err != nil {
+				klog.Errorf("invalid used cores %q in container device %q: %v", tmpstr[3], val, err)
+				continue
+			}
 			tmpdev.UUID = tmpstr[0]
 			tmpdev.Type = tmpstr[1]
-			devmem, _ := strconv.ParseInt(tmpstr[2], 10, 32)
 			tmpdev.Usedmem = uint(devmem)
-			devcores, _ := strconv.ParseInt(tmpstr[3], 10, 32)
 			tmpdev.Usedcores = uint(devcores)
 			contdev = append(contdev, tmpdev)
 		}

--- a/pkg/scheduler/api/devices/nvidia/vgpu/utils_test.go
+++ b/pkg/scheduler/api/devices/nvidia/vgpu/utils_test.go
@@ -334,3 +334,56 @@ func TestBinpackStacksSequentialPods(t *testing.T) {
 		t.Errorf("binpack should stack 3 sequential pods on the same GPU, got: %v", uuids)
 	}
 }
+
+func TestDecodeContainerDevicesRejectsInvalidUsage(t *testing.T) {
+	tests := []struct {
+		name string
+		str  string
+		want ContainerDevices
+	}{
+		{
+			name: "valid entry",
+			str:  "GPU-0,NVIDIA,4096,30:",
+			want: ContainerDevices{{UUID: "GPU-0", Type: "NVIDIA", Usedmem: 4096, Usedcores: 30}},
+		},
+		{
+			name: "negative memory is skipped",
+			str:  "GPU-0,NVIDIA,-5,30:",
+			want: ContainerDevices{},
+		},
+		{
+			name: "negative cores is skipped",
+			str:  "GPU-0,NVIDIA,4096,-1:",
+			want: ContainerDevices{},
+		},
+		{
+			name: "non-numeric usage is skipped",
+			str:  "GPU-0,NVIDIA,abc,30:",
+			want: ContainerDevices{},
+		},
+		{
+			name: "entry with missing fields is skipped",
+			str:  "GPU-0,NVIDIA:",
+			want: ContainerDevices{},
+		},
+		{
+			name: "valid entry kept when mixed with invalid",
+			str:  "GPU-0,NVIDIA,-5,30:GPU-1,NVIDIA,2048,10:",
+			want: ContainerDevices{{UUID: "GPU-1", Type: "NVIDIA", Usedmem: 2048, Usedcores: 10}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := decodeContainerDevices(tt.str)
+			if len(got) != len(tt.want) {
+				t.Fatalf("decodeContainerDevices(%q) returned %d devices, want %d", tt.str, len(got), len(tt.want))
+			}
+			for i := range tt.want {
+				if got[i] != tt.want[i] {
+					t.Errorf("device %d = %+v, want %+v", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Repro: a pod carrying a `volcano.sh/vgpu-ids-new` annotation with a negative used-memory field (for example `GPU-0,NVIDIA,-5,30`), or an entry with fewer than four comma-separated fields, gets decoded into the node's GPU bookkeeping (a pod can land on a node by setting `spec.nodeName` directly).
Cause: decodeContainerDevices casts the parsed memory and cores straight to uint and reads `tmpstr[2]`/`tmpstr[3]` without a length guard, so a negative value underflows to a near-maximum uint that corrupts per-device used-memory accounting, and a short entry indexes out of range and panics the scheduler.
Fix: check the field count and reject non-numeric or negative memory/core values before recording the device, which is what DecodeContainerDevices in the parent devices package already does.
