### PR TITLE
chore(security): pin Dockerfile base images to SHA256 hashes

### DIFF
--- a/benchmark/manifests/audit-exporter/Dockerfile
+++ b/benchmark/manifests/audit-exporter/Dockerfile
@@ -28,6 +28,6 @@ RUN cd volcano && \
     CGO_ENABLED=0 go build -o /kube-apiserver-audit-exporter \
         ./third_party/kube-apiserver-audit-exporter/cmd/kube-apiserver-audit-exporter
 
-FROM alpine:latest
+FROM alpine:latest@sha256:a2d49ea686c2adfe3c992e47dc3b5e7fa6e6b5055609400dc2acaeb241c829f4
 COPY --from=builder /kube-apiserver-audit-exporter /kube-apiserver-audit-exporter
 ENTRYPOINT ["/kube-apiserver-audit-exporter"]

--- a/benchmark/manifests/audit-exporter/Dockerfile
+++ b/benchmark/manifests/audit-exporter/Dockerfile
@@ -28,6 +28,6 @@ RUN cd volcano && \
     CGO_ENABLED=0 go build -o /kube-apiserver-audit-exporter \
         ./third_party/kube-apiserver-audit-exporter/cmd/kube-apiserver-audit-exporter
 
-FROM alpine:latest@sha256:a2d49ea686c2adfe3c992e47dc3b5e7fa6e6b5055609400dc2acaeb241c829f4
+FROM alpine:3.24.0@sha256:a2d49ea686c2adfe3c992e47dc3b5e7fa6e6b5055609400dc2acaeb241c829f4
 COPY --from=builder /kube-apiserver-audit-exporter /kube-apiserver-audit-exporter
 ENTRYPOINT ["/kube-apiserver-audit-exporter"]

--- a/benchmark/manifests/audit-exporter/Dockerfile
+++ b/benchmark/manifests/audit-exporter/Dockerfile
@@ -18,7 +18,7 @@
 # Build context must be the Volcano repo root so the build stage can see
 # third_party/, the top-level go.mod, and staging/.
 
-FROM golang:1.25.0 AS builder
+FROM golang:1.25.0@sha256:5502b0e56fca23feba76dbc5387ba59c593c02ccc2f0f7355871ea9a0852cebe AS builder
 WORKDIR /go/src/volcano.sh/
 COPY go.mod go.sum ./
 COPY staging/ ./staging/

--- a/example/custom-plugin/Dockerfile
+++ b/example/custom-plugin/Dockerfile
@@ -28,7 +28,7 @@ RUN cd volcano && CC=/usr/local/musl/bin/musl-gcc CGO_ENABLED=1 \
 RUN cd volcano && SUPPORT_PLUGINS=yes make vc-scheduler
 
 # Build vc scheduler image with plugin
-FROM alpine:latest
+FROM alpine:latest@sha256:a2d49ea686c2adfe3c992e47dc3b5e7fa6e6b5055609400dc2acaeb241c829f4
 COPY --from=builder /go/src/volcano.sh/volcano/_output/bin/vc-scheduler /vc-scheduler
 COPY --from=builder /go/src/volcano.sh/volcano/example/custom-plugin/magic.so /plugins/magic.so
 ENTRYPOINT ["/vc-scheduler"]

--- a/example/custom-plugin/Dockerfile
+++ b/example/custom-plugin/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24.0 AS builder
+FROM golang:1.24.0@sha256:3f7444391c51a11a039bf0359ee81cc64e663c17d787ad0e637a4de1a3f62a71 AS builder
 
 WORKDIR /go/src/volcano.sh/
 

--- a/example/custom-plugin/Dockerfile
+++ b/example/custom-plugin/Dockerfile
@@ -28,7 +28,7 @@ RUN cd volcano && CC=/usr/local/musl/bin/musl-gcc CGO_ENABLED=1 \
 RUN cd volcano && SUPPORT_PLUGINS=yes make vc-scheduler
 
 # Build vc scheduler image with plugin
-FROM alpine:latest@sha256:a2d49ea686c2adfe3c992e47dc3b5e7fa6e6b5055609400dc2acaeb241c829f4
+FROM alpine:3.24.0@sha256:a2d49ea686c2adfe3c992e47dc3b5e7fa6e6b5055609400dc2acaeb241c829f4
 COPY --from=builder /go/src/volcano.sh/volcano/_output/bin/vc-scheduler /vc-scheduler
 COPY --from=builder /go/src/volcano.sh/volcano/example/custom-plugin/magic.so /plugins/magic.so
 ENTRYPOINT ["/vc-scheduler"]

