### PR TITLE
feat(scheduler): add timeout-based inqueue downgrade for stale jobs

### DIFF
--- a/pkg/scheduler/actions/enqueue/enqueue.go
+++ b/pkg/scheduler/actions/enqueue/enqueue.go
@@ -17,6 +17,7 @@ limitations under the License.
 package enqueue
 
 import (
+	"strconv"
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -27,6 +28,12 @@ import (
 	"volcano.sh/volcano/pkg/scheduler/api"
 	"volcano.sh/volcano/pkg/scheduler/framework"
 	"volcano.sh/volcano/pkg/scheduler/util"
+)
+
+const (
+	// DefaultInqueueTimeout is the default duration a job is allowed to stay in Inqueue state
+	// before being downgraded back to Pending.
+	DefaultInqueueTimeout = 5 * time.Minute
 )
 
 type Action struct{}
@@ -45,6 +52,10 @@ func (enqueue *Action) Execute(ssn *framework.Session) {
 	klog.V(5).Infof("Enter Enqueue ...")
 	defer klog.V(5).Infof("Leaving Enqueue ...")
 
+	// Phase 1: Evict timed-out Inqueue jobs back to Pending to release quota.
+	enqueue.evictTimedOutInqueueJobs(ssn)
+
+	// Phase 2: Normal enqueue logic.
 	queues := util.NewPriorityQueue(ssn.QueueOrderFn)
 	queueSet := sets.NewString()
 	jobsMap := map[api.QueueID]*util.PriorityQueue{}
@@ -96,11 +107,76 @@ func (enqueue *Action) Execute(ssn *framework.Session) {
 			ssn.JobEnqueued(job)
 			job.PodGroup.Status.Phase = scheduling.PodGroupInqueue
 			ssn.Jobs[job.UID] = job
+
+			// Record the enqueue timestamp for timeout tracking.
+			if job.EnqueueTimestamp.IsZero() {
+				job.EnqueueTimestamp = metav1.Time{Time: time.Now()}
+			}
 		}
 
 		// Added Queue back until no job in Queue.
 		queues.Push(queue)
 	}
+}
+
+// evictTimedOutInqueueJobs iterates over all jobs in the Inqueue state and downgrades
+// those that have exceeded their inqueue timeout back to Pending, releasing quota.
+func (enqueue *Action) evictTimedOutInqueueJobs(ssn *framework.Session) {
+	for _, job := range ssn.Jobs {
+		if job.PodGroup == nil || job.PodGroup.Status.Phase != scheduling.PodGroupInqueue {
+			continue
+		}
+
+		// Initialize the enqueue timestamp if it's not set (e.g. for jobs that were
+		// already Inqueue before this feature was introduced).
+		if job.EnqueueTimestamp.IsZero() {
+			job.EnqueueTimestamp = metav1.Time{Time: time.Now()}
+			ssn.Jobs[job.UID] = job
+			ssn.MarkJobDirty(job.UID)
+			continue
+		}
+
+		timeout := getInqueueTimeout(job)
+		elapsed := time.Since(job.EnqueueTimestamp.Time)
+		if elapsed < timeout {
+			continue
+		}
+
+		klog.V(3).Infof("Job <%s/%s> exceeded inqueue timeout (%v > %v), downgrading to Pending",
+			job.Namespace, job.Name, elapsed, timeout)
+
+		// Downgrade to Pending.
+		job.PodGroup.Status.Phase = scheduling.PodGroupPending
+		job.EnqueueTimestamp = metav1.Time{} // reset timestamp
+
+		// Notify plugins to release the inqueue quota.
+		ssn.JobInqueueEvicted(job)
+
+		ssn.Jobs[job.UID] = job
+	}
+}
+
+// getInqueueTimeout returns the inqueue timeout for a job. It checks for an annotation
+// override first, and falls back to DefaultInqueueTimeout.
+func getInqueueTimeout(job *api.JobInfo) time.Duration {
+	if job.PodGroup == nil {
+		return DefaultInqueueTimeout
+	}
+	annotations := job.PodGroup.GetAnnotations()
+	if annotations == nil {
+		return DefaultInqueueTimeout
+	}
+	timeoutStr, found := annotations[api.JobInqueueTimeoutAnnotation]
+	if !found {
+		return DefaultInqueueTimeout
+	}
+	timeoutSeconds, err := strconv.Atoi(timeoutStr)
+	if err != nil || timeoutSeconds <= 0 {
+		klog.Warningf("Invalid inqueue-timeout annotation value %q for job <%s/%s>, using default %v",
+			timeoutStr, job.Namespace, job.Name, DefaultInqueueTimeout)
+		return DefaultInqueueTimeout
+	}
+	return time.Duration(timeoutSeconds) * time.Second
 }
 
 func (enqueue *Action) UnInitialize() {}

