### PR TITLE
Fix agent scheduler queue cleanup on early exits

### DIFF
--- a/pkg/agentscheduler/scheduler.go
+++ b/pkg/agentscheduler/scheduler.go
@@ -153,6 +153,11 @@ func (worker *Worker) runOnce() {
 	snapshotStart := time.Now()
 	if err := worker.framework.Cache.UpdateSnapshot(snapshot); err != nil {
 		klog.Errorf("Failed to update snapshot in worker %d: %v, skip this scheduling cycle", worker.index, err)
+		queue := worker.framework.Cache.SchedulingQueue()
+		if err := queue.AddUnschedulableIfNotPresent(klog.Background(), schedCtx.QueuedPodInfo, queue.SchedulingCycle()); err != nil {
+			klog.ErrorS(err, "Failed to add pod back to scheduling queue",
+				"pod", klog.KObj(schedCtx.QueuedPodInfo.Pod))
+		}
 		return
 	}
 	agentmetrics.UpdateUpdateSnapshotDuration(time.Since(snapshotStart))
@@ -199,6 +204,7 @@ func (worker *Worker) generateNextSchedulingContext() (*agentapi.SchedulingConte
 	task, exist := worker.framework.Cache.GetTaskInfo(schedulingapi.TaskID(podInfo.Pod.UID))
 	if !exist {
 		klog.Warningf("Task %s/%s not found in cache, skip scheduling", podInfo.Pod.Namespace, podInfo.Pod.Name)
+		queue.Done(podInfo.Pod.UID)
 		return nil, nil
 	}
 

--- a/pkg/agentscheduler/scheduler_test.go
+++ b/pkg/agentscheduler/scheduler_test.go
@@ -1,19 +1,25 @@
 package agentscheduler
 
 import (
+	"errors"
 	"fmt"
 	v1 "k8s.io/api/core/v1"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	"k8s.io/klog/v2"
+	"k8s.io/kubernetes/pkg/features"
 	"sync"
 	"testing"
 
 	"volcano.sh/volcano/cmd/agent-scheduler/app/options"
 	scheduleroptions "volcano.sh/volcano/cmd/scheduler/app/options"
 	agentapi "volcano.sh/volcano/pkg/agentscheduler/api"
+	agentcache "volcano.sh/volcano/pkg/agentscheduler/cache"
 	"volcano.sh/volcano/pkg/agentscheduler/framework"
 	agentuthelper "volcano.sh/volcano/pkg/agentscheduler/uthelper"
 	schedulingapi "volcano.sh/volcano/pkg/scheduler/api"
 	"volcano.sh/volcano/pkg/scheduler/conf"
+	k8sutil "volcano.sh/volcano/pkg/scheduler/plugins/util/k8s"
 	"volcano.sh/volcano/pkg/scheduler/util"
 	commonutil "volcano.sh/volcano/pkg/util"
 )
@@ -25,6 +31,14 @@ func (a *noopAction) OnActionInit(_ []conf.Configuration)                       
 func (a *noopAction) Initialize()                                                   {}
 func (a *noopAction) Execute(_ *framework.Framework, _ *agentapi.SchedulingContext) {}
 func (a *noopAction) UnInitialize()                                                 {}
+
+type failingSnapshotCache struct {
+	agentcache.Cache
+}
+
+func (c *failingSnapshotCache) UpdateSnapshot(_ *k8sutil.Snapshot) error {
+	return errors.New("injected snapshot failure")
+}
 
 func TestConcurrentRunOnce(t *testing.T) {
 	agentuthelper.InitTestEnv(t)
@@ -74,5 +88,78 @@ func TestConcurrentRunOnce(t *testing.T) {
 	close(panicCh)
 	for p := range panicCh {
 		t.Fatalf("unexpected panic in runOnce: %v", p)
+	}
+}
+
+func TestRunOnceCleansQueueWhenTaskMissing(t *testing.T) {
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.SchedulerQueueingHints, true)
+	agentuthelper.InitTestEnv(t)
+	options.ServerOpts.ShardingMode = commonutil.NoneShardingMode
+	scheduleroptions.ServerOpts.ShardingMode = commonutil.NoneShardingMode
+
+	testFwk, err := agentuthelper.NewTestFramework(
+		"test-scheduler",
+		1,
+		[]framework.Action{&noopAction{}},
+		nil,
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("failed to create test framework: %v", err)
+	}
+	defer testFwk.Close()
+
+	pod := util.BuildPod("default", "missing-task", "", v1.PodPending, v1.ResourceList{}, "", map[string]string{}, map[string]string{})
+	pod.Spec.SchedulerName = "test-scheduler"
+	testFwk.SchedulingQueue.Add(klog.Background(), pod)
+
+	worker := &Worker{
+		framework: testFwk.Frameworks[0],
+		index:     0,
+	}
+	worker.runOnce()
+
+	if pods := testFwk.SchedulingQueue.InFlightPods(); len(pods) != 0 {
+		t.Fatalf("expected no in-flight pods after missing task, got %d", len(pods))
+	}
+}
+
+func TestRunOnceRequeuesWhenSnapshotUpdateFails(t *testing.T) {
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.SchedulerQueueingHints, true)
+	agentuthelper.InitTestEnv(t)
+	options.ServerOpts.ShardingMode = commonutil.NoneShardingMode
+	scheduleroptions.ServerOpts.ShardingMode = commonutil.NoneShardingMode
+
+	testFwk, err := agentuthelper.NewTestFramework(
+		"test-scheduler",
+		1,
+		[]framework.Action{&noopAction{}},
+		nil,
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("failed to create test framework: %v", err)
+	}
+	defer testFwk.Close()
+
+	pod := util.BuildPod("default", "snapshot-failure", "", v1.PodPending, v1.ResourceList{}, "", map[string]string{}, map[string]string{})
+	pod.Spec.SchedulerName = "test-scheduler"
+	task := schedulingapi.NewTaskInfo(pod)
+	testFwk.MockCache.AddTaskInfo(task)
+	testFwk.SchedulingQueue.Add(klog.Background(), pod)
+
+	testFwk.Frameworks[0].Cache = &failingSnapshotCache{Cache: testFwk.MockCache}
+	worker := &Worker{
+		framework: testFwk.Frameworks[0],
+		index:     0,
+	}
+	worker.runOnce()
+
+	if pods := testFwk.SchedulingQueue.InFlightPods(); len(pods) != 0 {
+		t.Fatalf("expected no in-flight pods after snapshot failure, got %d", len(pods))
+	}
+	pendingPods, _ := testFwk.SchedulingQueue.PendingPods()
+	if len(pendingPods) != 1 {
+		t.Fatalf("expected pod to be requeued after snapshot failure, got %d pending pods", len(pendingPods))
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Fixes two early-return paths after agent-scheduler pops a pod from the scheduling queue:

- If the corresponding `TaskInfo` no longer exists, mark the pod as done in the queue.
- If snapshot update fails before scheduling starts, add the pod back to the scheduling queue.

This prevents popped pods from being left in the queue's in-flight state or dropped from the scheduling flow.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```