### PR TITLE
fix: move queue inqueue accounting from JobEnqueueable predicate to J…

### DIFF
--- a/pkg/scheduler/plugins/capacity/capacity.go
+++ b/pkg/scheduler/plugins/capacity/capacity.go
@@ -775,6 +775,26 @@ func (cp *capacityPlugin) OnSessionOpen(ssn *framework.Session) {
 			return util.Reject
 		}
 
+		return util.Permit
+	})
+
+	// JobEnqueuedFn is the commit hook: it runs only after the aggregate JobEnqueueable
+	// verdict is Permit (a later plugin's Reject short-circuits JobEnqueueable before this
+	// is called). Updating inqueue here, rather than inside the JobEnqueueableFn predicate,
+	// avoids leaving a phantom inqueue reservation on the queue (and every ancestor queue)
+	// when another enqueue plugin rejects the job after capacity has already voted Permit.
+	ssn.AddJobEnqueuedFn(cp.Name(), func(obj interface{}) {
+		job := obj.(*api.JobInfo)
+		attr := cp.queueOpts[job.Queue]
+		if attr == nil || attr.realCapability == nil {
+			return
+		}
+		// Mirror the JobEnqueueableFn early return: nothing is reserved when the job has
+		// neither MinResources nor DRA min resources.
+		if job.PodGroup.Spec.MinResources == nil && !(cp.dynamicResourceAllocationEnable && attr.dra != nil && job.GetMinDRAResources() != nil) {
+			return
+		}
+
 		// job enqueued
 		deductedResources := job.DeductSchGatedResources(job.GetMinResources())
 		attr.inqueue.Add(deductedResources)
@@ -796,7 +816,6 @@ func (cp *capacityPlugin) OnSessionOpen(ssn *framework.Session) {
 			}
 		}
 		klog.V(5).Infof("job <%s/%s> enqueued", job.Namespace, job.Name)
-		return util.Permit
 	})
 
 	ssn.AddPrePredicateFn(cp.Name(), func(task *api.TaskInfo) error {

--- a/pkg/scheduler/plugins/proportion/proportion.go
+++ b/pkg/scheduler/plugins/proportion/proportion.go
@@ -432,13 +432,26 @@ func (pp *proportionPlugin) OnSessionOpen(ssn *framework.Session) {
 		inqueue, resourceNames := r.LessEqualWithDimensionAndResourcesName(attr.realCapability, minReq)
 		klog.V(5).Infof("job %s inqueue %v", job.Name, inqueue)
 		if inqueue {
-			// deduct the resources of scheduling gated tasks in a job when calculating inqueued resources
-			// so that it will not block other jobs from being inqueued.
-			attr.inqueue.Add(job.DeductSchGatedResources(minReq))
 			return util.Permit
 		}
 		ssn.RecordPodGroupEvent(job.PodGroup, v1.EventTypeNormal, string(scheduling.PodGroupUnschedulableType), util.FormatResourceNames("queue resource quota insufficient", "insufficient", resourceNames))
 		return util.Reject
+	})
+
+	// JobEnqueuedFn is the commit hook: it runs only after the aggregate JobEnqueueable
+	// verdict is Permit (a later plugin's Reject short-circuits JobEnqueueable before this
+	// is called). Updating attr.inqueue here, rather than inside the JobEnqueueableFn
+	// predicate, avoids leaving a phantom inqueue reservation when another enqueue plugin
+	// rejects the job after proportion has already voted Permit.
+	ssn.AddJobEnqueuedFn(pp.Name(), func(obj interface{}) {
+		job := obj.(*api.JobInfo)
+		attr := pp.queueOpts[job.Queue]
+		if attr == nil || attr.realCapability == nil || job.PodGroup.Spec.MinResources == nil {
+			return
+		}
+		// deduct the resources of scheduling gated tasks in a job when calculating inqueued resources
+		// so that it will not block other jobs from being inqueued.
+		attr.inqueue.Add(job.DeductSchGatedResources(job.GetMinResources()))
 	})
 
 	ssn.AddSimulateAddTaskFn(pp.Name(), func(ctx context.Context, cycleState fwk.CycleState, taskToSchedule *api.TaskInfo, taskToAdd *api.TaskInfo, nodeInfo *api.NodeInfo) error {


### PR DESCRIPTION
## Summary

This PR fixes incorrect `inqueue` resource accounting in the `proportion` and `capacity` plugins by moving accounting updates from `JobEnqueueableFn` to `JobEnqueuedFn`.

Previously, both plugins updated `inqueue` resources during the enqueue eligibility check. If a later plugin rejected the job, the enqueue operation was aborted but the resource reservation remained, resulting in stale `inqueue` accounting and potential false queue-capacity rejections.

This change aligns both plugins with the pattern already used by the `overcommit` plugin, where resource accounting is only committed after the job is successfully enqueued.

## Root Cause

`JobEnqueueableFn` is a predicate phase and can be overruled by a later plugin returning `Reject`.

However, `proportion` and `capacity` were performing `inqueue` accounting as a side effect during this phase, causing phantom reservations when:
1. A plugin returned `Permit`
2. `inqueue` resources were updated
3. A later plugin returned `Reject`
4. The job was never enqueued

As a result, queue accounting became inflated for the remainder of the scheduling session.

## Fix

### Proportion Plugin
- Removed `attr.inqueue.Add(...)` from `JobEnqueueableFn`
- Added a `JobEnqueuedFn` hook to update `inqueue` resources only after successful enqueue

### Capacity Plugin
- Removed queue and ancestor `inqueue` updates from `JobEnqueueableFn`
- Added a `JobEnqueuedFn` hook to perform leaf queue, ancestor queue, and DRA `inqueue` accounting after successful enqueue

## Impact

- Prevents phantom `inqueue` reservations
- Eliminates false `queue resource quota insufficient` rejections caused by stale accounting
- Makes enqueue accounting independent of plugin ordering
- Preserves existing behavior for successfully enqueued jobs

## Testing

- `go build ./pkg/scheduler/plugins/proportion/... ./pkg/scheduler/plugins/capacity/...`
- `go test ./pkg/scheduler/plugins/proportion/...`
- `go test ./pkg/scheduler/plugins/capacity/...`
- `go test ./pkg/scheduler/actions/enqueue/...`
- `go test ./pkg/scheduler/framework/...`