### PR TITLE
avoid idle gpu memory underflow in getDevicesIdleGPUMemory

### DIFF
--- a/pkg/scheduler/api/devices/nvidia/gpushare/share.go
+++ b/pkg/scheduler/api/devices/nvidia/gpushare/share.go
@@ -34,7 +34,15 @@ func getDevicesIdleGPUMemory(gs *GPUDevices) map[int]uint {
 	res := map[int]uint{}
 	for id, allMemory := range devicesAllGPUMemory {
 		if usedMemory, found := devicesUsedGPUMemory[id]; found {
-			res[id] = allMemory - usedMemory
+			// usedMemory is summed from the pods accounted to this card, which can
+			// exceed the card capacity (for example a pod that sets volcano.sh/gpu-index
+			// itself). Clamp instead of subtracting so the unsigned result does not wrap
+			// around and make a full card look almost empty.
+			if usedMemory >= allMemory {
+				res[id] = 0
+			} else {
+				res[id] = allMemory - usedMemory
+			}
 		} else {
 			res[id] = allMemory
 		}

--- a/pkg/scheduler/api/devices/nvidia/gpushare/share_test.go
+++ b/pkg/scheduler/api/devices/nvidia/gpushare/share_test.go
@@ -1,0 +1,71 @@
+/*
+Copyright 2023 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gpushare
+
+import (
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+func gpuMemPod(uid string, mem int64) *v1.Pod {
+	return &v1.Pod{
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				{
+					Resources: v1.ResourceRequirements{
+						Limits: v1.ResourceList{
+							VolcanoGPUResource: *resource.NewQuantity(mem, resource.DecimalSI),
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestGetDevicesIdleGPUMemoryOverSubscribed(t *testing.T) {
+	// A card with 1000 memory whose accounted usage exceeds its capacity, e.g.
+	// because a pod set volcano.sh/gpu-index itself and was bound directly to the
+	// node, must report 0 idle memory rather than a wrapped-around uint that makes
+	// the full card look almost empty.
+	pod := gpuMemPod("p1", 3000)
+	pod.UID = "p1"
+	gs := &GPUDevices{
+		Name: "n1",
+		Device: map[int]*GPUDevice{
+			0: {
+				ID:     0,
+				Memory: 1000,
+				PodMap: map[string]*v1.Pod{string(pod.UID): pod},
+			},
+		},
+	}
+
+	idle := getDevicesIdleGPUMemory(gs)
+	if idle[0] != 0 {
+		t.Errorf("idle memory of over-subscribed card: want 0, got %d", idle[0])
+	}
+
+	// the predicate must not offer the full card to another pod.
+	newPod := gpuMemPod("p2", 500)
+	newPod.UID = "p2"
+	if ids := predicateGPUbyMemory(newPod, gs); len(ids) != 0 {
+		t.Errorf("over-subscribed card offered for allocation: %v", ids)
+	}
+}

--- a/pkg/scheduler/api/devices/nvidia/gpushare/share_test.go
+++ b/pkg/scheduler/api/devices/nvidia/gpushare/share_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 The Volcano Authors.
+Copyright 2026 The Volcano Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -23,7 +23,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 )
 
-func gpuMemPod(uid string, mem int64) *v1.Pod {
+func gpuMemPod(mem int64) *v1.Pod {
 	return &v1.Pod{
 		Spec: v1.PodSpec{
 			Containers: []v1.Container{
@@ -39,14 +39,10 @@ func gpuMemPod(uid string, mem int64) *v1.Pod {
 	}
 }
 
-func TestGetDevicesIdleGPUMemoryOverSubscribed(t *testing.T) {
-	// A card with 1000 memory whose accounted usage exceeds its capacity, e.g.
-	// because a pod set volcano.sh/gpu-index itself and was bound directly to the
-	// node, must report 0 idle memory rather than a wrapped-around uint that makes
-	// the full card look almost empty.
-	pod := gpuMemPod("p1", 3000)
+func oversubscribedGPUDevices() *GPUDevices {
+	pod := gpuMemPod(3000)
 	pod.UID = "p1"
-	gs := &GPUDevices{
+	return &GPUDevices{
 		Name: "n1",
 		Device: map[int]*GPUDevice{
 			0: {
@@ -56,14 +52,21 @@ func TestGetDevicesIdleGPUMemoryOverSubscribed(t *testing.T) {
 			},
 		},
 	}
+}
+
+func TestGetDevicesIdleGPUMemory_OverSubscribedCardReportsZero(t *testing.T) {
+	gs := oversubscribedGPUDevices()
 
 	idle := getDevicesIdleGPUMemory(gs)
 	if idle[0] != 0 {
 		t.Errorf("idle memory of over-subscribed card: want 0, got %d", idle[0])
 	}
+}
 
-	// the predicate must not offer the full card to another pod.
-	newPod := gpuMemPod("p2", 500)
+func TestPredicateGPUbyMemory_OverSubscribedCardNotOffered(t *testing.T) {
+	gs := oversubscribedGPUDevices()
+
+	newPod := gpuMemPod(500)
 	newPod.UID = "p2"
 	if ids := predicateGPUbyMemory(newPod, gs); len(ids) != 0 {
 		t.Errorf("over-subscribed card offered for allocation: %v", ids)


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

1. getDevicesIdleGPUMemory reports a card's idle memory as allMemory - usedMemory, and both values are uint.
2. usedMemory is the sum of the pods accounted to that card by getUsedGPUMemory, and AddResource records a pod against whatever card its volcano.sh/gpu-index annotation names without checking capacity, so a pod bound directly to a node (or several pods pinned to the same card) can push the accounted usage past the card's memory.
3. Once usedMemory exceeds allMemory the unsigned subtraction wraps to a near-max value, so predicateGPUbyMemory treats a full card as almost empty and keeps offering it to other pods, placing more memory on it than the card has.

Clamped the idle value to zero once usage reaches capacity so the result can no longer wrap. Added a regression test that drives the accounted usage above the card capacity and checks the card reports zero idle memory and is not offered by the predicate.

#### Which issue(s) this PR fixes:

N/A

#### Special notes for your reviewer:

The clamp lives in the accounting helper, so every caller of getDevicesIdleGPUMemory is covered rather than the current predicate path alone.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
