### PR TITLE
fix(nodeorder): reuse session NodeMap and unify Score plugins through BatchNodeOrderFn

### DIFF
--- a/pkg/agentscheduler/plugins/nodeorder/nodeorder.go
+++ b/pkg/agentscheduler/plugins/nodeorder/nodeorder.go
@@ -64,7 +64,7 @@ func (np *nodeOrderPlugin) OnPluginInit(fwk *framework.Framework) {
 
 	fwk.AddBatchNodeOrderFn(np.Name(), func(task *api.TaskInfo, nodeInfo []*api.NodeInfo) (map[string]float64, error) {
 		state := k8sframework.NewCycleState()
-		return np.BatchNodeOrderFn(task, nodeInfo, state)
+		return np.BatchNodeOrderFn(task, nodeInfo, fwk.GetSnapshot().GetFwkNodeInfoMap(), state)
 	})
 }
 

--- a/pkg/scheduler/plugins/nodeorder/nodeorder.go
+++ b/pkg/scheduler/plugins/nodeorder/nodeorder.go
@@ -188,7 +188,7 @@ func (pp *NodeOrderPlugin) OnSessionOpen(ssn *framework.Session) {
 
 	ssn.AddBatchNodeOrderFn(pp.Name(), func(task *api.TaskInfo, nodeInfo []*api.NodeInfo) (map[string]float64, error) {
 		state := k8sframework.NewCycleState()
-		return pp.BatchNodeOrderFn(task, nodeInfo, state)
+		return pp.BatchNodeOrderFn(task, nodeInfo, nodeMap, state)
 	})
 }
 
@@ -329,13 +329,15 @@ func (pp *NodeOrderPlugin) NodeOrderFn(task *api.TaskInfo, node *api.NodeInfo, k
 	return nodeScore, nil
 }
 
