### PR TITLE
Fix agent scheduler config hot reload not affecting running workers

### DIFF
--- a/pkg/agentscheduler/actions/allocate/allocate.go
+++ b/pkg/agentscheduler/actions/allocate/allocate.go
@@ -57,6 +57,8 @@ func (alloc *Action) Name() string {
 
 // OnActionInit initializes the plugin. It is called once when the framework is created.
 func (alloc *Action) OnActionInit(configurations []conf.Configuration) {
+	alloc.enablePredicateErrorCache = true
+	alloc.candidateNodeCount = DefaultCandidateNodeCount
 	alloc.parseArguments(configurations)
 }
 

--- a/pkg/agentscheduler/actions/allocate/allocate_test.go
+++ b/pkg/agentscheduler/actions/allocate/allocate_test.go
@@ -31,6 +31,7 @@ import (
 	"volcano.sh/volcano/pkg/agentscheduler/framework"
 	agentuthelper "volcano.sh/volcano/pkg/agentscheduler/uthelper"
 	"volcano.sh/volcano/pkg/scheduler/api"
+	"volcano.sh/volcano/pkg/scheduler/conf"
 	"volcano.sh/volcano/pkg/scheduler/util"
 	commonutil "volcano.sh/volcano/pkg/util"
 )
@@ -174,5 +175,31 @@ func TestConcurrentMultiWorkerScheduling(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestActionReloadRestoresDefaultArguments(t *testing.T) {
+	action := New()
+
+	action.OnActionInit([]conf.Configuration{{
+		Name: action.Name(),
+		Arguments: map[string]interface{}{
+			CandidateNodeCountKey:           10,
+			conf.EnablePredicateErrCacheKey: false,
+		},
+	}})
+	if action.candidateNodeCount != 10 {
+		t.Fatalf("expected candidateNodeCount to be 10, got %d", action.candidateNodeCount)
+	}
+	if action.enablePredicateErrorCache {
+		t.Fatal("expected predicate error cache to be disabled")
+	}
+
+	action.OnActionInit(nil)
+	if action.candidateNodeCount != DefaultCandidateNodeCount {
+		t.Fatalf("expected candidateNodeCount to be reset to %d, got %d", DefaultCandidateNodeCount, action.candidateNodeCount)
+	}
+	if !action.enablePredicateErrorCache {
+		t.Fatal("expected predicate error cache to be reset to enabled")
 	}
 }

--- a/pkg/agentscheduler/actions/factory.go
+++ b/pkg/agentscheduler/actions/factory.go
@@ -26,5 +26,7 @@ import (
 )
 
 func init() {
-	framework.RegisterAction(allocate.New())
+	framework.RegisterActionBuilder("allocate", func() framework.Action {
+		return allocate.New()
+	})
 }

--- a/pkg/agentscheduler/framework/plugins.go
+++ b/pkg/agentscheduler/framework/plugins.go
@@ -221,14 +221,23 @@ func (f *Framework) NodeOrderReduceFn(task *api.TaskInfo, pluginNodeScoreMap map
 }
 
 // Action management
-var actionMap = map[string]Action{}
+type ActionBuilder func() Action
+
+var actionBuilders = map[string]ActionBuilder{}
 
 // RegisterAction register action
 func RegisterAction(act Action) {
+	RegisterActionBuilder(act.Name(), func() Action {
+		return act
+	})
+}
+
+// RegisterActionBuilder registers the action builder.
+func RegisterActionBuilder(name string, ab ActionBuilder) {
 	pluginMutex.Lock()
 	defer pluginMutex.Unlock()
 
-	actionMap[act.Name()] = act
+	actionBuilders[name] = ab
 }
 
 // GetAction get the action by name
@@ -236,6 +245,9 @@ func GetAction(name string) (Action, bool) {
 	pluginMutex.RLock()
 	defer pluginMutex.RUnlock()
 
-	act, found := actionMap[name]
-	return act, found
+	ab, found := actionBuilders[name]
+	if !found {
+		return nil, false
+	}
+	return ab(), true
 }

--- a/pkg/agentscheduler/scheduler.go
+++ b/pkg/agentscheduler/scheduler.go
@@ -63,9 +63,12 @@ type Scheduler struct {
 	disableDefaultConf bool
 	workerCount        int
 	shardingMode       string
+	workers            []*Worker
+	configApplied      bool
 }
 
 type Worker struct {
+	mutex     sync.RWMutex
 	framework *framework.Framework
 	index     int
 }
@@ -99,19 +102,14 @@ func NewAgentScheduler(config *rest.Config, opt *options.ServerOption) (*Schedul
 // initializes the cache, and begins the scheduling process.
 func (sched *Scheduler) Run(stopCh <-chan struct{}) {
 	sched.loadSchedulerConf()
-	go sched.watchSchedulerConf(stopCh)
 	// Start cache for policy.
-	sched.cache.SetMetricsConf(sched.metricsConf)
+	sched.cache.SetMetricsConf(sched.getMetricsConf())
 	sched.cache.Run(stopCh)
-
-	for _, action := range sched.actions {
-		action.OnActionInit(sched.configurations)
-	}
 
 	klog.V(2).Infof("Scheduler completes Initialization and start to run %d workers", sched.workerCount)
 	for i := range sched.workerCount {
-		worker := &Worker{index: i}
-		worker.framework = framework.NewFramework(sched.actions, sched.tiers, sched.cache, sched.configurations)
+		worker := sched.newWorker(i)
+		sched.addWorker(worker)
 		go func() {
 			for {
 				select {
@@ -123,6 +121,7 @@ func (sched *Scheduler) Run(stopCh <-chan struct{}) {
 			}
 		}()
 	}
+	go sched.watchSchedulerConf(stopCh)
 	if options.ServerOpts.EnableCacheDumper {
 		sched.dumper.ListenForSignal(stopCh)
 	}
@@ -146,14 +145,22 @@ func (worker *Worker) runOnce() {
 		return
 	}
 
+	worker.mutex.RLock()
+	defer worker.mutex.RUnlock()
+	if worker.framework == nil {
+		klog.Errorf("Framework is not initialized in worker %d", worker.index)
+		return
+	}
+	fwk := worker.framework
+
 	scheduleStartTime := time.Now()
 
 	// Update snapshot from cache before scheduling
-	snapshot := worker.framework.GetSnapshot()
+	snapshot := fwk.GetSnapshot()
 	snapshotStart := time.Now()
-	if err := worker.framework.Cache.UpdateSnapshot(snapshot); err != nil {
+	if err := fwk.Cache.UpdateSnapshot(snapshot); err != nil {
 		klog.Errorf("Failed to update snapshot in worker %d: %v, skip this scheduling cycle", worker.index, err)
-		queue := worker.framework.Cache.SchedulingQueue()
+		queue := fwk.Cache.SchedulingQueue()
 		if err := queue.AddUnschedulableIfNotPresent(klog.Background(), schedCtx.QueuedPodInfo, queue.SchedulingCycle()); err != nil {
 			klog.ErrorS(err, "Failed to add pod back to scheduling queue",
 				"pod", klog.KObj(schedCtx.QueuedPodInfo.Pod))
@@ -162,36 +169,74 @@ func (worker *Worker) runOnce() {
 	}
 	agentmetrics.UpdateUpdateSnapshotDuration(time.Since(snapshotStart))
 
-	worker.framework.Cache.OnWorkerStartSchedulingCycle(worker.index, schedCtx)
+	fwk.Cache.OnWorkerStartSchedulingCycle(worker.index, schedCtx)
 
 	// TODO: Call OnCycleStart for all plugins
-	// worker.framework.OnCycleStart()
+	// fwk.OnCycleStart()
 
 	defer func() {
 		agentmetrics.UpdateWorkerSchedulingCycleDuration(schedulermetrics.Duration(scheduleStartTime))
 		// TODO: Call OnCycleEnd for all plugins
-		// worker.framework.OnCycleEnd()
-		worker.framework.Cache.OnWorkerEndSchedulingCycle(worker.index)
-		worker.framework.ClearCycleState()
+		// fwk.OnCycleEnd()
+		fwk.Cache.OnWorkerEndSchedulingCycle(worker.index)
+		fwk.ClearCycleState()
 	}()
 
-	for _, action := range worker.framework.Actions {
+	for _, action := range fwk.Actions {
 		actionStartTime := time.Now()
-		action.Execute(worker.framework, schedCtx)
+		action.Execute(fwk, schedCtx)
 		schedulermetrics.UpdateActionDuration(action.Name(), schedulermetrics.Duration(actionStartTime))
 	}
 }
 
+func (sched *Scheduler) newWorker(index int) *Worker {
+	actions, tiers, configurations := sched.getFrameworkConfig()
+	return &Worker{
+		index:     index,
+		framework: framework.NewFramework(actions, tiers, sched.cache, configurations),
+	}
+}
+
+func (sched *Scheduler) addWorker(worker *Worker) {
+	sched.mutex.Lock()
+	defer sched.mutex.Unlock()
+	sched.workers = append(sched.workers, worker)
+}
+
+func (sched *Scheduler) getFrameworkConfig() ([]framework.Action, []conf.Tier, []conf.Configuration) {
+	sched.mutex.Lock()
+	defer sched.mutex.Unlock()
+	return sched.actions, sched.tiers, sched.configurations
+}
+
+func (sched *Scheduler) getMetricsConf() map[string]string {
+	sched.mutex.Lock()
+	defer sched.mutex.Unlock()
+	return sched.metricsConf
+}
+
+func (sched *Scheduler) getWorkers() []*Worker {
+	sched.mutex.Lock()
+	defer sched.mutex.Unlock()
+	workers := make([]*Worker, len(sched.workers))
+	copy(workers, sched.workers)
+	return workers
+}
+
 // generateNextSchedulingContext generates a new scheduling context for the next task to be scheduled.
 func (worker *Worker) generateNextSchedulingContext() (*agentapi.SchedulingContext, error) {
-	if worker.framework == nil {
+	worker.mutex.RLock()
+	var cache schedcache.Cache
+	if worker.framework != nil {
+		cache = worker.framework.Cache
+	}
+	worker.mutex.RUnlock()
+
+	if cache == nil {
 		return nil, fmt.Errorf("framework is not initialized")
 	}
-	if worker.framework.Cache == nil {
-		return nil, fmt.Errorf("cache is not initialized")
-	}
 
-	queue := worker.framework.Cache.SchedulingQueue()
+	queue := cache.SchedulingQueue()
 	if queue == nil {
 		return nil, fmt.Errorf("scheduling queue is not initialized")
 	}
@@ -200,8 +245,11 @@ func (worker *Worker) generateNextSchedulingContext() (*agentapi.SchedulingConte
 	if err != nil {
 		return nil, fmt.Errorf("failed to pop scheduling task: %w", err)
 	}
+	if podInfo == nil || podInfo.Pod == nil {
+		return nil, nil
+	}
 
-	task, exist := worker.framework.Cache.GetTaskInfo(schedulingapi.TaskID(podInfo.Pod.UID))
+	task, exist := cache.GetTaskInfo(schedulingapi.TaskID(podInfo.Pod.UID))
 	if !exist {
 		klog.Warningf("Task %s/%s not found in cache, skip scheduling", podInfo.Pod.Namespace, podInfo.Pod.Name)
 		queue.Done(podInfo.Pod.UID)
@@ -233,6 +281,10 @@ func (sched *Scheduler) loadSchedulerConf() {
 				klog.Fatalf("Invalid default configuration: unmarshal Scheduler config %s failed: %v", DefaultSchedulerConf, err)
 			}
 		})
+		if len(sched.schedulerConf) == 0 {
+			sched.applySchedulerConf(sched.actions, sched.tiers, sched.configurations, sched.metricsConf)
+			return
+		}
 	}
 
 	var config string
@@ -244,6 +296,7 @@ func (sched *Scheduler) loadSchedulerConf() {
 			}
 			klog.Errorf("Failed to read the Scheduler config in '%s', using previous configuration: %v",
 				sched.schedulerConf, err)
+			sched.applyDefaultConfIfNeeded()
 			return
 		}
 		config = strings.TrimSpace(string(confData))
@@ -255,7 +308,31 @@ func (sched *Scheduler) loadSchedulerConf() {
 			klog.Fatalf("Invalid scheduler configuration and default configuration fallback is disabled")
 		}
 		klog.Errorf("Scheduler config %s is invalid: %v", config, err)
+		sched.applyDefaultConfIfNeeded()
 		return
+	}
+
+	sched.applySchedulerConf(actions, tiers, configurations, metricsConf)
+}
+
+func (sched *Scheduler) applyDefaultConfIfNeeded() {
+	sched.mutex.Lock()
+	applied := sched.configApplied
+	actions := sched.actions
+	tiers := sched.tiers
+	configurations := sched.configurations
+	metricsConf := sched.metricsConf
+	sched.mutex.Unlock()
+
+	if applied || len(actions) == 0 {
+		return
+	}
+	sched.applySchedulerConf(actions, tiers, configurations, metricsConf)
+}
+
+func (sched *Scheduler) applySchedulerConf(actions []framework.Action, tiers []conf.Tier, configurations []conf.Configuration, metricsConf map[string]string) {
+	for _, action := range actions {
+		action.OnActionInit(configurations)
 	}
 
 	sched.mutex.Lock()
@@ -263,10 +340,25 @@ func (sched *Scheduler) loadSchedulerConf() {
 	sched.tiers = tiers
 	sched.configurations = configurations
 	sched.metricsConf = metricsConf
-	defer sched.mutex.Unlock()
+	sched.configApplied = true
+	sched.mutex.Unlock()
+
+	workers := sched.getWorkers()
+	for _, worker := range workers {
+		sched.applyWorkerFramework(worker, actions, tiers, configurations)
+	}
+}
+
+func (sched *Scheduler) applyWorkerFramework(worker *Worker, actions []framework.Action, tiers []conf.Tier, configurations []conf.Configuration) {
+	worker.mutex.Lock()
+	defer worker.mutex.Unlock()
+	worker.framework = framework.NewFramework(actions, tiers, sched.cache, configurations)
 }
 
 func (sched *Scheduler) getSchedulerConf() (actions []string, plugins []string) {
+	sched.mutex.Lock()
+	defer sched.mutex.Unlock()
+
 	for _, action := range sched.actions {
 		actions = append(actions, action.Name())
 	}
@@ -282,6 +374,7 @@ func (sched *Scheduler) watchSchedulerConf(stopCh <-chan struct{}) {
 	if sched.fileWatcher == nil {
 		return
 	}
+	defer sched.fileWatcher.Close()
 	eventCh := sched.fileWatcher.Events()
 	errCh := sched.fileWatcher.Errors()
 	for {
@@ -293,7 +386,7 @@ func (sched *Scheduler) watchSchedulerConf(stopCh <-chan struct{}) {
 			klog.V(4).Infof("watch %s event: %v", sched.schedulerConf, event)
 			if event.Op&fsnotify.Write == fsnotify.Write || event.Op&fsnotify.Create == fsnotify.Create {
 				sched.loadSchedulerConf()
-				sched.cache.SetMetricsConf(sched.metricsConf)
+				sched.cache.SetMetricsConf(sched.getMetricsConf())
 			}
 		case err, ok := <-errCh:
 			if !ok {

--- a/pkg/agentscheduler/scheduler_test.go
+++ b/pkg/agentscheduler/scheduler_test.go
@@ -3,19 +3,25 @@ package agentscheduler
 import (
 	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
 	v1 "k8s.io/api/core/v1"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/features"
-	"sync"
-	"testing"
 
 	"volcano.sh/volcano/cmd/agent-scheduler/app/options"
 	scheduleroptions "volcano.sh/volcano/cmd/scheduler/app/options"
 	agentapi "volcano.sh/volcano/pkg/agentscheduler/api"
 	agentcache "volcano.sh/volcano/pkg/agentscheduler/cache"
 	"volcano.sh/volcano/pkg/agentscheduler/framework"
+	"volcano.sh/volcano/pkg/agentscheduler/plugins/predicates"
 	agentuthelper "volcano.sh/volcano/pkg/agentscheduler/uthelper"
 	schedulingapi "volcano.sh/volcano/pkg/scheduler/api"
 	"volcano.sh/volcano/pkg/scheduler/conf"
@@ -38,6 +44,221 @@ type failingSnapshotCache struct {
 
 func (c *failingSnapshotCache) UpdateSnapshot(_ *k8sutil.Snapshot) error {
 	return errors.New("injected snapshot failure")
+}
+
+type initCountingAction struct {
+	name      string
+	initCount atomic.Int32
+}
+
+func (a *initCountingAction) Name() string { return a.name }
+func (a *initCountingAction) OnActionInit(_ []conf.Configuration) {
+	a.initCount.Add(1)
+}
+func (a *initCountingAction) Initialize()                                                   {}
+func (a *initCountingAction) Execute(_ *framework.Framework, _ *agentapi.SchedulingContext) {}
+func (a *initCountingAction) UnInitialize()                                                 {}
+
+func TestUnmarshalSchedulerConfCreatesFreshActionInstances(t *testing.T) {
+	agentuthelper.InitTestEnv(t)
+	framework.RegisterActionBuilder("fresh-action", func() framework.Action {
+		return &initCountingAction{name: "fresh-action"}
+	})
+
+	conf := `
+actions: "fresh-action"
+tiers:
+- plugins:
+  - name: predicates
+`
+	firstActions, _, _, _, err := UnmarshalSchedulerConf(conf)
+	if err != nil {
+		t.Fatalf("failed to unmarshal first config: %v", err)
+	}
+	secondActions, _, _, _, err := UnmarshalSchedulerConf(conf)
+	if err != nil {
+		t.Fatalf("failed to unmarshal second config: %v", err)
+	}
+	if firstActions[0] == secondActions[0] {
+		t.Fatal("expected each config load to create a fresh action instance")
+	}
+}
+
+func TestLoadSchedulerConfInitializesDefaultConfig(t *testing.T) {
+	agentuthelper.InitTestEnv(t)
+	action := &initCountingAction{name: "test-default"}
+	framework.RegisterAction(action)
+
+	originalDefaultSchedulerConf := DefaultSchedulerConf
+	DefaultSchedulerConf = `
+actions: "test-default"
+tiers:
+- plugins:
+  - name: predicates
+`
+	t.Cleanup(func() {
+		DefaultSchedulerConf = originalDefaultSchedulerConf
+	})
+
+	sched := &Scheduler{
+		cache: agentcache.NewDefaultMockSchedulerCache("test-scheduler"),
+	}
+	sched.loadSchedulerConf()
+
+	if action.initCount.Load() != 1 {
+		t.Fatalf("expected default config action to be initialized once, got %d", action.initCount.Load())
+	}
+}
+
+func TestLoadSchedulerConfInitializesDefaultConfigWhenConfigFileIsMissing(t *testing.T) {
+	agentuthelper.InitTestEnv(t)
+	action := &initCountingAction{name: "test-default-missing-file"}
+	framework.RegisterAction(action)
+
+	originalDefaultSchedulerConf := DefaultSchedulerConf
+	DefaultSchedulerConf = `
+actions: "test-default-missing-file"
+tiers:
+- plugins:
+  - name: predicates
+`
+	t.Cleanup(func() {
+		DefaultSchedulerConf = originalDefaultSchedulerConf
+	})
+
+	sched := &Scheduler{
+		cache:         agentcache.NewDefaultMockSchedulerCache("test-scheduler"),
+		schedulerConf: filepath.Join(t.TempDir(), "missing.conf"),
+	}
+	sched.loadSchedulerConf()
+
+	if action.initCount.Load() != 1 {
+		t.Fatalf("expected fallback default config action to be initialized once, got %d", action.initCount.Load())
+	}
+}
+
+func TestLoadSchedulerConfRefreshesWorkerFramework(t *testing.T) {
+	agentuthelper.InitTestEnv(t)
+	framework.RegisterAction(&noopAction{})
+
+	confPath := filepath.Join(t.TempDir(), "agent-scheduler.conf")
+	writeSchedulerConf(t, confPath, `
+actions: "noop"
+tiers:
+- plugins:
+  - name: predicates
+  - name: nodeorder
+`)
+
+	mockCache := agentcache.NewDefaultMockSchedulerCache("test-scheduler")
+	sched := &Scheduler{
+		cache:              mockCache,
+		schedulerConf:      confPath,
+		disableDefaultConf: true,
+	}
+	sched.loadSchedulerConf()
+
+	worker := sched.newWorker(0)
+	sched.addWorker(worker)
+	oldFramework := worker.framework
+
+	if enabled := predicateEnabled(t, oldFramework); enabled == nil || !*enabled {
+		t.Fatalf("expected predicates to be enabled before reload, got %v", enabled)
+	}
+
+	writeSchedulerConf(t, confPath, `
+actions: "noop"
+tiers:
+- plugins:
+  - name: predicates
+    enablePredicate: false
+  - name: nodeorder
+`)
+	sched.loadSchedulerConf()
+
+	worker.mutex.RLock()
+	newFramework := worker.framework
+	worker.mutex.RUnlock()
+
+	if newFramework == oldFramework {
+		t.Fatal("expected worker framework to be replaced after scheduler config reload")
+	}
+	if enabled := predicateEnabled(t, newFramework); enabled == nil || *enabled {
+		t.Fatalf("expected predicates to be disabled after reload, got %v", enabled)
+	}
+}
+
+func TestLoadSchedulerConfDoesNotWaitForIdleWorkerPop(t *testing.T) {
+	agentuthelper.InitTestEnv(t)
+	framework.RegisterAction(&noopAction{})
+
+	confPath := filepath.Join(t.TempDir(), "agent-scheduler.conf")
+	writeSchedulerConf(t, confPath, `
+actions: "noop"
+tiers:
+- plugins:
+  - name: predicates
+`)
+
+	testFwk, err := agentuthelper.NewTestFramework(
+		"test-scheduler",
+		1,
+		[]framework.Action{&noopAction{}},
+		agentuthelper.DefaultTiers(),
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("failed to create test framework: %v", err)
+	}
+	defer testFwk.Close()
+
+	sched := &Scheduler{
+		cache:              testFwk.MockCache,
+		schedulerConf:      confPath,
+		disableDefaultConf: true,
+	}
+	sched.loadSchedulerConf()
+	worker := sched.newWorker(0)
+	sched.addWorker(worker)
+
+	runOnceStarted := make(chan struct{})
+	go func() {
+		close(runOnceStarted)
+		worker.runOnce()
+	}()
+	<-runOnceStarted
+
+	reloadDone := make(chan struct{})
+	go func() {
+		sched.loadSchedulerConf()
+		close(reloadDone)
+	}()
+
+	select {
+	case <-reloadDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("scheduler config reload blocked while worker was waiting for a pod")
+	}
+}
+
+func writeSchedulerConf(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
+		t.Fatalf("failed to write scheduler config: %v", err)
+	}
+}
+
+func predicateEnabled(t *testing.T, fwk *framework.Framework) *bool {
+	t.Helper()
+	for _, tier := range fwk.Tiers {
+		for _, plugin := range tier.Plugins {
+			if plugin.Name == predicates.PluginName {
+				return plugin.EnabledPredicate
+			}
+		}
+	}
+	t.Fatalf("failed to find %s plugin", predicates.PluginName)
+	return nil
 }
 
 func TestConcurrentRunOnce(t *testing.T) {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

This PR fixes agent scheduler configuration hot reload so that updated scheduler configuration is applied to already running workers.

Previously, `watchSchedulerConf` could reload the scheduler config and log a successful reload, but existing workers kept using the framework created during scheduler startup. As a result, changes to plugin configuration, such as disabling `predicates.enablePredicate`, did not affect newly scheduled Pods until the agent scheduler Pod was restarted.

This PR updates the agent scheduler to:

- Track running workers in the scheduler.
- Rebuild each worker's framework after scheduler config reload succeeds.
- Re-run action initialization when applying a new config.
- Avoid holding the worker framework lock while waiting on `SchedulingQueue.Pop`.
- Preserve default config fallback behavior and action initialization.

#### Which issue(s) this PR fixes:

Fixes #5553

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```