### PR TITLE
docs: add tiername usage documentation for NetworkTopologyAware

### DIFF
--- a/docs/design/Network Topology Aware Scheduling.md
+++ b/docs/design/Network Topology Aware Scheduling.md
@@ -287,6 +287,39 @@ spec:
                   cpu: "4"
 ```
 
+## Topology Tier Selection
+
+A topology tier represents a performance domain within the cluster network hierarchy. In complex data center networks, switches and nodes are connected in a tree-like hierarchical structure. The latency and bandwidth characteristics differ between different levels of the network tree.
+
+A typical topology hierarchy is defined as follows:
+
+```text
+region
+ └── zone
+      └── rack
+           └── host
+```
+
+In this tree, the parent-child relationship dictates the topology levels. Real performance domains (such as switches or TORs) are represented by `HyperNode` CRDs, each categorized under a specific `tier` (an integer value) or `tierName` (a string identifier).
+
+To configure topology-aware scheduling affinity levels, Volcano supports selecting the scheduling boundary using either the tier level or name. The `highestTierName` field allows users to specify the highest network topology tier name the job or partition is permitted to span during scheduling.
+
+How the scheduler limits topology awareness according to the selected tier name:
+
+- If `highestTierName` is configured, Volcano looks up the name in the cluster's HyperNode tier name map (built from `HyperNode.spec.tierName` fields) at scheduling session initialization and translates it into the corresponding numerical `highestTierAllowed`. The value must match an existing `HyperNode.spec.tierName` defined in the cluster's HyperNodes. If no HyperNode in the cluster has a matching `spec.tierName`, the translation is skipped and no tier constraint is applied for that job.
+- Once translated, the scheduler limits topology awareness such that the job or partition is only scheduled within HyperNodes at or below the numerical tier representing that name.
+
+Examples:
+
+- **`highestTierName: zone`**: The scheduler limits topology constraints to the `zone` level (meaning scheduling considers topology up to the zone level and permits spanning multiple racks within a zone, but not across zones).
+- **`highestTierName: rack`**: The scheduler limits topology constraints to the `rack` level (meaning scheduling considers topology up to the rack level, and does not permit spanning across different racks).
+
+Default Behavior:
+
+- If `networkTopology` is not configured, no topology-aware scheduling is applied.
+- If `mode: soft` is configured, topology affinity is preferred but no hard boundary is enforced.
+- If `mode: hard` is configured, `highestTierAllowed` or `highestTierName` can be used to define the scheduling boundary.
+
 # Implementation
 
 ## Overview
@@ -596,9 +629,9 @@ Add admission for hyperNode for two aspects validation
      subGroupPolicy:
        - name: "task0" # Taken from jobSpec.tasks[].name
          subGroupSize: 3 # Taken from jobSpec.tasks[].partitionPolicy.partitionSize
-         labelSelector: 
-           matchLabels: 
-             volcano.sh/task-spec: task0   # The label is automatically added to VCJob pods upon creation to indicate their task information.
+         labelSelector:
+           matchLabels:
+             volcano.sh/task-spec: task0 # The label is automatically added to VCJob pods upon creation to indicate their task information.
          matchLabelKeys:
            - volcano.sh/partition-id
          networkTopology: # Taken from jobSpec.tasks[].partitionPolicy.networkTopology
@@ -606,9 +639,9 @@ Add admission for hyperNode for two aspects validation
            highestTierAllowed: 1
        - name: "task1" # Taken from jobSpec.tasks[].name
          subGroupSize: 2 # Taken from jobSpec.tasks[].partitionPolicy.partitionSize
-         labelSelector: 
-           matchLabels: 
-             volcano.sh/task-spec: task1   # The label is automatically added to VCJob pods upon creation to indicate their task information.
+         labelSelector:
+           matchLabels:
+             volcano.sh/task-spec: task1 # The label is automatically added to VCJob pods upon creation to indicate their task information.
          matchLabelKeys:
            - volcano.sh/partition-id
          networkTopology: # Taken from jobSpec.tasks[].partitionPolicy.networkTopology
@@ -693,8 +726,8 @@ type JobInfo struct {
   ```yaml
   subGroupPolicy:
     - name: "task0"
-      labelSelector: 
-        matchLabels: 
+      labelSelector:
+        matchLabels:
           volcano.sh/task-spec: task0
       matchLabelKeys:
         - volcano.sh/partition-id

