### PR TITLE
fix(networkqos): correct wording and spacing in option flag descriptions

### DIFF
--- a/cmd/network-qos/tools/options/options.go
+++ b/cmd/network-qos/tools/options/options.go
@@ -33,11 +33,11 @@ type Options struct {
 // AddFlags is responsible for add flags from the given FlagSet instance for current GenericOptions.
 func (o *Options) AddFlags(c *cobra.Command) {
 	c.Flags().StringVar(&o.CheckoutInterval, utils.NetWorkQoSCheckInterval, o.CheckoutInterval, "check interval is the interval of checking and updating the offline jobs bandwidth limit")
-	c.Flags().StringVar(&o.OnlineBandwidthWatermark, utils.OnlineBandwidthWatermarkKey, o.OnlineBandwidthWatermark, "online-bandwidth-watermark is is the bandwidth threshold of online jobs, "+
-		"is the sum of bandwidth of all online pods")
-	c.Flags().StringVar(&o.OfflineLowBandwidth, utils.OfflineLowBandwidthKey, o.OfflineLowBandwidth, "offline-low-bandwidth is the maximum amount of network bandwidth that can be used by offline jobs when the"+
-		"bandwidth usage of online jobs exceeds the defined threshold(online-bandwidth-watermark)")
-	c.Flags().StringVar(&o.OfflineHighBandwidth, utils.OfflineHighBandwidthKey, o.OfflineHighBandwidth, "offline-high-bandwidth is the maximum amount of network bandwidth that can be used by offline jobs when the"+
-		"bandwidth usage of online jobs not reach to the defined threshold(online-bandwidth-watermark)")
+	c.Flags().StringVar(&o.OnlineBandwidthWatermark, utils.OnlineBandwidthWatermarkKey, o.OnlineBandwidthWatermark, "online-bandwidth-watermark is the bandwidth threshold of online jobs, "+
+		"which is the sum of the bandwidth of all online pods")
+	c.Flags().StringVar(&o.OfflineLowBandwidth, utils.OfflineLowBandwidthKey, o.OfflineLowBandwidth, "offline-low-bandwidth is the maximum amount of network bandwidth that can be used by offline jobs when the "+
+		"bandwidth usage of online jobs exceeds the defined threshold (online-bandwidth-watermark)")
+	c.Flags().StringVar(&o.OfflineHighBandwidth, utils.OfflineHighBandwidthKey, o.OfflineHighBandwidth, "offline-high-bandwidth is the maximum amount of network bandwidth that can be used by offline jobs when the "+
+		"bandwidth usage of online jobs does not reach the defined threshold (online-bandwidth-watermark)")
 	c.Flags().BoolVar(&o.EnableNetworkQoS, utils.EnableNetworkQoS, o.EnableNetworkQoS, "enable networkqos")
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The network-qos option flag descriptions had text errors visible in `--help`:

- `online-bandwidth-watermark` had a duplicated "is" and a comma splice.
- `offline-low-bandwidth` and `offline-high-bandwidth` were missing a space between two concatenated string literals, so the help rendered "...when thebandwidth usage...".
- `offline-high-bandwidth` read "not reach to", and both offline descriptions were missing a space before "(online-bandwidth-watermark)".

#### Which issue(s) this PR fixes:

NONE

#### Special notes for your reviewer:

Help-text only; no behavior change.
