### PR TITLE
fix(webhook): add separator between PodGroup validation errors

### DIFF
--- a/pkg/webhooks/admission/podgroups/validate/validate_podgroup.go
+++ b/pkg/webhooks/admission/podgroups/validate/validate_podgroup.go
@@ -90,12 +90,16 @@ func Validate(ar admissionv1.AdmissionReview) *admissionv1.AdmissionResponse {
 
 // validatePodGroup validates a PodGroup when it's being created
 func validatePodGroup(pg *schedulingv1beta1.PodGroup) string {
-	var errMsg string
+	var errs []string
 
-	errMsg += checkQueueState(pg.Spec.Queue)
-	errMsg += validateNetworkTopology(pg.Spec.NetworkTopology, pg.Spec.SubGroupPolicy)
+	if msg := checkQueueState(pg.Spec.Queue); msg != "" {
+		errs = append(errs, msg)
+	}
+	if msg := validateNetworkTopology(pg.Spec.NetworkTopology, pg.Spec.SubGroupPolicy); msg != "" {
+		errs = append(errs, msg)
+	}
 
-	return errMsg
+	return strings.Join(errs, "; ")
 }
 
 // checkQueueState verifies if the queue exists and is in the open state

--- a/pkg/webhooks/admission/podgroups/validate/validate_podgroup.go
+++ b/pkg/webhooks/admission/podgroups/validate/validate_podgroup.go
@@ -93,10 +93,10 @@ func validatePodGroup(pg *schedulingv1beta1.PodGroup) string {
 	var errs []string
 
 	if msg := checkQueueState(pg.Spec.Queue); msg != "" {
-		errs = append(errs, msg)
+		errs = append(errs, strings.TrimSpace(msg))
 	}
 	if msg := validateNetworkTopology(pg.Spec.NetworkTopology, pg.Spec.SubGroupPolicy); msg != "" {
-		errs = append(errs, msg)
+		errs = append(errs, strings.TrimSpace(msg))
 	}
 
 	return strings.Join(errs, "; ")

--- a/pkg/webhooks/admission/podgroups/validate/validate_podgroup_test.go
+++ b/pkg/webhooks/admission/podgroups/validate/validate_podgroup_test.go
@@ -37,6 +37,10 @@ func TestValidatePodGroup(t *testing.T) {
 		podGroup    *schedulingv1beta1.PodGroup
 		queue       *schedulingv1beta1.Queue
 		expectError bool
+		// msgContains lists substrings that must all be present in the
+		// rejection message, used to assert that multiple validation errors
+		// are reported and properly separated.
+		msgContains []string
 	}{
 		{
 			name: "valid podgroup with open queue",
@@ -209,6 +213,29 @@ func TestValidatePodGroup(t *testing.T) {
 			queue:       &schedulingv1beta1.Queue{},
 			expectError: true,
 		},
+		{
+			name: "invalid podgroup failing both queue and networkTopology checks reports a separated message",
+			podGroup: &schedulingv1beta1.PodGroup{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "PodGroup",
+					APIVersion: "scheduling.volcano.sh/v1beta1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-podgroup",
+				},
+				Spec: schedulingv1beta1.PodGroupSpec{
+					Queue: "test-queue",
+					NetworkTopology: &schedulingv1beta1.NetworkTopologySpec{
+						Mode:               schedulingv1beta1.HardNetworkTopologyMode,
+						HighestTierAllowed: &highestTierAllowed,
+						HighestTierName:    "volcano.sh/hypernode",
+					},
+				},
+			},
+			queue:       &schedulingv1beta1.Queue{},
+			expectError: true,
+			msgContains: []string{"unable to find queue", "; ", "must not specify 'highestTierAllowed' and 'highestTierName'"},
+		},
 	}
 
 	for _, tt := range tests {
@@ -249,6 +276,10 @@ func TestValidatePodGroup(t *testing.T) {
 				t.Errorf("Expected error but got allowed response")
 			} else if !tt.expectError && !response.Allowed {
 				t.Errorf("Expected allowed response but got error: %v", response.Result.Message)
+			}
+
+			for _, want := range tt.msgContains {
+				assert.Contains(t, response.Result.Message, want)
 			}
 		})
 	}

--- a/pkg/webhooks/admission/podgroups/validate/validate_podgroup_test.go
+++ b/pkg/webhooks/admission/podgroups/validate/validate_podgroup_test.go
@@ -278,8 +278,12 @@ func TestValidatePodGroup(t *testing.T) {
 				t.Errorf("Expected allowed response but got error: %v", response.Result.Message)
 			}
 
-			for _, want := range tt.msgContains {
-				assert.Contains(t, response.Result.Message, want)
+			if len(tt.msgContains) > 0 {
+				if assert.NotNil(t, response.Result) {
+					for _, want := range tt.msgContains {
+						assert.Contains(t, response.Result.Message, want)
+					}
+				}
 			}
 		})
 	}


### PR DESCRIPTION
Fixes #5443

### What this fixes

`validatePodGroup` built its rejection message by appending each validator's output with `+=` and no separator:

```go
errMsg += checkQueueState(pg.Spec.Queue)
errMsg += validateNetworkTopology(pg.Spec.NetworkTopology, pg.Spec.SubGroupPolicy)
```

So when a PodGroup failed more than one check at once (for example a non-existent queue *and* an invalid `networkTopology`), the two messages ran together mid-sentence and the rejection was hard to read.

This collects each non-empty message into a slice and joins them with `"; "`, so the errors are reported as distinct, readable items. An empty slice still joins to `""`, so the valid (no-error) path is unchanged.

### Test

Added a case to `TestValidatePodGroup` that fails both the queue and the `networkTopology` checks at the same time, and asserts the resulting message contains both fragments and the `"; "` separator.

---

cc @DevMhrn — you mentioned on the issue that you might pick this up. I already had the fix and test ready so I went ahead and opened it, but happy to defer or close this if you'd rather take it. Either way, no problem at all.
