### PR TITLE
webhooks: validate root child queue resources

### DIFF
--- a/pkg/webhooks/admission/queues/validate/validate_queue.go
+++ b/pkg/webhooks/admission/queues/validate/validate_queue.go
@@ -329,44 +329,28 @@ func validateQueueDeleting(queueName string) error {
 	return nil
 }
 
-// needsValidateHierarchicalQueue determines if hierarchy resource validation is necessary
-// Returns true only if:
-// - Queue is not the root queue itself AND
-// - Either it's a CREATE operation OR resources (capability/deserved/guarantee) changed on UPDATE OR parent changed on UPDATE
+// needsValidateHierarchicalQueue determines if hierarchy resource validation is necessary.
 func needsValidateHierarchicalQueue(queue, oldQueue *schedulingv1beta1.Queue, operation admissionv1.Operation) bool {
-	// Only the root queue itself should skip validation completely
-	if queue.Name == "root" {
-		return false
-	}
-
-	// For CREATE operations, always validate
 	if operation == admissionv1.Create {
-		return true
+		return queue.Name != "root"
 	}
 
-	// For UPDATE operations, only validate if resources or parent changed
 	if operation == admissionv1.Update && oldQueue != nil {
-		// Check if parent changed
 		if queue.Spec.Parent != oldQueue.Spec.Parent {
 			return true
 		}
-		// Check if capability changed
 		if !equality.Semantic.DeepEqual(queue.Spec.Capability, oldQueue.Spec.Capability) {
 			return true
 		}
-		// Check if deserved changed
 		if !equality.Semantic.DeepEqual(queue.Spec.Deserved, oldQueue.Spec.Deserved) {
 			return true
 		}
-		// Check if guarantee changed
 		if !equality.Semantic.DeepEqual(queue.Spec.Guarantee.Resource, oldQueue.Spec.Guarantee.Resource) {
 			return true
 		}
-		// No resource or parent changes, skip validation
 		return false
 	}
 
-	// Default: skip validation
 	return false
 }
 
