### PR TITLE
cli: respect job namespace when running from file

### DIFF
--- a/pkg/cli/job/run.go
+++ b/pkg/cli/job/run.go
@@ -98,8 +98,12 @@ func RunJob(ctx context.Context) error {
 		job = constructLaunchJobFlagsJob(launchJobFlags, req, limit)
 	}
 
+	if job.Namespace == "" {
+		job.Namespace = launchJobFlags.Namespace
+	}
+
 	jobClient := versioned.NewForConfigOrDie(config)
-	newJob, err := jobClient.BatchV1alpha1().Jobs(launchJobFlags.Namespace).Create(ctx, job, metav1.CreateOptions{})
+	newJob, err := jobClient.BatchV1alpha1().Jobs(job.Namespace).Create(ctx, job, metav1.CreateOptions{})
 	if err != nil {
 		return err
 	}

--- a/pkg/cli/job/run_test.go
+++ b/pkg/cli/job/run_test.go
@@ -33,8 +33,10 @@ import (
 
 func TestCreateJob(t *testing.T) {
 	response := v1alpha1.Job{}
+	requestPath := ""
 
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestPath = r.URL.Path
 		w.Header().Set("Content-Type", "application/json")
 		val, err := json.Marshal(response)
 		if err == nil {
@@ -47,7 +49,9 @@ func TestCreateJob(t *testing.T) {
 	defer server.Close()
 
 	fileName := time.Now().Format("20060102150405999") + "testCreateJob.yaml"
-	val, err := json.Marshal(response)
+	fileJob := v1alpha1.Job{}
+	fileJob.Namespace = "file-ns"
+	val, err := json.Marshal(fileJob)
 	if err != nil {
 		panic(err)
 	}
@@ -61,19 +65,23 @@ func TestCreateJob(t *testing.T) {
 		Name        string
 		ExpectValue error
 		FileName    string
+		ExpectPath  string
 	}{
 		{
 			Name:        "CreateJob",
 			ExpectValue: nil,
+			ExpectPath:  "/apis/batch.volcano.sh/v1alpha1/namespaces/test/jobs",
 		},
 		{
 			Name:        "CreateJobWithFile",
 			FileName:    fileName,
 			ExpectValue: nil,
+			ExpectPath:  "/apis/batch.volcano.sh/v1alpha1/namespaces/file-ns/jobs",
 		},
 	}
 
 	for i, testcase := range testCases {
+		requestPath = ""
 		launchJobFlags = &runFlags{
 			CommonFlags: util.CommonFlags{
 				Master: server.URL,
@@ -81,11 +89,15 @@ func TestCreateJob(t *testing.T) {
 			Name:      "test",
 			Namespace: "test",
 			Requests:  "cpu=1000m,memory=100Mi",
+			FileName:  testcase.FileName,
 		}
 
 		err := RunJob(context.TODO())
 		if err != nil {
 			t.Errorf("case %d (%s): expected: %v, got %v ", i, testcase.Name, testcase.ExpectValue, err)
+		}
+		if requestPath != testcase.ExpectPath {
+			t.Errorf("case %d (%s): expected path: %v, got %v ", i, testcase.Name, testcase.ExpectPath, requestPath)
 		}
 	}
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

`vcctl job run -f` reads the Job object from yaml, but still creates it in the namespace from the CLI flag. Since the flag defaults to `default`, a yaml with `metadata.namespace` set can fail with a namespace mismatch.

This makes the file path use the job namespace when present.

#### Which issue(s) this PR fixes:

N/A

#### Does this PR introduce a user-facing change?

```release-note
vcctl job run -f now respects metadata.namespace from the job yaml.