### PR TITLE
perf(scheduler): replace O(n²) victim intersection with O(n) hash-set lookup

### DIFF
--- a/pkg/scheduler/framework/session_plugins.go
+++ b/pkg/scheduler/framework/session_plugins.go
@@ -247,17 +247,16 @@ func (ssn *Session) Reclaimable(reclaimer *api.TaskInfo, reclaimees []*api.TaskI
 			if victims == nil {
 				victims = candidates
 			} else {
+				candidateSet := make(map[api.TaskID]struct{}, len(candidates))
+				for _, c := range candidates {
+					candidateSet[c.UID] = struct{}{}
+				}
 				var intersection []*api.TaskInfo
-				// Get intersection of victims and candidates.
 				for _, v := range victims {
-					for _, c := range candidates {
-						if v.UID == c.UID {
-							intersection = append(intersection, v)
-						}
+					if _, ok := candidateSet[v.UID]; ok {
+						intersection = append(intersection, v)
 					}
 				}
-
-				// Update victims to intersection
 				victims = intersection
 			}
 		}
@@ -297,17 +296,16 @@ func (ssn *Session) Preemptable(preemptor *api.TaskInfo, preemptees []*api.TaskI
 			if victims == nil {
 				victims = candidates
 			} else {
+				candidateSet := make(map[api.TaskID]struct{}, len(candidates))
+				for _, c := range candidates {
+					candidateSet[c.UID] = struct{}{}
+				}
 				var intersection []*api.TaskInfo
-				// Get intersection of victims and candidates.
 				for _, v := range victims {
-					for _, c := range candidates {
-						if v.UID == c.UID {
-							intersection = append(intersection, v)
-						}
+					if _, ok := candidateSet[v.UID]; ok {
+						intersection = append(intersection, v)
 					}
 				}
-
-				// Update victims to intersection
 				victims = intersection
 			}
 		}
@@ -342,12 +340,14 @@ func (ssn *Session) UnifiedEvictable(ctx *api.EvictionContext, candidates []*api
 			if victims == nil {
 				victims = result
 			} else {
+				resultSet := make(map[api.TaskID]struct{}, len(result))
+				for _, c := range result {
+					resultSet[c.UID] = struct{}{}
+				}
 				var intersection []*api.TaskInfo
 				for _, v := range victims {
-					for _, c := range result {
-						if v.UID == c.UID {
-							intersection = append(intersection, v)
-						}
+					if _, ok := resultSet[v.UID]; ok {
+						intersection = append(intersection, v)
 					}
 				}
 				victims = intersection

--- a/pkg/scheduler/framework/session_plugins.go
+++ b/pkg/scheduler/framework/session_plugins.go
@@ -251,7 +251,7 @@ func (ssn *Session) Reclaimable(reclaimer *api.TaskInfo, reclaimees []*api.TaskI
 				for _, c := range candidates {
 					candidateSet[c.UID] = struct{}{}
 				}
-				var intersection []*api.TaskInfo
+				intersection := make([]*api.TaskInfo, 0, len(victims))
 				for _, v := range victims {
 					if _, ok := candidateSet[v.UID]; ok {
 						intersection = append(intersection, v)
@@ -300,7 +300,7 @@ func (ssn *Session) Preemptable(preemptor *api.TaskInfo, preemptees []*api.TaskI
 				for _, c := range candidates {
 					candidateSet[c.UID] = struct{}{}
 				}
-				var intersection []*api.TaskInfo
+				intersection := make([]*api.TaskInfo, 0, len(victims))
 				for _, v := range victims {
 					if _, ok := candidateSet[v.UID]; ok {
 						intersection = append(intersection, v)
@@ -344,7 +344,7 @@ func (ssn *Session) UnifiedEvictable(ctx *api.EvictionContext, candidates []*api
 				for _, c := range result {
 					resultSet[c.UID] = struct{}{}
 				}
-				var intersection []*api.TaskInfo
+				intersection := make([]*api.TaskInfo, 0, len(victims))
 				for _, v := range victims {
 					if _, ok := resultSet[v.UID]; ok {
 						intersection = append(intersection, v)

--- a/pkg/scheduler/framework/session_plugins.go
+++ b/pkg/scheduler/framework/session_plugins.go
@@ -251,7 +251,10 @@ func (ssn *Session) Reclaimable(reclaimer *api.TaskInfo, reclaimees []*api.TaskI
 				for _, c := range candidates {
 					candidateSet[c.UID] = struct{}{}
 				}
-				intersection := make([]*api.TaskInfo, 0, len(victims))
+				// Keep intersection nil until the first match so an empty result
+				// stays nil, matching the nil-vs-empty semantics victims != nil
+				// checks rely on below and in callers.
+				var intersection []*api.TaskInfo
 				for _, v := range victims {
 					if _, ok := candidateSet[v.UID]; ok {
 						intersection = append(intersection, v)
@@ -300,7 +303,10 @@ func (ssn *Session) Preemptable(preemptor *api.TaskInfo, preemptees []*api.TaskI
 				for _, c := range candidates {
 					candidateSet[c.UID] = struct{}{}
 				}
-				intersection := make([]*api.TaskInfo, 0, len(victims))
+				// Keep intersection nil until the first match so an empty result
+				// stays nil, matching the nil-vs-empty semantics victims != nil
+				// checks rely on below and in callers.
+				var intersection []*api.TaskInfo
 				for _, v := range victims {
 					if _, ok := candidateSet[v.UID]; ok {
 						intersection = append(intersection, v)
@@ -344,7 +350,10 @@ func (ssn *Session) UnifiedEvictable(ctx *api.EvictionContext, candidates []*api
 				for _, c := range result {
 					resultSet[c.UID] = struct{}{}
 				}
-				intersection := make([]*api.TaskInfo, 0, len(victims))
+				// Keep intersection nil until the first match so an empty result
+				// stays nil, matching the nil-vs-empty semantics victims != nil
+				// checks rely on below and in callers.
+				var intersection []*api.TaskInfo
 				for _, v := range victims {
 					if _, ok := resultSet[v.UID]; ok {
 						intersection = append(intersection, v)

--- a/pkg/scheduler/framework/session_plugins_intersection_bench_test.go
+++ b/pkg/scheduler/framework/session_plugins_intersection_bench_test.go
@@ -1,0 +1,129 @@
+/*
+Copyright 2025 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package framework
+
+import (
+	"fmt"
+	"testing"
+
+	"volcano.sh/volcano/pkg/scheduler/api"
+	"volcano.sh/volcano/pkg/scheduler/conf"
+)
+
+func makeBenchTasks(n int) []*api.TaskInfo {
+	tasks := make([]*api.TaskInfo, n)
+	for i := range tasks {
+		tasks[i] = &api.TaskInfo{UID: api.TaskID(fmt.Sprintf("task-%d", i))}
+	}
+	return tasks
+}
+
+// BenchmarkReclaimableIntersection measures the two-plugin intersection path in
+// Reclaimable with increasing task counts. The first plugin admits all n tasks;
+// the second admits only the first half, producing an n/2 intersection.
+func BenchmarkReclaimableIntersection(b *testing.B) {
+	for _, n := range []int{100, 500, 1000} {
+		n := n
+		b.Run(fmt.Sprintf("n=%d", n), func(b *testing.B) {
+			enabled := true
+			tasks := makeBenchTasks(n)
+			half := tasks[:n/2]
+			ssn := &Session{
+				Tiers: []conf.Tier{{Plugins: []conf.PluginOption{
+					{Name: "p1", EnabledReclaimable: &enabled},
+					{Name: "p2", EnabledReclaimable: &enabled},
+				}}},
+				reclaimableFns: map[string]api.EvictableFn{},
+			}
+			ssn.AddReclaimableFn("p1", func(_ *api.TaskInfo, _ []*api.TaskInfo) ([]*api.TaskInfo, int) {
+				return tasks, 1
+			})
+			ssn.AddReclaimableFn("p2", func(_ *api.TaskInfo, _ []*api.TaskInfo) ([]*api.TaskInfo, int) {
+				return half, 1
+			})
+			reclaimer := &api.TaskInfo{}
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				ssn.Reclaimable(reclaimer, tasks)
+			}
+		})
+	}
+}
+
+// BenchmarkPreemptableIntersection mirrors BenchmarkReclaimableIntersection for
+// the Preemptable path.
+func BenchmarkPreemptableIntersection(b *testing.B) {
+	for _, n := range []int{100, 500, 1000} {
+		n := n
+		b.Run(fmt.Sprintf("n=%d", n), func(b *testing.B) {
+			enabled := true
+			tasks := makeBenchTasks(n)
+			half := tasks[:n/2]
+			ssn := &Session{
+				Tiers: []conf.Tier{{Plugins: []conf.PluginOption{
+					{Name: "p1", EnabledPreemptable: &enabled},
+					{Name: "p2", EnabledPreemptable: &enabled},
+				}}},
+				preemptableFns: map[string]api.EvictableFn{},
+			}
+			ssn.AddPreemptableFn("p1", func(_ *api.TaskInfo, _ []*api.TaskInfo) ([]*api.TaskInfo, int) {
+				return tasks, 1
+			})
+			ssn.AddPreemptableFn("p2", func(_ *api.TaskInfo, _ []*api.TaskInfo) ([]*api.TaskInfo, int) {
+				return half, 1
+			})
+			preemptor := &api.TaskInfo{}
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				ssn.Preemptable(preemptor, tasks)
+			}
+		})
+	}
+}
+
+// BenchmarkUnifiedEvictableIntersection mirrors the above for the
+// UnifiedEvictable path.
+func BenchmarkUnifiedEvictableIntersection(b *testing.B) {
+	for _, n := range []int{100, 500, 1000} {
+		n := n
+		b.Run(fmt.Sprintf("n=%d", n), func(b *testing.B) {
+			tasks := makeBenchTasks(n)
+			half := tasks[:n/2]
+			ctx := &api.EvictionContext{Kind: api.EvictionKindGangPreempt}
+			ssn := &Session{
+				Tiers: []conf.Tier{{Plugins: []conf.PluginOption{
+					{Name: "p1"},
+					{Name: "p2"},
+				}}},
+				unifiedEvictableFns: map[string]api.UnifiedEvictableFn{},
+			}
+			ssn.AddUnifiedEvictableFn("p1", func(_ *api.EvictionContext, _ []*api.TaskInfo) ([]*api.TaskInfo, int) {
+				return tasks, 1
+			})
+			ssn.AddUnifiedEvictableFn("p2", func(_ *api.EvictionContext, _ []*api.TaskInfo) ([]*api.TaskInfo, int) {
+				return half, 1
+			})
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				ssn.UnifiedEvictable(ctx, tasks)
+			}
+		})
+	}
+}

--- a/pkg/scheduler/framework/session_plugins_test.go
+++ b/pkg/scheduler/framework/session_plugins_test.go
@@ -315,3 +315,196 @@ func TestHyperNodeGradientForJobFn_NoPluginKeepsCurrentFallback(t *testing.T) {
 	result := ssn.HyperNodeGradientForJobFn(&api.JobInfo{}, root, api.PurposeEvict)
 	assert.Equal(t, [][]*api.HyperNodeInfo{{root}}, result)
 }
+
+func boolPtr(v bool) *bool { return &v }
+
+func TestReclaimable_NoMatchingPlugin(t *testing.T) {
+	ssn := &Session{
+		Tiers:          []conf.Tier{{Plugins: []conf.PluginOption{{Name: "p1", EnabledReclaimable: boolPtr(true)}}}},
+		reclaimableFns: map[string]api.EvictableFn{},
+	}
+	result := ssn.Reclaimable(&api.TaskInfo{}, []*api.TaskInfo{{UID: "a"}})
+	assert.Nil(t, result)
+}
+
+func TestReclaimable_SinglePlugin(t *testing.T) {
+	taskA := &api.TaskInfo{UID: "a"}
+	taskB := &api.TaskInfo{UID: "b"}
+	ssn := &Session{
+		Tiers:          []conf.Tier{{Plugins: []conf.PluginOption{{Name: "p1", EnabledReclaimable: boolPtr(true)}}}},
+		reclaimableFns: map[string]api.EvictableFn{},
+	}
+	ssn.AddReclaimableFn("p1", func(_ *api.TaskInfo, _ []*api.TaskInfo) ([]*api.TaskInfo, int) {
+		return []*api.TaskInfo{taskA, taskB}, 1
+	})
+	result := ssn.Reclaimable(&api.TaskInfo{}, []*api.TaskInfo{taskA, taskB})
+	assert.Equal(t, []*api.TaskInfo{taskA, taskB}, result)
+}
+
+func TestReclaimable_TwoPlugins_Intersection(t *testing.T) {
+	taskA := &api.TaskInfo{UID: "a"}
+	taskB := &api.TaskInfo{UID: "b"}
+	taskC := &api.TaskInfo{UID: "c"}
+	ssn := &Session{
+		Tiers: []conf.Tier{{Plugins: []conf.PluginOption{
+			{Name: "p1", EnabledReclaimable: boolPtr(true)},
+			{Name: "p2", EnabledReclaimable: boolPtr(true)},
+		}}},
+		reclaimableFns: map[string]api.EvictableFn{},
+	}
+	ssn.AddReclaimableFn("p1", func(_ *api.TaskInfo, _ []*api.TaskInfo) ([]*api.TaskInfo, int) {
+		return []*api.TaskInfo{taskA, taskB}, 1
+	})
+	ssn.AddReclaimableFn("p2", func(_ *api.TaskInfo, _ []*api.TaskInfo) ([]*api.TaskInfo, int) {
+		return []*api.TaskInfo{taskB, taskC}, 1
+	})
+	result := ssn.Reclaimable(&api.TaskInfo{}, []*api.TaskInfo{taskA, taskB, taskC})
+	assert.Equal(t, []*api.TaskInfo{taskB}, result)
+}
+
+func TestReclaimable_OrderingFollowsVictims(t *testing.T) {
+	taskA := &api.TaskInfo{UID: "a"}
+	taskB := &api.TaskInfo{UID: "b"}
+	taskC := &api.TaskInfo{UID: "c"}
+	ssn := &Session{
+		Tiers: []conf.Tier{{Plugins: []conf.PluginOption{
+			{Name: "p1", EnabledReclaimable: boolPtr(true)},
+			{Name: "p2", EnabledReclaimable: boolPtr(true)},
+		}}},
+		reclaimableFns: map[string]api.EvictableFn{},
+	}
+	// p1 returns C,B,A order; p2 returns A,B,C order
+	ssn.AddReclaimableFn("p1", func(_ *api.TaskInfo, _ []*api.TaskInfo) ([]*api.TaskInfo, int) {
+		return []*api.TaskInfo{taskC, taskB, taskA}, 1
+	})
+	ssn.AddReclaimableFn("p2", func(_ *api.TaskInfo, _ []*api.TaskInfo) ([]*api.TaskInfo, int) {
+		return []*api.TaskInfo{taskA, taskB, taskC}, 1
+	})
+	result := ssn.Reclaimable(&api.TaskInfo{}, []*api.TaskInfo{taskA, taskB, taskC})
+	// output must follow victims (p1) ordering: C,B,A
+	assert.Equal(t, []*api.TaskInfo{taskC, taskB, taskA}, result)
+}
+
+func TestReclaimable_EmptyResultBlocksTier(t *testing.T) {
+	taskA := &api.TaskInfo{UID: "a"}
+	ssn := &Session{
+		Tiers: []conf.Tier{
+			{Plugins: []conf.PluginOption{
+				{Name: "p1", EnabledReclaimable: boolPtr(true)},
+				{Name: "blocker", EnabledReclaimable: boolPtr(true)},
+			}},
+			{Plugins: []conf.PluginOption{
+				{Name: "fallback", EnabledReclaimable: boolPtr(true)},
+			}},
+		},
+		reclaimableFns: map[string]api.EvictableFn{},
+	}
+	ssn.AddReclaimableFn("p1", func(_ *api.TaskInfo, _ []*api.TaskInfo) ([]*api.TaskInfo, int) {
+		return []*api.TaskInfo{taskA}, 1
+	})
+	ssn.AddReclaimableFn("blocker", func(_ *api.TaskInfo, _ []*api.TaskInfo) ([]*api.TaskInfo, int) {
+		return []*api.TaskInfo{}, 1
+	})
+	ssn.AddReclaimableFn("fallback", func(_ *api.TaskInfo, _ []*api.TaskInfo) ([]*api.TaskInfo, int) {
+		return []*api.TaskInfo{taskA}, 1
+	})
+	result := ssn.Reclaimable(&api.TaskInfo{}, []*api.TaskInfo{taskA})
+	assert.Equal(t, []*api.TaskInfo{taskA}, result)
+}
+
+func TestReclaimable_AbstainSkipped(t *testing.T) {
+	taskA := &api.TaskInfo{UID: "a"}
+	ssn := &Session{
+		Tiers: []conf.Tier{{Plugins: []conf.PluginOption{
+			{Name: "abstainer", EnabledReclaimable: boolPtr(true)},
+			{Name: "permitter", EnabledReclaimable: boolPtr(true)},
+		}}},
+		reclaimableFns: map[string]api.EvictableFn{},
+	}
+	ssn.AddReclaimableFn("abstainer", func(_ *api.TaskInfo, _ []*api.TaskInfo) ([]*api.TaskInfo, int) {
+		return nil, 0
+	})
+	ssn.AddReclaimableFn("permitter", func(_ *api.TaskInfo, _ []*api.TaskInfo) ([]*api.TaskInfo, int) {
+		return []*api.TaskInfo{taskA}, 1
+	})
+	result := ssn.Reclaimable(&api.TaskInfo{}, []*api.TaskInfo{taskA})
+	assert.Equal(t, []*api.TaskInfo{taskA}, result)
+}
+
+func TestPreemptable_TwoPlugins_Intersection(t *testing.T) {
+	taskA := &api.TaskInfo{UID: "a"}
+	taskB := &api.TaskInfo{UID: "b"}
+	taskC := &api.TaskInfo{UID: "c"}
+	ssn := &Session{
+		Tiers: []conf.Tier{{Plugins: []conf.PluginOption{
+			{Name: "p1", EnabledPreemptable: boolPtr(true)},
+			{Name: "p2", EnabledPreemptable: boolPtr(true)},
+		}}},
+		preemptableFns: map[string]api.EvictableFn{},
+	}
+	ssn.AddPreemptableFn("p1", func(_ *api.TaskInfo, _ []*api.TaskInfo) ([]*api.TaskInfo, int) {
+		return []*api.TaskInfo{taskA, taskB}, 1
+	})
+	ssn.AddPreemptableFn("p2", func(_ *api.TaskInfo, _ []*api.TaskInfo) ([]*api.TaskInfo, int) {
+		return []*api.TaskInfo{taskB, taskC}, 1
+	})
+	result := ssn.Preemptable(&api.TaskInfo{}, []*api.TaskInfo{taskA, taskB, taskC})
+	assert.Equal(t, []*api.TaskInfo{taskB}, result)
+}
+
+func TestPreemptable_OrderingFollowsVictims(t *testing.T) {
+	taskA := &api.TaskInfo{UID: "a"}
+	taskB := &api.TaskInfo{UID: "b"}
+	taskC := &api.TaskInfo{UID: "c"}
+	ssn := &Session{
+		Tiers: []conf.Tier{{Plugins: []conf.PluginOption{
+			{Name: "p1", EnabledPreemptable: boolPtr(true)},
+			{Name: "p2", EnabledPreemptable: boolPtr(true)},
+		}}},
+		preemptableFns: map[string]api.EvictableFn{},
+	}
+	ssn.AddPreemptableFn("p1", func(_ *api.TaskInfo, _ []*api.TaskInfo) ([]*api.TaskInfo, int) {
+		return []*api.TaskInfo{taskC, taskB, taskA}, 1
+	})
+	ssn.AddPreemptableFn("p2", func(_ *api.TaskInfo, _ []*api.TaskInfo) ([]*api.TaskInfo, int) {
+		return []*api.TaskInfo{taskA, taskB, taskC}, 1
+	})
+	result := ssn.Preemptable(&api.TaskInfo{}, []*api.TaskInfo{taskA, taskB, taskC})
+	assert.Equal(t, []*api.TaskInfo{taskC, taskB, taskA}, result)
+}
+
+func TestPreemptable_EmptyResultBlocksTier(t *testing.T) {
+	taskA := &api.TaskInfo{UID: "a"}
+	ssn := &Session{
+		Tiers: []conf.Tier{
+			{Plugins: []conf.PluginOption{
+				{Name: "p1", EnabledPreemptable: boolPtr(true)},
+				{Name: "blocker", EnabledPreemptable: boolPtr(true)},
+			}},
+			{Plugins: []conf.PluginOption{
+				{Name: "fallback", EnabledPreemptable: boolPtr(true)},
+			}},
+		},
+		preemptableFns: map[string]api.EvictableFn{},
+	}
+	ssn.AddPreemptableFn("p1", func(_ *api.TaskInfo, _ []*api.TaskInfo) ([]*api.TaskInfo, int) {
+		return []*api.TaskInfo{taskA}, 1
+	})
+	ssn.AddPreemptableFn("blocker", func(_ *api.TaskInfo, _ []*api.TaskInfo) ([]*api.TaskInfo, int) {
+		return []*api.TaskInfo{}, 1
+	})
+	ssn.AddPreemptableFn("fallback", func(_ *api.TaskInfo, _ []*api.TaskInfo) ([]*api.TaskInfo, int) {
+		return []*api.TaskInfo{taskA}, 1
+	})
+	result := ssn.Preemptable(&api.TaskInfo{}, []*api.TaskInfo{taskA})
+	assert.Equal(t, []*api.TaskInfo{taskA}, result)
+}
+
+func TestPreemptable_NoMatchingPlugin(t *testing.T) {
+	ssn := &Session{
+		Tiers:          []conf.Tier{{Plugins: []conf.PluginOption{{Name: "p1", EnabledPreemptable: boolPtr(true)}}}},
+		preemptableFns: map[string]api.EvictableFn{},
+	}
+	result := ssn.Preemptable(&api.TaskInfo{}, []*api.TaskInfo{{UID: "a"}})
+	assert.Nil(t, result)
+}

--- a/pkg/scheduler/framework/session_plugins_test.go
+++ b/pkg/scheduler/framework/session_plugins_test.go
@@ -18,6 +18,7 @@ package framework
 
 import (
 	"fmt"
+	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -235,6 +236,40 @@ func TestUnifiedEvictable_EmptyCandidatesBlocksTier(t *testing.T) {
 	assert.Equal(t, api.TaskID("a"), result[0].UID)
 }
 
+// TestUnifiedEvictable_DisjointIntersectionStaysNilAndFallsThrough is the
+// UnifiedEvictable analogue of the Reclaimable/Preemptable nil-vs-empty
+// regression test.
+func TestUnifiedEvictable_DisjointIntersectionStaysNilAndFallsThrough(t *testing.T) {
+	taskA := &api.TaskInfo{UID: "a"}
+	taskB := &api.TaskInfo{UID: "b"}
+	ctx := &api.EvictionContext{Kind: api.EvictionKindGangPreempt}
+
+	ssn := &Session{
+		Tiers: []conf.Tier{
+			{Plugins: []conf.PluginOption{
+				{Name: "p1"},
+				{Name: "p2"},
+			}},
+			{Plugins: []conf.PluginOption{
+				{Name: "fallback"},
+			}},
+		},
+		unifiedEvictableFns: map[string]api.UnifiedEvictableFn{},
+	}
+	ssn.AddUnifiedEvictableFn("p1", func(_ *api.EvictionContext, _ []*api.TaskInfo) ([]*api.TaskInfo, int) {
+		return []*api.TaskInfo{taskA}, 1
+	})
+	ssn.AddUnifiedEvictableFn("p2", func(_ *api.EvictionContext, _ []*api.TaskInfo) ([]*api.TaskInfo, int) {
+		return []*api.TaskInfo{taskB}, 1 // disjoint from p1 -> empty intersection
+	})
+	ssn.AddUnifiedEvictableFn("fallback", func(_ *api.EvictionContext, _ []*api.TaskInfo) ([]*api.TaskInfo, int) {
+		return []*api.TaskInfo{taskA}, 1
+	})
+
+	result := ssn.UnifiedEvictable(ctx, []*api.TaskInfo{taskA, taskB})
+	assert.Equal(t, []*api.TaskInfo{taskA}, result, "tier 1's empty intersection must fall through to tier 2's fallback")
+}
+
 func TestUnifiedEvictable_NoPluginsReturnsNil(t *testing.T) {
 	ctx := &api.EvictionContext{Kind: api.EvictionKindGangPreempt}
 	ssn := &Session{
@@ -431,6 +466,75 @@ func TestReclaimable_AbstainSkipped(t *testing.T) {
 	assert.Equal(t, []*api.TaskInfo{taskA}, result)
 }
 
+// TestReclaimable_DisjointIntersectionStaysNilAndFallsThrough covers the
+// nil-vs-empty regression: when two plugins in the same tier return
+// non-empty but disjoint candidate sets, the intersection has zero elements.
+// That must leave victims == nil (not a non-nil empty slice), so the tier
+// loop's `if victims != nil { return victims }` check falls through to the
+// next tier instead of prematurely returning an empty result.
+func TestReclaimable_DisjointIntersectionStaysNilAndFallsThrough(t *testing.T) {
+	taskA := &api.TaskInfo{UID: "a"}
+	taskB := &api.TaskInfo{UID: "b"}
+	ssn := &Session{
+		Tiers: []conf.Tier{
+			{Plugins: []conf.PluginOption{
+				{Name: "p1", EnabledReclaimable: boolPtr(true)},
+				{Name: "p2", EnabledReclaimable: boolPtr(true)},
+			}},
+			{Plugins: []conf.PluginOption{
+				{Name: "fallback", EnabledReclaimable: boolPtr(true)},
+			}},
+		},
+		reclaimableFns: map[string]api.EvictableFn{},
+	}
+	ssn.AddReclaimableFn("p1", func(_ *api.TaskInfo, _ []*api.TaskInfo) ([]*api.TaskInfo, int) {
+		return []*api.TaskInfo{taskA}, 1
+	})
+	ssn.AddReclaimableFn("p2", func(_ *api.TaskInfo, _ []*api.TaskInfo) ([]*api.TaskInfo, int) {
+		return []*api.TaskInfo{taskB}, 1 // disjoint from p1 -> empty intersection
+	})
+	ssn.AddReclaimableFn("fallback", func(_ *api.TaskInfo, _ []*api.TaskInfo) ([]*api.TaskInfo, int) {
+		return []*api.TaskInfo{taskA}, 1
+	})
+	result := ssn.Reclaimable(&api.TaskInfo{}, []*api.TaskInfo{taskA, taskB})
+	assert.Equal(t, []*api.TaskInfo{taskA}, result, "tier 1's empty intersection must fall through to tier 2's fallback")
+	if !reflect.DeepEqual(result, []*api.TaskInfo{taskA}) {
+		t.Fatalf("reflect.DeepEqual mismatch: got %#v", result)
+	}
+}
+
+// TestReclaimable_EmptyIntersectionWithinTierReinitializes covers the same
+// nil-vs-empty distinction within a single tier: after p1/p2 produce an
+// empty intersection, victims must reset to nil so plugin p3's candidates
+// re-initialize victims from scratch rather than intersecting against a
+// non-nil empty slice (which would incorrectly stay empty forever).
+func TestReclaimable_EmptyIntersectionWithinTierReinitializes(t *testing.T) {
+	taskA := &api.TaskInfo{UID: "a"}
+	taskB := &api.TaskInfo{UID: "b"}
+	taskC := &api.TaskInfo{UID: "c"}
+	ssn := &Session{
+		Tiers: []conf.Tier{
+			{Plugins: []conf.PluginOption{
+				{Name: "p1", EnabledReclaimable: boolPtr(true)},
+				{Name: "p2", EnabledReclaimable: boolPtr(true)},
+				{Name: "p3", EnabledReclaimable: boolPtr(true)},
+			}},
+		},
+		reclaimableFns: map[string]api.EvictableFn{},
+	}
+	ssn.AddReclaimableFn("p1", func(_ *api.TaskInfo, _ []*api.TaskInfo) ([]*api.TaskInfo, int) {
+		return []*api.TaskInfo{taskA}, 1
+	})
+	ssn.AddReclaimableFn("p2", func(_ *api.TaskInfo, _ []*api.TaskInfo) ([]*api.TaskInfo, int) {
+		return []*api.TaskInfo{taskB}, 1 // disjoint -> empty intersection, victims must go back to nil
+	})
+	ssn.AddReclaimableFn("p3", func(_ *api.TaskInfo, _ []*api.TaskInfo) ([]*api.TaskInfo, int) {
+		return []*api.TaskInfo{taskC}, 1
+	})
+	result := ssn.Reclaimable(&api.TaskInfo{}, []*api.TaskInfo{taskA, taskB, taskC})
+	assert.Equal(t, []*api.TaskInfo{taskC}, result)
+}
+
 func TestPreemptable_TwoPlugins_Intersection(t *testing.T) {
 	taskA := &api.TaskInfo{UID: "a"}
 	taskB := &api.TaskInfo{UID: "b"}
@@ -507,4 +611,36 @@ func TestPreemptable_NoMatchingPlugin(t *testing.T) {
 	}
 	result := ssn.Preemptable(&api.TaskInfo{}, []*api.TaskInfo{{UID: "a"}})
 	assert.Nil(t, result)
+}
+
+// TestPreemptable_DisjointIntersectionStaysNilAndFallsThrough is the
+// Preemptable analogue of the Reclaimable nil-vs-empty regression test: a
+// disjoint (non-empty candidates, empty intersection) result within tier 1
+// must leave victims nil so tier 2's fallback plugin is consulted.
+func TestPreemptable_DisjointIntersectionStaysNilAndFallsThrough(t *testing.T) {
+	taskA := &api.TaskInfo{UID: "a"}
+	taskB := &api.TaskInfo{UID: "b"}
+	ssn := &Session{
+		Tiers: []conf.Tier{
+			{Plugins: []conf.PluginOption{
+				{Name: "p1", EnabledPreemptable: boolPtr(true)},
+				{Name: "p2", EnabledPreemptable: boolPtr(true)},
+			}},
+			{Plugins: []conf.PluginOption{
+				{Name: "fallback", EnabledPreemptable: boolPtr(true)},
+			}},
+		},
+		preemptableFns: map[string]api.EvictableFn{},
+	}
+	ssn.AddPreemptableFn("p1", func(_ *api.TaskInfo, _ []*api.TaskInfo) ([]*api.TaskInfo, int) {
+		return []*api.TaskInfo{taskA}, 1
+	})
+	ssn.AddPreemptableFn("p2", func(_ *api.TaskInfo, _ []*api.TaskInfo) ([]*api.TaskInfo, int) {
+		return []*api.TaskInfo{taskB}, 1 // disjoint from p1 -> empty intersection
+	})
+	ssn.AddPreemptableFn("fallback", func(_ *api.TaskInfo, _ []*api.TaskInfo) ([]*api.TaskInfo, int) {
+		return []*api.TaskInfo{taskA}, 1
+	})
+	result := ssn.Preemptable(&api.TaskInfo{}, []*api.TaskInfo{taskA, taskB})
+	assert.Equal(t, []*api.TaskInfo{taskA}, result, "tier 1's empty intersection must fall through to tier 2's fallback")
 }


### PR DESCRIPTION
### Title

**perf(scheduler): replace O(n²) victim intersection with O(n) hash-set lookup**

This PR optimizes victim list intersection in the scheduler framework.

`Reclaimable()`, `Preemptable()`, and `UnifiedEvictable()` currently compute the intersection of victim lists returned by scheduler plugins using nested loops, resulting in **O(|victims| × |candidates|)** time complexity for each intersection.

This change replaces the nested-loop implementation with a hash-based lookup by constructing a `map[api.TaskID]struct{}` for one list and performing constant-time membership checks while iterating over the other list. The overall complexity is reduced to **O(n + m)**.

The optimization is applied consistently to all three methods in `pkg/scheduler/framework/session_plugins.go`.

The existing behavior is preserved:

* the output ordering remains unchanged by iterating over the same outer slice as before;
* task UIDs are unique, so the resulting intersection is identical to the previous implementation;
* no scheduling policy or public API is modified.

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

* Replaces quadratic victim intersection with a linear hash-based lookup.
* Reduces scheduler CPU overhead during reclaim and preemption.
* Improves scalability for workloads with large victim lists.
* Preserves existing scheduling behavior and result ordering.

#### Which issue(s) this PR fixes:

Fixes #5540 

#### Special notes for your reviewer:

* This is an algorithmic optimization only.
* No functional behavior or scheduling decisions are changed.
* The resulting victim list preserves the same ordering as the previous implementation.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
