### PR TITLE
[Enhancement] Optimize network-topology-aware plugin and document scoring extensibility

### DIFF
--- a/docs/design/node-scoring-extensibility-guidelines.md
+++ b/docs/design/node-scoring-extensibility-guidelines.md
@@ -1,0 +1,66 @@
+# Node Scoring Extensibility Guidelines
+
+Volcano provides multiple extensibility points to customize the node scoring process during scheduling. This document outlines best practices and standard guidelines for plugin developers implementing these points. 
+
+## Architectural Overview
+
+The `PrioritizeNodes` phase in Volcano calculates the optimal placement for tasks by generating a score for every node. The framework calls multiple extension points (`NodeOrderFn`, `NodeOrderMapFn`/`NodeOrderReduceFn`, and `BatchNodeOrderFn`). Because node scoring is extremely frequent and often operates over thousands of nodes, performance and concurrency are critical.
+
+## 1. NodeOrderFn vs BatchNodeOrderFn
+
+### NodeOrderFn
+- **Primary Use Case:** Independent, scalar-based node assignments. For example, simple checks matching node labels to task requirements or localized node statistics.
+- **Concurrency Model:** Managed by the framework. The scheduling framework evaluates `NodeOrderFn` using `workqueue.ParallelizeUntil`, executing the evaluation for all nodes concurrently. 
+- **Guideline:** Strictly direct CPU-bound operations to `NodeOrderFn` whenever possible to automatically benefit from framework-level parallelism without implementing your own locking primitives.
+
+### BatchNodeOrderFn
+- **Primary Use Case:** When a plugin requires evaluating aggregated state across the *entire* node list simultaneously before scoring (similar to PreScore semantics) or when performing operations that benefit from I/O consolidation (such as Extender webhooks).
+- **Concurrency Model:** Managed by the plugin. Unlike `NodeOrderFn`, the framework passes the entire node slice to the plugin in a single execution thread. 
+- **Guideline:** Do **not** use sequential/serial `for _, node := range nodes` loops for CPU-bound evaluations in `BatchNodeOrderFn`, as this will serialize the scoring process and bottleneck the entire scheduler. Plugin developers **must** utilize `workqueue.ParallelizeUntil` to evaluate node scores concurrently if they iterate through nodes within this function.
+
+## 2. Lock-Free Map Execution
+
+When using `workqueue.ParallelizeUntil` within your `BatchNodeOrderFn`, you must avoid global locks (e.g., `sync.Mutex`) when assigning scores, as this leads to heavy lock contention.
+
+**Optimization approach:**
+Pre-allocate an array/slice of the same length as the nodes slice (since the index is guaranteed unique per goroutine) to collect the intermediate scores. After the `workqueue.ParallelizeUntil` successfully exits, aggregate these array values into the returned `map[string]float64` cleanly in a fast serial loop.
+
+### Bad Example (Lock Contention)
+
+```go
+var mu sync.Mutex
+nodeScores := make(map[string]float64)
+
+workqueue.ParallelizeUntil(context.TODO(), 16, len(nodes), func(index int) {
+    node := nodes[index]
+    score := calculateHeavyScore(node)
+    
+    // BAD: Heavy lock contention on thousands of nodes
+    mu.Lock()
+    nodeScores[node.Name] = score
+    mu.Unlock()
+})
+```
+
+### Good Example (Lock-Free)
+
+```go
+nodeScores := make(map[string]float64)
+nodeScoresList := make([]float64, len(nodes))
+
+// Lock-Free concurrent execution
+workqueue.ParallelizeUntil(context.TODO(), 16, len(nodes), func(index int) {
+    node := nodes[index]
+    nodeScoresList[index] = calculateHeavyScore(node)
+})
+
+// Fast serial aggregation
+for i, node := range nodes {
+    nodeScores[node.Name] = nodeScoresList[i]
+}
+```
+
+## Summary
+- Use `NodeOrderFn` for simple, independent node scoring to get automatic framework parallelism.
+- Use `BatchNodeOrderFn` only for I/O consolidation or cross-node aggregated calculations.
+- Always use `workqueue.ParallelizeUntil` and lock-free slice pre-allocation if iterating through nodes inside `BatchNodeOrderFn`.

