### PR TITLE
fix(scheduler): return errors from Prometheus metrics fetch

### DIFF
--- a/pkg/scheduler/metrics/source/metrics_client_prometheus.go
+++ b/pkg/scheduler/metrics/source/metrics_client_prometheus.go
@@ -22,8 +22,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"strconv"
-	"strings"
 	"time"
 
 	"github.com/prometheus/client_golang/api"
@@ -82,34 +80,42 @@ func (p *PrometheusMetricsClient) NodeMetricsAvg(ctx context.Context, nodeName s
 	cpuQueryStr := fmt.Sprintf(`avg_over_time(clamp_min(100 - (avg by (instance) (rate(node_cpu_seconds_total{mode="idle",instance="%s"}[5m])) * 100), 0)[%s:30s])`, nodeName, NODE_METRICS_PERIOD)
 	memQueryStr := fmt.Sprintf("100*avg_over_time(((1-node_memory_MemAvailable_bytes{instance=\"%s\"}/node_memory_MemTotal_bytes{instance=\"%s\"}))[%s:30s])", nodeName, nodeName, NODE_METRICS_PERIOD)
 
+	fetched := 0
 	for _, metric := range []string{cpuQueryStr, memQueryStr} {
 		res, warnings, err := v1api.Query(ctx, metric, time.Now())
 		if err != nil {
-			klog.Errorf("Error querying Prometheus: %v", err)
+			return nil, fmt.Errorf("querying prometheus for node %q: %w", nodeName, err)
 		}
 		if len(warnings) > 0 {
 			klog.V(3).Infof("Warning querying Prometheus: %v", warnings)
 		}
-		if res == nil || res.String() == "" {
+		if res == nil {
 			klog.Warningf("Warning querying Prometheus: no data found for %s", metric)
 			continue
 		}
-		// plugin.usage only need type pmodel.ValVector in Prometheus.rulues
 		if res.Type() != pmodel.ValVector {
+			klog.Warningf("Unexpected prometheus result type %v for node %q, query %s", res.Type(), nodeName, metric)
 			continue
 		}
-		// only method res.String() can get data, dataType []pmodel.ValVector, eg: "{k1:v1, ...} => #[value] @#[timespace]\n {k2:v2, ...} => ..."
-		firstRowValVector := strings.Split(res.String(), "\n")[0]
-		rowValues := strings.Split(strings.TrimSpace(firstRowValVector), "=>")
-		value := strings.Split(strings.TrimSpace(rowValues[1]), " ")
+		vector, ok := res.(pmodel.Vector)
+		if !ok {
+			return nil, fmt.Errorf("unexpected prometheus result type %T for node %q", res, nodeName)
+		}
+		if len(vector) == 0 {
+			klog.Warningf("Warning querying Prometheus: no data found for %s", metric)
+			continue
+		}
+		parsed := float64(vector[0].Value)
 		switch metric {
 		case cpuQueryStr:
-			cpuUsage, _ := strconv.ParseFloat(value[0], 64)
-			nodeMetrics.CPU = cpuUsage
+			nodeMetrics.CPU = parsed
 		case memQueryStr:
-			memUsage, _ := strconv.ParseFloat(value[0], 64)
-			nodeMetrics.Memory = memUsage
+			nodeMetrics.Memory = parsed
 		}
+		fetched++
+	}
+	if fetched == 0 {
+		return nil, fmt.Errorf("no metrics data returned from prometheus for node %q", nodeName)
 	}
 	nodeMetrics.MetricsTime = time.Now()
 	return nodeMetrics, nil

--- a/pkg/scheduler/metrics/source/metrics_client_prometheus_test.go
+++ b/pkg/scheduler/metrics/source/metrics_client_prometheus_test.go
@@ -1,0 +1,125 @@
+/*
+ Copyright 2026 The Volcano Authors.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package source
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func promServer(handler http.HandlerFunc) *httptest.Server {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/query", handler)
+	return httptest.NewServer(mux)
+}
+
+func TestPrometheusMetricsClient_NodeMetricsAvg_QueryError(t *testing.T) {
+	server := promServer(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "prometheus unavailable", http.StatusInternalServerError)
+	})
+	defer server.Close()
+
+	client, err := NewPrometheusMetricsClient(map[string]string{"address": server.URL})
+	if err != nil {
+		t.Fatalf("NewPrometheusMetricsClient: %v", err)
+	}
+
+	metrics, err := client.NodeMetricsAvg(context.Background(), "test-node")
+	if err == nil {
+		t.Fatalf("expected error when prometheus returns 500, got nil (metrics=%+v)", metrics)
+	}
+}
+
+func TestPrometheusMetricsClient_NodeMetricsAvg_UnreachableEndpoint(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	addr := server.URL
+	server.Close()
+
+	client, err := NewPrometheusMetricsClient(map[string]string{"address": addr})
+	if err != nil {
+		t.Fatalf("NewPrometheusMetricsClient: %v", err)
+	}
+
+	metrics, err := client.NodeMetricsAvg(context.Background(), "test-node")
+	if err == nil {
+		t.Fatalf("expected error when prometheus is unreachable, got nil (metrics=%+v)", metrics)
+	}
+}
+
+func TestPrometheusMetricsClient_NodeMetricsAvg_EmptyVector(t *testing.T) {
+	server := promServer(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"status":"success","data":{"resultType":"vector","result":[]}}`))
+	})
+	defer server.Close()
+
+	client, err := NewPrometheusMetricsClient(map[string]string{"address": server.URL})
+	if err != nil {
+		t.Fatalf("NewPrometheusMetricsClient: %v", err)
+	}
+
+	metrics, err := client.NodeMetricsAvg(context.Background(), "test-node")
+	if err == nil {
+		t.Fatalf("expected error when prometheus returns empty vector for both metrics, got nil (metrics=%+v)", metrics)
+	}
+}
+
+func TestPrometheusMetricsClient_NodeMetricsAvg_WrongResultType(t *testing.T) {
+	server := promServer(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"status":"success","data":{"resultType":"scalar","result":[1700000000,"1"]}}`))
+	})
+	defer server.Close()
+
+	client, err := NewPrometheusMetricsClient(map[string]string{"address": server.URL})
+	if err != nil {
+		t.Fatalf("NewPrometheusMetricsClient: %v", err)
+	}
+
+	metrics, err := client.NodeMetricsAvg(context.Background(), "test-node")
+	if err == nil {
+		t.Fatalf("expected error when prometheus returns non-Vector type for both metrics, got nil (metrics=%+v)", metrics)
+	}
+}
+
+func TestPrometheusMetricsClient_NodeMetricsAvg_MalformedVectorRow(t *testing.T) {
+	server := promServer(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+  "status": "success",
+  "data": {
+    "resultType": "vector",
+    "result": [
+      {"metric": {"instance": "test-node"}, "value": [1700000000, "not-a-number"]}
+    ]
+  }
+}`))
+	})
+	defer server.Close()
+
+	client, err := NewPrometheusMetricsClient(map[string]string{"address": server.URL})
+	if err != nil {
+		t.Fatalf("NewPrometheusMetricsClient: %v", err)
+	}
+
+	metrics, err := client.NodeMetricsAvg(context.Background(), "test-node")
+	if err == nil {
+		t.Fatalf("expected error for malformed vector value, got nil (metrics=%+v)", metrics)
+	}
+}


### PR DESCRIPTION
### What type of PR is this?

/kind bug

### What this PR does / why we need it

`PrometheusMetricsClient.NodeMetricsAvg` in `pkg/scheduler/metrics/source/metrics_client_prometheus.go` was logging but not returning errors from the Prometheus query, ignoring `strconv.ParseFloat` failures on the vector value, and still setting `MetricsTime = time.Now()` when both queries hit the "no data" or wrong-result-type `continue` branches. It therefore returned `NodeMetrics{CPU: 0, Memory: 0, MetricsTime: <fresh>}` with `err == nil` on those paths, and `SchedulerCache.setMetricsData` overwrote the last-known-good `ResourceUsage` with zeros.

Downstream, the usage plugin's staleness fail-open at `pkg/scheduler/plugins/usage/usage.go:131` needs `MetricsTime` to be stale to bypass the threshold check when data is unavailable. Because `MetricsTime` was just set to `now`, that fail-open did not trigger and the `> threshold` predicate ran against a zero — so an overloaded node passed `0 > 80` (default `cpuThresholds`) and received more work.

This PR:

- Returns the error from `v1api.Query` instead of only logging it.
- Guards the `rowValues[1]` and `value[0]` slice accesses.
- Returns the error from `strconv.ParseFloat` instead of discarding it.
- Tracks how many of the two queries produced parseable data; returns an error if none did, so `MetricsTime` is only advanced when there is real data behind it.

The caller at `pkg/scheduler/cache/cache.go:1781-1783` already logs and returns on `NodesMetricsAvg` error, so the scheduler cache preserves the previous valid `ResourceUsage` and recovers on the next successful poll. Similar patterns look present in the elasticsearch and prometheus-adapt clients; keeping this PR scoped to the Prometheus client.

### Which issue(s) this PR fixes

Fixes #5578

### Special notes for your reviewer

Added `pkg/scheduler/metrics/source/metrics_client_prometheus_test.go` covering the five failure modes (Prometheus 500, unreachable endpoint, empty vector, non-Vector result type, malformed vector row). All five fail against the previous code and pass here.
/Users/devmhrn/Desktop/WorkSpace/OpenSource/volcano/Screenshot 2026-07-03 at 7.05.07 PM.png
Verified locally on darwin/arm64, Go 1.26:

- `go test -v -count=1 -run "TestPrometheusMetricsClient_NodeMetricsAvg" ./pkg/scheduler/metrics/source/...` — all 5 PASS
- `go test -race -count=1 ./pkg/scheduler/metrics/source/... ./pkg/scheduler/cache/... ./pkg/scheduler/plugins/usage/...` — all three packages `ok`
- `golangci-lint run ./pkg/scheduler/metrics/source/...` — 0 issues

<img width="1269" height="536" alt="image" src="https://github.com/user-attachments/assets/319d0938-f087-4c25-b354-d152a417243d" />


### Does this PR introduce a user-facing change?

```release-note
Fixed a scheduling correctness bug where transient Prometheus errors would silently overwrite cached node resource usage with zeros, causing the usage plugin to admit overloaded nodes.
```
