### PR TITLE
[release-1.13] Fix isDependsOnPodsReady to treat Succeeded pods as ready

### DIFF
--- a/pkg/controllers/job/job_controller_actions.go
+++ b/pkg/controllers/job/job_controller_actions.go
@@ -618,6 +618,11 @@ func (cc *jobcontroller) isDependsOnPodsReady(task string, job *batch.Job) bool 
 			continue
 		}
 
+		if pod.Status.Phase == v1.PodSucceeded {
+			runningPodCount++
+			continue
+		}
+
 		allContainerReady := true
 		for _, containerStatus := range pod.Status.ContainerStatuses {
 			if !containerStatus.Ready {

--- a/pkg/controllers/job/job_controller_actions_test.go
+++ b/pkg/controllers/job/job_controller_actions_test.go
@@ -1141,3 +1141,190 @@ func TestAppendJobCondition(t *testing.T) {
 		})
 	}
 }
+
+func TestIsDependsOnPodsReady(t *testing.T) {
+	namespace := "test"
+	jobName := "job1"
+
+	testcases := []struct {
+		Name          string
+		Task          string
+		Job           *v1alpha1.Job
+		Pods          []*v1.Pod
+		ExpectedReady bool
+	}{
+		{
+			Name: "DependsOn task has all pods succeeded",
+			Task: "task1",
+			Job: &v1alpha1.Job{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      jobName,
+					Namespace: namespace,
+				},
+				Spec: v1alpha1.JobSpec{
+					Tasks: []v1alpha1.TaskSpec{
+						{
+							Name:         "task1",
+							Replicas:     2,
+							MinAvailable: ptr.To[int32](2),
+							Template: v1.PodTemplateSpec{
+								ObjectMeta: metav1.ObjectMeta{
+									Name: "task1",
+								},
+							},
+						},
+						{
+							Name:     "task2",
+							Replicas: 1,
+							DependsOn: &v1alpha1.DependsOn{
+								Name: []string{"task1"},
+							},
+						},
+					},
+				},
+			},
+			Pods: []*v1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "job1-task1-0",
+						Namespace: namespace,
+					},
+					Status: v1.PodStatus{
+						Phase: v1.PodSucceeded,
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "job1-task1-1",
+						Namespace: namespace,
+					},
+					Status: v1.PodStatus{
+						Phase: v1.PodSucceeded,
+					},
+				},
+			},
+			ExpectedReady: true,
+		},
+		{
+			Name: "DependsOn task has pods running and ready",
+			Task: "task1",
+			Job: &v1alpha1.Job{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      jobName,
+					Namespace: namespace,
+				},
+				Spec: v1alpha1.JobSpec{
+					Tasks: []v1alpha1.TaskSpec{
+						{
+							Name:         "task1",
+							Replicas:     1,
+							MinAvailable: ptr.To[int32](1),
+							Template: v1.PodTemplateSpec{
+								ObjectMeta: metav1.ObjectMeta{
+									Name: "task1",
+								},
+							},
+						},
+						{
+							Name:     "task2",
+							Replicas: 1,
+							DependsOn: &v1alpha1.DependsOn{
+								Name: []string{"task1"},
+							},
+						},
+					},
+				},
+			},
+			Pods: []*v1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "job1-task1-0",
+						Namespace: namespace,
+					},
+					Status: v1.PodStatus{
+						Phase: v1.PodRunning,
+						ContainerStatuses: []v1.ContainerStatus{
+							{Ready: true},
+						},
+					},
+				},
+			},
+			ExpectedReady: true,
+		},
+		{
+			Name: "DependsOn task has pods running but not ready",
+			Task: "task1",
+			Job: &v1alpha1.Job{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      jobName,
+					Namespace: namespace,
+				},
+				Spec: v1alpha1.JobSpec{
+					Tasks: []v1alpha1.TaskSpec{
+						{
+							Name:         "task1",
+							Replicas:     1,
+							MinAvailable: ptr.To[int32](1),
+							Template: v1.PodTemplateSpec{
+								ObjectMeta: metav1.ObjectMeta{
+									Name: "task1",
+								},
+							},
+						},
+						{
+							Name:     "task2",
+							Replicas: 1,
+							DependsOn: &v1alpha1.DependsOn{
+								Name: []string{"task1"},
+							},
+						},
+					},
+				},
+			},
+			Pods: []*v1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "job1-task1-0",
+						Namespace: namespace,
+					},
+					Status: v1.PodStatus{
+						Phase: v1.PodRunning,
+						ContainerStatuses: []v1.ContainerStatus{
+							{Ready: false},
+						},
+					},
+				},
+			},
+			ExpectedReady: false,
+		},
+	}
+
+	for i, tc := range testcases {
+		t.Run(tc.Name, func(t *testing.T) {
+			fakeController := newFakeController()
+
+			_, err := fakeController.vcClient.BatchV1alpha1().Jobs(namespace).Create(context.TODO(), tc.Job, metav1.CreateOptions{})
+			if err != nil {
+				t.Fatalf("Failed to create job: %v", err)
+			}
+			err = fakeController.cache.Add(tc.Job)
+			if err != nil {
+				t.Fatalf("Failed to add job to cache: %v", err)
+			}
+			fakeController.jobInformer.Informer().GetIndexer().Add(tc.Job)
+
+			for _, pod := range tc.Pods {
+				_, err := fakeController.kubeClient.CoreV1().Pods(namespace).Create(context.TODO(), pod, metav1.CreateOptions{})
+				if err != nil {
+					t.Fatalf("Failed to create pod: %v", err)
+				}
+				fakeController.podInformer.Informer().GetIndexer().Add(pod)
+			}
+
+			ready := fakeController.isDependsOnPodsReady(tc.Task, tc.Job)
+			if ready != tc.ExpectedReady {
+				t.Errorf("Case %d (%s): expected ready: %v, got: %v", i, tc.Name, tc.ExpectedReady, ready)
+			}
+		})
+	}
+}

