### PR TITLE
fix(networkqos): match cni plugin by type

### DIFF
--- a/pkg/networkqos/cni/config.go
+++ b/pkg/networkqos/cni/config.go
@@ -76,17 +76,7 @@ func (p *ConfHandler) AddOrUpdateCniPluginToConfList(configPath, name string, pl
 			return fmt.Errorf("failed to get cni from cni conflist")
 		}
 
-		pluginName, ok := existedPlugin["name"]
-		if !ok {
-			continue
-		}
-
-		pluginNameInStr, ok := pluginName.(string)
-		if !ok {
-			continue
-		}
-
-		if pluginNameInStr == name {
+		if isCNIPluginMatched(existedPlugin, name) {
 			break
 		}
 	}
@@ -131,12 +121,8 @@ func (p *ConfHandler) DeleteCniPluginFromConfList(configPath, name string) (err 
 		if !ok {
 			return fmt.Errorf("failed to get cni from cni conflist")
 		}
-		pluginName, ok := pl["name"].(string)
-		if !ok {
-			continue
-		}
 
-		if pluginName == name {
+		if isCNIPluginMatched(pl, name) {
 			break
 		}
 	}
@@ -155,4 +141,14 @@ func (p *ConfHandler) DeleteCniPluginFromConfList(configPath, name string) (err 
 	err = os.WriteFile(configPath, newCniConf, 0750)
 	klog.InfoS("Delete cni plugin successfully", "cni-conf", string(newCniConf))
 	return err
+}
+
+func isCNIPluginMatched(plugin map[string]interface{}, name string) bool {
+	pluginName, ok := plugin["name"].(string)
+	if ok && pluginName == name {
+		return true
+	}
+
+	pluginType, ok := plugin["type"].(string)
+	return ok && pluginType == name
 }

--- a/pkg/networkqos/cni/config_test.go
+++ b/pkg/networkqos/cni/config_test.go
@@ -139,6 +139,85 @@ var fileWithNewNetworkQoS = `{
     ]
 }`
 
+var fileWithNetworkQoSTypeOnly = `{
+    "cniVersion": "0.3.1",
+    "name": "default-network",
+    "plugins": [
+        {
+            "args": {
+                "phynet": "phy_net1",
+                "secret_name": "canal-secret",
+                "tenant_id": "",
+                "vpc_id": "00a6a77c-83c8-405f-b7e8-d8648adfafa7"
+            },
+            "capabilities": {
+                "bandwidth": true
+            },
+            "ipam": {
+                "subnet": "172.16.0.0/16"
+            },
+            "name": "default-network",
+            "type": "vpc-router"
+        },
+        {
+            "capabilities": {
+                "portMappings": true
+            },
+            "externalSetMarkChain": "KUBE-MARK-MASQ",
+            "type": "portmap"
+        },
+        {
+            "args": {
+                "colocation": "true",
+                "offline-high-bandwidth": "50MB",
+                "offline-low-bandwidth": "20MB",
+                "online-bandwidth-watermark": "50MB"
+            },
+            "type": "network-qos"
+        }
+    ]
+}`
+
+var fileWithNetworkQoSNamedDifferently = `{
+    "cniVersion": "0.3.1",
+    "name": "default-network",
+    "plugins": [
+        {
+            "args": {
+                "phynet": "phy_net1",
+                "secret_name": "canal-secret",
+                "tenant_id": "",
+                "vpc_id": "00a6a77c-83c8-405f-b7e8-d8648adfafa7"
+            },
+            "capabilities": {
+                "bandwidth": true
+            },
+            "ipam": {
+                "subnet": "172.16.0.0/16"
+            },
+            "name": "default-network",
+            "type": "vpc-router"
+        },
+        {
+            "capabilities": {
+                "portMappings": true
+            },
+            "externalSetMarkChain": "KUBE-MARK-MASQ",
+            "type": "portmap"
+        },
+        {
+            "args": {
+                "colocation": "true",
+                "offline-high-bandwidth": "50MB",
+                "offline-low-bandwidth": "20MB",
+                "online-bandwidth-watermark": "50MB"
+            },
+            "name": "old-network-qos",
+            "type": "network-qos"
+        }
+    ]
+}`
+
 var fileWithoutPlugins = `{
     "cniVersion": "0.3.1",
     "name": "default-network"
@@ -208,6 +287,40 @@ func TestAddOrUpdateCniPluginToConfList(t *testing.T) {
 				},
 			},
 			fileContent:         fileWithNetworkQoS,
+			expectedFileContent: fileWithNewNetworkQoS,
+			expectedError:       false,
+		},
+
+		{
+			name: "cni-plugin-update-by-type",
+			plugin: map[string]interface{}{
+				"name": "network-qos",
+				"type": "network-qos",
+				"args": map[string]string{
+					utils.NodeColocationEnable:        "true",
+					utils.OnlineBandwidthWatermarkKey: "100MB",
+					utils.OfflineLowBandwidthKey:      "20MB",
+					utils.OfflineHighBandwidthKey:     "100MB",
+				},
+			},
+			fileContent:         fileWithNetworkQoSTypeOnly,
+			expectedFileContent: fileWithNewNetworkQoS,
+			expectedError:       false,
+		},
+
+		{
+			name: "cni-plugin-update-by-type-with-different-name",
+			plugin: map[string]interface{}{
+				"name": "network-qos",
+				"type": "network-qos",
+				"args": map[string]string{
+					utils.NodeColocationEnable:        "true",
+					utils.OnlineBandwidthWatermarkKey: "100MB",
+					utils.OfflineLowBandwidthKey:      "20MB",
+					utils.OfflineHighBandwidthKey:     "100MB",
+				},
+			},
+			fileContent:         fileWithNetworkQoSNamedDifferently,
 			expectedFileContent: fileWithNewNetworkQoS,
 			expectedError:       false,
 		},
@@ -366,6 +479,20 @@ func TestDeleteCniPluginFromConfList(t *testing.T) {
 		{
 			name:                "cni-plugin-delete",
 			fileContent:         fileWithNetworkQoS,
+			expectedFileContent: fileWithoutNetworkQoS,
+			expectedError:       false,
+		},
+
+		{
+			name:                "cni-plugin-delete-by-type",
+			fileContent:         fileWithNetworkQoSTypeOnly,
+			expectedFileContent: fileWithoutNetworkQoS,
+			expectedError:       false,
+		},
+
+		{
+			name:                "cni-plugin-delete-by-type-with-different-name",
+			fileContent:         fileWithNetworkQoSNamedDifferently,
 			expectedFileContent: fileWithoutNetworkQoS,
 			expectedError:       false,
 		},


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

`network-qos` CNI config update/delete only matched an existing plugin by `name`.

Some CNI entries may only have `type`, so an existing `type: network-qos` entry could be missed. In that case prepare appends another `network-qos` plugin instead of updating the existing one, and delete does not remove the old entry.

This matches by `name` or `type` and adds test coverage for type-only entries.

#### Which issue(s) this PR fixes:

Fixes #5515

#### Special notes for your reviewer:

NONE

#### Does this PR introduce a user-facing change?

```release-note
NONE