### PR TITLE
fix: use queue UID consistently as map key for preemption/reclamation (#5479)

### DIFF
--- a/pkg/scheduler/actions/gangpreempt/gangpreempt.go
+++ b/pkg/scheduler/actions/gangpreempt/gangpreempt.go
@@ -104,10 +104,11 @@ func (gp *Action) Execute(ssn *framework.Session) {
 		if !ssn.JobStarving(job) {
 			continue
 		}
-		if _, found := preemptorsMap[job.Queue]; !found {
-			preemptorsMap[job.Queue] = util.NewPriorityQueue(ssn.JobOrderFn)
+		queue := ssn.Queues[job.Queue]
+		if _, found := preemptorsMap[queue.UID]; !found {
+			preemptorsMap[queue.UID] = util.NewPriorityQueue(ssn.JobOrderFn)
 		}
-		preemptorsMap[job.Queue].Push(job)
+		preemptorsMap[queue.UID].Push(job)
 	}
 
 	for !queues.Empty() {

--- a/pkg/scheduler/actions/preempt/preempt.go
+++ b/pkg/scheduler/actions/preempt/preempt.go
@@ -136,11 +136,12 @@ func (pmpt *Action) Execute(ssn *framework.Session) {
 			continue
 		}
 
-		if _, found := preemptorsMap[job.Queue]; !found {
-			preemptorsMap[job.Queue] = util.NewPriorityQueue(ssn.JobOrderFn)
+		queue := ssn.Queues[job.Queue]
+		if _, found := preemptorsMap[queue.UID]; !found {
+			preemptorsMap[queue.UID] = util.NewPriorityQueue(ssn.JobOrderFn)
 		}
-		preemptorsMap[job.Queue].Push(job)
-		underRequestByQueue[job.Queue] = append(underRequestByQueue[job.Queue], job)
+		preemptorsMap[queue.UID].Push(job)
+		underRequestByQueue[queue.UID] = append(underRequestByQueue[queue.UID], job)
 		preemptorTasks[job.UID] = util.NewPriorityQueue(ssn.TaskOrderFn)
 		for _, task := range job.TaskStatusIndex[api.Pending] {
 			if task.SchGated {

--- a/pkg/scheduler/actions/reclaim/reclaim.go
+++ b/pkg/scheduler/actions/reclaim/reclaim.go
@@ -88,10 +88,11 @@ func (ra *Action) Execute(ssn *framework.Session) {
 		}
 
 		if ssn.JobStarving(job) {
-			if _, found := preemptorsMap[job.Queue]; !found {
-				preemptorsMap[job.Queue] = util.NewPriorityQueue(ssn.JobOrderFn)
+			queue := ssn.Queues[job.Queue]
+			if _, found := preemptorsMap[queue.UID]; !found {
+				preemptorsMap[queue.UID] = util.NewPriorityQueue(ssn.JobOrderFn)
 			}
-			preemptorsMap[job.Queue].Push(job)
+			preemptorsMap[queue.UID].Push(job)
 			preemptorTasks[job.UID] = util.NewPriorityQueue(ssn.TaskOrderFn)
 			for _, task := range job.TaskStatusIndex[api.Pending] {
 				if task.SchGated {


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
This PR fixes a critical bug in Volcano's preemption and reclamation logic where map keys were inconsistent. The scheduler was storing jobs using Queue Name (job.Queue) but retrieving them using Queue UID (queue.UID). This caused the lookup to return nil, causing preemption to silently fail. High-priority jobs would remain pending even when low-priority jobs should have been preempted.

This fix changes the storage logic in gangpreempt, preempt, and reclaim actions to consistently use job.QueueUID as the map key, matching the retrieval logic which already correctly uses queue.UID.

#### Which issue(s) this PR fixes:
Fixes #5479

#### Special notes for  reviewer:
This is a focused fix that only changes 3 files (gangpreempt, preempt, reclaim). The changes are minimal and address the root cause of the issue. The Windows build failure (unix.Umask) is pre-existing and not related to this PR.

#### Does this PR introduce a user-facing change?
```release-note
Fixed preemption and reclamation actions that were silently failing due to queue name vs UID map key mismatch. High-priority jobs can now properly preempt low-priority jobs.
Signed-off-by: viveksantoshkumardubey@gmail.com

