### PR TITLE
fix(vgpu): sync TaskInfo annotations during bind lifecycle

### DIFF
--- a/pkg/scheduler/api/devices/ascend/hami/device_info.go
+++ b/pkg/scheduler/api/devices/ascend/hami/device_info.go
@@ -315,18 +315,18 @@ func (ads *AscendDevices) ScoreNode(pod *v1.Pod, policy string) float64 {
 	return score
 }
 
-func (ads *AscendDevices) Allocate(kubeClient kubernetes.Interface, pod *v1.Pod) error {
+func (ads *AscendDevices) Allocate(kubeClient kubernetes.Interface, pod *v1.Pod) (*devices.DeviceReservation, error) {
 	klog.V(4).Infof("Allocate device %s to Pod %s", ads.Type, pod.Name)
 	if NodeLockEnable {
 		nodelock.UseClient(kubeClient)
 		err := nodelock.LockNode(ads.NodeName, NodeLockAscend)
 		if err != nil {
-			return errors.Errorf("node %s locked for %s. err: %s", ads.NodeName, pod.Name, err.Error())
+			return nil, errors.Errorf("node %s locked for %s hami vnpu. lockname %s", ads.NodeName, pod.Name, err.Error())
 		}
 	}
 	podDevs, err := ads.selectDevices(pod, ads.Policy)
 	if err != nil {
-		return errors.Errorf("failed to select ascend devices for pod %s: %v", pod.Name, err)
+		return nil, errors.Errorf("failed to select ascend devices for pod %s: %v", pod.Name, err)
 	}
 	annotations := ads.CreateAnnotations(pod, podDevs)
 
@@ -338,19 +338,19 @@ func (ads *AscendDevices) Allocate(kubeClient kubernetes.Interface, pod *v1.Pod)
 
 	err = devices.PatchPodAnnotations(kubeClient, pod, annotations)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	klog.V(4).Infof("Allocate Success. device %s Pod %s", ads.Type, pod.Name)
-	return nil
+	return nil, nil
 }
 
-func (ads *AscendDevices) Release(kubeClient kubernetes.Interface, pod *v1.Pod) error {
+func (ads *AscendDevices) Release(kubeClient kubernetes.Interface, pod *v1.Pod) (*devices.DeviceReservation, error) {
 	if ads == nil || pod == nil || pod.Annotations == nil {
-		return nil
+		return nil, nil
 	}
 	ads.SubResource(pod)
 	if pod.Annotations[util.DeviceBindPhase] == DeviceBindSuccess {
-		return nil
+		return nil, nil
 	}
 	keys := []string{
 		util.AssignedNodeAnnotations,
@@ -367,12 +367,15 @@ func (ads *AscendDevices) Release(kubeClient kubernetes.Interface, pod *v1.Pod) 
 		)
 	}
 	if err := devices.RemovePodAnnotations(kubeClient, pod, keys); err != nil {
-		return err
+		return nil, err
 	}
 	for _, k := range keys {
 		delete(pod.Annotations, k)
 	}
-	return nil
+	return &devices.DeviceReservation{
+		DeviceType:  ads.Type,
+		Annotations: devices.AnnotationKeyMap(keys),
+	}, nil
 }
 
 func (ads *AscendDevices) GetIgnoredDevices() []string {

--- a/pkg/scheduler/api/devices/ascend/hami/device_info.go
+++ b/pkg/scheduler/api/devices/ascend/hami/device_info.go
@@ -180,6 +180,7 @@ func (ads *AscendDevices) SubResource(pod *v1.Pod) {
 	ano_key := devices.SupportDevices[ads.Type]
 	ano, ok := pod.Annotations[ano_key]
 	if !ok {
+		ads.subResourceByUID(pod)
 		return
 	}
 	con_devs, err := devices.DecodeContainerDevices(ano)
@@ -198,6 +199,21 @@ func (ads *AscendDevices) SubResource(pod *v1.Pod) {
 			ads.SubResourceUsage(dev, cono_dev.Usedcores, cono_dev.Usedmem)
 			klog.V(5).Infof("sub resource usage for pod %s. device %s usedmem %d usedcore %d", pod.Name, dev.DeviceInfo.ID, cono_dev.Usedmem, cono_dev.Usedcores)
 		}
+	}
+}
+
+func (ads *AscendDevices) subResourceByUID(pod *v1.Pod) {
+	if pod == nil {
+		return
+	}
+	for _, dev := range ads.Devices {
+		usage, ok := dev.PodMap[string(pod.UID)]
+		if !ok {
+			continue
+		}
+		delete(dev.PodMap, string(pod.UID))
+		ads.SubResourceUsage(dev, usage.Usedcores, usage.Usedmem)
+		klog.V(5).Infof("sub resource usage for pod %s by uid. device %s usedmem %d usedcore %d", pod.Name, dev.DeviceInfo.ID, usage.Usedmem, usage.Usedcores)
 	}
 }
 
@@ -336,16 +352,15 @@ func (ads *AscendDevices) Allocate(kubeClient kubernetes.Interface, pod *v1.Pod)
 	annotations[util.DeviceBindPhase] = "allocating"
 	annotations[util.BindTimeAnnotations] = strconv.FormatInt(time.Now().Unix(), 10)
 
-	err = devices.PatchPodAnnotations(kubeClient, pod, annotations)
-	if err != nil {
-		return nil, err
-	}
 	klog.V(4).Infof("Allocate Success. device %s Pod %s", ads.Type, pod.Name)
-	return nil, nil
+	return &devices.DeviceReservation{
+		DeviceType:  ads.Type,
+		Annotations: annotations,
+	}, nil
 }
 
 func (ads *AscendDevices) Release(kubeClient kubernetes.Interface, pod *v1.Pod) (*devices.DeviceReservation, error) {
-	if ads == nil || pod == nil || pod.Annotations == nil {
+	if ads == nil || pod == nil {
 		return nil, nil
 	}
 	ads.SubResource(pod)
@@ -365,12 +380,6 @@ func (ads *AscendDevices) Release(kubeClient kubernetes.Interface, pod *v1.Pod) 
 			devices.SupportDevices[commonWord],
 			fmt.Sprintf("huawei.com/%s", commonWord),
 		)
-	}
-	if err := devices.RemovePodAnnotations(kubeClient, pod, keys); err != nil {
-		return nil, err
-	}
-	for _, k := range keys {
-		delete(pod.Annotations, k)
 	}
 	return &devices.DeviceReservation{
 		DeviceType:  ads.Type,

--- a/pkg/scheduler/api/devices/ascend/hami/device_info_test.go
+++ b/pkg/scheduler/api/devices/ascend/hami/device_info_test.go
@@ -898,7 +898,7 @@ func hamiPodWithAnnotations(phase string) *v1.Pod {
 	}
 }
 
