### PR TITLE
fix(vgpu): release node lock on scheduler rollback

### DIFF
--- a/pkg/scheduler/api/devices/nvidia/vgpu/device_info.go
+++ b/pkg/scheduler/api/devices/nvidia/vgpu/device_info.go
@@ -278,7 +278,16 @@ func (gs *GPUDevices) HasDeviceRequest(pod *v1.Pod) bool {
 }
 
 func (gs *GPUDevices) Release(kubeClient kubernetes.Interface, pod *v1.Pod) error {
-	if gs == nil || pod == nil || pod.Annotations == nil {
+	if gs == nil || pod == nil {
+		return nil
+	}
+	if NodeLockEnable && kubeClient != nil {
+		_ = nodelock.UseClient(kubeClient)
+		if err := nodelock.ReleaseNodeLock(gs.Name, DeviceName); err != nil {
+			klog.ErrorS(err, "failed to release vgpu node lock", "node", gs.Name, "lock", DeviceName)
+		}
+	}
+	if pod.Annotations == nil {
 		return nil
 	}
 	// Release is required for rollback paths (e.g. UnPipeline) where NodeInfo

--- a/pkg/scheduler/api/devices/nvidia/vgpu/device_info_test.go
+++ b/pkg/scheduler/api/devices/nvidia/vgpu/device_info_test.go
@@ -273,3 +273,56 @@ func TestReleaseKeepsCommittedAnnotations(t *testing.T) {
 		t.Errorf("committed pod's vgpu-ids-new must be preserved on apiserver")
 	}
 }
+
+func TestReleaseBestEffortReleasesNodeLock(t *testing.T) {
+	pod := podWithVGPUAnnotations("allocating")
+	node := &v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "node-a",
+			Annotations: map[string]string{
+				DeviceName: "2026-01-02T03:04:05Z",
+			},
+		},
+	}
+	client := fake.NewSimpleClientset(pod, node)
+	gs := &GPUDevices{Name: "node-a"}
+
+	old := NodeLockEnable
+	NodeLockEnable = true
+	defer func() { NodeLockEnable = old }()
+
+	if err := gs.Release(client, pod); err != nil {
+		t.Fatalf("Release returned error: %v", err)
+	}
+
+	gotNode, err := client.CoreV1().Nodes().Get(context.Background(), "node-a", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get node: %v", err)
+	}
+	if _, ok := gotNode.Annotations[DeviceName]; ok {
+		t.Fatalf("expected node lock annotation %q to be removed", DeviceName)
+	}
+}
+
+func TestReleaseNodeLockErrorDoesNotFailRelease(t *testing.T) {
+	pod := podWithVGPUAnnotations("allocating")
+	client := fake.NewSimpleClientset(pod)
+	gs := &GPUDevices{Name: "missing-node"}
+
+	old := NodeLockEnable
+	NodeLockEnable = true
+	defer func() { NodeLockEnable = old }()
+
+	if err := gs.Release(client, pod); err != nil {
+		t.Fatalf("Release should not fail even when lock release fails: %v", err)
+	}
+
+	for _, k := range []string{
+		AssignedNodeAnnotations, AssignedIDsAnnotations,
+		AssignedIDsToAllocateAnnotations, DeviceBindPhase,
+	} {
+		if _, ok := pod.Annotations[k]; ok {
+			t.Errorf("in-memory annotation %s should have been removed", k)
+		}
+	}
+}


### PR DESCRIPTION
Ensure vGPU scheduler release path always attempts to free node lock to reduce stale lock accumulation during rollback and cleanup.
#### What type of PR is this?
/kind bug
#### What this PR does / why we need it:
This PR updates vGPU `Release` to always attempt `ReleaseNodeLock` when release is invoked.
Why:
- Lock is acquired during allocation.
- In rollback/cleanup scenarios, stale lock can remain and block subsequent scheduling attempts.
- Lock release should be best-effort and not blocked by bind-phase branching.
What is changed:
- In vGPU `Release`, attempt `nodelock.ReleaseNodeLock(gs.Name, DeviceName)` as an early best-effort step.
- Keep release flow non-blocking: lock release errors are logged and do not abort normal cleanup logic.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Notice that do not add `Fixes` if the issue is associated with multiple PRs.
-->
Fixes #5532
#### Special notes for your reviewer:
This PR is intentionally narrow and only covers lock release behavior.
Annotation synchronization is handled in a separate PR.
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
Improve vGPU rollback robustness by making scheduler release path attempt node-lock cleanup to reduce stale lock blocking.
