### PR TITLE
Add injectHostsEnv flag to svc plugin

### DIFF
--- a/docs/user-guide/how_to_use_svc_plugin.md
+++ b/docs/user-guide/how_to_use_svc_plugin.md
@@ -12,11 +12,11 @@ all pods under the job automatically. Namely, `pod.spec.hostname` is `pod.metada
 * Once `svc` plugin is configured, value of field `subdomain` under `spec` will be filled out to be **the job name** for
 all pods under the job automatically. Namely, `pod.spec.subdomain` is `job.metadata.name`.
 * Once `svc` plugin is configured, environment variables `VC_%s_NUM` will be registered to all the containers(including
-initContainers) under the job automatically. `%s` will be replaced by the **task name** which the pod belongs to. The value
+initContainers) under the job automatically, unless the flag `inject-hosts-env` is set to `false`. `%s` will be replaced by the **task name** which the pod belongs to. The value
 of the environment variable is the **task replicas**. The number of the environment variables depends on the number of tasks,
 which is usually `2` for most AI and Big Data jobs contains 2 roles. For example, a Spark job contains `driver` and `executor`.
 * Once `svc` plugin is configured, environment variables `VC_%s_HOSTS` will be registered to all the containers(including 
-initContainers) under the job automatically. `%s` will be replaced by the **task name** which the pod belongs to. The value
+initContainers) under the job automatically, unless the flag `inject-hosts-env` is set to `false`. `%s` will be replaced by the **task name** which the pod belongs to. The value
 of the environment variable are the domains of all the pods under the task. The number of the environment variables depends
 on the number of tasks, which is usually `2` for most AI and Big Data jobs contains 2 roles. For example, a TensorFlow job
 contains `ps` and `worker`.
@@ -26,12 +26,15 @@ host files under the directory `/etc/volcano/`.
 * A headless service whose name is the same with job will be created.
 * If `disable-network-policy` is set to be false, a `NetworkPolicy` object with the type `Ingress` will be created for
 the job.
+* If `inject-hosts-env` is set to be false, hosts env variables including `VC_%s_HOSTS` and `VC_%s_NUM` will not be injected
+into pod containers; hosts information will still be accessible via the mounted ConfigMap files under `/etc/volcano/`.
 
 ## Arguments
-| ID  | Name                          | Value           | Default Value | Required | Description                                          | Example                                       |
-|-----|-------------------------------|-----------------|---------------|----------|------------------------------------------------------|-----------------------------------------------|
-| 1   | `publish-not-ready-addresses` | `true`/`false`  | `false`       | N        | whether publish the pod address when it is not ready | svc: ["--publish-not-ready-addresses=true"]   |
-| 2   | `disable-network-policy`      | `true`/`false`  | `false`       | N        | whether disable network policy for the job           | svc: ["--disable-network-policy=true"]        |
+| ID | Name                          | Value           | Default Value | Required | Description                                           | Example                                     |
+|----|-------------------------------|-----------------|---------------|----------|-------------------------------------------------------|---------------------------------------------|
+| 1  | `publish-not-ready-addresses` | `true`/`false`  | `false`       | N        | whether publish the pod address when it is not ready  | svc: ["--publish-not-ready-addresses=true"] |
+| 2  | `disable-network-policy`      | `true`/`false`  | `false`       | N        | whether disable network policy for the job            | svc: ["--disable-network-policy=true"]      |
+| 3  | `inject-hosts-env`            | `true`/`false`  | `true`        | N        | whether inject the hosts environment variables        | svc: ["--inject-hosts-env=true"]            |
 
 ## Examples
 ```yaml
@@ -44,7 +47,7 @@ spec:
   schedulerName: volcano
   plugins:
     env: []
-    svc: ["--publish-not-ready-addresses=false", "--disable-network-policy=false"]  ## SVC plugin register
+    svc: ["--publish-not-ready-addresses=false", "--disable-network-policy=false", "--inject-hosts-env=true"]  ## SVC plugin register
   policies:
     - event: PodEvicted
       action: RestartJob

