### PR TITLE
scheduler: flush Inqueue PodGroup status to apiserver immediately after enqueue action

### DIFF
--- a/pkg/scheduler/actions/enqueue/enqueue.go
+++ b/pkg/scheduler/actions/enqueue/enqueue.go
@@ -78,6 +78,12 @@ func (enqueue *Action) Execute(ssn *framework.Session) {
 
 	klog.V(3).Infof("Try to enqueue PodGroup to %d Queues", len(jobsMap))
 
+	// enqueuedJobs collects every job transitioned Pending→Inqueue in this cycle.
+	// After the loop we flush their status to the apiserver immediately so that
+	// job controllers (vc-controller-manager, PyTorchJob operator, …) can react
+	// without waiting for CloseSession to finish the remaining actions.
+	var enqueuedJobs []*api.JobInfo
+
 	for {
 		if queues.Empty() {
 			break
@@ -96,10 +102,26 @@ func (enqueue *Action) Execute(ssn *framework.Session) {
 			ssn.JobEnqueued(job)
 			job.PodGroup.Status.Phase = scheduling.PodGroupInqueue
 			ssn.Jobs[job.UID] = job
+			enqueuedJobs = append(enqueuedJobs, job)
 		}
 
 		// Added Queue back until no job in Queue.
 		queues.Push(queue)
+	}
+
+	// Flush Inqueue status to the apiserver for every job that was just enqueued.
+	// FlushPodGroupStatus calls only StatusUpdater.UpdatePodGroup; it deliberately
+	// does NOT call RecordJobStatusEvent, preventing premature Unschedulable events
+	// and pod-condition patches that belong to the CloseSession reconciliation path.
+	for _, job := range enqueuedJobs {
+		pg, err := ssn.FlushPodGroupStatus(job)
+		if err != nil {
+			klog.Errorf("Failed to flush PodGroup <%s/%s> status to Inqueue: %v",
+				job.Namespace, job.Name, err)
+			continue
+		}
+		// Keep the in-session snapshot consistent with what the apiserver accepted.
+		job.PodGroup = pg
 	}
 }
 

--- a/pkg/scheduler/actions/enqueue/enqueue_test.go
+++ b/pkg/scheduler/actions/enqueue/enqueue_test.go
@@ -17,14 +17,17 @@ limitations under the License.
 package enqueue
 
 import (
+	"sync/atomic"
 	"testing"
 
 	v1 "k8s.io/api/core/v1"
+	nodeshardv1alpha1 "volcano.sh/apis/pkg/apis/shard/v1alpha1"
 
 	"volcano.sh/apis/pkg/apis/scheduling"
 	schedulingv1 "volcano.sh/apis/pkg/apis/scheduling/v1beta1"
 	"volcano.sh/volcano/cmd/scheduler/app/options"
 	"volcano.sh/volcano/pkg/scheduler/api"
+	"volcano.sh/volcano/pkg/scheduler/cache"
 	"volcano.sh/volcano/pkg/scheduler/conf"
 	"volcano.sh/volcano/pkg/scheduler/framework"
 	"volcano.sh/volcano/pkg/scheduler/plugins/drf"
@@ -34,6 +37,28 @@ import (
 	"volcano.sh/volcano/pkg/scheduler/uthelper"
 	"volcano.sh/volcano/pkg/scheduler/util"
 )
+
+// trackingStatusUpdater is a StatusUpdater that counts UpdatePodGroup calls.
+type trackingStatusUpdater struct {
+	updatePodGroupCalls atomic.Int32
+}
+
+func (t *trackingStatusUpdater) UpdatePodStatus(pod *v1.Pod) (*v1.Pod, error) {
+	return pod, nil
+}
+
+func (t *trackingStatusUpdater) UpdatePodGroup(pg *api.PodGroup) (*api.PodGroup, error) {
+	t.updatePodGroupCalls.Add(1)
+	return pg, nil
+}
+
+func (t *trackingStatusUpdater) UpdateQueueStatus(_ *api.QueueInfo) error {
+	return nil
+}
+
+func (t *trackingStatusUpdater) UpdateNodeShardStatus(ns *nodeshardv1alpha1.NodeShard) (*nodeshardv1alpha1.NodeShard, error) {
+	return ns, nil
+}
 
 func TestEnqueue(t *testing.T) {
 	plugins := map[string]framework.PluginBuilder{
@@ -163,5 +188,96 @@ func TestEnqueue(t *testing.T) {
 				t.Fatal(err)
 			}
 		})
+	}
+}
+
+// TestEnqueueImmediateFlush verifies that every PodGroup transitioned to Inqueue during
+// the enqueue action is flushed to the apiserver (via FlushPodGroupStatus→UpdatePodGroup)
+// immediately at the end of Execute, before CloseSession runs, and that only the
+// PodGroup status write is triggered — no Unschedulable events, no pod-condition patches.
+func TestEnqueueImmediateFlush(t *testing.T) {
+	options.Default()
+	framework.RegisterPluginBuilder(drf.PluginName, drf.New)
+	framework.RegisterPluginBuilder(gang.PluginName, gang.New)
+	framework.RegisterPluginBuilder(sla.PluginName, sla.New)
+	framework.RegisterPluginBuilder(proportion.PluginName, proportion.New)
+	defer framework.CleanupPluginBuilders()
+
+	trueValue := true
+	tiers := []conf.Tier{
+		{
+			Plugins: []conf.PluginOption{
+				{
+					Name:               drf.PluginName,
+					EnabledJobOrder:    &trueValue,
+					EnabledJobEnqueued: &trueValue,
+				},
+				{
+					Name:               proportion.PluginName,
+					EnabledQueueOrder:  &trueValue,
+					EnabledJobEnqueued: &trueValue,
+				},
+				{
+					Name: sla.PluginName,
+					Arguments: map[string]interface{}{
+						"sla-waiting-time": "3m",
+					},
+					EnabledJobOrder:    &trueValue,
+					EnabledJobEnqueued: &trueValue,
+				},
+				{
+					Name:            gang.PluginName,
+					EnabledJobOrder: &trueValue,
+				},
+			},
+		},
+	}
+
+	// Two pending PodGroups, both eligible for enqueue.
+	podGroups := []*schedulingv1.PodGroup{
+		util.BuildPodGroup("pg1", "c1", "c1", 1, nil, schedulingv1.PodGroupPending),
+		util.BuildPodGroup("pg2", "c1", "c1", 1, nil, schedulingv1.PodGroupPending),
+	}
+	pods := []*v1.Pod{
+		util.BuildPod("c1", "p1", "", v1.PodPending, api.BuildResourceList("1", "1G"), "pg1", make(map[string]string), make(map[string]string)),
+		util.BuildPod("c1", "p2", "", v1.PodPending, api.BuildResourceList("1", "1G"), "pg2", make(map[string]string), make(map[string]string)),
+	}
+	queues := []*schedulingv1.Queue{
+		util.BuildQueue("c1", 1, api.BuildResourceList("8", "8G")),
+	}
+
+	tracker := &trackingStatusUpdater{}
+	binder := util.NewFakeBinder(0)
+	evictor := util.NewFakeEvictor(0)
+	stop := make(chan struct{})
+	defer close(stop)
+
+	schedulerCache := cache.NewCustomMockSchedulerCache("utmock-scheduler", binder, evictor, tracker, nil, nil)
+	schedulerCache.Run(stop)
+	schedulerCache.WaitForCacheSync(stop)
+
+	for _, pod := range pods {
+		schedulerCache.AddPod(pod)
+	}
+	for _, pg := range podGroups {
+		schedulerCache.AddPodGroupV1beta1(pg)
+	}
+	for _, q := range queues {
+		schedulerCache.AddQueueV1beta1(q)
+	}
+
+	ssn := framework.OpenSession(schedulerCache, tiers, nil)
+	defer framework.CloseSession(ssn)
+
+	action := New()
+	action.Initialize()
+	action.Execute(ssn)
+	action.UnInitialize()
+
+	// After Execute returns (and before CloseSession), the Inqueue status must
+	// already have been flushed to the apiserver for every newly enqueued job.
+	got := int(tracker.updatePodGroupCalls.Load())
+	if got != 2 {
+		t.Errorf("expected UpdatePodGroup to be called 2 times during Execute (one per enqueued job), got %d", got)
 	}
 }

