### PR TITLE
fix(webhook): honor --default-queue flag in mutating webhooks

### DIFF
--- a/cmd/webhook-manager/app/options/options.go
+++ b/cmd/webhook-manager/app/options/options.go
@@ -34,6 +34,7 @@ const (
 	defaultHealthzAddress       = ":11251"
 	defaultGracefulShutdownTime = time.Second * 30
 	defaultMaxQueueDepth        = 5
+	defaultQueue                = "default"
 )
 
 // Config admission-controller server config.
@@ -67,6 +68,8 @@ type Config struct {
 	MaxQueueDepth int
 	// EnableRootQueueProtection if true, root queue's resource attributes (capability, deserved, guarantee) cannot be modified
 	EnableRootQueueProtection bool
+	// DefaultQueue is the queue assigned to a Job/PodGroup that does not specify one. It defaults to "default" when empty.
+	DefaultQueue string
 }
 
 type DecryptFunc func(c *Config) error
@@ -103,6 +106,7 @@ func (c *Config) AddFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&c.EnableQueueAllocatedPodsCheck, "enable-queue-allocated-pods-check", false, "If true, queue deletion will be rejected when the queue has allocated pods.")
 	fs.IntVar(&c.MaxQueueDepth, "max-queue-depth", defaultMaxQueueDepth, "The maximum depth of hierarchical queues.")
 	fs.BoolVar(&c.EnableRootQueueProtection, "enable-root-queue-protection", true, "If true, root queue's resource attributes (capability, deserved, guarantee) cannot be modified.")
+	fs.StringVar(&c.DefaultQueue, "default-queue", defaultQueue, "The default queue name assigned to a Job/PodGroup that does not specify one. Passing an empty value falls back to \"default\" to preserve backward-compatible behavior of always defaulting an unset queue.")
 }
 
 // CheckPortOrDie check valid port range.

