### PR TITLE
job/state: fix wrong expected phase in test failure messages

### DIFF
--- a/pkg/controllers/job/job_state_test.go
+++ b/pkg/controllers/job/job_state_test.go
@@ -1353,7 +1353,7 @@ func TestRunningState_Execute(t *testing.T) {
 			} else if testcase.Action == busv1alpha1.AbortJobAction {
 				// always jump to aborting firstly
 				if jobInfo.Job.Status.State.Phase != v1alpha1.Aborting {
-					t.Errorf("Expected Job phase to %s, but got %s in case %d", v1alpha1.Restarting, jobInfo.Job.Status.State.Phase, i)
+					t.Errorf("Expected Job phase to %s, but got %s in case %d", v1alpha1.Aborting, jobInfo.Job.Status.State.Phase, i)
 				}
 			} else if testcase.Action == busv1alpha1.TerminateJobAction {
 				// always jump to terminating firstly
@@ -1363,7 +1363,7 @@ func TestRunningState_Execute(t *testing.T) {
 			} else if testcase.Action == busv1alpha1.CompleteJobAction {
 				// always jump to completing firstly
 				if jobInfo.Job.Status.State.Phase != v1alpha1.Completing {
-					t.Errorf("Expected Job phase to %s, but got %s in case %d", v1alpha1.Restarting, jobInfo.Job.Status.State.Phase, i)
+					t.Errorf("Expected Job phase to %s, but got %s in case %d", v1alpha1.Completing, jobInfo.Job.Status.State.Phase, i)
 				}
 			} else {
 				total := state.TotalTasks(testcase.JobInfo.Job)


### PR DESCRIPTION

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

In `TestRunningState_Execute` (`pkg/controllers/job/job_state_test.go`), the
`AbortJobAction` and `CompleteJobAction` branches guard on the correct phases
(`v1alpha1.Aborting` and `v1alpha1.Completing`), but their `t.Errorf` messages
both print `v1alpha1.Restarting` as the expected phase. If either assertion ever
fails, the diagnostic names the wrong phase, which would mislead anyone debugging
the failure.

This changes the two messages to print the phase that is actually being checked,
matching the guard on the line directly above each one and the pattern already
used by the sibling `TestPendingState_Execute` in the same file (which correctly
prints `Aborting` and `Completing`). The `RestartJobAction` and
`TerminateJobAction` branches are untouched because their `Restarting` /
`Terminating` messages are already correct.

This is a diagnostic-message-only change: no test behavior changes and the
package tests stay green.

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

Exactly two lines change and both are inside message strings, so there is no
behavior change. The two branches I did not touch (`RestartJobAction`,
`TerminateJobAction`) already print the phase they guard on, and `Restarting`
looks like a copy-paste artifact that was carried into the Abort/Complete
branches. You can confirm the intended pattern against `TestPendingState_Execute`
in the same file.

Verification I ran locally:
- `gofmt -l pkg/controllers/job/job_state_test.go` -> no output
- `go vet ./pkg/controllers/job/...` -> clean
- `go test ./pkg/controllers/job/ -run TestRunningState_Execute -v -count=1` -> PASS
- `go test ./pkg/controllers/job/` -> ok
- As a sanity check I temporarily forced the Abort guard to fail and confirmed
  the message then names `Aborting` (previously it would have said `Restarting`),
  then reverted.

AI disclosure (per contributing.md AI Guidance): I used an AI assistant to help
locate and describe this issue. I have reviewed and understand every line of the
change and can explain the reasoning behind it; happy to answer any "why"
questions in review.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
