### PR TITLE
rescheduling: fix non-functional pod-count threshold in lowNodeUtilization

### DIFF
--- a/pkg/agentscheduler/cache/cache.go
+++ b/pkg/agentscheduler/cache/cache.go
@@ -423,6 +423,7 @@ func buildQueueingHintMap() k8sschedulingqueue.QueueingHintMap {
 func (sc *SchedulerCache) addEventHandler() {
 	handlers := make(map[string]cache.ResourceEventHandlerRegistration, 10)
 	var handlerRegistration cache.ResourceEventHandlerRegistration
+	var err error
 	informerFactory := informers.NewSharedInformerFactory(sc.kubeClient, sc.resyncPeriod)
 	sc.informerFactory = informerFactory
 
@@ -449,7 +450,7 @@ func (sc *SchedulerCache) addEventHandler() {
 
 	// create informer for node information
 	sc.nodeInformer = informerFactory.Core().V1().Nodes()
-	handlerRegistration, _ = sc.nodeInformer.Informer().AddEventHandler(
+	handlerRegistration, err = sc.nodeInformer.Informer().AddEventHandler(
 		cache.FilteringResourceEventHandler{
 			FilterFunc: func(obj interface{}) bool {
 				switch t := obj.(type) {
@@ -474,13 +475,16 @@ func (sc *SchedulerCache) addEventHandler() {
 			},
 		},
 	)
+	if err != nil {
+		klog.Fatalf("Failed to add event handler for node informer: %v", err)
+	}
 	//real node sync is handled in queue instead of event handler, use tracker to track the handling status in node queue
 	sc.nodeInitialEventTracker = schedulercache.NewQueueHandlerTracker(handlerRegistration)
 	handlers["node"] = sc.nodeInitialEventTracker
 
 	sc.podInformer = informerFactory.Core().V1().Pods()
 	// 1. Pods already scheduled, refresh its state in cache
-	handlerRegistration, _ = sc.podInformer.Informer().AddEventHandler(
+	handlerRegistration, err = sc.podInformer.Informer().AddEventHandler(
 		cache.FilteringResourceEventHandler{
 			FilterFunc: func(obj interface{}) bool {
 				switch v := obj.(type) {
@@ -507,10 +511,13 @@ func (sc *SchedulerCache) addEventHandler() {
 				DeleteFunc: sc.DeletePodFromCache,
 			},
 		})
+	if err != nil {
+		klog.Fatalf("Failed to add event handler for pod cache informer: %v", err)
+	}
 	handlers["pod-cache"] = handlerRegistration
 
 	// 2. Pods not scheduled yet, and needed to be scheduled by agent scheduler, add them to scheduling queue
-	handlerRegistration, _ = sc.podInformer.Informer().AddEventHandler(
+	handlerRegistration, err = sc.podInformer.Informer().AddEventHandler(
 		cache.FilteringResourceEventHandler{
 			FilterFunc: func(obj interface{}) bool {
 				switch v := obj.(type) {
@@ -538,17 +545,23 @@ func (sc *SchedulerCache) addEventHandler() {
 				DeleteFunc: sc.DeletePodFromSchedulingQueue,
 			},
 		})
+	if err != nil {
+		klog.Fatalf("Failed to add event handler for pod scheduling queue informer: %v", err)
+	}
 	handlers["pod-queue"] = handlerRegistration
 
 	vcinformers := vcinformer.NewSharedInformerFactory(sc.vcClient, sc.resyncPeriod)
 	sc.vcInformerFactory = vcinformers
 	if sc.shardingMode == util.HardShardingMode || sc.shardingMode == util.SoftShardingMode {
 		sc.nodeShardInformer = sc.vcInformerFactory.Shard().V1alpha1().NodeShards()
-		handlerRegistration, _ = sc.nodeShardInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		handlerRegistration, err = sc.nodeShardInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 			AddFunc:    sc.AddNodeShard,
 			UpdateFunc: sc.UpdateNodeShard,
 			DeleteFunc: sc.DeleteNodeShard,
 		})
+		if err != nil {
+			klog.Fatalf("Failed to add event handler for nodeShard informer: %v", err)
+		}
 		sc.nodeShardLister = sc.vcInformerFactory.Shard().V1alpha1().NodeShards().Lister()
 		handlers["nodeShard"] = handlerRegistration
 	}

--- a/pkg/scheduler/cache/cache.go
+++ b/pkg/scheduler/cache/cache.go
@@ -626,6 +626,7 @@ func newSchedulerCache(config *rest.Config, schedulerNames []string, defaultQueu
 func (sc *SchedulerCache) addEventHandler() {
 	handlers := make(map[string]cache.ResourceEventHandlerRegistration, 10)
 	var handlerRegistration cache.ResourceEventHandlerRegistration
+	var err error
 	informerFactory := informers.NewSharedInformerFactory(sc.kubeClient, sc.resyncPeriod)
 	sc.informerFactory = informerFactory
 
@@ -648,7 +649,7 @@ func (sc *SchedulerCache) addEventHandler() {
 
 	// create informer for node information
 	sc.nodeInformer = informerFactory.Core().V1().Nodes()
-	handlerRegistration, _ = sc.nodeInformer.Informer().AddEventHandler(
+	handlerRegistration, err = sc.nodeInformer.Informer().AddEventHandler(
 		cache.FilteringResourceEventHandler{
 			FilterFunc: func(obj interface{}) bool {
 				switch t := obj.(type) {
@@ -673,6 +674,9 @@ func (sc *SchedulerCache) addEventHandler() {
 			},
 		},
 	)
+	if err != nil {
+		klog.Fatalf("Failed to add event handler for node informer: %v", err)
+	}
 	//real node sync is handled in queue instead of event handler, use tracker to track the handling status in node queue
 	sc.nodeInitialEventTracker = schedulercache.NewQueueHandlerTracker(handlerRegistration)
 	handlers["node"] = sc.nodeInitialEventTracker
@@ -686,13 +690,16 @@ func (sc *SchedulerCache) addEventHandler() {
 	sc.vaInformer = informerFactory.Storage().V1().VolumeAttachments()
 	sc.vaInformer.Informer()
 	sc.csiNodeInformer = informerFactory.Storage().V1().CSINodes()
-	handlerRegistration, _ = sc.csiNodeInformer.Informer().AddEventHandler(
+	handlerRegistration, err = sc.csiNodeInformer.Informer().AddEventHandler(
 		cache.ResourceEventHandlerDetailedFuncs{
 			AddFunc:    sc.AddOrUpdateCSINode,
 			UpdateFunc: sc.UpdateCSINode,
 			DeleteFunc: sc.DeleteCSINode,
 		},
 	)
+	if err != nil {
+		klog.Fatalf("Failed to add event handler for csiNode informer: %v", err)
+	}
 	handlers["csiNode"] = handlerRegistration
 
 	if options.ServerOpts != nil && options.ServerOpts.EnableCSIStorage && utilfeature.DefaultFeatureGate.Enabled(features.CSIStorage) {
@@ -704,7 +711,7 @@ func (sc *SchedulerCache) addEventHandler() {
 
 	sc.podInformer = informerFactory.Core().V1().Pods()
 	// create informer for pod information
-	handlerRegistration, _ = sc.podInformer.Informer().AddEventHandler(
+	handlerRegistration, err = sc.podInformer.Informer().AddEventHandler(
 		cache.FilteringResourceEventHandler{
 			FilterFunc: func(obj interface{}) bool {
 				switch v := obj.(type) {
@@ -735,25 +742,34 @@ func (sc *SchedulerCache) addEventHandler() {
 				DeleteFunc: sc.DeletePod,
 			},
 		})
+	if err != nil {
+		klog.Fatalf("Failed to add event handler for pod informer: %v", err)
+	}
 
 	handlers["pod"] = handlerRegistration
 
 	if options.ServerOpts != nil && options.ServerOpts.EnablePriorityClass && utilfeature.DefaultFeatureGate.Enabled(features.PriorityClass) {
 		sc.pcInformer = informerFactory.Scheduling().V1().PriorityClasses()
-		handlerRegistration, _ = sc.pcInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		handlerRegistration, err = sc.pcInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 			AddFunc:    sc.AddPriorityClass,
 			UpdateFunc: sc.UpdatePriorityClass,
 			DeleteFunc: sc.DeletePriorityClass,
 		})
+		if err != nil {
+			klog.Fatalf("Failed to add event handler for priorityClass informer: %v", err)
+		}
 		handlers["pc"] = handlerRegistration
 	}
 
 	sc.quotaInformer = informerFactory.Core().V1().ResourceQuotas()
-	handlerRegistration, _ = sc.quotaInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	handlerRegistration, err = sc.quotaInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc:    sc.AddResourceQuota,
 		UpdateFunc: sc.UpdateResourceQuota,
 		DeleteFunc: sc.DeleteResourceQuota,
 	})
+	if err != nil {
+		klog.Fatalf("Failed to add event handler for quota informer: %v", err)
+	}
 	handlers["quota"] = handlerRegistration
 
 	vcinformers := vcinformer.NewSharedInformerFactory(sc.vcClient, sc.resyncPeriod)
@@ -761,7 +777,7 @@ func (sc *SchedulerCache) addEventHandler() {
 
 	// create informer for PodGroup(v1beta1) information
 	sc.podGroupInformerV1beta1 = vcinformers.Scheduling().V1beta1().PodGroups()
-	handlerRegistration, _ = sc.podGroupInformerV1beta1.Informer().AddEventHandler(
+	handlerRegistration, err = sc.podGroupInformerV1beta1.Informer().AddEventHandler(
 		cache.FilteringResourceEventHandler{
 			FilterFunc: func(obj interface{}) bool {
 				var pg *vcv1beta1.PodGroup
@@ -787,44 +803,59 @@ func (sc *SchedulerCache) addEventHandler() {
 				DeleteFunc: sc.DeletePodGroupV1beta1,
 			},
 		})
+	if err != nil {
+		klog.Fatalf("Failed to add event handler for podGroup informer: %v", err)
+	}
 	handlers["podgroup"] = handlerRegistration
 
 	// create informer(v1beta1) for Queue information
 	sc.queueInformerV1beta1 = vcinformers.Scheduling().V1beta1().Queues()
-	handlerRegistration, _ = sc.queueInformerV1beta1.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	handlerRegistration, err = sc.queueInformerV1beta1.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc:    sc.AddQueueV1beta1,
 		UpdateFunc: sc.UpdateQueueV1beta1,
 		DeleteFunc: sc.DeleteQueueV1beta1,
 	})
+	if err != nil {
+		klog.Fatalf("Failed to add event handler for queue informer: %v", err)
+	}
 	handlers["queue"] = handlerRegistration
 
 	if utilfeature.DefaultFeatureGate.Enabled(features.ResourceTopology) {
 		sc.cpuInformer = vcinformers.Nodeinfo().V1alpha1().Numatopologies()
-		handlerRegistration, _ = sc.cpuInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		handlerRegistration, err = sc.cpuInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 			AddFunc:    sc.AddNumaInfoV1alpha1,
 			UpdateFunc: sc.UpdateNumaInfoV1alpha1,
 			DeleteFunc: sc.DeleteNumaInfoV1alpha1,
 		})
+		if err != nil {
+			klog.Fatalf("Failed to add event handler for numaTopology informer: %v", err)
+		}
 		handlers["cpu"] = handlerRegistration
 	}
 
 	sc.hyperNodeInformer = sc.vcInformerFactory.Topology().V1alpha1().HyperNodes()
-	handlerRegistration, _ = sc.hyperNodeInformer.Informer().AddEventHandler(cache.ResourceEventHandlerDetailedFuncs{
+	handlerRegistration, err = sc.hyperNodeInformer.Informer().AddEventHandler(cache.ResourceEventHandlerDetailedFuncs{
 		AddFunc:    sc.AddHyperNode,
 		UpdateFunc: sc.UpdateHyperNode,
 		DeleteFunc: sc.DeleteHyperNode,
 	})
+	if err != nil {
+		klog.Fatalf("Failed to add event handler for hyperNode informer: %v", err)
+	}
 	//real hypernode sync is handled in queue instead of event handler, use tracker to track the handling status in hypenode queue
 	sc.hyperNodesInitialEventTracker = schedulercache.NewQueueHandlerTracker(handlerRegistration)
 	handlers["hypernode"] = sc.hyperNodesInitialEventTracker
 
 	if options.ServerOpts.ShardingMode == util.HardShardingMode || options.ServerOpts.ShardingMode == util.SoftShardingMode {
 		sc.nodeShardInformer = sc.vcInformerFactory.Shard().V1alpha1().NodeShards()
-		handlerRegistration, _ = sc.nodeShardInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		handlerRegistration, err = sc.nodeShardInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 			AddFunc:    sc.AddNodeShard,
 			UpdateFunc: sc.UpdateNodeShard,
 			DeleteFunc: sc.DeleteNodeShard,
 		})
+		if err != nil {
+			klog.Fatalf("Failed to add event handler for nodeShard informer: %v", err)
+		}
 		handlers["nodeShard"] = handlerRegistration
 	}
 

--- a/pkg/scheduler/plugins/rescheduling/low_node_utilization.go
+++ b/pkg/scheduler/plugins/rescheduling/low_node_utilization.go
@@ -99,9 +99,9 @@ func parseThreshold(thresholdsConfig map[string]int, lnuc *LowNodeUtilizationCon
 		if ok {
 			config["memory"] = float64(memoryThreshold)
 		}
-		podThreshold, ok := thresholdsConfig["pod"]
+		podThreshold, ok := thresholdsConfig["pods"]
 		if ok {
-			config["pod"] = float64(podThreshold)
+			config["pods"] = float64(podThreshold)
 		}
 	}
 }
@@ -186,6 +186,10 @@ func highThresholdFilter(usage *NodeUtilization, config interface{}) bool {
 func isContinueEvictPods(usage *NodeUtilization, totalAllocatableResource map[v1.ResourceName]*resource.Quantity, config interface{}) bool {
 	var isNodeOverused bool
 	utilizationConfig := parseArgToConfig(config)
+	if utilizationConfig == nil {
+		klog.V(4).Infof("lack of LowNodeUtilizationConf pointer parameter")
+		return false
+	}
 	for rName, usage := range usage.utilization {
 		if threshold, ok := utilizationConfig.TargetThresholds[string(rName)]; ok {
 			if usage >= threshold {

--- a/pkg/scheduler/plugins/rescheduling/node_utilization_util.go
+++ b/pkg/scheduler/plugins/rescheduling/node_utilization_util.go
@@ -58,16 +58,22 @@ func groupNodesByUtilization(nodeUtilizationList []*NodeUtilization, lowThreshol
 func getNodeUtilization() []*NodeUtilization {
 	nodeUtilizationList := make([]*NodeUtilization, 0)
 	for _, nodeInfo := range Session.Nodes {
+		pods := nodeInfo.Pods()
+		podUtilization := 0.0
+		if maxPods := nodeInfo.Node.Status.Allocatable[v1.ResourcePods]; maxPods.Value() > 0 {
+			podUtilization = float64(len(pods)) / float64(maxPods.Value()) * 100
+		}
 		nodeUtilization := &NodeUtilization{
 			nodeInfo: nodeInfo.Node,
 			utilization: map[v1.ResourceName]float64{
 				v1.ResourceCPU:    nodeInfo.ResourceUsage.CPUUsageAvg[MetricsPeriod],
 				v1.ResourceMemory: nodeInfo.ResourceUsage.MEMUsageAvg[MetricsPeriod],
+				v1.ResourcePods:   podUtilization,
 			},
-			pods: nodeInfo.Pods(),
+			pods: pods,
 		}
 		nodeUtilizationList = append(nodeUtilizationList, nodeUtilization)
-		klog.V(4).Infof("node: %s, cpu: %v, memory: %v\n", nodeUtilization.nodeInfo.Name, nodeUtilization.utilization[v1.ResourceCPU], nodeUtilization.utilization[v1.ResourceMemory])
+		klog.V(4).Infof("node: %s, cpu: %v, memory: %v, pods: %v\n", nodeUtilization.nodeInfo.Name, nodeUtilization.utilization[v1.ResourceCPU], nodeUtilization.utilization[v1.ResourceMemory], nodeUtilization.utilization[v1.ResourcePods])
 	}
 	return nodeUtilizationList
 }

--- a/pkg/webhooks/admission/jobs/mutate/mutate_job.go
+++ b/pkg/webhooks/admission/jobs/mutate/mutate_job.go
@@ -93,7 +93,10 @@ func Jobs(ar admissionv1.AdmissionReview) *admissionv1.AdmissionResponse {
 	var patchBytes []byte
 	switch ar.Request.Operation {
 	case admissionv1.Create:
-		patchBytes, _ = createPatch(job)
+		patchBytes, err = createPatch(job)
+		if err != nil {
+			return util.ToAdmissionResponse(err)
+		}
 	default:
 		err = fmt.Errorf("expect operation to be 'CREATE' ")
 		return util.ToAdmissionResponse(err)

--- a/pkg/webhooks/admission/pods/mutate/mutate_pod.go
+++ b/pkg/webhooks/admission/pods/mutate/mutate_pod.go
@@ -85,7 +85,10 @@ func Pods(ar admissionv1.AdmissionReview) *admissionv1.AdmissionResponse {
 	var patchBytes []byte
 	switch ar.Request.Operation {
 	case admissionv1.Create:
-		patchBytes, _ = createPatch(pod)
+		patchBytes, err = createPatch(pod)
+		if err != nil {
+			return util.ToAdmissionResponse(err)
+		}
 	default:
 		err = fmt.Errorf("expect operation to be 'CREATE' ")
 		return util.ToAdmissionResponse(err)


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
The `lowNodeUtilization` rescheduling strategy supports three resource dimensions
(CPU, memory, pod count) but the pod-count dimension was entirely non-functional
due to three independent bugs stacked on top of each other.

**Bug 1 — pod utilization never measured** (`node_utilization_util.go`)
`getNodeUtilization()` only populated CPU and memory in the utilization map;
`v1.ResourcePods` was never added. Pod count was stored in `nodeUtilization.pods`
but never compared against any threshold.
Fix: compute `(currentPodCount / allocatablePods) * 100` and store it under
`v1.ResourcePods`.

**Bug 2 — config key mismatch `"pod"` vs `"pods"`** (`low_node_utilization.go`)
The default config and docs use key `"pods"` (plural). `parseThreshold()` looked
for `"pod"` (singular), so user-supplied pod thresholds were silently discarded.
Fix: use `"pods"` consistently in both the lookup and the assignment.

**Bug 3 — nil-pointer dereference in `isContinueEvictPods()`** (`low_node_utilization.go`)
`parseArgToConfig()` returns `nil` when the config value is not a
`LowNodeUtilizationConf`. `isContinueEvictPods()` had no nil guard and would
panic on the next line.
Fix: return `false` immediately when `utilizationConfig == nil`.

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:
All three bugs must be fixed together — fixing any one in isolation still leaves
the pod-count threshold non-functional end-to-end.

#### Does this PR introduce a user-facing change?

```release-note
Fixed pod-count threshold in the lowNodeUtilization rescheduling strategy.
Setting `pods` in `thresholds`/`targetThresholds` config now correctly
measures and enforces pod count per node.