--- a/docs/design/Network Topology Aware Scheduling.md
+++ b/docs/design/Network Topology Aware Scheduling.md
@@ -106,7 +106,7 @@ spec:
   tier: 1
   members:
     - name: node0
-      name: node1
+    - name: node1
 ---
 version: topology.volcano.sh/v1alpha1
 kind: HyperNode
@@ -114,8 +114,8 @@ name: s1
 spec:
   tier: 1
   members:
-    name: node2
-    name: node3
+    - name: node2
+    - name: node3
 ---
 version: topology.volcano.sh/v1alpha1
 kind: HyperNode
@@ -123,8 +123,8 @@ name: s2
 spec:
   tier: 1
   members:
-    name: node4
-    name: node5
+    - name: node4
+    - name: node5
 ---
 version: topology.volcano.sh/v1alpha1
 kind: HyperNode
@@ -132,8 +132,8 @@ name: s3
 spec:
   tier: 1
   members:
-    name: node6
-    name: node7
+    - name: node6
+    - name: node7
 ---
 version: topology.volcano.sh/v1alpha1
 kind: HyperNode
@@ -141,16 +141,17 @@ name: s4
 spec:
   tier: 2
   members:
-    name: s0
-    name: s1
+    - name: s0
+    - name: s1
+---
 version: topology.volcano.sh/v1alpha1
 kind: HyperNode
 name: s5
 spec:
   tier: 2
   members:
-    name: s2
-    name: s3
+    - name: s2
+    - name: s3
 ---
 version: topology.volcano.sh/v1alpha1
 kind: HyperNode
@@ -158,8 +159,8 @@ name: s6
 spec:
   tier: 3
   members:
-    name: s4
-    name: s5
+    - name: s4
+    - name: s5
 ```
 
 Example 2:  
@@ -171,12 +172,12 @@ version: topology.volcano.sh/v1alpha1
 kind: HyperNode
 name: roce-network0
 spec:
-tier: 2
+  tier: 2
   members:
-  - name: nvlink-network0
-    type: HyperNode
-  - name: nvlink-network1
-    type: HyperNode
+    - name: nvlink-network0
+      type: HyperNode
+    - name: nvlink-network1
+      type: HyperNode
 ---
 version: topology.volcano.sh/v1alpha1
 kind: HyperNode
@@ -184,10 +185,10 @@ name: roce-network1
 spec:
   tier: 2
   members:
-  - name: nvlink-network2
-    type: HyperNode
-  - name: nvlink-network3
-    type: HyperNode
+    - name: nvlink-network2
+      type: HyperNode
+    - name: nvlink-network3
+      type: HyperNode
 ---
 version: topology.volcano.sh/v1alpha1
 kind: HyperNode
@@ -195,10 +196,10 @@ name: nvlink_network-0
 spec:
   tier: 1
   members:
-  - name: node1
-    type: Node
-    name: node2
-    type: Node
+    - name: node1
+      type: Node
+    - name: node2
+      type: Node
 ---
 version: topology.volcano.sh/v1alpha1
 kind: HyperNode
@@ -206,10 +207,10 @@ name: nvlink_network-1
 spec:
   tier: 1
   members:
-  - name: node3
-    type: Node
-    name: node4
-    type: Node
+    - name: node3
+      type: Node
+    - name: node4
+      type: Node
 ---
 version: topology.volcano.sh/v1alpha1
 kind: HyperNode
@@ -217,10 +218,10 @@ name: nvlink_network-2
 spec:
   tier: 1
   members:
-  - name: node5
-    type: Node
-    name: node6
-    type: Node
+    - name: node5
+      type: Node
+    - name: node6
+      type: Node
 ---
 version: topology.volcano.sh/v1alpha1
 kind: HyperNode
@@ -228,10 +229,10 @@ name: nvlink_network-3
 spec:
   tier: 1
   members:
-  - name: node7
-    type: Node
-    name: node8
-    type: Node
+    - name: node7
+      type: Node
+    - name: node8
+      type: Node
 ```
 
 ### network topology generation and update

--- a/docs/design/Network Topology Aware Scheduling.md
+++ b/docs/design/Network Topology Aware Scheduling.md
@@ -105,15 +105,15 @@ name: s0
 spec:
   tier: 1
   members:
