### PR TITLE
[Performance]scheduler: reduce predicate failure bookkeeping

### DIFF
--- a/pkg/scheduler/framework/session.go
+++ b/pkg/scheduler/framework/session.go
@@ -557,6 +557,8 @@ func updateQueueStatus(ssn *Session) {
 }
 
 func closeSession(ssn *Session) {
+	logTaskFitErrors(ssn)
+
 	ju := NewJobUpdater(ssn)
 	ju.UpdateAll()
 
@@ -576,6 +578,24 @@ func closeSession(ssn *Session) {
 	ssn.cache.OnSessionClose()
 
 	klog.V(3).Infof("Close Session %v", ssn.UID)
+}
+
+func logTaskFitErrors(ssn *Session) {
+	if !klog.V(3).Enabled() {
+		return
+	}
+	for _, job := range ssn.Jobs {
+		for taskID, fitErr := range job.NodesFitErrors {
+			if fitErr == nil {
+				continue
+			}
+			task, ok := job.Tasks[taskID]
+			if !ok {
+				continue
+			}
+			klog.InfoS("Task unschedulable", "task", klog.KRef(task.Namespace, task.Name), "reason", fitErr.Error())
+		}
+	}
 }
 
 func getPodGroupPhase(jobInfo *api.JobInfo, unschedulable bool) scheduling.PodGroupPhase {

--- a/pkg/scheduler/framework/session.go
+++ b/pkg/scheduler/framework/session.go
@@ -557,6 +557,8 @@ func updateQueueStatus(ssn *Session) {
 }
 
 func closeSession(ssn *Session) {
+	logTaskFitErrors(ssn)
+
 	ju := NewJobUpdater(ssn)
 	ju.UpdateAll()
 
@@ -576,6 +578,24 @@ func closeSession(ssn *Session) {
 	ssn.cache.OnSessionClose()
 
 	klog.V(3).Infof("Close Session %v", ssn.UID)
+}
+
+func logTaskFitErrors(ssn *Session) {
+	if !klog.V(5).Enabled() {
+		return
+	}
+	for _, job := range ssn.Jobs {
+		for taskID, fitErr := range job.NodesFitErrors {
+			if fitErr == nil {
+				continue
+			}
+			task, ok := job.Tasks[taskID]
+			if !ok {
+				continue
+			}
+			klog.V(5).InfoS("Task unschedulable", "task", klog.KRef(task.Namespace, task.Name), "reason", fitErr.Error())
+		}
+	}
 }
 
 func getPodGroupPhase(jobInfo *api.JobInfo, unschedulable bool) scheduling.PodGroupPhase {

--- a/pkg/scheduler/util/predicate_helper.go
+++ b/pkg/scheduler/util/predicate_helper.go
@@ -19,7 +19,6 @@ package util
 import (
 	"context"
 	"fmt"
-	"sync"
 	"sync/atomic"
 	"time"
 
@@ -43,7 +42,6 @@ type predicateHelper struct {
 
 // PredicateNodes returns the specified number of nodes that fit a task
 func (ph *predicateHelper) PredicateNodes(task *api.TaskInfo, nodes []*api.NodeInfo, fn api.PredicateFn, enableErrorCache bool, nodesInShard sets.Set[string]) ([]*api.NodeInfo, *api.FitErrors) {
-	var errorLock sync.RWMutex
 	fe := api.NewFitErrors()
 
 	// don't enable error cache if task's TaskRole is empty, because different pods with empty TaskRole will all
@@ -70,6 +68,11 @@ func (ph *predicateHelper) PredicateNodes(task *api.TaskInfo, nodes []*api.NodeI
 	if nodeErrorCache == nil {
 		nodeErrorCache = map[string]error{}
 	}
+	type nodePredicateError struct {
+		nodeName string
+		err      error
+	}
+	nodeErrors := make([]nodePredicateError, allNodes)
 
 	startIndex := int(lastProcessedNodeIndex.Load())
 
@@ -87,37 +90,23 @@ func (ph *predicateHelper) PredicateNodes(task *api.TaskInfo, nodes []*api.NodeI
 		// Check if the task had "predicate" failure before.
 		// And then check if the task failed to predict on this node before.
 		if enableErrorCache && taskFailedBefore {
-			errorLock.RLock()
 			errC, ok := nodeErrorCache[node.Name]
-			errorLock.RUnlock()
 
 			if ok {
-				errorLock.Lock()
-				fe.SetNodeError(node.Name, errC)
-				errorLock.Unlock()
+				nodeErrors[index] = nodePredicateError{nodeName: node.Name, err: errC}
 				return
 			}
 		}
 
 		if options.ServerOpts.ShardingMode == util.HardShardingMode && !nodesInShard.Has(node.Name) {
-			klog.V(3).Infof("Predicates failed: node %s is not in scheduler shard", node.Name)
 			err := fmt.Errorf("node isn't in scheduler node shard")
-			errorLock.Lock()
-			nodeErrorCache[node.Name] = err
-			ph.taskPredicateErrorCache[taskGroupid] = nodeErrorCache
-			fe.SetNodeError(node.Name, err)
-			errorLock.Unlock()
+			nodeErrors[index] = nodePredicateError{nodeName: node.Name, err: err}
 			return
 		}
 
 		// TODO (k82cn): Enable eCache for performance improvement.
 		if err := fn(task, node); err != nil {
-			klog.V(3).Infof("Predicates failed: %v", err)
-			errorLock.Lock()
-			nodeErrorCache[node.Name] = err
-			ph.taskPredicateErrorCache[taskGroupid] = nodeErrorCache
-			fe.SetNodeError(node.Name, err)
-			errorLock.Unlock()
+			nodeErrors[index] = nodePredicateError{nodeName: node.Name, err: err}
 			return
 		}
 
@@ -136,10 +125,25 @@ func (ph *predicateHelper) PredicateNodes(task *api.TaskInfo, nodes []*api.NodeI
 	workqueue.ParallelizeUntil(ctx, 16, allNodes, checkNode)
 	metrics.UpdateSchedulingStageDuration(metrics.SchedulingStagePredicate, time.Since(predicateStart))
 
+	predicateNodes = predicateNodes[:numFoundNodes]
+	for _, nodeErr := range nodeErrors {
+		if nodeErr.err == nil {
+			continue
+		}
+		if enableErrorCache {
+			nodeErrorCache[nodeErr.nodeName] = nodeErr.err
+		}
+		if len(predicateNodes) == 0 {
+			fe.SetNodeError(nodeErr.nodeName, nodeErr.err)
+		}
+	}
+	if enableErrorCache && len(nodeErrorCache) > 0 {
+		ph.taskPredicateErrorCache[taskGroupid] = nodeErrorCache
+	}
+
 	newIndex := int64((startIndex + int(processedNodes)) % allNodes)
 	lastProcessedNodeIndex.Store(newIndex)
 
-	predicateNodes = predicateNodes[:numFoundNodes]
 	return predicateNodes, fe
 }
 

--- a/pkg/scheduler/util/predicate_helper_test.go
+++ b/pkg/scheduler/util/predicate_helper_test.go
@@ -104,6 +104,35 @@ func TestPredicateNodes(t *testing.T) {
 			expectedErrCache: map[string]map[string]string{},
 		},
 		{
+			name: "predicate success keeps enabled error cache",
+			task: &api.TaskInfo{
+				Job:       "job1",
+				TaskRole:  "worker",
+				Namespace: "ns",
+				Name:      "task",
+			},
+			nodes: []*api.NodeInfo{
+				{Name: "node1"},
+				{Name: "node2"},
+			},
+			nodesInShard:     sets.New[string]("node1", "node2"),
+			shardingMode:     commonutil.NoneShardingMode,
+			enableErrorCache: true,
+			predicateFn: func(_ *api.TaskInfo, node *api.NodeInfo) error {
+				if node.Name == "node1" {
+					return fmt.Errorf("predicate failed")
+				}
+				return nil
+			},
+			expectedNodes: []string{"node2"},
+			expectedErr:   "",
+			expectedErrCache: map[string]map[string]string{
+				"job1/worker": {
+					"node1": "predicate failed",
+				},
+			},
+		},
+		{
 			name: "hard sharding rejects nodes outside shard",
 			task: &api.TaskInfo{
 				Job:       "job1",
@@ -120,11 +149,7 @@ func TestPredicateNodes(t *testing.T) {
 			predicateFn:      func(*api.TaskInfo, *api.NodeInfo) error { return nil },
 			expectedNodes:    []string{},
 			expectedErr:      "0/1 nodes are unavailable: 1 node isn't in scheduler node shard.",
-			expectedErrCache: map[string]map[string]string{
-				"job1/worker": {
-					"node2": "node isn't in scheduler node shard",
-				},
-			},
+			expectedErrCache: map[string]map[string]string{},
 		},
 		{
 			name: "soft sharding allows nodes outside shard",
@@ -164,12 +189,7 @@ func TestPredicateNodes(t *testing.T) {
 			predicateFn:      func(*api.TaskInfo, *api.NodeInfo) error { return nil },
 			expectedNodes:    []string{"node1"},
 			expectedErr:      "",
-			expectedErrCache: map[string]map[string]string{
-				"job1/worker": {
-					"node2": "node isn't in scheduler node shard",
-					"node3": "node isn't in scheduler node shard",
-				},
-			},
+			expectedErrCache: map[string]map[string]string{},
 		},
 	}
 


### PR DESCRIPTION
#### What type of PR is this?

/kind performance

#### What this PR does / why we need it:

This reduces the work done on the predicate failure path.

When many nodes fail predicate, `PredicateNodes` used to write predicate errors into shared maps from worker goroutines and log every failed node at `V(3)`. This PR records failed nodes in a per-index slice during parallel predicate, then updates the predicate error cache after workers finish.

`FitErrors` are now populated only when no candidate node is found. The predicate error cache is still kept when `enableErrorCache` is enabled, so homogeneous gang tasks can continue to reuse failed node results.

#### Which issue(s) this PR fixes:

N/A

#### Special notes for your reviewer:

`PredicateFn` is unchanged. This keeps the existing plugin extension point compatible.

AI assistance was used to prepare this patch.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
