### PR TITLE
fix(cli): correct flag descriptions in vcctl pod command

### DIFF
--- a/pkg/cli/pod/pod.go
+++ b/pkg/cli/pod/pod.go
@@ -78,8 +78,8 @@ func InitListFlags(cmd *cobra.Command) {
 
 	cmd.Flags().StringVarP(&listPodFlags.QueueName, "queue", "q", "", "list pod with specified queue name")
 	cmd.Flags().StringVarP(&listPodFlags.JobName, "job", "j", "", "list pod with specified job name")
-	cmd.Flags().StringVarP(&listPodFlags.Namespace, "namespace", "n", "default", "the namespace of job")
-	cmd.Flags().BoolVarP(&listPodFlags.allNamespace, "all-namespaces", "", false, "list jobs in all namespaces")
+	cmd.Flags().StringVarP(&listPodFlags.Namespace, "namespace", "n", "default", "the namespace of pod")
+	cmd.Flags().BoolVarP(&listPodFlags.allNamespace, "all-namespaces", "", false, "list pods in all namespaces")
 }
 
 // ListPods lists all pods details created by vcjob


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The `pod` subcommand's flag help text referred to "job" and "jobs". It was
copied from the `job` command and never updated, so `vcctl pod --help` showed
misleading descriptions:

- `--namespace` read "the namespace of job"
- `--all-namespaces` read "list jobs in all namespaces"

Both now refer to pods.

#### Which issue(s) this PR fixes:

NONE

#### Special notes for your reviewer:

Help-text only; no behavior change.