-func (pp *NodeOrderPlugin) BatchNodeOrderFn(task *api.TaskInfo, nodeInfo []*api.NodeInfo, state *k8sframework.CycleState) (map[string]float64, error) {
+func (pp *NodeOrderPlugin) BatchNodeOrderFn(task *api.TaskInfo, nodeInfo []*api.NodeInfo, nodeMap map[string]fwk.NodeInfo, state *k8sframework.CycleState) (map[string]float64, error) {
 	nodeInfos := make([]fwk.NodeInfo, 0, len(nodeInfo))
 	nodes := make([]*v1.Node, 0, len(nodeInfo))
 	for _, node := range nodeInfo {
-		newNodeInfo := &k8sframework.NodeInfo{}
-		newNodeInfo.SetNode(node.Node)
-		nodeInfos = append(nodeInfos, newNodeInfo)
+		info, ok := nodeMap[node.Name]
+		if !ok {
+			continue
+		}
+		nodeInfos = append(nodeInfos, info)
 		nodes = append(nodes, node.Node)
 	}
 	nodeScores := make(map[string]float64, len(nodes))

--- a/pkg/scheduler/plugins/nodeorder/nodeorder.go
+++ b/pkg/scheduler/plugins/nodeorder/nodeorder.go
@@ -71,8 +71,16 @@ type NodeOrderPlugin struct {
 	pluginArguments       framework.Arguments
 	weight                priorityWeight
 	Handle                fwk.Handle
-	ScorePlugins          map[string]nodescore.BaseScorePlugin
+	ScorePlugins          map[string]scorePluginEntry
 	NodeOrderScorePlugins map[string]ScorePluginWithWeight
+}
+
+// scorePluginEntry contains the plugin that both have PreScore and Score extension points, and the weight of the plugin,
+// if all the plugins have both PreScore/Score in the future, we can remove ScorePluginWithWeight and use the scorePluginEntry instead.
+type scorePluginEntry struct {
+	plugin     nodescore.BaseScorePlugin
+	normalizer fwk.ScoreExtensions // If the plugin implements ScoreExtensions, normalizer is the plugin itself; otherwise, it can be EmptyNormalizer.
+	weight     int
 }
 
 type ScorePluginWithWeight struct {
@@ -186,14 +194,14 @@ func (pp *NodeOrderPlugin) OnSessionOpen(ssn *framework.Session) {
 		return pp.NodeOrderFn(task, node, nodeInfo, state)
 	})
 
-	ssn.AddBatchNodeOrderFn(pp.Name(), func(task *api.TaskInfo, nodeInfo []*api.NodeInfo) (map[string]float64, error) {
+	ssn.AddBatchNodeOrderFn(pp.Name(), func(task *api.TaskInfo, nodes []*api.NodeInfo) (map[string]float64, error) {
 		state := k8sframework.NewCycleState()
-		return pp.BatchNodeOrderFn(task, nodeInfo, nodeMap, state)
+		return pp.BatchNodeOrderFn(task, nodes, nodeMap, state)
 	})
 }
 
 func (pp *NodeOrderPlugin) InitPlugin() {
-	scorePlugins := map[string]nodescore.BaseScorePlugin{}
+	scorePlugins := map[string]scorePluginEntry{}
 	nodeOrderScorePlugins := map[string]ScorePluginWithWeight{}
 
 	fts := feature.Features{
@@ -211,7 +219,11 @@ func (pp *NodeOrderPlugin) InitPlugin() {
 		}
 		if p, err := noderesources.NewFit(context.TODO(), leastAllocatedArgs, pp.Handle, fts); err == nil {
 			leastAllocated := p.(*noderesources.Fit)
-			nodeOrderScorePlugins[leastAllocated.Name()+"_LeastAllocated"] = ScorePluginWithWeight{leastAllocated, pp.weight.leastReqWeight}
+			scorePlugins[leastAllocated.Name()+"_LeastAllocated"] = scorePluginEntry{
+				plugin:     leastAllocated,
+				normalizer: &nodescore.EmptyNormalizer{},
+				weight:     pp.weight.leastReqWeight,
+			}
 		} else {
 			klog.Errorf("Failed to init Least Allocated plugin %v", err)
 		}
@@ -227,7 +239,11 @@ func (pp *NodeOrderPlugin) InitPlugin() {
 		}
 		if p, err := noderesources.NewFit(context.TODO(), mostAllocatedArgs, pp.Handle, fts); err == nil {
 			mostAllocation := p.(*noderesources.Fit)
-			nodeOrderScorePlugins[mostAllocation.Name()+"_MostAllocated"] = ScorePluginWithWeight{mostAllocation, pp.weight.mostReqWeight}
+			scorePlugins[mostAllocation.Name()+"_MostAllocated"] = scorePluginEntry{
+				plugin:     mostAllocation,
+				normalizer: &nodescore.EmptyNormalizer{},
+				weight:     pp.weight.mostReqWeight,
+			}
 		} else {
 			klog.Errorf("Failed to init Most Allocated plugin %v", err)
 		}
@@ -244,7 +260,11 @@ func (pp *NodeOrderPlugin) InitPlugin() {
 		}
 		if p, err := noderesources.NewBalancedAllocation(context.TODO(), blArgs, pp.Handle, fts); err == nil {
 			balancedAllocation := p.(*noderesources.BalancedAllocation)
-			nodeOrderScorePlugins[balancedAllocation.Name()] = ScorePluginWithWeight{balancedAllocation, pp.weight.balancedResourceWeight}
+			scorePlugins[balancedAllocation.Name()] = scorePluginEntry{
+				plugin:     balancedAllocation,
+				normalizer: &nodescore.EmptyNormalizer{},
+				weight:     pp.weight.balancedResourceWeight,
+			}
 		} else {
 			klog.Errorf("Failed to init Balanced Resource Allocation plugin %v", err)
 		}
@@ -257,7 +277,11 @@ func (pp *NodeOrderPlugin) InitPlugin() {
 		}
 		if p, err := nodeaffinity.New(context.TODO(), naArgs, pp.Handle, fts); err == nil {
 			nodeAffinity := p.(*nodeaffinity.NodeAffinity)
-			nodeOrderScorePlugins[nodeAffinity.Name()] = ScorePluginWithWeight{nodeAffinity, pp.weight.nodeAffinityWeight}
+			scorePlugins[nodeAffinity.Name()] = scorePluginEntry{
+				plugin:     nodeAffinity,
+				normalizer: nodeAffinity,
+				weight:     pp.weight.nodeAffinityWeight,
+			}
 		} else {
 			klog.Errorf("Failed to init Node Affinity plugin %v", err)
 		}
@@ -278,7 +302,11 @@ func (pp *NodeOrderPlugin) InitPlugin() {
 		plArgs := &config.InterPodAffinityArgs{}
 		if p, err := interpodaffinity.New(context.TODO(), plArgs, pp.Handle, fts); err == nil {
 			interPodAffinity := p.(*interpodaffinity.InterPodAffinity)
-			scorePlugins[interpodaffinity.Name] = interPodAffinity
+			scorePlugins[interpodaffinity.Name] = scorePluginEntry{
+				plugin:     interPodAffinity,
+				normalizer: interPodAffinity,
+				weight:     pp.weight.podAffinityWeight,
+			}
 		} else {
 			klog.Errorf("Failed to init InterPodAffinity plugin %v", err)
 		}
@@ -288,7 +316,11 @@ func (pp *NodeOrderPlugin) InitPlugin() {
 	if pp.weight.taintTolerationWeight != 0 {
 		if p, err := tainttoleration.New(context.TODO(), nil, pp.Handle, fts); err == nil {
 			taintToleration := p.(*tainttoleration.TaintToleration)
-			scorePlugins[tainttoleration.Name] = taintToleration
+			scorePlugins[tainttoleration.Name] = scorePluginEntry{
+				plugin:     taintToleration,
+				normalizer: taintToleration,
+				weight:     pp.weight.taintTolerationWeight,
+			}
 		} else {
 			klog.Errorf("Failed to init TaintToleration plugin %v", err)
 		}
@@ -301,7 +333,11 @@ func (pp *NodeOrderPlugin) InitPlugin() {
 		}
 		if p, err := podtopologyspread.New(context.TODO(), ptsArgs, pp.Handle, fts); err == nil {
 			podTopologySpread := p.(*podtopologyspread.PodTopologySpread)
-			scorePlugins[podtopologyspread.Name] = podTopologySpread
+			scorePlugins[podtopologyspread.Name] = scorePluginEntry{
+				plugin:     podTopologySpread,
+				normalizer: podTopologySpread,
+				weight:     pp.weight.podTopologySpreadWeight,
+			}
 		} else {
 			klog.Errorf("Failed to init PodTopologySpread plugin %v", err)
 		}
@@ -329,93 +365,28 @@ func (pp *NodeOrderPlugin) NodeOrderFn(task *api.TaskInfo, node *api.NodeInfo, k
 	return nodeScore, nil
 }
 
-func (pp *NodeOrderPlugin) BatchNodeOrderFn(task *api.TaskInfo, nodeInfo []*api.NodeInfo, nodeMap map[string]fwk.NodeInfo, state *k8sframework.CycleState) (map[string]float64, error) {
-	nodeInfos := make([]fwk.NodeInfo, 0, len(nodeInfo))
-	nodes := make([]*v1.Node, 0, len(nodeInfo))
-	for _, node := range nodeInfo {
-		info, ok := nodeMap[node.Name]
-		if !ok {
-			continue
+// BatchNodeOrderFn scores all candidate nodes for the given task in one call.
+func (pp *NodeOrderPlugin) BatchNodeOrderFn(task *api.TaskInfo, nodes []*api.NodeInfo, nodeMap map[string]fwk.NodeInfo, state *k8sframework.CycleState) (map[string]float64, error) {
+	nodeInfos := make([]fwk.NodeInfo, 0, len(nodes))
+	for _, node := range nodes {
+		if info, ok := nodeMap[node.Name]; ok {
+			nodeInfos = append(nodeInfos, info)
 		}
-		nodeInfos = append(nodeInfos, info)
-		nodes = append(nodes, node.Node)
 	}
 	nodeScores := make(map[string]float64, len(nodes))
 
-	var podAffinityScores map[string]float64
-	var err error
-	if pp.ScorePlugins[interpodaffinity.Name] != nil {
-		podAffinityScores, err = interPodAffinityScore(pp.ScorePlugins[interpodaffinity.Name].(*interpodaffinity.InterPodAffinity), state, task.Pod, nodeInfos, pp.weight.podAffinityWeight)
+	for name, entry := range pp.ScorePlugins {
+		scores, err := nodescore.CalculatePluginScore(name, entry.plugin, entry.normalizer, state, task.Pod, nodeInfos, entry.weight)
 		if err != nil {
 			return nil, err
 		}
-	}
-
-	var nodeTolerationScores map[string]float64
-	if pp.ScorePlugins[tainttoleration.Name] != nil {
-		nodeTolerationScores, err = taintTolerationScore(pp.ScorePlugins[tainttoleration.Name].(*tainttoleration.TaintToleration), state, task.Pod, nodeInfos, pp.weight.taintTolerationWeight)
-		if err != nil {
-			return nil, err
+		for n, s := range scores {
+			nodeScores[n] += s
 		}
-	}
-
-	var podTopologySpreadScores map[string]float64
-	if pp.ScorePlugins[podtopologyspread.Name] != nil {
-		podTopologySpreadScores, err = podTopologySpreadScore(pp.ScorePlugins[podtopologyspread.Name].(*podtopologyspread.PodTopologySpread), state, task.Pod, nodeInfos, pp.weight.podTopologySpreadWeight)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	for _, node := range nodes {
-		score := 0.0
-		if podAffinityScores != nil {
-			score += podAffinityScores[node.Name]
-		}
-		if nodeTolerationScores != nil {
-			score += nodeTolerationScores[node.Name]
-		}
-		if podTopologySpreadScores != nil {
-			score += podTopologySpreadScores[node.Name]
-		}
-		nodeScores[node.Name] = score
 	}
 
 	klog.V(4).Infof("Batch Total Score for task %s/%s is: %v", task.Namespace, task.Name, nodeScores)
 	return nodeScores, nil
-}
-
-func interPodAffinityScore(
-	interPodAffinity *interpodaffinity.InterPodAffinity,
-	state fwk.CycleState,
-	pod *v1.Pod,
-	nodeInfos []fwk.NodeInfo,
-	podAffinityWeight int,
-) (map[string]float64, error) {
-	return nodescore.CalculatePluginScore(interPodAffinity.Name(), interPodAffinity, interPodAffinity,
-		state, pod, nodeInfos, podAffinityWeight)
-}
-
-func taintTolerationScore(
-	taintToleration *tainttoleration.TaintToleration,
-	cycleState fwk.CycleState,
-	pod *v1.Pod,
-	nodeInfos []fwk.NodeInfo,
-	taintTolerationWeight int,
-) (map[string]float64, error) {
-	return nodescore.CalculatePluginScore(taintToleration.Name(), taintToleration, taintToleration,
-		cycleState, pod, nodeInfos, taintTolerationWeight)
-}
-
-func podTopologySpreadScore(
-	podTopologySpread *podtopologyspread.PodTopologySpread,
-	cycleState fwk.CycleState,
-	pod *v1.Pod,
-	nodeInfos []fwk.NodeInfo,
-	podTopologySpreadWeight int,
-) (map[string]float64, error) {
-	return nodescore.CalculatePluginScore(podTopologySpread.Name(), podTopologySpread, podTopologySpread,
-		cycleState, pod, nodeInfos, podTopologySpreadWeight)
 }
 
 func (pp *NodeOrderPlugin) OnSessionClose(ssn *framework.Session) {

--- a/pkg/scheduler/plugins/nodeorder/nodeorder.go
+++ b/pkg/scheduler/plugins/nodeorder/nodeorder.go
@@ -75,8 +75,8 @@ type NodeOrderPlugin struct {
 	NodeOrderScorePlugins map[string]ScorePluginWithWeight
 }
 
-// scorePluginEntry contains the plugin that both have PreScore and Score extension points, and the weight of the plugin,
-// if all the plugins have both PreScore/Score in the future, we can remove ScorePluginWithWeight and use the scorePluginEntry instead.
+// scorePluginEntry contains a plugin that has both PreScore and Score extension points.
+// If all score plugins support PreScore in the future, ScorePluginWithWeight can be replaced by scorePluginEntry.
 type scorePluginEntry struct {
 	plugin     nodescore.BaseScorePlugin
 	normalizer fwk.ScoreExtensions // If the plugin implements ScoreExtensions, normalizer is the plugin itself; otherwise, it can be EmptyNormalizer.
@@ -367,12 +367,7 @@ func (pp *NodeOrderPlugin) NodeOrderFn(task *api.TaskInfo, node *api.NodeInfo, k
 
 // BatchNodeOrderFn scores all candidate nodes for the given task in one call.
 func (pp *NodeOrderPlugin) BatchNodeOrderFn(task *api.TaskInfo, nodes []*api.NodeInfo, nodeMap map[string]fwk.NodeInfo, state *k8sframework.CycleState) (map[string]float64, error) {
-	nodeInfos := make([]fwk.NodeInfo, 0, len(nodes))
-	for _, node := range nodes {
-		if info, ok := nodeMap[node.Name]; ok {
-			nodeInfos = append(nodeInfos, info)
-		}
-	}
+	nodeInfos := nodescore.NodeInfosForCandidateNodes(nodes, nodeMap)
 	nodeScores := make(map[string]float64, len(nodes))
 
 	for name, entry := range pp.ScorePlugins {

--- a/pkg/scheduler/plugins/nodeorder/nodeorder_test.go
+++ b/pkg/scheduler/plugins/nodeorder/nodeorder_test.go
@@ -362,20 +362,26 @@ func TestInitPlugin(t *testing.T) {
 			name:   "default weights",
 			weight: calculateWeight(nil),
 			expectNodeOrderKeys: []string{
-				noderesources.Name + "_LeastAllocated",
-				noderesources.BalancedAllocationName,
-				nodeaffinity.Name,
 				imagelocality.Name,
 			},
 			expectNoNodeOrderKeys: []string{
+				noderesources.Name + "_LeastAllocated",
 				noderesources.Name + "_MostAllocated",
+				noderesources.BalancedAllocationName,
+				nodeaffinity.Name,
 			},
 			expectScorePlugins: []string{
+				noderesources.Name + "_LeastAllocated",
+				noderesources.BalancedAllocationName,
+				nodeaffinity.Name,
 				interpodaffinity.Name,
 				tainttoleration.Name,
 				podtopologyspread.Name,
 			},
-			expectNotInScorePlugins: []string{},
+			expectNotInScorePlugins: []string{
+				noderesources.Name + "_MostAllocated",
+				imagelocality.Name,
+			},
 		},
 		{
 			name:                  "all weights zero",
@@ -384,6 +390,10 @@ func TestInitPlugin(t *testing.T) {
 			expectNoNodeOrderKeys: []string{noderesources.Name + "_LeastAllocated", noderesources.Name + "_MostAllocated", noderesources.BalancedAllocationName, nodeaffinity.Name, imagelocality.Name},
 			expectScorePlugins:    []string{},
 			expectNotInScorePlugins: []string{
+				noderesources.Name + "_LeastAllocated",
+				noderesources.Name + "_MostAllocated",
+				noderesources.BalancedAllocationName,
+				nodeaffinity.Name,
 				interpodaffinity.Name,
 				tainttoleration.Name,
 				podtopologyspread.Name,

--- a/pkg/scheduler/plugins/predicates/predicates.go
+++ b/pkg/scheduler/plugins/predicates/predicates.go
@@ -323,11 +323,9 @@ func (pp *PredicatesPlugin) OnSessionOpen(ssn *framework.Session) {
 	// Therefore, a BatchNodeOrder extension point needs to be added in here, as volumebinding involves PreScore and Score extension points
 	ssn.AddBatchNodeOrderFn(pp.Name(), func(task *api.TaskInfo, nodes []*api.NodeInfo) (map[string]float64, error) {
 		state := ssn.GetCycleState(task.UID)
-		nodeInfoList, err := pp.Handle.SnapshotSharedLister().NodeInfos().List()
-		if err != nil {
-			klog.Errorf("Failed to list nodes from snapshot: %v", err)
-			return nil, err
-		}
+		// The candidate nodes have already been selected by PredicateNodes.
+		// Reusing them here avoids expanding BatchNodeOrder back to the full scheduler snapshot.
+		nodeInfoList := nodescore.NodeInfosForCandidateNodes(nodes, nodeMap)
 		return pp.BatchNodeOrder(task, nodeInfoList, state)
 	})
 

--- a/pkg/scheduler/plugins/util/nodescore/score_helper.go
+++ b/pkg/scheduler/plugins/util/nodescore/score_helper.go
@@ -24,6 +24,8 @@ import (
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2"
 	fwk "k8s.io/kube-scheduler/framework"
+
+	"volcano.sh/volcano/pkg/scheduler/api"
 )
 
 type BaseScorePlugin interface {
@@ -37,6 +39,19 @@ type EmptyNormalizer struct{}
 
 func (e *EmptyNormalizer) NormalizeScore(ctx context.Context, state fwk.CycleState, p *v1.Pod, scores fwk.NodeScoreList) *fwk.Status {
 	return nil
+}
+
+func NodeInfosForCandidateNodes(nodes []*api.NodeInfo, nodeMap map[string]fwk.NodeInfo) []fwk.NodeInfo {
+	nodeInfos := make([]fwk.NodeInfo, 0, len(nodes))
+	for _, node := range nodes {
+		if node == nil {
+			continue
+		}
+		if nodeInfo, ok := nodeMap[node.Name]; ok {
+			nodeInfos = append(nodeInfos, nodeInfo)
+		}
+	}
+	return nodeInfos
 }
 
 func CalculatePluginScore(

--- a/pkg/scheduler/plugins/util/nodescore/score_helper_test.go
+++ b/pkg/scheduler/plugins/util/nodescore/score_helper_test.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2026 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nodescore
+
+import (
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	fwk "k8s.io/kube-scheduler/framework"
+	k8sframework "k8s.io/kubernetes/pkg/scheduler/framework"
+
+	"volcano.sh/volcano/pkg/scheduler/api"
+)
+
+func TestNodeInfosForCandidateNodes(t *testing.T) {
+	nodeA := &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-a"}}
+	nodeB := &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-b"}}
+	nodeC := &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-c"}}
+	nodeD := &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-d"}}
+
+	k8sNodeInfoA := k8sframework.NewNodeInfo()
+	k8sNodeInfoA.SetNode(nodeA)
+	k8sNodeInfoB := k8sframework.NewNodeInfo()
+	k8sNodeInfoB.SetNode(nodeB)
+	k8sNodeInfoC := k8sframework.NewNodeInfo()
+	k8sNodeInfoC.SetNode(nodeC)
+
+	got := NodeInfosForCandidateNodes(
+		[]*api.NodeInfo{api.NewNodeInfo(nodeA), nil, api.NewNodeInfo(nodeD), api.NewNodeInfo(nodeC)},
+		map[string]fwk.NodeInfo{
+			"node-a": k8sNodeInfoA,
+			"node-b": k8sNodeInfoB,
+			"node-c": k8sNodeInfoC,
+		},
+	)
+
+	if len(got) != 2 {
+		t.Fatalf("expected 2 candidate node infos, got %d", len(got))
+	}
+	if got[0].Node().Name != "node-a" {
+		t.Fatalf("expected first node to be node-a, got %s", got[0].Node().Name)
+	}
+	if got[1].Node().Name != "node-c" {
+		t.Fatalf("expected second node to be node-c, got %s", got[1].Node().Name)
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

While doing volcano benchmark testing, pprof showed two avoidable costs in node scoring.

1. `noderesources.Fit` and `BalancedAllocation` were recomputing the pod resource request on every per-node Score call. The root cause is that the `nodeorder` plugin scored these via the per-node `NodeOrderFn` path, which never calls `PreScore`, so the parsed `podRequests` cached by `PreScore` was never populated and the work was repeated for every candidate node.

The batch path (`BatchNodeOrderFn`) already goes through `nodescore.CalculatePluginScore`, which runs `PreScore` once per batch and then scores nodes in parallel. Moving the affected plugins into the batch path fixes that duplicated CPU work.

2. The predicates plugin's `BatchNodeOrder` callback was still listing all nodes from the scheduler snapshot. That expanded scoring back to the full cluster even after `PredicateNodes` had selected a smaller candidate set. This PR reuses the candidate nodes passed into `BatchNodeOrderFn` and looks up their populated kube-scheduler `NodeInfo` from the session `NodeMap`.

While doing this I also hit a latent bug: the existing `BatchNodeOrderFn` constructed an empty `fwk.NodeInfo` via `SetNode(node.Node)`, leaving `Allocatable`/`Requested` unset. The previously batched plugins happened not to read those fields, but `Fit` / `BalancedAllocation` can read them once moved to the batch path. The fix is to look up populated `NodeInfo` from the scheduler snapshot map instead of building a new one.

The PR is split into three commits:

1. `fix(nodeorder): reuse session NodeMap in BatchNodeOrderFn` - pass `nodeMap` into `BatchNodeOrderFn` and look up populated `NodeInfo` from it.
2. `refactor(nodeorder): unify Score plugins through BatchNodeOrderFn` - move `Fit (Least/Most)`, `BalancedAllocation`, and `NodeAffinity` to the batch scoring path so they run through `CalculatePluginScore` and benefit from `PreScore` caching. `ImageLocality` has no upstream `PreScore`, so it stays in `NodeOrderScorePlugins`.
3. `fix(nodeorder): score only candidate nodes in predicates batch path` - make predicates `BatchNodeOrder` score only the candidate nodes passed by `prioritizeNodes`, and share the candidate-node-to-NodeInfo conversion with nodeorder.

#### Which issue(s) this PR fixes:

Fixes #5498

#### Special notes for your reviewer:

Environment used for the latest check:

- VM: 32 vCPU, 64G single machine
- KWOK nodes: 5000 nodes
- Test scenario: 50 jobs, 16 replicas per job, 800 pods total

Observed improvement from this PR as a whole:

| Version | go test time | Scoring total | allocate total | Audit P50 | Audit P90 | Audit P99 |
|---|---:|---:|---:|---:|---:|---:|
| without #5497 | 5.27s | 2.704s | 3.537s | 2.731s | 5.266s | 7.899s |
| with #5497 | 4.83s | 1.329s | 2.234s | 1.638s | 2.958s | 3.982s |
| Improvement | 8.35% | 50.85% | 36.84% | 40.02% | 43.83% | 49.59% |

The large delta comes from #5497 keeping both nodeorder and predicates batch scoring on the candidate-node path, instead of repeatedly doing per-node work or expanding predicates scoring back to the full 5000-node snapshot.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```