### PR TITLE
fix(agentscheduler): copy ImageStates into fwk NodeInfo snapshot

### DIFF
--- a/pkg/scheduler/plugins/util/k8s/snapshot.go
+++ b/pkg/scheduler/plugins/util/k8s/snapshot.go
@@ -137,6 +137,7 @@ func (s *Snapshot) addOrUpdateNode(nodeInfo *api.NodeInfo) {
 	// Create k8s NodeInfo from vcNodeInfo
 	fwkNodeInfo := framework.NewNodeInfo(volcanoNodeInfo.Pods()...)
 	fwkNodeInfo.SetNode(volcanoNodeInfo.Node)
+	fwkNodeInfo.ImageStates = volcanoNodeInfo.CloneImageSummary()
 
 	idx, exists := s.nodeNameToIndex[nodeName]
 	if exists {

--- a/pkg/scheduler/plugins/util/k8s/snapshot.go
+++ b/pkg/scheduler/plugins/util/k8s/snapshot.go
@@ -139,6 +139,7 @@ func (s *Snapshot) addOrUpdateNode(nodeInfo *api.NodeInfo) {
 	// Create k8s NodeInfo from vcNodeInfo
 	fwkNodeInfo := framework.NewNodeInfo(volcanoNodeInfo.Pods()...)
 	fwkNodeInfo.SetNode(volcanoNodeInfo.Node)
+	fwkNodeInfo.ImageStates = volcanoNodeInfo.CloneImageSummary()
 
 	idx, exists := s.nodeNameToIndex[nodeName]
 	if exists {

--- a/pkg/scheduler/plugins/util/k8s/snapshot_test.go
+++ b/pkg/scheduler/plugins/util/k8s/snapshot_test.go
@@ -410,6 +410,65 @@ func TestSnapshot_UpdateAffinityLists(t *testing.T) {
 	}
 }
 
+func TestSnapshot_AddOrUpdateNodes_ImageStates(t *testing.T) {
+	node := api.NewNodeInfo(&v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "node-1",
+		},
+		Status: v1.NodeStatus{
+			Allocatable: v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("4"),
+				v1.ResourceMemory: resource.MustParse("8Gi"),
+			},
+		},
+	})
+	node.ImageStates = map[string]*fwk.ImageStateSummary{
+		"docker.io/library/nginx:latest": {
+			Size:     100 * 1024 * 1024,
+			NumNodes: 3,
+		},
+		"docker.io/library/redis:7": {
+			Size:     50 * 1024 * 1024,
+			NumNodes: 5,
+		},
+	}
+
+	snapshot := NewEmptySnapshot()
+	snapshot.AddOrUpdateNodes([]*api.NodeInfo{node})
+
+	k8sNodeInfo, err := snapshot.GetK8sNodeInfo("node-1")
+	if err != nil {
+		t.Fatalf("unexpected error getting k8s node info: %v", err)
+	}
+
+	imageStates := k8sNodeInfo.GetImageStates()
+	if len(imageStates) != 2 {
+		t.Fatalf("expected 2 image states in fwk NodeInfo, got %d", len(imageStates))
+	}
+
+	nginxState, ok := imageStates["docker.io/library/nginx:latest"]
+	if !ok {
+		t.Fatalf("expected nginx image state")
+	}
+	if nginxState.Size != 100*1024*1024 {
+		t.Errorf("expected nginx size 100MB, got %d", nginxState.Size)
+	}
+	if nginxState.NumNodes != 3 {
+		t.Errorf("expected nginx NumNodes 3, got %d", nginxState.NumNodes)
+	}
+
+	redisState, ok := imageStates["docker.io/library/redis:7"]
+	if !ok {
+		t.Fatalf("expected redis image state")
+	}
+	if redisState.Size != 50*1024*1024 {
+		t.Errorf("expected redis size 50MB, got %d", redisState.Size)
+	}
+	if redisState.NumNodes != 5 {
+		t.Errorf("expected redis NumNodes 5, got %d", redisState.NumNodes)
+	}
+}
+
 func TestSnapshot_DeleteNode(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/pkg/scheduler/plugins/util/k8s/snapshot_test.go
+++ b/pkg/scheduler/plugins/util/k8s/snapshot_test.go
@@ -352,6 +352,65 @@ func TestSnapshot_AddOrUpdateNodes(t *testing.T) {
 	}
 }
 
