### PR TITLE
perf: replace O(n) NodeList scans with O(1) index map in AddOrUpdateNode/RemoveNode

### DIFF
--- a/pkg/scheduler/cache/cache.go
+++ b/pkg/scheduler/cache/cache.go
@@ -149,6 +149,7 @@ type SchedulerCache struct {
 	NodeShards           map[string]*schedulingapi.NodeShardInfo
 	PriorityClasses      map[string]*schedulingv1.PriorityClass
 	NodeList             []string
+	nodeListIndex        map[string]int
 	defaultPriorityClass *schedulingv1.PriorityClass
 	defaultPriority      int32
 	CSINodesStatus       map[string]*schedulingapi.CSINodeStatusInfo
@@ -568,6 +569,7 @@ func newSchedulerCache(config *rest.Config, schedulerNames []string, defaultQueu
 		NodeShards:          make(map[string]*schedulingapi.NodeShardInfo),
 
 		NodeList:            []string{},
+		nodeListIndex:       make(map[string]int),
 		nodeWorkers:         nodeWorkers,
 		resourceSyncTimeout: resourceSyncTimeout,
 	}

--- a/pkg/scheduler/cache/cache_mock.go
+++ b/pkg/scheduler/cache/cache_mock.go
@@ -142,6 +142,7 @@ func newMockSchedulerCache(schedulerName string) *SchedulerCache {
 		NodeShards:             make(map[string]*schedulingapi.NodeShardInfo),
 
 		NodeList:       []string{},
+		nodeListIndex:  make(map[string]int),
 		binderRegistry: NewBinderRegistry(),
 		resyncPeriod:   0,
 	}

--- a/pkg/scheduler/cache/cache_test.go
+++ b/pkg/scheduler/cache/cache_test.go
@@ -24,6 +24,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"sort"
 	"sync"
 	"testing"
 	"time"
@@ -222,8 +223,33 @@ func TestSchedulerCache_Bind_NodeWithInsufficientResources(t *testing.T) {
 	}
 }
 