--- a/example/integrations/mpi/Dockerfile
+++ b/example/integrations/mpi/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM ubuntu:22.04@sha256:4f838adc7181d9039ac795a7d0aba05a9bd9ecd480d294483169c5def983b64d
 MAINTAINER volcano <maintainer@volcano.sh>
 RUN  apt-get update --fix-missing \
      && apt-get install -y libopenmpi-dev openmpi-bin \

--- a/example/integrations/mxnet/train/Dockerfile
+++ b/example/integrations/mxnet/train/Dockerfile
@@ -1,4 +1,4 @@
-FROM mxnet/python:1.4.0_cpu_mkl_py3
+FROM mxnet/python:1.9.1_cpu_py3@sha256:aad3f8fa3658601c7d7ddc33fadc8ec92f5aa9edd47673b8d619a13e4da8e2ba
 
 RUN apt-get update \
     && apt-get install -y git

--- a/example/integrations/tensorflow/benchmark/Dockerfile
+++ b/example/integrations/tensorflow/benchmark/Dockerfile
@@ -9,5 +9,5 @@ RUN  apt-get update --fix-missing \
 && apt-get install -y git \
 && apt-get clean \
 && rm -rf /var/lib/apt/lists/*
-RUN pip install tf-nightly-gpu \
+RUN pip install tf-nightly-gpu==1.15.0.dev20190827 \
 && git clone https://github.com/tensorflow/benchmarks.git /opt/tf-benchmarks

--- a/example/integrations/tensorflow/benchmark/Dockerfile
+++ b/example/integrations/tensorflow/benchmark/Dockerfile
@@ -3,7 +3,7 @@
 # original image is: gcr.io/kubeflow/tf-benchmarks-cpu:v20171202-bdab599-dirty-284af3,
 # the image needs an update to use the latest tf-benchmark logic
 # ref => https://github.com/tensorflow/benchmarks/tree/master/scripts/tf_cnn_benchmarks.
-FROM python:2.7
+FROM python:2.7@sha256:cfa62318c459b1fde9e0841c619906d15ada5910d625176e24bf692cf8a2601d
 MAINTAINER volcano <volcano-sh@googlegroups.com>
 RUN  apt-get update --fix-missing \
 && apt-get install -y git \

--- a/hack/generate-groups.sh
+++ b/hack/generate-groups.sh
@@ -50,8 +50,8 @@ shift 4
   # To support running this script from anywhere, first cd into this directory,
   # and then install with forced module mode on and fully qualified name.
   cd "$(dirname "${0}")"
-  GO111MODULE=on GOOS=${OS} go get k8s.io/code-generator/cmd/{defaulter-gen,client-gen,lister-gen,informer-gen,deepcopy-gen}
-  GO111MODULE=on GOOS=${OS} go install k8s.io/code-generator/cmd/{defaulter-gen,client-gen,lister-gen,informer-gen,deepcopy-gen}
+  GO111MODULE=on GOOS=${OS} go get k8s.io/code-generator/cmd/{defaulter-gen,client-gen,lister-gen,informer-gen,deepcopy-gen}@v0.35.3
+  GO111MODULE=on GOOS=${OS} go install k8s.io/code-generator/cmd/{defaulter-gen,client-gen,lister-gen,informer-gen,deepcopy-gen}@v0.35.3
 )
 # Go installs the above commands to get installed in $GOBIN if defined, and $GOPATH/bin otherwise:
 GOBIN="$(go env GOBIN)"

--- a/hack/generate-internal-groups.sh
+++ b/hack/generate-internal-groups.sh
@@ -18,6 +18,8 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+GOPATH="${GOPATH:-$(go env GOPATH)}"
+
 # generate-internal-groups generates everything for a project with internal types, e.g. an
 # user-provided API server based on k8s.io/apiserver.
 

--- a/hack/local-up-cluster.sh
+++ b/hack/local-up-cluster.sh
@@ -38,7 +38,7 @@ function install_tools {
         mkdir -p ${VC_HOME}/volcano/$d
     done
 
-    go get -u github.com/cloudflare/cfssl/cmd/...
+    go install github.com/cloudflare/cfssl/cmd/...@v1.6.4
 }
 
 function build_binaries {

--- a/hack/update-gencode.sh
+++ b/hack/update-gencode.sh
@@ -34,6 +34,6 @@ bash hack/generate-groups.sh "deepcopy,client,informer,lister" \
 bash hack/generate-internal-groups.sh "deepcopy,conversion" \
   volcano.sh/apis/pkg/apis/ volcano.sh/apis/pkg/apis volcano.sh/apis/pkg/apis\
   "scheduling:v1beta1"   \
-  --output-base "$(dirname "${BASH_SOURCE[0]}")/../../.." \
+  --output-base "${SCRIPT_ROOT}/_tmp" \
   --go-header-file ${SCRIPT_ROOT}/hack/boilerplate/boilerplate.go.txt
 

--- a/installer/dockerfile/agent-scheduler/Dockerfile
+++ b/installer/dockerfile/agent-scheduler/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.25.0 AS builder
+FROM golang:1.25.0@sha256:5502b0e56fca23feba76dbc5387ba59c593c02ccc2f0f7355871ea9a0852cebe AS builder
 WORKDIR /go/src/volcano.sh/
 COPY go.mod go.sum ./
 # Copy staging directory before go mod download since go.mod has replace directive

--- a/installer/dockerfile/agent-scheduler/Dockerfile
+++ b/installer/dockerfile/agent-scheduler/Dockerfile
@@ -21,6 +21,6 @@ RUN go mod download
 ADD . volcano
 RUN cd volcano && make vc-agent-scheduler
 
-FROM alpine:latest
+FROM alpine:latest@sha256:a2d49ea686c2adfe3c992e47dc3b5e7fa6e6b5055609400dc2acaeb241c829f4
 COPY --from=builder /go/src/volcano.sh/volcano/_output/bin/vc-agent-scheduler /vc-agent-scheduler
 ENTRYPOINT ["/vc-agent-scheduler"]

--- a/installer/dockerfile/agent-scheduler/Dockerfile
+++ b/installer/dockerfile/agent-scheduler/Dockerfile
@@ -21,6 +21,6 @@ RUN go mod download
 ADD . volcano
 RUN cd volcano && make vc-agent-scheduler
 
-FROM alpine:latest@sha256:a2d49ea686c2adfe3c992e47dc3b5e7fa6e6b5055609400dc2acaeb241c829f4
+FROM alpine:3.24.0@sha256:a2d49ea686c2adfe3c992e47dc3b5e7fa6e6b5055609400dc2acaeb241c829f4
 COPY --from=builder /go/src/volcano.sh/volcano/_output/bin/vc-agent-scheduler /vc-agent-scheduler
 ENTRYPOINT ["/vc-agent-scheduler"]

--- a/installer/dockerfile/agent/Dockerfile
+++ b/installer/dockerfile/agent/Dockerfile
@@ -15,7 +15,7 @@
 ARG OPEN_EULER_IMAGE_TAG
 ARG BWM_RPM_NAME
 
-FROM golang:1.25.0 AS builder
+FROM golang:1.25.0@sha256:5502b0e56fca23feba76dbc5387ba59c593c02ccc2f0f7355871ea9a0852cebe AS builder
 WORKDIR /go/src/volcano.sh/
 COPY go.mod go.sum ./
 # Copy staging directory before go mod download since go.mod has replace directive
@@ -24,7 +24,7 @@ RUN go mod download
 ADD . volcano
 RUN cd volcano && make vc-agent
 
-FROM openeuler/openeuler:${OPEN_EULER_IMAGE_TAG} AS repo
+FROM openeuler/openeuler:22.03-lts-sp2@sha256:e8c56d3579a10fedd43c5e123db1143b6dcbe4cb59a6e45d6b0b2cf9b13a0c3b AS repo
 WORKDIR /
 RUN yum install -y cpio && \
     yum install -y --downloadonly --destdir=./ oncn-bwm && \

--- a/installer/dockerfile/agent/Dockerfile
+++ b/installer/dockerfile/agent/Dockerfile
@@ -30,7 +30,7 @@ RUN yum install -y cpio && \
     yum install -y --downloadonly --destdir=./ oncn-bwm && \
     rpm2cpio $(ls | grep oncn-bwm) | cpio -div
 
-FROM alpine:latest
+FROM alpine:latest@sha256:a2d49ea686c2adfe3c992e47dc3b5e7fa6e6b5055609400dc2acaeb241c829f4
 RUN apk add sudo libcap
 COPY --from=builder /go/src/volcano.sh/volcano/_output/bin/vc-agent /vc-agent
 COPY --from=builder /go/src/volcano.sh/volcano/_output/bin/network-qos \

--- a/installer/dockerfile/agent/Dockerfile
+++ b/installer/dockerfile/agent/Dockerfile
@@ -30,7 +30,7 @@ RUN yum install -y cpio && \
     yum install -y --downloadonly --destdir=./ oncn-bwm && \
     rpm2cpio $(ls | grep oncn-bwm) | cpio -div
 
-FROM alpine:latest@sha256:a2d49ea686c2adfe3c992e47dc3b5e7fa6e6b5055609400dc2acaeb241c829f4
+FROM alpine:3.24.0@sha256:a2d49ea686c2adfe3c992e47dc3b5e7fa6e6b5055609400dc2acaeb241c829f4
 RUN apk add sudo libcap
 COPY --from=builder /go/src/volcano.sh/volcano/_output/bin/vc-agent /vc-agent
 COPY --from=builder /go/src/volcano.sh/volcano/_output/bin/network-qos \

--- a/installer/dockerfile/controller-manager/Dockerfile
+++ b/installer/dockerfile/controller-manager/Dockerfile
@@ -21,6 +21,6 @@ RUN go mod download
 ADD . volcano
 RUN cd volcano && make vc-controller-manager
 
-FROM alpine:latest@sha256:a2d49ea686c2adfe3c992e47dc3b5e7fa6e6b5055609400dc2acaeb241c829f4
+FROM alpine:3.24.0@sha256:a2d49ea686c2adfe3c992e47dc3b5e7fa6e6b5055609400dc2acaeb241c829f4
 COPY --from=builder /go/src/volcano.sh/volcano/_output/bin/vc-controller-manager /vc-controller-manager
 ENTRYPOINT ["/vc-controller-manager"]

--- a/installer/dockerfile/controller-manager/Dockerfile
+++ b/installer/dockerfile/controller-manager/Dockerfile
@@ -21,6 +21,6 @@ RUN go mod download
 ADD . volcano
 RUN cd volcano && make vc-controller-manager
 
-FROM alpine:latest
+FROM alpine:latest@sha256:a2d49ea686c2adfe3c992e47dc3b5e7fa6e6b5055609400dc2acaeb241c829f4
 COPY --from=builder /go/src/volcano.sh/volcano/_output/bin/vc-controller-manager /vc-controller-manager
 ENTRYPOINT ["/vc-controller-manager"]

--- a/installer/dockerfile/controller-manager/Dockerfile
+++ b/installer/dockerfile/controller-manager/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.25.0 AS builder
+FROM golang:1.25.0@sha256:5502b0e56fca23feba76dbc5387ba59c593c02ccc2f0f7355871ea9a0852cebe AS builder
 WORKDIR /go/src/volcano.sh/
 COPY go.mod go.sum ./
 # Copy staging directory before go mod download since go.mod has replace directive

--- a/installer/dockerfile/scheduler/Dockerfile
+++ b/installer/dockerfile/scheduler/Dockerfile
@@ -21,6 +21,6 @@ RUN go mod download
 ADD . volcano
 RUN cd volcano && make vc-scheduler
 
-FROM alpine:latest@sha256:a2d49ea686c2adfe3c992e47dc3b5e7fa6e6b5055609400dc2acaeb241c829f4
+FROM alpine:3.24.0@sha256:a2d49ea686c2adfe3c992e47dc3b5e7fa6e6b5055609400dc2acaeb241c829f4
 COPY --from=builder /go/src/volcano.sh/volcano/_output/bin/vc-scheduler /vc-scheduler
 ENTRYPOINT ["/vc-scheduler"]

--- a/installer/dockerfile/scheduler/Dockerfile
+++ b/installer/dockerfile/scheduler/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.25.0 AS builder
+FROM golang:1.25.0@sha256:5502b0e56fca23feba76dbc5387ba59c593c02ccc2f0f7355871ea9a0852cebe AS builder
 WORKDIR /go/src/volcano.sh/
 COPY go.mod go.sum ./
 # Copy staging directory before go mod download since go.mod has replace directive

--- a/installer/dockerfile/scheduler/Dockerfile
+++ b/installer/dockerfile/scheduler/Dockerfile
@@ -21,6 +21,6 @@ RUN go mod download
 ADD . volcano
 RUN cd volcano && make vc-scheduler
 
-FROM alpine:latest
+FROM alpine:latest@sha256:a2d49ea686c2adfe3c992e47dc3b5e7fa6e6b5055609400dc2acaeb241c829f4
 COPY --from=builder /go/src/volcano.sh/volcano/_output/bin/vc-scheduler /vc-scheduler
 ENTRYPOINT ["/vc-scheduler"]

--- a/installer/dockerfile/webhook-manager/Dockerfile
+++ b/installer/dockerfile/webhook-manager/Dockerfile
@@ -21,7 +21,7 @@ RUN go mod download
 ADD . volcano
 RUN cd volcano && make vc-webhook-manager
 
-FROM alpine:latest
+FROM alpine:latest@sha256:a2d49ea686c2adfe3c992e47dc3b5e7fa6e6b5055609400dc2acaeb241c829f4
 ARG KUBE_VERSION="1.35.0"
 ARG TARGETARCH
 ARG APK_MIRROR

--- a/installer/dockerfile/webhook-manager/Dockerfile
+++ b/installer/dockerfile/webhook-manager/Dockerfile
@@ -21,7 +21,7 @@ RUN go mod download
 ADD . volcano
 RUN cd volcano && make vc-webhook-manager
 
-FROM alpine:latest@sha256:a2d49ea686c2adfe3c992e47dc3b5e7fa6e6b5055609400dc2acaeb241c829f4
+FROM alpine:3.24.0@sha256:a2d49ea686c2adfe3c992e47dc3b5e7fa6e6b5055609400dc2acaeb241c829f4
 ARG KUBE_VERSION="1.35.0"
 ARG TARGETARCH
 ARG APK_MIRROR

--- a/installer/dockerfile/webhook-manager/Dockerfile
+++ b/installer/dockerfile/webhook-manager/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.25.0 AS builder
+FROM golang:1.25.0@sha256:5502b0e56fca23feba76dbc5387ba59c593c02ccc2f0f7355871ea9a0852cebe AS builder
 WORKDIR /go/src/volcano.sh/
 COPY go.mod go.sum ./
 # Copy staging directory before go mod download since go.mod has replace directive

--- a/staging/src/volcano.sh/apis/hack/generate-groups.sh
+++ b/staging/src/volcano.sh/apis/hack/generate-groups.sh
@@ -46,7 +46,7 @@ APIS_PKG="$3"
 GROUPS_WITH_VERSIONS="$4"
 shift 4
 
-go install k8s.io/code-generator/cmd/{defaulter-gen,client-gen,lister-gen,informer-gen,deepcopy-gen,conversion-gen}@v0.34.1
+go install k8s.io/code-generator/cmd/{defaulter-gen,client-gen,lister-gen,informer-gen,deepcopy-gen,conversion-gen}@v0.35.3
 
 # Go installs the above commands to get installed in $GOBIN if defined, and $GOPATH/bin otherwise:
 GOBIN="$(go env GOBIN)"

--- a/staging/src/volcano.sh/apis/hack/generate-internal-groups.sh
+++ b/staging/src/volcano.sh/apis/hack/generate-internal-groups.sh
@@ -47,7 +47,7 @@ EXT_APIS_PKG="$4"
 GROUPS_WITH_VERSIONS="$5"
 shift 5
 
-go install k8s.io/code-generator/cmd/{defaulter-gen,conversion-gen,client-gen,lister-gen,informer-gen,deepcopy-gen,openapi-gen}@v0.34.1
+go install k8s.io/code-generator/cmd/{defaulter-gen,conversion-gen,client-gen,lister-gen,informer-gen,deepcopy-gen,openapi-gen}@v0.35.3
 
 # Go installs the above commands to get installed in $GOBIN if defined, and $GOPATH/bin otherwise:
 GOBIN="$(go env GOBIN)"

--- a/staging/src/volcano.sh/apis/hack/kube_codegen.sh
+++ b/staging/src/volcano.sh/apis/hack/kube_codegen.sh
@@ -108,7 +108,7 @@ function kube::codegen::gen_helpers() {
             defaulter-gen
         )
         # shellcheck disable=2046 # printf word-splitting is intentional
-        GO111MODULE=on go install $(printf "k8s.io/code-generator/cmd/%s " "${BINS[@]}")
+        GO111MODULE=on go install $(printf "k8s.io/code-generator/cmd/%s@v0.35.3 " "${BINS[@]}")
     )
     # Go installs in $GOBIN if defined, and $GOPATH/bin otherwise
     gobin="${GOBIN:-$(go env GOPATH)/bin}"
@@ -327,7 +327,7 @@ function kube::codegen::gen_openapi() {
             openapi-gen
         )
         # shellcheck disable=2046 # printf word-splitting is intentional
-        GO111MODULE=on go install $(printf "k8s.io/kube-openapi/cmd/%s " "${BINS[@]}")
+        GO111MODULE=on go install $(printf "k8s.io/kube-openapi/cmd/%s@v0.0.0-20250910181357-589584f1c912 " "${BINS[@]}")
     )
     # Go installs in $GOBIN if defined, and $GOPATH/bin otherwise
     gobin="${GOBIN:-$(go env GOPATH)/bin}"
@@ -549,7 +549,7 @@ function kube::codegen::gen_client() {
             lister-gen
         )
         # shellcheck disable=2046 # printf word-splitting is intentional
-        GO111MODULE=on go install $(printf "k8s.io/code-generator/cmd/%s " "${BINS[@]}")
+        GO111MODULE=on go install $(printf "k8s.io/code-generator/cmd/%s@v0.35.3 " "${BINS[@]}")
     )
     # Go installs in $GOBIN if defined, and $GOPATH/bin otherwise
     gobin="${GOBIN:-$(go env GOPATH)/bin}"
@@ -720,7 +720,7 @@ function kube::codegen::gen_register() {
             register-gen
         )
         # shellcheck disable=2046 # printf word-splitting is intentional
-        GO111MODULE=on go install $(printf "k8s.io/code-generator/cmd/%s " "${BINS[@]}")
+        GO111MODULE=on go install $(printf "k8s.io/code-generator/cmd/%s@v0.35.3 " "${BINS[@]}")
     )
     # Go installs in $GOBIN if defined, and $GOPATH/bin otherwise
     gobin="${GOBIN:-$(go env GOPATH)/bin}"

--- a/staging/src/volcano.sh/apis/pkg/client/clientset/versioned/fake/clientset_generated.go
+++ b/staging/src/volcano.sh/apis/pkg/client/clientset/versioned/fake/clientset_generated.go
@@ -52,10 +52,6 @@ import (
 // It's backed by a very simple object tracker that processes creates, updates and deletions as-is,
 // without applying any field management, validations and/or defaults. It shouldn't be considered a replacement
 // for a real clientset and is mostly useful in simple unit tests.
-//
-// Deprecated: NewClientset replaces this with support for field management, which significantly improves
-// server side apply testing. NewClientset is only available when apply configurations are generated (e.g.
-// via --with-applyconfig).
 func NewSimpleClientset(objects ...runtime.Object) *Clientset {
 	o := testing.NewObjectTracker(scheme, codecs.UniversalDecoder())
 	for _, obj := range objects {
@@ -116,6 +112,10 @@ func (c *Clientset) IsWatchListSemanticsUnSupported() bool {
 // It's backed by a very simple object tracker that processes creates, updates and deletions as-is,
 // without applying any validations and/or defaults. It shouldn't be considered a replacement
 // for a real clientset and is mostly useful in simple unit tests.
+//
+// Compared to NewSimpleClientset, the Clientset returned here supports field tracking and thus
+// server-side apply. Beware though that support in that for CRDs is missing
+// (https://github.com/kubernetes/kubernetes/issues/126850).
 func NewClientset(objects ...runtime.Object) *Clientset {
 	o := testing.NewFieldManagedObjectTracker(
 		scheme,


### PR DESCRIPTION
What type of PR is this?
/kind feature

What this PR does / why we need it
This PR improves the OpenSSF Scorecard metrics by pinning the Docker base images to explicit SHA256 hashes. This will increase the `Pinned-Dependencies` metric score for Volcano.

Which issue(s) this PR fixes:
Part of #5366 (improve CLOMonitor score).

Special notes for  reviewer:
GitHub Actions were recently pinned in PR #5469. This PR covers the Docker images that were missed.