@@ -441,7 +425,16 @@ func getSingleResource(r *api.Resource, name v1.ResourceName) float64 {
 // Recursively searches for the ancestor queue that recently defines the capability
 func findNearestAncestorCapability(q *schedulingv1beta1.Queue, rname v1.ResourceName) (float64, bool) {
 	parent := q.Spec.Parent
-	for parent != "" && parent != "root" {
+	if parent == "" && q.Name != "root" {
+		parent = "root"
+	}
+	visited := map[string]struct{}{}
+	for parent != "" {
+		if _, ok := visited[parent]; ok {
+			return 0, false
+		}
+		visited[parent] = struct{}{}
+
 		pq, err := config.QueueLister.Get(parent)
 		if err != nil {
 			return 0, false
@@ -456,6 +449,9 @@ func findNearestAncestorCapability(q *schedulingv1beta1.Queue, rname v1.Resource
 		}
 
 		parent = pq.Spec.Parent
+		if parent == "" && pq.Name != "root" {
+			parent = "root"
+		}
 	}
 	return 0, false
 }
@@ -529,28 +525,34 @@ func validateQueueDepth(queue *schedulingv1beta1.Queue) error {
 // - Parent's capability >= each child's capability
 // - Sum of children's guarantee/deserved <= parent's limit
 func validateHierarchicalQueueResources(queue *schedulingv1beta1.Queue) error {
+	parentName := queue.Spec.Parent
+	if parentName == "" && queue.Name != "root" {
+		parentName = "root"
+	}
+
 	// If this is a child queue, validate against parent
-	if queue.Spec.Parent != "" && queue.Spec.Parent != "root" {
+	if parentName != "" {
 		// Get parent queue directly using lister
-		parentQueue, err := config.QueueLister.Get(queue.Spec.Parent)
-		if err != nil {
-			return fmt.Errorf("parent queue %s not found: %v", queue.Spec.Parent, err)
+		parentQueue, err := config.QueueLister.Get(parentName)
+		if err != nil && parentName != "root" {
+			return fmt.Errorf("parent queue %s not found: %v", parentName, err)
 		}
+		if err == nil {
+			// Check queue's capability <= ancestors's capability
+			if err := validateChildAgainstAncestor(queue); err != nil {
+				return err
+			}
 
-		// Check queue's capability <= ancestors's capability
-		if err := validateChildAgainstAncestor(queue); err != nil {
-			return err
-		}
+			// Get siblings using index
+			siblings, err := config.GetQueuesByParent(parentName)
+			if err != nil {
+				return fmt.Errorf("failed to get sibling queues: %v", err)
+			}
 
-		// Get siblings using index
-		siblings, err := config.GetQueuesByParent(queue.Spec.Parent)
-		if err != nil {
-			return fmt.Errorf("failed to get sibling queues: %v", err)
-		}
-
-		// Check sum of all siblings' (including this queue) guarantee/deserved <= parent's limit
-		if err := validateSiblingsSum(queue, parentQueue, siblings); err != nil {
-			return err
+			// Check sum of all siblings' (including this queue) guarantee/deserved <= parent's limit
+			if err := validateSiblingsSum(queue, parentQueue, siblings); err != nil {
+				return err
+			}
 		}
 	}
 
@@ -596,18 +598,20 @@ func validateSiblingsSum(queue, parent *schedulingv1beta1.Queue, siblings []*sch
 
 	parentGuarantee := api.NewResource(parent.Spec.Guarantee.Resource)
 	parentDeserved := api.NewResource(parent.Spec.Deserved)
+	checkGuarantee := parent.Name != "root" || len(parent.Spec.Guarantee.Resource) != 0
+	checkDeserved := parent.Name != "root" || len(parent.Spec.Deserved) != 0
 
 	// siblings are already filtered by parent, just exclude self
 	for _, sibling := range siblings {
 		if sibling.Name != queue.Name {
 			totalGuarantee.Add(api.NewResource(sibling.Spec.Guarantee.Resource))
-			if parentGuarantee.LessPartly(totalGuarantee, api.Zero) {
+			if checkGuarantee && parentGuarantee.LessPartly(totalGuarantee, api.Zero) {
 				return fmt.Errorf("parent queue %s validation failed: sum of children's guarantee (%s) exceeds parent's guarantee limit (%s)",
 					parent.Name, totalGuarantee, parentGuarantee)
 			}
 
 			totalDeserved.Add(api.NewResource(sibling.Spec.Deserved))
-			if parentDeserved.LessPartly(totalDeserved, api.Zero) {
+			if checkDeserved && parentDeserved.LessPartly(totalDeserved, api.Zero) {
 				return fmt.Errorf("parent queue %s validation failed: sum of children's deserved (%s) exceeds parent's deserved limit (%s)",
 					parent.Name, totalDeserved, parentDeserved)
 			}
@@ -616,13 +620,13 @@ func validateSiblingsSum(queue, parent *schedulingv1beta1.Queue, siblings []*sch
 
 	// Add the current queue's resources
 	totalGuarantee.Add(api.NewResource(queue.Spec.Guarantee.Resource))
-	if parentGuarantee.LessPartly(totalGuarantee, api.Zero) {
+	if checkGuarantee && parentGuarantee.LessPartly(totalGuarantee, api.Zero) {
 		return fmt.Errorf("parent queue %s validation failed: sum of children's guarantee (%s) exceeds parent's guarantee limit (%s)",
 			parent.Name, totalGuarantee, parentGuarantee)
 	}
 
 	totalDeserved.Add(api.NewResource(queue.Spec.Deserved))
-	if parentDeserved.LessPartly(totalDeserved, api.Zero) {
+	if checkDeserved && parentDeserved.LessPartly(totalDeserved, api.Zero) {
 		return fmt.Errorf("parent queue %s validation failed: sum of children's deserved (%s) exceeds parent's deserved limit (%s)",
 			parent.Name, totalDeserved, parentDeserved)
 	}
@@ -665,17 +669,19 @@ func validateChildrenConstraints(parent *schedulingv1beta1.Queue, children []*sc
 
 	parentGuarantee := api.NewResource(parent.Spec.Guarantee.Resource)
 	parentDeserved := api.NewResource(parent.Spec.Deserved)
+	checkGuarantee := parent.Name != "root" || len(parent.Spec.Guarantee.Resource) != 0
+	checkDeserved := parent.Name != "root" || len(parent.Spec.Deserved) != 0
 
 	for _, child := range children {
 		// Accumulate children's guarantee and deserved
 		totalGuarantee.Add(api.NewResource(child.Spec.Guarantee.Resource))
-		if parentGuarantee.LessPartly(totalGuarantee, api.Zero) {
+		if checkGuarantee && parentGuarantee.LessPartly(totalGuarantee, api.Zero) {
 			return fmt.Errorf("queue %s validation failed: sum of children's guarantee (%s) exceeds parent's guarantee limit (%s)",
 				parent.Name, totalGuarantee, parentGuarantee)
 		}
 
 		totalDeserved.Add(api.NewResource(child.Spec.Deserved))
-		if parentDeserved.LessPartly(totalDeserved, api.Zero) {
+		if checkDeserved && parentDeserved.LessPartly(totalDeserved, api.Zero) {
 			return fmt.Errorf("queue %s validation failed: sum of children's deserved (%s) exceeds parent's deserved limit (%s)",
 				parent.Name, totalDeserved, parentDeserved)
 		}

--- a/pkg/webhooks/admission/queues/validate/validate_queue_test.go
+++ b/pkg/webhooks/admission/queues/validate/validate_queue_test.go
@@ -2187,6 +2187,82 @@ func setupQueueInformerWithIndex(factory informers.SharedInformerFactory) cache.
 	return queueInformer
 }
 
+func TestValidateRootChildResources(t *testing.T) {
+	config.VolcanoClient = fakeclient.NewSimpleClientset()
+	informerFactory := informers.NewSharedInformerFactory(config.VolcanoClient, 0)
+	queueInformer := setupQueueInformerWithIndex(informerFactory)
+	config.QueueInformer = queueInformer
+	config.QueueLister = informerFactory.Scheduling().V1beta1().Queues().Lister()
+
+	root := &schedulingv1beta1.Queue{
+		ObjectMeta: metav1.ObjectMeta{Name: "root"},
+		Spec: schedulingv1beta1.QueueSpec{
+			Weight:     1,
+			Capability: v1.ResourceList{v1.ResourceCPU: resource.MustParse("10")},
+			Deserved:   v1.ResourceList{v1.ResourceCPU: resource.MustParse("10")},
+			Guarantee: schedulingv1beta1.Guarantee{
+				Resource: v1.ResourceList{v1.ResourceCPU: resource.MustParse("10")},
+			},
+		},
+	}
+	rootChild := &schedulingv1beta1.Queue{
+		ObjectMeta: metav1.ObjectMeta{Name: "root-child-a"},
+		Spec: schedulingv1beta1.QueueSpec{
+			Weight:   1,
+			Deserved: v1.ResourceList{v1.ResourceCPU: resource.MustParse("8")},
+			Guarantee: schedulingv1beta1.Guarantee{
+				Resource: v1.ResourceList{v1.ResourceCPU: resource.MustParse("8")},
+			},
+		},
+	}
+
+	if err := queueInformer.GetIndexer().Add(root); err != nil {
+		t.Fatal(err)
+	}
+	if err := queueInformer.GetIndexer().Add(rootChild); err != nil {
+		t.Fatal(err)
+	}
+
+	newRootChild := &schedulingv1beta1.Queue{
+		ObjectMeta: metav1.ObjectMeta{Name: "root-child-b"},
+		Spec: schedulingv1beta1.QueueSpec{
+			Weight:   1,
+			Deserved: v1.ResourceList{v1.ResourceCPU: resource.MustParse("8")},
+			Guarantee: schedulingv1beta1.Guarantee{
+				Resource: v1.ResourceList{v1.ResourceCPU: resource.MustParse("8")},
+			},
+		},
+	}
+	if err := validateHierarchicalQueueResources(newRootChild); err == nil {
+		t.Fatal("expected root child guarantee to be rejected")
+	}
+
+	rootWithoutQuota := root.DeepCopy()
+	rootWithoutQuota.Spec.Deserved = nil
+	rootWithoutQuota.Spec.Guarantee = schedulingv1beta1.Guarantee{}
+	if err := queueInformer.GetIndexer().Update(rootWithoutQuota); err != nil {
+		t.Fatal(err)
+	}
+	if err := validateHierarchicalQueueResources(newRootChild); err != nil {
+		t.Fatalf("expected root child without root quota to pass, got %v", err)
+	}
+}
+
+func TestNeedsValidateHierarchicalQueueRootUpdate(t *testing.T) {
+	oldRoot := &schedulingv1beta1.Queue{
+		ObjectMeta: metav1.ObjectMeta{Name: "root"},
+		Spec: schedulingv1beta1.QueueSpec{
+			Capability: v1.ResourceList{v1.ResourceCPU: resource.MustParse("20")},
+		},
+	}
+	root := oldRoot.DeepCopy()
+	root.Spec.Capability = v1.ResourceList{v1.ResourceCPU: resource.MustParse("10")}
+
+	if !needsValidateHierarchicalQueue(root, oldRoot, admissionv1.Update) {
+		t.Fatal("expected root resource update to require hierarchy validation")
+	}
+}
+
 func TestValidateQueueDepthDynamic(t *testing.T) {
 	// Setup fake client and lister
 	config.VolcanoClient = fakeclient.NewSimpleClientset()
@@ -2265,6 +2341,23 @@ func TestValidateChildAgainstAncestorForCapability(t *testing.T) {
 	stopCh := make(chan struct{})
 	defer close(stopCh)
 
+	root := &schedulingv1beta1.Queue{
+		ObjectMeta: metav1.ObjectMeta{Name: "root"},
+		Spec: schedulingv1beta1.QueueSpec{
+			Parent: "root",
+			Weight: 1,
+			Capability: v1.ResourceList{
+				v1.ResourceCPU: resource.MustParse("100"),
+			},
+		},
+	}
+	rootChild := &schedulingv1beta1.Queue{
+		ObjectMeta: metav1.ObjectMeta{Name: "root-child"},
+		Spec: schedulingv1beta1.QueueSpec{
+			Weight: 1,
+		},
+	}
+
 	// Build a 3-level hierarchy: root -> grandparent -> parent -> child
 	// grandparent: CPU=100, Memory=100Gi, GPU=8
 	grandparent := &schedulingv1beta1.Queue{
@@ -2302,6 +2395,8 @@ func TestValidateChildAgainstAncestorForCapability(t *testing.T) {
 		},
 	}
 
+	_, _ = config.VolcanoClient.SchedulingV1beta1().Queues().Create(context.TODO(), root, metav1.CreateOptions{})
+	_, _ = config.VolcanoClient.SchedulingV1beta1().Queues().Create(context.TODO(), rootChild, metav1.CreateOptions{})
 	_, _ = config.VolcanoClient.SchedulingV1beta1().Queues().Create(context.TODO(), grandparent, metav1.CreateOptions{})
 	_, _ = config.VolcanoClient.SchedulingV1beta1().Queues().Create(context.TODO(), parent, metav1.CreateOptions{})
 	_, _ = config.VolcanoClient.SchedulingV1beta1().Queues().Create(context.TODO(), parentNoCap, metav1.CreateOptions{})
@@ -2315,6 +2410,21 @@ func TestValidateChildAgainstAncestorForCapability(t *testing.T) {
 		expectErr bool
 		errSubstr string
 	}{
+		{
+			name: "Child under empty-parent queue checks root capability",
+			child: &schedulingv1beta1.Queue{
+				ObjectMeta: metav1.ObjectMeta{Name: "child-under-root-child"},
+				Spec: schedulingv1beta1.QueueSpec{
+					Parent: "root-child",
+					Weight: 1,
+					Capability: v1.ResourceList{
+						v1.ResourceCPU: resource.MustParse("200"),
+					},
+				},
+			},
+			expectErr: true,
+			errSubstr: "exceeds its ancestor's capability",
+		},
 		{
 			name: "Child CPU exceeds direct parent capability",
 			child: &schedulingv1beta1.Queue{

--- a/pkg/webhooks/router/indexer.go
+++ b/pkg/webhooks/router/indexer.go
@@ -37,13 +37,16 @@ func QueueParentIndexFunc(obj interface{}) ([]string, error) {
 		return []string{}, nil
 	}
 
+	if queue.Name == "root" {
+		return []string{}, nil
+	}
+
 	// Index by parent name
 	if queue.Spec.Parent != "" {
 		return []string{queue.Spec.Parent}, nil
 	}
 
-	// Root queue or queues without parent
-	return []string{}, nil
+	return []string{"root"}, nil
 }
 
 // GetQueuesByParent returns all queues that have the specified parent using the queue parent index.
@@ -78,7 +81,11 @@ func (asc *AdmissionServiceConfig) GetQueuesByParent(parentName string) ([]*sche
 
 	queues := make([]*schedulingv1beta1.Queue, 0)
 	for _, queue := range allQueues {
-		if queue.Spec.Parent == parentName {
+		queueParent := queue.Spec.Parent
+		if queue.Name != "root" && queueParent == "" {
+			queueParent = "root"
+		}
+		if queueParent == parentName {
 			queues = append(queues, queue)
 		}
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Queue admission skipped resource validation for direct children of the `root` queue.

This makes root children follow the same hierarchy checks as other child queues when the root queue exists, so their capability/deserved/guarantee values are validated against root limits.

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

Added a regression test for root child capability and guarantee validation.

#### Does this PR introduce a user-facing change?

```release-note
NONE