### PR TITLE
scheduler/api: suppress MaxFloat64 sentinel values in Resource.String()

### DIFF
--- a/pkg/scheduler/api/resource_info.go
+++ b/pkg/scheduler/api/resource_info.go
@@ -44,6 +44,10 @@ const (
 
 const (
 	minResource float64 = 0.1
+
+	// unlimitedResourceStr is printed by Resource.String() when a field holds
+	// math.MaxFloat64, which is used as a sentinel meaning "no limit".
+	unlimitedResourceStr = "<unlimited>"
 )
 
 // DimensionDefaultValue means default value for black resource dimension
@@ -168,7 +172,7 @@ func (r *Resource) Clone() *Resource {
 
 // String returns resource details in string format
 func (r *Resource) String() string {
-	str := fmt.Sprintf("cpu %0.2f, memory %0.2f", r.MilliCPU, r.Memory)
+	str := fmt.Sprintf("cpu %s, memory %s", formatResourceValue(r.MilliCPU), formatResourceValue(r.Memory))
 	// Sort scalar resource names to ensure consistent string output
 	var resourceNames []string
 	for rName := range r.ScalarResources {
@@ -176,9 +180,21 @@ func (r *Resource) String() string {
 	}
 	sort.Strings(resourceNames)
 	for _, rName := range resourceNames {
-		str = fmt.Sprintf("%s, %s %0.2f", str, rName, r.ScalarResources[v1.ResourceName(rName)])
+		val := r.ScalarResources[v1.ResourceName(rName)]
+		str = fmt.Sprintf("%s, %s %s", str, rName, formatResourceValue(val))
 	}
 	return str
+}
+
+// formatResourceValue formats a resource quantity for human-readable output.
+// It returns unlimitedResourceStr when v equals math.MaxFloat64, which is used
+// throughout the scheduler as a sentinel value meaning "no resource limit".
+// Otherwise it returns the value formatted to two decimal places.
+func formatResourceValue(v float64) string {
+	if v == math.MaxFloat64 {
+		return unlimitedResourceStr
+	}
+	return fmt.Sprintf("%0.2f", v)
 }
 
 // ResourceNames returns all resource types

--- a/pkg/scheduler/api/resource_info.go
+++ b/pkg/scheduler/api/resource_info.go
@@ -50,6 +50,13 @@ const (
 	unlimitedResourceStr = "<unlimited>"
 )
 
+// IsUnlimited reports whether v is one of the scheduler's "no limit" sentinels:
+// math.MaxFloat64 (used for cpu/memory, see InfiniteResource) or
+// float64(math.MaxInt64) (used for scalar resources, see capacity.go).
+func IsUnlimited(v float64) bool {
+	return v == math.MaxFloat64 || v == float64(math.MaxInt64)
+}
+
 // DimensionDefaultValue means default value for black resource dimension
 type DimensionDefaultValue int
 
@@ -185,13 +192,11 @@ func (r *Resource) String() string {
 	}
 	return str
 }
-
 // formatResourceValue formats a resource quantity for human-readable output.
-// It returns unlimitedResourceStr when v equals math.MaxFloat64, which is used
-// throughout the scheduler as a sentinel value meaning "no resource limit".
-// Otherwise it returns the value formatted to two decimal places.
+// It returns unlimitedResourceStr when v is one of the scheduler's "unlimited"
+// sentinel values. Otherwise it returns the value formatted to two decimal places.
 func formatResourceValue(v float64) string {
-	if v == math.MaxFloat64 {
+	if IsUnlimited(v) {
 		return unlimitedResourceStr
 	}
 	return fmt.Sprintf("%0.2f", v)

--- a/pkg/scheduler/api/resource_info_test.go
+++ b/pkg/scheduler/api/resource_info_test.go
@@ -126,15 +126,27 @@ func TestResourceString(t *testing.T) {
 			expected: "cpu 4000.00, memory <unlimited>",
 		},
 		{
-			name: "MaxFloat64 in scalar resource prints as <unlimited>",
+			name: "MaxInt64 in scalar resource prints as <unlimited>",
 			resource: &Resource{
 				MilliCPU: 1000,
 				Memory:   2048,
 				ScalarResources: map[v1.ResourceName]float64{
-					"nvidia.com/gpu": math.MaxFloat64,
+					"nvidia.com/gpu": float64(math.MaxInt64),
 				},
 			},
 			expected: "cpu 1000.00, memory 2048.00, nvidia.com/gpu <unlimited>",
+		},
+		{
+			name: "mixed finite and both sentinel types",
+			resource: &Resource{
+				MilliCPU: math.MaxFloat64,
+				Memory:   4096,
+				ScalarResources: map[v1.ResourceName]float64{
+					"nvidia.com/gpu": float64(math.MaxInt64),
+					"pods":           float64(math.MaxInt64),
+				},
+			},
+			expected: "cpu <unlimited>, memory 4096.00, nvidia.com/gpu <unlimited>, pods <unlimited>",
 		},
 	}
 

--- a/pkg/scheduler/api/resource_info_test.go
+++ b/pkg/scheduler/api/resource_info_test.go
@@ -79,6 +79,75 @@ func TestInfiniteResource(t *testing.T) {
 	}
 }
 
+// TestResourceString verifies that Resource.String() formats sentinel values correctly.
+// Regression test for https://github.com/volcano-sh/volcano/issues/5148:
+// when MilliCPU, Memory, or a scalar resource holds math.MaxFloat64 (the sentinel used
+// by the capacity/proportion plugins to represent "no limit"), String() must return
+// "<unlimited>" instead of a 308-digit floating-point literal.
+func TestResourceString(t *testing.T) {
+	tests := []struct {
+		name     string
+		resource *Resource
+		expected string
+	}{
+		{
+			name: "normal cpu and memory values",
+			resource: &Resource{
+				MilliCPU: 2000,
+				Memory:   4096,
+			},
+			expected: "cpu 2000.00, memory 4096.00",
+		},
+		{
+			name: "normal values with scalar resources",
+			resource: &Resource{
+				MilliCPU: 1000,
+				Memory:   2048,
+				ScalarResources: map[v1.ResourceName]float64{
+					"nvidia.com/gpu": 4,
+				},
+			},
+			expected: "cpu 1000.00, memory 2048.00, nvidia.com/gpu 4.00",
+		},
+		{
+			// Regression: math.MaxFloat64 is the sentinel value assigned to capability
+			// and realCapability when no queue capacity limit is configured.
+			// It must NOT appear as a 308-digit number in log output.
+			name:     "MaxFloat64 sentinel for cpu and memory prints as <unlimited>",
+			resource: InfiniteResource(),
+			expected: "cpu <unlimited>, memory <unlimited>",
+		},
+		{
+			name: "mixed: finite cpu, MaxFloat64 memory",
+			resource: &Resource{
+				MilliCPU: 4000,
+				Memory:   math.MaxFloat64,
+			},
+			expected: "cpu 4000.00, memory <unlimited>",
+		},
+		{
+			name: "MaxFloat64 in scalar resource prints as <unlimited>",
+			resource: &Resource{
+				MilliCPU: 1000,
+				Memory:   2048,
+				ScalarResources: map[v1.ResourceName]float64{
+					"nvidia.com/gpu": math.MaxFloat64,
+				},
+			},
+			expected: "cpu 1000.00, memory 2048.00, nvidia.com/gpu <unlimited>",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.resource.String()
+			if got != tt.expected {
+				t.Errorf("Resource.String() = %q, want %q", got, tt.expected)
+			}
+		})
+	}
+}
+
 func TestResourceAddScalar(t *testing.T) {
 	tests := []struct {
 		resource       *Resource


### PR DESCRIPTION
## What this PR does

When a queue has no explicit capability configured, Volcano uses `math.MaxFloat64` internally as a sentinel value representing unlimited resources.

Currently, `Resource.String()` formats these values using `%0.2f`, which results in extremely large numeric values appearing in scheduler logs. This makes log output difficult to read and obscures the actual meaning of the value.

This PR updates `Resource.String()` to render `math.MaxFloat64` as `<unlimited>` while preserving the existing formatting for normal resource values.

## Changes

* Add a helper to format resource values for display.
* Render `math.MaxFloat64` as `<unlimited>`.
* Update `Resource.String()` to use the helper for CPU, memory, and scalar resources.
* Add regression tests covering:

  * Normal resource values
  * Unlimited CPU and memory values
  * Mixed finite/unlimited values
  * Unlimited scalar resources

## Example

Before:

cpu 179769313486231570000000000000000000000000000000000000...

After:

cpu <unlimited>

## Testing

```bash
go test ./pkg/scheduler/api/... -run TestResourceString -v
go test ./pkg/scheduler/api/... -count=1
```

Fixes #5148
