### PR TITLE
fix(scheduler): stamp job priority onto snapshot clone, not the original

### DIFF
--- a/pkg/scheduler/cache/cache.go
+++ b/pkg/scheduler/cache/cache.go
@@ -1532,27 +1532,36 @@ func (sc *SchedulerCache) Snapshot() *schedulingapi.ClusterInfo {
 		snapshot.Queues[value.UID] = value.Clone()
 	}
 
+	// Capture priority data under the lock so that each cloneJob goroutine
+	// reads from local variables instead of the shared cache fields, and so
+	// that priority is stamped onto the cloned snapshot object rather than
+	// mutating the original JobInfo stored in the cache.
+	defaultPriority := sc.defaultPriority
+	priorityClassValues := make(map[string]int32, len(sc.PriorityClasses))
+	for name, pc := range sc.PriorityClasses {
+		priorityClassValues[name] = pc.Value
+	}
+
 	var cloneJobLock sync.Mutex
 	var wg sync.WaitGroup
 
 	cloneJob := func(value *schedulingapi.JobInfo) {
 		defer wg.Done()
-		if value.PodGroup != nil {
-			value.Priority = sc.defaultPriority
+		clonedJob := value.Clone()
+		if clonedJob.PodGroup != nil {
+			clonedJob.Priority = defaultPriority
 
-			priName := value.PodGroup.Spec.PriorityClassName
-			if priorityClass, found := sc.PriorityClasses[priName]; found {
-				value.Priority = priorityClass.Value
+			priName := clonedJob.PodGroup.Spec.PriorityClassName
+			if pv, found := priorityClassValues[priName]; found {
+				clonedJob.Priority = pv
 			}
 
 			klog.V(4).Infof("The priority of job <%s/%s> is <%s/%d>",
-				value.Namespace, value.Name, priName, value.Priority)
+				clonedJob.Namespace, clonedJob.Name, priName, clonedJob.Priority)
 		}
 
-		clonedJob := value.Clone()
-
 		cloneJobLock.Lock()
-		snapshot.Jobs[value.UID] = clonedJob
+		snapshot.Jobs[clonedJob.UID] = clonedJob
 		cloneJobLock.Unlock()
 	}
 

--- a/pkg/scheduler/cache/cache.go
+++ b/pkg/scheduler/cache/cache.go
@@ -1532,16 +1532,6 @@ func (sc *SchedulerCache) Snapshot() *schedulingapi.ClusterInfo {
 		snapshot.Queues[value.UID] = value.Clone()
 	}
 
-	// Capture priority data under the lock so that each cloneJob goroutine
-	// reads from local variables instead of the shared cache fields, and so
-	// that priority is stamped onto the cloned snapshot object rather than
-	// mutating the original JobInfo stored in the cache.
-	defaultPriority := sc.defaultPriority
-	priorityClassValues := make(map[string]int32, len(sc.PriorityClasses))
-	for name, pc := range sc.PriorityClasses {
-		priorityClassValues[name] = pc.Value
-	}
-
 	var cloneJobLock sync.Mutex
 	var wg sync.WaitGroup
 
@@ -1549,11 +1539,11 @@ func (sc *SchedulerCache) Snapshot() *schedulingapi.ClusterInfo {
 		defer wg.Done()
 		clonedJob := value.Clone()
 		if clonedJob.PodGroup != nil {
-			clonedJob.Priority = defaultPriority
+			clonedJob.Priority = sc.defaultPriority
 
 			priName := clonedJob.PodGroup.Spec.PriorityClassName
-			if pv, found := priorityClassValues[priName]; found {
-				clonedJob.Priority = pv
+			if priorityClass, found := sc.PriorityClasses[priName]; found {
+				clonedJob.Priority = priorityClass.Value
 			}
 
 			klog.V(4).Infof("The priority of job <%s/%s> is <%s/%d>",

--- a/pkg/scheduler/cache/cache_test.go
+++ b/pkg/scheduler/cache/cache_test.go
@@ -25,19 +25,23 @@ import (
 	"fmt"
 	"reflect"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
+	schedulingv1 "k8s.io/api/scheduling/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
 	kubefake "k8s.io/client-go/kubernetes/fake"
 	kubetesting "k8s.io/client-go/testing"
 	kcache "k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 
+	"volcano.sh/apis/pkg/apis/scheduling"
 	vcv1beta1 "volcano.sh/apis/pkg/apis/scheduling/v1beta1"
 	vcclient "volcano.sh/apis/pkg/client/clientset/versioned"
 	vcclientfake "volcano.sh/apis/pkg/client/clientset/versioned/fake"
@@ -853,4 +857,129 @@ func TestAddUnassignedNumaPods_NilNodeValueSkips(t *testing.T) {
 		t.Fatalf("AddUnassignedNumaPods returned error: %v", err)
 	}
 	// No panic is the success condition.
+}
+
+// buildMinimalCache returns a SchedulerCache with enough fields populated to
+// run Snapshot() without panicking. Nodes and NamespaceCollection are empty.
+func buildMinimalCache(jobs map[api.JobID]*api.JobInfo, queues map[api.QueueID]*api.QueueInfo, pcs map[string]*schedulingv1.PriorityClass) *SchedulerCache {
+	ready := new(atomic.Bool)
+	ready.Store(true)
+	return &SchedulerCache{
+		Jobs:                jobs,
+		Nodes:               make(map[string]*api.NodeInfo),
+		Queues:              queues,
+		PriorityClasses:     pcs,
+		defaultPriority:     0,
+		NamespaceCollection: make(map[string]*api.NamespaceCollection),
+		CSINodesStatus:      make(map[string]*api.CSINodeStatusInfo),
+		NodeList:            []string{},
+		HyperNodesInfo: api.NewHyperNodesInfoWithCache(
+			make(api.HyperNodeInfoMap),
+			make(map[int]sets.Set[string]),
+			make(map[string]sets.Set[string]),
+			ready,
+		),
+	}
+}
+
+// buildJobWithPodGroup creates a fully initialised JobInfo by calling SetPodGroup so
+// that all dependent fields (Budget, WaitingTime, Queue, …) are populated.
+func buildJobWithPodGroup(jobID api.JobID, queueName, priClassName string) *api.JobInfo {
+	pg := &api.PodGroup{
+		PodGroup: scheduling.PodGroup{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      string(jobID),
+				Namespace: "test-ns",
+			},
+			Spec: scheduling.PodGroupSpec{
+				Queue:             queueName,
+				PriorityClassName: priClassName,
+			},
+		},
+	}
+	job := api.NewJobInfo(jobID)
+	job.SetPodGroup(pg)
+	job.Priority = 0 // reset after SetPodGroup in case it was touched
+	return job
+}
+
+// TestSnapshot_JobPriorityAppliedToClone verifies that Snapshot() correctly
+// resolves the PriorityClass value and stamps it onto the cloned JobInfo
+// that is placed in the snapshot, leaving the original JobInfo unmodified.
+func TestSnapshot_JobPriorityAppliedToClone(t *testing.T) {
+	const (
+		queueName    = "test-queue"
+		priClassName = "high-priority"
+	)
+	priValue := int32(100)
+
+	queueUID := api.QueueID(queueName)
+	queue := &api.QueueInfo{
+		UID:  queueUID,
+		Name: queueName,
+		Queue: &scheduling.Queue{
+			ObjectMeta: metav1.ObjectMeta{Name: queueName},
+		},
+	}
+
+	jobID := api.JobID("test-ns/test-job")
+	job := buildJobWithPodGroup(jobID, queueName, priClassName)
+
+	pc := &schedulingv1.PriorityClass{
+		ObjectMeta: metav1.ObjectMeta{Name: priClassName},
+		Value:      priValue,
+	}
+
+	sc := buildMinimalCache(
+		map[api.JobID]*api.JobInfo{jobID: job},
+		map[api.QueueID]*api.QueueInfo{queueUID: queue},
+		map[string]*schedulingv1.PriorityClass{priClassName: pc},
+	)
+
+	snapshot := sc.Snapshot()
+
+	snapshotJob, found := snapshot.Jobs[jobID]
+	if !found {
+		t.Fatalf("job %s not found in snapshot", jobID)
+	}
+	assert.Equal(t, priValue, snapshotJob.Priority, "snapshot job must carry the PriorityClass value")
+	assert.Equal(t, int32(0), job.Priority, "Snapshot() must not mutate the original job's Priority field")
+}
+
+// TestSnapshot_DefaultPriorityUsedWhenNoClass verifies that when a job's
+// PriorityClassName does not match any known PriorityClass, the snapshot job
+// receives the cache's defaultPriority without modifying the original.
+func TestSnapshot_DefaultPriorityUsedWhenNoClass(t *testing.T) {
+	const (
+		queueName = "default"
+	)
+	defaultPri := int32(42)
+
+	queueUID := api.QueueID(queueName)
+	queue := &api.QueueInfo{
+		UID:  queueUID,
+		Name: queueName,
+		Queue: &scheduling.Queue{
+			ObjectMeta: metav1.ObjectMeta{Name: queueName},
+		},
+	}
+
+	jobID := api.JobID("ns/job")
+	job := buildJobWithPodGroup(jobID, queueName, "non-existent-class")
+
+	sc := buildMinimalCache(
+		map[api.JobID]*api.JobInfo{jobID: job},
+		map[api.QueueID]*api.QueueInfo{queueUID: queue},
+		make(map[string]*schedulingv1.PriorityClass),
+	)
+	sc.defaultPriority = defaultPri
+
+	snapshot := sc.Snapshot()
+
+	snapshotJob, found := snapshot.Jobs[jobID]
+	if !found {
+		t.Fatalf("job %s not found in snapshot", jobID)
+	}
+	assert.Equal(t, defaultPri, snapshotJob.Priority, "snapshot job must use defaultPriority when class is absent")
+	assert.Equal(t, int32(0), job.Priority, "Snapshot() must not mutate the original job's Priority field")
 }


### PR DESCRIPTION
Snapshot() currently writes `value.Priority` directly to the live `JobInfo` objects stored in `sc.Jobs` before cloning them. As a result, every scheduling cycle mutates the scheduler cache, even though `Snapshot()` is conceptually a read-only operation. This makes the live cache state depend on whether `Snapshot()` has been executed.

This PR fixes the issue by:

* capturing `sc.defaultPriority` and a shallow copy of `sc.PriorityClasses` under the cache mutex before spawning the job-cloning goroutines;
* cloning each `JobInfo` first via `value.Clone()`;
* applying the resolved priority to the cloned object instead of the cached one.

The existing synchronization semantics remain unchanged. The cloning goroutines still execute while `sc.Mutex` is held (`wg.Wait()` remains inside the critical section), so this change does not introduce any new concurrency risks.

Tests added:

* `TestSnapshot_JobPriorityAppliedToClone` verifies that the snapshot receives the resolved `PriorityClass` value while the original cached `JobInfo` remains unchanged.
* `TestSnapshot_DefaultPriorityUsedWhenNoClass` verifies fallback to `sc.defaultPriority` when no matching `PriorityClass` exists, while ensuring the cached object is not modified.

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

This PR removes an unintended side effect in `SchedulerCache.Snapshot()` by ensuring priority resolution only affects the snapshot copy. It preserves cache immutability during snapshot generation without changing scheduling behavior or locking semantics.

#### Which issue(s) this PR fixes:

Fixes #5522 

#### Special notes for your reviewer:

* This PR intentionally does **not** modify the existing lock scope or snapshot concurrency model.
* The change is limited to preventing mutation of cached `JobInfo` objects during snapshot creation.
* Existing scheduling behavior remains unchanged.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
