### PR TITLE
Add in-scope/out-of-scope to SECURITY-INSIGHTS.yml

### DIFF
--- a/SECURITY-INSIGHTS.yml
+++ b/SECURITY-INSIGHTS.yml
@@ -63,6 +63,16 @@ vulnerability-reporting:
   accepts-vulnerability-reports: true
   email-contact: 'volcano-security@googlegroups.com'
   security-policy: 'https://github.com/volcano-sh/community/blob/master/SECURITY.md'
+  in-scope:
+    - 'Privilege escalation or scheduling-decision bypass in the Volcano scheduler, controller-manager, and admission webhooks'
+    - 'Tenant isolation breakout across Queues, PodGroups, and namespaces (e.g. quota, fair-share, or preemption affecting another tenant''s workloads)'
+    - 'Improper RBAC defaults in the shipped manifests and Helm charts that grant excessive permissions to Volcano components'
+    - 'Insecure handling of user-controlled CRD fields (Job, Queue, PodGroup) that leads to host or cluster compromise'
+  out-of-scope:
+    - 'Vulnerabilities in Kubernetes core, the kube-apiserver, or other core Kubernetes components, which are handled by the Kubernetes security process at https://kubernetes.io/security/'
+    - 'Issues that only affect unsupported Volcano releases; only the latest supported releases receive fixes'
+    - 'Insecure configuration in a consuming cluster, such as disabling admission webhooks, relaxing the provided RBAC, or running components with custom privileges'
+    - 'Reports requiring pre-existing cluster-admin or equivalent privileged access, since such access already permits the reported impact'
 
 dependencies:
   dependencies-lists:


### PR DESCRIPTION
### What type of PR is this?

/kind cleanup
/area security

### What this PR does / why we need it:

The `vulnerability-reporting` section of `SECURITY-INSIGHTS.yml` currently
declares only `accepts-vulnerability-reports`, `email-contact` and
`security-policy`. It is missing the `in-scope` and `out-of-scope` subsections
defined by the OpenSSF Security Insights schema. This PR fills them in so the
document is complete and Volcano's security posture reporting (CLOMonitor /
Scorecard) reflects an explicit vulnerability reporting scope.

The scope is described in terms of Volcano's actual attack surface:

- **In-scope:** privilege escalation or scheduling-decision bypass in the
  scheduler, controller-manager and admission webhooks; tenant isolation breakout
  across Queues, PodGroups and namespaces (quota, fair-share, or preemption
  affecting another tenant's workloads); insecure RBAC defaults in the shipped
  manifests and Helm charts; and insecure handling of user-controlled CRD fields
  (Job, Queue, PodGroup).
- **Out-of-scope:** vulnerabilities in Kubernetes core (delegated to the upstream
  Kubernetes security process), issues that only affect unsupported Volcano
  releases, insecure configuration in a consuming cluster, and reports that
  require pre-existing privileged (cluster-admin) access.

Maintainers should feel free to adjust the scope wording to match the security
team's intended reporting boundaries.

### Special notes for your reviewer:

The scope items reflect my reading of Volcano's architecture and the Kubernetes
ecosystem security conventions; please correct anything that does not match the
maintainers' intended reporting scope.

> AI usage disclosure: I used an AI assistant to help draft the scope wording and
> the prose in this PR. The technical content reflects my own review of Volcano's
> architecture, and I take responsibility for the change.
