### PR TITLE
Add top-level permissions to reusable workflows

### DIFF
--- a/.github/workflows/docker_images.yaml
+++ b/.github/workflows/docker_images.yaml
@@ -3,12 +3,10 @@ name: Build Images
 on:
   workflow_call:
 
+permissions: read-all
 
 jobs:
   build-images:
-    permissions:
-      contents: read
-      actions: write
     runs-on: ubuntu-24.04
     steps:
       - name: Free Disk Space

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -15,98 +15,56 @@ permissions: read-all
 
 jobs:
   build-images:
-    permissions:
-      contents: read
-      actions: write
     uses: ./.github/workflows/docker_images.yaml
 
   e2e-admission:
     needs: build-images
-    permissions:
-      contents: read
-      actions: write
     uses: ./.github/workflows/e2e_admission.yaml
 
   e2e-cronjob:
     needs: build-images
-    permissions:
-      contents: read
-      actions: write
     uses: ./.github/workflows/e2e_cronjob.yaml
 
   e2e-dra:
     needs: build-images
-    permissions:
-      contents: read
-      actions: write
     uses: ./.github/workflows/e2e_dra.yml
 
   e2e-gangevict:
     needs: build-images
-    permissions:
-      contents: read
-      actions: write
     uses: ./.github/workflows/e2e_gangevict.yaml
 
   e2e-hypernode:
     needs: build-images
-    permissions:
-      contents: read
-      actions: write
     uses: ./.github/workflows/e2e_hypernode.yaml
 
   e2e-parallel-jobs:
     needs: build-images
-    permissions:
-      contents: read
-      actions: write
     uses: ./.github/workflows/e2e_parallel_jobs.yaml
 
   e2e-scheduling-actions:
     needs: build-images
-    permissions:
-      contents: read
-      actions: write
     uses: ./.github/workflows/e2e_scheduling_actions.yaml
 
   e2e-scheduling-gates:
     needs: build-images
-    permissions:
-      contents: read
-      actions: write
     uses: ./.github/workflows/e2e_scheduling_gates.yaml
 
   e2e-scheduling-basic:
     needs: build-images
-    permissions:
-      contents: read
-      actions: write
     uses: ./.github/workflows/e2e_scheduling_basic.yaml
 
   e2e-sequence:
     needs: build-images
-    permissions:
-      contents: read
-      actions: write
     uses: ./.github/workflows/e2e_sequence.yaml
 
   e2e-spark:
     needs: build-images
-    permissions:
-      contents: read
-      actions: write
     uses: ./.github/workflows/e2e_spark.yaml
 
   e2e-vcctl:
     needs: build-images
-    permissions:
-      contents: read
-      actions: write
     uses: ./.github/workflows/e2e_vcctl.yaml
 
   e2e-shard:
     needs: build-images
-    permissions:
-      contents: read
-      actions: write
     uses: ./.github/workflows/e2e_shard.yaml

--- a/.github/workflows/e2e_admission.yaml
+++ b/.github/workflows/e2e_admission.yaml
@@ -3,12 +3,10 @@ name: E2E Admission
 on:
   workflow_call:
 
+permissions: read-all
 
 jobs:
   e2e_admission_policy:
-    permissions:
-      contents: read
-      actions: write
     runs-on: ubuntu-24.04
     name: E2E about Admission Policy
     timeout-minutes: 50
@@ -64,9 +62,6 @@ jobs:
           path: ${{ github.workspace }}/e2e-admission-logs
 
   e2e_admission_webhook:
-    permissions:
-      contents: read
-      actions: write
     runs-on: ubuntu-24.04
     name: E2E about Admission Webhook
     timeout-minutes: 50

--- a/.github/workflows/e2e_cronjob.yaml
+++ b/.github/workflows/e2e_cronjob.yaml
@@ -3,12 +3,10 @@ name: E2E CRONJOB
 on:
   workflow_call:
 
+permissions: read-all
 
 jobs:
   cronjob:
-    permissions:
-      contents: read
-      actions: write
     runs-on: ubuntu-24.04
     name: E2E about CRONJOB
     timeout-minutes: 70

--- a/.github/workflows/e2e_dra.yml
+++ b/.github/workflows/e2e_dra.yml
@@ -3,12 +3,10 @@ name: E2E DRA
 on:
   workflow_call:
 
+permissions: read-all
 
 jobs:
   e2e_dra:
-    permissions:
-      contents: read
-      actions: write
     runs-on: ubuntu-24.04
     name: E2E about DRA
     timeout-minutes: 40

--- a/.github/workflows/e2e_gangevict.yaml
+++ b/.github/workflows/e2e_gangevict.yaml
@@ -3,12 +3,10 @@ name: E2E Gang Eviction
 on:
   workflow_call:
 
+permissions: read-all
 
 jobs:
   e2e_gangevict:
