### PR TITLE
perf: remove unnecessary Clone() in NodeInfo.SetNode

### DIFF
--- a/pkg/scheduler/api/node_info.go
+++ b/pkg/scheduler/api/node_info.go
@@ -340,26 +340,14 @@ func (ni *NodeInfo) setNodeState(node *v1.Node) {
 
 // SetNode sets kubernetes node object to nodeInfo object
 func (ni *NodeInfo) SetNode(node *v1.Node) {
-	ni.setNodeState(node)
-	if !ni.Ready() {
+	if node == nil {
+		ni.setNodeState(nil)
 		klog.Warningf("Failed to set node info for %s, phase: %s, reason: %s",
 			ni.Name, ni.State.Phase, ni.State.Reason)
 		return
 	}
-
-	// Dry run, make sure all fields other than `State` are in the original state.
-	copy := ni.Clone()
-	copy.setNode(node)
-	copy.setNodeState(node)
-	if !copy.Ready() {
-		klog.Warningf("SetNode makes node %s not ready, phase: %s, reason: %s",
-			copy.Name, copy.State.Phase, copy.State.Reason)
-		// Set state of node to !Ready, left other fields untouched
-		ni.State = copy.State
-		return
-	}
-
 	ni.setNode(node)
+	ni.setNodeState(node)
 }
 
 // setNodeOthersResource initialize sharable devices

--- a/pkg/scheduler/api/node_info.go
+++ b/pkg/scheduler/api/node_info.go
@@ -340,14 +340,13 @@ func (ni *NodeInfo) setNodeState(node *v1.Node) {
 
 // SetNode sets kubernetes node object to nodeInfo object
 func (ni *NodeInfo) SetNode(node *v1.Node) {
-	if node == nil {
-		ni.setNodeState(nil)
+	ni.setNodeState(node)
+	if !ni.Ready() {
 		klog.Warningf("Failed to set node info for %s, phase: %s, reason: %s",
 			ni.Name, ni.State.Phase, ni.State.Reason)
 		return
 	}
 	ni.setNode(node)
-	ni.setNodeState(node)
 }
 
 // setNodeOthersResource initialize sharable devices

--- a/pkg/scheduler/api/node_info_test.go
+++ b/pkg/scheduler/api/node_info_test.go
@@ -315,6 +315,29 @@ func BenchmarkSetNode(b *testing.B) {
 	}
 }
 
+// BenchmarkNodeInfoClone measures the per-call cost of Clone() to show what
+// SetNode was paying on every invocation before this optimization.
+func BenchmarkNodeInfoClone(b *testing.B) {
+	node := buildNode("n1", nil, BuildResourceList("16", "32G", []ScalarResource{{Name: "pods", Value: "110"}}...))
+
+	pods := make([]*v1.Pod, 20)
+	for i := range pods {
+		pods[i] = buildPod("default", fmt.Sprintf("p%d", i), "n1", v1.PodRunning,
+			BuildResourceList("100m", "128Mi"), []metav1.OwnerReference{}, make(map[string]string))
+	}
+
+	ni := NewNodeInfo(node)
+	for _, pod := range pods {
+		_ = ni.AddTask(NewTaskInfo(pod))
+	}
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_ = ni.Clone()
+	}
+}
+
 func TestCloneOthersPreservesTypedNilDevices(t *testing.T) {
 	ni := &NodeInfo{
 		Name: "test-node",

--- a/pkg/scheduler/api/node_info_test.go
+++ b/pkg/scheduler/api/node_info_test.go
@@ -17,6 +17,7 @@
 package api
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
 
@@ -284,6 +285,32 @@ func TestNodeInfo_SetNode(t *testing.T) {
 		if !nodeInfoEqual(ni, test.expected2) {
 			t.Errorf("recovered %d: \n expected\t%v, \n got\t\t%v \n",
 				i, test.expected2, ni)
+		}
+	}
+}
+
+func BenchmarkSetNode(b *testing.B) {
+	node1 := buildNode("n1", nil, BuildResourceList("16", "32G", []ScalarResource{{Name: "pods", Value: "110"}}...))
+	node2 := buildNode("n1", nil, BuildResourceList("16", "32G", []ScalarResource{{Name: "pods", Value: "110"}}...))
+
+	pods := make([]*v1.Pod, 20)
+	for i := range pods {
+		pods[i] = buildPod("default", fmt.Sprintf("p%d", i), "n1", v1.PodRunning,
+			BuildResourceList("100m", "128Mi"), []metav1.OwnerReference{}, make(map[string]string))
+	}
+
+	ni := NewNodeInfo(node1)
+	for _, pod := range pods {
+		_ = ni.AddTask(NewTaskInfo(pod))
+	}
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		if i%2 == 0 {
+			ni.SetNode(node2)
+		} else {
+			ni.SetNode(node1)
 		}
 	}
 }


### PR DESCRIPTION
## What type of PR is this?

/kind cleanup

## What this PR does / why we need it

`NodeInfo.SetNode()` currently performs a defensive `NodeInfo.Clone()` before applying every node update. The cloned object is used only for a readiness check and is discarded immediately afterward.

After reviewing the implementation, the clone was found to be unnecessary. `setNodeState()` only marks a node as `NotReady` when the input node is `nil`; for any non-nil node it always sets the state to `Ready`. As a result, the readiness check on the cloned `NodeInfo` always succeeds, making the clone redundant.

This PR removes the unnecessary clone while preserving the existing nil-node guard before calling `setNode()`. Since `setNode()` rebuilds the node's resource accounting from the current `Tasks` map, the scheduler behavior remains unchanged while avoiding an expensive deep copy on every node update.

### Changes

- Remove the redundant `NodeInfo.Clone()` call from `SetNode()`
- Preserve the existing nil-node safety check
- Remove the unused dry-run logic
- Reduce unnecessary CPU usage and memory allocations during frequent node updates

## Which issue(s) this PR fixes

Fixes #5555 

## Special notes for your reviewer

- `setNode()` was reviewed to ensure it remains safe without the defensive clone.
- Resource accounting is recomputed from the existing `Tasks` map, making the operation idempotent.
- This change preserves the existing behavior while eliminating unnecessary allocations on node heartbeats, informer resyncs, and other node update events.

## Does this PR introduce a user-facing change?

```release-note
NONE
```