### PR TITLE
fix(controller): handle multi-container pod exit codes

### DIFF
--- a/pkg/controllers/apis/request.go
+++ b/pkg/controllers/apis/request.go
@@ -37,6 +37,7 @@ type Request struct {
 	PartitionID string
 	Event       v1alpha1.Event
 	ExitCode    int32
+	ExitCodes   string
 	Action      v1alpha1.Action
 	JobVersion  int32
 }

--- a/pkg/controllers/job/job_controller_handler.go
+++ b/pkg/controllers/job/job_controller_handler.go
@@ -268,16 +268,13 @@ func (cc *jobcontroller) updatePod(oldObj, newObj interface{}) {
 
 	event := bus.OutOfSyncEvent
 	var exitCode int32
+	var exitCodes string
 
 	switch newPod.Status.Phase {
 	case v1.PodFailed:
 		if oldPod.Status.Phase != v1.PodFailed {
 			event = bus.PodFailedEvent
-			// TODO: currently only one container pod is supported by volcano
-			// Once multi containers pod is supported, update accordingly.
-			if len(newPod.Status.ContainerStatuses) > 0 && newPod.Status.ContainerStatuses[0].State.Terminated != nil {
-				exitCode = newPod.Status.ContainerStatuses[0].State.Terminated.ExitCode
-			}
+			exitCode, exitCodes = getNonZeroExitCodes(newPod.Status.ContainerStatuses)
 		}
 	case v1.PodSucceeded:
 		if oldPod.Status.Phase != v1.PodSucceeded &&
@@ -314,12 +311,32 @@ func (cc *jobcontroller) updatePod(oldObj, newObj interface{}) {
 		PartitionID: apis.GetPartitionID(newPod),
 		Event:       event,
 		ExitCode:    exitCode,
+		ExitCodes:   exitCodes,
 		JobVersion:  int32(dVersion),
 	}
 
 	key := jobhelpers.GetJobKeyByReq(&req)
 	queue := cc.getWorkerQueue(key)
 	queue.Add(req)
+}
+
+func getNonZeroExitCodes(containerStatuses []v1.ContainerStatus) (int32, string) {
+	var exitCode int32
+	var exitCodes string
+	for _, status := range containerStatuses {
+		if status.State.Terminated == nil {
+			continue
+		}
+		code := status.State.Terminated.ExitCode
+		if code == 0 {
+			continue
+		}
+		if exitCode == 0 {
+			exitCode = code
+		}
+		exitCodes += fmt.Sprintf("%d,", code)
+	}
+	return exitCode, exitCodes
 }
 
 func (cc *jobcontroller) deletePod(obj interface{}) {

--- a/pkg/controllers/job/job_controller_util.go
+++ b/pkg/controllers/job/job_controller_util.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"sort"
 	"strconv"
+	"strings"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -241,7 +242,7 @@ func applyPolicies(job *batch.Job, req *apis.Request) (delayAct *delayAction) {
 					}
 
 					// 0 is not an error code, is prevented in validation admission controller
-					if policy.ExitCode != nil && *policy.ExitCode == req.ExitCode {
+					if policy.ExitCode != nil && matchExitCode(req, *policy.ExitCode) {
 						delayAct.action = policy.Action
 						if policy.Timeout != nil {
 							delayAct.delay = policy.Timeout.Duration
@@ -271,7 +272,7 @@ func applyPolicies(job *batch.Job, req *apis.Request) (delayAct *delayAction) {
 		}
 
 		// 0 is not an error code, is prevented in validation admission controller
-		if policy.ExitCode != nil && *policy.ExitCode == req.ExitCode {
+		if policy.ExitCode != nil && matchExitCode(req, *policy.ExitCode) {
 			delayAct.action = policy.Action
 			if policy.Timeout != nil {
 				delayAct.delay = policy.Timeout.Duration
@@ -281,6 +282,16 @@ func applyPolicies(job *batch.Job, req *apis.Request) (delayAct *delayAction) {
 	}
 
 	return
+}
+
+func matchExitCode(req *apis.Request, exitCode int32) bool {
+	if exitCode == 0 {
+		return false
+	}
+	if len(req.ExitCodes) != 0 {
+		return strings.Contains(","+req.ExitCodes, fmt.Sprintf(",%d,", exitCode))
+	}
+	return req.ExitCode == exitCode
 }
 
 func shouldConfigureTimeout(event v1alpha1.Event) bool {

--- a/pkg/controllers/job/job_controller_util_test.go
+++ b/pkg/controllers/job/job_controller_util_test.go
@@ -478,6 +478,187 @@ func contains(slice []string, item string) bool {
 	return false
 }
 
+func TestGetNonZeroExitCodes(t *testing.T) {
+	statuses := []v1.ContainerStatus{
+		{
+			Name: "succeeded",
+			State: v1.ContainerState{
+				Terminated: &v1.ContainerStateTerminated{ExitCode: 0},
+			},
+		},
+		{
+			Name: "running",
+			State: v1.ContainerState{
+				Running: &v1.ContainerStateRunning{},
+			},
+		},
+		{
+			Name: "failed-42",
+			State: v1.ContainerState{
+				Terminated: &v1.ContainerStateTerminated{ExitCode: 42},
+			},
+		},
+		{
+			Name: "failed-2",
+			State: v1.ContainerState{
+				Terminated: &v1.ContainerStateTerminated{ExitCode: 2},
+			},
+		},
+	}
+
+	expectedExitCode := int32(42)
+	expectedExitCodes := "42,2,"
+	exitCode, exitCodes := getNonZeroExitCodes(statuses)
+	if exitCode != expectedExitCode {
+		t.Errorf("expected exit code %d, got %d", expectedExitCode, exitCode)
+	}
+	if exitCodes != expectedExitCodes {
+		t.Errorf("expected exit codes %s, got %s", expectedExitCodes, exitCodes)
+	}
+}
+
+func TestApplyPoliciesWithExitCodes(t *testing.T) {
+	namespace := "test"
+	errorCode2 := int32(2)
+	errorCode42 := int32(42)
+	zeroExitCode := int32(0)
+
+	testcases := []struct {
+		name      string
+		job       *v1alpha1.Job
+		request   *apis.Request
+		returnVal busv1alpha1.Action
+	}{
+		{
+			name: "task policy matches any regular container exit code",
+			job: &v1alpha1.Job{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "job1",
+					Namespace: namespace,
+				},
+				Spec: v1alpha1.JobSpec{
+					SchedulerName: "volcano",
+					Tasks: []v1alpha1.TaskSpec{
+						{
+							Name:     "task1",
+							Replicas: 1,
+							Policies: []v1alpha1.LifecyclePolicy{
+								{
+									Action:   busv1alpha1.RestartTaskAction,
+									ExitCode: &errorCode42,
+								},
+							},
+						},
+					},
+				},
+			},
+			request: &apis.Request{
+				TaskName:  "task1",
+				ExitCodes: "2,42,",
+			},
+			returnVal: busv1alpha1.RestartTaskAction,
+		},
+		{
+			name: "exit code policy order is preserved",
+			job: &v1alpha1.Job{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "job1",
+					Namespace: namespace,
+				},
+				Spec: v1alpha1.JobSpec{
+					SchedulerName: "volcano",
+					Tasks: []v1alpha1.TaskSpec{
+						{
+							Name:     "task1",
+							Replicas: 1,
+							Policies: []v1alpha1.LifecyclePolicy{
+								{
+									Action:   busv1alpha1.TerminateJobAction,
+									ExitCode: &errorCode42,
+								},
+								{
+									Action:   busv1alpha1.RestartTaskAction,
+									ExitCode: &errorCode2,
+								},
+							},
+						},
+					},
+				},
+			},
+			request: &apis.Request{
+				TaskName:  "task1",
+				ExitCodes: "2,42,",
+			},
+			returnVal: busv1alpha1.TerminateJobAction,
+		},
+		{
+			name: "job policy matches any regular container exit code",
+			job: &v1alpha1.Job{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "job1",
+					Namespace: namespace,
+				},
+				Spec: v1alpha1.JobSpec{
+					SchedulerName: "volcano",
+					Tasks: []v1alpha1.TaskSpec{
+						{
+							Name:     "task1",
+							Replicas: 1,
+						},
+					},
+					Policies: []v1alpha1.LifecyclePolicy{
+						{
+							Action:   busv1alpha1.TerminateJobAction,
+							ExitCode: &errorCode42,
+						},
+					},
+				},
+			},
+			request: &apis.Request{
+				ExitCodes: "2,42,",
+			},
+			returnVal: busv1alpha1.TerminateJobAction,
+		},
+		{
+			name: "zero exit code does not match",
+			job: &v1alpha1.Job{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "job1",
+					Namespace: namespace,
+				},
+				Spec: v1alpha1.JobSpec{
+					SchedulerName: "volcano",
+					Tasks: []v1alpha1.TaskSpec{
+						{
+							Name:     "task1",
+							Replicas: 1,
+						},
+					},
+					Policies: []v1alpha1.LifecyclePolicy{
+						{
+							Action:   busv1alpha1.TerminateJobAction,
+							ExitCode: &zeroExitCode,
+						},
+					},
+				},
+			},
+			request: &apis.Request{
+				ExitCodes: "0,",
+			},
+			returnVal: busv1alpha1.SyncJobAction,
+		},
+	}
+
+	for _, testcase := range testcases {
+		t.Run(testcase.name, func(t *testing.T) {
+			action := applyPolicies(testcase.job, testcase.request)
+			if action.action != testcase.returnVal {
+				t.Errorf("expected action %s, got %s", testcase.returnVal, action.action)
+			}
+		})
+	}
+}
+
 func TestApplyPolicies(t *testing.T) {
 	namespace := "test"
 	errorCode0 := int32(0)


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

vcjob pod failure handling only used `ContainerStatuses[0]` when setting the exit code for lifecycle policy matching.

That breaks multi-container pods when the first container exits successfully and another regular container fails with the configured `exitCode`.

This PR scans all terminated regular container statuses, records non-zero exit codes, and lets `LifecyclePolicy.ExitCode` match any of them while keeping the existing policy order.

Init containers are intentionally not included here, per the issue discussion.

#### Which issue(s) this PR fixes:

Fixes #5452

#### Special notes for your reviewer:

Kept `ExitCode` for existing request behavior and added internal multi-code matching without changing the public API.

#### Does this PR introduce a user-facing change?

```release-note
Fix vcjob lifecycle exitCode policy matching for failed multi-container pods.