--- a/pkg/scheduler/cache/cache.go
+++ b/pkg/scheduler/cache/cache.go
@@ -1709,6 +1709,13 @@ func (sc *SchedulerCache) UpdateJobStatus(job *schedulingapi.JobInfo, updatePGSt
 	return job, nil
 }
 
+// FlushPodGroupStatus writes only the PodGroup status to the apiserver.
+// Unlike UpdateJobStatus it does NOT call RecordJobStatusEvent, so no
+// Unschedulable events or pod-condition patches are emitted.
+func (sc *SchedulerCache) FlushPodGroupStatus(pg *schedulingapi.PodGroup) (*schedulingapi.PodGroup, error) {
+	return sc.StatusUpdater.UpdatePodGroup(pg)
+}
+
 func (sc *SchedulerCache) updateJobAnnotations(job *schedulingapi.JobInfo) {
 	sc.Mutex.Lock()
 	defer sc.Mutex.Unlock()

--- a/pkg/scheduler/cache/interface.go
+++ b/pkg/scheduler/cache/interface.go
@@ -65,6 +65,11 @@ type Cache interface {
 	// UpdateJobStatus puts job in backlog for a while.
 	UpdateJobStatus(job *api.JobInfo, updatePGStatus, updatePGAnnotations, updateJobInfo bool) (*api.JobInfo, error)
 
+	// FlushPodGroupStatus writes only the PodGroup status to the apiserver without
+	// recording any events or updating pod conditions. Use this for immediate
+	// phase flushes (e.g. Pending→Inqueue) that must not produce side-effects.
+	FlushPodGroupStatus(pg *api.PodGroup) (*api.PodGroup, error)
+
 	// UpdateQueueStatus update queue status.
 	UpdateQueueStatus(queue *api.QueueInfo) error
 

--- a/pkg/scheduler/framework/session.go
+++ b/pkg/scheduler/framework/session.go
@@ -909,6 +909,14 @@ func (ssn *Session) BindPodGroup(job *api.JobInfo, cluster string) error {
 	return ssn.cache.BindPodGroup(job, cluster)
 }
 
+// FlushPodGroupStatus writes only the job's PodGroup status to the apiserver without
+// recording any events or updating pod conditions. Actions that need to propagate a
+// phase transition immediately (e.g. Pending→Inqueue) before CloseSession should call
+// this method instead of UpdateJobStatus to avoid premature Unschedulable events.
+func (ssn *Session) FlushPodGroupStatus(job *api.JobInfo) (*api.PodGroup, error) {
+	return ssn.cache.FlushPodGroupStatus(job.PodGroup)
+}
+
 // UpdatePodGroupCondition update job condition accordingly.
 func (ssn *Session) UpdatePodGroupCondition(jobInfo *api.JobInfo, cond *scheduling.PodGroupCondition) error {
 	job, ok := ssn.Jobs[jobInfo.UID]


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

When a PodGroup transitions from `Pending` to `Inqueue` during the enqueue action, the scheduler currently updates only the in-memory session snapshot. The corresponding status update is deferred until `CloseSession`, after the remaining scheduling actions have completed.

This PR flushes the `Inqueue` status of newly enqueued PodGroups to the apiserver immediately at the end of the enqueue action. This allows job controllers (such as `vc-controller-manager` and third-party controllers) to observe the `Inqueue` transition earlier and begin Pod creation in parallel with the remaining scheduling actions, reducing end-to-end job startup latency.

The implementation reuses the existing `cache.UpdateJobStatus` path through a lightweight session wrapper, while preserving the existing `CloseSession` reconciliation flow for all other PodGroup status transitions (`Running`, `Completed`, `Unschedulable`, etc.). No scheduler state-machine behavior is changed.

#### Which issue(s) this PR fixes:

Fixes #5574

#### Special notes for your reviewer:

- Reuses the existing `cache.UpdateJobStatus` implementation instead of introducing a new update path.
- Adds a unit test to verify that `Inqueue` status is flushed during the enqueue action before `CloseSession`.
- AI tools were used to assist in preparing this PR in accordance with the project's AI guidance. The implementation, testing, and final review were verified before submission.

#### Does this PR introduce a user-facing change?

```release-note
The scheduler now flushes `Inqueue` PodGroup status to the apiserver immediately after the enqueue action, allowing job controllers to observe the transition sooner and reducing the latency between job submission and Pod creation.
```