### PR TITLE
use int64 for partition policy product checks in admit_job

### DIFF
--- a/pkg/webhooks/admission/jobs/validate/admit_job.go
+++ b/pkg/webhooks/admission/jobs/validate/admit_job.go
@@ -306,13 +306,17 @@ func validateJobUpdate(old, new *v1alpha1.Job) error {
 func validatePartitionPolicy(task v1alpha1.TaskSpec, job *v1alpha1.Job) string {
 	var msg string
 	if task.PartitionPolicy != nil {
+		// Compute the products in int64 so large user-supplied partition counts
+		// cannot wrap the int32 product back onto a small Replicas/MinAvailable.
+		totalProduct := int64(task.PartitionPolicy.TotalPartitions) * int64(task.PartitionPolicy.PartitionSize)
+		minProduct := int64(task.PartitionPolicy.MinPartitions) * int64(task.PartitionPolicy.PartitionSize)
 		if task.PartitionPolicy.TotalPartitions <= 0 {
 			msg += fmt.Sprintf("'TotalPartitions' must be greater than 0 in task: %s, job: %s", task.Name, job.Name)
 		} else if task.PartitionPolicy.PartitionSize <= 0 {
 			msg += fmt.Sprintf("'PartitionSize' must be greater than 0 in task: %s, job: %s", task.Name, job.Name)
-		} else if task.Replicas != task.PartitionPolicy.TotalPartitions*task.PartitionPolicy.PartitionSize {
+		} else if int64(task.Replicas) != totalProduct {
 			msg += fmt.Sprintf("'Replicas' are not equal to TotalPartitions*PartitionSize in task: %s, job: %s", task.Name, job.Name)
-		} else if task.MinAvailable != nil && task.PartitionPolicy.MinPartitions > 0 && task.PartitionPolicy.MinPartitions*task.PartitionPolicy.PartitionSize != *task.MinAvailable {
+		} else if task.MinAvailable != nil && task.PartitionPolicy.MinPartitions > 0 && minProduct != int64(*task.MinAvailable) {
 			// Only enforce the minAvailable == minPartitions*partitionSize relationship
 			// when minPartitions is explicitly set (> 0). When minPartitions is omitted
 			// (defaults to 0), minAvailable falls back to replicas, so skip this check.

--- a/pkg/webhooks/admission/jobs/validate/admit_job_test.go
+++ b/pkg/webhooks/admission/jobs/validate/admit_job_test.go
@@ -1291,6 +1291,90 @@ func TestValidateJobCreate(t *testing.T) {
 			ret:            "'Replicas' are not equal to TotalPartitions*PartitionSize in task: task-1, job: task-with-invalid-PartitionPolicy",
 			ExpectErr:      true,
 		},
+		// task-with-overflow-PartitionPolicy: TotalPartitions*PartitionSize wraps in int32 to equal Replicas
+		{
+			Name:                     "task-with-overflow-PartitionPolicy",
+			PodLevelResourcesEnabled: false,
+			Job: v1alpha1.Job{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "task-with-overflow-PartitionPolicy",
+					Namespace: namespace,
+				},
+				Spec: v1alpha1.JobSpec{
+					MinAvailable: 1,
+					Queue:        "default",
+					Tasks: []v1alpha1.TaskSpec{
+						{
+							Name:     "task-1",
+							Replicas: 2,
+							PartitionPolicy: &v1alpha1.PartitionPolicySpec{
+								PartitionSize:   3,
+								TotalPartitions: 1431655766,
+							},
+							Template: v1.PodTemplateSpec{
+								ObjectMeta: metav1.ObjectMeta{
+									Labels: map[string]string{"name": "test"},
+								},
+								Spec: v1.PodSpec{
+									Containers: []v1.Container{
+										{
+											Name:  "fake-name",
+											Image: "busybox:1.24",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			reviewResponse: admissionv1.AdmissionResponse{Allowed: false},
+			ret:            "'Replicas' are not equal to TotalPartitions*PartitionSize in task: task-1, job: task-with-overflow-PartitionPolicy",
+			ExpectErr:      true,
+		},
+		// task-with-overflow-MinAvailable-PartitionPolicy: MinPartitions*PartitionSize wraps in int32 to equal MinAvailable
+		{
+			Name:                     "task-with-overflow-MinAvailable-PartitionPolicy",
+			PodLevelResourcesEnabled: false,
+			Job: v1alpha1.Job{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "task-with-overflow-MinAvailable-PartitionPolicy",
+					Namespace: namespace,
+				},
+				Spec: v1alpha1.JobSpec{
+					MinAvailable: 1,
+					Queue:        "default",
+					Tasks: []v1alpha1.TaskSpec{
+						{
+							Name:         "task-1",
+							MinAvailable: &minAvailable,
+							Replicas:     8,
+							PartitionPolicy: &v1alpha1.PartitionPolicySpec{
+								PartitionSize:   4,
+								TotalPartitions: 2,
+								MinPartitions:   1073741825,
+							},
+							Template: v1.PodTemplateSpec{
+								ObjectMeta: metav1.ObjectMeta{
+									Labels: map[string]string{"name": "test"},
+								},
+								Spec: v1.PodSpec{
+									Containers: []v1.Container{
+										{
+											Name:  "fake-name",
+											Image: "busybox:1.24",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			reviewResponse: admissionv1.AdmissionResponse{Allowed: false},
+			ret:            "'MinAvailable' is not equal to MinPartitions*PartitionSize in task: task-1, job: task-with-overflow-MinAvailable-PartitionPolicy",
+			ExpectErr:      true,
+		},
 		// task-with-valid-PartitionPolicy: replicas equal to TotalPartitions*PartitionSize
 		{
 			Name:                     "task-with-valid-PartitionPolicy",


### PR DESCRIPTION
1. validatePartitionPolicy checks Replicas == TotalPartitions*PartitionSize and MinAvailable == MinPartitions*PartitionSize using int32 multiplication on the task fields, which a namespace user controls when creating a Job.
2. a large factor makes the int32 product wrap back down to the small Replicas/MinAvailable value, so the consistency check passes and an inconsistent partition policy is admitted. For example TotalPartitions=1431655766, PartitionSize=3, Replicas=2 wraps to 2 and validates.
3. Widened both products to int64 before comparing so wraparound can no longer satisfy the check, and added a regression case to TestValidateJobCreate.
