### PR TITLE
agent: support init containers in cgroup resource calculation

### DIFF
--- a/pkg/agent/utils/pod/resources.go
+++ b/pkg/agent/utils/pod/resources.go
@@ -52,11 +52,50 @@ type Resources struct {
 // CalculateExtendResources calculates pod and container that use extend resource level cgroup resource, include cpu and memory
 func CalculateExtendResources(pod *v1.Pod) []Resources {
 	containerRes := []Resources{}
-	cpuSharesTotal, cpuLimitsTotal, memoryLimitsTotal := int64(0), int64(0), int64(0)
+	appCpuSharesTotal, appCpuLimitsTotal, appMemoryLimitsTotal := int64(0), int64(0), int64(0)
+	initCpuSharesMax, initCpuLimitsMax, initMemoryLimitsMax := int64(0), int64(0), int64(0)
 	// track if limits were applied for each resource.
 	cpuLimitsDeclared := true
 	memoryLimitsDeclared := true
-	// TODO: support init containers.
+
+	// process init containers
+	for _, ic := range pod.Spec.InitContainers {
+		id := FindContainerIDByName(pod, ic.Name)
+		// set cpu share.
+		cpuReq, ok := ic.Resources.Requests[apis.GetExtendResourceCPU()]
+		if ok && !cpuReq.IsZero() {
+			cpuShares := int64(milliCPUToShares(cpuReq.Value()))
+			containerRes = append(containerRes, Resources{CgroupSubSystem: cgroup.CgroupCpuSubsystem, ContainerID: id, SubPath: cgroup.CPUShareFileName, Value: cpuShares})
+			if cpuShares > initCpuSharesMax {
+				initCpuSharesMax = cpuShares
+			}
+		}
+
+		// set cpu quota.
+		cpuLimits, ok := ic.Resources.Limits[apis.GetExtendResourceCPU()]
+		if ok && !cpuLimits.IsZero() {
+			cpuQuota := milliCPUToQuota(cpuLimits.Value(), quotaPeriod)
+			containerRes = append(containerRes, Resources{CgroupSubSystem: cgroup.CgroupCpuSubsystem, ContainerID: id, SubPath: cgroup.CPUQuotaTotalFile, Value: cpuQuota})
+			if cpuQuota > initCpuLimitsMax {
+				initCpuLimitsMax = cpuQuota
+			}
+		} else {
+			cpuLimitsDeclared = false
+		}
+
+		// set memory limit.
+		memoryLimit, ok := ic.Resources.Limits[apis.GetExtendResourceMemory()]
+		if ok && !memoryLimit.IsZero() {
+			containerRes = append(containerRes, Resources{CgroupSubSystem: cgroup.CgroupMemorySubsystem, ContainerID: id, SubPath: cgroup.MemoryLimitFile, Value: memoryLimit.Value()})
+			if memoryLimit.Value() > initMemoryLimitsMax {
+				initMemoryLimitsMax = memoryLimit.Value()
+			}
+		} else {
+			memoryLimitsDeclared = false
+		}
+	}
+
+	// process app containers
 	for _, c := range pod.Spec.Containers {
 		id := FindContainerIDByName(pod, c.Name)
 		// set cpu share.
@@ -64,7 +103,7 @@ func CalculateExtendResources(pod *v1.Pod) []Resources {
 		if ok && !cpuReq.IsZero() {
 			cpuShares := int64(milliCPUToShares(cpuReq.Value()))
 			containerRes = append(containerRes, Resources{CgroupSubSystem: cgroup.CgroupCpuSubsystem, ContainerID: id, SubPath: cgroup.CPUShareFileName, Value: cpuShares})
-			cpuSharesTotal += cpuShares
+			appCpuSharesTotal += cpuShares
 		}
 
 		// set cpu quota.
@@ -72,7 +111,7 @@ func CalculateExtendResources(pod *v1.Pod) []Resources {
 		if ok && !cpuLimits.IsZero() {
 			cpuQuota := milliCPUToQuota(cpuLimits.Value(), quotaPeriod)
 			containerRes = append(containerRes, Resources{CgroupSubSystem: cgroup.CgroupCpuSubsystem, ContainerID: id, SubPath: cgroup.CPUQuotaTotalFile, Value: cpuQuota})
-			cpuLimitsTotal += cpuQuota
+			appCpuLimitsTotal += cpuQuota
 		} else {
 			cpuLimitsDeclared = false
 		}
@@ -81,7 +120,7 @@ func CalculateExtendResources(pod *v1.Pod) []Resources {
 		memoryLimit, ok := c.Resources.Limits[apis.GetExtendResourceMemory()]
 		if ok && !memoryLimit.IsZero() {
 			containerRes = append(containerRes, Resources{CgroupSubSystem: cgroup.CgroupMemorySubsystem, ContainerID: id, SubPath: cgroup.MemoryLimitFile, Value: memoryLimit.Value()})
-			memoryLimitsTotal += memoryLimit.Value()
+			appMemoryLimitsTotal += memoryLimit.Value()
 		} else {
 			memoryLimitsDeclared = false
 		}
@@ -92,6 +131,10 @@ func CalculateExtendResources(pod *v1.Pod) []Resources {
 		return containerRes
 	}
 
+	cpuSharesTotal := appCpuSharesTotal
+	if initCpuSharesMax > cpuSharesTotal {
+		cpuSharesTotal = initCpuSharesMax
+	}
 	if cpuSharesTotal == 0 {
 		// Align with min cpu share value in kubelet.
 		cpuSharesTotal = minShares
@@ -101,10 +144,18 @@ func CalculateExtendResources(pod *v1.Pod) []Resources {
 
 	// pod level should not set limit when exists one container has no cpu limit.
 	if cpuLimitsDeclared {
+		cpuLimitsTotal := appCpuLimitsTotal
+		if initCpuLimitsMax > cpuLimitsTotal {
+			cpuLimitsTotal = initCpuLimitsMax
+		}
 		containerRes = append(containerRes, Resources{CgroupSubSystem: cgroup.CgroupCpuSubsystem, SubPath: cgroup.CPUQuotaTotalFile, Value: cpuLimitsTotal})
 	}
 	// pod level should not set limit when exists one container has no memory limit.
 	if memoryLimitsDeclared {
+		memoryLimitsTotal := appMemoryLimitsTotal
+		if initMemoryLimitsMax > memoryLimitsTotal {
+			memoryLimitsTotal = initMemoryLimitsMax
+		}
 		containerRes = append(containerRes, Resources{CgroupSubSystem: cgroup.CgroupMemorySubsystem, SubPath: cgroup.MemoryLimitFile, Value: memoryLimitsTotal})
 	}
 	return containerRes
@@ -155,10 +206,115 @@ func milliCPUToShares(milliCPU int64) uint64 {
 
 func CalculateExtendResourcesV2(pod *v1.Pod) []Resources {
 	containerRes := []Resources{}
-	cpuWeightTotal, cpuMaxTotal, memoryMaxTotal := int64(0), int64(0), int64(0)
+	appCpuWeightTotal, appCpuMaxTotal, appMemoryMaxTotal := int64(0), int64(0), int64(0)
+	initCpuWeightMax, initCpuMaxMax, initMemoryMaxMax := int64(0), int64(0), int64(0)
 	cpuLimitsDeclared := true
 	memoryLimitsDeclared := true
 
+	// process init containers
+	for _, ic := range pod.Spec.InitContainers {
+		id := FindContainerIDByName(pod, ic.Name)
+		cpuReq, ok := ic.Resources.Requests[apis.GetExtendResourceCPU()]
+		if ok && !cpuReq.IsZero() {
+			cpuWeight := int64(milliCPUToWeight(cpuReq.Value()))
+			containerRes = append(containerRes, Resources{
+				CgroupSubSystem: cgroup.CgroupCpuSubsystem,
+				ContainerID:     id,
+				SubPath:         cgroup.CPUWeightFileV2,
+				Value:           cpuWeight,
+			})
+			if cpuWeight > initCpuWeightMax {
+				initCpuWeightMax = cpuWeight
+			}
+		}
+
+		cpuLimits, ok := ic.Resources.Limits[apis.GetExtendResourceCPU()]
+		if ok {
+			// In cgroup v2, both zero and non-zero limits are meaningful
+			// Zero limit means unlimited, non-zero limit means specific quota
+			cpuMaxStr := milliCPUToMax(cpuLimits.Value(), quotaPeriod)
+			if cpuMaxStr == "max 100000" {
+				containerRes = append(containerRes, Resources{
+					CgroupSubSystem: cgroup.CgroupCpuSubsystem,
+					ContainerID:     id,
+					SubPath:         cgroup.CPUQuotaTotalFileV2,
+					Value:           -1,
+				})
+			} else {
+				// For cgroup v2, we need to write the full "quota period" string
+				// We'll use a special Value and handle it in resources.go
+				var cpuQuota, period int64
+				n, err := fmt.Sscanf(cpuMaxStr, "%d %d", &cpuQuota, &period)
+				if err != nil {
+					klog.ErrorS(err, "Failed to parse CPU max string",
+						"container", ic.Name,
+						"cpuMaxStr", cpuMaxStr)
+				} else if n != 2 {
+					klog.ErrorS(nil, "Incomplete CPU max string parsing",
+						"container", ic.Name,
+						"cpuMaxStr", cpuMaxStr,
+						"matchedCount", n)
+				} else {
+					// Validate and use the expected period
+					if period != quotaPeriod {
+						klog.ErrorS(nil, "Unexpected CPU period value, using default",
+							"container", ic.Name,
+							"expected", quotaPeriod,
+							"actual", period)
+						period = quotaPeriod
+					}
+					containerRes = append(containerRes, Resources{
+						CgroupSubSystem: cgroup.CgroupCpuSubsystem,
+						ContainerID:     id,
+						SubPath:         cgroup.CPUQuotaTotalFileV2,
+						Value:           cpuQuota,
+					})
+					if cpuQuota > initCpuMaxMax {
+						initCpuMaxMax = cpuQuota
+					}
+				}
+			}
+		} else {
+			cpuLimitsDeclared = false
+		}
+
+		memoryLimits, ok := ic.Resources.Limits[apis.GetExtendResourceMemory()]
+		if ok {
+			// In cgroup v2, both zero and non-zero limits are meaningful
+			// Zero limit means unlimited, non-zero limit means specific limit
+			memoryMaxStr := memoryLimitToMax(memoryLimits.Value())
+			if memoryMaxStr == "max" {
+				containerRes = append(containerRes, Resources{
+					CgroupSubSystem: cgroup.CgroupMemorySubsystem,
+					ContainerID:     id,
+					SubPath:         cgroup.MemoryMaxFileV2,
+					Value:           -1,
+				})
+			} else {
+				var memMax int64
+				memMax, err := strconv.ParseInt(memoryMaxStr, 10, 64)
+				if err == nil {
+					containerRes = append(containerRes, Resources{
+						CgroupSubSystem: cgroup.CgroupMemorySubsystem,
+						ContainerID:     id,
+						SubPath:         cgroup.MemoryMaxFileV2,
+						Value:           memMax,
+					})
+					if memMax > initMemoryMaxMax {
+						initMemoryMaxMax = memMax
+					}
+				} else {
+					klog.ErrorS(err, "Failed to parse memory limit",
+						"container", ic.Name,
+						"memoryMaxStr", memoryMaxStr)
+				}
+			}
+		} else {
+			memoryLimitsDeclared = false
+		}
+	}
+
+	// process app containers
 	for _, c := range pod.Spec.Containers {
 		id := FindContainerIDByName(pod, c.Name)
 		cpuReq, ok := c.Resources.Requests[apis.GetExtendResourceCPU()]
@@ -170,7 +326,7 @@ func CalculateExtendResourcesV2(pod *v1.Pod) []Resources {
 				SubPath:         cgroup.CPUWeightFileV2,
 				Value:           cpuWeight,
 			})
-			cpuWeightTotal += cpuWeight
+			appCpuWeightTotal += cpuWeight
 		}
 
 		cpuLimits, ok := c.Resources.Limits[apis.GetExtendResourceCPU()]
@@ -214,7 +370,7 @@ func CalculateExtendResourcesV2(pod *v1.Pod) []Resources {
 						SubPath:         cgroup.CPUQuotaTotalFileV2,
 						Value:           cpuQuota,
 					})
-					cpuMaxTotal += cpuQuota
+					appCpuMaxTotal += cpuQuota
 				}
 			}
 		} else {
@@ -243,7 +399,7 @@ func CalculateExtendResourcesV2(pod *v1.Pod) []Resources {
 						SubPath:         cgroup.MemoryMaxFileV2,
 						Value:           memMax,
 					})
-					memoryMaxTotal += memMax
+					appMemoryMaxTotal += memMax
 				} else {
 					klog.ErrorS(err, "Failed to parse memory limit",
 						"container", c.Name,
@@ -260,6 +416,10 @@ func CalculateExtendResourcesV2(pod *v1.Pod) []Resources {
 		return containerRes
 	}
 
+	cpuWeightTotal := appCpuWeightTotal
+	if initCpuWeightMax > cpuWeightTotal {
+		cpuWeightTotal = initCpuWeightMax
+	}
 	if cpuWeightTotal == 0 {
 		// Align with min cpu share value in kubelet.
 		cpuWeightTotal = 100
@@ -272,6 +432,10 @@ func CalculateExtendResourcesV2(pod *v1.Pod) []Resources {
 	})
 
 	if cpuLimitsDeclared {
+		cpuMaxTotal := appCpuMaxTotal
+		if initCpuMaxMax > cpuMaxTotal {
+			cpuMaxTotal = initCpuMaxMax
+		}
 		if cpuMaxTotal == 0 {
 			containerRes = append(containerRes, Resources{
 				CgroupSubSystem: cgroup.CgroupCpuSubsystem,
@@ -288,6 +452,10 @@ func CalculateExtendResourcesV2(pod *v1.Pod) []Resources {
 	}
 
 	if memoryLimitsDeclared {
+		memoryMaxTotal := appMemoryMaxTotal
+		if initMemoryMaxMax > memoryMaxTotal {
+			memoryMaxTotal = initMemoryMaxMax
+		}
 		if memoryMaxTotal == 0 {
 			containerRes = append(containerRes, Resources{
 				CgroupSubSystem: cgroup.CgroupMemorySubsystem,

--- a/pkg/agent/utils/pod/resources_test.go
+++ b/pkg/agent/utils/pod/resources_test.go
@@ -159,11 +159,272 @@ func TestCalculateExtendResources(t *testing.T) {
 			},
 			want: []Resources{},
 		},
+		{
+			name: "both init and app containers with custom resources",
+			pod: &v1.Pod{
+				Spec: v1.PodSpec{
+					InitContainers: []v1.Container{
+						{
+							Name: "init-container-1",
+							Resources: v1.ResourceRequirements{
+								Limits: map[v1.ResourceName]resource.Quantity{
+									"kubernetes.io/batch-cpu":    *resource.NewQuantity(2000, resource.DecimalSI),
+									"kubernetes.io/batch-memory": *resource.NewQuantity(400, resource.BinarySI),
+								},
+								Requests: map[v1.ResourceName]resource.Quantity{
+									"kubernetes.io/batch-cpu": *resource.NewQuantity(1000, resource.DecimalSI),
+								},
+							},
+						},
+					},
+					Containers: []v1.Container{
+						{
+							Name: "container-1",
+							Resources: v1.ResourceRequirements{
+								Limits: map[v1.ResourceName]resource.Quantity{
+									"kubernetes.io/batch-cpu":    *resource.NewQuantity(1000, resource.DecimalSI),
+									"kubernetes.io/batch-memory": *resource.NewQuantity(200, resource.BinarySI),
+								},
+								Requests: map[v1.ResourceName]resource.Quantity{
+									"kubernetes.io/batch-cpu": *resource.NewQuantity(500, resource.DecimalSI),
+								},
+							},
+						},
+						{
+							Name: "container-2",
+							Resources: v1.ResourceRequirements{
+								Limits: map[v1.ResourceName]resource.Quantity{
+									"kubernetes.io/batch-cpu":    *resource.NewQuantity(500, resource.DecimalSI),
+									"kubernetes.io/batch-memory": *resource.NewQuantity(200, resource.BinarySI),
+								},
+								Requests: map[v1.ResourceName]resource.Quantity{
+									"kubernetes.io/batch-cpu": *resource.NewQuantity(300, resource.DecimalSI),
+								},
+							},
+						},
+					},
+				},
+				Status: v1.PodStatus{
+					ContainerStatuses: []v1.ContainerStatus{
+						{
+							Name:        "container-1",
+							ContainerID: "containerd://111",
+						},
+						{
+							Name:        "container-2",
+							ContainerID: "docker://222",
+						},
+					},
+					InitContainerStatuses: []v1.ContainerStatus{
+						{
+							Name:        "init-container-1",
+							ContainerID: "docker://000",
+						},
+					},
+				},
+			},
+			want: []Resources{
+				// init-container-1
+				{
+					CgroupSubSystem: "cpu",
+					ContainerID:     "docker://000",
+					SubPath:         "cpu.shares",
+					Value:           1024,
+				},
+				{
+					CgroupSubSystem: "cpu",
+					ContainerID:     "docker://000",
+					SubPath:         "cpu.cfs_quota_us",
+					Value:           200000,
+				},
+				{
+					CgroupSubSystem: "memory",
+					ContainerID:     "docker://000",
+					SubPath:         "memory.limit_in_bytes",
+					Value:           400,
+				},
+				// container-1
+				{
+					CgroupSubSystem: "cpu",
+					ContainerID:     "containerd://111",
+					SubPath:         "cpu.shares",
+					Value:           512,
+				},
+				{
+					CgroupSubSystem: "cpu",
+					ContainerID:     "containerd://111",
+					SubPath:         "cpu.cfs_quota_us",
+					Value:           100000,
+				},
+				{
+					CgroupSubSystem: "memory",
+					ContainerID:     "containerd://111",
+					SubPath:         "memory.limit_in_bytes",
+					Value:           200,
+				},
+				// container-2
+				{
+					CgroupSubSystem: "cpu",
+					ContainerID:     "docker://222",
+					SubPath:         "cpu.shares",
+					Value:           307,
+				},
+				{
+					CgroupSubSystem: "cpu",
+					ContainerID:     "docker://222",
+					SubPath:         "cpu.cfs_quota_us",
+					Value:           50000,
+				},
+				{
+					CgroupSubSystem: "memory",
+					ContainerID:     "docker://222",
+					SubPath:         "memory.limit_in_bytes",
+					Value:           200,
+				},
+				// pod level
+				{
+					CgroupSubSystem: "cpu",
+					SubPath:         "cpu.shares",
+					Value:           1024, // max(512+307, 1024) = 1024
+				},
+				{
+					CgroupSubSystem: "cpu",
+					SubPath:         "cpu.cfs_quota_us",
+					Value:           200000, // max(100000+50000, 200000) = 200000
+				},
+				{
+					CgroupSubSystem: "memory",
+					SubPath:         "memory.limit_in_bytes",
+					Value:           400, // max(200+200, 400) = 400
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := CalculateExtendResources(tt.pod); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("CalculateExtendResources() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCalculateExtendResourcesV2(t *testing.T) {
+	tests := []struct {
+		name string
+		pod  *v1.Pod
+		want []Resources
+	}{
+		{
+			name: "both init and app containers with custom resources",
+			pod: &v1.Pod{
+				Spec: v1.PodSpec{
+					InitContainers: []v1.Container{
+						{
+							Name: "init-container-1",
+							Resources: v1.ResourceRequirements{
+								Limits: map[v1.ResourceName]resource.Quantity{
+									"kubernetes.io/batch-cpu":    *resource.NewQuantity(2000, resource.DecimalSI),
+									"kubernetes.io/batch-memory": *resource.NewQuantity(400, resource.BinarySI),
+								},
+								Requests: map[v1.ResourceName]resource.Quantity{
+									"kubernetes.io/batch-cpu": *resource.NewQuantity(1000, resource.DecimalSI),
+								},
+							},
+						},
+					},
+					Containers: []v1.Container{
+						{
+							Name: "container-1",
+							Resources: v1.ResourceRequirements{
+								Limits: map[v1.ResourceName]resource.Quantity{
+									"kubernetes.io/batch-cpu":    *resource.NewQuantity(1000, resource.DecimalSI),
+									"kubernetes.io/batch-memory": *resource.NewQuantity(200, resource.BinarySI),
+								},
+								Requests: map[v1.ResourceName]resource.Quantity{
+									"kubernetes.io/batch-cpu": *resource.NewQuantity(500, resource.DecimalSI),
+								},
+							},
+						},
+					},
+				},
+				Status: v1.PodStatus{
+					ContainerStatuses: []v1.ContainerStatus{
+						{
+							Name:        "container-1",
+							ContainerID: "containerd://111",
+						},
+					},
+					InitContainerStatuses: []v1.ContainerStatus{
+						{
+							Name:        "init-container-1",
+							ContainerID: "docker://000",
+						},
+					},
+				},
+			},
+			want: []Resources{
+				// init container-1
+				{
+					CgroupSubSystem: "cpu",
+					ContainerID:     "docker://000",
+					SubPath:         "cpu.weight",
+					Value:           100, // 1000 / 10
+				},
+				{
+					CgroupSubSystem: "cpu",
+					ContainerID:     "docker://000",
+					SubPath:         "cpu.max",
+					Value:           200000, // 2000 * 100000 / 1000
+				},
+				{
+					CgroupSubSystem: "memory",
+					ContainerID:     "docker://000",
+					SubPath:         "memory.max",
+					Value:           400,
+				},
+				// container-1
+				{
+					CgroupSubSystem: "cpu",
+					ContainerID:     "containerd://111",
+					SubPath:         "cpu.weight",
+					Value:           50, // 500 / 10
+				},
+				{
+					CgroupSubSystem: "cpu",
+					ContainerID:     "containerd://111",
+					SubPath:         "cpu.max",
+					Value:           100000,
+				},
+				{
+					CgroupSubSystem: "memory",
+					ContainerID:     "containerd://111",
+					SubPath:         "memory.max",
+					Value:           200,
+				},
+				// pod level
+				{
+					CgroupSubSystem: "cpu",
+					SubPath:         "cpu.weight",
+					Value:           100, // max(50, 100)
+				},
+				{
+					CgroupSubSystem: "cpu",
+					SubPath:         "cpu.max",
+					Value:           200000, // max(100000, 200000)
+				},
+				{
+					CgroupSubSystem: "memory",
+					SubPath:         "memory.max",
+					Value:           400, // max(200, 400)
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := CalculateExtendResourcesV2(tt.pod); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("CalculateExtendResourcesV2() = %v, want %v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
#### What type of PR is this?

Bug fix

#### What this PR does / why we need it:

`CalculateExtendResources` (cgroup v1) and `CalculateExtendResourcesV2` (cgroup v2) in `pkg/agent/utils/pod/resources.go` skip `pod.Spec.InitContainers` entirely. This means:

1. Init containers never get container-level cgroup limits (cpu shares/weight, cpu quota/max, memory limit/max).
2. Pod-level cgroup aggregates only reflect app containers, violating the Kubernetes resource model where effective pod resources = `max(sum(apps), max(inits))`.

This PR adds init container processing to both functions and computes pod-level aggregates correctly.

**Before** — only app containers processed:

```go
// TODO: support init containers.
for _, c := range pod.Spec.Containers {
    cpuShares := int64(milliCPUToShares(cpuReq.Value()))
    cpuSharesTotal += cpuShares
    // ...
}
// pod level
containerRes = append(containerRes, Resources{..., Value: cpuSharesTotal})
```

**After** — init containers processed, pod-level uses `max(sum(apps), max(inits))`:

```go
// process init containers — track max (they run sequentially)
for _, ic := range pod.Spec.InitContainers {
    cpuShares := int64(milliCPUToShares(cpuReq.Value()))
    if cpuShares > initCpuSharesMax {
        initCpuSharesMax = cpuShares
    }
    // ...container-level cgroup entries written here
}

// process app containers — sum (they run concurrently)
for _, c := range pod.Spec.Containers {
    cpuShares := int64(milliCPUToShares(cpuReq.Value()))
    appCpuSharesTotal += cpuShares
    // ...
}

// pod level: max(sum_apps, max_inits)
cpuSharesTotal := appCpuSharesTotal
if initCpuSharesMax > cpuSharesTotal {
    cpuSharesTotal = initCpuSharesMax
}
```

**Aggregation logic (cgroup v1):**

```mermaid
graph TD
    A([Pod]) --> B["Init containers<br/>(sequential)"]
    A --> C["App containers<br/>(concurrent)"]
    B --> D["max(init₁, init₂, ...)"]
    C --> E["sum(app₁ + app₂ + ...)"]
    D --> F["Pod cgroup =<br/>max(sum_apps, max_inits)"]
    E --> F
```

**Aggregation logic (cgroup v2):**

```mermaid
graph TD
    A([Pod]) --> B["Init containers<br/>cpu.weight / cpu.max / memory.max"]
    A --> C["App containers<br/>cpu.weight / cpu.max / memory.max"]
    B --> D["max across init containers"]
    C --> E["sum across app containers"]
    D --> F["Pod cgroup v2 =<br/>max(sum_apps, max_inits)"]
    E --> F
```

#### Which issue(s) this PR fixes:

Fixes https://github.com/volcano-sh/volcano/issues/5407

#### Special notes for your reviewer:

- The same aggregation pattern is applied to both `CalculateExtendResources` (v1) and `CalculateExtendResourcesV2` (v2).
- Unit tests added for both versions covering pods with init containers that exceed, equal, and fall below app container totals.
- Tests cross-compiled with `GOOS=linux` (cgroup dependency requires linux syscalls).

#### Does this PR introduce a user-facing change?

```release-note
volcano-agent now sets cgroup limits for init containers and includes them in pod-level resource aggregation using max(sum(apps), max(inits)).
```
