### PR TITLE
Add vGPU pod identity annotations

### DIFF
--- a/pkg/scheduler/api/devices/nvidia/vgpu/device_info.go
+++ b/pkg/scheduler/api/devices/nvidia/vgpu/device_info.go
@@ -291,6 +291,9 @@ func (gs *GPUDevices) Release(kubeClient kubernetes.Interface, pod *v1.Pod) erro
 
 	keys := []string{
 		AssignedNodeAnnotations,          // volcano.sh/vgpu-node
+		AssignedPodNameAnnotations,       // volcano.sh/vgpu-pod-name
+		AssignedPodNamespaceAnnotations,  // volcano.sh/vgpu-pod-namespace
+		AssignedPodUIDAnnotations,        // volcano.sh/vgpu-pod-uid
 		AssignedIDsAnnotations,           // volcano.sh/vgpu-ids-new
 		AssignedIDsToAllocateAnnotations, // volcano.sh/devices-to-allocate
 		AssignedTimeAnnotations,          // volcano.sh/vgpu-time
@@ -324,6 +327,16 @@ func (gs *GPUDevices) Allocate(kubeClient kubernetes.Interface, pod *v1.Pod) err
 	if VGPUEnable {
 		klog.V(4).Infoln("hami-vgpu DeviceSharing:Into AllocateToPod", pod.Name)
 		if alreadyAssignedOnNode(pod, gs.Name) {
+			identityAnnotations := podIdentityAnnotations(pod)
+			if err := patchPodAnnotations(kubeClient, pod, identityAnnotations); err != nil {
+				return err
+			}
+			if pod.Annotations == nil {
+				pod.Annotations = map[string]string{}
+			}
+			for k, v := range identityAnnotations {
+				pod.Annotations[k] = v
+			}
 			klog.V(4).InfoS("hami-vgpu DeviceSharing: skip duplicate AllocateToPod",
 				"pod", pod.Name, "namespace", pod.Namespace, "node", gs.Name)
 			return nil
@@ -343,6 +356,9 @@ func (gs *GPUDevices) Allocate(kubeClient kubernetes.Interface, pod *v1.Pod) err
 
 		annotations := make(map[string]string)
 		annotations[AssignedNodeAnnotations] = gs.Name
+		for k, v := range podIdentityAnnotations(pod) {
+			annotations[k] = v
+		}
 		annotations[AssignedTimeAnnotations] = strconv.FormatInt(time.Now().Unix(), 10)
 		annotations[AssignedIDsAnnotations] = encodePodDevices(device)
 		annotations[AssignedIDsToAllocateAnnotations] = annotations[AssignedIDsAnnotations]
@@ -424,4 +440,12 @@ func alreadyAssignedOnNode(pod *v1.Pod, nodeName string) bool {
 
 	return pod.Annotations[AssignedNodeAnnotations] == nodeName &&
 		pod.Annotations[AssignedIDsAnnotations] != ""
+}
+
+func podIdentityAnnotations(pod *v1.Pod) map[string]string {
+	return map[string]string{
+		AssignedPodNameAnnotations:      pod.Name,
+		AssignedPodNamespaceAnnotations: pod.Namespace,
+		AssignedPodUIDAnnotations:       string(pod.UID),
+	}
 }

--- a/pkg/scheduler/api/devices/nvidia/vgpu/device_info_test.go
+++ b/pkg/scheduler/api/devices/nvidia/vgpu/device_info_test.go
@@ -204,8 +204,12 @@ func podWithVGPUAnnotations(phase string) *v1.Pod {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "worker-0",
 			Namespace: "default",
+			UID:       types.UID("worker-0-uid-1234"),
 			Annotations: map[string]string{
 				AssignedNodeAnnotations:          "node-a",
+				AssignedPodNameAnnotations:       "worker-0",
+				AssignedPodNamespaceAnnotations:  "default",
+				AssignedPodUIDAnnotations:        "worker-0-uid-1234",
 				AssignedIDsAnnotations:           "GPU-aaaa,NVIDIA,80,0:",
 				AssignedIDsToAllocateAnnotations: "GPU-aaaa,NVIDIA,80,0:",
 				AssignedTimeAnnotations:          "1700000000",
@@ -231,6 +235,9 @@ func TestReleaseCleansSpeculativeAnnotations(t *testing.T) {
 	for _, k := range []string{
 		AssignedNodeAnnotations, AssignedIDsAnnotations,
 		AssignedIDsToAllocateAnnotations, DeviceBindPhase,
+		AssignedPodNameAnnotations, AssignedPodNamespaceAnnotations,
+		AssignedPodUIDAnnotations, AssignedTimeAnnotations,
+		BindTimeAnnotations,
 	} {
 		if _, ok := pod.Annotations[k]; ok {
 			t.Errorf("in-memory annotation %s should have been removed", k)
@@ -244,11 +251,16 @@ func TestReleaseCleansSpeculativeAnnotations(t *testing.T) {
 	if err != nil {
 		t.Fatalf("get pod: %v", err)
 	}
-	if _, ok := got.Annotations[AssignedNodeAnnotations]; ok {
-		t.Errorf("apiserver annotation %s should have been removed", AssignedNodeAnnotations)
-	}
-	if _, ok := got.Annotations[AssignedIDsAnnotations]; ok {
-		t.Errorf("apiserver annotation %s should have been removed", AssignedIDsAnnotations)
+	for _, k := range []string{
+		AssignedNodeAnnotations, AssignedIDsAnnotations,
+		AssignedIDsToAllocateAnnotations, DeviceBindPhase,
+		AssignedPodNameAnnotations, AssignedPodNamespaceAnnotations,
+		AssignedPodUIDAnnotations, AssignedTimeAnnotations,
+		BindTimeAnnotations,
+	} {
+		if _, ok := got.Annotations[k]; ok {
+			t.Errorf("apiserver annotation %s should have been removed", k)
+		}
 	}
 	if got.Annotations["keep-me"] != "yes" {
 		t.Errorf("non-device annotation must be preserved on apiserver")
@@ -268,8 +280,102 @@ func TestReleaseKeepsCommittedAnnotations(t *testing.T) {
 	if pod.Annotations[AssignedNodeAnnotations] != "node-a" {
 		t.Errorf("committed pod's vgpu-node must be preserved in-memory")
 	}
+	if pod.Annotations[AssignedPodNameAnnotations] != "worker-0" {
+		t.Errorf("committed pod's vgpu-pod-name must be preserved in-memory")
+	}
+	if pod.Annotations[AssignedPodNamespaceAnnotations] != "default" {
+		t.Errorf("committed pod's vgpu-pod-namespace must be preserved in-memory")
+	}
+	if pod.Annotations[AssignedPodUIDAnnotations] != "worker-0-uid-1234" {
+		t.Errorf("committed pod's vgpu-pod-uid must be preserved in-memory")
+	}
 	got, _ := client.CoreV1().Pods("default").Get(context.Background(), "worker-0", metav1.GetOptions{})
 	if got.Annotations[AssignedIDsAnnotations] == "" {
 		t.Errorf("committed pod's vgpu-ids-new must be preserved on apiserver")
+	}
+	if got.Annotations[AssignedPodNameAnnotations] != "worker-0" {
+		t.Errorf("committed pod's vgpu-pod-name must be preserved on apiserver")
+	}
+	if got.Annotations[AssignedPodNamespaceAnnotations] != "default" {
+		t.Errorf("committed pod's vgpu-pod-namespace must be preserved on apiserver")
+	}
+	if got.Annotations[AssignedPodUIDAnnotations] != "worker-0-uid-1234" {
+		t.Errorf("committed pod's vgpu-pod-uid must be preserved on apiserver")
+	}
+}
+
+func TestAllocateWritesPodIdentityAnnotations(t *testing.T) {
+	VGPUEnable = true
+	defer func() { VGPUEnable = false }()
+
+	gs := makeGPUDevices("node-a", 1, 80000, 4)
+	pod := makeVGPUPod("worker-0", "default", "worker-0", 40000, false, "")
+	client := fake.NewSimpleClientset(pod)
+
+	if err := gs.Allocate(client, pod); err != nil {
+		t.Fatalf("Allocate returned error: %v", err)
+	}
+
+	if pod.Annotations[AssignedPodNameAnnotations] != pod.Name {
+		t.Errorf("expected in-memory pod name annotation %q, got %q", pod.Name, pod.Annotations[AssignedPodNameAnnotations])
+	}
+	if pod.Annotations[AssignedPodNamespaceAnnotations] != pod.Namespace {
+		t.Errorf("expected in-memory pod namespace annotation %q, got %q", pod.Namespace, pod.Annotations[AssignedPodNamespaceAnnotations])
+	}
+	if pod.Annotations[AssignedPodUIDAnnotations] != string(pod.UID) {
+		t.Errorf("expected in-memory pod UID annotation %q, got %q", pod.UID, pod.Annotations[AssignedPodUIDAnnotations])
+	}
+
+	got, err := client.CoreV1().Pods(pod.Namespace).Get(context.Background(), pod.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get pod: %v", err)
+	}
+	if got.Annotations[AssignedPodNameAnnotations] != pod.Name {
+		t.Errorf("expected apiserver pod name annotation %q, got %q", pod.Name, got.Annotations[AssignedPodNameAnnotations])
+	}
+	if got.Annotations[AssignedPodNamespaceAnnotations] != pod.Namespace {
+		t.Errorf("expected apiserver pod namespace annotation %q, got %q", pod.Namespace, got.Annotations[AssignedPodNamespaceAnnotations])
+	}
+	if got.Annotations[AssignedPodUIDAnnotations] != string(pod.UID) {
+		t.Errorf("expected apiserver pod UID annotation %q, got %q", pod.UID, got.Annotations[AssignedPodUIDAnnotations])
+	}
+}
+
+func TestAllocateBackfillsPodIdentityAnnotationsWhenAlreadyAssigned(t *testing.T) {
+	VGPUEnable = true
+	defer func() { VGPUEnable = false }()
+
+	pod := makeVGPUPod("worker-0", "default", "worker-0", 40000, false, "")
+	pod.Annotations[AssignedNodeAnnotations] = "node-a"
+	pod.Annotations[AssignedIDsAnnotations] = "GPU-0000A,NVIDIA,40000,0:"
+	client := fake.NewSimpleClientset(pod)
+	gs := makeGPUDevices("node-a", 1, 80000, 4)
+
+	if err := gs.Allocate(client, pod); err != nil {
+		t.Fatalf("Allocate returned error: %v", err)
+	}
+
+	if pod.Annotations[AssignedPodNameAnnotations] != pod.Name {
+		t.Errorf("expected in-memory pod name annotation %q, got %q", pod.Name, pod.Annotations[AssignedPodNameAnnotations])
+	}
+	if pod.Annotations[AssignedPodNamespaceAnnotations] != pod.Namespace {
+		t.Errorf("expected in-memory pod namespace annotation %q, got %q", pod.Namespace, pod.Annotations[AssignedPodNamespaceAnnotations])
+	}
+	if pod.Annotations[AssignedPodUIDAnnotations] != string(pod.UID) {
+		t.Errorf("expected in-memory pod UID annotation %q, got %q", pod.UID, pod.Annotations[AssignedPodUIDAnnotations])
+	}
+
+	got, err := client.CoreV1().Pods(pod.Namespace).Get(context.Background(), pod.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get pod: %v", err)
+	}
+	if got.Annotations[AssignedPodNameAnnotations] != pod.Name {
+		t.Errorf("expected apiserver pod name annotation %q, got %q", pod.Name, got.Annotations[AssignedPodNameAnnotations])
+	}
+	if got.Annotations[AssignedPodNamespaceAnnotations] != pod.Namespace {
+		t.Errorf("expected apiserver pod namespace annotation %q, got %q", pod.Namespace, got.Annotations[AssignedPodNamespaceAnnotations])
+	}
+	if got.Annotations[AssignedPodUIDAnnotations] != string(pod.UID) {
+		t.Errorf("expected apiserver pod UID annotation %q, got %q", pod.UID, got.Annotations[AssignedPodUIDAnnotations])
 	}
 }

--- a/pkg/scheduler/api/devices/nvidia/vgpu/type.go
+++ b/pkg/scheduler/api/devices/nvidia/vgpu/type.go
@@ -26,6 +26,9 @@ const (
 	AssignedIDsAnnotations           = "volcano.sh/vgpu-ids-new"
 	AssignedIDsToAllocateAnnotations = "volcano.sh/devices-to-allocate"
 	AssignedNodeAnnotations          = "volcano.sh/vgpu-node"
+	AssignedPodNameAnnotations       = "volcano.sh/vgpu-pod-name"
+	AssignedPodNamespaceAnnotations  = "volcano.sh/vgpu-pod-namespace"
+	AssignedPodUIDAnnotations        = "volcano.sh/vgpu-pod-uid"
 	BindTimeAnnotations              = "volcano.sh/bind-time"
 	DeviceBindPhase                  = "volcano.sh/bind-phase"
 


### PR DESCRIPTION
## Summary

Add pod identity annotations to vGPU allocation metadata so downstream device plugins can identify the exact allocation target instead of relying only on timestamp ordering.

New annotations:
- `volcano.sh/vgpu-pod-name`
- `volcano.sh/vgpu-pod-namespace`
- `volcano.sh/vgpu-pod-uid`

The annotations are written alongside existing vGPU allocation metadata and are cleaned up on speculative release while preserved for committed `bind-phase=success` pods.

## Related Issue

Related to #5532.

## Testing

- `go test ./pkg/scheduler/api/devices/nvidia/vgpu`