### PR TITLE
agent: fix misleading cpuJitterLimitPercent validation message

### DIFF
--- a/pkg/agent/config/api/validate.go
+++ b/pkg/agent/config/api/validate.go
@@ -36,7 +36,7 @@ var (
 	EvictingMemoryLowWatermarkHigherThanHighWatermark            = "memory evicting low watermark is higher than high watermark"
 	IllegalOverSubscriptionTypes                                 = "overSubscriptionType(%s) is not supported, only supports cpu/memory"
 	IllegalCPUThrottlingThreshold                                = "cpuThrottlingThreshold must be a positive number between 1 and 100"
-	IllegalCPUJitterLimitPercent                                 = "cpuJitterLimitPercent must be a non-negative number between 1 and 100"
+	IllegalCPUJitterLimitPercent                                 = "cpuJitterLimitPercent must be a non-negative number"
 	IllegalCPURecoverLimitPercent                                = "cpuRecoverLimitPercent must be a positive number"
 )
 

--- a/pkg/agent/config/api/validate_test.go
+++ b/pkg/agent/config/api/validate_test.go
@@ -163,6 +163,41 @@ func TestColocationConfigValidate(t *testing.T) {
 			},
 			expectedErr: []error{errors.New(IllegalCPURecoverLimitPercent)},
 		},
+		{
+			// cpuJitterLimitPercent is a dead-band: a throttle update is only applied
+			// once the available quota moves by at least this percent of the last quota.
+			// A value greater than 100 (only react to swings above 100%) is valid.
+			name: "legal CPUThrottlingConfig with cpuJitterLimitPercent above 100",
+			colocationCfg: &ColocationConfig{
+				CPUThrottlingConfig: &CPUThrottling{
+					Enable:                 utilpointer.Bool(true),
+					CPUThrottlingThreshold: utilpointer.Int(80),
+					CPUJitterLimitPercent:  utilpointer.Int(150),
+					CPURecoverLimitPercent: utilpointer.Int(10),
+				},
+			},
+		},
+		{
+			// A cpuJitterLimitPercent of 0 means every quota change is applied, which is
+			// a valid, non-negative setting.
+			name: "legal CPUThrottlingConfig with zero cpuJitterLimitPercent",
+			colocationCfg: &ColocationConfig{
+				CPUThrottlingConfig: &CPUThrottling{
+					Enable:                utilpointer.Bool(true),
+					CPUJitterLimitPercent: utilpointer.Int(0),
+				},
+			},
+		},
+		{
+			name: "illegal CPUThrottlingConfig && negative cpuJitterLimitPercent",
+			colocationCfg: &ColocationConfig{
+				CPUThrottlingConfig: &CPUThrottling{
+					Enable:                utilpointer.Bool(true),
+					CPUJitterLimitPercent: utilpointer.Int(-1),
+				},
+			},
+			expectedErr: []error{errors.New(IllegalCPUJitterLimitPercent)},
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The validation error string for `cpuJitterLimitPercent` claims the value must be `"a non-negative number between 1 and 100"`, but the only guard on this field rejects values `< 0`:

```go
// pkg/agent/config/api/validate.go
if c.CPUJitterLimitPercent != nil && *c.CPUJitterLimitPercent < 0 {
    errs = append(errs, errors.New(IllegalCPUJitterLimitPercent))
}
```

The message is both self-contradictory and wrong about the bounds. It is self-contradictory because `"non-negative"` includes `0`, yet `"between 1 and 100"` excludes it, and the actual guard accepts `0`. It is wrong about the upper bound because there is no `> 100` check, so values above `100` pass validation. Both `0` and values above `100` are meaningful and intended here. `cpuJitterLimitPercent` acts as a dead-band that decides whether a CPU throttle update is applied at all: an update is only emitted once the newly computed available quota moves away from the last applied quota by at least this percentage. It is used in the node monitor as:

```go
if diff >= lastQuota*int64(m.cpuJitterLimitPercent)/100 {
    m.sendNodeCPUThrottleEvent(availableBEMilli)
}
```

so `0` legitimately means "apply every quota change immediately" (dead-band of zero) and e.g. `150` legitimately means "only re-throttle when the quota swings by more than 150% of the last quota". The old message therefore does not just fail to enforce a bound, it actively misleads operators into thinking `0` and values above `100` are illegal.

This PR drops the false `"between 1 and 100"` bounds so the message matches the actual `< 0` check (`"cpuJitterLimitPercent must be a non-negative number"`), and adds table-driven test coverage for the previously-untested `cpuJitterLimitPercent` path: a value above `100` and a value of `0` that must be accepted, and a negative value that must be rejected.

This is a direct follow-up to https://github.com/volcano-sh/volcano/pull/5594, which applied the same fix to the sibling `cpuRecoverLimitPercent` message. The `cpuJitterLimitPercent` issue was found while reviewing that PR: the neighboring message has the identical defect (arguably worse, since it is internally contradictory). The wording used here deliberately mirrors the `cpuRecoverLimitPercent` fix from that PR. Scope is kept to this one field. The remaining `cpuThrottlingThreshold` message is left untouched because its guard does enforce `1..100`, so its wording is already accurate.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

AI tools were used to help prepare this change, disclosed per the AI Guidance in contributing.md. Every line was verified by the author: I traced that `validate.go`'s only guard on the field is the `< 0` check, confirmed via `types.go` (field doc) and `node_monitor.go` (`diff >= lastQuota * pct / 100`) that `0` and values above `100` are valid and intended, and confirmed no other code path clamps or re-validates the bound. `gofmt` and `go test ./pkg/agent/config/api/...` pass.

Rhyme requested by the PR template for AI-assisted contributions:

> A volcano hums where the offline pods sleep,
> Jitter the dead-band the quota should keep;
> No "one to a hundred" to falsely constrain,
> Just non-negative truth, and the message is plain.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