-func TestHAMiReleaseCleansSpeculativeAnnotations(t *testing.T) {
+func TestHAMiReleaseReturnsSpeculativeAnnotationKeys(t *testing.T) {
 	cleanup := setupReleaseTestKeys()
 	defer cleanup()
 
@@ -919,8 +919,8 @@ func TestHAMiReleaseCleansSpeculativeAnnotations(t *testing.T) {
 		testSupportKey,
 		testHuaweiKey,
 	} {
-		if _, ok := pod.Annotations[k]; ok {
-			t.Errorf("in-memory annotation %s should have been removed", k)
+		if _, ok := pod.Annotations[k]; !ok {
+			t.Errorf("in-memory annotation %s should not be removed during Release", k)
 		}
 		if reservation == nil || reservation.Annotations == nil {
 			t.Fatalf("Release should return annotation keys removed from TaskInfo.PodAnnotations")
@@ -937,8 +937,8 @@ func TestHAMiReleaseCleansSpeculativeAnnotations(t *testing.T) {
 	if err != nil {
 		t.Fatalf("get pod: %v", err)
 	}
-	if _, ok := got.Annotations[util.AssignedNodeAnnotations]; ok {
-		t.Errorf("apiserver annotation %s should have been removed", util.AssignedNodeAnnotations)
+	if _, ok := got.Annotations[util.AssignedNodeAnnotations]; !ok {
+		t.Errorf("apiserver annotation %s should not be removed during Release", util.AssignedNodeAnnotations)
 	}
 	if got.Annotations["keep-me"] != "yes" {
 		t.Errorf("non-device annotation must be preserved on apiserver")

--- a/pkg/scheduler/api/devices/ascend/hami/device_info_test.go
+++ b/pkg/scheduler/api/devices/ascend/hami/device_info_test.go
@@ -748,7 +748,7 @@ func TestAllocateAddsNodeLockAscendWhenEnabled(t *testing.T) {
 			"device-1": createTestAscendAllocateDevice("device-1"),
 		},
 	}
-	err := ads.Allocate(client, pod)
+	_, err := ads.Allocate(client, pod)
 	assert.NoError(t, err)
 
 	gotNode, getErr := client.CoreV1().Nodes().Get(context.Background(), nodeName, metav1.GetOptions{})
@@ -906,7 +906,8 @@ func TestHAMiReleaseCleansSpeculativeAnnotations(t *testing.T) {
 	client := fake.NewSimpleClientset(pod)
 	ads := &AscendDevices{NodeName: "node-a"}
 
-	if err := ads.Release(client, pod); err != nil {
+	reservation, err := ads.Release(client, pod)
+	if err != nil {
 		t.Fatalf("Release returned error: %v", err)
 	}
 
@@ -920,6 +921,12 @@ func TestHAMiReleaseCleansSpeculativeAnnotations(t *testing.T) {
 	} {
 		if _, ok := pod.Annotations[k]; ok {
 			t.Errorf("in-memory annotation %s should have been removed", k)
+		}
+		if reservation == nil || reservation.Annotations == nil {
+			t.Fatalf("Release should return annotation keys removed from TaskInfo.PodAnnotations")
+		}
+		if _, ok := reservation.Annotations[k]; !ok {
+			t.Errorf("reservation should request deletion of annotation %s", k)
 		}
 	}
 	if pod.Annotations["keep-me"] != "yes" {
@@ -946,7 +953,7 @@ func TestHAMiReleaseKeepsCommittedAnnotations(t *testing.T) {
 	client := fake.NewSimpleClientset(pod)
 	ads := &AscendDevices{NodeName: "node-a"}
 
-	if err := ads.Release(client, pod); err != nil {
+	if _, err := ads.Release(client, pod); err != nil {
 		t.Fatalf("Release returned error: %v", err)
 	}
 	if pod.Annotations[util.AssignedNodeAnnotations] != "node-a" {

--- a/pkg/scheduler/api/devices/ascend/mindcluster/ascend310p/vnpu/device_info.go
+++ b/pkg/scheduler/api/devices/ascend/mindcluster/ascend310p/vnpu/device_info.go
@@ -179,17 +179,17 @@ func (ns *NPUDevices) ScoreNode(pod *v1.Pod, schedulePolicy string) float64 {
 	return 0
 }
 
-func (ns *NPUDevices) Allocate(kubeClient kubernetes.Interface, pod *v1.Pod) error {
+func (ns *NPUDevices) Allocate(kubeClient kubernetes.Interface, pod *v1.Pod) (*devices.DeviceReservation, error) {
 	klog.V(4).Infoln("DeviceSharing:Into AllocateToPod", pod.Name)
 	if ns == nil {
 		klog.V(LogDebugLev).Infof("UseAnnotation failed: %s", ArgumentError)
-		return errors.New(ArgumentError)
+		return nil, errors.New(ArgumentError)
 	}
 
 	podResReq, err := ns.GetPodResource(pod)
 	if err != nil {
 		klog.V(LogErrorLev).Infof("%s UseAnnotation get require task resource failed: %s", ns.Name, err)
-		return err
+		return nil, err
 	}
 
 	_, ok := ns.DowngradeCache[pod.Name]
@@ -200,27 +200,30 @@ func (ns *NPUDevices) Allocate(kubeClient kubernetes.Interface, pod *v1.Pod) err
 	allocChipID, err := ns.SelectChipFromNode(podResReq)
 	if err != nil {
 		klog.V(LogErrorLev).Infof("UseAnnotation dynamic %s on %s err: %s", pod.Name, ns.NodeInf.Name, err)
-		return err
+		return nil, err
 	}
 	klog.V(LogDebugLev).Infof("dynamic vnpu UseAnnotation allocChipID:<%s>", allocChipID)
 	ns.SetNPUTopologyToPodFn(kubeClient, pod, podResReq, allocChipID, ns.VT)
-	return nil
+	return nil, nil
 }
 
-func (ns *NPUDevices) Release(kubeClient kubernetes.Interface, pod *v1.Pod) error {
+func (ns *NPUDevices) Release(kubeClient kubernetes.Interface, pod *v1.Pod) (*devices.DeviceReservation, error) {
 	if ns == nil || pod == nil || pod.Annotations == nil {
-		return nil
+		return nil, nil
 	}
 	ns.SubResource(pod)
 
 	keys := []string{PodPredicateTime, AscendNPUCore}
 	if err := devices.RemovePodAnnotations(kubeClient, pod, keys); err != nil {
-		return err
+		return nil, err
 	}
 	for _, k := range keys {
 		delete(pod.Annotations, k)
 	}
-	return nil
+	return &devices.DeviceReservation{
+		DeviceType:  DeviceName,
+		Annotations: devices.AnnotationKeyMap(keys),
+	}, nil
 }
 
 func (ns *NPUDevices) GetStatus() string {

--- a/pkg/scheduler/api/devices/ascend/mindcluster/ascend310p/vnpu/device_info.go
+++ b/pkg/scheduler/api/devices/ascend/mindcluster/ascend310p/vnpu/device_info.go
@@ -85,7 +85,10 @@ func (ns *NPUDevices) AddResource(pod *v1.Pod) {
 	if !ns.HasDeviceRequest(pod) {
 		return
 	}
+	ns.addResource(pod.Annotations, pod)
+}
 
+func (ns *NPUDevices) addResource(annotations map[string]string, pod *v1.Pod) {
 	//Upper level mechanism has assured that the pod(task) has been scheduled to this node
 	//Judge if the pod has resource request on this device
 	podRes, err := ns.GetPodResource(pod)
@@ -94,10 +97,14 @@ func (ns *NPUDevices) AddResource(pod *v1.Pod) {
 			ns.NodeInf.Name, err)
 	}
 
-	coreAnnotation, ok := pod.Annotations[AscendNPUCore]
+	coreAnnotation, ok := annotations[AscendNPUCore]
 	if !ok {
 		return
 	}
+	if ns.PodAllocation == nil {
+		ns.PodAllocation = make(map[types.UID]string)
+	}
+	ns.PodAllocation[pod.UID] = coreAnnotation
 	ascendNPUCoreSplit := strings.Split(coreAnnotation, "-")
 
 	var allocChipID, chipVTemplate string
@@ -130,8 +137,12 @@ func (ns *NPUDevices) SubResource(pod *v1.Pod) {
 
 	coreAnnotation, ok := pod.Annotations[AscendNPUCore]
 	if !ok {
-		return
+		coreAnnotation, ok = ns.PodAllocation[pod.UID]
+		if !ok {
+			return
+		}
 	}
+	delete(ns.PodAllocation, pod.UID)
 
 	ascendNPUCoreSplit := strings.Split(coreAnnotation, "-")
 
@@ -203,23 +214,21 @@ func (ns *NPUDevices) Allocate(kubeClient kubernetes.Interface, pod *v1.Pod) (*d
 		return nil, err
 	}
 	klog.V(LogDebugLev).Infof("dynamic vnpu UseAnnotation allocChipID:<%s>", allocChipID)
-	ns.SetNPUTopologyToPodFn(kubeClient, pod, podResReq, allocChipID, ns.VT)
-	return nil, nil
+	annotations := ns.BuildNPUTopologyAnnotations(pod, podResReq, allocChipID, ns.VT)
+	ns.addResource(annotations, pod)
+	return &devices.DeviceReservation{
+		DeviceType:  DeviceName,
+		Annotations: annotations,
+	}, nil
 }
 
 func (ns *NPUDevices) Release(kubeClient kubernetes.Interface, pod *v1.Pod) (*devices.DeviceReservation, error) {
-	if ns == nil || pod == nil || pod.Annotations == nil {
+	if ns == nil || pod == nil {
 		return nil, nil
 	}
 	ns.SubResource(pod)
 
 	keys := []string{PodPredicateTime, AscendNPUCore}
-	if err := devices.RemovePodAnnotations(kubeClient, pod, keys); err != nil {
-		return nil, err
-	}
-	for _, k := range keys {
-		delete(pod.Annotations, k)
-	}
 	return &devices.DeviceReservation{
 		DeviceType:  DeviceName,
 		Annotations: devices.AnnotationKeyMap(keys),
@@ -292,6 +301,7 @@ func (ns *NPUDevices) DeepCopy() interface{} {
 		UnhealthyChipIds: make(map[int]struct{}, len(ns.NPUDevice.UnhealthyChipIds)),
 		DowngradeCache:   make(map[string]struct{}, len(ns.NPUDevice.DowngradeCache)),
 		ConCache:         make(map[string]map[types.UID]struct{}, len(ns.NPUDevice.ConCache)),
+		PodAllocation:    make(map[types.UID]string, len(ns.NPUDevice.PodAllocation)),
 	}
 	for k, v := range ns.NPUDevice.VT.Data {
 		cp.NPUDevice.VT.Data[k] = v
@@ -308,6 +318,9 @@ func (ns *NPUDevices) DeepCopy() interface{} {
 			newInner[uid] = struct{}{}
 		}
 		cp.NPUDevice.ConCache[k] = newInner
+	}
+	for uid, coreAnnotation := range ns.NPUDevice.PodAllocation {
+		cp.NPUDevice.PodAllocation[uid] = coreAnnotation
 	}
 	for id, chip := range ns.NPUDevice.Chips {
 		newChip := &VChip{

--- a/pkg/scheduler/api/devices/ascend/mindcluster/ascend310p/vnpu/device_manage.go
+++ b/pkg/scheduler/api/devices/ascend/mindcluster/ascend310p/vnpu/device_manage.go
@@ -17,7 +17,6 @@ limitations under the License.
 package vnpu
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"sort"
@@ -26,9 +25,7 @@ import (
 	"time"
 
 	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
 )
 
@@ -527,44 +524,35 @@ func (ns *NPUDevices) taskAICPUCanBeDowngrade(podResReq VResource) bool {
 	return false
 }
 
-// SetNPUTopologyToPodFn write chip to pod annotation AscendNPUCore
-func (ns *NPUDevices) SetNPUTopologyToPodFn(kubeClient kubernetes.Interface, pod *v1.Pod, podResReq VResource, allocChipID string, chipVTemplate VTemplate) {
+// BuildNPUTopologyAnnotations returns the chip assignment annotations that must
+// be carried by the Pod bind request.
+func (ns *NPUDevices) BuildNPUTopologyAnnotations(pod *v1.Pod, podResReq VResource, allocChipID string, chipVTemplate VTemplate) map[string]string {
 	if ns == nil || pod == nil {
-		klog.V(LogDebugLev).Infof("SetNPUTopologyToPodFn failed: %s", ArgumentError)
-		return
+		klog.V(LogDebugLev).Infof("BuildNPUTopologyAnnotations failed: %s", ArgumentError)
+		return nil
 	}
 	tmp := strconv.FormatInt(time.Now().UnixNano(), Base10)
-	pod.Annotations[PodPredicateTime] = tmp
 	// 1. whole card
 	if ns.IsResourceWholeCard(podResReq.Aicore) {
-		pod.Annotations[AscendNPUCore] = allocChipID
-
-		patch := AddNPUAllocationPatch(allocChipID, "", tmp)
-		_, err := kubeClient.CoreV1().Pods(pod.Namespace).Patch(context.TODO(), pod.Name, types.JSONPatchType, []byte(patch), metav1.PatchOptions{})
-		if err != nil {
-			klog.V(LogErrorLev).Infof("patch pod %s failed: %v", pod.Name, err)
-		}
-
 		klog.V(LogInfoLev).Infof("dynamic vnpu setNPUTopologyToPod %s top:%s.", pod.Name, allocChipID)
-		return
+		return map[string]string{
+			PodPredicateTime: tmp,
+			AscendNPUCore:    allocChipID,
+		}
 	}
 
 	for curTemplate, jobVResource := range chipVTemplate.Data {
 		if podResReq != jobVResource {
 			continue
 		}
-		pod.Annotations[AscendNPUCore] = fmt.Sprintf("%s-%s", allocChipID, curTemplate)
-
-		patch := AddNPUAllocationPatch(allocChipID, curTemplate, tmp)
-		_, err := kubeClient.CoreV1().Pods(pod.Namespace).Patch(context.TODO(), pod.Name, types.JSONPatchType, []byte(patch), metav1.PatchOptions{})
-		if err != nil {
-			klog.V(LogErrorLev).Infof("patch pod %s failed: %v", pod.Name, err)
+		allocValue := fmt.Sprintf("%s-%s", allocChipID, curTemplate)
+		klog.V(LogInfoLev).Infof("dynamic vnpu setNPUTopologyToPod %s top:%s.", pod.Name, allocValue)
+		return map[string]string{
+			PodPredicateTime: tmp,
+			AscendNPUCore:    allocValue,
 		}
-
-		klog.V(LogInfoLev).Infof("dynamic vnpu setNPUTopologyToPod %s top:%s.", pod.Name,
-			pod.Annotations[AscendNPUCore])
-		return
 	}
+	return nil
 }
 
 // SelectChipFromNode get chip with least resource that meets vRes requirements

--- a/pkg/scheduler/api/devices/ascend/mindcluster/ascend310p/vnpu/type.go
+++ b/pkg/scheduler/api/devices/ascend/mindcluster/ascend310p/vnpu/type.go
@@ -43,6 +43,11 @@ type NPUDevice struct {
 	// for Concurrent task. not same core request task only has one on a node in same time.
 	// nodeName: templateName:taskUID
 	ConCache map[string]map[types.UID]struct{} //types.UID equals to pod.UID
+
+	// PodAllocation records scheduler-owned chip assignment annotations for pods
+	// allocated in the current session. It lets Release roll back in-memory state
+	// without depending on Pod.Annotations being mutated before bind.
+	PodAllocation map[types.UID]string
 }
 
 type NodeInf struct {

--- a/pkg/scheduler/api/devices/nvidia/gpushare/device_info.go
+++ b/pkg/scheduler/api/devices/nvidia/gpushare/device_info.go
@@ -17,13 +17,10 @@ limitations under the License.
 package gpushare
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/pkg/errors"
 	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
 
@@ -115,11 +112,23 @@ func (gs *GPUDevices) SubResource(pod *v1.Pod) {
 	gpuRes := getGPUMemoryOfPod(pod)
 	gpuNumRes := getGPUNumberOfPod(pod)
 	if gpuRes > 0 || gpuNumRes > 0 {
-		ids := GetGPUIndex(pod)
-		for _, id := range ids {
-			if dev := gs.Device[id]; dev != nil {
-				delete(dev.PodMap, string(pod.UID))
-			}
+		gs.removePodFromDeviceMap(pod, GetGPUIndex(pod))
+	}
+}
+
+func (gs *GPUDevices) removePodFromDeviceMap(pod *v1.Pod, ids []int) {
+	if pod == nil {
+		return
+	}
+	if len(ids) == 0 {
+		for _, dev := range gs.Device {
+			delete(dev.PodMap, string(pod.UID))
+		}
+		return
+	}
+	for _, id := range ids {
+		if dev := gs.Device[id]; dev != nil {
+			delete(dev.PodMap, string(pod.UID))
 		}
 	}
 }
@@ -137,18 +146,11 @@ func (gs *GPUDevices) AddQueueResource(pod *v1.Pod) map[string]float64 {
 }
 
 func (gs *GPUDevices) Release(kubeClient kubernetes.Interface, pod *v1.Pod) (*devices.DeviceReservation, error) {
+	if pod == nil {
+		return nil, nil
+	}
 	ids := GetGPUIndex(pod)
-	patch := RemoveGPUIndexPatch()
-	_, err := kubeClient.CoreV1().Pods(pod.Namespace).Patch(context.TODO(), pod.Name, types.JSONPatchType, []byte(patch), metav1.PatchOptions{})
-	if err != nil {
-		return nil, errors.Errorf("patch pod %s failed with patch %s: %v", pod.Name, patch, err)
-	}
-
-	for _, id := range ids {
-		if dev, ok := gs.Device[id]; ok {
-			delete(dev.PodMap, string(pod.UID))
-		}
-	}
+	gs.removePodFromDeviceMap(pod, ids)
 
 	klog.V(4).Infof("predicates with gpu sharing, update pod %s/%s deallocate from node [%s]", pod.Namespace, pod.Name, gs.Name)
 	return &devices.DeviceReservation{
@@ -223,27 +225,21 @@ func (gs *GPUDevices) Allocate(kubeClient kubernetes.Interface, pod *v1.Pod) (*d
 			return nil, errors.Errorf("the node %s can't place the pod %s in ns %s", pod.Spec.NodeName, pod.Name, pod.Namespace)
 		}
 		id := ids[0]
-		patch := AddGPUIndexPatch([]int{id})
-		pod, err := kubeClient.CoreV1().Pods(pod.Namespace).Patch(context.TODO(), pod.Name, types.JSONPatchType, []byte(patch), metav1.PatchOptions{})
-		if err != nil {
-			return nil, errors.Errorf("patch pod %s failed with patch %s: %v", pod.Name, patch, err)
-		}
 		dev, ok := gs.Device[id]
 		if !ok {
 			return nil, errors.Errorf("failed to get GPU %d from node %s", id, gs.Name)
 		}
 		dev.PodMap[string(pod.UID)] = pod
 		klog.V(4).Infof("predicates with gpu sharing, update pod %s/%s allocate to node [%s]", pod.Namespace, pod.Name, gs.Name)
+		return &devices.DeviceReservation{
+			DeviceType:  DeviceName,
+			Annotations: gpuIndexAnnotations([]int{id}),
+		}, nil
 	}
 	if getGPUNumberOfPod(pod) > 0 {
 		ids := predicateGPUbyNumber(pod, gs)
 		if len(ids) == 0 {
 			return nil, errors.Errorf("the node %s can't place the pod %s in ns %s", pod.Spec.NodeName, pod.Name, pod.Namespace)
-		}
-		patch := AddGPUIndexPatch(ids)
-		pod, err := kubeClient.CoreV1().Pods(pod.Namespace).Patch(context.TODO(), pod.Name, types.JSONPatchType, []byte(patch), metav1.PatchOptions{})
-		if err != nil {
-			return nil, errors.Errorf("patch pod %s failed with patch %s: %v", pod.Name, patch, err)
 		}
 		for _, id := range ids {
 			dev, ok := gs.Device[id]
@@ -253,6 +249,10 @@ func (gs *GPUDevices) Allocate(kubeClient kubernetes.Interface, pod *v1.Pod) (*d
 			dev.PodMap[string(pod.UID)] = pod
 		}
 		klog.V(4).Infof("predicates with gpu number, update pod %s/%s allocate to node [%s]", pod.Namespace, pod.Name, gs.Name)
+		return &devices.DeviceReservation{
+			DeviceType:  DeviceName,
+			Annotations: gpuIndexAnnotations(ids),
+		}, nil
 	}
 	return nil, nil
 }

--- a/pkg/scheduler/api/devices/nvidia/gpushare/device_info.go
+++ b/pkg/scheduler/api/devices/nvidia/gpushare/device_info.go
@@ -136,12 +136,12 @@ func (gs *GPUDevices) AddQueueResource(pod *v1.Pod) map[string]float64 {
 	return map[string]float64{}
 }
 
-func (gs *GPUDevices) Release(kubeClient kubernetes.Interface, pod *v1.Pod) error {
+func (gs *GPUDevices) Release(kubeClient kubernetes.Interface, pod *v1.Pod) (*devices.DeviceReservation, error) {
 	ids := GetGPUIndex(pod)
 	patch := RemoveGPUIndexPatch()
 	_, err := kubeClient.CoreV1().Pods(pod.Namespace).Patch(context.TODO(), pod.Name, types.JSONPatchType, []byte(patch), metav1.PatchOptions{})
 	if err != nil {
-		return errors.Errorf("patch pod %s failed with patch %s: %v", pod.Name, patch, err)
+		return nil, errors.Errorf("patch pod %s failed with patch %s: %v", pod.Name, patch, err)
 	}
 
 	for _, id := range ids {
@@ -151,7 +151,10 @@ func (gs *GPUDevices) Release(kubeClient kubernetes.Interface, pod *v1.Pod) erro
 	}
 
 	klog.V(4).Infof("predicates with gpu sharing, update pod %s/%s deallocate from node [%s]", pod.Namespace, pod.Name, gs.Name)
-	return nil
+	return &devices.DeviceReservation{
+		DeviceType:  DeviceName,
+		Annotations: devices.AnnotationKeyMap([]string{PredicateTime, GPUIndex}),
+	}, nil
 }
 
 func (gs *GPUDevices) FilterNode(pod *v1.Pod, schedulePolicy string) (int, string, error) {
@@ -205,29 +208,29 @@ func (gs *GPUDevices) ScoreNode(pod *v1.Pod, schedulePolicy string) float64 {
 	return 0
 }
 
-func (gs *GPUDevices) Allocate(kubeClient kubernetes.Interface, pod *v1.Pod) error {
+func (gs *GPUDevices) Allocate(kubeClient kubernetes.Interface, pod *v1.Pod) (*devices.DeviceReservation, error) {
 	klog.V(4).Infoln("DeviceSharing:Into AllocateToPod", pod.Name)
 	if getGPUMemoryOfPod(pod) > 0 {
 		if NodeLockEnable {
 			nodelock.UseClient(kubeClient)
 			err := nodelock.LockNode(gs.Name, "gpu")
 			if err != nil {
-				return errors.Errorf("node %s locked for lockname gpushare %s", gs.Name, err.Error())
+				return nil, errors.Errorf("node %s locked for lockname gpushare %s", gs.Name, err.Error())
 			}
 		}
 		ids := predicateGPUbyMemory(pod, gs)
 		if len(ids) == 0 {
-			return errors.Errorf("the node %s can't place the pod %s in ns %s", pod.Spec.NodeName, pod.Name, pod.Namespace)
+			return nil, errors.Errorf("the node %s can't place the pod %s in ns %s", pod.Spec.NodeName, pod.Name, pod.Namespace)
 		}
 		id := ids[0]
 		patch := AddGPUIndexPatch([]int{id})
 		pod, err := kubeClient.CoreV1().Pods(pod.Namespace).Patch(context.TODO(), pod.Name, types.JSONPatchType, []byte(patch), metav1.PatchOptions{})
 		if err != nil {
-			return errors.Errorf("patch pod %s failed with patch %s: %v", pod.Name, patch, err)
+			return nil, errors.Errorf("patch pod %s failed with patch %s: %v", pod.Name, patch, err)
 		}
 		dev, ok := gs.Device[id]
 		if !ok {
-			return errors.Errorf("failed to get GPU %d from node %s", id, gs.Name)
+			return nil, errors.Errorf("failed to get GPU %d from node %s", id, gs.Name)
 		}
 		dev.PodMap[string(pod.UID)] = pod
 		klog.V(4).Infof("predicates with gpu sharing, update pod %s/%s allocate to node [%s]", pod.Namespace, pod.Name, gs.Name)
@@ -235,21 +238,21 @@ func (gs *GPUDevices) Allocate(kubeClient kubernetes.Interface, pod *v1.Pod) err
 	if getGPUNumberOfPod(pod) > 0 {
 		ids := predicateGPUbyNumber(pod, gs)
 		if len(ids) == 0 {
-			return errors.Errorf("the node %s can't place the pod %s in ns %s", pod.Spec.NodeName, pod.Name, pod.Namespace)
+			return nil, errors.Errorf("the node %s can't place the pod %s in ns %s", pod.Spec.NodeName, pod.Name, pod.Namespace)
 		}
 		patch := AddGPUIndexPatch(ids)
 		pod, err := kubeClient.CoreV1().Pods(pod.Namespace).Patch(context.TODO(), pod.Name, types.JSONPatchType, []byte(patch), metav1.PatchOptions{})
 		if err != nil {
-			return errors.Errorf("patch pod %s failed with patch %s: %v", pod.Name, patch, err)
+			return nil, errors.Errorf("patch pod %s failed with patch %s: %v", pod.Name, patch, err)
 		}
 		for _, id := range ids {
 			dev, ok := gs.Device[id]
 			if !ok {
-				return errors.Errorf("failed to get GPU %d from node %s", id, gs.Name)
+				return nil, errors.Errorf("failed to get GPU %d from node %s", id, gs.Name)
 			}
 			dev.PodMap[string(pod.UID)] = pod
 		}
 		klog.V(4).Infof("predicates with gpu number, update pod %s/%s allocate to node [%s]", pod.Namespace, pod.Name, gs.Name)
 	}
-	return nil
+	return nil, nil
 }

--- a/pkg/scheduler/api/devices/nvidia/gpushare/device_info_test.go
+++ b/pkg/scheduler/api/devices/nvidia/gpushare/device_info_test.go
@@ -21,6 +21,8 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
 )
 
 func TestGetGPUMemoryOfPod(t *testing.T) {
@@ -170,5 +172,46 @@ func TestGetGPUNumberOfPod(t *testing.T) {
 				t.Errorf("unexpected result, want: %v, got: %v", tc.want, got)
 			}
 		})
+	}
+}
+
+func TestReleaseReturnsRemovedAnnotationKeys(t *testing.T) {
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "worker-0",
+			Namespace: "default",
+			UID:       "pod-uid",
+			Annotations: map[string]string{
+				PredicateTime: "1700000000",
+				GPUIndex:      "0",
+			},
+		},
+	}
+	client := fake.NewSimpleClientset(pod)
+	gs := &GPUDevices{
+		Name: "node-a",
+		Device: map[int]*GPUDevice{
+			0: {
+				ID:     0,
+				PodMap: map[string]*v1.Pod{string(pod.UID): pod},
+			},
+		},
+	}
+
+	reservation, err := gs.Release(client, pod)
+	if err != nil {
+		t.Fatalf("Release returned error: %v", err)
+	}
+	if _, ok := gs.Device[0].PodMap[string(pod.UID)]; ok {
+		t.Fatalf("Release should remove pod from GPU device map")
+	}
+	if reservation == nil || reservation.Annotations == nil {
+		t.Fatalf("Release should return annotation keys removed from TaskInfo.PodAnnotations")
+	}
+	if _, ok := reservation.Annotations[GPUIndex]; !ok {
+		t.Fatalf("reservation should request deletion of annotation %s", GPUIndex)
+	}
+	if _, ok := reservation.Annotations[PredicateTime]; !ok {
+		t.Fatalf("reservation should request deletion of annotation %s", PredicateTime)
 	}
 }

--- a/pkg/scheduler/api/devices/nvidia/gpushare/share.go
+++ b/pkg/scheduler/api/devices/nvidia/gpushare/share.go
@@ -197,6 +197,13 @@ func AddGPUIndexPatch(ids []int) string {
 		escapeJSONPointer(GPUIndex), idsstring)
 }
 
+func gpuIndexAnnotations(ids []int) map[string]string {
+	return map[string]string{
+		PredicateTime: strconv.FormatInt(time.Now().UnixNano(), 10),
+		GPUIndex:      strings.Trim(strings.Replace(fmt.Sprint(ids), " ", ",", -1), "[]"),
+	}
+}
+
 // RemoveGPUIndexPatch returns the patch removing GPU index
 func RemoveGPUIndexPatch() string {
 	return fmt.Sprintf(`[{"op": "remove", "path": "/metadata/annotations/%s"},`+

--- a/pkg/scheduler/api/devices/nvidia/vgpu/device_info.go
+++ b/pkg/scheduler/api/devices/nvidia/vgpu/device_info.go
@@ -277,18 +277,20 @@ func (gs *GPUDevices) HasDeviceRequest(pod *v1.Pod) bool {
 	return false
 }
 
-func (gs *GPUDevices) Release(kubeClient kubernetes.Interface, pod *v1.Pod) error {
-	if gs == nil || pod == nil || pod.Annotations == nil {
-		return nil
+func (gs *GPUDevices) Release(kubeClient kubernetes.Interface, pod *v1.Pod) (*devices.DeviceReservation, error) {
+	if gs == nil || pod == nil {
+		return nil, nil
 	}
-	// Release is required for rollback paths (e.g. UnPipeline) where NodeInfo
-	// does not invoke subResource for Pipelined tasks.
+	// Roll back the in-memory device ledger for UnPipeline/UnAllocate paths.
 	gs.SubResource(pod)
 
-	if pod.Annotations[DeviceBindPhase] == "success" {
-		return nil
+	// Once binding succeeds, vgpu-device-plugin owns these annotations.
+	// The scheduler must not clean them again.
+	if pod.Annotations != nil && pod.Annotations[DeviceBindPhase] == "success" {
+		return nil, nil
 	}
 
+	// Clean allocation annotations persisted to the apiserver.
 	keys := []string{
 		AssignedNodeAnnotations,          // volcano.sh/vgpu-node
 		AssignedIDsAnnotations,           // volcano.sh/vgpu-ids-new
@@ -298,12 +300,12 @@ func (gs *GPUDevices) Release(kubeClient kubernetes.Interface, pod *v1.Pod) erro
 		DeviceBindPhase,                  // volcano.sh/bind-phase
 	}
 	if err := devices.RemovePodAnnotations(kubeClient, pod, keys); err != nil {
-		return err
+		return nil, err
 	}
-	for _, k := range keys {
-		delete(pod.Annotations, k)
-	}
-	return nil
+	return &devices.DeviceReservation{
+		DeviceType:  DeviceName,
+		Annotations: devices.AnnotationKeyMap(keys),
+	}, nil
 }
 
 func (gs *GPUDevices) FilterNode(pod *v1.Pod, schedulePolicy string) (int, string, error) {
@@ -320,54 +322,43 @@ func (gs *GPUDevices) FilterNode(pod *v1.Pod, schedulePolicy string) (int, strin
 	return devices.Success, "", nil
 }
 
-func (gs *GPUDevices) Allocate(kubeClient kubernetes.Interface, pod *v1.Pod) error {
-	if VGPUEnable {
-		klog.V(4).Infoln("hami-vgpu DeviceSharing:Into AllocateToPod", pod.Name)
-		if alreadyAssignedOnNode(pod, gs.Name) {
-			klog.V(4).InfoS("hami-vgpu DeviceSharing: skip duplicate AllocateToPod",
-				"pod", pod.Name, "namespace", pod.Namespace, "node", gs.Name)
-			return nil
-		}
-		fit, device, _, err := checkNodeGPUSharingPredicateAndScore(pod, gs, false, SchedulePolicy)
-		if err != nil || !fit {
-			klog.ErrorS(err, "Failed to allocate vgpu task", "pod", pod.Name)
-			return err
-		}
-		if NodeLockEnable {
-			nodelock.UseClient(kubeClient)
-			err = nodelock.LockNode(gs.Name, DeviceName)
-			if err != nil {
-				return errors.Errorf("node %s locked for %s hamivgpu lockname %s", gs.Name, pod.Name, err.Error())
-			}
-		}
-
-		annotations := make(map[string]string)
-		annotations[AssignedNodeAnnotations] = gs.Name
-		annotations[AssignedTimeAnnotations] = strconv.FormatInt(time.Now().Unix(), 10)
-		annotations[AssignedIDsAnnotations] = encodePodDevices(device)
-		annotations[AssignedIDsToAllocateAnnotations] = annotations[AssignedIDsAnnotations]
-
-		annotations[DeviceBindPhase] = "allocating"
-		annotations[BindTimeAnnotations] = strconv.FormatInt(time.Now().Unix(), 10)
-		// Keep in-memory pod object in sync so rollback paths (UnPipeline ->
-		// Deallocate -> Release) can see allocated IDs before apiserver watch
-		// catches up.
-		if pod.Annotations == nil {
-			pod.Annotations = map[string]string{}
-		}
-		for k, v := range annotations {
-			pod.Annotations[k] = v
-		}
-		// To avoid that the pod allocated info updating latency, add it first
-		gs.addToPodMap(annotations, pod)
-		err = patchPodAnnotations(kubeClient, pod, annotations)
-		if err != nil {
-			return err
-		}
-
-		klog.V(3).Infoln("DeviceSharing:Allocate Success")
+func (gs *GPUDevices) Allocate(kubeClient kubernetes.Interface, pod *v1.Pod) (*devices.DeviceReservation, error) {
+	if !VGPUEnable {
+		return nil, nil
 	}
-	return nil
+	klog.V(4).Infoln("hami-vgpu DeviceSharing:Into AllocateToPod", pod.Name)
+	fit, device, _, err := checkNodeGPUSharingPredicateAndScore(pod, gs, false, SchedulePolicy)
+	if err != nil || !fit {
+		klog.ErrorS(err, "Failed to allocate vgpu task", "pod", pod.Name)
+		return nil, err
+	}
+	if NodeLockEnable {
+		nodelock.UseClient(kubeClient)
+		err = nodelock.LockNode(gs.Name, DeviceName)
+		if err != nil {
+			return nil, errors.Errorf("node %s locked for %s hamivgpu lockname %s", gs.Name, pod.Name, err.Error())
+		}
+	}
+
+	annotations := make(map[string]string)
+	annotations[AssignedNodeAnnotations] = gs.Name
+	annotations[AssignedTimeAnnotations] = strconv.FormatInt(time.Now().Unix(), 10)
+	annotations[AssignedIDsAnnotations] = encodePodDevices(device)
+	annotations[AssignedIDsToAllocateAnnotations] = annotations[AssignedIDsAnnotations]
+	annotations[DeviceBindPhase] = "allocating"
+	annotations[BindTimeAnnotations] = strconv.FormatInt(time.Now().Unix(), 10)
+
+	// Update the in-memory device ledger without mutating shared pod annotations.
+	// Passing annotations directly avoids concurrent reads/writes on the shared Pod map.
+	gs.addToPodMap(annotations, pod)
+
+	// Return allocation annotations so predicates can carry the same values on
+	// the binding request. The apiserver merges Binding annotations into the Pod
+	// atomically with node assignment.
+	return &devices.DeviceReservation{
+		DeviceType:  DeviceName,
+		Annotations: annotations,
+	}, nil
 }
 
 // DeepCopy returns a deep copy of GPUDevices for use in dry-run simulation.
@@ -415,13 +406,4 @@ func (gs *GPUDevices) DeepCopy() interface{} {
 		cp.Device[id] = newDev
 	}
 	return cp
-}
-
-func alreadyAssignedOnNode(pod *v1.Pod, nodeName string) bool {
-	if pod == nil || pod.Annotations == nil || nodeName == "" {
-		return false
-	}
-
-	return pod.Annotations[AssignedNodeAnnotations] == nodeName &&
-		pod.Annotations[AssignedIDsAnnotations] != ""
 }

--- a/pkg/scheduler/api/devices/nvidia/vgpu/device_info.go
+++ b/pkg/scheduler/api/devices/nvidia/vgpu/device_info.go
@@ -290,7 +290,6 @@ func (gs *GPUDevices) Release(kubeClient kubernetes.Interface, pod *v1.Pod) (*de
 		return nil, nil
 	}
 
-	// Clean allocation annotations persisted to the apiserver.
 	keys := []string{
 		AssignedNodeAnnotations,          // volcano.sh/vgpu-node
 		AssignedIDsAnnotations,           // volcano.sh/vgpu-ids-new
@@ -298,9 +297,6 @@ func (gs *GPUDevices) Release(kubeClient kubernetes.Interface, pod *v1.Pod) (*de
 		AssignedTimeAnnotations,          // volcano.sh/vgpu-time
 		BindTimeAnnotations,              // volcano.sh/bind-time
 		DeviceBindPhase,                  // volcano.sh/bind-phase
-	}
-	if err := devices.RemovePodAnnotations(kubeClient, pod, keys); err != nil {
-		return nil, err
 	}
 	return &devices.DeviceReservation{
 		DeviceType:  DeviceName,

--- a/pkg/scheduler/api/devices/nvidia/vgpu/device_info_test.go
+++ b/pkg/scheduler/api/devices/nvidia/vgpu/device_info_test.go
@@ -217,42 +217,44 @@ func podWithVGPUAnnotations(phase string) *v1.Pod {
 	}
 }
 
-// A discarded (speculative) allocation must have its device annotations removed so it
-// cannot survive onto a different node. Regression test for volcano-sh/volcano#5335.
+// TestReleaseCleansSpeculativeAnnotations verifies that Release cleans apiserver annotations
+// without mutating the in-memory Pod annotation map. This avoids concurrent map writes on
+// shared Pod objects.
 func TestReleaseCleansSpeculativeAnnotations(t *testing.T) {
 	pod := podWithVGPUAnnotations("allocating")
 	client := fake.NewSimpleClientset(pod)
 	gs := &GPUDevices{Name: "node-a"}
 
-	if err := gs.Release(client, pod); err != nil {
+	reservation, err := gs.Release(client, pod)
+	if err != nil {
 		t.Fatalf("Release returned error: %v", err)
 	}
 
-	for _, k := range []string{
-		AssignedNodeAnnotations, AssignedIDsAnnotations,
-		AssignedIDsToAllocateAnnotations, DeviceBindPhase,
-	} {
-		if _, ok := pod.Annotations[k]; ok {
-			t.Errorf("in-memory annotation %s should have been removed", k)
-		}
-	}
-	if pod.Annotations["keep-me"] != "yes" {
-		t.Errorf("non-device annotation must be preserved in-memory")
-	}
-
+	// Release removes annotations from the apiserver via RemovePodAnnotations.
 	got, err := client.CoreV1().Pods("default").Get(context.Background(), "worker-0", metav1.GetOptions{})
 	if err != nil {
 		t.Fatalf("get pod: %v", err)
 	}
-	if _, ok := got.Annotations[AssignedNodeAnnotations]; ok {
-		t.Errorf("apiserver annotation %s should have been removed", AssignedNodeAnnotations)
-	}
-	if _, ok := got.Annotations[AssignedIDsAnnotations]; ok {
-		t.Errorf("apiserver annotation %s should have been removed", AssignedIDsAnnotations)
+	for _, k := range []string{
+		AssignedNodeAnnotations, AssignedIDsAnnotations,
+		AssignedIDsToAllocateAnnotations, DeviceBindPhase,
+	} {
+		if _, ok := got.Annotations[k]; ok {
+			t.Errorf("apiserver annotation %s should have been removed", k)
+		}
+		if reservation == nil || reservation.Annotations == nil {
+			t.Fatalf("Release should return annotation keys removed from TaskInfo.PodAnnotations")
+		}
+		if _, ok := reservation.Annotations[k]; !ok {
+			t.Errorf("reservation should request deletion of annotation %s", k)
+		}
 	}
 	if got.Annotations["keep-me"] != "yes" {
 		t.Errorf("non-device annotation must be preserved on apiserver")
 	}
+
+	// Release no longer mutates the in-memory Pod annotation map.
+	// Device allocation annotations flow through TaskInfo.PodAnnotations and bind carry.
 }
 
 // A committed/running pod (device plugin set bind-phase=success) must NOT be stripped,
@@ -262,7 +264,7 @@ func TestReleaseKeepsCommittedAnnotations(t *testing.T) {
 	client := fake.NewSimpleClientset(pod)
 	gs := &GPUDevices{Name: "node-a"}
 
-	if err := gs.Release(client, pod); err != nil {
+	if _, err := gs.Release(client, pod); err != nil {
 		t.Fatalf("Release returned error: %v", err)
 	}
 	if pod.Annotations[AssignedNodeAnnotations] != "node-a" {

--- a/pkg/scheduler/api/devices/nvidia/vgpu/device_info_test.go
+++ b/pkg/scheduler/api/devices/nvidia/vgpu/device_info_test.go
@@ -217,10 +217,9 @@ func podWithVGPUAnnotations(phase string) *v1.Pod {
 	}
 }
 
-// TestReleaseCleansSpeculativeAnnotations verifies that Release cleans apiserver annotations
-// without mutating the in-memory Pod annotation map. This avoids concurrent map writes on
-// shared Pod objects.
-func TestReleaseCleansSpeculativeAnnotations(t *testing.T) {
+// TestReleaseReturnsSpeculativeAnnotationKeys verifies that Release only reports
+// the speculative annotation keys that should be removed from TaskInfo.PodAnnotations.
+func TestReleaseReturnsSpeculativeAnnotationKeys(t *testing.T) {
 	pod := podWithVGPUAnnotations("allocating")
 	client := fake.NewSimpleClientset(pod)
 	gs := &GPUDevices{Name: "node-a"}
@@ -230,7 +229,6 @@ func TestReleaseCleansSpeculativeAnnotations(t *testing.T) {
 		t.Fatalf("Release returned error: %v", err)
 	}
 
-	// Release removes annotations from the apiserver via RemovePodAnnotations.
 	got, err := client.CoreV1().Pods("default").Get(context.Background(), "worker-0", metav1.GetOptions{})
 	if err != nil {
 		t.Fatalf("get pod: %v", err)
@@ -239,8 +237,8 @@ func TestReleaseCleansSpeculativeAnnotations(t *testing.T) {
 		AssignedNodeAnnotations, AssignedIDsAnnotations,
 		AssignedIDsToAllocateAnnotations, DeviceBindPhase,
 	} {
-		if _, ok := got.Annotations[k]; ok {
-			t.Errorf("apiserver annotation %s should have been removed", k)
+		if _, ok := got.Annotations[k]; !ok {
+			t.Errorf("apiserver annotation %s should not be removed during Release", k)
 		}
 		if reservation == nil || reservation.Annotations == nil {
 			t.Fatalf("Release should return annotation keys removed from TaskInfo.PodAnnotations")
@@ -252,9 +250,6 @@ func TestReleaseCleansSpeculativeAnnotations(t *testing.T) {
 	if got.Annotations["keep-me"] != "yes" {
 		t.Errorf("non-device annotation must be preserved on apiserver")
 	}
-
-	// Release no longer mutates the in-memory Pod annotation map.
-	// Device allocation annotations flow through TaskInfo.PodAnnotations and bind carry.
 }
 
 // A committed/running pod (device plugin set bind-phase=success) must NOT be stripped,

--- a/pkg/scheduler/api/devices/nvidia/vgpu/utils.go
+++ b/pkg/scheduler/api/devices/nvidia/vgpu/utils.go
@@ -17,8 +17,6 @@ limitations under the License.
 package vgpu
 
 import (
-	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"sort"
@@ -26,9 +24,6 @@ import (
 	"strings"
 
 	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	k8stypes "k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
 
 	"volcano.sh/apis/pkg/apis/scheduling/v1beta1"
@@ -527,31 +522,6 @@ func GPUScore(schedulePolicy string, device *GPUDevice) float64 {
 		score = float64(0)
 	}
 	return score
-}
-
-func patchPodAnnotations(kubeClient kubernetes.Interface, pod *v1.Pod, annotations map[string]string) error {
-	type patchMetadata struct {
-		Annotations map[string]string `json:"annotations,omitempty"`
-	}
-	type patchPod struct {
-		Metadata patchMetadata `json:"metadata"`
-		//Spec     patchSpec     `json:"spec,omitempty"`
-	}
-
-	p := patchPod{}
-	p.Metadata.Annotations = annotations
-
-	bytes, err := json.Marshal(p)
-	if err != nil {
-		return err
-	}
-	_, err = kubeClient.CoreV1().Pods(pod.Namespace).
-		Patch(context.Background(), pod.Name, k8stypes.StrategicMergePatchType, bytes, metav1.PatchOptions{})
-	if err != nil {
-		klog.Errorf("patch pod %v failed, %v", pod.Name, err)
-	}
-
-	return err
 }
 
 func getConfig() config.NvidiaConfig {

--- a/pkg/scheduler/api/devices/reservation.go
+++ b/pkg/scheduler/api/devices/reservation.go
@@ -1,0 +1,58 @@
+/*
+Copyright 2025 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package devices
+
+// DeviceReservation is the common return contract for Devices.Allocate/Release.
+// Device implementations only fill the fields they need; predicates consumes the
+// result and forwards annotation data into the bind pipeline.
+type DeviceReservation struct {
+	// DeviceType identifies the device implementation that produced the reservation.
+	DeviceType string
+
+	// Annotations contains Pod annotation key/value pairs for this reservation.
+	// Allocate callers merge these values into TaskInfo.PodAnnotations for bind carry.
+	// Release callers only use the keys to delete corresponding bind annotations.
+	Annotations map[string]string
+
+	// Opaque is reserved for device-specific data and is not interpreted by the framework.
+	Opaque map[string]string
+}
+
+func (r *DeviceReservation) AnnotationKeys() []string {
+	if r == nil || len(r.Annotations) == 0 {
+		return nil
+	}
+	keys := make([]string, 0, len(r.Annotations))
+	for key := range r.Annotations {
+		keys = append(keys, key)
+	}
+	return keys
+}
+
+// AnnotationKeyMap builds an annotation map that carries only keys.
+// Release implementations use it to tell the scheduler which keys must be
+// removed from TaskInfo.PodAnnotations before the bind request is submitted.
+func AnnotationKeyMap(keys []string) map[string]string {
+	if len(keys) == 0 {
+		return nil
+	}
+	annotations := make(map[string]string, len(keys))
+	for _, key := range keys {
+		annotations[key] = ""
+	}
+	return annotations
+}

--- a/pkg/scheduler/api/job_info.go
+++ b/pkg/scheduler/api/job_info.go
@@ -154,6 +154,22 @@ type TaskInfo struct {
 	NumaInfo *TopologyInfo
 	Pod      *v1.Pod
 
+	// PodAnnotations is the scheduler-owned annotation set that will be submitted
+	// with the Pod bind request.
+	//
+	// TaskInfo intentionally keeps Pod as a shared informer object instead of
+	// deep-copying the whole Pod during scheduler snapshots. Mutating
+	// Pod.Annotations from scheduling callbacks can race with informer event
+	// handling because the underlying map may still be shared with the cache.
+	// PodAnnotations is initialized from a cloned Pod.Annotations map and is the
+	// only mutable annotation state that scheduling plugins should use.
+	//
+	// This map is owned by one scheduling session. Plugins may merge final
+	// annotations after a node has been selected, such as in AllocateFunc, or
+	// immediately before the bind request is enqueued. Predicate callbacks that
+	// evaluate candidate nodes in parallel must not write to this map.
+	PodAnnotations map[string]string
+
 	// CustomBindErrHandler is a custom callback func called when task bind err.
 	CustomBindErrHandler func() error `json:"-"`
 	// CustomBindErrHandlerSucceeded indicates whether CustomBindErrHandler is executed successfully.
@@ -209,6 +225,7 @@ func NewTaskInfo(pod *v1.Pod) *TaskInfo {
 		TaskRole:                    role,
 		Priority:                    1,
 		Pod:                         pod,
+		PodAnnotations:              maps.Clone(pod.Annotations),
 		Resreq:                      resReq,
 		InitResreq:                  initResReq,
 		Preemptable:                 preemptable,
@@ -262,6 +279,25 @@ func calSchedulingGated(pod *v1.Pod) bool {
 	return false
 }
 
+func (ti *TaskInfo) MergePodAnnotations(annotations map[string]string) {
+	if ti == nil || len(annotations) == 0 {
+		return
+	}
+	if ti.PodAnnotations == nil {
+		ti.PodAnnotations = map[string]string{}
+	}
+	maps.Copy(ti.PodAnnotations, annotations)
+}
+
+func (ti *TaskInfo) DeletePodAnnotations(keys ...string) {
+	if ti == nil || ti.PodAnnotations == nil || len(keys) == 0 {
+		return
+	}
+	for _, key := range keys {
+		delete(ti.PodAnnotations, key)
+	}
+}
+
 func (ti *TaskInfo) SetPodResourceDecision() error {
 	if ti.NumaInfo == nil || len(ti.NumaInfo.ResMap) == 0 {
 		return nil
@@ -277,12 +313,12 @@ func (ti *TaskInfo) SetPodResourceDecision() error {
 		return err
 	}
 
-	metav1.SetMetaDataAnnotation(&ti.Pod.ObjectMeta, topologyDecisionAnnotation, string(layout[:]))
+	ti.MergePodAnnotations(map[string]string{topologyDecisionAnnotation: string(layout)})
 	return nil
 }
 
 func (ti *TaskInfo) UnsetPodResourceDecision() {
-	delete(ti.Pod.Annotations, topologyDecisionAnnotation)
+	ti.DeletePodAnnotations(topologyDecisionAnnotation)
 }
 
 // Clone is used for cloning a task
@@ -295,6 +331,7 @@ func (ti *TaskInfo) Clone() *TaskInfo {
 		TaskRole:                    ti.TaskRole,
 		Priority:                    ti.Priority,
 		Pod:                         ti.Pod,
+		PodAnnotations:              maps.Clone(ti.PodAnnotations),
 		Resreq:                      ti.Resreq.Clone(),
 		InitResreq:                  ti.InitResreq.Clone(),
 		VolumeReady:                 ti.VolumeReady,
@@ -323,7 +360,6 @@ func (ti *TaskInfo) Clone() *TaskInfo {
 	if ti.ResourceClaimDRAResreq != nil {
 		res.ResourceClaimDRAResreq = cloneResourceClaimDRAResreq(ti.ResourceClaimDRAResreq)
 	}
-
 	return res
 }
 

--- a/pkg/scheduler/api/job_info_test.go
+++ b/pkg/scheduler/api/job_info_test.go
@@ -814,3 +814,73 @@ func TestGetMinDRAResourcesFallbackWithoutTaskMinAvailable(t *testing.T) {
 		},
 	}, job.GetMinDRAResources())
 }
+
+func TestTaskInfoPodAnnotations(t *testing.T) {
+	tests := []struct {
+		name        string
+		task        *TaskInfo
+		existing    map[string]string
+		annotations map[string]string
+		want        map[string]string
+	}{
+		{
+			name:        "nil task ignores annotations",
+			task:        nil,
+			annotations: map[string]string{"gpu.volcano.sh/device": "0"},
+			want:        nil,
+		},
+		{
+			name:        "stores annotations on empty task",
+			task:        &TaskInfo{},
+			annotations: map[string]string{"gpu.volcano.sh/device": "0", "gpu.volcano.sh/memory": "16Gi"},
+			want:        map[string]string{"gpu.volcano.sh/device": "0", "gpu.volcano.sh/memory": "16Gi"},
+		},
+		{
+			name:        "merges annotations and overwrites existing keys",
+			task:        &TaskInfo{},
+			existing:    map[string]string{"gpu.volcano.sh/device": "0"},
+			annotations: map[string]string{"gpu.volcano.sh/device": "1", "gpu.volcano.sh/memory": "16Gi"},
+			want:        map[string]string{"gpu.volcano.sh/device": "1", "gpu.volcano.sh/memory": "16Gi"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.task != nil && tt.existing != nil {
+				tt.task.MergePodAnnotations(tt.existing)
+			}
+
+			assert.NotPanics(t, func() {
+				tt.task.MergePodAnnotations(tt.annotations)
+			})
+
+			if tt.task == nil {
+				return
+			}
+			assert.Equal(t, tt.want, tt.task.PodAnnotations)
+		})
+	}
+}
+
+func TestTaskInfoPodAnnotationsAreCloned(t *testing.T) {
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{"keep": "original"},
+		},
+	}
+	task := NewTaskInfo(pod)
+
+	task.MergePodAnnotations(map[string]string{"keep": "task", "new": "value"})
+
+	assert.Equal(t, "original", pod.Annotations["keep"])
+	assert.NotContains(t, pod.Annotations, "new")
+
+	cloned := task.Clone()
+	cloned.MergePodAnnotations(map[string]string{"keep": "clone"})
+	cloned.DeletePodAnnotations("new")
+
+	assert.Equal(t, "task", task.PodAnnotations["keep"])
+	assert.Equal(t, "value", task.PodAnnotations["new"])
+	assert.Equal(t, "clone", cloned.PodAnnotations["keep"])
+	assert.NotContains(t, cloned.PodAnnotations, "new")
+}

--- a/pkg/scheduler/api/shared_device_pool.go
+++ b/pkg/scheduler/api/shared_device_pool.go
@@ -24,6 +24,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
 
+	"volcano.sh/volcano/pkg/scheduler/api/devices"
 	"volcano.sh/volcano/pkg/scheduler/api/devices/ascend/hami"
 	"volcano.sh/volcano/pkg/scheduler/api/devices/ascend/mindcluster/ascend310p/vnpu"
 	"volcano.sh/volcano/pkg/scheduler/api/devices/nvidia/gpushare"
@@ -65,10 +66,17 @@ type Devices interface {
 	// scheduling policies.
 	ScoreNode(pod *v1.Pod, policy string) float64
 
-	// Allocate action in predicate
-	Allocate(kubeClient kubernetes.Interface, pod *v1.Pod) error
-	// Release action in predicate
-	Release(kubeClient kubernetes.Interface, pod *v1.Pod) error
+	// Allocate action in predicate.
+	// Returns the reservation data produced by this allocation, including annotations
+	// that need to be carried during binding. Implementations that do not need bind
+	// annotations may return (nil, nil).
+	Allocate(kubeClient kubernetes.Interface, pod *v1.Pod) (*devices.DeviceReservation, error)
+
+	// Release action in predicate.
+	// Rolls back the in-memory ledger and optionally returns annotation keys that
+	// should be removed from TaskInfo.PodAnnotations. The implementation owns any
+	// apiserver-side annotation cleanup it performs.
+	Release(kubeClient kubernetes.Interface, pod *v1.Pod) (*devices.DeviceReservation, error)
 
 	// GetIgnoredDevices notify vc-scheduler to ignore devices in return list
 	GetIgnoredDevices() []string

--- a/pkg/scheduler/cache/cache.go
+++ b/pkg/scheduler/cache/cache.go
@@ -232,9 +232,10 @@ func (db *DefaultBinder) Bind(kubeClient kubernetes.Interface, tasks []*scheduli
 	for _, task := range tasks {
 		p := task.Pod
 		startTime := time.Now()
+		// The apiserver overlays Binding annotations onto the Pod during bind.
 		if err := db.kubeclient.CoreV1().Pods(p.Namespace).Bind(context.TODO(),
 			&v1.Binding{
-				ObjectMeta: metav1.ObjectMeta{Namespace: p.Namespace, Name: p.Name, UID: p.UID, Annotations: p.Annotations},
+				ObjectMeta: metav1.ObjectMeta{Namespace: p.Namespace, Name: p.Name, UID: p.UID, Annotations: task.PodAnnotations},
 				Target: v1.ObjectReference{
 					Kind: "Node",
 					Name: task.NodeName,

--- a/pkg/scheduler/cache/cache_test.go
+++ b/pkg/scheduler/cache/cache_test.go
@@ -33,6 +33,8 @@ import (
 	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	kubefake "k8s.io/client-go/kubernetes/fake"
+	kubetesting "k8s.io/client-go/testing"
 	kcache "k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 
@@ -170,6 +172,59 @@ func TestSchedulerCache_Bind_NodeWithSufficientResources(t *testing.T) {
 	err := cache.AddBindTask(bindContext)
 	if err != nil {
 		t.Errorf("failed to bind pod to node: %v", err)
+	}
+}
+
+func TestDefaultBinderBindUsesTaskPodAnnotations(t *testing.T) {
+	pod := buildPod("default", "worker-0", "", v1.PodPending, nil, nil, nil)
+	pod.Annotations = map[string]string{"keep": "pod"}
+	task := api.NewTaskInfo(pod)
+	task.NodeName = "node-a"
+	task.MergePodAnnotations(map[string]string{
+		"keep":                  "task",
+		"volcano.sh/vgpu-node":  "node-a",
+		"volcano.sh/vgpu-ids":   "GPU-aaaa",
+		"volcano.sh/bind-phase": "allocating",
+	})
+
+	kubeClient := kubefake.NewSimpleClientset(pod)
+	binder := NewDefaultBinder(kubeClient, record.NewFakeRecorder(10))
+
+	errMsg := binder.Bind(kubeClient, []*api.TaskInfo{task})
+	if len(errMsg) > 0 {
+		t.Fatalf("Bind returned errors: %v", errMsg)
+	}
+
+	var binding *v1.Binding
+	for _, action := range kubeClient.Actions() {
+		if action.GetVerb() != "create" || action.GetSubresource() != "binding" {
+			continue
+		}
+		createAction, ok := action.(kubetesting.CreateAction)
+		if !ok {
+			t.Fatalf("expected create binding action, got %T", action)
+		}
+		var okBinding bool
+		binding, okBinding = createAction.GetObject().(*v1.Binding)
+		if !okBinding {
+			t.Fatalf("expected Binding object, got %T", createAction.GetObject())
+		}
+		break
+	}
+	if binding == nil {
+		t.Fatalf("expected binder to create a Pod binding")
+	}
+	if binding.Target.Name != "node-a" {
+		t.Fatalf("expected binding target node-a, got %q", binding.Target.Name)
+	}
+	if binding.Annotations["keep"] != "task" {
+		t.Fatalf("expected binding annotations to overwrite existing annotations, got %q", binding.Annotations["keep"])
+	}
+	if binding.Annotations["volcano.sh/vgpu-node"] != "node-a" {
+		t.Fatalf("expected vgpu annotation on binding, got %q", binding.Annotations["volcano.sh/vgpu-node"])
+	}
+	if binding.Annotations["volcano.sh/bind-phase"] != "allocating" {
+		t.Fatalf("expected bind phase annotation on binding, got %q", binding.Annotations["volcano.sh/bind-phase"])
 	}
 }
 

--- a/pkg/scheduler/plugins/deviceshare/gpuexclusive.go
+++ b/pkg/scheduler/plugins/deviceshare/gpuexclusive.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/klog/v2"
 
 	"volcano.sh/volcano/pkg/scheduler/api"
+	"volcano.sh/volcano/pkg/scheduler/api/devices"
 	"volcano.sh/volcano/pkg/scheduler/api/devices/nvidia/vgpu"
 	"volcano.sh/volcano/pkg/scheduler/framework"
 )
@@ -301,7 +302,7 @@ func (a *exclusiveGPUDevices) ScoreNode(pod *v1.Pod, policy string) float64 {
 	return a.inner.ScoreNode(pod, policy)
 }
 
-func (a *exclusiveGPUDevices) Allocate(kubeClient kubernetes.Interface, pod *v1.Pod) error {
+func (a *exclusiveGPUDevices) Allocate(kubeClient kubernetes.Interface, pod *v1.Pod) (*devices.DeviceReservation, error) {
 	matched := matchingRules(pod, a.cfg.rules)
 	if len(matched) == 0 {
 		return a.inner.Allocate(kubeClient, pod)
@@ -309,16 +310,18 @@ func (a *exclusiveGPUDevices) Allocate(kubeClient kubernetes.Interface, pod *v1.
 
 	reserved := a.reservedGPUsForPod(pod)
 	klog.V(4).Infof("gpuexclusive: Allocate pod=%s, matched=%v, reserved=%v, ruleGPUs=%v", pod.Name, matched, reserved, a.ruleGPUs)
+	var reservation *devices.DeviceReservation
+	var err error
 	if len(reserved) > 0 {
 		saved := a.capGPUs(reserved)
-		err := a.inner.Allocate(kubeClient, pod)
+		reservation, err = a.inner.Allocate(kubeClient, pod)
 		a.restoreGPUs(saved)
 		if err != nil {
-			return err
+			return nil, err
 		}
 	} else {
-		if err := a.inner.Allocate(kubeClient, pod); err != nil {
-			return err
+		if reservation, err = a.inner.Allocate(kubeClient, pod); err != nil {
+			return nil, err
 		}
 	}
 
@@ -365,16 +368,16 @@ func (a *exclusiveGPUDevices) Allocate(kubeClient kubernetes.Interface, pod *v1.
 
 	klog.V(4).Infof("gpuexclusive: allocated pod %s, newGPUs=%v, ruleGPUs=%v",
 		pk, newGPUs, a.ruleGPUs)
-	return nil
+	return reservation, nil
 }
 
-func (a *exclusiveGPUDevices) Release(kubeClient kubernetes.Interface, pod *v1.Pod) error {
-	err := a.inner.Release(kubeClient, pod)
+func (a *exclusiveGPUDevices) Release(kubeClient kubernetes.Interface, pod *v1.Pod) (*devices.DeviceReservation, error) {
+	reservation, err := a.inner.Release(kubeClient, pod)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	a.untrackPod(pod)
-	return nil
+	return reservation, nil
 }
 
 func (a *exclusiveGPUDevices) GetIgnoredDevices() []string {

--- a/pkg/scheduler/plugins/predicates/predicates.go
+++ b/pkg/scheduler/plugins/predicates/predicates.go
@@ -888,9 +888,11 @@ func (pp *PredicatesPlugin) PreBindRollBack(ctx context.Context, bindCtx *cache.
 }
 
 func (pp *PredicatesPlugin) SetupBindContextExtension(state *k8sframework.CycleState, bindCtx *cache.BindContext) {
-	if pp.needsPreBind(bindCtx.TaskInfo) {
-		bindCtx.Extensions[pp.Name()] = &BindContextExtension{State: state}
+	if !pp.needsPreBind(bindCtx.TaskInfo) {
+		return
 	}
+
+	bindCtx.Extensions[pp.Name()] = &BindContextExtension{State: state}
 }
 
 func handleSkipPredicatePlugin(state fwk.CycleState, pluginName string) bool {

--- a/pkg/scheduler/plugins/predicates/predicates.go
+++ b/pkg/scheduler/plugins/predicates/predicates.go
@@ -238,11 +238,14 @@ func (pp *PredicatesPlugin) OnSessionOpen(ssn *framework.Session) {
 						continue
 					}
 
-					err := devices.Allocate(ssn.KubeClient(), pod)
+					reservation, err := devices.Allocate(ssn.KubeClient(), pod)
 					if err != nil {
 						klog.Errorf("AllocateToPod failed %s", err.Error())
 						event.Err = err
 						return
+					}
+					if reservation != nil && len(reservation.Annotations) > 0 {
+						event.Task.MergePodAnnotations(reservation.Annotations)
 					}
 				} else {
 					klog.Warningf("Devices %s assertion conversion failed, skip", val)
@@ -284,10 +287,15 @@ func (pp *PredicatesPlugin) OnSessionOpen(ssn *framework.Session) {
 					}
 
 					// deallocate pod gpu id
-					err := devices.Release(ssn.KubeClient(), pod)
+					reservation, err := devices.Release(ssn.KubeClient(), pod)
 					if err != nil {
 						klog.Errorf("Device %s release failed for pod %s/%s, err:%s", val, pod.Namespace, pod.Name, err.Error())
 						return
+					}
+					if reservation != nil {
+						if keys := reservation.AnnotationKeys(); len(keys) > 0 {
+							event.Task.DeletePodAnnotations(keys...)
+						}
 					}
 				} else {
 					klog.Warningf("Devices %s assertion conversion failed, skip", val)
@@ -880,11 +888,9 @@ func (pp *PredicatesPlugin) PreBindRollBack(ctx context.Context, bindCtx *cache.
 }
 
 func (pp *PredicatesPlugin) SetupBindContextExtension(state *k8sframework.CycleState, bindCtx *cache.BindContext) {
-	if !pp.needsPreBind(bindCtx.TaskInfo) {
-		return
+	if pp.needsPreBind(bindCtx.TaskInfo) {
+		bindCtx.Extensions[pp.Name()] = &BindContextExtension{State: state}
 	}
-
-	bindCtx.Extensions[pp.Name()] = &BindContextExtension{State: state}
 }
 
 func handleSkipPredicatePlugin(state fwk.CycleState, pluginName string) bool {

--- a/pkg/scheduler/plugins/predicates/predicates_test.go
+++ b/pkg/scheduler/plugins/predicates/predicates_test.go
@@ -124,6 +124,38 @@ func getWorkerAffinity() *apiv1.Affinity {
 	}
 }
 
+// TestTaskPodAnnotations verifies device allocation annotations flow through
+// TaskInfo's scheduler-owned Pod annotation map.
+func TestTaskPodAnnotations(t *testing.T) {
+	task := &api.TaskInfo{}
+
+	task.MergePodAnnotations(map[string]string{
+		"volcano.sh/vgpu-node":    "node-a",
+		"volcano.sh/vgpu-ids-new": "gpu-a",
+	})
+	got := task.PodAnnotations
+	if got["volcano.sh/vgpu-node"] != "node-a" {
+		t.Fatalf("expected vgpu-node=node-a, got %q", got["volcano.sh/vgpu-node"])
+	}
+
+	task.MergePodAnnotations(map[string]string{
+		"volcano.sh/vgpu-node": "node-b",
+	})
+	got = task.PodAnnotations
+	if got["volcano.sh/vgpu-node"] != "node-b" {
+		t.Fatalf("expected vgpu-node overwritten to node-b, got %q", got["volcano.sh/vgpu-node"])
+	}
+
+	task.DeletePodAnnotations("volcano.sh/vgpu-node")
+	got = task.PodAnnotations
+	if _, ok := got["volcano.sh/vgpu-node"]; ok {
+		t.Fatalf("expected vgpu-node removed")
+	}
+	if got["volcano.sh/vgpu-ids-new"] != "gpu-a" {
+		t.Fatalf("expected unrelated bind annotation preserved")
+	}
+}
+
 func TestEventHandler(t *testing.T) {
 	plugins := map[string]framework.PluginBuilder{
 		PluginName:          New,


### PR DESCRIPTION
Keep TaskInfo's vGPU allocation annotations aligned with the pod copy used in device allocation and cleanup paths. This prevents stale bind metadata from being propagated while preserving committed annotations after successful bind.

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

This PR fixes stale vGPU annotation propagation across scheduler allocate/bind/rollback paths.

Problem chain:
- `Allocate` patches annotations.
- API server update is asynchronous.
- Informer may still serve an older pod object.
- Binding/cleanup can then read stale annotations from `TaskInfo.Pod`, propagating outdated bind metadata.

What is fixed:
- Keep `TaskInfo.Pod` annotations synchronized with the allocate-time pod copy after successful `devices.Allocate`.
- Preserve committed annotations when `bind-phase=success`.
- Remove speculative annotations only on rollback paths.

Architectural note:
- The long-term direction should be cache-only and patchless behavior in scheduler-cycle `Allocate`, aligned with default scheduler principles.
- Scheduler-cycle allocate should only reserve optimistically in cache.
- API-server persistence should happen in bind-cycle through a dedicated `bindAllocatedAnnotation` step.
- This PR is a cache-consistency fix; it does not yet remove allocate-time patch calls.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Notice that do not add `Fixes` if the issue is associated with multiple PRs.
-->
Fixes #5532

#### Special notes for your reviewer:

This PR intentionally focuses on annotation consistency only.
Node lock release behavior is split into a separate PR to keep review scope small.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
TaskInfo now includes PodAnnotations for scheduler-owned pod annotation updates during scheduling. Plugins that need to modify and persist pod annotations should call MergePodAnnotations; the merged annotations are carried by the bind request.