### PR TITLE
fix(scheduler): use milli-units for scalar resources in GetInqueueRes…

### DIFF
--- a/pkg/scheduler/plugins/util/util.go
+++ b/pkg/scheduler/plugins/util/util.go
@@ -126,10 +126,15 @@ func GetInqueueResource(job *api.JobInfo, allocated *api.Resource) *api.Resource
 			if inqueue.ScalarResources == nil {
 				inqueue.ScalarResources = make(map[v1.ResourceName]float64)
 			}
+			// Scalar resources are stored in milli-units throughout api.Resource
+			// (see NewResource, which uses MilliValue() for scalar resources), so
+			// allocated.ScalarResources is in milli-units. Use MilliValue() here as
+			// well to keep units consistent; otherwise scalar (e.g. GPU/hugepages)
+			// inqueue accounting is off by 1000x.
 			if allocatedMount, ok := allocated.ScalarResources[rName]; !ok {
-				inqueue.ScalarResources[rName] = float64(rQuantity.Value())
+				inqueue.ScalarResources[rName] = float64(rQuantity.MilliValue())
 			} else {
-				reservedScalarRes := float64(rQuantity.Value()) - allocatedMount
+				reservedScalarRes := float64(rQuantity.MilliValue()) - allocatedMount
 				if reservedScalarRes > 0 {
 					inqueue.ScalarResources[rName] = reservedScalarRes
 				}

--- a/pkg/scheduler/plugins/util/util_test.go
+++ b/pkg/scheduler/plugins/util/util_test.go
@@ -1,0 +1,108 @@
+/*
+Copyright 2024 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+
+	"volcano.sh/apis/pkg/apis/scheduling"
+	"volcano.sh/volcano/pkg/scheduler/api"
+)
+
+const gpuResourceName = v1.ResourceName("nvidia.com/gpu")
+
+func newJobWithMinResources(rl v1.ResourceList) *api.JobInfo {
+	return &api.JobInfo{
+		PodGroup: &api.PodGroup{
+			PodGroup: scheduling.PodGroup{
+				Spec: scheduling.PodGroupSpec{
+					MinResources: &rl,
+				},
+			},
+		},
+	}
+}
+
+// TestGetInqueueResourceScalarUnits guards against a unit-mismatch regression:
+// api.Resource stores scalar resources (e.g. GPU, hugepages) in milli-units
+// (NewResource uses MilliValue()), and allocated.ScalarResources is therefore in
+// milli-units. GetInqueueResource must produce scalar values in the same milli-unit
+// scale; otherwise queue inqueue accounting for scalar resources is off by 1000x.
+func TestGetInqueueResourceScalarUnits(t *testing.T) {
+	tests := []struct {
+		name        string
+		minRes      v1.ResourceList
+		allocated   *api.Resource
+		wantCPU     float64
+		wantMem     float64
+		wantScalars map[v1.ResourceName]float64
+	}{
+		{
+			name: "gpu with nothing allocated is reported in milli-units",
+			minRes: v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("4"),
+				v1.ResourceMemory: resource.MustParse("8Gi"),
+				gpuResourceName:   resource.MustParse("8"),
+			},
+			allocated: api.EmptyResource(),
+			wantCPU:   4000,
+			wantMem:   float64(8 * 1024 * 1024 * 1024),
+			wantScalars: map[v1.ResourceName]float64{
+				// 8 GPUs == 8000 milli-units, matching api.NewResource.
+				gpuResourceName: 8000,
+			},
+		},
+		{
+			name: "gpu partially allocated subtracts in consistent milli-units",
+			minRes: v1.ResourceList{
+				gpuResourceName: resource.MustParse("8"),
+			},
+			// 2 GPUs already allocated == 2000 milli-units.
+			allocated: &api.Resource{
+				ScalarResources: map[v1.ResourceName]float64{
+					gpuResourceName: 2000,
+				},
+			},
+			wantScalars: map[v1.ResourceName]float64{
+				// (8000 - 2000) milli-units still reserved.
+				gpuResourceName: 6000,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			job := newJobWithMinResources(tt.minRes)
+			got := GetInqueueResource(job, tt.allocated)
+
+			if got.MilliCPU != tt.wantCPU {
+				t.Errorf("MilliCPU = %v, want %v", got.MilliCPU, tt.wantCPU)
+			}
+			if tt.wantMem != 0 && got.Memory != tt.wantMem {
+				t.Errorf("Memory = %v, want %v", got.Memory, tt.wantMem)
+			}
+			for name, want := range tt.wantScalars {
+				if gotVal := got.ScalarResources[name]; gotVal != want {
+					t.Errorf("ScalarResources[%s] = %v, want %v", name, gotVal, want)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

Fix incorrect scalar resource accounting in `GetInqueueResource()` caused by a unit mismatch between scalar resources stored in `api.Resource` and values derived from `PodGroup.MinResources`.

Scalar resources (e.g. GPUs, hugepages, and extended resources) are represented in milli-units throughout Volcano's resource model. However, `GetInqueueResource()` used `resource.Quantity.Value()` when calculating scalar inqueue reservations while subtracting allocations already stored in milli-units, resulting in inconsistent accounting and incorrect queue admission decisions.

## Root Cause

The scalar resource branch in `GetInqueueResource()` used:

```go
float64(rQuantity.Value())
```

while:

```go
allocated.ScalarResources
```

stores scalar resources in milli-units.

This caused:

- Scalar reservations to be reported 1000x smaller than expected
- Incorrect subtraction for partially allocated jobs
- GPU and extended-resource dimensions to disappear from inqueue accounting
- Queue capacity checks to evaluate against incomplete resource usage

## Fix

Replace `Value()` with `MilliValue()` for scalar resources:

```go
if allocatedMount, ok := allocated.ScalarResources[rName]; !ok {
    inqueue.ScalarResources[rName] = float64(rQuantity.MilliValue())
} else {
    reservedScalarRes := float64(rQuantity.MilliValue()) - allocatedMount
    if reservedScalarRes > 0 {
        inqueue.ScalarResources[rName] = reservedScalarRes
    }
}
```

This keeps scalar resource accounting consistent with the rest of the scheduler resource model and aligns inqueue reservations with allocated, capability, and min-resource calculations.

## Impact

### Before

- GPU and extended-resource inqueue reservations were significantly undercounted
- Capacity and proportion plugins could over-admit GPU workloads
- Large numbers of unschedulable pods could be created
- Queue quota enforcement for scalar resources could be bypassed

### After

- Scalar resource accounting is consistent across scheduler components
- Queue admission correctly reserves GPU and extended resources
- Capacity and overcommit protections behave as intended
- Excess pending pod creation is prevented

## Testing

Added regression tests covering scalar resource accounting in:

```text
pkg/scheduler/plugins/util/util_test.go
```

Verified:

- GPU reservations are reported in milli-units
- Partially allocated GPU resources are subtracted correctly
- Existing capacity, proportion, overcommit, and util plugin tests continue to pass

## Type of Change

- [x] Bug fix
- [x] Added regression tests
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update