+func TestSnapshot_AddOrUpdateNodes_ImageStates(t *testing.T) {
+	node := api.NewNodeInfo(&v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "node-1",
+		},
+		Status: v1.NodeStatus{
+			Allocatable: v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("4"),
+				v1.ResourceMemory: resource.MustParse("8Gi"),
+			},
+		},
+	})
+	node.ImageStates = map[string]*fwk.ImageStateSummary{
+		"docker.io/library/nginx:latest": {
+			Size:     100 * 1024 * 1024,
+			NumNodes: 3,
+		},
+		"docker.io/library/redis:7": {
+			Size:     50 * 1024 * 1024,
+			NumNodes: 5,
+		},
+	}
+
+	snapshot := NewEmptySnapshot()
+	snapshot.AddOrUpdateNodes([]*api.NodeInfo{node})
+
+	k8sNodeInfo, err := snapshot.GetK8sNodeInfo("node-1")
+	if err != nil {
+		t.Fatalf("unexpected error getting k8s node info: %v", err)
+	}
+
+	imageStates := k8sNodeInfo.GetImageStates()
+	if len(imageStates) != 2 {
+		t.Fatalf("expected 2 image states in fwk NodeInfo, got %d", len(imageStates))
+	}
+
+	nginxState, ok := imageStates["docker.io/library/nginx:latest"]
+	if !ok {
+		t.Fatalf("expected nginx image state")
+	}
+	if nginxState.Size != 100*1024*1024 {
+		t.Errorf("expected nginx size 100MB, got %d", nginxState.Size)
+	}
+	if nginxState.NumNodes != 3 {
+		t.Errorf("expected nginx NumNodes 3, got %d", nginxState.NumNodes)
+	}
+
+	redisState, ok := imageStates["docker.io/library/redis:7"]
+	if !ok {
+		t.Fatalf("expected redis image state")
+	}
+	if redisState.Size != 50*1024*1024 {
+		t.Errorf("expected redis size 50MB, got %d", redisState.Size)
+	}
+	if redisState.NumNodes != 5 {
+		t.Errorf("expected redis NumNodes 5, got %d", redisState.NumNodes)
+	}
+}
+
 func TestSnapshot_DeleteNode(t *testing.T) {
 	tests := []struct {
 		name        string


### PR DESCRIPTION

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

In the agent scheduler snapshot, `Snapshot.addOrUpdateNode`
(`pkg/scheduler/plugins/util/k8s/snapshot.go`) builds the kube-scheduler
`framework.NodeInfo` with `NewNodeInfo(...)` followed by `SetNode(...)`, but it
never copies `ImageStates` from the cloned Volcano `NodeInfo`. `NewNodeInfo`
leaves `ImageStates` as an empty map, so the `framework.NodeInfo` that the agent
scheduler uses for scoring always has no image state.

The default `imagelocality` score plugin reads that map in `Score` (via
`GetImageStates()`). With it empty, no image ever matches, so the plugin returns
0 for every node and image-locality scheduling is silently disabled in the agent
scheduler.

The main scheduler path already handles this. `GenerateNodeMapAndSlice`
(`pkg/scheduler/framework/util.go`) sets
`nodeInfo.ImageStates = node.CloneImageSummary()` right after `SetNode`. This PR
mirrors that single line in the agent scheduler snapshot so both paths behave the
same.

The data is already present at the source, so this only propagates it: the agent
cache populates `NodeInfo.ImageStates` (`addNodeImageStates` in
`pkg/agentscheduler/cache/event_handlers.go`), and `NodeInfo.Clone()` preserves
it via `CloneImageSummary()`. It is simply never handed to the `framework.NodeInfo`
that the scorer consumes.

A regression test (`TestSnapshot_AddOrUpdateNodes_ImageStates`) is added: it puts
non-empty `ImageStates` on a node, runs `AddOrUpdateNodes`, and asserts the
image states survive onto the `framework.NodeInfo` returned by
`GetK8sNodeInfo`. It fails before the fix (0 image states) and passes after.

#### Which issue(s) this PR fixes:

Fixes #
<!-- No open issue tracks this; it mirrors the main-scheduler fix in commit
73e2289e ("fix(scheduler): restore ImageStates in GenerateNodeMapAndSlice")
for the parallel agent-scheduler snapshot path. Leave blank / remove `Fixes` if
no issue is filed, or file a short issue first and link it. -->

#### Special notes for your reviewer:

- The fix is one line and intentionally mirrors `pkg/scheduler/framework/util.go`
  (`GenerateNodeMapAndSlice`) exactly: same field, same helper
  (`CloneImageSummary()`), same position right after `SetNode`.
- AI disclosure (per the AI Guidance): I used an AI assistant while preparing this
  change. I traced the bug and its consumer chain, wrote and ran the tests, and
  understand and can explain every line.
- Heads-up on a possible overlap: PR #5501 also edits `addOrUpdateNode`
  (`Clone()` -> `ShallowClone()`), but it does not add the `ImageStates` line, so
  this fix is still needed. If #5501 merges first this will be a trivial rebase
  (keep this `ImageStates` line, take the `ShallowClone` change).

#### Does this PR introduce a user-facing change?

```release-note
Fixed image locality scoring being silently disabled in the agent scheduler because node image states were not propagated into the framework NodeInfo snapshot.
```

---

## The diff

```diff
diff --git a/pkg/scheduler/plugins/util/k8s/snapshot.go b/pkg/scheduler/plugins/util/k8s/snapshot.go
index 55dae4db..f43b1663 100644
--- a/pkg/scheduler/plugins/util/k8s/snapshot.go
+++ b/pkg/scheduler/plugins/util/k8s/snapshot.go
@@ -137,6 +137,7 @@ func (s *Snapshot) addOrUpdateNode(nodeInfo *api.NodeInfo) {
 	// Create k8s NodeInfo from vcNodeInfo
 	fwkNodeInfo := framework.NewNodeInfo(volcanoNodeInfo.Pods()...)
 	fwkNodeInfo.SetNode(volcanoNodeInfo.Node)
+	fwkNodeInfo.ImageStates = volcanoNodeInfo.CloneImageSummary()
 
 	idx, exists := s.nodeNameToIndex[nodeName]
 	if exists {
```

(plus `TestSnapshot_AddOrUpdateNodes_ImageStates`, +59 lines, in
`snapshot_test.go`)
