### PR TITLE
feat: add nodegroup resource limits

### DIFF
--- a/docs/user-guide/how_to_use_nodegroup_plugin.md
+++ b/docs/user-guide/how_to_use_nodegroup_plugin.md
@@ -35,6 +35,48 @@ Create queue and bind nodegroup to it.
            preferredDuringSchedulingIgnoredDuringExecution:
            - <groupname>
    ```
+
+### Configure queue resource limits for each nodegroup
+
+Use the `volcano.sh/nodegroup-resource-limits` annotation to limit how many resources a queue can allocate from each nodegroup.
+
+```yaml
+apiVersion: scheduling.volcano.sh/v1beta1
+kind: Queue
+metadata:
+  name: default
+  annotations:
+    volcano.sh/nodegroup-resource-limits: |
+      {
+        "groupname1": {"cpu": "100", "memory": "200Gi"},
+        "groupname2": {"cpu": "50"}
+      }
+spec:
+  reclaimable: true
+  weight: 1
+  affinity:
+    nodeGroupAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+      - groupname1
+      - groupname2
+      preferredDuringSchedulingIgnoredDuringExecution:
+      - groupname1
+```
+
+For a task from queue `Q` scheduled to a node in nodegroup `G`, the plugin checks:
+
+```text
+allocated(Q, G) + task request <= limit(Q, G)
+```
+
+If the future usage exceeds the configured limit, the node is rejected for that task. Other allowed nodegroups remain schedulable, so the queue can prefer `groupname1` and overflow to `groupname2` when the logical limit for `groupname1` is reached.
+
+Only resource dimensions explicitly listed for a nodegroup are limited. For example, `{"groupname2": {"cpu": "50"}}` limits CPU usage in `groupname2` and does not add a memory limit for that nodegroup.
+
+If this annotation is absent, existing nodegroup behavior is unchanged. If a nodegroup is not listed in the annotation, that nodegroup has no extra limit from this feature.
+
+The annotation is not inherited by child queues when hierarchical nodegroup affinity is enabled. Each queue that needs per-nodegroup limits must define its own annotation.
+
 ### submit a vcjob
 
 submit vcjob job-1 to default queue.

--- a/pkg/scheduler/plugins/nodegroup/errors.go
+++ b/pkg/scheduler/plugins/nodegroup/errors.go
@@ -25,6 +25,10 @@ const (
 	errNodeGroupLabelNotFound = "node group label not found"
 	// errNodeUnsatisfied is returned when the node does not satisfy the node group affinity.
 	errNodeUnsatisfied = "node does not satisfy the node group affinity"
+	// errNodeGroupResourceLimitInvalid is returned when queue nodegroup resource limit annotation is invalid.
+	errNodeGroupResourceLimitInvalid = "node group resource limit annotation invalid"
+	// errNodeGroupResourceLimitExceeded is returned when the queue exceeds the nodegroup resource limit.
+	errNodeGroupResourceLimitExceeded = "node group resource limit exceeded"
 )
 
 func newFitErr(task *api.TaskInfo, node *api.NodeInfo, reason string) error {

--- a/pkg/scheduler/plugins/nodegroup/nodegroup.go
+++ b/pkg/scheduler/plugins/nodegroup/nodegroup.go
@@ -18,21 +18,23 @@ package nodegroup
 
 import (
 	"container/list"
+	"encoding/json"
 	"errors"
 	"fmt"
 
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog/v2"
 
+	schedulingv1 "volcano.sh/apis/pkg/apis/scheduling/v1beta1"
 	"volcano.sh/volcano/pkg/scheduler/api"
 	"volcano.sh/volcano/pkg/scheduler/framework"
 )
 
 const (
 	// PluginName indicates name of volcano scheduler plugin.
-	PluginName       = "nodegroup"
-	NodeGroupNameKey = "volcano.sh/nodegroup-name"
-	rootQueueID      = "root"
+	PluginName  = "nodegroup"
+	rootQueueID = "root"
 
 	BaseScore = 100
 )
@@ -76,9 +78,17 @@ func (np *nodeGroupPlugin) Name() string {
 }
 
 type queueAttr struct {
-	queueID   api.QueueID
-	ancestors *list.List
-	affinity  *queueGroupAffinity
+	queueID                 api.QueueID
+	ancestors               *list.List
+	affinity                *queueGroupAffinity
+	nodeGroupResourceLimits map[string]*nodeGroupResourceLimit
+	nodeGroupAllocated      map[string]*api.Resource
+	resourceLimitErr        error
+}
+
+type nodeGroupResourceLimit struct {
+	resource *api.Resource
+	names    sets.Set[v1.ResourceName]
 }
 
 type queueGroupAffinity struct {
@@ -90,11 +100,43 @@ type queueGroupAffinity struct {
 }
 
 func newQueueAttr(queue *api.QueueInfo) *queueAttr {
+	limits, err := parseNodeGroupResourceLimits(queue)
 	return &queueAttr{
-		queueID:   queue.UID,
-		ancestors: list.New(),
-		affinity:  newQueueGroupAffinity(queue),
+		queueID:                 queue.UID,
+		ancestors:               list.New(),
+		affinity:                newQueueGroupAffinity(queue),
+		nodeGroupResourceLimits: limits,
+		nodeGroupAllocated:      make(map[string]*api.Resource),
+		resourceLimitErr:        err,
 	}
+}
+
+func parseNodeGroupResourceLimits(queue *api.QueueInfo) (map[string]*nodeGroupResourceLimit, error) {
+	if queue == nil || queue.Queue == nil || len(queue.Queue.Annotations) == 0 {
+		return nil, nil
+	}
+	raw := queue.Queue.Annotations[schedulingv1.NodeGroupResourceLimitsAnnotationKey]
+	if raw == "" {
+		return nil, nil
+	}
+
+	resourceLists := map[string]v1.ResourceList{}
+	if err := json.Unmarshal([]byte(raw), &resourceLists); err != nil {
+		return nil, fmt.Errorf("parse annotation %s: %w", schedulingv1.NodeGroupResourceLimitsAnnotationKey, err)
+	}
+
+	limits := make(map[string]*nodeGroupResourceLimit, len(resourceLists))
+	for group, resourceList := range resourceLists {
+		limit := &nodeGroupResourceLimit{
+			resource: api.NewResource(resourceList),
+			names:    sets.New[v1.ResourceName](),
+		}
+		for name := range resourceList {
+			limit.names.Insert(name)
+		}
+		limits[group] = limit
+	}
+	return limits, nil
 }
 
 func newQueueGroupAffinity(queue *api.QueueInfo) *queueGroupAffinity {
@@ -257,13 +299,123 @@ func (np *nodeGroupPlugin) updateAffinityFromAncestor(attr *queueAttr) {
 	}
 }
 
+func (np *nodeGroupPlugin) initNodeGroupAllocated(ssn *framework.Session) {
+	for _, job := range ssn.Jobs {
+		attr := np.queueAttrs[job.Queue]
+		if attr == nil {
+			continue
+		}
+		for status, tasks := range job.TaskStatusIndex {
+			if !api.AllocatedStatus(status) {
+				continue
+			}
+			for _, task := range tasks {
+				np.addNodeGroupAllocated(ssn, attr, task)
+			}
+		}
+	}
+}
+
+func (np *nodeGroupPlugin) addNodeGroupAllocated(ssn *framework.Session, attr *queueAttr, task *api.TaskInfo) {
+	group, ok := np.taskNodeGroup(ssn, task)
+	if !ok {
+		return
+	}
+	allocated := attr.nodeGroupAllocated[group]
+	if allocated == nil {
+		allocated = api.EmptyResource()
+		attr.nodeGroupAllocated[group] = allocated
+	}
+	allocated.Add(task.Resreq)
+}
+
+func (np *nodeGroupPlugin) subNodeGroupAllocated(ssn *framework.Session, attr *queueAttr, task *api.TaskInfo) {
+	group, ok := np.taskNodeGroup(ssn, task)
+	if !ok {
+		return
+	}
+	allocated := attr.nodeGroupAllocated[group]
+	if allocated == nil {
+		return
+	}
+	allocated.Sub(task.Resreq)
+}
+
+func (np *nodeGroupPlugin) taskNodeGroup(ssn *framework.Session, task *api.TaskInfo) (string, bool) {
+	if task == nil || task.NodeName == "" {
+		return "", false
+	}
+	node := ssn.Nodes[task.NodeName]
+	if node == nil || node.Node == nil || node.Node.Labels == nil {
+		return "", false
+	}
+	group, ok := node.Node.Labels[schedulingv1.NodeGroupNameKey]
+	return group, ok
+}
+
+func (np *nodeGroupPlugin) checkNodeGroupResourceLimit(task *api.TaskInfo, group string, attr *queueAttr) error {
+	if attr.resourceLimitErr != nil {
+		return attr.resourceLimitErr
+	}
+	if len(attr.nodeGroupResourceLimits) == 0 {
+		return nil
+	}
+	limit := attr.nodeGroupResourceLimits[group]
+	if limit == nil {
+		return nil
+	}
+
+	allocated := attr.nodeGroupAllocated[group]
+	if allocated == nil {
+		allocated = api.EmptyResource()
+	}
+	futureUsed := allocated.Clone().Add(task.Resreq)
+	if resourceNames := limitedResourceExceededNames(futureUsed, limit); len(resourceNames) > 0 {
+		return fmt.Errorf("nodegroup %s resource limit exceeded, insufficient resources: %v", group, resourceNames)
+	}
+	return nil
+}
+
+func limitedResourceExceededNames(used *api.Resource, limit *nodeGroupResourceLimit) []string {
+	if used == nil || limit == nil || limit.resource == nil || limit.names.Len() == 0 {
+		return nil
+	}
+
+	var resourceNames []string
+	if limit.names.Has(v1.ResourceCPU) && greaterThanResourceLimit(used.MilliCPU, limit.resource.MilliCPU) {
+		resourceNames = append(resourceNames, string(v1.ResourceCPU))
+	}
+	if limit.names.Has(v1.ResourceMemory) && greaterThanResourceLimit(used.Memory, limit.resource.Memory) {
+		resourceNames = append(resourceNames, string(v1.ResourceMemory))
+	}
+
+	for name := range limit.names {
+		switch name {
+		case v1.ResourceCPU, v1.ResourceMemory:
+			continue
+		}
+		if greaterThanResourceLimit(used.Get(name), limit.resource.Get(name)) {
+			resourceNames = append(resourceNames, string(name))
+		}
+	}
+	return resourceNames
+}
+
+func greaterThanResourceLimit(used, limit float64) bool {
+	return used > limit && used-limit >= api.GetMinResource()
+}
+
 func (np *nodeGroupPlugin) OnSessionOpen(ssn *framework.Session) {
 	np.initQueueAttrs(ssn)
+	np.initNodeGroupAllocated(ssn)
 	for id, attr := range np.queueAttrs {
 		if attr.affinity != nil {
 			klog.V(4).Infof("queue <%v> affinity: anti-required %v, anti-preferred %v, required %v, preferred %v",
 				id, attr.affinity.queueGroupAntiAffinityRequired.UnsortedList(), attr.affinity.queueGroupAntiAffinityPreferred.UnsortedList(),
 				attr.affinity.queueGroupAffinityRequired.UnsortedList(), attr.affinity.queueGroupAffinityPreferred.UnsortedList())
+		}
+		if attr.resourceLimitErr != nil {
+			klog.Errorf("queue <%v> has invalid %s annotation: %v", id, schedulingv1.NodeGroupResourceLimitsAnnotationKey, attr.resourceLimitErr)
 		}
 	}
 
@@ -272,7 +424,7 @@ func (np *nodeGroupPlugin) OnSessionOpen(ssn *framework.Session) {
 		if node.Node.Labels == nil {
 			return score, nil
 		}
-		group, exist := node.Node.Labels[NodeGroupNameKey]
+		group, exist := node.Node.Labels[schedulingv1.NodeGroupNameKey]
 		if !exist {
 			return score, nil
 		}
@@ -300,6 +452,9 @@ func (np *nodeGroupPlugin) OnSessionOpen(ssn *framework.Session) {
 			return fmt.Errorf("job %s not found in session", task.Job)
 		}
 		attr := np.queueAttrs[job.Queue]
+		if attr != nil && attr.resourceLimitErr != nil {
+			return newFitErr(task, node, errNodeGroupResourceLimitInvalid)
+		}
 
 		// Check if the queue has any node group affinity rules
 		unsetAffinity := attr == nil || attr.affinity == nil ||
@@ -310,7 +465,7 @@ func (np *nodeGroupPlugin) OnSessionOpen(ssn *framework.Session) {
 
 		group, exist := "", false
 		if node.Node.Labels != nil {
-			group, exist = node.Node.Labels[NodeGroupNameKey]
+			group, exist = node.Node.Labels[schedulingv1.NodeGroupNameKey]
 		}
 
 		if !exist {
@@ -331,12 +486,42 @@ func (np *nodeGroupPlugin) OnSessionOpen(ssn *framework.Session) {
 		if err := attr.affinity.predicate(group); err != nil {
 			return newFitErr(task, node, errNodeUnsatisfied)
 		}
+		if err := np.checkNodeGroupResourceLimit(task, group, attr); err != nil {
+			klog.V(3).Infof("task <%s>/<%s> queue %s on nodegroup %s rejected by nodegroup resource limit: %v", task.Namespace, task.Name, job.Queue, group, err)
+			return newFitErr(task, node, errNodeGroupResourceLimitExceeded)
+		}
 		klog.V(4).Infof("task <%s>/<%s> queue %s on node %s of nodegroup %v", task.Namespace, task.Name, job.Queue, node.Name, group)
 		return nil
 	}
 
 	ssn.AddPredicateFn(np.Name(), predicateFn)
+
+	ssn.AddEventHandler(&framework.EventHandler{
+		AllocateFunc: func(event *framework.Event) {
+			job := ssn.Jobs[event.Task.Job]
+			if job == nil {
+				return
+			}
+			attr := np.queueAttrs[job.Queue]
+			if attr == nil {
+				return
+			}
+			np.addNodeGroupAllocated(ssn, attr, event.Task)
+		},
+		DeallocateFunc: func(event *framework.Event) {
+			job := ssn.Jobs[event.Task.Job]
+			if job == nil {
+				return
+			}
+			attr := np.queueAttrs[job.Queue]
+			if attr == nil {
+				return
+			}
+			np.subNodeGroupAllocated(ssn, attr, event.Task)
+		},
+	})
 }
 
 func (np *nodeGroupPlugin) OnSessionClose(ssn *framework.Session) {
+	np.queueAttrs = nil
 }

--- a/pkg/scheduler/plugins/nodegroup/nodegroup_test.go
+++ b/pkg/scheduler/plugins/nodegroup/nodegroup_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package nodegroup
 
 import (
+	"errors"
 	"fmt"
 	"testing"
 
@@ -45,16 +46,16 @@ func TestNodeGroup(t *testing.T) {
 	p6 := util.BuildPod("c1", "p6", "", v1.PodPending, api.BuildResourceList("2", "4Gi"), "pg6", nil, nil)
 
 	n1 := util.BuildNode("n1", api.BuildResourceList("2", "4Gi"), map[string]string{
-		NodeGroupNameKey: "group1",
+		schedulingv1.NodeGroupNameKey: "group1",
 	})
 	n2 := util.BuildNode("n2", api.BuildResourceList("4", "16Gi"), map[string]string{
-		NodeGroupNameKey: "group2",
+		schedulingv1.NodeGroupNameKey: "group2",
 	})
 	n3 := util.BuildNode("n3", api.BuildResourceList("4", "16Gi"), map[string]string{
-		NodeGroupNameKey: "group3",
+		schedulingv1.NodeGroupNameKey: "group3",
 	})
 	n4 := util.BuildNode("n4", api.BuildResourceList("4", "16Gi"), map[string]string{
-		NodeGroupNameKey: "group4",
+		schedulingv1.NodeGroupNameKey: "group4",
 	})
 	n5 := util.BuildNode("n5", api.BuildResourceList("4", "16Gi"), make(map[string]string))
 
@@ -381,4 +382,277 @@ func TestNodeGroup(t *testing.T) {
 		})
 	}
 
+}
+
+func TestNodeGroupResourceLimits(t *testing.T) {
+	plugins := map[string]framework.PluginBuilder{PluginName: New}
+	trueValue := true
+	tiers := []conf.Tier{
+		{
+			Plugins: []conf.PluginOption{
+				{
+					Name:             PluginName,
+					EnabledNodeOrder: &trueValue,
+					EnabledPredicate: &trueValue,
+				},
+			},
+		},
+	}
+
+	nodeResource := api.BuildResourceList("16", "64Gi", api.ScalarResource{Name: string(v1.ResourcePods), Value: "32"})
+	n1 := util.BuildNode("n1", nodeResource, map[string]string{
+		schedulingv1.NodeGroupNameKey: "group1",
+	})
+	n2 := util.BuildNode("n2", nodeResource, map[string]string{
+		schedulingv1.NodeGroupNameKey: "group2",
+	})
+
+	affinity := &schedulingv1.Affinity{
+		NodeGroupAffinity: &schedulingv1.NodeGroupAffinity{
+			RequiredDuringSchedulingIgnoredDuringExecution:  []string{"group1", "group2"},
+			PreferredDuringSchedulingIgnoredDuringExecution: []string{"group1"},
+		},
+	}
+
+	tests := []struct {
+		name           string
+		queue          *schedulingv1.Queue
+		pods           []*v1.Pod
+		podGroups      []*schedulingv1.PodGroup
+		targetTaskName string
+		expectedStatus map[string]int
+	}{
+		{
+			name: "no annotation keeps existing behavior",
+			queue: util.MakeQueue("q-no-limit").
+				Affinity(affinity).
+				Obj(),
+			pods: []*v1.Pod{
+				util.BuildPod("limit", "pending", "", v1.PodPending, api.BuildResourceList("2", "4Gi"), "pg-pending", nil, nil),
+			},
+			podGroups: []*schedulingv1.PodGroup{
+				util.BuildPodGroup("pg-pending", "limit", "q-no-limit", 0, nil, ""),
+			},
+			targetTaskName: "pending",
+			expectedStatus: map[string]int{
+				"n1": api.Success,
+				"n2": api.Success,
+			},
+		},
+		{
+			name: "under nodegroup limit permits preferred nodegroup",
+			queue: util.MakeQueue("q-under-limit").
+				Affinity(affinity).
+				Annotations(map[string]string{
+					schedulingv1.NodeGroupResourceLimitsAnnotationKey: `{"group1":{"cpu":"3","memory":"8Gi"}}`,
+				}).
+				Obj(),
+			pods: []*v1.Pod{
+				util.BuildPod("limit", "pending", "", v1.PodPending, api.BuildResourceList("2", "4Gi"), "pg-pending", nil, nil),
+			},
+			podGroups: []*schedulingv1.PodGroup{
+				util.BuildPodGroup("pg-pending", "limit", "q-under-limit", 0, nil, ""),
+			},
+			targetTaskName: "pending",
+			expectedStatus: map[string]int{
+				"n1": api.Success,
+				"n2": api.Success,
+			},
+		},
+		{
+			name: "omitted resource dimension is unlimited",
+			queue: util.MakeQueue("q-cpu-only-limit").
+				Affinity(affinity).
+				Annotations(map[string]string{
+					schedulingv1.NodeGroupResourceLimitsAnnotationKey: `{"group1":{"cpu":"3"}}`,
+				}).
+				Obj(),
+			pods: []*v1.Pod{
+				util.BuildPod("limit", "pending", "", v1.PodPending, api.BuildResourceList("2", "4Gi"), "pg-pending", nil, nil),
+			},
+			podGroups: []*schedulingv1.PodGroup{
+				util.BuildPodGroup("pg-pending", "limit", "q-cpu-only-limit", 0, nil, ""),
+			},
+			targetTaskName: "pending",
+			expectedStatus: map[string]int{
+				"n1": api.Success,
+				"n2": api.Success,
+			},
+		},
+		{
+			name: "specified resource dimension is enforced",
+			queue: util.MakeQueue("q-cpu-only-over-limit").
+				Affinity(affinity).
+				Annotations(map[string]string{
+					schedulingv1.NodeGroupResourceLimitsAnnotationKey: `{"group1":{"cpu":"1"}}`,
+				}).
+				Obj(),
+			pods: []*v1.Pod{
+				util.BuildPod("limit", "pending", "", v1.PodPending, api.BuildResourceList("2", "4Gi"), "pg-pending", nil, nil),
+			},
+			podGroups: []*schedulingv1.PodGroup{
+				util.BuildPodGroup("pg-pending", "limit", "q-cpu-only-over-limit", 0, nil, ""),
+			},
+			targetTaskName: "pending",
+			expectedStatus: map[string]int{
+				"n1": api.UnschedulableAndUnresolvable,
+				"n2": api.Success,
+			},
+		},
+		{
+			name: "over nodegroup limit rejects preferred nodegroup and permits fallback",
+			queue: util.MakeQueue("q-over-limit").
+				Affinity(affinity).
+				Annotations(map[string]string{
+					schedulingv1.NodeGroupResourceLimitsAnnotationKey: `{"group1":{"cpu":"3","memory":"8Gi"}}`,
+				}).
+				Obj(),
+			pods: []*v1.Pod{
+				util.BuildPod("limit", "used", "n1", v1.PodRunning, api.BuildResourceList("2", "4Gi"), "pg-used", nil, nil),
+				util.BuildPod("limit", "pending", "", v1.PodPending, api.BuildResourceList("2", "4Gi"), "pg-pending", nil, nil),
+			},
+			podGroups: []*schedulingv1.PodGroup{
+				util.BuildPodGroup("pg-used", "limit", "q-over-limit", 0, nil, schedulingv1.PodGroupRunning),
+				util.BuildPodGroup("pg-pending", "limit", "q-over-limit", 0, nil, ""),
+			},
+			targetTaskName: "pending",
+			expectedStatus: map[string]int{
+				"n1": api.UnschedulableAndUnresolvable,
+				"n2": api.Success,
+			},
+		},
+		{
+			name: "invalid annotation rejects queue tasks",
+			queue: util.MakeQueue("q-invalid-limit").
+				Affinity(affinity).
+				Annotations(map[string]string{
+					schedulingv1.NodeGroupResourceLimitsAnnotationKey: `{"group1":{"cpu":`,
+				}).
+				Obj(),
+			pods: []*v1.Pod{
+				util.BuildPod("limit", "pending", "", v1.PodPending, api.BuildResourceList("2", "4Gi"), "pg-pending", nil, nil),
+			},
+			podGroups: []*schedulingv1.PodGroup{
+				util.BuildPodGroup("pg-pending", "limit", "q-invalid-limit", 0, nil, ""),
+			},
+			targetTaskName: "pending",
+			expectedStatus: map[string]int{
+				"n1": api.UnschedulableAndUnresolvable,
+				"n2": api.UnschedulableAndUnresolvable,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			common := uthelper.TestCommonStruct{
+				Name:      test.name,
+				PodGroups: test.podGroups,
+				Queues:    []*schedulingv1.Queue{test.queue},
+				Pods:      test.pods,
+				Nodes:     []*v1.Node{n1, n2},
+				Plugins:   plugins,
+			}
+			ssn := common.RegisterSession(tiers, nil)
+			defer common.Close()
+
+			var targetTask *api.TaskInfo
+		findTargetTask:
+			for _, job := range ssn.Jobs {
+				for _, task := range job.Tasks {
+					if task.Name == test.targetTaskName {
+						targetTask = task
+						break findTargetTask
+					}
+				}
+			}
+			if targetTask == nil {
+				t.Fatalf("target task %s not found", test.targetTaskName)
+			}
+
+			for _, node := range ssn.Nodes {
+				err := ssn.PredicateFn(targetTask, node)
+				code := fitErrorCode(t, err)
+				if expect := test.expectedStatus[node.Name]; expect != code {
+					t.Errorf("task %s on node %s expect status code %v, but got %v", targetTask.Name, node.Name, expect, code)
+				}
+			}
+		})
+	}
+}
+
+func fitErrorCode(t *testing.T, err error) int {
+	t.Helper()
+	if err == nil {
+		return api.Success
+	}
+	var fitErr *api.FitError
+	if !errors.As(err, &fitErr) {
+		t.Fatalf("expected *api.FitError, got %T: %v", err, err)
+	}
+	if len(fitErr.Status) == 0 {
+		t.Fatalf("expected *api.FitError with status, got empty status: %v", err)
+	}
+	return fitErr.Status[0].Code
+}
+
+func TestNodeGroupResourceLimitAllocationEvent(t *testing.T) {
+	plugins := map[string]framework.PluginBuilder{PluginName: New}
+	trueValue := true
+	tiers := []conf.Tier{
+		{
+			Plugins: []conf.PluginOption{
+				{
+					Name:             PluginName,
+					EnabledNodeOrder: &trueValue,
+					EnabledPredicate: &trueValue,
+				},
+			},
+		},
+	}
+
+	n1 := util.BuildNode("n1", api.BuildResourceList("16", "64Gi", api.ScalarResource{Name: string(v1.ResourcePods), Value: "32"}), map[string]string{
+		schedulingv1.NodeGroupNameKey: "group1",
+	})
+	queue := util.MakeQueue("q-event-limit").
+		Affinity(&schedulingv1.Affinity{
+			NodeGroupAffinity: &schedulingv1.NodeGroupAffinity{
+				RequiredDuringSchedulingIgnoredDuringExecution: []string{"group1"},
+			},
+		}).
+		Annotations(map[string]string{
+			schedulingv1.NodeGroupResourceLimitsAnnotationKey: `{"group1":{"cpu":"3","memory":"8Gi"}}`,
+		}).
+		Obj()
+
+	p1 := util.BuildPod("limit", "pending-1", "", v1.PodPending, api.BuildResourceList("2", "4Gi"), "pg-1", nil, nil)
+	p2 := util.BuildPod("limit", "pending-2", "", v1.PodPending, api.BuildResourceList("2", "4Gi"), "pg-2", nil, nil)
+
+	common := uthelper.TestCommonStruct{
+		Name: "allocation event updates nodegroup usage",
+		PodGroups: []*schedulingv1.PodGroup{
+			util.BuildPodGroup("pg-1", "limit", "q-event-limit", 0, nil, ""),
+			util.BuildPodGroup("pg-2", "limit", "q-event-limit", 0, nil, ""),
+		},
+		Queues:  []*schedulingv1.Queue{queue},
+		Pods:    []*v1.Pod{p1, p2},
+		Nodes:   []*v1.Node{n1},
+		Plugins: plugins,
+	}
+	ssn := common.RegisterSession(tiers, nil)
+	defer common.Close()
+
+	task1 := ssn.Jobs[api.JobID("limit/pg-1")].Tasks[api.TaskID("limit-pending-1")]
+	task2 := ssn.Jobs[api.JobID("limit/pg-2")].Tasks[api.TaskID("limit-pending-2")]
+	node := ssn.Nodes["n1"]
+
+	if err := ssn.PredicateFn(task1, node); err != nil {
+		t.Fatalf("first task should fit before allocation event, got %v", err)
+	}
+	if err := ssn.Allocate(task1, node); err != nil {
+		t.Fatalf("allocate first task: %v", err)
+	}
+	if err := ssn.PredicateFn(task2, node); err == nil {
+		t.Fatalf("second task should exceed nodegroup resource limit after allocation event")
+	}
 }

--- a/staging/src/volcano.sh/apis/pkg/apis/scheduling/v1beta1/labels.go
+++ b/staging/src/volcano.sh/apis/pkg/apis/scheduling/v1beta1/labels.go
@@ -51,6 +51,12 @@ const QueueNameAnnotationKey = GroupName + "/queue-name"
 // gate management and the name of the scheduling gate that controls queue admission.
 const QueueAllocationGateKey = GroupName + "/queue-allocation-gate"
 
+// NodeGroupNameKey is the label key of Node to identify which nodegroup it belongs to.
+const NodeGroupNameKey = AnnotationPrefix + "nodegroup-name"
+
+// NodeGroupResourceLimitsAnnotationKey is the annotation key of Queue to limit resources each nodegroup can allocate.
+const NodeGroupResourceLimitsAnnotationKey = AnnotationPrefix + "nodegroup-resource-limits"
+
 // PodPreemptable is the key of preemptable
 const PodPreemptable = "volcano.sh/preemptable"
 


### PR DESCRIPTION
## Summary

- Add `volcano.sh/nodegroup-resource-limits` queue annotation to cap queue usage per nodegroup.
- Track allocated resources by `queue + nodegroup` in the nodegroup plugin and reject nodes when future usage would exceed the configured limit.
- Add unit tests for no annotation, under-limit scheduling, fallback after preferred nodegroup reaches its logical limit, invalid annotation handling, and allocation event accounting.
- Document the new annotation in the nodegroup plugin user guide.

Closes #4954

## Test Plan

- [x] `go test ./pkg/scheduler/plugins/nodegroup`