--- a/cmd/webhook-manager/app/options/options_test.go
+++ b/cmd/webhook-manager/app/options/options_test.go
@@ -61,6 +61,7 @@ func TestAddFlags(t *testing.T) {
 		EnableQueueAllocatedPodsCheck: false,
 		MaxQueueDepth:                 defaultMaxQueueDepth,
 		EnableRootQueueProtection:     true,
+		DefaultQueue:                  defaultQueue,
 	}
 
 	if !equality.Semantic.DeepEqual(expected, s) {

--- a/cmd/webhook-manager/app/server.go
+++ b/cmd/webhook-manager/app/server.go
@@ -100,6 +100,7 @@ func Run(config *options.Config) error {
 			service.Config.EnableQueueAllocatedPodsCheck = config.EnableQueueAllocatedPodsCheck
 			service.Config.MaxQueueDepth = config.MaxQueueDepth
 			service.Config.EnableRootQueueProtection = config.EnableRootQueueProtection
+			service.Config.DefaultQueue = config.DefaultQueue
 		}
 
 		klog.V(3).Infof("Registered '%s' as webhook.", service.Path)

--- a/installer/helm/chart/volcano/templates/admission.yaml
+++ b/installer/helm/chart/volcano/templates/admission.yaml
@@ -5,6 +5,7 @@
 {{ $admission_main_csc := or .Values.custom.admission_main_csc .Values.custom.default_csc }}
 {{ $admission_ns := or .Values.custom.admission_ns .Values.custom.default_ns }}
 {{ $scheduler_name := .Values.custom.scheduler_name }}
+{{ $default_queue := .Values.custom.default_queue }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -144,6 +145,9 @@ spec:
             - --webhook-service-name={{ .Release.Name }}-admission-service
             {{- if $scheduler_name }}
             - --scheduler-name={{- $scheduler_name }}
+            {{- end }}
+            {{- if $default_queue }}
+            - --default-queue={{- $default_queue }}
             {{- end }}
             {{- if .Values.custom.admission_feature_gates }}
             - --feature-gates={{ .Values.custom.admission_feature_gates }}

--- a/installer/helm/chart/volcano/templates/scheduler.yaml
+++ b/installer/helm/chart/volcano/templates/scheduler.yaml
@@ -5,6 +5,7 @@
 {{ $scheduler_main_csc := or .Values.custom.scheduler_main_csc .Values.custom.default_csc }}
 {{ $scheduler_ns := or .Values.custom.scheduler_ns .Values.custom.default_ns }}
 {{ $scheduler_name := .Values.custom.scheduler_name }}
+{{ $default_queue := .Values.custom.default_queue }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -205,6 +206,9 @@ spec:
             - --scheduler-conf=/volcano.scheduler/{{base .Values.basic.scheduler_config_file}}
             {{- if $scheduler_name }}
             - --scheduler-name={{- $scheduler_name }}
+            {{- end }}
+            {{- if $default_queue }}
+            - --default-queue={{- $default_queue }}
             {{- end }}
             - --enable-healthz=true
             {{- if .Values.custom.scheduler_metrics_enable }}

--- a/installer/helm/chart/volcano/values.yaml
+++ b/installer/helm/chart/volcano/values.yaml
@@ -38,6 +38,7 @@ custom:
   scheduler_pprof_enable: false
   scheduler_plugins_dir: ""
   scheduler_name: ~
+  default_queue: ~
   leader_elect_enable: false
   # ValidatingAdmissionPolicy settings (auto-enabled for K8s >= 1.30)
   vap_enable: false

--- a/pkg/webhooks/admission/jobs/mutate/mutate_job.go
+++ b/pkg/webhooks/admission/jobs/mutate/mutate_job.go
@@ -145,9 +145,16 @@ func createPatch(job *v1alpha1.Job) ([]byte, error) {
 func patchDefaultQueue(job *v1alpha1.Job) *patchOperation {
 	//Add default queue if not specified.
 	if job.Spec.Queue == "" {
-		return &patchOperation{Op: "add", Path: "/spec/queue", Value: DefaultQueue}
+		return &patchOperation{Op: "add", Path: "/spec/queue", Value: resolveDefaultQueue()}
 	}
 	return nil
+}
+
+func resolveDefaultQueue() string {
+	if config.DefaultQueue != "" {
+		return config.DefaultQueue
+	}
+	return DefaultQueue
 }
 
 func patchDefaultScheduler(job *v1alpha1.Job) *patchOperation {

--- a/pkg/webhooks/admission/jobs/mutate/mutate_job_test.go
+++ b/pkg/webhooks/admission/jobs/mutate/mutate_job_test.go
@@ -480,3 +480,64 @@ func TestMutateSpecPartitionPolicyDefaults(t *testing.T) {
 		})
 	}
 }
+
+func TestPatchDefaultQueue(t *testing.T) {
+	tests := []struct {
+		name           string
+		configDefault  string
+		jobQueue       string
+		wantPatch      bool
+		wantQueueValue string
+	}{
+		{
+			name:           "custom default queue is applied when queue is empty",
+			configDefault:  "test",
+			jobQueue:       "",
+			wantPatch:      true,
+			wantQueueValue: "test",
+		},
+		{
+			name:           "falls back to default when no default configured",
+			configDefault:  "",
+			jobQueue:       "",
+			wantPatch:      true,
+			wantQueueValue: DefaultQueue,
+		},
+		{
+			name:           "explicit queue is left untouched",
+			configDefault:  "test",
+			jobQueue:       "my-queue",
+			wantPatch:      false,
+			wantQueueValue: "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			prev := config.DefaultQueue
+			config.DefaultQueue = tc.configDefault
+			defer func() { config.DefaultQueue = prev }()
+
+			job := &v1alpha1.Job{
+				Spec: v1alpha1.JobSpec{Queue: tc.jobQueue},
+			}
+
+			patch := patchDefaultQueue(job)
+			if !tc.wantPatch {
+				if patch != nil {
+					t.Fatalf("expected no patch, got %+v", patch)
+				}
+				return
+			}
+			if patch == nil {
+				t.Fatalf("expected a patch, got nil")
+			}
+			if patch.Path != "/spec/queue" || patch.Op != "add" {
+				t.Fatalf("unexpected patch op/path: %+v", patch)
+			}
+			if patch.Value != tc.wantQueueValue {
+				t.Errorf("expected queue %q, got %v", tc.wantQueueValue, patch.Value)
+			}
+		})
+	}
+}

--- a/pkg/webhooks/admission/podgroups/mutate/mutate_podgroup.go
+++ b/pkg/webhooks/admission/podgroups/mutate/mutate_podgroup.go
@@ -102,6 +102,11 @@ func PodGroups(ar admissionv1.AdmissionReview) *admissionv1.AdmissionResponse {
 }
 
 func createPodGroupPatch(podgroup *schedulingv1beta1.PodGroup) ([]byte, error) {
+	if podgroup.Spec.Queue == "" {
+		return json.Marshal([]patchOperation{
+			{Op: "add", Path: "/spec/queue", Value: resolveDefaultQueue()},
+		})
+	}
 	if podgroup.Spec.Queue != schedulingv1beta1.DefaultQueue {
 		return nil, nil
 	}
@@ -122,4 +127,11 @@ func createPodGroupPatch(podgroup *schedulingv1beta1.PodGroup) ([]byte, error) {
 	}
 
 	return nil, nil
+}
+
+func resolveDefaultQueue() string {
+	if config.DefaultQueue != "" {
+		return config.DefaultQueue
+	}
+	return schedulingv1beta1.DefaultQueue
 }

--- a/pkg/webhooks/admission/podgroups/mutate/mutate_podgroup_test.go
+++ b/pkg/webhooks/admission/podgroups/mutate/mutate_podgroup_test.go
@@ -35,6 +35,7 @@ func Test_createPodGroupPatch(t *testing.T) {
 		name          string
 		podgroup      *schedulingv1beta1.PodGroup
 		nsAnnotations map[string]string
+		configDefault string
 		wantPatch     []patchOperation
 		wantErr       bool
 	}{
@@ -88,6 +89,44 @@ func Test_createPodGroupPatch(t *testing.T) {
 			wantPatch:     nil,
 			wantErr:       false,
 		},
+		{
+			name: "empty queue patched to configured default",
+			podgroup: &schedulingv1beta1.PodGroup{
+				Spec: schedulingv1beta1.PodGroupSpec{},
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "test-ns",
+				},
+			},
+			nsAnnotations: nil,
+			configDefault: "team-a",
+			wantPatch: []patchOperation{
+				{
+					Op:    "add",
+					Path:  "/spec/queue",
+					Value: "team-a",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "empty queue patched to hardcoded default when no configured default",
+			podgroup: &schedulingv1beta1.PodGroup{
+				Spec: schedulingv1beta1.PodGroupSpec{},
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "test-ns",
+				},
+			},
+			nsAnnotations: nil,
+			configDefault: "",
+			wantPatch: []patchOperation{
+				{
+					Op:    "add",
+					Path:  "/spec/queue",
+					Value: schedulingv1beta1.DefaultQueue,
+				},
+			},
+			wantErr: false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -108,7 +147,8 @@ func Test_createPodGroupPatch(t *testing.T) {
 			}
 
 			config = &router.AdmissionServiceConfig{
-				KubeClient: client,
+				KubeClient:   client,
+				DefaultQueue: tt.configDefault,
 			}
 
 			got, err := createPodGroupPatch(tt.podgroup)

--- a/pkg/webhooks/router/interface.go
+++ b/pkg/webhooks/router/interface.go
@@ -42,6 +42,7 @@ type AdmissionServiceConfig struct {
 	EnableQueueAllocatedPodsCheck bool
 	MaxQueueDepth                 int
 	EnableRootQueueProtection     bool
+	DefaultQueue                  string
 }
 
 type AdmissionService struct {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The mutating webhooks for Jobs and PodGroups hardcoded "default" when patching an empty queue, so setting --default-queue on the webhook-manager had no effect at admission. The scheduler-side flag is read after the webhook has already mutated the spec, so it never reached the affected objects.

This adds --default-queue to the webhook-manager, plumbs it through AdmissionServiceConfig.DefaultQueue, and uses it in both the Job and PodGroup patch paths. The flag default stays "default" for backward compatibility, and an operator-supplied empty value still falls back to it. The Helm chart is updated so custom.default_queue is passed to both the admission and scheduler deployments.

#### Which issue(s) this PR fixes:

Fixes #4548

#### Special notes for your reviewer:

Verified locally with:
- `go test ./pkg/webhooks/admission/jobs/mutate/... ./pkg/webhooks/admission/podgroups/mutate/... ./cmd/webhook-manager/...`
- `go vet` on the same packages
- `make verify` for gofmt

The PodGroup mutator change is gated on `Spec.Queue == ""` so the existing namespace-annotation behavior (when `Spec.Queue == "default"`) is preserved unchanged.

- Al used for writing the commit , descriptions and tests.

#### Does this PR introduce a user-facing change?

Yes, operators can now set `--default-queue` on the webhook-manager (or `custom.default_queue` via Helm) to control the default queue applied to Jobs and PodGroups at admission time.

```release-note
The webhook-manager now honors a `--default-queue` flag (and the `custom.default_queue` Helm value) that controls the default queue applied to Jobs and PodGroups at admission time.
```