### PR TITLE
fix(capacity): copy parent ancestors to avoid slice aliasing in hiera…

### DIFF
--- a/pkg/scheduler/plugins/capacity/capacity.go
+++ b/pkg/scheduler/plugins/capacity/capacity.go
@@ -1480,7 +1480,16 @@ func (cp *capacityPlugin) updateAncestors(queue *api.QueueInfo, ssn *framework.S
 	}
 
 	cp.queueOpts[parentInfo.UID].children[queue.UID] = cp.queueOpts[queue.UID]
-	cp.queueOpts[queue.UID].ancestors = append(cp.queueOpts[parentInfo.UID].ancestors, parentInfo.UID)
+	// Build a fresh backing array instead of append-ing onto the parent's
+	// ancestors slice. append would reuse the parent's backing array whenever it
+	// has spare capacity, causing sibling subtrees' ancestors slices to alias the
+	// same memory and overwrite each other in deep hierarchies, which corrupts the
+	// ancestor chain used for hierarchical quota enforcement.
+	parentAncestors := cp.queueOpts[parentInfo.UID].ancestors
+	ancestors := make([]api.QueueID, len(parentAncestors)+1)
+	copy(ancestors, parentAncestors)
+	ancestors[len(ancestors)-1] = parentInfo.UID
+	cp.queueOpts[queue.UID].ancestors = ancestors
 	return nil
 }
 
