### PR TITLE
perf(scheduler): remove lock contention in PrioritizeNodes map phase

### DIFF
--- a/pkg/scheduler/util/scheduler_helper.go
+++ b/pkg/scheduler/util/scheduler_helper.go
@@ -27,7 +27,6 @@ import (
 	"math"
 	"math/rand"
 	"sort"
-	"sync"
 	"sync/atomic"
 	"time"
 
@@ -50,6 +49,13 @@ const (
 )
 
 var lastProcessedNodeIndex atomic.Int64
+
+// nodeScoreResult holds the per-node scoring output collected by parallel workers.
+type nodeScoreResult struct {
+	pluginScores map[string]float64
+	orderScore   float64
+	err          error
+}
 
 // CalculateNumOfFeasibleNodesToFind returns the number of feasible nodes that once found,
 // the scheduler stops its search for more feasible nodes.
@@ -76,34 +82,41 @@ func CalculateNumOfFeasibleNodesToFind(numAllNodes int32) (numNodes int32) {
 
 // PrioritizeNodes returns a map whose key is node's score and value are corresponding nodes
 func PrioritizeNodes(task *api.TaskInfo, nodes []*api.NodeInfo, batchFn api.BatchNodeOrderFn, mapFn api.NodeOrderMapFn, reduceFn api.NodeOrderReduceFn) map[float64][]*api.NodeInfo {
-	pluginNodeScoreMap := map[string]fwk.NodeScoreList{}
-	nodeOrderScoreMap := map[string]float64{}
 	nodeScores := map[float64][]*api.NodeInfo{}
-	var workerLock sync.Mutex
+
+	results := make([]nodeScoreResult, len(nodes))
+
 	scoreNode := func(index int) {
 		node := nodes[index]
-		mapScores, orderScore, err := mapFn(task, node)
+		pluginScores, orderScore, err := mapFn(task, node)
 		if err != nil {
+			results[index].err = err
 			klog.Errorf("Error in Calculating Priority for the node:%v", err)
 			return
 		}
-
-		workerLock.Lock()
-		for plugin, score := range mapScores {
-			nodeScoreList, ok := pluginNodeScoreMap[plugin]
-			if !ok {
-				nodeScoreList = fwk.NodeScoreList{}
-			}
-			hp := fwk.NodeScore{}
-			hp.Name = node.Name
-			hp.Score = int64(math.Floor(score))
-			pluginNodeScoreMap[plugin] = append(nodeScoreList, hp)
-		}
-		nodeOrderScoreMap[node.Name] = orderScore
-		workerLock.Unlock()
+		// Lock-free write to pre-allocated slice at unique index
+		results[index].pluginScores = pluginScores
+		results[index].orderScore = orderScore
 	}
 	scoreStart := time.Now()
 	workqueue.ParallelizeUntil(context.TODO(), 16, len(nodes), scoreNode)
+
+	pluginNodeScoreMap := map[string]fwk.NodeScoreList{}
+	nodeOrderScoreMap := make(map[string]float64, len(nodes))
+	for index, res := range results {
+		if res.err != nil {
+			continue
+		}
+		nodeName := nodes[index].Name
+		for plugin, score := range res.pluginScores {
+			pluginNodeScoreMap[plugin] = append(pluginNodeScoreMap[plugin], fwk.NodeScore{
+				Name:  nodeName,
+				Score: int64(math.Floor(score)),
+			})
+		}
+		nodeOrderScoreMap[nodeName] = res.orderScore
+	}
+
 	reduceScores, err := reduceFn(task, pluginNodeScoreMap)
 	if err != nil {
 		klog.Errorf("Error in Calculating Priority for the node:%v", err)

--- a/pkg/scheduler/util/scheduler_helper_test.go
+++ b/pkg/scheduler/util/scheduler_helper_test.go
@@ -21,11 +21,14 @@ limitations under the License.
 package util
 
 import (
+	"fmt"
+	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/util/sets"
+	fwk "k8s.io/kube-scheduler/framework"
 
 	"volcano.sh/volcano/cmd/scheduler/app/options"
 	"volcano.sh/volcano/pkg/scheduler/api"
@@ -706,5 +709,162 @@ func TestSelectBestHyperNodeAndScore(t *testing.T) {
 					tc.name, tc.expectedScore, score)
 			}
 		})
+	}
+}
+
+func TestPrioritizeNodes(t *testing.T) {
+	task := &api.TaskInfo{Name: "task1", Namespace: "default"}
+	node1 := &api.NodeInfo{Name: "node1"}
+	node2 := &api.NodeInfo{Name: "node2"}
+	node3 := &api.NodeInfo{Name: "node3"}
+
+	noopBatch := func(*api.TaskInfo, []*api.NodeInfo) (map[string]float64, error) {
+		return nil, nil
+	}
+	noopMap := func(*api.TaskInfo, *api.NodeInfo) (map[string]float64, float64, error) {
+		return nil, 0, nil
+	}
+	noopReduce := func(*api.TaskInfo, map[string]fwk.NodeScoreList) (map[string]float64, error) {
+		return nil, nil
+	}
+
+	testCases := []struct {
+		name     string
+		nodes    []*api.NodeInfo
+		batchFn  api.BatchNodeOrderFn
+		mapFn    api.NodeOrderMapFn
+		reduceFn api.NodeOrderReduceFn
+		expected map[string]float64
+	}{
+		{
+			name:     "empty node list",
+			batchFn:  noopBatch,
+			mapFn:    noopMap,
+			reduceFn: noopReduce,
+		},
+		{
+			name:  "scores from batch, order and reduce are summed",
+			nodes: []*api.NodeInfo{node1, node2},
+			batchFn: func(_ *api.TaskInfo, _ []*api.NodeInfo) (map[string]float64, error) {
+				return map[string]float64{"node1": 10, "node2": 20}, nil
+			},
+			mapFn: func(_ *api.TaskInfo, n *api.NodeInfo) (map[string]float64, float64, error) {
+				order := map[string]float64{"node1": 1, "node2": 2}
+				return map[string]float64{"plugin": 5}, order[n.Name], nil
+			},
+			reduceFn: func(_ *api.TaskInfo, m map[string]fwk.NodeScoreList) (map[string]float64, error) {
+				out := map[string]float64{}
+				for _, list := range m {
+					for _, ns := range list {
+						out[ns.Name] += 3
+					}
+				}
+				return out, nil
+			},
+			// node1: batch(10) + order(1) + reduce(3) = 14
+			// node2: batch(20) + order(2) + reduce(3) = 25
+			expected: map[string]float64{"node1": 14, "node2": 25},
+		},
+		{
+			name:    "mapFn error on one node still scores the others",
+			nodes:   []*api.NodeInfo{node1, node2, node3},
+			batchFn: noopBatch,
+			mapFn: func(_ *api.TaskInfo, n *api.NodeInfo) (map[string]float64, float64, error) {
+				if n.Name == "node2" {
+					return nil, 0, fmt.Errorf("map failed")
+				}
+				return nil, 7, nil
+			},
+			reduceFn: noopReduce,
+			// node1: order(7) = 7
+			// node2: mapFn errored, skipped during merge, defaults to 0
+			// node3: order(7) = 7
+			expected: map[string]float64{"node1": 7, "node2": 0, "node3": 7},
+		},
+		{
+			name:  "batchFn error returns empty result",
+			nodes: []*api.NodeInfo{node1, node2},
+			batchFn: func(*api.TaskInfo, []*api.NodeInfo) (map[string]float64, error) {
+				return nil, fmt.Errorf("batch failed")
+			},
+			mapFn:    noopMap,
+			reduceFn: noopReduce,
+		},
+		{
+			name:    "reduceFn error returns empty result",
+			nodes:   []*api.NodeInfo{node1, node2},
+			batchFn: noopBatch,
+			mapFn:   noopMap,
+			reduceFn: func(*api.TaskInfo, map[string]fwk.NodeScoreList) (map[string]float64, error) {
+				return nil, fmt.Errorf("reduce failed")
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := PrioritizeNodes(task, tc.nodes, tc.batchFn, tc.mapFn, tc.reduceFn)
+			got := map[string]float64{}
+			for score, nodes := range result {
+				for _, n := range nodes {
+					got[n.Name] = score
+				}
+			}
+			if tc.expected == nil {
+				if len(got) != 0 {
+					t.Errorf("Test case '%s' failed. Expected empty result, but got: %v", tc.name, got)
+				}
+				return
+			}
+			if !reflect.DeepEqual(got, tc.expected) {
+				t.Errorf("Test case '%s' failed. Expected: %v, but got: %v", tc.name, tc.expected, got)
+			}
+		})
+	}
+}
+
+// TestPrioritizeNodesNoRace runs PrioritizeNodes over a large number of nodes
+// under the Go race detector to verify that the lock-free map phase does not
+// cause any data races or let any node scores get dropped or overwritten.
+func TestPrioritizeNodesNoRace(t *testing.T) {
+	const numNodes = 500
+	task := &api.TaskInfo{Name: "task1", Namespace: "default"}
+	nodes := make([]*api.NodeInfo, numNodes)
+	nameToIdx := make(map[string]int, numNodes)
+	for i := range nodes {
+		name := fmt.Sprintf("node-%d", i)
+		nodes[i] = &api.NodeInfo{Name: name}
+		nameToIdx[name] = i
+	}
+
+	result := PrioritizeNodes(
+		task, nodes,
+		func(_ *api.TaskInfo, ns []*api.NodeInfo) (map[string]float64, error) {
+			scores := make(map[string]float64, len(ns))
+			for _, n := range ns {
+				scores[n.Name] = float64(nameToIdx[n.Name] * 10)
+			}
+			return scores, nil
+		},
+		func(_ *api.TaskInfo, n *api.NodeInfo) (map[string]float64, float64, error) {
+			return nil, float64(nameToIdx[n.Name]), nil
+		},
+		func(*api.TaskInfo, map[string]fwk.NodeScoreList) (map[string]float64, error) {
+			return nil, nil
+		},
+	)
+
+	got := map[string]float64{}
+	for score, ns := range result {
+		for _, n := range ns {
+			got[n.Name] = score
+		}
+	}
+	for i, n := range nodes {
+		// node-i: order(i) + batch(i*10) = i*11
+		expected := float64(i * 11)
+		if got[n.Name] != expected {
+			t.Errorf("Node %s: expected score %v, but got %v", n.Name, expected, got[n.Name])
+		}
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/area performance

#### What this PR does / why we need it:

`PrioritizeNodes` already runs per-node scoring across 16 workers via`workqueue.ParallelizeUntil`, but every worker takes a shared`sync.Mutex` before writing back into `pluginNodeScoreMap` / `nodeOrderScoreMap`. On large clusters this serializes most of the scoring work and shows up as a hotspot in scheduling latency.

This PR removes the mutex: each worker writes into its own slot of a pre-allocated `[]nodeScoreResult`, and the per-plugin maps are populated by a single serial merge after `ParallelizeUntil` returns.

This PR will not introduce concurrent execution for BatchNodeOrderFn with NodeOrderMapFn, I think there might be risk when some of the users don't notice the concurrent execution and have concurrent write/read on the session's struct, so I think only remove lock contention in the PrioritizeNodes is enough currently

#### Which issue(s) this PR fixes:

Partially addresses #5082.

#### Special notes for your reviewer:

Improvement results:
- Environment:
  - VM: 32vCPU, 64G single machine
  - KWOK nodes: 5000 nodes
  - Test scenario: 50 jobs, 16 replicas per job, 800 pods total
  - Prometheus KWOK node/cAdvisor scrape noise filtered by #5492
  - Latency below is calculated from raw audit events (`pod create -> pods/binding create`) to avoid coarse Prometheus histogram buckets hiding P99 changes.

  | Version | Runs | Raw P50 avg | Raw P90 avg | Raw P99 avg | Throughput avg | Binding window avg |
  |---|---:|---:|---:|---:|---:|---:|
  | without #5491 | 5 | 3619.94 ms | 5719.50 ms | 6279.99 ms | 152.99 pods/s | 5.23 s |
  | with #5491 | 5 | 3391.66 ms | 5339.04 ms | 5853.35 ms | 165.69 pods/s | 4.83 s |
  | Improvement | - | 6.31% | 6.65% | 6.79% | 8.30% | 7.65% |

  The Prometheus histogram report showed only a small P99 delta because the buckets around this range are coarse (`8090.47 ms -> 8075.54 ms`, 0.18%), while raw audit events show the P99 improvement more accurately.



#### Does this PR introduce a user-facing change?

```release-note
NONE
```

