### PR TITLE
Fix unbounded job.Status.Conditions growth

### DIFF
--- a/pkg/controllers/job/job_controller_actions.go
+++ b/pkg/controllers/job/job_controller_actions.go
@@ -1077,7 +1077,9 @@ func appendJobCondition(conditions []batch.JobCondition, c batch.JobCondition) [
 	}
 	conditions = append(conditions, c)
 	if len(conditions) > maxJobConditions {
-		conditions = conditions[len(conditions)-maxJobConditions:]
+		newConditions := make([]batch.JobCondition, maxJobConditions)
+		copy(newConditions, conditions[len(conditions)-maxJobConditions:])
+		return newConditions
 	}
 	return conditions
 }

--- a/pkg/controllers/job/job_controller_actions.go
+++ b/pkg/controllers/job/job_controller_actions.go
@@ -1073,6 +1073,7 @@ const maxJobConditions = 32
 // only the most recent maxJobConditions entries are kept.
 func appendJobCondition(conditions []batch.JobCondition, c batch.JobCondition) []batch.JobCondition {
 	if n := len(conditions); n > 0 && conditions[n-1].Status == c.Status {
+		conditions[n-1] = c
 		return conditions
 	}
 	conditions = append(conditions, c)

--- a/pkg/controllers/job/job_controller_actions.go
+++ b/pkg/controllers/job/job_controller_actions.go
@@ -232,7 +232,7 @@ func (cc *jobcontroller) killPods(jobInfo *apis.JobInfo, podRetainPhase state.Ph
 		if updateStatus(&job.Status) {
 			job.Status.State.LastTransitionTime = metav1.Now()
 			jobCondition := newCondition(job.Status.State.Phase, &job.Status.State.LastTransitionTime)
-			job.Status.Conditions = append(job.Status.Conditions, jobCondition)
+			job.Status.Conditions = appendJobCondition(job.Status.Conditions, jobCondition)
 		}
 	}
 
@@ -423,7 +423,7 @@ func (cc *jobcontroller) syncJob(jobInfo *apis.JobInfo, updateStatus state.Updat
 		}
 		job.Status.State.LastTransitionTime = metav1.Now()
 		jobCondition = newCondition(job.Status.State.Phase, &job.Status.State.LastTransitionTime)
-		job.Status.Conditions = append(job.Status.Conditions, jobCondition)
+		job.Status.Conditions = appendJobCondition(job.Status.Conditions, jobCondition)
 		newJob, err := cc.vcClient.BatchV1alpha1().Jobs(job.Namespace).UpdateStatus(context.TODO(), job, metav1.UpdateOptions{})
 		if err != nil {
 			klog.Errorf("Failed to update status of Job %v/%v: %v",
@@ -609,7 +609,7 @@ func (cc *jobcontroller) syncJob(jobInfo *apis.JobInfo, updateStatus state.Updat
 	job.Status = newStatus
 	job.Status.State.LastTransitionTime = metav1.Now()
 	jobCondition = newCondition(job.Status.State.Phase, &job.Status.State.LastTransitionTime)
-	job.Status.Conditions = append(job.Status.Conditions, jobCondition)
+	job.Status.Conditions = appendJobCondition(job.Status.Conditions, jobCondition)
 	newJob, err := cc.vcClient.BatchV1alpha1().Jobs(job.Namespace).UpdateStatus(context.TODO(), job, metav1.UpdateOptions{})
 	if err != nil {
 		klog.Errorf("Failed to update status of Job %v/%v: %v",
@@ -967,7 +967,7 @@ func (cc *jobcontroller) initJobStatus(job *batch.Job) (*batch.Job, error) {
 	job.Status.State.LastTransitionTime = metav1.Now()
 	job.Status.MinAvailable = job.Spec.MinAvailable
 	jobCondition := newCondition(job.Status.State.Phase, &job.Status.State.LastTransitionTime)
-	job.Status.Conditions = append(job.Status.Conditions, jobCondition)
+	job.Status.Conditions = appendJobCondition(job.Status.Conditions, jobCondition)
 	newJob, err := cc.vcClient.BatchV1alpha1().Jobs(job.Namespace).UpdateStatus(context.TODO(), job, metav1.UpdateOptions{})
 	if err != nil {
 		klog.Errorf("Failed to update status of Job %v/%v: %v",
@@ -1060,6 +1060,26 @@ func newCondition(status batch.JobPhase, lastTransitionTime *metav1.Time) batch.
 		Status:             status,
 		LastTransitionTime: lastTransitionTime,
 	}
+}
+
+// maxJobConditions is the upper bound on the number of conditions retained in
+// job.Status.Conditions.  Keeping the slice bounded prevents the etcd object
+// from growing without limit on long-running or frequently-restarted jobs.
+const maxJobConditions = 32
+
+// appendJobCondition appends c to conditions, but skips the append when the
+// incoming phase matches the most-recent entry (no-op transition).  If the
+// slice would exceed maxJobConditions the oldest entries are discarded so that
+// only the most recent maxJobConditions entries are kept.
+func appendJobCondition(conditions []batch.JobCondition, c batch.JobCondition) []batch.JobCondition {
+	if n := len(conditions); n > 0 && conditions[n-1].Status == c.Status {
+		return conditions
+	}
+	conditions = append(conditions, c)
+	if len(conditions) > maxJobConditions {
+		conditions = conditions[len(conditions)-maxJobConditions:]
+	}
+	return conditions
 }
 
 func setPgSubGroupPolicy(pg *scheduling.PodGroup, tasks []batch.TaskSpec) {

--- a/pkg/controllers/job/job_controller_actions.go
+++ b/pkg/controllers/job/job_controller_actions.go
@@ -1062,27 +1062,16 @@ func newCondition(status batch.JobPhase, lastTransitionTime *metav1.Time) batch.
 	}
 }
 
-// maxJobConditions is the upper bound on the number of conditions retained in
-// job.Status.Conditions.  Keeping the slice bounded prevents the etcd object
-// from growing without limit on long-running or frequently-restarted jobs.
-const maxJobConditions = 32
-
-// appendJobCondition appends c to conditions, but skips the append when the
-// incoming phase matches the most-recent entry (no-op transition).  If the
-// slice would exceed maxJobConditions the oldest entries are discarded so that
-// only the most recent maxJobConditions entries are kept.
+// appendJobCondition appends c to conditions. If a condition with the same
+// phase already exists, it is removed and the new condition is appended at the end.
 func appendJobCondition(conditions []batch.JobCondition, c batch.JobCondition) []batch.JobCondition {
-	if n := len(conditions); n > 0 && conditions[n-1].Status == c.Status {
-		conditions[n-1] = c
-		return conditions
+	res := make([]batch.JobCondition, 0, len(conditions))
+	for _, cond := range conditions {
+		if cond.Status != c.Status {
+			res = append(res, cond)
+		}
 	}
-	conditions = append(conditions, c)
-	if len(conditions) > maxJobConditions {
-		newConditions := make([]batch.JobCondition, maxJobConditions)
-		copy(newConditions, conditions[len(conditions)-maxJobConditions:])
-		return newConditions
-	}
-	return conditions
+	return append(res, c)
 }
 
 func setPgSubGroupPolicy(pg *scheduling.PodGroup, tasks []batch.TaskSpec) {

--- a/pkg/controllers/job/job_controller_actions_test.go
+++ b/pkg/controllers/job/job_controller_actions_test.go
@@ -1481,3 +1481,81 @@ func TestGetSubGroupPolicy(t *testing.T) {
 		})
 	}
 }
+
+func TestAppendJobCondition(t *testing.T) {
+	testcases := []struct {
+		Name          string
+		Conditions    []v1alpha1.JobCondition
+		NewCondition  v1alpha1.JobCondition
+		ExpectedLen   int
+		ExpectedPhase v1alpha1.JobPhase
+	}{
+		{
+			Name:       "Append to empty conditions",
+			Conditions: []v1alpha1.JobCondition{},
+			NewCondition: v1alpha1.JobCondition{
+				Status: v1alpha1.Pending,
+			},
+			ExpectedLen:   1,
+			ExpectedPhase: v1alpha1.Pending,
+		},
+		{
+			Name: "Skip append if phase is same as last",
+			Conditions: []v1alpha1.JobCondition{
+				{Status: v1alpha1.Pending},
+				{Status: v1alpha1.Running},
+			},
+			NewCondition: v1alpha1.JobCondition{
+				Status: v1alpha1.Running,
+			},
+			ExpectedLen:   2,
+			ExpectedPhase: v1alpha1.Running,
+		},
+		{
+			Name: "Append if phase is different",
+			Conditions: []v1alpha1.JobCondition{
+				{Status: v1alpha1.Pending},
+				{Status: v1alpha1.Running},
+			},
+			NewCondition: v1alpha1.JobCondition{
+				Status: v1alpha1.Completed,
+			},
+			ExpectedLen:   3,
+			ExpectedPhase: v1alpha1.Completed,
+		},
+		{
+			Name: "Cap at maxJobConditions",
+			Conditions: func() []v1alpha1.JobCondition {
+				conds := make([]v1alpha1.JobCondition, maxJobConditions)
+				for i := range conds {
+					// alternate phases so they don't dedup
+					if i%2 == 0 {
+						conds[i] = v1alpha1.JobCondition{Status: v1alpha1.Running}
+					} else {
+						conds[i] = v1alpha1.JobCondition{Status: v1alpha1.Restarting}
+					}
+				}
+				return conds
+			}(),
+			NewCondition: v1alpha1.JobCondition{
+				Status: v1alpha1.Failed,
+			},
+			ExpectedLen:   maxJobConditions,
+			ExpectedPhase: v1alpha1.Failed, // oldest got truncated, newest appended
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.Name, func(t *testing.T) {
+			result := appendJobCondition(tc.Conditions, tc.NewCondition)
+
+			if len(result) != tc.ExpectedLen {
+				t.Errorf("Expected length %d, got %d", tc.ExpectedLen, len(result))
+			}
+
+			if result[len(result)-1].Status != tc.ExpectedPhase {
+				t.Errorf("Expected last phase %v, got %v", tc.ExpectedPhase, result[len(result)-1].Status)
+			}
+		})
+	}
+}

--- a/pkg/controllers/job/job_controller_actions_test.go
+++ b/pkg/controllers/job/job_controller_actions_test.go
@@ -1500,16 +1500,16 @@ func TestAppendJobCondition(t *testing.T) {
 			ExpectedPhase: v1alpha1.Pending,
 		},
 		{
-			Name: "Skip append if phase is same as last",
+			Name: "Replace existing condition with same phase",
 			Conditions: []v1alpha1.JobCondition{
 				{Status: v1alpha1.Pending},
 				{Status: v1alpha1.Running},
 			},
 			NewCondition: v1alpha1.JobCondition{
-				Status: v1alpha1.Running,
+				Status: v1alpha1.Pending,
 			},
 			ExpectedLen:   2,
-			ExpectedPhase: v1alpha1.Running,
+			ExpectedPhase: v1alpha1.Pending,
 		},
 		{
 			Name: "Append if phase is different",
@@ -1522,26 +1522,6 @@ func TestAppendJobCondition(t *testing.T) {
 			},
 			ExpectedLen:   3,
 			ExpectedPhase: v1alpha1.Completed,
-		},
-		{
-			Name: "Cap at maxJobConditions",
-			Conditions: func() []v1alpha1.JobCondition {
-				conds := make([]v1alpha1.JobCondition, maxJobConditions)
-				for i := range conds {
-					// alternate phases so they don't dedup
-					if i%2 == 0 {
-						conds[i] = v1alpha1.JobCondition{Status: v1alpha1.Running}
-					} else {
-						conds[i] = v1alpha1.JobCondition{Status: v1alpha1.Restarting}
-					}
-				}
-				return conds
-			}(),
-			NewCondition: v1alpha1.JobCondition{
-				Status: v1alpha1.Failed,
-			},
-			ExpectedLen:   maxJobConditions,
-			ExpectedPhase: v1alpha1.Failed, // oldest got truncated, newest appended
 		},
 	}
 


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
This PR fixes an issue where `job.Status.Conditions` grows unbounded during frequent job phase transitions (especially for jobs with `RestartJob` policies that retry often). Previously, every phase transition unconditionally appended a new condition without deduplication or a maximum length check. 

For heavily retried jobs, this slice could easily accumulate thousands of entries, eventually causing the `UpdateStatus` call to permanently fail with `etcdserver: request is too large`. At this point, the job becomes unrecoverable without manual deletion.

This fix introduces an `appendJobCondition` helper that:
1. Skips appending if the new condition's phase is identical to the most recent one (deduplicating redundant consecutive states).
2. Enforces a hard cap of `maxJobConditions = 32`, truncating the oldest entries to ensure the etcd object size remains bounded and safe.

#### Which issue(s) this PR fixes:
Fixes #5421

#### Special notes for your reviewer:
The `maxJobConditions` is set to 32, which is more than enough to capture the recent historical context of a job's state transitions without risking etcd size limits.

#### Does this PR introduce a user-facing change?
```release-note
Fixed an issue where frequently restarting jobs could exceed etcd object size limits by capping `job.Status.Conditions` to a maximum of 32 entries and deduplicating consecutive identical phases.
