### PR TITLE
fix: dedupe shared CSI volume attach usage

### DIFF
--- a/pkg/scheduler/api/job_info.go
+++ b/pkg/scheduler/api/job_info.go
@@ -133,6 +133,8 @@ type TaskInfo struct {
 	ResourceClaimKeys []string
 	// ResourceClaimDRAResreq stores per-claim DRA resources for shared-claim deduplication.
 	ResourceClaimDRAResreq map[string]map[string]*DRAResource
+	// CSIVolumes stores CSI volume names by attach limit resource.
+	CSIVolumes map[v1.ResourceName][]string
 
 	TransactionContext
 	// LastTransaction holds the context of last scheduling transaction
@@ -322,6 +324,12 @@ func (ti *TaskInfo) Clone() *TaskInfo {
 	}
 	if ti.ResourceClaimDRAResreq != nil {
 		res.ResourceClaimDRAResreq = cloneResourceClaimDRAResreq(ti.ResourceClaimDRAResreq)
+	}
+	if ti.CSIVolumes != nil {
+		res.CSIVolumes = make(map[v1.ResourceName][]string, len(ti.CSIVolumes))
+		for k, v := range ti.CSIVolumes {
+			res.CSIVolumes[k] = append([]string(nil), v...)
+		}
 	}
 
 	return res

--- a/pkg/scheduler/api/node_info.go
+++ b/pkg/scheduler/api/node_info.go
@@ -71,6 +71,7 @@ type NodeInfo struct {
 	ResourceUsage *NodeUsage
 
 	Tasks             map[TaskID]*TaskInfo
+	CSIVolumes        map[v1.ResourceName]map[string]int
 	NumaInfo          *NumatopoInfo
 	NumaChgFlag       NumaChgFlag
 	NumaSchedulerInfo *NumatopoInfo
@@ -411,33 +412,87 @@ func (ni *NodeInfo) setNode(node *v1.Node) {
 	ni.Pipelined = EmptyResource()
 	ni.Idle = NewResource(node.Status.Allocatable).Add(ni.OversubscriptionResource)
 	ni.Used = EmptyResource()
+	ni.CSIVolumes = nil
 
 	for _, ti := range ni.Tasks {
+		resreq := ni.csiResourceRequest(ti, 0)
 		switch ti.Status {
 		case Releasing:
-			ni.allocateIdleResource(ti)
-			ni.Releasing.Add(ti.Resreq)
-			ni.Used.Add(ti.Resreq)
+			ni.allocateIdleResource(ti, resreq)
+			ni.Releasing.Add(resreq)
+			ni.Used.Add(resreq)
 		case Pipelined:
-			ni.Pipelined.Add(ti.Resreq)
+			ni.Pipelined.Add(resreq)
 		default:
-			ni.allocateIdleResource(ti)
-			ni.Used.Add(ti.Resreq)
+			ni.allocateIdleResource(ti, resreq)
+			ni.Used.Add(resreq)
 			ni.addResource(ti.Pod)
+		}
+		ni.addCSIVolumes(ti)
+	}
+}
+
+func (ni *NodeInfo) allocateIdleResource(ti *TaskInfo, resreq *Resource) {
+	ok, resources := resreq.LessEqualWithResourcesName(ni.Idle, Zero)
+	if ok {
+		ni.Idle.sub(resreq)
+		return
+	}
+
+	ni.Idle.sub(resreq)
+	klog.ErrorS(nil, "Idle resources turn into negative after allocated",
+		"nodeName", ni.Name, "task", klog.KObj(ti.Pod), "resources", resources, "idle", ni.Idle.String(), "req", resreq.String())
+}
+
+func (ni *NodeInfo) csiResourceRequest(ti *TaskInfo, refCount int) *Resource {
+	resreq := ti.Resreq.Clone()
+	for resourceName, volumes := range ti.CSIVolumes {
+		for _, volume := range volumes {
+			count := ni.CSIVolumes[resourceName][volume]
+			if count <= refCount || resreq.ScalarResources[resourceName] <= 0 {
+				continue
+			}
+			resreq.ScalarResources[resourceName]--
+		}
+	}
+	return resreq
+}
+
+func (ni *NodeInfo) addCSIVolumes(ti *TaskInfo) {
+	for resourceName, volumes := range ti.CSIVolumes {
+		if ni.CSIVolumes == nil {
+			ni.CSIVolumes = make(map[v1.ResourceName]map[string]int)
+		}
+		if ni.CSIVolumes[resourceName] == nil {
+			ni.CSIVolumes[resourceName] = make(map[string]int)
+		}
+		for _, volume := range volumes {
+			ni.CSIVolumes[resourceName][volume]++
 		}
 	}
 }
 
-func (ni *NodeInfo) allocateIdleResource(ti *TaskInfo) {
-	ok, resources := ti.Resreq.LessEqualWithResourcesName(ni.Idle, Zero)
-	if ok {
-		ni.Idle.sub(ti.Resreq)
+func (ni *NodeInfo) removeCSIVolumes(ti *TaskInfo) {
+	if ni.CSIVolumes == nil {
 		return
 	}
-
-	ni.Idle.sub(ti.Resreq)
-	klog.ErrorS(nil, "Idle resources turn into negative after allocated",
-		"nodeName", ni.Name, "task", klog.KObj(ti.Pod), "resources", resources, "idle", ni.Idle.String(), "req", ti.Resreq.String())
+	for resourceName, volumes := range ti.CSIVolumes {
+		if ni.CSIVolumes[resourceName] == nil {
+			continue
+		}
+		for _, volume := range volumes {
+			ni.CSIVolumes[resourceName][volume]--
+			if ni.CSIVolumes[resourceName][volume] == 0 {
+				delete(ni.CSIVolumes[resourceName], volume)
+			}
+		}
+		if len(ni.CSIVolumes[resourceName]) == 0 {
+			delete(ni.CSIVolumes, resourceName)
+		}
+	}
+	if len(ni.CSIVolumes) == 0 {
+		ni.CSIVolumes = nil
+	}
 }
 
 // AddTask is used to add a task in nodeInfo object
@@ -460,26 +515,28 @@ func (ni *NodeInfo) AddTask(task *TaskInfo) error {
 	ti := task.Clone()
 
 	if ni.Node != nil {
+		resreq := ni.csiResourceRequest(ti, 0)
 		switch ti.Status {
 		case Releasing:
-			ni.allocateIdleResource(ti)
-			ni.Releasing.Add(ti.Resreq)
-			ni.Used.Add(ti.Resreq)
+			ni.allocateIdleResource(ti, resreq)
+			ni.Releasing.Add(resreq)
+			ni.Used.Add(resreq)
 		case Pipelined:
-			ni.Pipelined.Add(ti.Resreq)
+			ni.Pipelined.Add(resreq)
 		case Binding:
 			// When task in Binding status, it will bind to node, we should double-check whether idle resources are enough to put task before bind to apiserver.
-			if ok, resNames := ti.Resreq.LessEqualWithResourcesName(ni.Idle, Zero); !ok {
-				return fmt.Errorf("node %s resources %v are not enough to put task <%s/%s>, idle: %s, req: %s", ni.Name, resNames, ti.Namespace, ti.Name, ni.Idle.String(), ti.Resreq.String())
+			if ok, resNames := resreq.LessEqualWithResourcesName(ni.Idle, Zero); !ok {
+				return fmt.Errorf("node %s resources %v are not enough to put task <%s/%s>, idle: %s, req: %s", ni.Name, resNames, ti.Namespace, ti.Name, ni.Idle.String(), resreq.String())
 			}
-			ni.allocateIdleResource(ti)
-			ni.Used.Add(ti.Resreq)
+			ni.allocateIdleResource(ti, resreq)
+			ni.Used.Add(resreq)
 			ni.addResource(ti.Pod)
 		default:
-			ni.allocateIdleResource(ti)
-			ni.Used.Add(ti.Resreq)
+			ni.allocateIdleResource(ti, resreq)
+			ni.Used.Add(resreq)
 			ni.addResource(ti.Pod)
 		}
+		ni.addCSIVolumes(ti)
 	}
 
 	if ni.NumaInfo != nil {
@@ -506,18 +563,20 @@ func (ni *NodeInfo) RemoveTask(ti *TaskInfo) {
 	}
 
 	if ni.Node != nil {
+		resreq := ni.csiResourceRequest(task, 1)
 		switch task.Status {
 		case Releasing:
-			ni.Releasing.Sub(task.Resreq)
-			ni.Idle.Add(task.Resreq)
-			ni.Used.Sub(task.Resreq)
+			ni.Releasing.Sub(resreq)
+			ni.Idle.Add(resreq)
+			ni.Used.Sub(resreq)
 		case Pipelined:
-			ni.Pipelined.Sub(task.Resreq)
+			ni.Pipelined.Sub(resreq)
 		default:
-			ni.Idle.Add(task.Resreq)
-			ni.Used.Sub(task.Resreq)
+			ni.Idle.Add(resreq)
+			ni.Used.Sub(resreq)
 			ni.subResource(ti.Pod)
 		}
+		ni.removeCSIVolumes(task)
 	}
 
 	if ni.NumaInfo != nil {

--- a/pkg/scheduler/api/node_info_test.go
+++ b/pkg/scheduler/api/node_info_test.go
@@ -198,6 +198,44 @@ func TestNodeInfo_RemovePod(t *testing.T) {
 	}
 }
 
+func TestNodeInfo_SharedCSIVolumes(t *testing.T) {
+	attachLimit := v1.ResourceName("attachable-volumes-csi-test")
+	node := buildNode("n1", nil, BuildResourceList("2", "2G", []ScalarResource{{Name: string(attachLimit), Value: "1m"}, {Name: "pods", Value: "10"}}...))
+	pod1 := buildPod("c1", "p1", "n1", v1.PodRunning, BuildResourceList("1", "1G"), nil, make(map[string]string))
+	pod2 := buildPod("c1", "p2", "n1", v1.PodRunning, BuildResourceList("1", "1G"), nil, make(map[string]string))
+	task1 := NewTaskInfo(pod1)
+	task2 := NewTaskInfo(pod2)
+
+	task1.Resreq.AddScalar(attachLimit, 1)
+	task2.Resreq.AddScalar(attachLimit, 1)
+	task1.CSIVolumes = map[v1.ResourceName][]string{attachLimit: {"pv1"}}
+	task2.CSIVolumes = map[v1.ResourceName][]string{attachLimit: {"pv1"}}
+
+	ni := NewNodeInfo(node)
+	if err := ni.AddTask(task1); err != nil {
+		t.Fatalf("add task1 failed: %v", err)
+	}
+	if err := ni.AddTask(task2); err != nil {
+		t.Fatalf("add task2 failed: %v", err)
+	}
+	if ni.Used.ScalarResources[attachLimit] != 1 {
+		t.Fatalf("expected used csi volume 1, got %v", ni.Used.ScalarResources[attachLimit])
+	}
+	if ni.Idle.ScalarResources[attachLimit] != 0 {
+		t.Fatalf("expected idle csi volume 0, got %v", ni.Idle.ScalarResources[attachLimit])
+	}
+
+	ni.RemoveTask(task1)
+	if ni.Used.ScalarResources[attachLimit] != 1 {
+		t.Fatalf("expected used csi volume 1 after removing shared task, got %v", ni.Used.ScalarResources[attachLimit])
+	}
+
+	ni.RemoveTask(task2)
+	if ni.Used.ScalarResources[attachLimit] != 0 {
+		t.Fatalf("expected used csi volume 0 after removing last task, got %v", ni.Used.ScalarResources[attachLimit])
+	}
+}
+
 func TestNodeInfo_SetNode(t *testing.T) {
 	// case1
 	case01Node1 := buildNode("n1", nil, BuildResourceList("10", "10G", []ScalarResource{{Name: "pods", Value: "15"}}...))

--- a/pkg/scheduler/cache/event_handlers.go
+++ b/pkg/scheduler/cache/event_handlers.go
@@ -85,8 +85,6 @@ func (sc *SchedulerCache) getOrCreateJob(pi *schedulingapi.TaskInfo) *scheduling
 }
 
 // addPodCSIVolumesToTask counts the csi volumes used by task
-// @Lily922 TODO: support counting shared volumes. Currently, if two different pods use the same attachable volume
-// and scheduled on the same nodes the volume will be count twice, but actually only use one attachable limit resource
 func (sc *SchedulerCache) addPodCSIVolumesToTask(pi *schedulingapi.TaskInfo) error {
 	volumes, err := sc.getPodCSIVolumes(pi.Pod)
 	if err != nil {
@@ -94,14 +92,15 @@ func (sc *SchedulerCache) addPodCSIVolumesToTask(pi *schedulingapi.TaskInfo) err
 		return err
 	}
 
-	for key, count := range volumes {
-		pi.Resreq.AddScalar(key, float64(count))
+	pi.CSIVolumes = volumes
+	for key, volumeNames := range volumes {
+		pi.Resreq.AddScalar(key, float64(len(volumeNames)))
 	}
 	return nil
 }
 
-func (sc *SchedulerCache) getPodCSIVolumes(pod *v1.Pod) (map[v1.ResourceName]int64, error) {
-	volumes := make(map[v1.ResourceName]int64)
+func (sc *SchedulerCache) getPodCSIVolumes(pod *v1.Pod) (map[v1.ResourceName][]string, error) {
+	volumes := make(map[v1.ResourceName][]string)
 	for _, vol := range pod.Spec.Volumes {
 		pvcName := ""
 		isEphemeral := false
@@ -154,10 +153,12 @@ func (sc *SchedulerCache) getPodCSIVolumes(pod *v1.Pod) (map[v1.ResourceName]int
 		// For unattachable volume, set the limits number to a very large value, in this way, scheduling will never
 		// be limited due to insufficient quantity of it.
 		k := v1.ResourceName(volumeutil.GetCSIAttachLimitKey(driverName))
-		if _, ok := volumes[k]; !ok {
-			volumes[k] = 1
-		} else {
-			volumes[k] += 1
+		volumeName := fmt.Sprintf("%s/%s", pvc.Namespace, pvc.Name)
+		if pvc.Spec.VolumeName != "" {
+			volumeName = pvc.Spec.VolumeName
+		}
+		if !slices.Contains(volumes[k], volumeName) {
+			volumes[k] = append(volumes[k], volumeName)
 		}
 	}
 	return volumes, nil


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

This PR fixes CSI attach limit accounting for shared PVCs on the same node.

Volcano already counts CSI attachable volumes as scalar resources on each task. When two pods on the same node use the same PVC, the node should consume one attach slot for that volume, not one slot per pod. This change keeps the per-task CSI volume identity and deduplicates the attach resource while updating node resource accounting.

#### Which issue(s) this PR fixes:

Fixes #5531

#### Special notes for your reviewer:

NONE

#### Does this PR introduce a user-facing change?

```release-note
Fix CSI attach limit accounting for shared PVCs on the same node.