### PR TITLE
fix(allocate): honor NeedContinueAllocating after PrePredicate failures

### DIFF
--- a/pkg/scheduler/actions/allocate/allocate.go
+++ b/pkg/scheduler/actions/allocate/allocate.go
@@ -783,6 +783,9 @@ func (alloc *Action) allocateResourcesForTasks(subJob *api.SubJobInfo, tasks *ut
 				fitErrors.SetNodeError(ni.Name, err)
 			}
 			job.NodesFitErrors[task.UID] = fitErrors
+			if job.NeedContinueAllocating(subJob.UID) {
+				continue
+			}
 			break
 		}
 
@@ -821,9 +824,8 @@ func (alloc *Action) allocateResourcesForTasks(subJob *api.SubJobInfo, tasks *ut
 			// otherwise, should continue to find other allocatable task
 			if job.NeedContinueAllocating(subJob.UID) {
 				continue
-			} else {
-				break
 			}
+			break
 		}
 
 		if subJob.WithNetworkTopology() {


### PR DESCRIPTION
## What this PR does

This PR makes the handling of `PrePredicateFn()` failures consistent with the existing predicate failure path in `allocateResourcesForTasks()`.

Instead of always terminating the allocation loop, the scheduler now consults `job.NeedContinueAllocating()` before deciding whether to continue processing remaining tasks.

## Why is this change needed?

`PrePredicateFn()` failures represent task-level scheduling failures. Applying the same continuation policy as predicate failures avoids prematurely stopping allocation when remaining tasks may still be eligible for scheduling.

## Does this PR introduce user-facing changes?

No.

This change only affects the scheduler's internal allocation flow when `PrePredicateFn()` returns an error.

Fixes #5527 