--- a/docs/design/node-scoring-extensibility-guidelines.md
+++ b/docs/design/node-scoring-extensibility-guidelines.md
@@ -15,7 +15,7 @@ The `PrioritizeNodes` phase in Volcano calculates the optimal placement for task
 
 ### BatchNodeOrderFn
 - **Primary Use Case:** When a plugin requires evaluating aggregated state across the *entire* node list simultaneously before scoring (similar to PreScore semantics) or when performing operations that benefit from I/O consolidation (such as Extender webhooks).
-- **Concurrency Model:** Managed by the plugin. Unlike `NodeOrderFn`, the framework passes the entire node slice to the plugin in a single execution thread. 
+- **Concurrency Model:** Managed by the plugin. Unlike `NodeOrderFn`, the framework passes the entire node slice to the plugin in a single goroutine. 
 - **Guideline:** Do **not** use sequential/serial `for _, node := range nodes` loops for CPU-bound evaluations in `BatchNodeOrderFn`, as this will serialize the scoring process and bottleneck the entire scheduler. Plugin developers **must** utilize `workqueue.ParallelizeUntil` to evaluate node scores concurrently if they iterate through nodes within this function.
 
 ## 2. Lock-Free Map Execution

--- a/pkg/scheduler/plugins/network-topology-aware/network_topology_aware.go
+++ b/pkg/scheduler/plugins/network-topology-aware/network_topology_aware.go
@@ -36,7 +36,13 @@ import (
 
 const (
 	// PluginName indicates name of volcano scheduler plugin.
-	PluginName            = "network-topology-aware"
+	PluginName = "network-topology-aware"
+
+	// batchNodeOrderFnWorkers is the number of concurrent goroutines used during node scoring
+	batchNodeOrderFnWorkers = 16
+)
+
+const (
 	FullScore             = 1.0
 	ZeroScore             = 0.0
 	NetworkTopologyWeight = "weight"
@@ -500,7 +506,7 @@ func (nta *networkTopologyAwarePlugin) batchNodeOrderFnForNormalPods(ssn *framew
 	}
 
 	nodeScoresList := make([]float64, len(nodes))
-	workqueue.ParallelizeUntil(context.TODO(), 16, len(nodes), func(index int) {
+	workqueue.ParallelizeUntil(context.TODO(), batchNodeOrderFnWorkers, len(nodes), func(index int) {
 		node := nodes[index]
 		totalScore := 0.0
 		for tier := nta.hyperNodesTier.minTier; tier <= nta.hyperNodesTier.maxTier; tier++ {
@@ -571,33 +577,46 @@ func (nta *networkTopologyAwarePlugin) batchNodeOrderFnForNetworkAwarePods(ssn *
 	if allocatedHyperNode == "" {
 		return nodeScores, nil
 	}
+
+	// Pre-build node to hypernode map to avoid O(N) lookup inside the parallel loops.
+	nodeToHyperNode := make(map[string]string)
+	if len(ssn.HyperNodesTiers) > 0 {
+		lowestTier := ssn.HyperNodesTiers[0]
+		for hyperNodeName := range ssn.HyperNodesSetByTier[lowestTier] {
+			for _, node := range ssn.RealNodesList[hyperNodeName] {
+				nodeToHyperNode[node.Name] = hyperNodeName
+			}
+		}
+	}
+
 	// Calculate score based on LCAHyperNode tier.
 	nodeScoresList := make([]float64, len(nodes))
-	workqueue.ParallelizeUntil(context.TODO(), 16, len(nodes), func(index int) {
+	workqueue.ParallelizeUntil(context.TODO(), batchNodeOrderFnWorkers, len(nodes), func(index int) {
 		node := nodes[index]
-		hyperNode := util.FindHyperNodeForNode(node.Name, ssn.RealNodesList, ssn.HyperNodesTiers, ssn.HyperNodesSetByTier)
+		hyperNode := nodeToHyperNode[node.Name]
 		score := nta.networkTopologyAwareScore(hyperNode, allocatedHyperNode, ssn.HyperNodes)
 		nodeScoresList[index] = score
 	})
 
 	var maxScore float64 = -1
-	scoreToNodes := map[float64][]string{}
+	var candidateNodes []string
 	for i, node := range nodes {
 		score := nodeScoresList[i]
 		nodeScores[node.Name] = score
-		if score >= maxScore {
+		if score > maxScore {
 			maxScore = score
-			scoreToNodes[maxScore] = append(scoreToNodes[maxScore], node.Name)
+			candidateNodes = []string{node.Name}
+		} else if score == maxScore {
+			candidateNodes = append(candidateNodes, node.Name)
 		}
 	}
 
 	// Calculate score based on the number of tasks scheduled for the subjob when max score of node has more than one.
-	if len(scoreToNodes[maxScore]) > 1 {
-		candidateNodes := scoreToNodes[maxScore]
+	if len(candidateNodes) > 1 {
 		candidateScores := make([]float64, len(candidateNodes))
-		workqueue.ParallelizeUntil(context.TODO(), 16, len(candidateNodes), func(index int) {
+		workqueue.ParallelizeUntil(context.TODO(), batchNodeOrderFnWorkers, len(candidateNodes), func(index int) {
 			node := candidateNodes[index]
-			hyperNode := util.FindHyperNodeForNode(node, ssn.RealNodesList, ssn.HyperNodesTiers, ssn.HyperNodesSetByTier)
+			hyperNode := nodeToHyperNode[node]
 			candidateScores[index] = nta.scoreWithTaskNum(hyperNode, subJob.Tasks, ssn.RealNodesList)
 		})
 		for i, node := range candidateNodes {

--- a/pkg/scheduler/plugins/network-topology-aware/network_topology_aware.go
+++ b/pkg/scheduler/plugins/network-topology-aware/network_topology_aware.go
@@ -17,12 +17,14 @@ limitations under the License.
 package networktopologyaware
 
 import (
+	"context"
 	"fmt"
 	"math"
 	"sort"
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2"
 	fwk "k8s.io/kube-scheduler/framework"
 	"k8s.io/utils/set"
@@ -497,7 +499,9 @@ func (nta *networkTopologyAwarePlugin) batchNodeOrderFnForNormalPods(ssn *framew
 		return nodeScores, nil
 	}
 
-	for _, node := range nodes {
+	nodeScoresList := make([]float64, len(nodes))
+	workqueue.ParallelizeUntil(context.TODO(), 16, len(nodes), func(index int) {
+		node := nodes[index]
 		totalScore := 0.0
 		for tier := nta.hyperNodesTier.minTier; tier <= nta.hyperNodesTier.maxTier; tier++ {
 			// If no hypernode is found at this tier, this tierScore is FullScore finally, because we prefer to schedule pods to nodes that do not belong to any hypernode.
@@ -510,7 +514,11 @@ func (nta *networkTopologyAwarePlugin) batchNodeOrderFnForNormalPods(ssn *framew
 			}
 			totalScore += tierWeights[tier] * tierScore
 		}
-		nodeScores[node.Name] = totalScore / totalTierWeight
+		nodeScoresList[index] = totalScore / totalTierWeight
+	})
+
+	for i, node := range nodes {
+		nodeScores[node.Name] = nodeScoresList[i]
 	}
 	return nodeScores, nil
 }
@@ -564,24 +572,36 @@ func (nta *networkTopologyAwarePlugin) batchNodeOrderFnForNetworkAwarePods(ssn *
 		return nodeScores, nil
 	}
 	// Calculate score based on LCAHyperNode tier.
-	var maxScore float64 = -1
-	scoreToNodes := map[float64][]string{}
-	for _, node := range nodes {
+	nodeScoresList := make([]float64, len(nodes))
+	workqueue.ParallelizeUntil(context.TODO(), 16, len(nodes), func(index int) {
+		node := nodes[index]
 		hyperNode := util.FindHyperNodeForNode(node.Name, ssn.RealNodesList, ssn.HyperNodesTiers, ssn.HyperNodesSetByTier)
 		score := nta.networkTopologyAwareScore(hyperNode, allocatedHyperNode, ssn.HyperNodes)
+		nodeScoresList[index] = score
+	})
+
+	var maxScore float64 = -1
+	scoreToNodes := map[float64][]string{}
+	for i, node := range nodes {
+		score := nodeScoresList[i]
 		nodeScores[node.Name] = score
 		if score >= maxScore {
 			maxScore = score
 			scoreToNodes[maxScore] = append(scoreToNodes[maxScore], node.Name)
 		}
 	}
+
 	// Calculate score based on the number of tasks scheduled for the subjob when max score of node has more than one.
 	if len(scoreToNodes[maxScore]) > 1 {
 		candidateNodes := scoreToNodes[maxScore]
-		for _, node := range candidateNodes {
+		candidateScores := make([]float64, len(candidateNodes))
+		workqueue.ParallelizeUntil(context.TODO(), 16, len(candidateNodes), func(index int) {
+			node := candidateNodes[index]
 			hyperNode := util.FindHyperNodeForNode(node, ssn.RealNodesList, ssn.HyperNodesTiers, ssn.HyperNodesSetByTier)
-			taskNumScore := nta.scoreWithTaskNum(hyperNode, subJob.Tasks, ssn.RealNodesList)
-			nodeScores[node] += taskNumScore
+			candidateScores[index] = nta.scoreWithTaskNum(hyperNode, subJob.Tasks, ssn.RealNodesList)
+		})
+		for i, node := range candidateNodes {
+			nodeScores[node] += candidateScores[i]
 		}
 	}
 

--- a/pkg/scheduler/plugins/network-topology-aware/network_topology_aware.go
+++ b/pkg/scheduler/plugins/network-topology-aware/network_topology_aware.go
@@ -82,6 +82,8 @@ type networkTopologyAwarePlugin struct {
 	maxHyperNodesForEviction int
 	// hyperNodeResourceCache stores the resource status of hypernodes to avoid repeated calculation: hypernode -> resourceStatus
 	hyperNodeResourceCache map[string]*resourceStatus
+	// nodeToHyperNode maps node name to hypernode name to avoid O(N) lookup during scoring
+	nodeToHyperNode map[string]string
 }
 
 type priorityWeight struct {
@@ -137,6 +139,22 @@ func (nta *networkTopologyAwarePlugin) initHyperNodeResourceCache(ssn *framework
 	}
 }
 
+func (nta *networkTopologyAwarePlugin) initNodeToHyperNode(ssn *framework.Session) {
+	if nta.nodeToHyperNode == nil {
+		nta.nodeToHyperNode = make(map[string]string)
+	}
+
+	// Pre-build node to hypernode map to avoid O(N) lookup inside the parallel loops.
+	if len(ssn.HyperNodesTiers) > 0 {
+		lowestTier := ssn.HyperNodesTiers[0]
+		for hyperNodeName := range ssn.HyperNodesSetByTier[lowestTier] {
+			for _, node := range ssn.RealNodesList[hyperNodeName] {
+				nta.nodeToHyperNode[node.Name] = hyperNodeName
+			}
+		}
+	}
+}
+
 /*
    The arguments of the networktopologyaware plugin can refer to the following configuration:
    tiers:
@@ -162,6 +180,7 @@ func New(arguments framework.Arguments) framework.Plugin {
 		hyperNodesTier:           &hyperNodesTier{},
 		maxHyperNodesForEviction: getMaxHyperNodesForEviction(arguments),
 		hyperNodeResourceCache:   make(map[string]*resourceStatus),
+		nodeToHyperNode:          make(map[string]string),
 	}
 	klog.V(5).InfoS("successfully built plugin", "name", PluginName, "arguments", plugin.String())
 	return &plugin
@@ -289,6 +308,7 @@ func (nta *networkTopologyAwarePlugin) OnSessionOpen(ssn *framework.Session) {
 	}()
 	nta.hyperNodesTier.init(ssn.HyperNodesTiers)
 	nta.initHyperNodeResourceCache(ssn)
+	nta.initNodeToHyperNode(ssn)
 
 	ssn.AddHyperNodeOrderFn(nta.Name(), func(subJob *api.SubJobInfo, hyperNodes map[string][]*api.NodeInfo) (map[string]float64, error) {
 		return nta.HyperNodeOrderFn(ssn, subJob, hyperNodes)
@@ -578,22 +598,11 @@ func (nta *networkTopologyAwarePlugin) batchNodeOrderFnForNetworkAwarePods(ssn *
 		return nodeScores, nil
 	}
 
-	// Pre-build node to hypernode map to avoid O(N) lookup inside the parallel loops.
-	nodeToHyperNode := make(map[string]string)
-	if len(ssn.HyperNodesTiers) > 0 {
-		lowestTier := ssn.HyperNodesTiers[0]
-		for hyperNodeName := range ssn.HyperNodesSetByTier[lowestTier] {
-			for _, node := range ssn.RealNodesList[hyperNodeName] {
-				nodeToHyperNode[node.Name] = hyperNodeName
-			}
-		}
-	}
-
 	// Calculate score based on LCAHyperNode tier.
 	nodeScoresList := make([]float64, len(nodes))
 	workqueue.ParallelizeUntil(context.TODO(), batchNodeOrderFnWorkers, len(nodes), func(index int) {
 		node := nodes[index]
-		hyperNode := nodeToHyperNode[node.Name]
+		hyperNode := nta.nodeToHyperNode[node.Name]
 		score := nta.networkTopologyAwareScore(hyperNode, allocatedHyperNode, ssn.HyperNodes)
 		nodeScoresList[index] = score
 	})
@@ -616,7 +625,7 @@ func (nta *networkTopologyAwarePlugin) batchNodeOrderFnForNetworkAwarePods(ssn *
 		candidateScores := make([]float64, len(candidateNodes))
 		workqueue.ParallelizeUntil(context.TODO(), batchNodeOrderFnWorkers, len(candidateNodes), func(index int) {
 			node := candidateNodes[index]
-			hyperNode := nodeToHyperNode[node]
+			hyperNode := nta.nodeToHyperNode[node]
 			candidateScores[index] = nta.scoreWithTaskNum(hyperNode, subJob.Tasks, ssn.RealNodesList)
 		})
 		for i, node := range candidateNodes {

--- a/pkg/scheduler/plugins/network-topology-aware/network_topology_aware_test.go
+++ b/pkg/scheduler/plugins/network-topology-aware/network_topology_aware_test.go
@@ -3888,3 +3888,36 @@ func TestHyperNodeGradientForSubJobFn_NoSubJobPolicyRespectsHardTopology(t *test
 	gradients := ssn.HyperNodeGradientForSubJobFn(subJob, ssn.HyperNodes[rootName], api.PurposeEvict)
 	assert.Empty(t, gradients, "hard topology without feasible tier-1 domain should not fallback to root")
 }
+
+func TestBatchNodeOrderFnForNetworkAwarePods(t *testing.T) {
+	plugin := &networkTopologyAwarePlugin{
+		weight: getPriorityWeight(framework.Arguments{}),
+		hyperNodesTier: &hyperNodesTier{
+			minTier: 1,
+			maxTier: 2,
+		},
+	}
+	ssn := &framework.Session{
+		RealNodesList: map[string][]*api.NodeInfo{
+			"hn1": {{Name: "node1"}},
+			"hn2": {{Name: "node2"}},
+		},
+		HyperNodesTiers: []int{1, 2},
+		HyperNodesSetByTier: map[int]sets.Set[string]{
+			1: sets.New[string]("hn1", "hn2"),
+		},
+		HyperNodes: api.HyperNodeInfoMap{
+			"hn1": api.NewHyperNodeInfo(api.BuildHyperNode("hn1", 1, nil)),
+			"hn2": api.NewHyperNodeInfo(api.BuildHyperNode("hn2", 1, nil)),
+		},
+	}
+	task := &api.TaskInfo{TransactionContext: api.TransactionContext{JobAllocatedHyperNode: "hn1"}}
+	subJob := &api.SubJobInfo{Tasks: map[api.TaskID]*api.TaskInfo{"task1": task}}
+	nodes := []*api.NodeInfo{{Name: "node1"}, {Name: "node2"}}
+
+	scores, err := plugin.batchNodeOrderFnForNetworkAwarePods(ssn, task, subJob, nodes)
+	assert.NoError(t, err)
+	assert.Contains(t, scores, "node1")
+	assert.Contains(t, scores, "node2")
+	assert.GreaterOrEqual(t, scores["node1"], scores["node2"])
+}


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
This PR implements tasks 3 & 4 of issue #5082:
1. Refactors the `network-topology-aware` plugin to use `workqueue.ParallelizeUntil` instead of serial loops for node iteration in `batchNodeOrderFn`. This eliminates scheduling bottlenecks while preventing data races by using pre-allocated intermediate slices.
2. Introduces explicit developer documentation detailing standard best practices for Node Scoring Extensibility points (`NodeOrderFn` vs `BatchNodeOrderFn`) inside the codebase.

#### Which issue(s) this PR fixes:
Fixes #5082

#### Special notes for reviewer:
This branch specifically handles the `network-topology-aware` plugin parallelization and the developer documentation as discussed in the issue comments.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```