### PR TITLE
webhook: separate cronjob validation errors with "; "

### DIFF
--- a/pkg/webhooks/admission/cronjobs/validate/admit_cronjob.go
+++ b/pkg/webhooks/admission/cronjobs/validate/admit_cronjob.go
@@ -105,21 +105,41 @@ func AdmitCronjobs(ar admissionv1.AdmissionReview) *admissionv1.AdmissionRespons
 	return &reviewResponse
 }
 func validateCronJobCreate(cronjob *v1alpha1.CronJob, reviewResponse *admissionv1.AdmissionResponse) string {
-	msg := validateCronjobSpec(&cronjob.Spec, cronjob.Namespace)
-	msg += validateCronJobName(cronjob.Name)
+	msg := joinCronJobErrs(cronjob)
 	if msg != "" {
 		reviewResponse.Allowed = false
 	}
 	return msg
 }
 func validateCronJobUpdate(new *v1alpha1.CronJob) error {
-	msg := validateCronjobSpec(&new.Spec, new.Namespace)
-	msg += validateCronJobName(new.Name)
-
+	msg := joinCronJobErrs(new)
 	if msg != "" {
 		return errors.New(msg)
 	}
 	return nil
+}
+
+// joinCronJobErrs collects the non-empty messages from each CronJob validator.
+// When only one check fails, its message is returned verbatim so single-error
+// responses stay byte-for-byte identical to the previous behaviour. When more
+// than one check fails at once, the messages are trimmed and joined with "; "
+// so they are reported as distinct, readable items instead of running together
+// mid-sentence.
+func joinCronJobErrs(cronjob *v1alpha1.CronJob) string {
+	var errs []string
+	if msg := validateCronjobSpec(&cronjob.Spec, cronjob.Namespace); msg != "" {
+		errs = append(errs, msg)
+	}
+	if msg := validateCronJobName(cronjob.Name); msg != "" {
+		errs = append(errs, msg)
+	}
+	if len(errs) == 1 {
+		return errs[0]
+	}
+	for i := range errs {
+		errs[i] = strings.TrimSpace(errs[i])
+	}
+	return strings.Join(errs, "; ")
 }
 func validateCronjobSpec(spec *v1alpha1.CronJobSpec, nameSpace string) string {
 	var msg string

--- a/pkg/webhooks/admission/cronjobs/validate/admit_cronjob_test.go
+++ b/pkg/webhooks/admission/cronjobs/validate/admit_cronjob_test.go
@@ -412,3 +412,90 @@ func TestValidateCronJobName(t *testing.T) {
 		})
 	}
 }
+
+// TestJoinCronJobErrsSeparatesMultipleErrors checks that when a CronJob fails
+// more than one validation at once (here an invalid schedule and a too-long
+// name), the messages are reported as distinct items joined by "; " rather than
+// running together mid-sentence.
+func TestJoinCronJobErrsSeparatesMultipleErrors(t *testing.T) {
+	cronjob := &v1alpha1.CronJob{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      strings.Repeat("a", 53),
+			Namespace: metav1.NamespaceDefault,
+		},
+		Spec: v1alpha1.CronJobSpec{
+			Schedule:          "error schedule",
+			ConcurrencyPolicy: v1alpha1.AllowConcurrent,
+			JobTemplate: v1alpha1.JobTemplateSpec{
+				Spec: getJobTemplate(),
+			},
+		},
+	}
+
+	msg := joinCronJobErrs(cronjob)
+
+	for _, want := range []string{"schedule is not a valid cron expression", "; ", "must be no more than 52 characters"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("Expected %q in error, got %q", want, msg)
+		}
+	}
+}
+
+// TestJoinCronJobErrsSingleErrorUnchanged checks that when only one validator
+// fails, joinCronJobErrs returns that validator's message verbatim (including any
+// leading space) and does not introduce a "; " separator, so single-error
+// admission responses stay byte-for-byte identical to the previous behaviour.
+func TestJoinCronJobErrsSingleErrorUnchanged(t *testing.T) {
+	tests := []struct {
+		name    string
+		cronjob *v1alpha1.CronJob
+		want    string
+	}{
+		{
+			name: "only spec error keeps leading space",
+			cronjob: &v1alpha1.CronJob{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "valid-cronjob",
+					Namespace: metav1.NamespaceDefault,
+				},
+				Spec: v1alpha1.CronJobSpec{
+					Schedule:          "",
+					ConcurrencyPolicy: v1alpha1.AllowConcurrent,
+					JobTemplate: v1alpha1.JobTemplateSpec{
+						Spec: getJobTemplate(),
+					},
+				},
+			},
+			want: " schedule is required, but got empty",
+		},
+		{
+			name: "only name error",
+			cronjob: &v1alpha1.CronJob{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      strings.Repeat("a", 53),
+					Namespace: metav1.NamespaceDefault,
+				},
+				Spec: v1alpha1.CronJobSpec{
+					Schedule:          "* * * * *",
+					ConcurrencyPolicy: v1alpha1.AllowConcurrent,
+					JobTemplate: v1alpha1.JobTemplateSpec{
+						Spec: getJobTemplate(),
+					},
+				},
+			},
+			want: validateCronJobName(strings.Repeat("a", 53)),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := joinCronJobErrs(tt.cronjob)
+			if got != tt.want {
+				t.Errorf("joinCronJobErrs() = %q, want %q", got, tt.want)
+			}
+			if strings.Contains(got, "; ") {
+				t.Errorf("single-error message should not contain the %q separator, got %q", "; ", got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The CronJob create/update validators built their rejection message by appending
each validator's output with `+=` and no separator:

```go
msg := validateCronjobSpec(&cronjob.Spec, cronjob.Namespace)
msg += validateCronJobName(cronjob.Name)
```

So when a CronJob failed more than one check at once (for example an invalid
schedule *and* a name over 52 characters), the messages ran together mid-sentence
and the rejection was hard to read:

```
schedule is not a valid cron expressioncronJob name must be no more than 52 characters ...
```

This collects each non-empty message into a slice and joins them with `"; "`, so
the errors are reported as distinct, readable items. An empty slice still joins to
`""`, so valid CronJobs and single-error paths are unchanged. This is the CronJob
counterpart of the PodGroup fix in #5443 / #5487; it scopes only the CronJob
webhook (the optional `admit_job.go` cleanup mentioned in the issue is left out).

#### Which issue(s) this PR fixes:

Fixes #5489

#### Special notes for your reviewer:

I used an AI assistant to help draft this change; I reviewed and tested every line
and can explain why each change was made, and I'll respond to review comments
without AI tools, per contributing.md#ai-guidance. The fix mirrors the in-flight
PodGroup fix (#5487): `validateCronjobSpec`'s own output is left untouched, so the
existing leading-space test assertions still hold. Added a focused test that fails
both the schedule and name checks at once and asserts the `"; "` separator.

@aeron-gh - you mentioned on the issue you might start on this; it sat unclaimed for
a week so I went ahead with the fix and a regression test. Happy to defer or close
if you'd rather take it.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
