### PR TITLE
webhooks: reject malformed JDB percentages

### DIFF
--- a/installer/helm/chart/volcano/policy/pods-validating.yaml
+++ b/installer/helm/chart/volcano/policy/pods-validating.yaml
@@ -35,7 +35,7 @@ spec:
           int(object.metadata.annotations["volcano.sh/jdb-min-available"].replace('%', '')) > 0 &&
           int(object.metadata.annotations["volcano.sh/jdb-min-available"].replace('%', '')) < 100
         )
-      message: "jdb-min-available must be a positive integer or a valid percentage which between 1% ~ 99%"
+      message: "jdb-min-available must be a positive integer or a valid percentage between 1% and 99%"
       reason: Invalid
     # not allow negative values for jdb-max-unavailable
     - expression: |
@@ -49,7 +49,7 @@ spec:
           int(object.metadata.annotations["volcano.sh/jdb-max-unavailable"].replace('%', '')) > 0 &&
           int(object.metadata.annotations["volcano.sh/jdb-max-unavailable"].replace('%', '')) < 100
         )
-      message: "jdb-max-unavailable must be a positive integer or a valid percentage which between 1% ~ 99%"
+      message: "jdb-max-unavailable must be a positive integer or a valid percentage between 1% and 99%"
       reason: Invalid
 
 ---

--- a/pkg/webhooks/admission/pods/validate/admit_pod.go
+++ b/pkg/webhooks/admission/pods/validate/admit_pod.go
@@ -147,13 +147,19 @@ func validateIntPercentageStr(key, value string) error {
 		}
 		return nil
 	case intstr.String:
-		s := strings.Replace(tmp.StrVal, "%", "", -1)
+		if !strings.Contains(tmp.StrVal, "%") {
+			return fmt.Errorf("invalid value <%q> for %v, it must be a positive integer or a percentage between 1%% and 99%%", tmp.StrVal, key)
+		}
+		if strings.Count(tmp.StrVal, "%") != 1 || !strings.HasSuffix(tmp.StrVal, "%") {
+			return fmt.Errorf("invalid value <%q> for %v, it must be a valid percentage between 1%% and 99%%", tmp.StrVal, key)
+		}
+		s := strings.TrimSuffix(tmp.StrVal, "%")
 		v, err := strconv.Atoi(s)
 		if err != nil {
 			return fmt.Errorf("invalid value %v for %v", err, key)
 		}
 		if v <= 0 || v >= 100 {
-			return fmt.Errorf("invalid value <%q> for %v, it must be a valid percentage which between 1%% ~ 99%%", tmp.StrVal, key)
+			return fmt.Errorf("invalid value <%q> for %v, it must be a valid percentage between 1%% and 99%%", tmp.StrVal, key)
 		}
 		return nil
 	}

--- a/pkg/webhooks/admission/pods/validate/admit_pod_test.go
+++ b/pkg/webhooks/admission/pods/validate/admit_pod_test.go
@@ -132,3 +132,31 @@ func TestValidatePod(t *testing.T) {
 		}
 	}
 }
+
+func TestValidateIntPercentageStr(t *testing.T) {
+	testCases := []struct {
+		name      string
+		value     string
+		expectErr bool
+	}{
+		{"valid integer", "3", false},
+		{"valid percentage", "50%", false},
+		{"invalid string", "abc", true},
+		{"large integer", "3000000000", true},
+		{"double percent", "50%%", true},
+		{"percent in middle", "5%0", true},
+		{"percent prefix", "%50", true},
+		{"zero percent", "0%", true},
+		{"hundred percent", "100%", true},
+	}
+
+	for _, testCase := range testCases {
+		err := validateIntPercentageStr(vcschedulingv1.JDBMinAvailable, testCase.value)
+		if testCase.expectErr && err == nil {
+			t.Errorf("%s: expect error, but got nil", testCase.name)
+		}
+		if !testCase.expectErr && err != nil {
+			t.Errorf("%s: expect no error, but got %v", testCase.name, err)
+		}
+	}
+}

--- a/test/e2e/admission/pod_validation_test.go
+++ b/test/e2e/admission/pod_validation_test.go
@@ -152,7 +152,7 @@ var _ = ginkgo.Describe("Pod Validating E2E Test", func() {
 
 		_, err := testCtx.Kubeclient.CoreV1().Pods(testCtx.Namespace).Create(context.TODO(), pod, metav1.CreateOptions{})
 		gomega.Expect(err).To(gomega.HaveOccurred())
-		gomega.Expect(err.Error()).To(gomega.ContainSubstring("percentage which between 1% ~ 99%"))
+		gomega.Expect(err.Error()).To(gomega.ContainSubstring("percentage between 1% and 99%"))
 	})
 
 	ginkgo.It("Should reject pod creation with invalid percentage annotation (100%)", func() {
@@ -176,7 +176,7 @@ var _ = ginkgo.Describe("Pod Validating E2E Test", func() {
 
 		_, err := testCtx.Kubeclient.CoreV1().Pods(testCtx.Namespace).Create(context.TODO(), pod, metav1.CreateOptions{})
 		gomega.Expect(err).To(gomega.HaveOccurred())
-		gomega.Expect(err.Error()).To(gomega.ContainSubstring("percentage which between 1% ~ 99%"))
+		gomega.Expect(err.Error()).To(gomega.ContainSubstring("percentage between 1% and 99%"))
 	})
 
 	ginkgo.It("Should reject pod creation with invalid string annotation", func() {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Reject malformed JDB percentage annotations in the pod validating webhook.

Values like `50%%` were accepted because the validator removed all `%` chars before parsing. Now percentages must use the normal trailing `%` form.

#### Which issue(s) this PR fixes:

Fixes: None

#### Special notes for your reviewer:

NONE

#### Does this PR introduce a user-facing change?

```release-note
Reject malformed JDB percentage annotations in the pod validating webhook.