@@ -1678,7 +1687,12 @@ func (cp *capacityPlugin) queueAllocatableWithReserved(attr *queueAttr, candidat
 
 func (cp *capacityPlugin) checkQueueAllocatableHierarchically(ssn *framework.Session, queue *api.QueueInfo, candidate *api.TaskInfo) bool {
 	// If hierarchical queue is not enabled, list will only contain the queue itself.
-	list := append(cp.queueOpts[queue.UID].ancestors, queue.UID)
+	// Do not append onto the stored ancestors slice: that could mutate its shared
+	// backing array. Copy into a fresh slice instead.
+	ancestors := cp.queueOpts[queue.UID].ancestors
+	list := make([]api.QueueID, 0, len(ancestors)+1)
+	list = append(list, ancestors...)
+	list = append(list, queue.UID)
 	// Check whether the candidate task can be allocated to the queue and all its ancestors.
 	for i := len(list) - 1; i >= 0; i-- {
 		if !cp.queueAllocatable(ssn.Queues[list[i]], candidate, cp.dynamicResourceAllocationEnable, cp.draConsumableCapacityEnable) {
@@ -1724,7 +1738,12 @@ func (cp *capacityPlugin) jobEnqueueable(queue *api.QueueInfo, job *api.JobInfo)
 
 func (cp *capacityPlugin) checkJobEnqueueableHierarchically(ssn *framework.Session, queue *api.QueueInfo, job *api.JobInfo) bool {
 	// If hierarchical queue is not enabled, list will only contain the queue itself.
-	list := append(cp.queueOpts[queue.UID].ancestors, queue.UID)
+	// Do not append onto the stored ancestors slice: that could mutate its shared
+	// backing array. Copy into a fresh slice instead.
+	ancestors := cp.queueOpts[queue.UID].ancestors
+	list := make([]api.QueueID, 0, len(ancestors)+1)
+	list = append(list, ancestors...)
+	list = append(list, queue.UID)
 	// Check whether the job can be enqueued to the queue and all its ancestors.
 	for i := len(list) - 1; i >= 0; i-- {
 		if inqueue, resourceNames := cp.jobEnqueueable(ssn.Queues[list[i]], job); !inqueue {

--- a/pkg/scheduler/plugins/capacity/capacity_test.go
+++ b/pkg/scheduler/plugins/capacity/capacity_test.go
@@ -2079,3 +2079,92 @@ func TestJobEnqueuedUpdatesDRAInqueueForDRAOnlyJob(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+// Test_updateAncestors_noSliceAliasing is a regression test for a slice-aliasing
+// bug in updateAncestors. The ancestor chain of each queue was built with
+// `append(parent.ancestors, parentID)`. When the parent's ancestors slice had
+// spare capacity (which Go's growth pattern introduces once the slice reaches
+// length 5), append reused the parent's backing array, so sibling subtrees ended
+// up aliasing the same memory and overwrote each other's ancestor entries in deep
+// hierarchies. A corrupted ancestor chain makes the hierarchical capacity checks
+// enforce the wrong ancestor queue's quota (queue isolation / quota bypass).
+//
+// This builds a deep, branching hierarchy and asserts every queue gets the exact,
+// independent ancestor chain regardless of tree depth or sibling order.
+func Test_updateAncestors_noSliceAliasing(t *testing.T) {
+	// Linear spine root->l1->...->l6, then two branches under l6 that each have a
+	// child. Branch leaves (a/b) and their children (ga/gb) live at the depth where
+	// the aliasing bug corrupted siblings.
+	type qspec struct {
+		name   string
+		parent string
+	}
+	specs := []qspec{
+		{"root", ""},
+		{"l1", "root"},
+		{"l2", "l1"},
+		{"l3", "l2"},
+		{"l4", "l3"},
+		{"l5", "l4"},
+		{"l6", "l5"},
+		{"a", "l6"},
+		{"b", "l6"},
+		{"ga", "a"},
+		{"gb", "b"},
+	}
+
+	ssn := &framework.Session{Queues: map[api.QueueID]*api.QueueInfo{}}
+	for _, s := range specs {
+		q := &scheduling.Queue{
+			ObjectMeta: metav1.ObjectMeta{Name: s.name},
+			Spec:       scheduling.QueueSpec{Parent: s.parent},
+		}
+		ssn.Queues[api.QueueID(s.name)] = api.NewQueueInfo(q)
+	}
+
+	cp := &capacityPlugin{
+		rootQueue: rootQueueID,
+		queueOpts: map[api.QueueID]*queueAttr{},
+	}
+
+	// Mirror buildHierarchicalQueueAttrs' construction loop.
+	for _, s := range specs {
+		uid := api.QueueID(s.name)
+		if _, found := cp.queueOpts[uid]; found {
+			continue
+		}
+		cp.queueOpts[uid] = cp.newQueueAttr(ssn.Queues[uid])
+		if err := cp.updateAncestors(ssn.Queues[uid], ssn, map[api.QueueID]struct{}{}); err != nil {
+			t.Fatalf("updateAncestors(%s) returned error: %v", s.name, err)
+		}
+	}
+
+	// Expected ancestor chains (root-first, excluding the queue itself).
+	want := map[api.QueueID][]api.QueueID{
+		"root": {},
+		"l1":   {"root"},
+		"l2":   {"root", "l1"},
+		"l3":   {"root", "l1", "l2"},
+		"l4":   {"root", "l1", "l2", "l3"},
+		"l5":   {"root", "l1", "l2", "l3", "l4"},
+		"l6":   {"root", "l1", "l2", "l3", "l4", "l5"},
+		"a":    {"root", "l1", "l2", "l3", "l4", "l5", "l6"},
+		"b":    {"root", "l1", "l2", "l3", "l4", "l5", "l6"},
+		"ga":   {"root", "l1", "l2", "l3", "l4", "l5", "l6", "a"},
+		"gb":   {"root", "l1", "l2", "l3", "l4", "l5", "l6", "b"},
+	}
+
+	for uid, expected := range want {
+		got := cp.queueOpts[uid].ancestors
+		if len(got) != len(expected) {
+			t.Fatalf("queue %s: ancestors length = %d (%v), want %d (%v)",
+				uid, len(got), got, len(expected), expected)
+		}
+		for i := range expected {
+			if got[i] != expected[i] {
+				t.Fatalf("queue %s: ancestor[%d] = %q, want %q (full got=%v, want=%v)",
+					uid, i, got[i], expected[i], got, expected)
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Fix a slice-aliasing issue in hierarchical queue ancestor construction that could corrupt ancestor chains in deep queue hierarchies, leading to incorrect quota enforcement and resource accounting.

## Problem

`updateAncestors()` built a child queue's ancestor chain using:

```go
append(parent.ancestors, parentInfo.UID)
```

When the parent ancestor slice had spare capacity, Go reused the same backing array. As a result, sibling subtrees could unintentionally share memory, allowing later updates to overwrite ancestor entries belonging to other queues.

This could cause:

- Incorrect hierarchical quota validation
- Wrong enqueue admission decisions
- Resource accounting being attributed to the wrong ancestor queue
- Potential quota bypass or starvation scenarios in deep hierarchical queue trees

## Root Cause

The ancestor list stored in `queueOpts` was reused via `append()`, which allowed sibling queues to alias the same backing array.

Since hierarchical capacity and enqueue checks rely on ancestor chains, corrupted ancestry could propagate into scheduling decisions.

## Fix

### Ancestor Construction

- Replace direct `append()` usage in `updateAncestors()` with explicit slice allocation and copy.
- Ensure every queue receives an independent ancestor chain.

### Defensive Hardening

Avoid mutating stored ancestor slices in:

- `checkQueueAllocatableHierarchically()`
- `checkJobEnqueueableHierarchically()`

Both paths now construct temporary lists using fresh slices before appending queue IDs.

## Testing

Added regression test:

### `Test_updateAncestors_noSliceAliasing`

The test:

1. Creates a deep hierarchical queue tree with multiple sibling branches.
2. Builds ancestor chains using the scheduler logic.
3. Verifies every queue receives the expected ancestor path.
4. Ensures sibling branches cannot overwrite each other's ancestry.

The test reproduces the bug on the old implementation and passes with the fix.

## Verification

- ✅ Regression test passes
- ✅ Regression test fails on the pre-fix implementation
- ✅ Full capacity plugin test suite passes
- ✅ `go vet` passes successfully

## Impact

This change guarantees that ancestor chains remain isolated and immutable across sibling subtrees, restoring correct hierarchical quota enforcement, enqueue validation, and resource accounting for deep queue hierarchies while preserving existing behavior for shallow hierarchies.