### PR TITLE
Avoid skipping nodes prematurely when no reclaim candidates remain.

### DIFF
--- a/pkg/scheduler/actions/reclaim/reclaim.go
+++ b/pkg/scheduler/actions/reclaim/reclaim.go
@@ -202,6 +202,17 @@ func (ra *Action) reclaimForTask(ssn *framework.Session, stmt *framework.Stateme
 		}
 
 		if len(reclaimees) == 0 {
+			if task.InitResreq.LessEqual(n.FutureIdle(), api.Zero) {
+				nodeStmt := framework.NewStatement(ssn)
+				if err := nodeStmt.Pipeline(task, n.Name, false); err != nil {
+					klog.Errorf("Failed to pipeline Task <%s/%s> on Node <%s>",
+						task.Namespace, task.Name, n.Name)
+					nodeStmt.Discard()
+					continue
+				}
+				stmt.Merge(nodeStmt)
+				return
+			}
 			klog.V(4).Infof("No reclaimees on Node <%s>.", n.Name)
 			continue
 		}

--- a/pkg/scheduler/actions/reclaim/reclaim.go
+++ b/pkg/scheduler/actions/reclaim/reclaim.go
@@ -202,19 +202,16 @@ func (ra *Action) reclaimForTask(ssn *framework.Session, stmt *framework.Stateme
 		}
 
 		if len(reclaimees) == 0 {
-			if task.InitResreq.LessEqual(n.FutureIdle(), api.Zero) {
-				nodeStmt := framework.NewStatement(ssn)
-				if err := nodeStmt.Pipeline(task, n.Name, false); err != nil {
-					klog.Errorf("Failed to pipeline Task <%s/%s> on Node <%s>",
-						task.Namespace, task.Name, n.Name)
-					nodeStmt.Discard()
-					continue
-				}
-				stmt.Merge(nodeStmt)
-				return
+			// A task can only be pipelined here without any reclaimees if resources
+			// are actually being released on this node (FutureIdle > Idle), e.g. by
+			// an eviction earlier in this same reclaim pass. If the task already fits
+			// in the node's current Idle resources, it doesn't depend on reclaiming
+			// anything, so leave it for the allocate action to handle instead of
+			// bypassing its AllocatableFn checks here.
+			if task.InitResreq.LessEqual(n.Idle, api.Zero) {
+				klog.V(4).Infof("No reclaimees on Node <%s>.", n.Name)
+				continue
 			}
-			klog.V(4).Infof("No reclaimees on Node <%s>.", n.Name)
-			continue
 		}
 
 		victims := ssn.Reclaimable(task, reclaimees)
@@ -256,8 +253,8 @@ func (ra *Action) reclaimForTask(ssn *framework.Session, stmt *framework.Stateme
 		}
 
 		if err := nodeStmt.Pipeline(task, n.Name, evictionOccurred); err != nil {
-			klog.Errorf("Failed to pipeline Task <%s/%s> on Node <%s>",
-				task.Namespace, task.Name, n.Name)
+			klog.Errorf("Failed to pipeline Task <%s/%s> on Node <%s>: %v",
+				task.Namespace, task.Name, n.Name, err)
 			nodeStmt.Discard()
 			continue
 		}

--- a/pkg/scheduler/actions/reclaim/reclaim_test.go
+++ b/pkg/scheduler/actions/reclaim/reclaim_test.go
@@ -292,6 +292,57 @@ func TestReclaim(t *testing.T) {
 			ExpectEvicted:  []string{"c1/victim-pod"},
 		},
 		{
+			// Regression: reclaimForTask skipped nodes with sufficient FutureIdle when
+			// reclaimees was empty, causing unnecessary gang scheduling failures.
+			//
+			// Within a single scheduling session, Statement.Evict() transitions a task
+			// from Running to Releasing immediately. On the next reclaimForTask call
+			// (for a second pending gang task), the same node's already-evicted task
+			// is Releasing and therefore excluded from reclaimees. The unconditional
+			// "continue" on empty reclaimees prevented reaching the FutureIdle check,
+			// so the task was never pipelined and stmt.Commit() was never called.
+			//
+			// Setup:
+			//   • n1 has 2 CPU total, fully used by victim (2 CPU, Preemptable).
+			//   • pg-preemptor (minMember=2) needs two 1-CPU tasks pipelined.
+			//   • First reclaimForTask: evicts victim (now Releasing), pipelines task1.
+			//     FutureIdle = 0 idle + 2 releasing - 1 pipelined = 1 CPU.
+			//   • Second reclaimForTask: reclaimees=[] (victim is Releasing, not Running),
+			//     but FutureIdle (1 CPU) >= task2 (1 CPU) — must pipeline without evicting.
+			//
+			// Without the fix: second task skips node, JobPipelined returns false,
+			// stmt.Discard() rolls back the eviction — 0 evictions committed.
+			// With the fix: second task pipelines via FutureIdle, JobPipelined=true,
+			// stmt.Commit() — exactly 1 eviction committed.
+			Name: "pipeline second task via FutureIdle when reclaimees empty after prior eviction",
+			Plugins: map[string]framework.PluginBuilder{
+				conformance.PluginName: conformance.New,
+				gang.PluginName:        gang.New,
+				proportion.PluginName:  proportion.New,
+			},
+			PodGroups: []*schedulingv1beta1.PodGroup{
+				util.BuildPodGroupWithPrio("pg-victim", "c1", "q1", 0, nil, schedulingv1beta1.PodGroupRunning, "low-priority"),
+				util.BuildPodGroupWithPrio("pg-preemptor", "c1", "q2", 2, nil, schedulingv1beta1.PodGroupInqueue, "low-priority"),
+			},
+			Pods: []*v1.Pod{
+				// victim occupies all 2 CPU on n1; both preemptor tasks need 1 CPU each.
+				util.BuildPod("c1", "victim", "n1", v1.PodRunning, api.BuildResourceList("2", "2G"), "pg-victim", map[string]string{schedulingv1beta1.PodPreemptable: "true"}, make(map[string]string)),
+				util.BuildPod("c1", "preemptor-task1", "", v1.PodPending, api.BuildResourceList("1", "1G"), "pg-preemptor", make(map[string]string), make(map[string]string)),
+				util.BuildPod("c1", "preemptor-task2", "", v1.PodPending, api.BuildResourceList("1", "1G"), "pg-preemptor", make(map[string]string), make(map[string]string)),
+			},
+			Nodes: []*v1.Node{
+				util.BuildNode("n1", api.BuildResourceList("2", "2G", []api.ScalarResource{{Name: "pods", Value: "10"}}...), make(map[string]string)),
+			},
+			Queues: []*schedulingv1beta1.Queue{
+				// q1 deserves 1 CPU (weight 1 of 10), uses 2 CPU -> overused -> victim is reclaimable.
+				util.BuildQueue("q1", 1, nil),
+				// q2 deserves 9 CPU (weight 9 of 10), uses 0 -> starving -> preemptor reclaims.
+				util.BuildQueue("q2", 9, nil),
+			},
+			ExpectEvictNum: 1,
+			ExpectEvicted:  []string{"c1/victim"},
+		},
+		{
 			// Regression: the original victim loop placed the "resources satisfied"
 			// check AFTER each eviction rather than before it.  This caused at least
 			// one victim to be spuriously evicted even when the node's FutureIdle was

--- a/pkg/scheduler/actions/reclaim/reclaim_test.go
+++ b/pkg/scheduler/actions/reclaim/reclaim_test.go
@@ -292,28 +292,16 @@ func TestReclaim(t *testing.T) {
 			ExpectEvicted:  []string{"c1/victim-pod"},
 		},
 		{
-			// Regression: reclaimForTask skipped nodes with sufficient FutureIdle when
-			// reclaimees was empty, causing unnecessary gang scheduling failures.
+			// Regression (#5520): a gang's second task saw reclaimees=[] on n1 because
+			// the first task's eviction had already moved the victim to Releasing. The
+			// unconditional "continue" on empty reclaimees stopped before reaching the
+			// FutureIdle check, so the second task never pipelined, JobPipelined stayed
+			// false, and stmt.Discard() rolled back the first eviction, leaving the gang
+			// Pending with reclaim repeating the same evict/discard cycle each session.
 			//
-			// Within a single scheduling session, Statement.Evict() transitions a task
-			// from Running to Releasing immediately. On the next reclaimForTask call
-			// (for a second pending gang task), the same node's already-evicted task
-			// is Releasing and therefore excluded from reclaimees. The unconditional
-			// "continue" on empty reclaimees prevented reaching the FutureIdle check,
-			// so the task was never pipelined and stmt.Commit() was never called.
-			//
-			// Setup:
-			//   • n1 has 2 CPU total, fully used by victim (2 CPU, Preemptable).
-			//   • pg-preemptor (minMember=2) needs two 1-CPU tasks pipelined.
-			//   • First reclaimForTask: evicts victim (now Releasing), pipelines task1.
-			//     FutureIdle = 0 idle + 2 releasing - 1 pipelined = 1 CPU.
-			//   • Second reclaimForTask: reclaimees=[] (victim is Releasing, not Running),
-			//     but FutureIdle (1 CPU) >= task2 (1 CPU) — must pipeline without evicting.
-			//
-			// Without the fix: second task skips node, JobPipelined returns false,
-			// stmt.Discard() rolls back the eviction — 0 evictions committed.
-			// With the fix: second task pipelines via FutureIdle, JobPipelined=true,
-			// stmt.Commit() — exactly 1 eviction committed.
+			// With the fix, the second task pipelines via FutureIdle (1 CPU released by
+			// the first eviction, not yet reflected in Idle) even though reclaimees is
+			// empty, so JobPipelined succeeds and the eviction commits.
 			Name: "pipeline second task via FutureIdle when reclaimees empty after prior eviction",
 			Plugins: map[string]framework.PluginBuilder{
 				conformance.PluginName: conformance.New,
@@ -334,9 +322,9 @@ func TestReclaim(t *testing.T) {
 				util.BuildNode("n1", api.BuildResourceList("2", "2G", []api.ScalarResource{{Name: "pods", Value: "10"}}...), make(map[string]string)),
 			},
 			Queues: []*schedulingv1beta1.Queue{
-				// q1 deserves 1 CPU (weight 1 of 10), uses 2 CPU -> overused -> victim is reclaimable.
+				// q1 deserves 0.2 CPU (weight 1 of 10, cluster has 2 CPU), uses 2 CPU -> overused -> victim is reclaimable.
 				util.BuildQueue("q1", 1, nil),
-				// q2 deserves 9 CPU (weight 9 of 10), uses 0 -> starving -> preemptor reclaims.
+				// q2 deserves 1.8 CPU (weight 9 of 10, cluster has 2 CPU), uses 0 -> starving -> preemptor reclaims.
 				util.BuildQueue("q2", 9, nil),
 			},
 			ExpectEvictNum: 1,


### PR DESCRIPTION
## Description

Within a scheduling session, `Statement.Evict()` immediately transitions a task from `Running` to `Releasing`. When `reclaimForTask` later processes another task from the same gang on the same node, the previously evicted task is no longer considered a reclaim candidate because only `Running` and `Preemptable` tasks are collected into `reclaimees`.

When `reclaimees` becomes empty, `reclaimForTask` unconditionally skips the node before checking whether `FutureIdle()` already satisfies the pending task. As a result, resources released by earlier evictions in the same scheduling session are ignored, preventing additional tasks from being pipelined. For gang jobs, this can cause `JobPipelined()` to return false, triggering `stmt.Discard()` and rolling back all previous reclaim operations, resulting in repeated scheduling failures.

This PR avoids skipping nodes prematurely when reclaimees is empty. Instead of introducing a separate pipeline path, it falls through to the existing reclaim logic whenever the task depends on releasing resources (i.e. it fits FutureIdle() but not Idle()). This reuses the existing ValidateVictims → reclaim → pipeline flow, preserves existing behavior for idle resources, and avoids bypassing allocation checks.

A regression test has also been added to verify that subsequent gang tasks can be successfully pipelined using `FutureIdle()` after a prior eviction in the same scheduling session.

Fixes #5520

---

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

* Fixes an early-exit path in `reclaimForTask` that skipped nodes with an empty `reclaimees` list even when `FutureIdle()` already had sufficient resources.
* Reuses `FutureIdle()` resources created by prior evictions within the same scheduling session.
* Prevents repeated reclaim/discard scheduling cycles for affected gang jobs.
* Aligns reclaim behavior with the existing logic in `allocate.go` and the documented behavior of `ValidateVictims`.
* Adds a regression test covering the scenario where a second gang task pipelines via `FutureIdle()` after an earlier eviction.

#### Which issue(s) this PR fixes:

Fixes #5520

#### Special notes for your reviewer:

The change only affects the `reclaimees == 0` path. Existing reclaim behavior is unchanged when additional victims are required or when `FutureIdle()` is insufficient. The added regression test reproduces the reported gang scheduling failure and verifies that only a single eviction is needed while the remaining task is pipelined using `FutureIdle()`.

#### Does this PR introduce a user-facing change?

```release-note
Fix reclaim scheduling so nodes with sufficient FutureIdle resources are no longer skipped when no additional reclaim candidates remain, preventing repeated reclaim/discard scheduling cycles and improving gang scheduling success.
```
