### PR TITLE
docs: NamespaceQueue design proposal (#5251)

### DIFF
--- a/docs/design/namespace-queue.md
+++ b/docs/design/namespace-queue.md
@@ -62,8 +62,9 @@ namespaces may reference the same cluster `Queue`, and a namespace may host
 - Replacing or wrapping the cluster-scoped `Queue`. `NamespaceQueue` is
   **additive**; the current model is unchanged for clusters that do not opt in.
 - Introducing new tenant-isolation semantics.
-- Changing the meaning of `guarantee`, `deserved`, or `capability`. This proposal
-  does **not** alter how resource fields are defined or interpreted today.
+- Changing the meaning of `guarantee`, `capability`, or `weight`. The fields
+  `NamespaceQueueSpec` carries over from `Queue` keep their current definition and
+  interpretation; this proposal does not alter existing resource semantics.
 
 ## User Stories
 
@@ -89,50 +90,116 @@ exactly as before if I don't enable this feature.
 
 ### The `NamespaceQueue` CRD
 
-`NamespaceQueue` is namespace-scoped and **reuses the existing `QueueSpec`**, so
-`weight`, `capability`, `guarantee`, `deserved`, `reclaimable`, `priority`,
-`dequeueStrategy`, and `parent` keep identical semantics. This directly satisfies
-the non-goal of not changing resource-field meaning.
+`NamespaceQueue` is namespace-scoped and defines its own **`NamespaceQueueSpec`** —
+a curated subset of the cluster `Queue` surface (`parent`, `weight`, `capability`,
+`guarantee`). Each reused field keeps the same meaning it has on `Queue` today; the
+fields not carried over (`deserved`, `reclaimable`, `priority`, `dequeueStrategy`)
+are intentionally out of the v1 surface.
+
+Access control is **not** a field on `NamespaceQueueSpec`. Whether a namespace may
+parent its queues under a given cluster `Queue` is governed by a new
+`allowedNamespaces` field on the cluster `Queue` itself (see
+[Parent-queue ownership enforcement](#parent-queue-ownership-enforcement) below) —
+the authorization must be owned by the admin who owns the `Queue`, not declared by
+the tenant who is requesting to bind to it.
 
 ```go
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
-// +kubebuilder:resource:scope=Namespaced,shortName=nq
+// +kubebuilder:resource:path=namespacequeues,scope=Namespaced,shortName=nq
 
-// NamespaceQueue is the namespace-scoped counterpart of Queue.
+// NamespaceQueue is a namespace-scoped queue abstraction in Volcano scheduling.
 type NamespaceQueue struct {
     metav1.TypeMeta   `json:",inline"`
     metav1.ObjectMeta `json:"metadata,omitempty"`
 
-    // Spec reuses QueueSpec; spec.parent references either a NamespaceQueue in
-    // the same namespace or a cluster Queue (resolution is namespace-first).
-    Spec   QueueSpec            `json:"spec,omitempty"`
+    Spec   NamespaceQueueSpec   `json:"spec,omitempty"`
     Status NamespaceQueueStatus `json:"status,omitempty"`
+}
+
+type NamespaceQueueSpec struct {
+    // ===== 1. hierarchy (core) =====
+    // parent can be a cluster Queue or another NamespaceQueue
+    // (resolution is namespace-first).
+    Parent string `json:"parent"`
+
+    // ===== 2. scheduling policy =====
+    // queue weight used in fair sharing / DRF
+    Weight int32 `json:"weight,omitempty"`
+
+    // ===== 3. resource policy (optional) =====
+    // max resources this queue can use
+    Capability corev1.ResourceList `json:"capability,omitempty"`
+    // guaranteed resources
+    Guarantee corev1.ResourceList `json:"guarantee,omitempty"`
 }
 ```
 
-`NamespaceQueueStatus` extends the existing `QueueStatus` fields (State, the
-PodGroup counters, `Reservation`, `Allocated`) with a readiness gate the
-scheduler keys on:
+`NamespaceQueueStatus` is a purpose-built, trimmed status: a readiness gate the
+scheduler keys on, a human-readable failure reason, the scheduler-reported
+allocation, and the resolved child list for hierarchy introspection.
 
 ```go
 type NamespaceQueueStatus struct {
-    QueueStatus `json:",inline"`
+    // ===== 1. scheduler gate =====
+    // only Ready=true queues can enter the scheduling tree
+    Ready bool `json:"ready"`
 
-    // Ready reports whether cross-resource validation passed and the queue may
-    // enter the scheduler hierarchy tree. The scheduler ignores queues that are
-    // not Ready.
-    // +optional
-    Ready bool `json:"ready,omitempty"`
+    // failure reason for debugging (why the queue is not Ready)
+    Reason string `json:"reason,omitempty"`
 
-    // Conditions carries the validation result (parent existence, hierarchy
-    // validity, binding), so tenants can see *why* a queue is not Ready.
-    // +optional
-    Conditions []metav1.Condition `json:"conditions,omitempty"`
+    // ===== 2. runtime allocation =====
+    // actual allocated resources from the scheduler
+    Allocated corev1.ResourceList `json:"allocated,omitempty"`
+
 }
 ```
+
+### Parent-queue ownership enforcement
+
+Cluster `Queue`s are partitioned by cluster admins, who own the cluster-level
+quotas. Once tenants can freely set `NamespaceQueue.spec.parent`, nothing stops a
+tenant assigned to `queue-a` from creating a `NamespaceQueue` with
+`spec.parent: queue-b` and drawing from another team's slice. The authorization to
+attach under a cluster `Queue` must therefore live on the **`Queue`** side — owned
+by the admin who owns the `Queue` — never on the tenant-authored `NamespaceQueue`.
+
+We add a new field to the existing cluster **`QueueSpec`** (following the
+`AllowedRoutes` pattern from the Gateway API, where the infrastructure-owned
+`Gateway` — not the app-owned `Route` — declares which namespaces may attach):
+
+```go
+// QueueSpec (cluster-scoped Queue) — new field
+type QueueSpec struct {
+    // ... existing fields (weight, capability, deserved, guarantee, parent, ...)
+
+    // AllowedNamespaces lists the namespaces whose NamespaceQueues are permitted
+    // to set this Queue as their spec.parent. It is set by the cluster admin who
+    // owns this Queue. An empty/unset list means no namespace may parent under
+    // this Queue (deny by default), never "all namespaces".
+    // +optional
+    AllowedNamespaces []string `json:"allowedNamespaces,omitempty"`
+}
+```
+
+Enforcement happens in the `NamespaceQueue` **validating webhook** at admission:
+
+```
+On NamespaceQueue admit/update, if spec.parent resolves to a cluster Queue Q:
+    reject unless NamespaceQueue.metadata.namespace ∈ Q.spec.allowedNamespaces
+When spec.parent resolves to a same-namespace NamespaceQueue:
+    no cross-tenant check needed (both objects are tenant-owned in one namespace)
+```
+
+Because a tenant cannot edit the cluster-scoped `Queue` object (RBAC forbids it),
+a tenant cannot add its own namespace to `Q.spec.allowedNamespaces`, so it cannot
+grant itself access — the webhook denies `parent: queue-b` for an unlisted
+namespace. This is the concrete answer to the ownership question: the deny/allow
+decision is authored by the resource owner (admin) and merely *checked* against the
+requester (tenant). A future revision may replace the static list with a
+`namespaceSelector` for larger fleets.
 
 > `TODO(mentors)`: how should `spec.parent` distinguish "same-namespace
 > NamespaceQueue" from "cluster Queue"? Options:
@@ -200,13 +267,17 @@ A new controller under `pkg/controllers/namespacequeue/` mirrors
 `pkg/controllers/queue/` (controller + handler + state machine + actions):
 
 - **Cross-resource validation** reconciled into `status`: parent exists (same-ns
-  NamespaceQueue or cluster Queue), no cycles, child `deserved`/`guarantee` sums
-  ≤ parent, child `capability` ≤ parent — the same rules the capacity plugin
-  enforces, surfaced early. On success it sets `status.Ready = true` and a
-  `Validated` condition; on failure it sets `Ready = false` with a reason.
-- **Usage write-back**: watches `PodGroup`s in its namespace and populates the
-  inherited `QueueStatus` counters and `Allocated`, reusing the cluster queue
-  controller's logic.
+  NamespaceQueue or cluster Queue), no cycles, child `guarantee` sums ≤ parent,
+  child `capability` ≤ parent — the same rules the capacity plugin enforces,
+  surfaced early. (Parent-*ownership* — whether this namespace is allowed to
+  parent under the target cluster `Queue` — is enforced earlier, at admission, by
+  the validating webhook; see
+  [Parent-queue ownership enforcement](#parent-queue-ownership-enforcement).) On
+  success it sets `status.Ready = true`; on failure it sets `Ready = false` and
+  records `status.Reason`.
+- **Usage write-back**: watches `PodGroup`s in its namespace and populates
+  `status.Allocated`, reusing the cluster queue controller's allocation logic. It
+  also resolves and writes `status.Children` for hierarchy introspection.
 
 The scheduler continues to be the source of truth for the *global* tree; the
 controller provides fast, tenant-visible feedback and the readiness gate.
@@ -231,11 +302,17 @@ all apply unchanged to a mixed tree of cluster `Queue`s and `NamespaceQueue`s.
 
 - Validating/mutating webhooks for `NamespaceQueue` mirror
   `pkg/webhooks/admission/queues/` (basic spec checks + hierarchy annotation
-  prepend). Deep cross-resource validation lives in the controller/status, not
-  the webhook, to match how Volcano validates hierarchy today.
+  prepend). The webhook also enforces **parent-queue ownership**: when
+  `spec.parent` targets a cluster `Queue`, it rejects the object unless the
+  NamespaceQueue's namespace appears in that `Queue.spec.allowedNamespaces` (see
+  [Parent-queue ownership enforcement](#parent-queue-ownership-enforcement)).
+  Deeper cross-resource validation (cycles, resource sums) lives in the
+  controller/status, to match how Volcano validates hierarchy today.
 - A namespaced `Role` (+ optional aggregated `ClusterRole` label) grants tenants
   CRUD on `NamespaceQueue` in their own namespace — the concrete "no cluster
-  admin needed" mechanism.
+  admin needed" mechanism. Crucially, tenants get **no** write access to
+  cluster-scoped `Queue`, so they cannot edit `Queue.spec.allowedNamespaces` to
+  self-authorize.
 
 ## Feature gate
 
@@ -278,7 +355,11 @@ name-only against cluster `Queue`s, and the controller does not run.
 
 1. `spec.parent` disambiguation: convention (A) vs explicit `parentKind` (B).
 2. Mid-flight re-resolution when a shadowing NamespaceQueue appears.
-3. Whether `NamespaceQueueStatus` should embed `QueueStatus` or duplicate a
-   trimmed subset.
-4. RBAC packaging: ship a ready-made tenant `Role` in the Helm chart, or document
+3. `NamespaceQueueSpec` is a curated subset of `Queue` (`parent`, `weight`,
+   `capability`, `guarantee`) rather than a reuse of `QueueSpec`. Confirm the
+   dropped fields (`deserved`, `reclaimable`, `priority`, `dequeueStrategy`) are
+   acceptable to leave out of the v1 surface.
+4. `allowedNamespaces` model: is a static namespace list sufficient, or should it
+   support label selectors for larger multi-tenant fleets?
+5. RBAC packaging: ship a ready-made tenant `Role` in the Helm chart, or document
    only.

--- a/docs/design/namespace-queue.md
+++ b/docs/design/namespace-queue.md
@@ -4,104 +4,11 @@
 
 Tracking issue: [#5251](https://github.com/volcano-sh/volcano/issues/5251)
 
-> **Status: DRAFT for design review.** Items marked `TODO(mentors)` are open
-> questions to align on before implementation starts.
-
-## Motivation
-
-Volcano's `Queue` is a **cluster-scoped** resource. On multi-tenant platforms,
-tenants live in namespaces and typically cannot create cluster-wide CRDs without
-going through an admin review process. As a result, Volcano's hierarchical-queue
-feature (implemented on the `capacity` plugin) is in practice only accessible to
-cluster admins, not to the tenants who actually need it to configure their own
-scheduling strategy.
-
-Platforms that want to offer Volcano *as a service* are left with no native
-solution. Each one ends up building its own abstraction layer: a namespaced CRD,
-a controller that translates it into cluster `Queue` objects, and custom
-validation to stop tenants from breaking the global hierarchy and the scheduling
-cycle. This is duplicated work across every platform team, and it does not fully
-solve the problem: hierarchy validation in Volcano happens **inside the scheduler
-loop**, against the global queue tree, *after* the cluster `Queue` is already
-admitted. Those rules also evolve over time, so out-of-tree controllers go stale
-quickly.
-
-## Proposal
-
-We introduce a new **namespaced** CRD `NamespaceQueue` that participates natively
-in Volcano's existing queue hierarchy. The naming follows the Kubernetes
-`Role`/`ClusterRole` convention: `Queue` stays the cluster-scoped resource, and
-`NamespaceQueue` is its namespace-scoped counterpart.
-
-A `NamespaceQueue` explicitly names its parent, which is either another
-`NamespaceQueue` in the same namespace, or a cluster `Queue`. There is no
-artificial one-to-one binding between a namespace and a cluster `Queue`: multiple
-namespaces may reference the same cluster `Queue`, and a namespace may host
-`NamespaceQueue`s rooted under different cluster `Queue`s.
-
-### Goals
-
-- Provide a native namespaced queue primitive so platforms do not need to build
-  their own abstractions and duplicate validation logic.
-- Let tenants create and manage queue hierarchies **within their own namespaces**,
-  without cluster-admin intervention for every change.
-- Guarantee that a misconfiguration in one tenant's hierarchy cannot affect
-  scheduling for other tenants.
-- Remain **backward compatible**: clusters that do not opt in behave exactly as
-  today.
-- Support traditional workloads via the existing `PodGroup.spec.queue` /
-  `scheduling.volcano.sh/queue-name` path, enabling smooth migration: if a
-  `NamespaceQueue` with the same name as a cluster `Queue` exists in the
-  workload's namespace, newly admitted workloads resolve to the namespace-scoped
-  resource without changing workload semantics.
-- Deliver an end-to-end test suite covering core flows, including negative paths.
-- Provide user-facing docs in both the website and the repository.
-
-### Non-Goals
-
-- Replacing or wrapping the cluster-scoped `Queue`. `NamespaceQueue` is
-  **additive**; the current model is unchanged for clusters that do not opt in.
-- Introducing new tenant-isolation semantics.
-- Changing the meaning of `guarantee`, `capability`, or `weight`. The fields
-  `NamespaceQueueSpec` carries over from `Queue` keep their current definition and
-  interpretation; this proposal does not alter existing resource semantics.
-
-## User Stories
-
-### Story 1
-
-As a tenant with permissions only in my own namespace, I want to create a queue
-hierarchy under the cluster `Queue` my platform assigned me, and attach my
-`PodGroup`/`Job`s to it — without filing a ticket for the cluster admin on every
-change.
-
-### Story 2
-
-As a platform operator, I want a tenant's broken hierarchy (cycle, missing
-parent, over-committed child) to stay inert and never enter the global scheduler
-tree, so it cannot disturb other tenants' scheduling.
-
-### Story 3
-
-As an existing user, I want my current cluster `Queue`s and workloads to behave
-exactly as before if I don't enable this feature.
 
 ## Design detail
 
 ### The `NamespaceQueue` CRD
 
-`NamespaceQueue` is namespace-scoped and defines its own **`NamespaceQueueSpec`** —
-a curated subset of the cluster `Queue` surface (`parent`, `weight`, `capability`,
-`guarantee`). Each reused field keeps the same meaning it has on `Queue` today; the
-fields not carried over (`deserved`, `reclaimable`, `priority`, `dequeueStrategy`)
-are intentionally out of the v1 surface.
-
-Access control is **not** a field on `NamespaceQueueSpec`. Whether a namespace may
-parent its queues under a given cluster `Queue` is governed by a new
-`allowedNamespaces` field on the cluster `Queue` itself (see
-[Parent-queue ownership enforcement](#parent-queue-ownership-enforcement) below) —
-the authorization must be owned by the admin who owns the `Queue`, not declared by
-the tenant who is requesting to bind to it.
 
 ```go
 // +genclient
@@ -120,42 +27,83 @@ type NamespaceQueue struct {
 }
 
 type NamespaceQueueSpec struct {
-    // ===== 1. hierarchy (core) =====
-    // parent can be a cluster Queue or another NamespaceQueue
-    // (resolution is namespace-first).
+    // +kubebuilder:validation:Required 
     Parent string `json:"parent"`
 
-    // ===== 2. scheduling policy =====
-    // queue weight used in fair sharing / DRF
-    Weight int32 `json:"weight,omitempty"`
+    // +optional
+	  // +kubebuilder:default:=1
+	  Weight int32 `json:"weight,omitempty"`
 
-    // ===== 3. resource policy (optional) =====
-    // max resources this queue can use
-    Capability corev1.ResourceList `json:"capability,omitempty"`
-    // guaranteed resources
-    Guarantee corev1.ResourceList `json:"guarantee,omitempty"`
+    // +optional
+	  Capability corev1.ResourceList `json:"capability,omitempty"`
+
+    // +optional
+	  Deserved corev1.ResourceList `json:"deserved,omitempty"`
+
+    // +optional
+	  Guarantee Guarantee `json:"guarantee,omitempty"`
+
+    // +optional
+	  Priority int32 `json:"priority,omitempty"`
+
+    // +optional
+	  // +kubebuilder:default:=fifo
+	  // +kubebuilder:validation:Enum=fifo;traverse
+	  DequeueStrategy DequeueStrategy `json:"dequeueStrategy,omitempty"`
+
 }
 ```
-
-`NamespaceQueueStatus` is a purpose-built, trimmed status: a readiness gate the
-scheduler keys on, a human-readable failure reason, the scheduler-reported
-allocation, and the resolved child list for hierarchy introspection.
 
 ```go
 type NamespaceQueueStatus struct {
-    // ===== 1. scheduler gate =====
-    // only Ready=true queues can enter the scheduling tree
-    Ready bool `json:"ready"`
 
-    // failure reason for debugging (why the queue is not Ready)
-    Reason string `json:"reason,omitempty"`
+  // +optional
+  Phase string `json:"phase,omitempty" protobuf:"bytes,1,opt,name=phase"`
+  // State is state of Namespacequeue
+	// +kubebuilder:validation:Enum=Open;Closed;Closing;Unknown
+	// +optional
+	State QueueState `json:"state,omitempty" protobuf:"bytes,2,opt,name=state"`
 
-    // ===== 2. runtime allocation =====
-    // actual allocated resources from the scheduler
-    Allocated corev1.ResourceList `json:"allocated,omitempty"`
+	// The number of 'Unknown' PodGroup in this queue.
+	// +kubebuilder:validation:Minimum=0
+	// +optional
+	Unknown int32 `json:"unknown,omitempty" protobuf:"bytes,3,opt,name=unknown"`
+	// The number of 'Pending' PodGroup in this queue.
+	// +kubebuilder:validation:Minimum=0
+	// +optional
+	Pending int32 `json:"pending,omitempty" protobuf:"bytes,4,opt,name=pending"`
+	// The number of 'Running' PodGroup in this queue.
+	// +kubebuilder:validation:Minimum=0
+	// +optional
+	Running int32 `json:"running,omitempty" protobuf:"bytes,5,opt,name=running"`
+	// The number of `Inqueue` PodGroup in this queue.
+	// +kubebuilder:validation:Minimum=0
+	// +optional
+	Inqueue int32 `json:"inqueue,omitempty" protobuf:"bytes,6,opt,name=inqueue"`
+	// The number of `Completed` PodGroup in this queue.
+	// +kubebuilder:validation:Minimum=0
+	// +optional
+	Completed int32 `json:"completed,omitempty" protobuf:"bytes,7,opt,name=completed"`
 
+	// Reservation is the profile of resource reservation for queue
+	Reservation Reservation `json:"reservation,omitempty" protobuf:"bytes,8,opt,name=reservation"`
+
+	// Allocated is allocated resources in queue
+	// +optional
+	Allocated v1.ResourceList `json:"allocated" protobuf:"bytes,9,opt,name=allocated"`
 }
 ```
+
+
+```go
+type NamespaceQueueList struct {
+	metav1.TypeMeta `json:",inline"`
+	metav1.ListMeta `json:"metadata,omitempty"`
+	Items           []NamespaceQueue `json:"items"`
+}
+```
+
+
 
 ### Parent-queue ownership enforcement
 
@@ -184,182 +132,7 @@ type QueueSpec struct {
 }
 ```
 
-Enforcement happens in the `NamespaceQueue` **validating webhook** at admission:
 
-```
-On NamespaceQueue admit/update, if spec.parent resolves to a cluster Queue Q:
-    reject unless NamespaceQueue.metadata.namespace ∈ Q.spec.allowedNamespaces
-When spec.parent resolves to a same-namespace NamespaceQueue:
-    no cross-tenant check needed (both objects are tenant-owned in one namespace)
-```
 
-Because a tenant cannot edit the cluster-scoped `Queue` object (RBAC forbids it),
-a tenant cannot add its own namespace to `Q.spec.allowedNamespaces`, so it cannot
-grant itself access — the webhook denies `parent: queue-b` for an unlisted
-namespace. This is the concrete answer to the ownership question: the deny/allow
-decision is authored by the resource owner (admin) and merely *checked* against the
-requester (tenant). A future revision may replace the static list with a
-`namespaceSelector` for larger fleets.
 
-> `TODO(mentors)`: how should `spec.parent` distinguish "same-namespace
-> NamespaceQueue" from "cluster Queue"? Options:
-> - **(A) namespace-first by convention** — a bare name resolves to a
->   same-namespace `NamespaceQueue` first, else a cluster `Queue`. Simplest, but
->   ambiguous if both exist with that name.
-> - **(B) explicit `parentKind`** field (`NamespaceQueue` | `Queue`). Explicit,
->   no ambiguity, but adds surface area.
-> Recommendation: **(A)** to mirror the PodGroup resolution rule and keep the
-> spec unchanged; document the shadowing rule clearly.
 
-### QueueID namespace-qualification (core mechanism)
-
-The scheduler treats `api.QueueID` as an **opaque key**; it never assumes the ID
-equals the queue name. There is exactly one place that turns a name into a
-`QueueID` for the scheduler:
-
-```go
-// pkg/scheduler/api/queue_info.go  (NewQueueInfo)
-UID: QueueID(queue.Name)
-```
-
-For a `NamespaceQueue` we derive a **namespace-qualified synthetic ID**:
-
-- cluster `Queue`      → `QueueID(name)`            *(unchanged)*
-- `NamespaceQueue`     → `QueueID(namespace + "/" + name)`
-- synthetic root       → `QueueID("root")`          *(stays cluster-global)*
-
-Because every downstream consumer — the `capacity` tree
-(`queueAttr.children`/`ancestors`), leaf detection, bottom-up resource
-aggregation, hierarchical allocatable checks, and the flat `proportion` map —
-keys purely on `QueueID`, **they need no logic changes**. Only three
-"translation" points become namespace-aware:
-
-| Where | Today | Compatibility change |
-| --- | --- | --- |
-| `pkg/scheduler/api/queue_info.go` `NewQueueInfo` | `QueueID(name)` | qualify when the source object is a `NamespaceQueue` |
-| `capacity` parent lookup (`updateAncestors`) | `ssn.Queues[QueueID(spec.Parent)]` | resolve `spec.parent` namespace-first into the synthetic ID |
-| `pkg/scheduler/api/job_info.go` `SetPodGroup` | `QueueID(pg.Spec.Queue)` | resolve `(pg.Namespace, pg.Spec.Queue)` namespace-first |
-
-The `volcano.sh/hierarchy` / `hierarchy-weights` annotations store **queue name
-strings**, so their format is independent of namespace and the webhook mutator is
-unaffected.
-
-### PodGroup.spec.queue resolution (namespace-first)
-
-Resolution for a `PodGroup` in namespace `N` referencing queue name `Q`:
-
-1. If a `Ready` `NamespaceQueue` `N/Q` exists → use synthetic ID `QueueID("N/Q")`.
-2. Otherwise → fall back to cluster `Queue` `Q`, exactly as today.
-
-No new `PodGroup` field is required, and existing workloads are unaffected: with
-no `NamespaceQueue` present, step 1 never matches and behavior is identical to
-today. This is also the smooth-migration path — creating a same-named
-`NamespaceQueue` shadows the cluster `Queue` for *new* admissions only.
-
-> `TODO(mentors)`: migration semantics for **already-running** PodGroups when a
-> shadowing NamespaceQueue is created mid-flight — re-resolve on next session, or
-> pin at admission? Recommendation: resolve at admission and keep it stable for
-> the PodGroup's lifetime.
-
-### NamespaceQueue controller & status
-
-A new controller under `pkg/controllers/namespacequeue/` mirrors
-`pkg/controllers/queue/` (controller + handler + state machine + actions):
-
-- **Cross-resource validation** reconciled into `status`: parent exists (same-ns
-  NamespaceQueue or cluster Queue), no cycles, child `guarantee` sums ≤ parent,
-  child `capability` ≤ parent — the same rules the capacity plugin enforces,
-  surfaced early. (Parent-*ownership* — whether this namespace is allowed to
-  parent under the target cluster `Queue` — is enforced earlier, at admission, by
-  the validating webhook; see
-  [Parent-queue ownership enforcement](#parent-queue-ownership-enforcement).) On
-  success it sets `status.Ready = true`; on failure it sets `Ready = false` and
-  records `status.Reason`.
-- **Usage write-back**: watches `PodGroup`s in its namespace and populates
-  `status.Allocated`, reusing the cluster queue controller's allocation logic. It
-  also resolves and writes `status.Children` for hierarchy introspection.
-
-The scheduler continues to be the source of truth for the *global* tree; the
-controller provides fast, tenant-visible feedback and the readiness gate.
-
-### Scheduler ready-gating & isolation
-
-The scheduler cache watches `NamespaceQueue` (new `Add/Update/Delete` handlers in
-`pkg/scheduler/cache/event_handlers.go`) and **admits into the queue tree only
-those with `status.Ready == true`**. A misconfigured `NamespaceQueue` stays in
-etcd but never becomes a `QueueInfo`, so it cannot enter the capacity hierarchy
-tree or affect any other tenant — this is the isolation guarantee.
-
-### Capacity / proportion plugin compatibility
-
-No behavioral change is proposed for either plugin. They operate entirely on
-`QueueID` + the `spec.parent`/hierarchy annotations, both of which the synthetic
-ID and namespace-first parent resolution keep valid. The existing leaf-only
-scheduling rule, bottom-up aggregation, and `ancestorReclaimLevel` reclaim scope
-all apply unchanged to a mixed tree of cluster `Queue`s and `NamespaceQueue`s.
-
-### Webhook & RBAC
-
-- Validating/mutating webhooks for `NamespaceQueue` mirror
-  `pkg/webhooks/admission/queues/` (basic spec checks + hierarchy annotation
-  prepend). The webhook also enforces **parent-queue ownership**: when
-  `spec.parent` targets a cluster `Queue`, it rejects the object unless the
-  NamespaceQueue's namespace appears in that `Queue.spec.allowedNamespaces` (see
-  [Parent-queue ownership enforcement](#parent-queue-ownership-enforcement)).
-  Deeper cross-resource validation (cycles, resource sums) lives in the
-  controller/status, to match how Volcano validates hierarchy today.
-- A namespaced `Role` (+ optional aggregated `ClusterRole` label) grants tenants
-  CRUD on `NamespaceQueue` in their own namespace — the concrete "no cluster
-  admin needed" mechanism. Crucially, tenants get **no** write access to
-  cluster-scoped `Queue`, so they cannot edit `Queue.spec.allowedNamespaces` to
-  self-authorize.
-
-## Feature gate
-
-The whole feature sits behind a new gate, **default off**, so non-opting clusters
-are byte-for-byte unchanged:
-
-```go
-// pkg/features/volcano_features.go
-// NamespaceQueue enables the namespace-scoped NamespaceQueue CRD and its
-// namespace-first PodGroup queue resolution.
-NamespaceQueue featuregate.Feature = "NamespaceQueue"
-
-// in defaultVolcanoFeatureGates:
-NamespaceQueue: {Default: false, PreRelease: featuregate.Alpha},
-```
-
-When the gate is off, the cache does not watch `NamespaceQueue`, resolution is
-name-only against cluster `Queue`s, and the controller does not run.
-
-## Test plan
-
-- **Unit**: synthetic-ID derivation; namespace-first PodGroup resolution
-  (shadowing + fallback); controller validation → `status.Ready` transitions.
-- **E2E (Ginkgo, `test/e2e/`)**:
-  - tenant creates a `NamespaceQueue` under a cluster `Queue` and schedules a Job.
-  - two namespaces with same-named `NamespaceQueue`s scheduled independently.
-  - negative: cycle / missing parent / over-committed child ⇒ `Ready=false`, and
-    other tenants keep scheduling.
-  - backward-compat: gate off ⇒ existing cluster-queue e2e unchanged.
-
-## Limitations
-
-- Leaf-only scheduling is inherited from the capacity hierarchy design: jobs
-  attach only to leaf queues.
-- `TODO(mentors)`: cross-namespace parent (a NamespaceQueue parented by a
-  NamespaceQueue in *another* namespace) is out of scope for v1 — parents are
-  same-namespace NamespaceQueue or cluster Queue only.
-
-## Open questions for review
-
-1. `spec.parent` disambiguation: convention (A) vs explicit `parentKind` (B).
-2. Mid-flight re-resolution when a shadowing NamespaceQueue appears.
-3. `NamespaceQueueSpec` is a curated subset of `Queue` (`parent`, `weight`,
-   `capability`, `guarantee`) rather than a reuse of `QueueSpec`. Confirm the
-   dropped fields (`deserved`, `reclaimable`, `priority`, `dequeueStrategy`) are
-   acceptable to leave out of the v1 surface.
-4. `allowedNamespaces` model: is a static namespace list sufficient, or should it
-   support label selectors for larger multi-tenant fleets?
-5. RBAC packaging: ship a ready-made tenant `Role` in the Helm chart, or document
-   only.

--- a/docs/design/namespace-queue.md
+++ b/docs/design/namespace-queue.md
@@ -137,10 +137,10 @@ type QueueSpec struct {
 
 ### Control Plane
 
-Overview: The NamespaceQueue (NSQ) Controller operates as a background reconciliation loop (Reconcile Loop) based on the standard Kubernetes controller pattern. Its core mission is to act as a secure proxy and bridge between the tenant-facing NamespaceQueue (Namespaced-scoped) and the backend Volcano Queue (Cluster-scoped).
+Overview:
+The NamespaceQueue (NSQ) Controller follows the standard Kubernetes reconciliation pattern. It acts as a secure bridge between tenant-facing `NamespaceQueue` resources and backend cluster-level Volcano `Queue` resources.
 
-The controller watches both NamespaceQueue and backend Queue resources, driving the system toward the desired state through four sequential logical phases.
-
+The controller watches both resources and continuously reconciles them through four main phases to keep the backend state aligned with the tenant’s desired configuration.
 
 
 
@@ -392,5 +392,106 @@ func (r *NamespaceQueueReconciler) SetupWithManager(mgr ctrl.Manager) error {
 ```
 
 
+### Routing Plane Detailed Design
 
+
+Overview:
+The Routing Plane provides a simple abstraction for tenant queue routing. Tenants only need to specify a namespace-scoped queue name in `spec.queue` when submitting a workload, such as a `VolcanoJob`.
+
+Before the workload is stored, a Mutating Admission Webhook intercepts the request and rewrites the local queue name to the corresponding cluster-level physical Queue name. This keeps backend naming details hidden from tenants while ensuring the Volcano Scheduler receives the correct Queue identifier.
+
+
+Step 1: Admission Request Interception
+
+Logic Flow:
+
+- When a user submits a job through `kubectl apply`, the API Server forwards the request to the registered Mutating Webhook after authentication and authorization.
+
+- The webhook extracts the target object from the `AdmissionReview` request and performs basic validation.
+
+- If the request is a delete operation, or if the object is empty or invalid, the webhook allows the request to pass without mutation.
+
+
+```go
+func (h *VolcanoJobMutator) Handle(ctx context.Context, req admission.Request) admission.Response {
+	logger := log.FromContext(ctx)
+
+	// Intercept and decode the VolcanoJob object
+	job := &volcanov1alpha1.Job{}
+	err := h.decoder.Decode(req, job)
+	if err != nil {
+		return admission.Errored(http.StatusBadRequest, fmt.Errorf("failed to decode AdmissionReview request: %v", err))
+	}
+
+	// Bypass mutations if the request is an eviction or not relevant to creation/update
+	if req.Operation != admissionv1.Create && req.Operation != admissionv1.Update {
+		return admission.Allowed("bypass mutation for non-write operations")
+	}
+
+	// ... (Proceed to Step 2)
+}
+```
+
+
+
+Step 2: Namespace Context Resolution & Field Mutation
+
+
+Design Intent:
+Use the Job namespace as the tenant context, then rewrite the local queue name to its mapped physical Queue name according to the platform’s queue mapping rule.
+
+
+Detailed Mutation Logic:
+
+- The webhook reads `req.Namespace` as the tenant context.
+
+- It then reads `job.Spec.Queue` as the local queue name. If this field is empty, the request is rejected because tenants must explicitly specify a valid `NamespaceQueue`.
+
+- If `job.Spec.Queue` is provided, the webhook rewrites it to the physical queue name using the rule: `[Namespace]-[LocalQueueName]`.
+
+- Finally, the webhook updates `job.Spec.Queue` in memory and returns the mutation result to the API Server. No YAML file is modified during this process.
+
+```go
+tenantNamespace := req.Namespace
+	localQueueName := job.Spec.Queue
+
+	if localQueueName == "" {
+		return admission.Denied(fmt.Sprintf(
+			"multi-tenancy policy violation: you must explicitly specify a 'spec.queue' in namespace '%s'", 
+			tenantNamespace,
+		))
+	}
+
+	globalQueueName := fmt.Sprintf("%s-%s", tenantNamespace, localQueueName)
+	job.Spec.Queue = globalQueueName
+```
+
+
+
+Step 3: JSON Patch Generation & Persistence
+
+Design Intent:Return the queue mutation as a Kubernetes JSON Patch, allowing the API Server to apply the change before persisting the object to etcd.
+
+Implementation Details:
+
+- The webhook compares the original Job object with the mutated object and generates a standard JSON Patch, such as replacing `/spec/queue` with the physical Queue name.
+
+- The patch is returned to the API Server through an `AdmissionResponse`.
+
+- After applying the patch, the API Server persists the final Job object to etcd.
+
+- The Volcano Scheduler then uses the rewritten `spec.queue` value to match the corresponding backend Queue and schedule the workload.
+
+```go
+// Marshall the mutated job into standard JSON bytes
+	marshaledJob, err := json.Marshal(job)
+	if err != nil {
+		return admission.Errored(http.StatusInternalServerError, err)
+	}
+
+	// Generate standard RFC 6902 JSON Patch response automatically
+	// API Server will apply this patch and persist the mutated Job into etcd database
+	return admission.PatchResponseFromRaw(req.Object.Raw, marshaledJob)
+}
+```
 

--- a/docs/design/namespace-queue.md
+++ b/docs/design/namespace-queue.md
@@ -135,4 +135,262 @@ type QueueSpec struct {
 
 
 
+### Control Plane
+
+Overview: The NamespaceQueue (NSQ) Controller operates as a background reconciliation loop (Reconcile Loop) based on the standard Kubernetes controller pattern. Its core mission is to act as a secure proxy and bridge between the tenant-facing NamespaceQueue (Namespaced-scoped) and the backend Volcano Queue (Cluster-scoped).
+
+The controller watches both NamespaceQueue and backend Queue resources, driving the system toward the desired state through four sequential logical phases.
+
+
+
+
+Step 1: Fetch NSQ and Handle Deletion
+
+Design Intent:
+Use NSQ events as the entry point of the control loop and determine whether the object still exists or is being deleted.
+
+Logic Flow:
+
+- The controller receives an NSQ reconcile request and fetches the NSQ object by namespace and name.
+
+- If the NSQ no longer exists, it means the object has already been deleted from the cluster. The controller exits safely without further processing.
+
+- If the NSQ is being deleted, Kubernetes garbage collection will clean up the corresponding physical Queue through the previously set OwnerReference. Therefore, no extra cleanup logic is required in the controller.
+
+
+```go
+func (r *NamespaceQueueReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	logger := log.FromContext(ctx)
+
+	// === STEP 1: Fetch Source Object ===
+	nsq := &platformv1alpha1.NamespaceQueue{}
+	if err := r.Get(ctx, req.NamespacedName, nsq); err != nil {
+		if errors.IsNotFound(err) {
+			return ctrl.Result{}, nil // Cascade deletion handled by OwnerReference
+		}
+		return ctrl.Result{}, err
+	}
+
+	// === STEP 2: Multi-Tenancy & Authorization Validation ===
+	if err := r.validateNamespaceQueue(ctx, nsq); err != nil {
+		logger.Error(err, "NSQ security validation failed, intercepting propagation", "nsq", nsq.Name)
+		
+		nsq.Status.Phase = "Rejected"
+		nsq.Status.Reason = err.Error()
+		if updateErr := r.Status().Update(ctx, nsq); updateErr != nil {
+			return ctrl.Result{}, updateErr
+		}
+		return ctrl.Result{}, nil 
+	}
+
+	// === STEP 3: 1:1 Topology Translation ===
+	backendQueueName := fmt.Sprintf("%s-%s", nsq.Namespace, nsq.Name)
+	foundQueue := &volcanov1beta1.Queue{}
+
+	err := r.Get(ctx, client.ObjectKey{Name: backendQueueName}, foundQueue)
+	if err != nil && errors.IsNotFound(err) {
+		// Scenario A: Backend Queue not exists -> Create
+		logger.Info("Creating backend physical Volcano Queue", "queueName", backendQueueName)
+		
+		newQueue := r.buildVolcanoQueue(nsq, backendQueueName)
+		if err := r.Create(ctx, newQueue); err != nil {
+			return ctrl.Result{}, err // Trigger retry for self-healing
+		}
+
+		nsq.Status.Phase = "Admitted"
+		nsq.Status.Reason = "Successfully validated and admitted by platform controller."
+		nsq.Status.State = platformv1alpha1.QueueStateOpen
+		if err := r.Status().Update(ctx, nsq); err != nil {
+			return ctrl.Result{}, err
+		}
+		return ctrl.Result{}, nil
+	} else if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	// Scenario B: Backend Queue exists -> Update (Enforce Eventual Consistency)
+	logger.Info("Updating backend physical Volcano Queue spec", "queueName", backendQueueName)
+	expectedQueue := r.buildVolcanoQueue(nsq, backendQueueName)
+	
+	foundQueue.Spec = expectedQueue.Spec
+	if err := r.Update(ctx, foundQueue); err != nil {
+		return ctrl.Result{}, err
+	}
+
+	// === STEP 4: Bidirectional Status Sync ===
+	if err := r.syncQueueStatusToNSQ(ctx, nsq, foundQueue); err != nil {
+		return ctrl.Result{}, err
+	}
+
+	return ctrl.Result{}, nil
+}
+```
+
+
+Step 2: Validate Hierarchy and Authorization
+
+Design Intent:
+Prevent tenants from using `spec.parent` to attach to unauthorized queues or consume resources beyond their allowed scope.
+
+Logic Flow:
+
+- The controller first checks whether `spec.parent` points to a `NamespaceQueue` in the same Namespace.
+
+- If a parent `NamespaceQueue` exists, the controller validates that the child queue’s `Capability` does not exceed the parent’s limit. If it does, the request is rejected.
+
+- If no parent `NamespaceQueue` is found in the Namespace, the queue is treated as attaching to a cluster-level `Queue`.
+
+- In this case, the controller checks whether the tenant Namespace is included in the cluster Queue’s `spec.allowedNamespaces`.
+
+- If the Namespace is not authorized, the controller stops reconciliation, prevents the physical Queue from being created, and updates `NSQ.Status.Phase` to `Rejected` with the rejection reason.
+
+
+
+```go
+func (r *NamespaceQueueReconciler) validateNamespaceQueue(ctx context.Context, nsq *platformv1alpha1.NamespaceQueue) error {
+	currentNS := nsq.Namespace
+	parentName := nsq.Spec.Parent
+
+	// 1. Check if parent is a local NSQ within the same namespace (Sub-tree validation)
+	parentNSQ := &platformv1alpha1.NamespaceQueue{}
+	err := r.Get(ctx, client.ObjectKey{Namespace: currentNS, Name: parentName}, parentNSQ)
+	if err == nil {
+		if r.isResourceExceeded(nsq.Spec.Capability, parentNSQ.Spec.Capability) {
+			return fmt.Errorf("quota sub-tree violation: child capability exceeds parent NSQ '%s' limits", parentName)
+		}
+		return nil
+	}
+
+	// 2. Check if parent is a cluster-scoped Queue (Reverse Authorization ACL check)
+	globalQueue := &volcanov1beta1.Queue{}
+	err = r.Get(ctx, client.ObjectKey{Name: parentName}, globalQueue)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return fmt.Errorf("invalid parent target: '%s' is neither a local NamespaceQueue nor a cluster Queue", parentName)
+		}
+		return err
+	}
+
+	// Access Control List Check via AllowedNamespaces
+	allowed := false
+	for _, ns := range globalQueue.Spec.AllowedNamespaces { 
+		if ns == currentNS {
+			allowed = true
+			break
+		}
+	}
+
+	if !allowed {
+		return fmt.Errorf("multi-tenancy security violation: namespace '%s' is NOT permitted to parent under cluster Queue '%s'", currentNS, parentName)
+	}
+
+	// Validate against global queue capacity limits
+	if r.isResourceExceeded(nsq.Spec.Capability, globalQueue.Spec.Capability) {
+		return fmt.Errorf("quota root violation: root NSQ capability exceeds cluster Queue '%s' total capacity", parentName)
+	}
+
+	return nil
+}
+
+func (r *NamespaceQueueReconciler) isResourceExceeded(child, parent corev1.ResourceList) bool {
+	for resName, childQty := range child {
+		if parentQty, exists := parent[resName]; exists {
+			if childQty.Cmp(parentQty) > 0 {
+				return true // Overcommit detected
+			}
+		} else {
+			return true // Resource type not permitted by parent
+		}
+	}
+	return false
+}
+```
+
+Step 3: Translate and Clone Queue
+
+Design Intent:
+Convert the validated `NamespaceQueue` into a cluster-level Volcano `Queue`.
+
+Implementation Details:
+
+- The controller generates a globally unique physical Queue name using the format `[Namespace]-[NSQ-Name]` to avoid naming conflicts.
+
+- The controller copies scheduling fields from `NSQ.Spec` into Volcano `QueueSpec`, including `Weight`, `Capability`, `Deserved`, `Guarantee`, `Priority`, and `DequeueStrategy`.
+
+- The controller also handles the parent queue mapping. If the parent is another `NamespaceQueue` in the same Namespace, it rewrites the parent name to the corresponding physical Queue name.
+
+- This ensures that the backend Volcano queue hierarchy matches the frontend NSQ hierarchy.
+
+
+```go
+func (r *NamespaceQueueReconciler) buildVolcanoQueue(nsq *platformv1alpha1.NamespaceQueue, name string) *volcanov1beta1.Queue {
+	return &volcanov1beta1.Queue{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+			// Inject OwnerReference link to establish parent-child relationship for cascade deletion
+			OwnerReferences: []metav1.OwnerReference{
+				*metav1.NewControllerRef(nsq, platformv1alpha1.GroupVersion.WithKind("NamespaceQueue")),
+			},
+		},
+		Spec: volcanov1beta1.QueueSpec{
+			Weight:          nsq.Spec.Weight,
+			Capability:      nsq.Spec.Capability,
+			Deserved:        nsq.Spec.Deserved,
+			Guarantee:       nsq.Spec.Guarantee,
+			Priority:        nsq.Spec.Priority,
+			DequeueStrategy: volcanov1beta1.DequeueStrategy(nsq.Spec.DequeueStrategy),
+			
+			// Flattens the hierarchical relationship for backend volcano engine
+			Parent:          fmt.Sprintf("%s-%s", nsq.Namespace, nsq.Spec.Parent), 
+		},
+	}
+}
+```
+
+Step 4: Reconcile Queue and Sync Status
+
+Design Intent:
+Keep the physical Volcano `Queue` consistent with the tenant `NamespaceQueue`, and expose the backend queue status back to tenants.
+
+Reconciliation Mechanism:
+
+- The controller submits the physical `Queue` to the API Server.
+
+- If the physical `Queue` does not exist, the controller creates it.
+
+- If it already exists, the controller updates its `Spec` with the latest computed configuration, so tenant quota changes can take effect in the backend scheduler.
+
+- By declaring `Owns(&volcano.Queue{})`, the controller can detect when a physical `Queue` is accidentally deleted and recreate it automatically.
+
+- At the end of reconciliation, the controller copies key runtime fields from `Queue.Status` back to `NSQ.Status`, such as `State`, `Running`, `Pending`, and `Allocated`.
+
+- This allows tenants to view their queue state and workload scheduling progress directly from their own `NamespaceQueue`.
+
+
+``` go
+func (r *NamespaceQueueReconciler) syncQueueStatusToNSQ(ctx context.Context, nsq *platformv1alpha1.NamespaceQueue, q *volcanov1beta1.Queue) error {
+	// Pixels-level state back-filling to achieve observable closed-loop
+	nsq.Status.Phase = "Admitted"
+	nsq.Status.State = platformv1alpha1.QueueState(q.Status.State)
+	nsq.Status.Unknown = q.Status.Unknown
+	nsq.Status.Pending = q.Status.Pending
+	nsq.Status.Running = q.Status.Running
+	nsq.Status.Inqueue = q.Status.Inqueue
+	nsq.Status.Completed = q.Status.Completed
+	nsq.Status.Reservation = platformv1alpha1.Reservation(q.Status.Reservation)
+	nsq.Status.Allocated = q.Status.Allocated
+
+	return r.Status().Update(ctx, nsq)
+}
+
+func (r *NamespaceQueueReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&platformv1alpha1.NamespaceQueue{}). 
+		Owns(&volcanov1beta1.Queue{}).           // Informer watches backend cluster Queue for Self-healing
+		Complete(r)
+}
+```
+
+
+
 

--- a/docs/design/namespace-queue.md
+++ b/docs/design/namespace-queue.md
@@ -1,0 +1,284 @@
+# Namespace-scoped Queues for Tenant-authored Hierarchies
+
+[@gitGurugu](https://github.com/gitGurugu); Jul 3, 2026
+
+Tracking issue: [#5251](https://github.com/volcano-sh/volcano/issues/5251)
+
+> **Status: DRAFT for design review.** Items marked `TODO(mentors)` are open
+> questions to align on before implementation starts.
+
+## Motivation
+
+Volcano's `Queue` is a **cluster-scoped** resource. On multi-tenant platforms,
+tenants live in namespaces and typically cannot create cluster-wide CRDs without
+going through an admin review process. As a result, Volcano's hierarchical-queue
+feature (implemented on the `capacity` plugin) is in practice only accessible to
+cluster admins, not to the tenants who actually need it to configure their own
+scheduling strategy.
+
+Platforms that want to offer Volcano *as a service* are left with no native
+solution. Each one ends up building its own abstraction layer: a namespaced CRD,
+a controller that translates it into cluster `Queue` objects, and custom
+validation to stop tenants from breaking the global hierarchy and the scheduling
+cycle. This is duplicated work across every platform team, and it does not fully
+solve the problem: hierarchy validation in Volcano happens **inside the scheduler
+loop**, against the global queue tree, *after* the cluster `Queue` is already
+admitted. Those rules also evolve over time, so out-of-tree controllers go stale
+quickly.
+
+## Proposal
+
+We introduce a new **namespaced** CRD `NamespaceQueue` that participates natively
+in Volcano's existing queue hierarchy. The naming follows the Kubernetes
+`Role`/`ClusterRole` convention: `Queue` stays the cluster-scoped resource, and
+`NamespaceQueue` is its namespace-scoped counterpart.
+
+A `NamespaceQueue` explicitly names its parent, which is either another
+`NamespaceQueue` in the same namespace, or a cluster `Queue`. There is no
+artificial one-to-one binding between a namespace and a cluster `Queue`: multiple
+namespaces may reference the same cluster `Queue`, and a namespace may host
+`NamespaceQueue`s rooted under different cluster `Queue`s.
+
+### Goals
+
+- Provide a native namespaced queue primitive so platforms do not need to build
+  their own abstractions and duplicate validation logic.
+- Let tenants create and manage queue hierarchies **within their own namespaces**,
+  without cluster-admin intervention for every change.
+- Guarantee that a misconfiguration in one tenant's hierarchy cannot affect
+  scheduling for other tenants.
+- Remain **backward compatible**: clusters that do not opt in behave exactly as
+  today.
+- Support traditional workloads via the existing `PodGroup.spec.queue` /
+  `scheduling.volcano.sh/queue-name` path, enabling smooth migration: if a
+  `NamespaceQueue` with the same name as a cluster `Queue` exists in the
+  workload's namespace, newly admitted workloads resolve to the namespace-scoped
+  resource without changing workload semantics.
+- Deliver an end-to-end test suite covering core flows, including negative paths.
+- Provide user-facing docs in both the website and the repository.
+
+### Non-Goals
+
+- Replacing or wrapping the cluster-scoped `Queue`. `NamespaceQueue` is
+  **additive**; the current model is unchanged for clusters that do not opt in.
+- Introducing new tenant-isolation semantics.
+- Changing the meaning of `guarantee`, `deserved`, or `capability`. This proposal
+  does **not** alter how resource fields are defined or interpreted today.
+
+## User Stories
+
+### Story 1
+
+As a tenant with permissions only in my own namespace, I want to create a queue
+hierarchy under the cluster `Queue` my platform assigned me, and attach my
+`PodGroup`/`Job`s to it — without filing a ticket for the cluster admin on every
+change.
+
+### Story 2
+
+As a platform operator, I want a tenant's broken hierarchy (cycle, missing
+parent, over-committed child) to stay inert and never enter the global scheduler
+tree, so it cannot disturb other tenants' scheduling.
+
+### Story 3
+
+As an existing user, I want my current cluster `Queue`s and workloads to behave
+exactly as before if I don't enable this feature.
+
+## Design detail
+
+### The `NamespaceQueue` CRD
+
+`NamespaceQueue` is namespace-scoped and **reuses the existing `QueueSpec`**, so
+`weight`, `capability`, `guarantee`, `deserved`, `reclaimable`, `priority`,
+`dequeueStrategy`, and `parent` keep identical semantics. This directly satisfies
+the non-goal of not changing resource-field meaning.
+
+```go
+// +genclient
+// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+// +kubebuilder:object:root=true
+// +kubebuilder:subresource:status
+// +kubebuilder:resource:scope=Namespaced,shortName=nq
+
+// NamespaceQueue is the namespace-scoped counterpart of Queue.
+type NamespaceQueue struct {
+    metav1.TypeMeta   `json:",inline"`
+    metav1.ObjectMeta `json:"metadata,omitempty"`
+
+    // Spec reuses QueueSpec; spec.parent references either a NamespaceQueue in
+    // the same namespace or a cluster Queue (resolution is namespace-first).
+    Spec   QueueSpec            `json:"spec,omitempty"`
+    Status NamespaceQueueStatus `json:"status,omitempty"`
+}
+```
+
+`NamespaceQueueStatus` extends the existing `QueueStatus` fields (State, the
+PodGroup counters, `Reservation`, `Allocated`) with a readiness gate the
+scheduler keys on:
+
+```go
+type NamespaceQueueStatus struct {
+    QueueStatus `json:",inline"`
+
+    // Ready reports whether cross-resource validation passed and the queue may
+    // enter the scheduler hierarchy tree. The scheduler ignores queues that are
+    // not Ready.
+    // +optional
+    Ready bool `json:"ready,omitempty"`
+
+    // Conditions carries the validation result (parent existence, hierarchy
+    // validity, binding), so tenants can see *why* a queue is not Ready.
+    // +optional
+    Conditions []metav1.Condition `json:"conditions,omitempty"`
+}
+```
+
+> `TODO(mentors)`: how should `spec.parent` distinguish "same-namespace
+> NamespaceQueue" from "cluster Queue"? Options:
+> - **(A) namespace-first by convention** — a bare name resolves to a
+>   same-namespace `NamespaceQueue` first, else a cluster `Queue`. Simplest, but
+>   ambiguous if both exist with that name.
+> - **(B) explicit `parentKind`** field (`NamespaceQueue` | `Queue`). Explicit,
+>   no ambiguity, but adds surface area.
+> Recommendation: **(A)** to mirror the PodGroup resolution rule and keep the
+> spec unchanged; document the shadowing rule clearly.
+
+### QueueID namespace-qualification (core mechanism)
+
+The scheduler treats `api.QueueID` as an **opaque key**; it never assumes the ID
+equals the queue name. There is exactly one place that turns a name into a
+`QueueID` for the scheduler:
+
+```go
+// pkg/scheduler/api/queue_info.go  (NewQueueInfo)
+UID: QueueID(queue.Name)
+```
+
+For a `NamespaceQueue` we derive a **namespace-qualified synthetic ID**:
+
+- cluster `Queue`      → `QueueID(name)`            *(unchanged)*
+- `NamespaceQueue`     → `QueueID(namespace + "/" + name)`
+- synthetic root       → `QueueID("root")`          *(stays cluster-global)*
+
+Because every downstream consumer — the `capacity` tree
+(`queueAttr.children`/`ancestors`), leaf detection, bottom-up resource
+aggregation, hierarchical allocatable checks, and the flat `proportion` map —
+keys purely on `QueueID`, **they need no logic changes**. Only three
+"translation" points become namespace-aware:
+
+| Where | Today | Compatibility change |
+| --- | --- | --- |
+| `pkg/scheduler/api/queue_info.go` `NewQueueInfo` | `QueueID(name)` | qualify when the source object is a `NamespaceQueue` |
+| `capacity` parent lookup (`updateAncestors`) | `ssn.Queues[QueueID(spec.Parent)]` | resolve `spec.parent` namespace-first into the synthetic ID |
+| `pkg/scheduler/api/job_info.go` `SetPodGroup` | `QueueID(pg.Spec.Queue)` | resolve `(pg.Namespace, pg.Spec.Queue)` namespace-first |
+
+The `volcano.sh/hierarchy` / `hierarchy-weights` annotations store **queue name
+strings**, so their format is independent of namespace and the webhook mutator is
+unaffected.
+
+### PodGroup.spec.queue resolution (namespace-first)
+
+Resolution for a `PodGroup` in namespace `N` referencing queue name `Q`:
+
+1. If a `Ready` `NamespaceQueue` `N/Q` exists → use synthetic ID `QueueID("N/Q")`.
+2. Otherwise → fall back to cluster `Queue` `Q`, exactly as today.
+
+No new `PodGroup` field is required, and existing workloads are unaffected: with
+no `NamespaceQueue` present, step 1 never matches and behavior is identical to
+today. This is also the smooth-migration path — creating a same-named
+`NamespaceQueue` shadows the cluster `Queue` for *new* admissions only.
+
+> `TODO(mentors)`: migration semantics for **already-running** PodGroups when a
+> shadowing NamespaceQueue is created mid-flight — re-resolve on next session, or
+> pin at admission? Recommendation: resolve at admission and keep it stable for
+> the PodGroup's lifetime.
+
+### NamespaceQueue controller & status
+
+A new controller under `pkg/controllers/namespacequeue/` mirrors
+`pkg/controllers/queue/` (controller + handler + state machine + actions):
+
+- **Cross-resource validation** reconciled into `status`: parent exists (same-ns
+  NamespaceQueue or cluster Queue), no cycles, child `deserved`/`guarantee` sums
+  ≤ parent, child `capability` ≤ parent — the same rules the capacity plugin
+  enforces, surfaced early. On success it sets `status.Ready = true` and a
+  `Validated` condition; on failure it sets `Ready = false` with a reason.
+- **Usage write-back**: watches `PodGroup`s in its namespace and populates the
+  inherited `QueueStatus` counters and `Allocated`, reusing the cluster queue
+  controller's logic.
+
+The scheduler continues to be the source of truth for the *global* tree; the
+controller provides fast, tenant-visible feedback and the readiness gate.
+
+### Scheduler ready-gating & isolation
+
+The scheduler cache watches `NamespaceQueue` (new `Add/Update/Delete` handlers in
+`pkg/scheduler/cache/event_handlers.go`) and **admits into the queue tree only
+those with `status.Ready == true`**. A misconfigured `NamespaceQueue` stays in
+etcd but never becomes a `QueueInfo`, so it cannot enter the capacity hierarchy
+tree or affect any other tenant — this is the isolation guarantee.
+
+### Capacity / proportion plugin compatibility
+
+No behavioral change is proposed for either plugin. They operate entirely on
+`QueueID` + the `spec.parent`/hierarchy annotations, both of which the synthetic
+ID and namespace-first parent resolution keep valid. The existing leaf-only
+scheduling rule, bottom-up aggregation, and `ancestorReclaimLevel` reclaim scope
+all apply unchanged to a mixed tree of cluster `Queue`s and `NamespaceQueue`s.
+
+### Webhook & RBAC
+
+- Validating/mutating webhooks for `NamespaceQueue` mirror
+  `pkg/webhooks/admission/queues/` (basic spec checks + hierarchy annotation
+  prepend). Deep cross-resource validation lives in the controller/status, not
+  the webhook, to match how Volcano validates hierarchy today.
+- A namespaced `Role` (+ optional aggregated `ClusterRole` label) grants tenants
+  CRUD on `NamespaceQueue` in their own namespace — the concrete "no cluster
+  admin needed" mechanism.
+
+## Feature gate
+
+The whole feature sits behind a new gate, **default off**, so non-opting clusters
+are byte-for-byte unchanged:
+
+```go
+// pkg/features/volcano_features.go
+// NamespaceQueue enables the namespace-scoped NamespaceQueue CRD and its
+// namespace-first PodGroup queue resolution.
+NamespaceQueue featuregate.Feature = "NamespaceQueue"
+
+// in defaultVolcanoFeatureGates:
+NamespaceQueue: {Default: false, PreRelease: featuregate.Alpha},
+```
+
+When the gate is off, the cache does not watch `NamespaceQueue`, resolution is
+name-only against cluster `Queue`s, and the controller does not run.
+
+## Test plan
+
+- **Unit**: synthetic-ID derivation; namespace-first PodGroup resolution
+  (shadowing + fallback); controller validation → `status.Ready` transitions.
+- **E2E (Ginkgo, `test/e2e/`)**:
+  - tenant creates a `NamespaceQueue` under a cluster `Queue` and schedules a Job.
+  - two namespaces with same-named `NamespaceQueue`s scheduled independently.
+  - negative: cycle / missing parent / over-committed child ⇒ `Ready=false`, and
+    other tenants keep scheduling.
+  - backward-compat: gate off ⇒ existing cluster-queue e2e unchanged.
+
+## Limitations
+
+- Leaf-only scheduling is inherited from the capacity hierarchy design: jobs
+  attach only to leaf queues.
+- `TODO(mentors)`: cross-namespace parent (a NamespaceQueue parented by a
+  NamespaceQueue in *another* namespace) is out of scope for v1 — parents are
+  same-namespace NamespaceQueue or cluster Queue only.
+
+## Open questions for review
+
+1. `spec.parent` disambiguation: convention (A) vs explicit `parentKind` (B).
+2. Mid-flight re-resolution when a shadowing NamespaceQueue appears.
+3. Whether `NamespaceQueueStatus` should embed `QueueStatus` or duplicate a
+   trimmed subset.
+4. RBAC packaging: ship a ready-made tenant `Role` in the Helm chart, or document
+   only.

--- a/docs/design/namespace-queue.md
+++ b/docs/design/namespace-queue.md
@@ -1,6 +1,6 @@
 # Namespace-scoped Queues for Tenant-authored Hierarchies
 
-[@gitGurugu](https://github.com/gitGurugu); Jul 3, 2026
+[@gitGurugu](https://github.com/gitGurugu); Jul 8, 2026
 
 Tracking issue: [#5251](https://github.com/volcano-sh/volcano/issues/5251)
 
@@ -27,29 +27,33 @@ type NamespaceQueue struct {
 }
 
 type NamespaceQueueSpec struct {
-    // +kubebuilder:validation:Required 
+    // Parent points to either a local NamespaceQueue in the same Namespace
+    // or an authorized cluster-level Queue.
+    // +kubebuilder:validation:Required
     Parent string `json:"parent"`
 
+    // Deserved is the expected resource amount of this queue.
+    // Required when capacity plugin is used.
+    // +kubebuilder:validation:Required
+    Deserved corev1.ResourceList `json:"deserved"`
+
+    // Capability is the maximum resource limit this queue can use.
     // +optional
-	  // +kubebuilder:default:=1
-	  Weight int32 `json:"weight,omitempty"`
+    Capability corev1.ResourceList `json:"capability,omitempty"`
+
+    // Guarantee is the reserved resource for this queue.
+    // +optional
+    Guarantee volcanov1beta1.Guarantee `json:"guarantee,omitempty"`
 
     // +optional
-	  Capability corev1.ResourceList `json:"capability,omitempty"`
+    Priority int32 `json:"priority,omitempty"`
 
     // +optional
-	  Deserved corev1.ResourceList `json:"deserved,omitempty"`
+    DequeueStrategy DequeueStrategy `json:"dequeueStrategy,omitempty"`
 
+    // Deprecated: weight is only meaningful for proportion-style scheduling.
     // +optional
-	  Guarantee Guarantee `json:"guarantee,omitempty"`
-
-    // +optional
-	  Priority int32 `json:"priority,omitempty"`
-
-    // +optional
-	  // +kubebuilder:default:=fifo
-	  // +kubebuilder:validation:Enum=fifo;traverse
-	  DequeueStrategy DequeueStrategy `json:"dequeueStrategy,omitempty"`
+    Weight int32 `json:"weight,omitempty"`
 
 }
 ```
@@ -107,7 +111,7 @@ type NamespaceQueueList struct {
 
 ### Parent-queue ownership enforcement
 
-Cluster `Queue`s are partitioned by cluster admins, who own the cluster-level
+  Cluster `Queue`s are partitioned by cluster admins, who own the cluster-level
 quotas. Once tenants can freely set `NamespaceQueue.spec.parent`, nothing stops a
 tenant assigned to `queue-a` from creating a `NamespaceQueue` with
 `spec.parent: queue-b` and drawing from another team's slice. The authorization to
@@ -341,7 +345,7 @@ func (r *NamespaceQueueReconciler) buildVolcanoQueue(nsq *platformv1alpha1.Names
 			DequeueStrategy: volcanov1beta1.DequeueStrategy(nsq.Spec.DequeueStrategy),
 			
 			// Flattens the hierarchical relationship for backend volcano engine
-			Parent:          fmt.Sprintf("%s-%s", nsq.Namespace, nsq.Spec.Parent), 
+			Parent:          fmt.Sprintf("%s-%s", nsq.Namespace, nsq.Spec.Parent), //有问题
 		},
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This PR adds a design proposal for a namespace-scoped `NamespaceQueue` CRD,
letting tenants author and manage queue hierarchies within their own namespace
without cluster-admin intervention.

The proposal derives `NamespaceQueue` from the cluster-scoped `Queue` (reusing
`QueueSpec`, so guarantee/deserved/capability semantics are unchanged). It uses a
namespace-qualified `QueueID` and namespace-first `PodGroup.spec.queue`
resolution, so the `capacity` and `proportion` plugins need no behavioral change.
The whole feature sits behind a default-off `NamespaceQueue` feature gate, so
clusters that do not opt in are unchanged.

This is a **draft** opened to align on the design (see the `Open questions`
section) before implementation. It contains the design doc plus the feature-gate
registration only — no CRD/controller/scheduler code yet.

#### Which issue(s) this PR fixes:

Related to #5251

#### Special notes for your reviewer:

- This is a design-proposal draft PR; I'd especially appreciate feedback on the
  `Open questions for review` section (parent disambiguation, mid-flight
  re-resolution, status struct, RBAC packaging).
- AI disclosure: I used an AI coding assistant to help draft and structure the
  proposal document. I have reviewed and understand every part of it, and will
  respond to review comments myself.

#### Does this PR introduce a user-facing change?

```release-note
NONE
