### PR TITLE
fix(scheduler): propagate job anchor when both job and subJob use soft topology

### DIFF
--- a/pkg/scheduler/actions/allocate/allocate.go
+++ b/pkg/scheduler/actions/allocate/allocate.go
@@ -401,6 +401,12 @@ func (alloc *Action) allocateForJob(job *api.JobInfo, jobWorksheet *JobWorksheet
 				if stmt != nil && len(stmt.Operations()) > 0 {
 					stmtList = append(stmtList, stmt)
 					subJobsAllocationScore += allocationScore
+					// Propagate this subJob's anchor to the job so subsequent subJobs use it
+					// for node scoring. RecoverSubJobStatus will reset job.AllocatedHyperNode
+					// after each hyperNode dry-run, keeping iterations isolated.
+					if subJob.AllocatedHyperNode != "" {
+						job.AllocatedHyperNode = ssn.HyperNodes.GetLCAHyperNode(job.AllocatedHyperNode, subJob.AllocatedHyperNode)
+					}
 					// push back when subJob is ready and remain pending task
 					if !subJobWorksheet.Empty() {
 						jobWorksheetCopy.subJobs.Push(subJob)
@@ -738,6 +744,9 @@ func (alloc *Action) allocateResourcesForTasks(subJob *api.SubJobInfo, tasks *ut
 	ph := util.NewPredicateHelper()
 
 	allocatedHyperNode := subJob.AllocatedHyperNode
+	if allocatedHyperNode == "" {
+		allocatedHyperNode = job.AllocatedHyperNode
+	}
 
 	for !tasks.Empty() {
 		task := tasks.Pop().(*api.TaskInfo)

--- a/pkg/scheduler/actions/allocate/allocate_test.go
+++ b/pkg/scheduler/actions/allocate/allocate_test.go
@@ -5547,6 +5547,86 @@ func TestAllocateWithPartitionPolicyNetworkTopology(t *testing.T) {
 			ExpectBindsNum:   2,
 			MinimalBindCheck: true,
 		},
+		{
+			// Regression test for issue #5514: when both job and subGroup use soft topology the
+			// job-level anchor (AllocatedHyperNode) must be propagated to subsequent subJob
+			// gradient lookups so that workers are scored relative to where the master landed.
+			//
+			// Topology: s0(n1,n2) and s1(n3,n4) under root s2.  Each node holds exactly one
+			// 4-CPU pod.  The master subJob (size 1) and worker subJob (size 3) both set
+			// highestTierAllowed=1 (soft), so the job-level soft constraint (tier 2) drives
+			// allocation to s2 after Tier-1 candidates fail capacity checks.  Under s2 the
+			// anchor propagated from the master placement guides worker node scoring.
+			Name: "podgroup soft network topology and subGroup soft network topology, job falls to root tier, can allocate all pods",
+			PodGroups: []*schedulingv1.PodGroup{
+				util.BuildPodGroupWithSubGroupPolicy("pg1", "c1", "", "q1", 4, nil, schedulingv1.PodGroupInqueue, "soft", 2,
+					[]schedulingv1.SubGroupPolicySpec{
+						util.BuildSubGroupPolicyWithSubGroupSize("master", []string{"volcano.sh/task-spec"}, "soft", 1, 1),
+						util.BuildSubGroupPolicyWithSubGroupSize("worker", []string{"volcano.sh/task-instance"}, "soft", 1, 3),
+					}),
+			},
+			Pods: []*v1.Pod{
+				util.BuildPod("c1", "p1", "", v1.PodPending, api.BuildResourceList("4", "8G"), "pg1", map[string]string{"volcano.sh/task-spec": "master"}, nil),
+				util.BuildPod("c1", "p2", "", v1.PodPending, api.BuildResourceList("4", "8G"), "pg1", map[string]string{"volcano.sh/task-instance": "worker"}, nil),
+				util.BuildPod("c1", "p3", "", v1.PodPending, api.BuildResourceList("4", "8G"), "pg1", map[string]string{"volcano.sh/task-instance": "worker"}, nil),
+				util.BuildPod("c1", "p4", "", v1.PodPending, api.BuildResourceList("4", "8G"), "pg1", map[string]string{"volcano.sh/task-instance": "worker"}, nil),
+			},
+			Nodes: []*v1.Node{
+				util.BuildNode("s0-n1", api.BuildResourceList("4", "8Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), nil),
+				util.BuildNode("s0-n2", api.BuildResourceList("4", "8Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), nil),
+				util.BuildNode("s1-n3", api.BuildResourceList("4", "8Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), nil),
+				util.BuildNode("s1-n4", api.BuildResourceList("4", "8Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), nil),
+			},
+			HyperNodesSetByTier: map[int]sets.Set[string]{1: sets.New[string]("s0", "s1"), 2: sets.New[string]("s2")},
+			HyperNodesMap: map[string]*api.HyperNodeInfo{
+				"s0": api.NewHyperNodeInfo(api.BuildHyperNode("s0", 1, []api.MemberConfig{
+					{
+						Name:     "s0-n1",
+						Type:     topologyv1alpha1.MemberTypeNode,
+						Selector: "exact",
+					},
+					{
+						Name:     "s0-n2",
+						Type:     topologyv1alpha1.MemberTypeNode,
+						Selector: "exact",
+					},
+				})),
+				"s1": api.NewHyperNodeInfo(api.BuildHyperNode("s1", 1, []api.MemberConfig{
+					{
+						Name:     "s1-n3",
+						Type:     topologyv1alpha1.MemberTypeNode,
+						Selector: "exact",
+					},
+					{
+						Name:     "s1-n4",
+						Type:     topologyv1alpha1.MemberTypeNode,
+						Selector: "exact",
+					},
+				})),
+				"s2": api.NewHyperNodeInfo(api.BuildHyperNode("s2", 2, []api.MemberConfig{
+					{
+						Name:     "s0",
+						Type:     topologyv1alpha1.MemberTypeHyperNode,
+						Selector: "exact",
+					},
+					{
+						Name:     "s1",
+						Type:     topologyv1alpha1.MemberTypeHyperNode,
+						Selector: "exact",
+					},
+				})),
+			},
+			HyperNodes: map[string]sets.Set[string]{
+				"s0": sets.New[string]("s0-n1", "s0-n2"),
+				"s1": sets.New[string]("s1-n3", "s1-n4"),
+				"s2": sets.New[string]("s0-n1", "s0-n2", "s1-n3", "s1-n4"),
+			},
+			Queues: []*schedulingv1.Queue{
+				util.BuildQueue("q1", 1, nil),
+			},
+			MinimalBindCheck: true,
+			ExpectBindsNum:   4,
+		},
 	}
 
 	trueValue := true

--- a/pkg/scheduler/actions/allocate/recorder.go
+++ b/pkg/scheduler/actions/allocate/recorder.go
@@ -26,7 +26,8 @@ type Recorder struct {
 	jobDecisions    map[api.JobID]string
 	subJobDecisions map[api.JobID]map[string]map[api.SubJobID]string
 
-	subJobStatusSnapshot map[api.JobID]map[api.SubJobID]*SubJobStatus
+	subJobStatusSnapshot          map[api.JobID]map[api.SubJobID]*SubJobStatus
+	jobAllocatedHyperNodeSnapshot map[api.JobID]string
 }
 
 type SubJobStatus struct {
@@ -35,9 +36,10 @@ type SubJobStatus struct {
 
 func NewRecorder() *Recorder {
 	return &Recorder{
-		jobDecisions:         make(map[api.JobID]string),
-		subJobDecisions:      make(map[api.JobID]map[string]map[api.SubJobID]string),
-		subJobStatusSnapshot: make(map[api.JobID]map[api.SubJobID]*SubJobStatus),
+		jobDecisions:                  make(map[api.JobID]string),
+		subJobDecisions:               make(map[api.JobID]map[string]map[api.SubJobID]string),
+		subJobStatusSnapshot:          make(map[api.JobID]map[api.SubJobID]*SubJobStatus),
+		jobAllocatedHyperNodeSnapshot: make(map[api.JobID]string),
 	}
 }
 
@@ -99,6 +101,7 @@ func (d *Recorder) SnapshotSubJobStatus(job *api.JobInfo, worksheet *JobWorkshee
 		}
 	}
 	d.subJobStatusSnapshot[job.UID] = result
+	d.jobAllocatedHyperNodeSnapshot[job.UID] = job.AllocatedHyperNode
 }
 
 func (d *Recorder) RecoverSubJobStatus(job *api.JobInfo) {
@@ -110,5 +113,8 @@ func (d *Recorder) RecoverSubJobStatus(job *api.JobInfo) {
 		if subJob, found := job.SubJobs[subJobID]; found {
 			subJob.AllocatedHyperNode = status.AllocatedHyperNode
 		}
+	}
+	if snapshotHyperNode, ok := d.jobAllocatedHyperNodeSnapshot[job.UID]; ok {
+		job.AllocatedHyperNode = snapshotHyperNode
 	}
 }


### PR DESCRIPTION

## What type of PR is this?

/kind bug

## What this PR does / why we need it:

When both a PodGroup and its SubGroups are configured with **soft** network topology, successive SubJob allocations within the same HyperNode dry-run do not share placement information.

Previously, the first successfully allocated SubJob updated only `subJob.AllocatedHyperNode`. The corresponding `job.AllocatedHyperNode` was updated later during `UpdateDecisionToJob()`, after the dry-run had completed. As a result, the next SubJob started with an empty topology anchor, causing the first task's node scoring (`batchNodeOrderFnForNetworkAwarePods`) to treat all candidate nodes equally instead of preferring the HyperNode selected by previously allocated SubJobs.

This PR preserves the job-level topology anchor throughout the dry-run so that later SubJobs can make topology-aware placement decisions.

### Changes

**allocate.go**

* Propagate each successfully allocated SubJob's HyperNode to `job.AllocatedHyperNode` during the per-HyperNode dry-run using `GetLCAHyperNode()`.
* In `allocateResourcesForTasks()`, fall back to `job.AllocatedHyperNode` when `subJob.AllocatedHyperNode` is empty, ensuring the first task of a SubJob always has a topology anchor for node scoring.

**recorder.go**

* Extend `SnapshotSubJobStatus()` and `RecoverSubJobStatus()` to snapshot and restore `job.AllocatedHyperNode` together with each SubJob's `AllocatedHyperNode`, ensuring different dry-run attempts remain fully isolated.

#### Which issue(s) this PR fixes:

Fixes #5514

#### Special notes for your reviewer:

The original issue reproducer does not expose this behavior because, after the first SubJob is allocated, the remaining candidate nodes exactly match the remaining pod count, leaving no placement choice.

This change targets scenarios where the remaining candidate pool is larger than the remaining SubJob size. In those cases, preserving the job-level topology anchor allows subsequent SubJobs to continue preferring the same HyperNode instead of treating all candidate nodes equally.

#### Does this PR introduce a user-facing change?

```release-note
Improve soft network topology scheduling when both Job-level and SubJob-level topology policies are configured by preserving the job-level HyperNode anchor across SubJob allocations during scheduling. This allows subsequent SubJobs to make topology-aware placement decisions within the same scheduling cycle.
```