--- a/pkg/controllers/job/job_controller_actions_test.go
+++ b/pkg/controllers/job/job_controller_actions_test.go
@@ -1145,6 +1145,7 @@ func TestAppendJobCondition(t *testing.T) {
 func TestIsDependsOnPodsReady(t *testing.T) {
 	namespace := "test"
 	jobName := "job1"
+	int32Ptr := func(n int32) *int32 { return &n }
 
 	testcases := []struct {
 		Name          string
@@ -1166,7 +1167,7 @@ func TestIsDependsOnPodsReady(t *testing.T) {
 						{
 							Name:         "task1",
 							Replicas:     2,
-							MinAvailable: ptr.To[int32](2),
+							MinAvailable: int32Ptr(2),
 							Template: v1.PodTemplateSpec{
 								ObjectMeta: metav1.ObjectMeta{
 									Name: "task1",
@@ -1218,7 +1219,7 @@ func TestIsDependsOnPodsReady(t *testing.T) {
 						{
 							Name:         "task1",
 							Replicas:     1,
-							MinAvailable: ptr.To[int32](1),
+							MinAvailable: int32Ptr(1),
 							Template: v1.PodTemplateSpec{
 								ObjectMeta: metav1.ObjectMeta{
 									Name: "task1",
@@ -1264,7 +1265,7 @@ func TestIsDependsOnPodsReady(t *testing.T) {
 						{
 							Name:         "task1",
 							Replicas:     1,
-							MinAvailable: ptr.To[int32](1),
+							MinAvailable: int32Ptr(1),
 							Template: v1.PodTemplateSpec{
 								ObjectMeta: metav1.ObjectMeta{
 									Name: "task1",


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

This fixes the release-1.13 cherry-pick test build issue from #5548.

The cherry-picked test used `ptr.To[int32](...)`, but `pkg/controllers/job/job_controller_actions_test.go` on release-1.13 does not import `k8s.io/utils/ptr`. To keep the cherry-pick small, this uses a local `int32Ptr` helper inside `TestIsDependsOnPodsReady` instead of changing imports.

#### Which issue(s) this PR fixes:

Related to #5548

#### Special notes for your reviewer:

This is only the manual fix requested in https://github.com/volcano-sh/volcano/pull/5548#discussion_r3497281367.

#### Does this PR introduce a user-facing change?

```release-note
NONE