-  - name: node0
-    name: node1
+    - name: node0
+      name: node1
 ---
 version: topology.volcano.sh/v1alpha1
 kind: HyperNode
 name: s1
 spec:
-   tier: 1
-   members:
+  tier: 1
+  members:
     name: node2
     name: node3
 ---
@@ -121,8 +121,8 @@ version: topology.volcano.sh/v1alpha1
 kind: HyperNode
 name: s2
 spec:
-   tier: 1
-   members:
+  tier: 1
+  members:
     name: node4
     name: node5
 ---
@@ -130,8 +130,8 @@ version: topology.volcano.sh/v1alpha1
 kind: HyperNode
 name: s3
 spec:
-   tier: 1
-   members:
+  tier: 1
+  members:
     name: node6
     name: node7
 ---
@@ -139,16 +139,16 @@ version: topology.volcano.sh/v1alpha1
 kind: HyperNode
 name: s4
 spec:
-   tier: 2
-   members:
+  tier: 2
+  members:
     name: s0
     name: s1
 version: topology.volcano.sh/v1alpha1
 kind: HyperNode
 name: s5
 spec:
-   tier: 2
-   members:
+  tier: 2
+  members:
     name: s2
     name: s3
 ---
@@ -156,11 +156,10 @@ version: topology.volcano.sh/v1alpha1
 kind: HyperNode
 name: s6
 spec:
-   tier: 3
-   members:
+  tier: 3
+  members:
     name: s4
     name: s5
-
 ```
 
 Example 2:  
@@ -302,7 +301,24 @@ region
 
 In this tree, the parent-child relationship dictates the topology levels. Real performance domains (such as switches or TORs) are represented by `HyperNode` CRDs, each categorized under a specific `tier` (an integer value) or `tierName` (a string identifier).
 
-To configure topology-aware scheduling affinity levels, Volcano supports selecting the scheduling boundary using either the tier level or name. The `highestTierName` field allows users to specify the highest network topology tier name the job or partition is permitted to span during scheduling.
+To configure topology-aware scheduling affinity levels, Volcano supports selecting the scheduling boundary using either the numerical tier level or the tier name. These two fields are mutually exclusive and cannot be set simultaneously.
+
+### Tier Number (`highestTierAllowed`)
+
+The `highestTierAllowed` field allows users to specify the highest network topology tier as an integer. The scheduler limits topology awareness such that the job or partition is only scheduled within HyperNodes at or below the specified numerical tier.
+
+How the scheduler limits topology awareness according to the selected tier number:
+
+- If `highestTierAllowed` is configured, the scheduler directly uses the integer value to constrain scheduling. The job or partition is only placed on HyperNodes whose `tier` is less than or equal to `highestTierAllowed`.
+
+Examples:
+
+- **`highestTierAllowed: 1`**: The scheduler limits topology constraints to tier 1 (the lowest tier, closest to the nodes), meaning all pods must be co-located within a single leaf HyperNode.
+- **`highestTierAllowed: 2`**: The scheduler allows scheduling across HyperNodes up to tier 2, permitting pods to span racks within a zone but not across zones.
+
+### Tier Name (`highestTierName`)
+
+The `highestTierName` field allows users to specify the highest network topology tier as a human-readable string identifier (e.g., `zone`, `rack`). This is useful when cluster administrators assign meaningful names to topology tiers via `HyperNode.spec.tierName`.
 
 How the scheduler limits topology awareness according to the selected tier name:
 
@@ -314,7 +330,7 @@ Examples:
 - **`highestTierName: zone`**: The scheduler limits topology constraints to the `zone` level (meaning scheduling considers topology up to the zone level and permits spanning multiple racks within a zone, but not across zones).
 - **`highestTierName: rack`**: The scheduler limits topology constraints to the `rack` level (meaning scheduling considers topology up to the rack level, and does not permit spanning across different racks).
 
-Default Behavior:
+### Default Behavior
 
 - If `networkTopology` is not configured, no topology-aware scheduling is applied.
 - If `mode: soft` is configured, topology affinity is preferred but no hard boundary is enforced.

--- a/docs/user-guide/how_to_use_network_topology_aware_scheduling.md
+++ b/docs/user-guide/how_to_use_network_topology_aware_scheduling.md
@@ -45,7 +45,8 @@ In Volcano Jobs, the `NetworkTopology` field can be configured to describe the n
 - `mode`: Supports `hard` and `soft` modes.
   - `hard`: Hard constraint, tasks within the job must be deployed within the same HyperNode.
   - `soft`: Soft constraint, tasks are deployed within the same HyperNode as much as possible.
-- `highestTierAllowed`: Used with hard mode, indicating the highest tier of HyperNode allowed for job deployment. This field is not required when mode is soft.
+- `highestTierAllowed`: Used with hard mode, indicating the highest numerical tier level (integer) of HyperNode allowed for job deployment. This field is not required when mode is soft.
+- `highestTierName`: Used with hard mode, indicating the highest tier name (string) of HyperNode allowed for job deployment (e.g., `zone`, `rack`). Note that `highestTierAllowed` and `highestTierName` cannot be set simultaneously, and the value must match an existing `HyperNode.spec.tierName` in the cluster.
 
 For example, the following configuration means the job can only be deployed within HyperNodes of tier 2 or lower, such as s4 and s5, and their child nodes s0, s1, s2, s3. Otherwise, the job will remain in the Pending state:
 
@@ -54,6 +55,15 @@ spec:
   networkTopology:
     mode: hard
     highestTierAllowed: 2
+```
+
+Alternatively, you can specify the boundary constraint using a tier name:
+
+```yaml
+spec:
+  networkTopology:
+    mode: hard
+    highestTierName: zone
 ```
 
 By configuring this scheduling constraint, users can precisely control the network topology constraints of the job, ensuring that the job runs in the best performance domain that meets the conditions, thereby significantly improving training efficiency.