--- a/pkg/scheduler/actions/enqueue/enqueue.go
+++ b/pkg/scheduler/actions/enqueue/enqueue.go
@@ -109,9 +109,7 @@ func (enqueue *Action) Execute(ssn *framework.Session) {
 			ssn.Jobs[job.UID] = job
 
 			// Record the enqueue timestamp for timeout tracking.
-			if job.EnqueueTimestamp.IsZero() {
-				job.EnqueueTimestamp = metav1.Time{Time: time.Now()}
-			}
+			job.EnqueueTimestamp = metav1.Now()
 		}
 
 		// Added Queue back until no job in Queue.
@@ -130,8 +128,7 @@ func (enqueue *Action) evictTimedOutInqueueJobs(ssn *framework.Session) {
 		// Initialize the enqueue timestamp if it's not set (e.g. for jobs that were
 		// already Inqueue before this feature was introduced).
 		if job.EnqueueTimestamp.IsZero() {
-			job.EnqueueTimestamp = metav1.Time{Time: time.Now()}
-			ssn.Jobs[job.UID] = job
+			job.EnqueueTimestamp = metav1.Now()
 			ssn.MarkJobDirty(job.UID)
 			continue
 		}
@@ -151,8 +148,6 @@ func (enqueue *Action) evictTimedOutInqueueJobs(ssn *framework.Session) {
 
 		// Notify plugins to release the inqueue quota.
 		ssn.JobInqueueEvicted(job)
-
-		ssn.Jobs[job.UID] = job
 	}
 }
 

--- a/pkg/scheduler/actions/enqueue/enqueue_test.go
+++ b/pkg/scheduler/actions/enqueue/enqueue_test.go
@@ -121,6 +121,21 @@ func TestEnqueue(t *testing.T) {
 				"c1/pg1": scheduling.PodGroupPending,
 			},
 		},
+		{
+			Name: "invalid negative timeout annotation falls back to default and does not evict immediately",
+			PodGroups: []*schedulingv1.PodGroup{
+				util.BuildPodGroupWithAnno("pg1", "c1", "c1", 1, nil, schedulingv1.PodGroupInqueue, map[string]string{api.JobInqueueTimeoutAnnotation: "-1"}),
+			},
+			Pods: []*v1.Pod{
+				util.BuildPod("c1", "p1", "", v1.PodPending, api.BuildResourceList("1", "1G"), "pg1", make(map[string]string), make(map[string]string)),
+			},
+			Queues: []*schedulingv1.Queue{
+				util.BuildQueue("c1", 1, api.BuildResourceList("4", "4G")),
+			},
+			ExpectStatus: map[api.JobID]scheduling.PodGroupPhase{
+				"c1/pg1": scheduling.PodGroupInqueue,
+			},
+		},
 	}
 
 	trueValue := true