--- a/example/job-plugin.yaml
+++ b/example/job-plugin.yaml
@@ -17,7 +17,8 @@ spec:
     # Provide network information: hosts file(under path `/etc/volcano/`), headless service, etc.
     # :param publish-not-ready-addresses: publish not ready addresses(false by default)
     # :param disable-network-policy: disable network policy of the job(false by default)
-    svc: ["--publish-not-ready-addresses=false", "--disable-network-policy=false"]
+    # :param inject-hosts-env: inject host environment variables into pod containers(true by default)
+    svc: ["--publish-not-ready-addresses=false", "--disable-network-policy=false", "--inject-hosts-env=true"]
   maxRetry: 5
   queue: default
   tasks:

--- a/pkg/controllers/job/plugins/svc/svc.go
+++ b/pkg/controllers/job/plugins/svc/svc.go
@@ -44,11 +44,12 @@ type servicePlugin struct {
 	// flag parse args
 	publishNotReadyAddresses bool
 	disableNetworkPolicy     bool
+	injectHostsEnv           bool
 }
 
 // New creates service plugin.
 func New(client pluginsinterface.PluginClientset, arguments []string) pluginsinterface.PluginInterface {
-	servicePlugin := servicePlugin{pluginArguments: arguments, Clientset: client}
+	servicePlugin := servicePlugin{pluginArguments: arguments, Clientset: client, injectHostsEnv: true}
 
 	servicePlugin.addFlags()
 
@@ -65,6 +66,7 @@ func (sp *servicePlugin) addFlags() {
 		"set publishNotReadyAddresses of svc to true")
 	flagSet.BoolVar(&sp.disableNetworkPolicy, "disable-network-policy", sp.disableNetworkPolicy,
 		"set disableNetworkPolicy of svc to true")
+	flagSet.BoolVar(&sp.injectHostsEnv, "inject-hosts-env", sp.injectHostsEnv, "set injectHostsEnv of svc to false")
 
 	if err := flagSet.Parse(sp.pluginArguments); err != nil {
 		klog.Errorf("plugin %s flagset parse failed, err: %v", sp.Name(), err)
@@ -90,32 +92,37 @@ func (sp *servicePlugin) OnPodCreate(pod *v1.Pod, job *batch.Job) error {
 		pod.Spec.Subdomain = job.Name
 	}
 
-	var hostEnv []v1.EnvVar
-	var envNames []string
+	// The flag `inject-hosts-env` is used to control whether to inject the hosts and host number of each task as environment variables into the pod.
+	// This is to prevent the situation where the number of tasks is too large, resulting in the environment variable exceeding the maximum length limit.
+	// If the flag is set to true (by default), the hosts and host number of each task will be injected as environment variables into the pod.
+	if sp.injectHostsEnv {
+		var hostEnv []v1.EnvVar
+		var envNames []string
 
-	for _, ts := range job.Spec.Tasks {
-		// TODO(k82cn): The splitter and the prefix of env should be configurable.
-		formateENVKey := strings.Replace(ts.Name, "-", "_", -1)
-		envNames = append(envNames, fmt.Sprintf(EnvTaskHostFmt, strings.ToUpper(formateENVKey)), fmt.Sprintf(EnvHostNumFmt, strings.ToUpper(formateENVKey)))
-	}
+		for _, ts := range job.Spec.Tasks {
+			// TODO(k82cn): The splitter and the prefix of env should be configurable.
+			formateENVKey := strings.Replace(ts.Name, "-", "_", -1)
+			envNames = append(envNames, fmt.Sprintf(EnvTaskHostFmt, strings.ToUpper(formateENVKey)), fmt.Sprintf(EnvHostNumFmt, strings.ToUpper(formateENVKey)))
+		}
 
-	for _, name := range envNames {
-		hostEnv = append(hostEnv, v1.EnvVar{
-			Name: name,
-			ValueFrom: &v1.EnvVarSource{
-				ConfigMapKeyRef: &v1.ConfigMapKeySelector{
-					LocalObjectReference: v1.LocalObjectReference{Name: sp.cmName(job)},
-					Key:                  name,
-				}}},
-		)
-	}
+		for _, name := range envNames {
+			hostEnv = append(hostEnv, v1.EnvVar{
+				Name: name,
+				ValueFrom: &v1.EnvVarSource{
+					ConfigMapKeyRef: &v1.ConfigMapKeySelector{
+						LocalObjectReference: v1.LocalObjectReference{Name: sp.cmName(job)},
+						Key:                  name,
+					}}},
+			)
+		}
 
-	for i := range pod.Spec.Containers {
-		pod.Spec.Containers[i].Env = append(pod.Spec.Containers[i].Env, hostEnv...)
-	}
+		for i := range pod.Spec.Containers {
+			pod.Spec.Containers[i].Env = append(pod.Spec.Containers[i].Env, hostEnv...)
+		}
 
-	for i := range pod.Spec.InitContainers {
-		pod.Spec.InitContainers[i].Env = append(pod.Spec.InitContainers[i].Env, hostEnv...)
+		for i := range pod.Spec.InitContainers {
+			pod.Spec.InitContainers[i].Env = append(pod.Spec.InitContainers[i].Env, hostEnv...)
+		}
 	}
 
 	sp.mountConfigmap(pod, job)

--- a/test/e2e/jobseq/job_plugins.go
+++ b/test/e2e/jobseq/job_plugins.go
@@ -219,6 +219,59 @@ var _ = Describe("Job E2E Test: Test Job Plugins", func() {
 		Expect(err).To(HaveOccurred())
 	})
 
+	It("Test SVC Plugin with injectHostsEnv disabled", func() {
+		jobName := "svc-without-hosts-env"
+		taskName := "task"
+
+		_, rep := e2eutil.ComputeNode(testCtx, e2eutil.OneCPU)
+		Expect(rep).NotTo(Equal(0))
+
+		job := e2eutil.CreateJob(testCtx, &e2eutil.JobSpec{
+			Namespace: testCtx.Namespace,
+			Name:      jobName,
+			Plugins: map[string][]string{
+				"svc": {"--inject-hosts-env=false"},
+			},
+			Tasks: []e2eutil.TaskSpec{
+				{
+					Img:  e2eutil.DefaultNginxImage,
+					Req:  e2eutil.OneCPU,
+					Min:  1,
+					Rep:  rep,
+					Name: taskName,
+				},
+			},
+		})
+
+		err := e2eutil.WaitJobReady(testCtx, job)
+		Expect(err).NotTo(HaveOccurred())
+
+		pluginName := fmt.Sprintf("%s-svc", jobName)
+		_, err = testCtx.Kubeclient.CoreV1().ConfigMaps(testCtx.Namespace).Get(context.TODO(),
+			pluginName, v1.GetOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		pod, err := testCtx.Kubeclient.CoreV1().Pods(testCtx.Namespace).Get(context.TODO(),
+			fmt.Sprintf(helpers.PodNameFmt, jobName, taskName, 0), v1.GetOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		envNames := []string{
+			fmt.Sprintf(svc.EnvTaskHostFmt, strings.ToUpper(taskName)),
+			fmt.Sprintf(svc.EnvHostNumFmt, strings.ToUpper(taskName)),
+		}
+
+		containers := pod.Spec.Containers
+		containers = append(containers, pod.Spec.InitContainers...)
+		for _, container := range containers {
+			for _, name := range envNames {
+				for _, envi := range container.Env {
+					Expect(envi.Name).NotTo(Equal(name),
+						fmt.Sprintf("container: %s, env name: %s should not be injected", container.Name, name))
+				}
+			}
+		}
+	})
+
 	It("Check Functionality of all plugins", func() {
 		jobName := "job-with-all-plugin"
 		taskName := "task"


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

It adds a configurable flag to the existing svc plugin so that users can decide whether they want to inject environment variables from the hosts configmap to pod containers.
This is necessary because in large-scale scenarios a volcano job might create over 1000 pods, which make environment variable like `VC_%s_HOSTS` to exceed linux kernel limit, causing to the pod to fail at startup.

#### Which issue(s) this PR fixes:

Fixes # [5471](https://github.com/volcano-sh/volcano/issues/5471)

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
Yes.
```release-note
Added a flag `inject-hosts-env` to the service plugin allow mounting hosts environment variables to pod containers(true by default).
```