### PR TITLE
validate numa topology decision in AddTask and RemoveTask

### DIFF
--- a/pkg/scheduler/api/numa_info.go
+++ b/pkg/scheduler/api/numa_info.go
@@ -190,7 +190,7 @@ func (info *NumatopoInfo) RemoveTask(ti *TaskInfo) {
 		return
 	}
 
-	for numaID, resList := range ti.NumaInfo.ResMap {
+	for numaID, resList := range decision {
 		for resName, quantity := range resList {
 			resInfo, ok := info.NumaResMap[string(resName)]
 			if !ok {

--- a/pkg/scheduler/api/numa_info.go
+++ b/pkg/scheduler/api/numa_info.go
@@ -170,7 +170,15 @@ func (info *NumatopoInfo) AddTask(ti *TaskInfo) {
 
 	for numaID, resList := range numaInfo {
 		for resName, quantity := range resList {
-			info.NumaResMap[string(resName)].UsedPerNuma[numaID] += ResQuantity2Float64(resName, quantity)
+			resInfo, ok := info.NumaResMap[string(resName)]
+			if !ok {
+				continue
+			}
+			used := ResQuantity2Float64(resName, quantity)
+			if used < 0 {
+				continue
+			}
+			resInfo.UsedPerNuma[numaID] += used
 		}
 	}
 }
@@ -184,7 +192,15 @@ func (info *NumatopoInfo) RemoveTask(ti *TaskInfo) {
 
 	for numaID, resList := range ti.NumaInfo.ResMap {
 		for resName, quantity := range resList {
-			info.NumaResMap[string(resName)].UsedPerNuma[numaID] -= ResQuantity2Float64(resName, quantity)
+			resInfo, ok := info.NumaResMap[string(resName)]
+			if !ok {
+				continue
+			}
+			used := ResQuantity2Float64(resName, quantity)
+			if used < 0 {
+				continue
+			}
+			resInfo.UsedPerNuma[numaID] -= used
 		}
 	}
 }

--- a/pkg/scheduler/api/numa_info_test.go
+++ b/pkg/scheduler/api/numa_info_test.go
@@ -1,0 +1,81 @@
+/*
+Copyright 2025 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+import (
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/cpuset"
+)
+
+func newNumatopoInfoForTest() *NumatopoInfo {
+	return &NumatopoInfo{
+		Name: "node1",
+		NumaResMap: map[string]*ResourceInfo{
+			"cpu": {
+				Allocatable:        cpuset.New(0, 1, 2, 3),
+				Capacity:           4,
+				AllocatablePerNuma: map[int]float64{0: 4},
+				UsedPerNuma:        map[int]float64{0: 0},
+			},
+		},
+	}
+}
+
+func taskWithTopologyDecision(decision string) *TaskInfo {
+	return &TaskInfo{
+		Pod: &v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{topologyDecisionAnnotation: decision},
+			},
+		},
+	}
+}
+
+// A pod can carry an arbitrary volcano.sh/topology-decision annotation. AddTask
+// must not index NumaResMap with a resource the node does not track, otherwise
+// the nil entry is dereferenced and the scheduler panics.
+func TestAddTaskUnknownResource(t *testing.T) {
+	info := newNumatopoInfoForTest()
+	info.AddTask(taskWithTopologyDecision(`{"numa":{"0":{"nvidia.com/gpu":"1"}}}`))
+
+	if got := info.NumaResMap["cpu"].UsedPerNuma[0]; got != 0 {
+		t.Errorf("cpu UsedPerNuma[0] = %v, want 0", got)
+	}
+}
+
+// A negative usage in the decision would lower recorded usage below the real
+// value and make the node look emptier than it is, so it must be ignored.
+func TestAddTaskNegativeUsageIgnored(t *testing.T) {
+	info := newNumatopoInfoForTest()
+	info.AddTask(taskWithTopologyDecision(`{"numa":{"0":{"cpu":"-1000"}}}`))
+
+	if got := info.NumaResMap["cpu"].UsedPerNuma[0]; got != 0 {
+		t.Errorf("cpu UsedPerNuma[0] = %v, want 0", got)
+	}
+}
+
+func TestAddTaskValidUsage(t *testing.T) {
+	info := newNumatopoInfoForTest()
+	info.AddTask(taskWithTopologyDecision(`{"numa":{"0":{"cpu":"2"}}}`))
+
+	if got := info.NumaResMap["cpu"].UsedPerNuma[0]; got != 2000 {
+		t.Errorf("cpu UsedPerNuma[0] = %v, want 2000", got)
+	}
+}

--- a/pkg/scheduler/api/numa_info_test.go
+++ b/pkg/scheduler/api/numa_info_test.go
@@ -79,3 +79,19 @@ func TestAddTaskValidUsage(t *testing.T) {
 		t.Errorf("cpu UsedPerNuma[0] = %v, want 2000", got)
 	}
 }
+
+// RemoveTask must walk the decoded decision, the same source AddTask folds in.
+// A task can carry the topology-decision annotation while NumaInfo is unset, so
+// reading ti.NumaInfo.ResMap there would dereference a nil and panic.
+func TestRemoveTaskNilNumaInfo(t *testing.T) {
+	info := newNumatopoInfoForTest()
+	info.NumaResMap["cpu"].UsedPerNuma[0] = 2000
+
+	ti := taskWithTopologyDecision(`{"numa":{"0":{"cpu":"2"}}}`)
+	ti.NumaInfo = nil
+	info.RemoveTask(ti)
+
+	if got := info.NumaResMap["cpu"].UsedPerNuma[0]; got != 0 {
+		t.Errorf("cpu UsedPerNuma[0] = %v, want 0", got)
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

1. `NumatopoInfo.AddTask` and `RemoveTask` fold a pod into the node's per-NUMA usage from the `volcano.sh/topology-decision` pod annotation (via `GetPodResourceNumaInfo`), and any namespaced user can set that annotation on their own pods.
2. The decoded decision is trusted twice over: it indexes `info.NumaResMap[resName]` with no existence check, so a resource the node's NUMA topology does not track returns a nil `*ResourceInfo` and dereferencing it panics the scheduler; and the quantity is applied without a sign check, so a negative value lowers `UsedPerNuma` below the real usage and the node looks emptier than it is, leading to over-allocation.
3. Looked the resource up with the comma-ok form and skipped entries for unknown resources and for negative usage, at both `AddTask` and `RemoveTask`.

#### Which issue(s) this PR fixes:

N/A

#### Special notes for your reviewer:

Reproduced with a unit test in `numa_info_test.go`: a pod whose decision names `nvidia.com/gpu` on a node that only tracks `cpu` panics `AddTask` at `numa_info.go:173` before the change, and a `cpu:"-1000"` decision drives `UsedPerNuma` to `-1e6`. After the change both are skipped and a valid `cpu:"2"` decision still records `2000`. `go test ./pkg/scheduler/api/` passes.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