--- a/pkg/scheduler/api/job_info.go
+++ b/pkg/scheduler/api/job_info.go
@@ -397,6 +397,7 @@ type JobInfo struct {
 	PodGroup          *PodGroup
 
 	ScheduleStartTimestamp metav1.Time
+	EnqueueTimestamp       metav1.Time
 
 	Preemptable bool
 
@@ -751,6 +752,7 @@ func (ji *JobInfo) Clone() *JobInfo {
 	}
 
 	ji.CreationTimestamp.DeepCopyInto(&info.CreationTimestamp)
+	ji.EnqueueTimestamp.DeepCopyInto(&info.EnqueueTimestamp)
 
 	for task, minAvailable := range ji.TaskMinAvailable {
 		info.TaskMinAvailable[task] = minAvailable

--- a/pkg/scheduler/api/types.go
+++ b/pkg/scheduler/api/types.go
@@ -311,6 +311,9 @@ type VoteFn func(interface{}) int
 // JobEnqueuedFn is the func declaration used to call after job enqueued.
 type JobEnqueuedFn func(interface{})
 
+// JobInqueueEvictedFn is the func declaration used to call after job is evicted from inqueue phase.
+type JobInqueueEvictedFn func(interface{})
+
 // PredicateFn is the func declaration used to predicate node for task.
 type PredicateFn func(*TaskInfo, *NodeInfo) error
 

--- a/pkg/scheduler/api/well_known_labels.go
+++ b/pkg/scheduler/api/well_known_labels.go
@@ -47,4 +47,7 @@ const (
 	// to which the job is allocated. This typically represents the lowest common ancestor
 	// HyperNode in the scheduling hierarchy.
 	JobAllocatedHyperNode = "volcano.sh/job-allocated-hypernode"
+
+	// JobInqueueTimeoutAnnotation is the annotation key to specify how long a job is permitted to stay in the Inqueue state
+	JobInqueueTimeoutAnnotation = "volcano.sh/inqueue-timeout"
 )

--- a/pkg/scheduler/cache/cache.go
+++ b/pkg/scheduler/cache/cache.go
@@ -1722,6 +1722,7 @@ func (sc *SchedulerCache) updateJobInfo(job *schedulingapi.JobInfo) {
 
 	if jobInCache, ok := sc.Jobs[job.UID]; ok {
 		jobInCache.AllocatedHyperNode = job.AllocatedHyperNode
+		jobInCache.EnqueueTimestamp = job.EnqueueTimestamp
 		for subJobID, subJobInCache := range jobInCache.SubJobs {
 			if subJob, found := job.SubJobs[subJobID]; found {
 				subJobInCache.AllocatedHyperNode = subJob.AllocatedHyperNode

--- a/pkg/scheduler/framework/session.go
+++ b/pkg/scheduler/framework/session.go
@@ -139,6 +139,7 @@ type Session struct {
 	jobValidFns                   map[string]api.ValidateExFn
 	jobEnqueueableFns             map[string]api.VoteFn
 	jobEnqueuedFns                map[string]api.JobEnqueuedFn
+	jobInqueueEvictedFns          map[string]api.JobInqueueEvictedFn
 	targetJobFns                  map[string]api.TargetJobFn
 	reservedNodesFns              map[string]api.ReservedNodesFn
 	victimTasksFns                map[string][]api.VictimTasksFn
@@ -211,6 +212,7 @@ func openSession(cache cache.Cache) *Session {
 		jobValidFns:                   map[string]api.ValidateExFn{},
 		jobEnqueueableFns:             map[string]api.VoteFn{},
 		jobEnqueuedFns:                map[string]api.JobEnqueuedFn{},
+		jobInqueueEvictedFns:          map[string]api.JobInqueueEvictedFn{},
 		targetJobFns:                  map[string]api.TargetJobFn{},
 		reservedNodesFns:              map[string]api.ReservedNodesFn{},
 		victimTasksFns:                map[string][]api.VictimTasksFn{},

--- a/pkg/scheduler/framework/session_plugins.go
+++ b/pkg/scheduler/framework/session_plugins.go
@@ -160,6 +160,11 @@ func (ssn *Session) AddJobEnqueuedFn(name string, fn api.JobEnqueuedFn) {
 	ssn.jobEnqueuedFns[name] = fn
 }
 
+// AddJobInqueueEvictedFn add jobInqueueEvicted function
+func (ssn *Session) AddJobInqueueEvictedFn(name string, fn api.JobInqueueEvictedFn) {
+	ssn.jobInqueueEvictedFns[name] = fn
+}
+
 // AddTargetJobFn add targetjob function
 func (ssn *Session) AddTargetJobFn(name string, fn api.TargetJobFn) {
 	ssn.targetJobFns[name] = fn
@@ -617,6 +622,20 @@ func (ssn *Session) JobEnqueued(obj interface{}) {
 				continue
 			}
 			fn, found := ssn.jobEnqueuedFns[plugin.Name]
+			if !found {
+				continue
+			}
+
+			fn(obj)
+		}
+	}
+}
+
+// JobInqueueEvicted invoke jobInqueueEvictedFns function of the plugins
+func (ssn *Session) JobInqueueEvicted(obj interface{}) {
+	for _, tier := range ssn.Tiers {
+		for _, plugin := range tier.Plugins {
+			fn, found := ssn.jobInqueueEvictedFns[plugin.Name]
 			if !found {
 				continue
 			}

--- a/pkg/scheduler/framework/session_plugins.go
+++ b/pkg/scheduler/framework/session_plugins.go
@@ -635,6 +635,9 @@ func (ssn *Session) JobEnqueued(obj interface{}) {
 func (ssn *Session) JobInqueueEvicted(obj interface{}) {
 	for _, tier := range ssn.Tiers {
 		for _, plugin := range tier.Plugins {
+			if !isEnabled(plugin.EnabledJobEnqueued) {
+				continue
+			}
 			fn, found := ssn.jobInqueueEvictedFns[plugin.Name]
 			if !found {
 				continue

--- a/pkg/scheduler/plugins/capacity/capacity.go
+++ b/pkg/scheduler/plugins/capacity/capacity.go
@@ -813,6 +813,34 @@ func (cp *capacityPlugin) OnSessionOpen(ssn *framework.Session) {
 		klog.V(5).Infof("job <%s/%s> enqueued", job.Namespace, job.Name)
 	})
 
+	ssn.AddJobInqueueEvictedFn(cp.Name(), func(obj interface{}) {
+		job, ok := obj.(*api.JobInfo)
+		if !ok || job == nil || job.PodGroup == nil {
+			return
+		}
+		queueID := job.Queue
+		attr := cp.queueOpts[queueID]
+		if attr == nil {
+			return
+		}
+		if job.PodGroup.Spec.MinResources == nil && !(cp.dynamicResourceAllocationEnable && attr.dra != nil && job.GetMinDRAResources() != nil) {
+			return
+		}
+		deductedResources := job.DeductSchGatedResources(job.GetMinResources())
+		attr.inqueue.Sub(deductedResources)
+		// If enable hierarchy, update the inqueue resource for all ancestors queues
+		if hierarchyEnabled {
+			for _, ancestorID := range attr.ancestors {
+				ancestorAttr := cp.queueOpts[ancestorID]
+				if ancestorAttr == nil {
+					continue
+				}
+				ancestorAttr.inqueue.Sub(deductedResources)
+			}
+		}
+		klog.V(4).Infof("job <%s/%s> inqueue quota released after timeout eviction", job.Namespace, job.Name)
+	})
+
 	ssn.AddPrePredicateFn(cp.Name(), func(task *api.TaskInfo) error {
 		state := &capacityState{
 			queueAttrs: make(map[api.QueueID]*queueAttr),

--- a/pkg/scheduler/plugins/capacity/capacity.go
+++ b/pkg/scheduler/plugins/capacity/capacity.go
@@ -826,8 +826,19 @@ func (cp *capacityPlugin) OnSessionOpen(ssn *framework.Session) {
 		if job.PodGroup.Spec.MinResources == nil && !(cp.dynamicResourceAllocationEnable && attr.dra != nil && job.GetMinDRAResources() != nil) {
 			return
 		}
-		deductedResources := job.DeductSchGatedResources(job.GetMinResources())
+		deductedResources := job.DeductSchGatedResources(util.GetInqueueResource(job, job.Allocated))
 		attr.inqueue.Sub(deductedResources)
+		
+		var minDRAReq map[string]*api.DRAResource
+		if cp.dynamicResourceAllocationEnable && attr.dra != nil {
+			minDRAReq = job.GetMinDRAResources()
+			for deviceClass, req := range minDRAReq {
+				if inq := attr.dra.inqueue[deviceClass]; inq != nil {
+					inq.Sub(req)
+				}
+			}
+		}
+
 		// If enable hierarchy, update the inqueue resource for all ancestors queues
 		if hierarchyEnabled {
 			for _, ancestorID := range attr.ancestors {
@@ -836,6 +847,13 @@ func (cp *capacityPlugin) OnSessionOpen(ssn *framework.Session) {
 					continue
 				}
 				ancestorAttr.inqueue.Sub(deductedResources)
+				if cp.dynamicResourceAllocationEnable && ancestorAttr.dra != nil && minDRAReq != nil {
+					for deviceClass, req := range minDRAReq {
+						if inq := ancestorAttr.dra.inqueue[deviceClass]; inq != nil {
+							inq.Sub(req)
+						}
+					}
+				}
 			}
 		}
 		klog.V(4).Infof("job <%s/%s> inqueue quota released after timeout eviction", job.Namespace, job.Name)

--- a/pkg/scheduler/plugins/overcommit/overcommit.go
+++ b/pkg/scheduler/plugins/overcommit/overcommit.go
@@ -141,6 +141,18 @@ func (op *overcommitPlugin) OnSessionOpen(ssn *framework.Session) {
 		jobMinReq := job.GetMinResources()
 		op.inqueueResource.Add(job.DeductSchGatedResources(jobMinReq))
 	})
+
+	ssn.AddJobInqueueEvictedFn(op.Name(), func(obj interface{}) {
+		job, ok := obj.(*api.JobInfo)
+		if !ok || job == nil || job.PodGroup == nil {
+			return
+		}
+		if job.PodGroup.Spec.MinResources == nil {
+			return
+		}
+		inqueued := util.GetInqueueResource(job, job.Allocated)
+		op.inqueueResource.Sub(job.DeductSchGatedResources(inqueued))
+	})
 }
 
 func (op *overcommitPlugin) OnSessionClose(ssn *framework.Session) {

--- a/pkg/scheduler/plugins/proportion/proportion.go
+++ b/pkg/scheduler/plugins/proportion/proportion.go
@@ -452,6 +452,23 @@ func (pp *proportionPlugin) OnSessionOpen(ssn *framework.Session) {
 		attr.inqueue.Add(job.DeductSchGatedResources(job.GetMinResources()))
 	})
 
+	ssn.AddJobInqueueEvictedFn(pp.Name(), func(obj interface{}) {
+		job, ok := obj.(*api.JobInfo)
+		if !ok || job == nil || job.PodGroup == nil {
+			return
+		}
+		if job.PodGroup.Spec.MinResources == nil {
+			return
+		}
+		attr := pp.queueOpts[job.Queue]
+		if attr == nil {
+			return
+		}
+		attr.inqueue.Sub(job.DeductSchGatedResources(job.GetMinResources()))
+		klog.V(4).Infof("%s:%s/%s inqueue quota released after timeout eviction",
+			pp.Name(), job.Namespace, job.Name)
+	})
+
 	ssn.AddSimulateAddTaskFn(pp.Name(), func(ctx context.Context, cycleState fwk.CycleState, taskToSchedule *api.TaskInfo, taskToAdd *api.TaskInfo, nodeInfo *api.NodeInfo) error {
 		state, err := getProportionState(cycleState)
 		if err != nil {

--- a/pkg/scheduler/plugins/proportion/proportion.go
+++ b/pkg/scheduler/plugins/proportion/proportion.go
@@ -464,7 +464,7 @@ func (pp *proportionPlugin) OnSessionOpen(ssn *framework.Session) {
 		if attr == nil {
 			return
 		}
-		attr.inqueue.Sub(job.DeductSchGatedResources(job.GetMinResources()))
+		attr.inqueue.Sub(job.DeductSchGatedResources(util.GetInqueueResource(job, job.Allocated)))
 		klog.V(4).Infof("%s:%s/%s inqueue quota released after timeout eviction",
 			pp.Name(), job.Namespace, job.Name)
 	})


### PR DESCRIPTION
## What type of PR is this?

/kind feature

## What this PR does / why we need it

This PR implements a **timeout-based downgrade mechanism** for jobs stuck in the `Inqueue` state. Currently, once a job enters `Inqueue`, it holds queue quota indefinitely—even if it can never be scheduled (e.g., due to resource fragmentation or node affinity mismatches). This blocks higher-priority `Pending` jobs from enqueuing.

### Problem (Issue #5330)

The `Enqueue` action checks queue quota using:
```
(realCapability - inqueue - allocated + elastic) >= job.MinResources
```
Once low-priority jobs are enqueued, their `MinResources` are counted in `inqueue`, reducing the available quota. Higher-priority jobs arriving later find insufficient quota and remain stuck in `Pending`—even though they deserve the resources more.

### Solution: Timeout-Based Downgrade

Instead of greedy immediate preemption (which adds complexity and scheduler overhead), this PR introduces a **simple, safe timeout mechanism**:

1. **Track enqueue time**: Add `EnqueueTimestamp` to `JobInfo`, set when a job transitions to `Inqueue`.
2. **Evict stale jobs**: Before the normal enqueue loop, scan all `Inqueue` jobs. If a job has been `Inqueue` longer than the timeout (default: **5 minutes**), downgrade it back to `Pending`.
3. **Release quota**: Notify plugins (proportion, capacity) to subtract the job's `MinResources` from the queue's `inqueue` counter, freeing quota for other jobs.
4. **Re-enqueue fairly**: The downgraded job re-enters the normal priority-ordered enqueue competition, where higher-priority jobs now have a fair chance.

### Per-Job Timeout Override

Users can override the default 5-minute timeout per-job using the annotation:
```yaml
annotations:
  volcano.sh/inqueue-timeout: "600"  # 10 minutes, in seconds
```

## Which issue(s) this PR fixes

Fixes #5330

## Changes

| File | Change |
|------|--------|
| `pkg/scheduler/api/job_info.go` | Add `EnqueueTimestamp` field to `JobInfo`, copy in `Clone()` |
| `pkg/scheduler/api/well_known_labels.go` | Add `JobInqueueTimeoutAnnotation` constant |
| `pkg/scheduler/api/types.go` | Add `JobInqueueEvictedFn` callback type |
| `pkg/scheduler/cache/cache.go` | Sync `EnqueueTimestamp` in `updateJobInfo()` |
| `pkg/scheduler/framework/session.go` | Add `jobInqueueEvictedFns` map to `Session` |
| `pkg/scheduler/framework/session_plugins.go` | Add `AddJobInqueueEvictedFn()` and `JobInqueueEvicted()` |
| `pkg/scheduler/actions/enqueue/enqueue.go` | Add Phase 1 eviction loop + `getInqueueTimeout()` helper |
| `pkg/scheduler/plugins/proportion/proportion.go` | Register eviction callback to release `inqueue` quota |
| `pkg/scheduler/plugins/capacity/capacity.go` | Register eviction callback to release `inqueue` quota (with hierarchy support) |

## Testing

- [x] `go build ./pkg/scheduler/...` — **PASS**
- [x] `go vet ./pkg/scheduler/api/... ./pkg/scheduler/actions/enqueue/... ./pkg/scheduler/framework/... ./pkg/scheduler/plugins/proportion/... ./pkg/scheduler/plugins/capacity/...` — **PASS** (clean)
- [x] `go test ./pkg/scheduler/actions/enqueue/...` — **5/5 PASS**
- [x] `go test ./pkg/scheduler/plugins/proportion/...` — **7/7 PASS**
- [x] `go test ./pkg/scheduler/framework/...` — **PASS**

Signed-off-by: Shivansh Sahu