-    permissions:
-      contents: read
-      actions: write
     runs-on: ubuntu-24.04
     name: E2E about Gang Eviction
     timeout-minutes: 40

--- a/.github/workflows/e2e_hypernode.yaml
+++ b/.github/workflows/e2e_hypernode.yaml
@@ -3,12 +3,10 @@ name: E2E Hypernode
 on:
   workflow_call:
 
+permissions: read-all
 
 jobs:
   e2e_hypernode:
-    permissions:
-      contents: read
-      actions: write
     runs-on: ubuntu-24.04
     name: E2E about Hypernode
     timeout-minutes: 40

--- a/.github/workflows/e2e_parallel_jobs.yaml
+++ b/.github/workflows/e2e_parallel_jobs.yaml
@@ -3,12 +3,10 @@ name: E2E Parallel Jobs
 on:
   workflow_call:
 
+permissions: read-all
 
 jobs:
   e2e_parallel_jobs:
-    permissions:
-      contents: read
-      actions: write
     runs-on: ubuntu-24.04
     name: E2E about Parallel Jobs
     timeout-minutes: 40

--- a/.github/workflows/e2e_scheduling_actions.yaml
+++ b/.github/workflows/e2e_scheduling_actions.yaml
@@ -3,12 +3,10 @@ name: Scheduling Actions
 on:
   workflow_call:
 
+permissions: read-all
 
 jobs:
   e2e_scheduling_actions:
-    permissions:
-      contents: read
-      actions: write
     runs-on: ubuntu-24.04
     name: E2E about Scheduling Actions
     timeout-minutes: 50

--- a/.github/workflows/e2e_scheduling_basic.yaml
+++ b/.github/workflows/e2e_scheduling_basic.yaml
@@ -3,12 +3,10 @@ name: Basic scheduling Jobs
 on:
   workflow_call:
 
+permissions: read-all
 
 jobs:
   e2e_scheduling_basic:
-    permissions:
-      contents: read
-      actions: write
     runs-on: ubuntu-24.04
     name: E2E about Basic Scheduling
     timeout-minutes: 50

--- a/.github/workflows/e2e_scheduling_gates.yaml
+++ b/.github/workflows/e2e_scheduling_gates.yaml
@@ -3,12 +3,10 @@ name: Scheduling Gates
 on:
   workflow_call:
 
+permissions: read-all
 
 jobs:
   e2e_scheduling_gates:
-    permissions:
-      contents: read
-      actions: write
     runs-on: ubuntu-24.04
     name: E2E about Scheduling Gates
     timeout-minutes: 40

--- a/.github/workflows/e2e_sequence.yaml
+++ b/.github/workflows/e2e_sequence.yaml
@@ -3,12 +3,10 @@ name: E2E Sequence Jobs
 on:
   workflow_call:
 
+permissions: read-all
 
 jobs:
   e2e_sequence:
-    permissions:
-      contents: read
-      actions: write
     runs-on: ubuntu-24.04
     name: E2E about Sequence
     timeout-minutes: 50

--- a/.github/workflows/e2e_shard.yaml
+++ b/.github/workflows/e2e_shard.yaml
@@ -3,12 +3,10 @@ name: E2E Shard
 on:
   workflow_call:
 
+permissions: read-all
 
 jobs:
   e2e:
-    permissions:
-      contents: read
-      actions: write
     runs-on: ubuntu-24.04
     name: ${{ matrix.name }}
     timeout-minutes: 50

--- a/.github/workflows/e2e_spark.yaml
+++ b/.github/workflows/e2e_spark.yaml
@@ -3,12 +3,10 @@ name: E2E Spark Integration Test
 on:
   workflow_call:
 
+permissions: read-all
 
 jobs:
   k8s-integration-tests:
-    permissions:
-      contents: read
-      actions: write
     name: "E2E about Spark Integration test"
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/e2e_vcctl.yaml
+++ b/.github/workflows/e2e_vcctl.yaml
@@ -3,12 +3,10 @@ name: Vcctl Test
 on:
   workflow_call:
 
+permissions: read-all
 
 jobs:
   e2e_vcctl:
-    permissions:
-      contents: read
-      actions: write
     runs-on: ubuntu-24.04
     name: E2E about Volcano CLI
     timeout-minutes: 50


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Adds top-level `permissions: read-all` to all e2e workflows. Followed the rule described here: https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions, we can set all workflow top level permission to read-all, and openssf page Token-Permission section shows why the score low, because some workflow missed top level permission setting, and some of workflows should not set actions: write: https://scorecard.dev/viewer/?uri=github.com/volcano-sh/volcano


#### Which issue(s) this PR fixes:

Refs #5366

#### Special notes for your reviewer:

Followed #5369, the token permissions part in https://clomonitor.io/projects/cncf/volcano still didn't pass, openssf scorecard page can see the reason

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
