### PR TITLE
fix(nodeorder): log correct plugin weight in NodeOrderFn

### DIFF
--- a/pkg/scheduler/plugins/nodeorder/nodeorder.go
+++ b/pkg/scheduler/plugins/nodeorder/nodeorder.go
@@ -323,7 +323,10 @@ func (pp *NodeOrderPlugin) NodeOrderFn(task *api.TaskInfo, node *api.NodeInfo, k
 
 		// Score from each plugin is multiplied by its configured weight before being added to the total.
 		nodeScore += float64(score) * float64(p.weight)
-		klog.V(5).Infof("Node: %s, task<%s/%s> %s weight %d, score: %f", node.Name, task.Namespace, task.Name, name, p.weight, float64(score)*float64(p.weight))
+		// Score from each plugin is multiplied by its configured weight before being added to the total.
+		weightedScore := float64(score) * float64(p.weight)
+		nodeScore += weightedScore
+		klog.V(5).Infof("Node: %s, task<%s/%s> plugin %s weight %d, raw score: %d, weighted score: %f", node.Name, task.Namespace, task.Name, name, p.weight, score, weightedScore)
 	}
 	klog.V(4).Infof("Nodeorder Total Score for task<%s/%s> on node %s is: %f", task.Namespace, task.Name, node.Name, nodeScore)
 	return nodeScore, nil

--- a/pkg/scheduler/plugins/nodeorder/nodeorder.go
+++ b/pkg/scheduler/plugins/nodeorder/nodeorder.go
@@ -322,8 +322,6 @@ func (pp *NodeOrderPlugin) NodeOrderFn(task *api.TaskInfo, node *api.NodeInfo, k
 		}
 
 		// Score from each plugin is multiplied by its configured weight before being added to the total.
-		nodeScore += float64(score) * float64(p.weight)
-		// Score from each plugin is multiplied by its configured weight before being added to the total.
 		weightedScore := float64(score) * float64(p.weight)
 		nodeScore += weightedScore
 		klog.V(5).Infof("Node: %s, task<%s/%s> plugin %s weight %d, raw score: %d, weighted score: %f", node.Name, task.Namespace, task.Name, name, p.weight, score, weightedScore)

--- a/pkg/scheduler/plugins/nodeorder/nodeorder.go
+++ b/pkg/scheduler/plugins/nodeorder/nodeorder.go
@@ -321,9 +321,9 @@ func (pp *NodeOrderPlugin) NodeOrderFn(task *api.TaskInfo, node *api.NodeInfo, k
 			return 0, status.AsError()
 		}
 
-		// If imageLocalityWeight is provided, host.Score is multiplied with weight, if not, host.Score is added to total score.
+		// Score from each plugin is multiplied by its configured weight before being added to the total.
 		nodeScore += float64(score) * float64(p.weight)
-		klog.V(5).Infof("Node: %s, task<%s/%s> %s weight %d, score: %f", node.Name, task.Namespace, task.Name, name, pp.weight.imageLocalityWeight, float64(score)*float64(p.weight))
+		klog.V(5).Infof("Node: %s, task<%s/%s> %s weight %d, score: %f", node.Name, task.Namespace, task.Name, name, p.weight, float64(score)*float64(p.weight))
 	}
 	klog.V(4).Infof("Nodeorder Total Score for task<%s/%s> on node %s is: %f", task.Namespace, task.Name, node.Name, nodeScore)
 	return nodeScore, nil


### PR DESCRIPTION
## What this PR does

The debug log inside `NodeOrderFn()` reports `imageLocalityWeight` for every score plugin, even though the scheduler computes the score using each plugin's own configured weight (`p.weight`).

This PR updates the debug log to report the actual plugin weight used during score calculation, making V(5) scheduler logs consistent with the scheduler's behavior.

### Why is this change needed?

When multiple score plugins are configured with different weights, the current debug output can be misleading during troubleshooting because it always reports the ImageLocality weight regardless of which plugin generated the score.

### Does this PR introduce any user-facing changes?

No.

This change only corrects debug logging and does not affect scheduler behavior or score calculation.

Fixes #5509 
