### PR TITLE
fix(helm): prevent pending-install hang on Helm v4 by removing hook-s…

### DIFF
--- a/installer/helm/chart/volcano/templates/admission-init.yaml
+++ b/installer/helm/chart/volcano/templates/admission-init.yaml
@@ -69,7 +69,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-delete-policy": before-hook-creation
     "helm.sh/hook-weight": "5" # set a higher weight to reserve buffers.
   labels:
     app: volcano-admission-init
@@ -78,6 +78,7 @@ metadata:
     {{- end }}
 spec:
   backoffLimit: 3
+  ttlSecondsAfterFinished: {{ .Values.custom.admission_init_ttl | default 3600 }}
   template:
     spec:
       {{- if $admission_tolerations }}

--- a/installer/helm/chart/volcano/values.yaml
+++ b/installer/helm/chart/volcano/values.yaml
@@ -25,6 +25,7 @@ custom:
   metrics_enable: false
   admission_enable: true
   admission_replicas: 1
+  admission_init_ttl: 3600
   controller_enable: true
   controller_replicas: 1
   controller_metrics_enable: true

--- a/installer/volcano-development-vap-map.yaml
+++ b/installer/volcano-development-vap-map.yaml
@@ -234,12 +234,13 @@ metadata:
   namespace: volcano-system
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-delete-policy": before-hook-creation
     "helm.sh/hook-weight": "5" # set a higher weight to reserve buffers.
   labels:
     app: volcano-admission-init
 spec:
   backoffLimit: 3
+  ttlSecondsAfterFinished: 3600
   template:
     spec:
       securityContext:

--- a/installer/volcano-development-vap.yaml
+++ b/installer/volcano-development-vap.yaml
@@ -234,12 +234,13 @@ metadata:
   namespace: volcano-system
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-delete-policy": before-hook-creation
     "helm.sh/hook-weight": "5" # set a higher weight to reserve buffers.
   labels:
     app: volcano-admission-init
 spec:
   backoffLimit: 3
+  ttlSecondsAfterFinished: 3600
   template:
     spec:
       securityContext:

--- a/installer/volcano-development.yaml
+++ b/installer/volcano-development.yaml
@@ -234,12 +234,13 @@ metadata:
   namespace: volcano-system
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-delete-policy": before-hook-creation
     "helm.sh/hook-weight": "5" # set a higher weight to reserve buffers.
   labels:
     app: volcano-admission-init
 spec:
   backoffLimit: 3
+  ttlSecondsAfterFinished: 3600
   template:
     spec:
       securityContext:


### PR DESCRIPTION
## Summary
Fix Helm v4 pending-install hang caused by pre-install hook Job cleanup.

This PR mitigates issue #5468, where Volcano installations using Helm v4.x on Kubernetes v1.36.x can become stuck in `pending-install` after the `volcano-admission-init` pre-install hook Job completes successfully.

## Root Cause
Helm v4 introduced a new kstatus-based `StatusWatcher`. When the `admission-init` Job finishes, it emits a `SuccessCriteriaMet=True` condition just before the `Complete=True` condition. Due to `hook-succeeded` being in the Helm delete policy, Helm immediately deletes the Job before its own internal StatusWatcher has had a chance to fully process the terminal `Complete` state. This race condition causes Helm to stall and leave the release in a `pending-install` state.

Upstream Helm behavior tracking:
* helm/helm#31786
* helm/helm#32224
* helm/helm#32214

## Changes
* Removed `hook-succeeded` from the `helm.sh/hook-delete-policy` annotations for the `volcano-admission-init` Job, Role, and RoleBinding.
* Added `ttlSecondsAfterFinished` to the Job spec, defaulting to `3600` seconds (1 hour), configurable via `custom.admission_init_ttl` in `values.yaml`.

## Why the fix works
By relying on the native Kubernetes TTL controller (`ttlSecondsAfterFinished`) instead of Helm's immediate deletion (`hook-succeeded`), the Job remains in the cluster long enough for the Helm v4 watcher to successfully observe the `Complete` condition. A 3600-second TTL also ensures that if the pre-install hook fails, operators have a 1-hour window to retrieve logs and troubleshoot the failure.

## Release Notes
```release-note
Fix: Resolved a bug where Helm v4 installations would hang indefinitely in the `pending-install` state due to a race condition with the `volcano-admission-init` pre-install hook deletion.
