### PR TITLE
agent: fix misleading cpuRecoverLimitPercent validation message

### DIFF
--- a/pkg/agent/config/api/validate.go
+++ b/pkg/agent/config/api/validate.go
@@ -37,7 +37,7 @@ var (
 	IllegalOverSubscriptionTypes                                 = "overSubscriptionType(%s) is not supported, only supports cpu/memory"
 	IllegalCPUThrottlingThreshold                                = "cpuThrottlingThreshold must be a positive number between 1 and 100"
 	IllegalCPUJitterLimitPercent                                 = "cpuJitterLimitPercent must be a non-negative number between 1 and 100"
-	IllegalCPURecoverLimitPercent                                = "cpuRecoverLimitPercent must be a positive number between 1 and 100"
+	IllegalCPURecoverLimitPercent                                = "cpuRecoverLimitPercent must be a positive number"
 )
 
 type Validate interface {

--- a/pkg/agent/config/api/validate_test.go
+++ b/pkg/agent/config/api/validate_test.go
@@ -140,6 +140,29 @@ func TestColocationConfigValidate(t *testing.T) {
 			},
 			expectedErr: []error{errors.New(EvictingCPULowWatermarkHigherThanHighWatermark), errors.New(EvictingMemoryLowWatermarkHigherThanHighWatermark)},
 		},
+		{
+			// cpuRecoverLimitPercent is the maximum percent CPU quota increase allowed
+			// per interval, so a value greater than 100 (grow by more than 100%) is valid.
+			name: "legal CPUThrottlingConfig with cpuRecoverLimitPercent above 100",
+			colocationCfg: &ColocationConfig{
+				CPUThrottlingConfig: &CPUThrottling{
+					Enable:                 utilpointer.Bool(true),
+					CPUThrottlingThreshold: utilpointer.Int(80),
+					CPUJitterLimitPercent:  utilpointer.Int(10),
+					CPURecoverLimitPercent: utilpointer.Int(150),
+				},
+			},
+		},
+		{
+			name: "illegal CPUThrottlingConfig && non-positive cpuRecoverLimitPercent",
+			colocationCfg: &ColocationConfig{
+				CPUThrottlingConfig: &CPUThrottling{
+					Enable:                 utilpointer.Bool(true),
+					CPURecoverLimitPercent: utilpointer.Int(0),
+				},
+			},
+			expectedErr: []error{errors.New(IllegalCPURecoverLimitPercent)},
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The validation error string for `cpuRecoverLimitPercent` claims the value must be
`"between 1 and 100"`, but the only guard on this field rejects values `<= 0`:

```go
// pkg/agent/config/api/validate.go
if c.CPURecoverLimitPercent != nil && *c.CPURecoverLimitPercent <= 0 {
    errs = append(errs, errors.New(IllegalCPURecoverLimitPercent))
}
```

There is no upper-bound check, so a value above 100 passes validation. More
importantly, a value above 100 is meaningful and intended here.
`cpuRecoverLimitPercent` is documented as "the maximum percent CPU quota increase
allowed per interval" and is applied in the node monitor as:

```go
maxIncrease := lastQuota * int64(m.cpuRecoverLimitPercent) / 100
```

so e.g. `150` legitimately means "allow the CPU quota to grow by up to 150% per
interval". The old message therefore does not just fail to enforce the bound, it
actively misleads operators into thinking such values are illegal.

This PR drops the false `"between 1 and 100"` upper bound so the message matches
the actual check (mirroring the sibling `qosCheckInterval must be a positive
number` wording used for the same `<= 0` guard), and adds table-driven test
coverage for the previously-untested `cpuRecoverLimitPercent` path: one case above
100 that must be accepted, and one of `0` that must be rejected.

Scope is deliberately kept to this one field. The neighboring
`cpuJitterLimitPercent` / `cpuThrottlingThreshold` messages have their own
wording questions but are left untouched to keep this a single-purpose fix.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

AI tools were used to help prepare this change, disclosed per the AI Guidance in
contributing.md. I verified every line myself: I traced that `validate.go`'s only
guard on the field is the `<= 0` check, confirmed via `types.go` (field doc) and
`node_monitor.go` (`lastQuota * pct / 100`) that values above 100 are valid and
intended, and confirmed no other code path clamps or re-validates the upper bound.
I also checked the new "above 100 is accepted" test is a real guard by temporarily
injecting a wrong `> 100` check and watching that case fail, then reverting.
`gofmt`, `go vet`, and `go test ./pkg/agent/config/api/...` pass.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

Rationale for `NONE`: this only corrects an error-message string that describes an
already-existing validation rule; no config field, default, or accepted value
changes.