@@ -149,7 +159,7 @@ data:
           hypernode.binpack.resources.nvidia.com/gpu: 2                # HyperNode-Level bin packing weight for "nvidia.com/gpu" resources
           hypernode.binpack.resources.example.com/foo: 3               # HyperNode-Level bin packing weight for "example.com/foo" resources
           hypernode.binpack.normal-pod.enable: true                    # Whether or not to enable HyperNode-level bin packing for normal pods
-          hypernode.binpack.normal-pod.fading: 0.8                     # Parameter to control the weights of hypernodes of different tiers, i.e., the weights of hypernodes of tier `i` are math.Pow(fading, i-1) 
+          hypernode.binpack.normal-pod.fading: 0.8                     # Parameter to control the weights of hypernodes of different tiers, i.e., the weights of hypernodes of tier `i` are math.Pow(fading, i-1)
 ```
 
 ### 3.2 Building Network Topology

--- a/docs/user-guide/how_to_use_network_topology_aware_scheduling.md
+++ b/docs/user-guide/how_to_use_network_topology_aware_scheduling.md
@@ -271,7 +271,7 @@ Based on the following network topology, this chapter will demonstrate how workl
    network-topology-job-t0-6   1/1     Running   0          5s    192.168.0.16   node6
    network-topology-job-t0-7   1/1     Running   0          5s    192.168.0.17   node7
    ```
-   In this example, the entire Job is scheduled to HyperNode2 (Node0~Node7). The first partition (Pod0~Pod3) is scheduled to HyperNode0 (Node0~Node3), the second partitions (Pod4~Pod7) is scheduled to HyperNode1 (Node4~Node7), and each partition satisfies its own network topology constraints.
+   In this example, the entire Job is scheduled to HyperNode2 (Node0~~Node7). The first partition (Pod0~~Pod3) is scheduled to HyperNode0 (Node0~~Node3), the second partitions (Pod4~~Pod7) is scheduled to HyperNode1 (Node4~Node7), and each partition satisfies its own network topology constraints.
 
 #### 3.3.3 Deploying Using Volcano Job Without Network Topology Constraints
 


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

This PR updates the NetworkTopologyAware documentation to include guidance for using `highestTierName` (tiername).

The feature was introduced in #4795, but the design document and user guide did not explain how to configure topology-aware scheduling using tier names. This PR adds documentation describing topology tiers, `highestTierName` behavior, configuration examples, and usage recommendations.

#### Which issue(s) this PR fixes:

Fixes #5483

#### Special notes for your reviewer:

* Updated the NetworkTopologyAware design document.
* Updated the user guide with configuration examples and usage guidance.
* Documentation only; no code changes.

#### Does this PR introduce a user-facing change?

```release-note
Added documentation for the NetworkTopologyAware highestTierName (tiername) feature, including design details, configuration examples, and usage guidance.
```