+// sortedStringSliceEqual returns true if a and b contain the same elements regardless of order.
+func sortedStringSliceEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	ac := append([]string(nil), a...)
+	bc := append([]string(nil), b...)
+	sort.Strings(ac)
+	sort.Strings(bc)
+	return reflect.DeepEqual(ac, bc)
+}
+
+// verifyNodeListIndex asserts that nodeListIndex is consistent with NodeList.
+func verifyNodeListIndex(t *testing.T, sc *SchedulerCache) {
+	t.Helper()
+	if len(sc.nodeListIndex) != len(sc.NodeList) {
+		t.Errorf("nodeListIndex len %d != NodeList len %d", len(sc.nodeListIndex), len(sc.NodeList))
+		return
+	}
+	for i, name := range sc.NodeList {
+		if got := sc.nodeListIndex[name]; got != i {
+			t.Errorf("nodeListIndex[%s] = %d, want %d", name, got, i)
+		}
+	}
+}
+
 func TestNodeOperation(t *testing.T) {
-	// case 1
 	node1 := buildNode("n1", api.BuildResourceList("2000m", "10G"))
 	node2 := buildNode("n2", api.BuildResourceList("4000m", "16G"))
 	node3 := buildNode("n3", api.BuildResourceList("3000m", "12G"))
@@ -231,92 +257,142 @@ func TestNodeOperation(t *testing.T) {
 	nodeInfo2 := api.NewNodeInfo(node2)
 	nodeInfo3 := api.NewNodeInfo(node3)
 	tests := []struct {
-		deletedNode *v1.Node
-		nodes       []*v1.Node
-		expected    *SchedulerCache
-		delExpect   *SchedulerCache
+		name          string
+		deletedNode   *v1.Node
+		nodes         []*v1.Node
+		expectedNodes map[string]*api.NodeInfo
+		expectedList  []string
+		delNodes      map[string]*api.NodeInfo
+		delList       []string
 	}{
 		{
+			name:        "delete middle node",
 			deletedNode: node2,
 			nodes:       []*v1.Node{node1, node2, node3},
-			expected: &SchedulerCache{
-				Nodes: map[string]*api.NodeInfo{
-					"n1": nodeInfo1,
-					"n2": nodeInfo2,
-					"n3": nodeInfo3,
-				},
-				NodeList: []string{"n1", "n2", "n3"},
+			expectedNodes: map[string]*api.NodeInfo{
+				"n1": nodeInfo1,
+				"n2": nodeInfo2,
+				"n3": nodeInfo3,
 			},
-			delExpect: &SchedulerCache{
-				Nodes: map[string]*api.NodeInfo{
-					"n1": nodeInfo1,
-					"n3": nodeInfo3,
-				},
-				NodeList: []string{"n1", "n3"},
+			expectedList: []string{"n1", "n2", "n3"},
+			delNodes: map[string]*api.NodeInfo{
+				"n1": nodeInfo1,
+				"n3": nodeInfo3,
 			},
+			delList: []string{"n1", "n3"},
 		},
 		{
+			name:        "delete first node",
 			deletedNode: node1,
 			nodes:       []*v1.Node{node1, node2, node3},
-			expected: &SchedulerCache{
-				Nodes: map[string]*api.NodeInfo{
-					"n1": nodeInfo1,
-					"n2": nodeInfo2,
-					"n3": nodeInfo3,
-				},
-				NodeList: []string{"n1", "n2", "n3"},
+			expectedNodes: map[string]*api.NodeInfo{
+				"n1": nodeInfo1,
+				"n2": nodeInfo2,
+				"n3": nodeInfo3,
 			},
-			delExpect: &SchedulerCache{
-				Nodes: map[string]*api.NodeInfo{
-					"n2": nodeInfo2,
-					"n3": nodeInfo3,
-				},
-				NodeList: []string{"n2", "n3"},
+			expectedList: []string{"n1", "n2", "n3"},
+			delNodes: map[string]*api.NodeInfo{
+				"n2": nodeInfo2,
+				"n3": nodeInfo3,
 			},
+			delList: []string{"n2", "n3"},
 		},
 		{
+			name:        "delete last node",
 			deletedNode: node3,
 			nodes:       []*v1.Node{node1, node2, node3},
-			expected: &SchedulerCache{
-				Nodes: map[string]*api.NodeInfo{
-					"n1": nodeInfo1,
-					"n2": nodeInfo2,
-					"n3": nodeInfo3,
-				},
-				NodeList: []string{"n1", "n2", "n3"},
+			expectedNodes: map[string]*api.NodeInfo{
+				"n1": nodeInfo1,
+				"n2": nodeInfo2,
+				"n3": nodeInfo3,
 			},
-			delExpect: &SchedulerCache{
-				Nodes: map[string]*api.NodeInfo{
-					"n1": nodeInfo1,
-					"n2": nodeInfo2,
-				},
-				NodeList: []string{"n1", "n2"},
+			expectedList: []string{"n1", "n2", "n3"},
+			delNodes: map[string]*api.NodeInfo{
+				"n1": nodeInfo1,
+				"n2": nodeInfo2,
 			},
+			delList: []string{"n1", "n2"},
 		},
 	}
 
 	for i, test := range tests {
-		cache := &SchedulerCache{
-			Nodes:    make(map[string]*api.NodeInfo),
-			NodeList: []string{},
-		}
+		t.Run(test.name, func(t *testing.T) {
+			cache := &SchedulerCache{
+				Nodes:         make(map[string]*api.NodeInfo),
+				NodeList:      []string{},
+				nodeListIndex: make(map[string]int),
+			}
 
-		for _, n := range test.nodes {
-			cache.AddOrUpdateNode(n)
-		}
+			for _, n := range test.nodes {
+				cache.AddOrUpdateNode(n)
+			}
 
-		if !reflect.DeepEqual(cache, test.expected) {
-			t.Errorf("case %d: \n expected %v, \n got %v \n",
-				i, test.expected, cache)
-		}
+			if !reflect.DeepEqual(cache.Nodes, test.expectedNodes) {
+				t.Errorf("case %d: Nodes mismatch: expected %v, got %v", i, test.expectedNodes, cache.Nodes)
+			}
+			if !sortedStringSliceEqual(cache.NodeList, test.expectedList) {
+				t.Errorf("case %d: NodeList mismatch: expected %v, got %v", i, test.expectedList, cache.NodeList)
+			}
+			verifyNodeListIndex(t, cache)
 
-		// delete node
-		cache.RemoveNode(test.deletedNode.Name)
-		if !reflect.DeepEqual(cache, test.delExpect) {
-			t.Errorf("case %d: \n expected %v, \n got %v \n",
-				i, test.delExpect, cache)
-		}
+			cache.RemoveNode(test.deletedNode.Name)
+
+			if !reflect.DeepEqual(cache.Nodes, test.delNodes) {
+				t.Errorf("case %d: Nodes after delete: expected %v, got %v", i, test.delNodes, cache.Nodes)
+			}
+			if !sortedStringSliceEqual(cache.NodeList, test.delList) {
+				t.Errorf("case %d: NodeList after delete: expected %v, got %v", i, test.delList, cache.NodeList)
+			}
+			verifyNodeListIndex(t, cache)
+		})
 	}
+}
+
+func TestNodeListIndexNoDuplicate(t *testing.T) {
+	node := buildNode("n1", api.BuildResourceList("2000m", "10G"))
+	cache := &SchedulerCache{
+		Nodes:         make(map[string]*api.NodeInfo),
+		NodeList:      []string{},
+		nodeListIndex: make(map[string]int),
+	}
+
+	cache.AddOrUpdateNode(node)
+	cache.AddOrUpdateNode(node)
+
+	if len(cache.NodeList) != 1 {
+		t.Errorf("expected NodeList len 1 after double add, got %d", len(cache.NodeList))
+	}
+	if len(cache.nodeListIndex) != 1 {
+		t.Errorf("expected nodeListIndex len 1 after double add, got %d", len(cache.nodeListIndex))
+	}
+	verifyNodeListIndex(t, cache)
+}
+
+func TestNodeListIndexRemoveAndReAdd(t *testing.T) {
+	node := buildNode("n1", api.BuildResourceList("2000m", "10G"))
+	cache := &SchedulerCache{
+		Nodes:         make(map[string]*api.NodeInfo),
+		NodeList:      []string{},
+		nodeListIndex: make(map[string]int),
+	}
+
+	cache.AddOrUpdateNode(node)
+	cache.RemoveNode("n1")
+
+	if len(cache.NodeList) != 0 {
+		t.Errorf("expected empty NodeList after remove, got %v", cache.NodeList)
+	}
+	if len(cache.nodeListIndex) != 0 {
+		t.Errorf("expected empty nodeListIndex after remove, got %v", cache.nodeListIndex)
+	}
+
+	cache.Nodes = make(map[string]*api.NodeInfo)
+	cache.AddOrUpdateNode(node)
+
+	if len(cache.NodeList) != 1 || cache.NodeList[0] != "n1" {
+		t.Errorf("expected [n1] after re-add, got %v", cache.NodeList)
+	}
+	verifyNodeListIndex(t, cache)
 }
 
 func TestBindTasks(t *testing.T) {

--- a/pkg/scheduler/cache/event_handlers.go
+++ b/pkg/scheduler/cache/event_handlers.go
@@ -531,14 +531,14 @@ func (sc *SchedulerCache) AddOrUpdateNode(node *v1.Node) error {
 	}
 	sc.addNodeImageStates(node, sc.Nodes[node.Name])
 
-	var nodeExisted bool
-	for _, name := range sc.NodeList {
-		if name == node.Name {
-			nodeExisted = true
-			break
+	if sc.nodeListIndex == nil {
+		sc.nodeListIndex = make(map[string]int, len(sc.NodeList)+1)
+		for i, name := range sc.NodeList {
+			sc.nodeListIndex[name] = i
 		}
 	}
-	if !nodeExisted {
+	if _, exists := sc.nodeListIndex[node.Name]; !exists {
+		sc.nodeListIndex[node.Name] = len(sc.NodeList)
 		sc.NodeList = append(sc.NodeList, node.Name)
 	}
 	return nil
@@ -549,11 +549,14 @@ func (sc *SchedulerCache) RemoveNode(nodeName string) error {
 	sc.Mutex.Lock()
 	defer sc.Mutex.Unlock()
 
-	for i, name := range sc.NodeList {
-		if name == nodeName {
-			sc.NodeList = append(sc.NodeList[:i], sc.NodeList[i+1:]...)
-			break
+	if idx, exists := sc.nodeListIndex[nodeName]; exists {
+		last := len(sc.NodeList) - 1
+		if idx != last {
+			sc.NodeList[idx] = sc.NodeList[last]
+			sc.nodeListIndex[sc.NodeList[idx]] = idx
 		}
+		sc.NodeList = sc.NodeList[:last]
+		delete(sc.nodeListIndex, nodeName)
 	}
 	sc.removeNodeImageStates(nodeName)
 

--- a/pkg/scheduler/cache/event_handlers.go
+++ b/pkg/scheduler/cache/event_handlers.go
@@ -549,12 +549,19 @@ func (sc *SchedulerCache) RemoveNode(nodeName string) error {
 	sc.Mutex.Lock()
 	defer sc.Mutex.Unlock()
 
+	if sc.nodeListIndex == nil {
+		sc.nodeListIndex = make(map[string]int, len(sc.NodeList))
+		for i, name := range sc.NodeList {
+			sc.nodeListIndex[name] = i
+		}
+	}
 	if idx, exists := sc.nodeListIndex[nodeName]; exists {
 		last := len(sc.NodeList) - 1
 		if idx != last {
 			sc.NodeList[idx] = sc.NodeList[last]
 			sc.nodeListIndex[sc.NodeList[idx]] = idx
 		}
+		sc.NodeList[last] = ""
 		sc.NodeList = sc.NodeList[:last]
 		delete(sc.nodeListIndex, nodeName)
 	}

--- a/pkg/scheduler/cache/node_list_bench_test.go
+++ b/pkg/scheduler/cache/node_list_bench_test.go
@@ -37,35 +37,42 @@ func nodeName(i int) string {
 	return fmt.Sprintf("node-%04d", i)
 }
 
-func BenchmarkAddOrUpdateNode(b *testing.B) {
+// BenchmarkNodeListIndexAddOrUpdate measures only the NodeList/nodeListIndex membership
+// check and append path (no locking, no image states, no Nodes map writes).
+func BenchmarkNodeListIndexAddOrUpdate(b *testing.B) {
 	for _, n := range []int{100, 500, 2000} {
 		b.Run(fmt.Sprintf("nodes=%d", n), func(b *testing.B) {
-			nodes := make([]*nodeStub, n)
-			for i := range nodes {
-				nodes[i] = &nodeStub{name: nodeName(i)}
+			names := make([]string, n)
+			for i := range names {
+				names[i] = nodeName(i)
 			}
 			b.ResetTimer()
 			for iter := 0; iter < b.N; iter++ {
 				sc := makeCache(n)
-				for _, ns := range nodes {
-					sc.addOrUpdateNodeFast(ns.name)
+				for _, name := range names {
+					sc.addOrUpdateNodeFast(name)
 				}
 			}
 		})
 	}
 }
 
-func BenchmarkRemoveNode(b *testing.B) {
+// BenchmarkNodeListIndexRemove measures only the NodeList/nodeListIndex swap-delete path
+// (no locking, no NUMA cleanup). Setup is excluded from the timed region.
+func BenchmarkNodeListIndexRemove(b *testing.B) {
 	for _, n := range []int{100, 500, 2000} {
 		b.Run(fmt.Sprintf("nodes=%d", n), func(b *testing.B) {
 			b.ResetTimer()
 			for iter := 0; iter < b.N; iter++ {
+				b.StopTimer()
 				sc := makeCache(n)
 				for i := 0; i < n; i++ {
 					name := nodeName(i)
 					sc.nodeListIndex[name] = len(sc.NodeList)
 					sc.NodeList = append(sc.NodeList, name)
 				}
+				b.StartTimer()
+
 				for i := 0; i < n; i++ {
 					sc.removeNodeFast(nodeName(i))
 				}
@@ -73,8 +80,6 @@ func BenchmarkRemoveNode(b *testing.B) {
 		})
 	}
 }
-
-type nodeStub struct{ name string }
 
 // addOrUpdateNodeFast exercises only the NodeList/nodeListIndex logic (no locking, no image states).
 func (sc *SchedulerCache) addOrUpdateNodeFast(name string) {
@@ -92,6 +97,7 @@ func (sc *SchedulerCache) removeNodeFast(name string) {
 			sc.NodeList[idx] = sc.NodeList[last]
 			sc.nodeListIndex[sc.NodeList[idx]] = idx
 		}
+		sc.NodeList[last] = ""
 		sc.NodeList = sc.NodeList[:last]
 		delete(sc.nodeListIndex, name)
 	}

--- a/pkg/scheduler/cache/node_list_bench_test.go
+++ b/pkg/scheduler/cache/node_list_bench_test.go
@@ -1,0 +1,98 @@
+/*
+Copyright 2025 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cache
+
+import (
+	"fmt"
+	"testing"
+
+	api "volcano.sh/volcano/pkg/scheduler/api"
+)
+
+func makeCache(size int) *SchedulerCache {
+	sc := &SchedulerCache{
+		Nodes:         make(map[string]*api.NodeInfo, size),
+		NodeList:      make([]string, 0, size),
+		nodeListIndex: make(map[string]int, size),
+		imageStates:   make(map[string]*imageState),
+	}
+	return sc
+}
+
+func nodeName(i int) string {
+	return fmt.Sprintf("node-%04d", i)
+}
+
+func BenchmarkAddOrUpdateNode(b *testing.B) {
+	for _, n := range []int{100, 500, 2000} {
+		b.Run(fmt.Sprintf("nodes=%d", n), func(b *testing.B) {
+			nodes := make([]*nodeStub, n)
+			for i := range nodes {
+				nodes[i] = &nodeStub{name: nodeName(i)}
+			}
+			b.ResetTimer()
+			for iter := 0; iter < b.N; iter++ {
+				sc := makeCache(n)
+				for _, ns := range nodes {
+					sc.addOrUpdateNodeFast(ns.name)
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkRemoveNode(b *testing.B) {
+	for _, n := range []int{100, 500, 2000} {
+		b.Run(fmt.Sprintf("nodes=%d", n), func(b *testing.B) {
+			b.ResetTimer()
+			for iter := 0; iter < b.N; iter++ {
+				sc := makeCache(n)
+				for i := 0; i < n; i++ {
+					name := nodeName(i)
+					sc.nodeListIndex[name] = len(sc.NodeList)
+					sc.NodeList = append(sc.NodeList, name)
+				}
+				for i := 0; i < n; i++ {
+					sc.removeNodeFast(nodeName(i))
+				}
+			}
+		})
+	}
+}
+
+type nodeStub struct{ name string }
+
+// addOrUpdateNodeFast exercises only the NodeList/nodeListIndex logic (no locking, no image states).
+func (sc *SchedulerCache) addOrUpdateNodeFast(name string) {
+	if _, exists := sc.nodeListIndex[name]; !exists {
+		sc.nodeListIndex[name] = len(sc.NodeList)
+		sc.NodeList = append(sc.NodeList, name)
+	}
+}
+
+// removeNodeFast exercises only the NodeList/nodeListIndex logic (no locking, no NUMA cleanup).
+func (sc *SchedulerCache) removeNodeFast(name string) {
+	if idx, exists := sc.nodeListIndex[name]; exists {
+		last := len(sc.NodeList) - 1
+		if idx != last {
+			sc.NodeList[idx] = sc.NodeList[last]
+			sc.nodeListIndex[sc.NodeList[idx]] = idx
+		}
+		sc.NodeList = sc.NodeList[:last]
+		delete(sc.nodeListIndex, name)
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This PR improves the performance of node add/remove operations in the scheduler cache by eliminating O(n) `NodeList` scans while holding the global scheduler cache mutex.

Previously:
- `AddOrUpdateNode()` performed a linear scan over `NodeList` to determine whether a node already existed before appending it.
- `RemoveNode()` performed another linear scan to locate the node and removed it using append-splice, resulting in O(n) lookup and O(n) slice copying.

This PR introduces a `nodeListIndex` (`map[string]int`) that is maintained alongside `NodeList` to provide efficient lookups.

The implementation includes:
- Using `nodeListIndex` for O(1) membership checks in `AddOrUpdateNode()`.
- Using `nodeListIndex` together with swap-delete in `RemoveNode()` to eliminate both the linear scan and slice shifting.
- Lazy initialization of `nodeListIndex` from an existing `NodeList` to maintain compatibility with tests that construct `SchedulerCache` directly.
- Keeping `nodeListIndex` synchronized whenever nodes are added or removed.

Since `NodeList` ordering is not relied upon by the scheduler, swap-delete preserves the existing behavior while improving performance and reducing mutex hold time.

#### Which issue(s) this PR fixes:

Fixes #5591 

#### Special notes for your reviewer:

- This change is an internal performance optimization and does not modify scheduler behavior or public APIs.
- Existing tests were updated to validate `nodeListIndex` consistency.
- Added test coverage for duplicate add, remove, and re-add scenarios.
- Added benchmarks covering node add/remove operations at 100, 500, and 2000 node scale.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```