### PR TITLE
scheduler: check Elasticsearch response status before decoding metrics

### DIFF
--- a/pkg/scheduler/metrics/source/metrics_client_elasticsearch.go
+++ b/pkg/scheduler/metrics/source/metrics_client_elasticsearch.go
@@ -22,6 +22,8 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"errors"
+	"fmt"
+	"io"
 	"net/http"
 	"time"
 
@@ -146,9 +148,16 @@ func (e *ElasticsearchMetricsClient) NodeMetricsAvg(ctx context.Context, nodeNam
 		e.es.Search.WithBody(&buf),
 	)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("elasticsearch search request failed for node %s: %w", nodeName, err)
 	}
 	defer res.Body.Close()
+	if res.IsError() {
+		body, err := io.ReadAll(io.LimitReader(res.Body, maxBodySize))
+		if err != nil {
+			return nil, fmt.Errorf("elasticsearch search request failed for node %s: %s, failed to read response body: %w", nodeName, res.Status(), err)
+		}
+		return nil, fmt.Errorf("elasticsearch search request failed for node %s: %s: %s", nodeName, res.Status(), body)
+	}
 	var r struct {
 		Aggregations struct {
 			CPU struct {
@@ -161,7 +170,7 @@ func (e *ElasticsearchMetricsClient) NodeMetricsAvg(ctx context.Context, nodeNam
 	}
 	res.Body = http.MaxBytesReader(nil, res.Body, maxBodySize)
 	if err := json.NewDecoder(res.Body).Decode(&r); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to decode Elasticsearch metrics response for node %s: %w", nodeName, err)
 	}
 	// The data obtained from Elasticsearch is in decimals and needs to be multiplied by 100.
 	nodeMetrics.CPU = r.Aggregations.CPU.Value * 100

--- a/pkg/scheduler/metrics/source/metrics_client_elasticsearch_test.go
+++ b/pkg/scheduler/metrics/source/metrics_client_elasticsearch_test.go
@@ -81,9 +81,89 @@ func TestElasticsearchMetricsClientNodeMetricsAvg_MaxBodySizeExceeded(t *testing
 
 	if err == nil {
 		t.Error("Expected error due to response exceeding maxBodySize, but got nil")
-	} else {
-		if !strings.Contains(err.Error(), "body size limit") && !strings.Contains(err.Error(), "too large") {
-			t.Errorf("Expected error about body size limit, got: %v", err)
+	} else if (!strings.Contains(err.Error(), "body size limit") && !strings.Contains(err.Error(), "too large")) || !strings.Contains(err.Error(), "test-node") {
+		t.Errorf("Expected error about body size limit for test-node, got: %v", err)
+	}
+}
+
+func TestElasticsearchMetricsClientNodeMetricsAvg_ErrorResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("X-Elastic-Product", "Elasticsearch")
+		// The client issues an info request against "/" to verify the cluster
+		// before running the search; answer it successfully so the search itself
+		// is exercised.
+		if r.URL.Path == "/" {
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{"version": {"number": "7.17.7"}}`))
+			return
 		}
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte(`{"error": {"type": "search_phase_execution_exception", "reason": "all shards failed"}, "status": 500}`))
+	}))
+	defer server.Close()
+
+	client, err := NewElasticsearchMetricsClient(map[string]string{
+		"address": server.URL,
+	})
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	esClient, err := elasticsearch.NewClient(elasticsearch.Config{
+		Addresses: []string{server.URL},
+	})
+	if err != nil {
+		t.Fatalf("Failed to create ES client: %v", err)
+	}
+	client.es = esClient
+
+	_, err = client.NodeMetricsAvg(context.Background(), "test-node")
+
+	if err == nil {
+		t.Error("Expected error due to Elasticsearch returning an error response, but got nil")
+	} else if !strings.Contains(err.Error(), "500 Internal Server Error") ||
+		!strings.Contains(err.Error(), "test-node") ||
+		!strings.Contains(err.Error(), "all shards failed") {
+		t.Errorf("Expected error mentioning the status, node, and Elasticsearch failure reason, got: %v", err)
+	}
+}
+
+func TestElasticsearchMetricsClientNodeMetricsAvg_ErrorResponseBodyBounded(t *testing.T) {
+	const omittedReason = "reason after body limit"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("X-Elastic-Product", "Elasticsearch")
+		if r.URL.Path == "/" {
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{"version": {"number": "7.17.7"}}`))
+			return
+		}
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte(strings.Repeat("a", maxBodySize) + omittedReason))
+	}))
+	defer server.Close()
+
+	client, err := NewElasticsearchMetricsClient(map[string]string{
+		"address": server.URL,
+	})
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	esClient, err := elasticsearch.NewClient(elasticsearch.Config{
+		Addresses: []string{server.URL},
+	})
+	if err != nil {
+		t.Fatalf("Failed to create ES client: %v", err)
+	}
+	client.es = esClient
+
+	_, err = client.NodeMetricsAvg(context.Background(), "test-node")
+
+	if err == nil {
+		t.Error("Expected error due to Elasticsearch returning an error response, but got nil")
+	} else if strings.Contains(err.Error(), omittedReason) || !strings.Contains(err.Error(), "test-node") {
+		t.Errorf("Expected error response body for test-node to be limited to maxBodySize, got: %v", err)
 	}
 }


### PR DESCRIPTION

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

`NodeMetricsAvg` only checked the transport error returned by `es.Search`. The
go-elasticsearch client returns a nil transport error for HTTP 4xx/5xx responses,
so Elasticsearch error bodies were decoded as successful metrics with zero CPU
and memory values.

This change returns an error for HTTP failures and includes the node name, status,
and a response body bounded to `maxBodySize`. Transport and response decode errors
now include the node name as well. Tests cover the status, Elasticsearch reason,
node context, and response body bound.

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

The admission webhook E2E failure on the previous revision was unrelated. It
failed because `test-queue-open` already existed in two admission tests. This PR
only changes the scheduler Elasticsearch metrics client and its unit tests.

Verified with `make verify`, `make lint`,
`go vet ./pkg/scheduler/metrics/source/...`, and
`go test ./pkg/scheduler/metrics/...`.

Disclosure per the AI Guidance in `contributing.md`: I used an AI assistant while
preparing this change. I reviewed and verified every line myself, understand why
each change is here, and can explain and defend it in review.

#### Does this PR introduce a user-facing change?

```release-note
scheduler: Elasticsearch metrics errors now include bounded response details and node context instead of reporting zero utilization.
```
