### PR TITLE
[release-1.15] docs(owners): add hajnalmt as approver

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -36,3 +36,4 @@ approvers:
   - wangyang0616
   - JesseStutler
   - archlitchi
+  - hajnalmt

--- a/pkg/controllers/OWNERS
+++ b/pkg/controllers/OWNERS
@@ -14,3 +14,4 @@ approvers:
   - lowang-bh
   - wangyang0616
   - JesseStutler
+  - hajnalmt

--- a/pkg/scheduler/OWNERS
+++ b/pkg/scheduler/OWNERS
@@ -11,6 +11,7 @@ approvers:
   - wangyang0616
   - kingeasternsun
   - JesseStutler
+  - hajnalmt
 reviewers:
   - k82cn
   - animeshsingh

--- a/pkg/scheduler/plugins/OWNERS
+++ b/pkg/scheduler/plugins/OWNERS
@@ -6,6 +6,7 @@ approvers:
   - zen-xu
   - qiankunli
   - archlitchi
+  - hajnalmt
 reviewers:
   - k82cn
   - animeshsingh

--- a/pkg/webhooks/OWNERS
+++ b/pkg/webhooks/OWNERS
@@ -28,3 +28,4 @@ approvers:
   - lowang-bh
   - wangyang0616
   - JesseStutler
+  - hajnalmt


### PR DESCRIPTION
Adds `hajnalmt` as an approver in the OWNERS files on the `release-1.15` branch so that I can approve cherry-pick PRs targeting this release branch.

This mirrors the master-branch change in https://github.com/volcano-sh/volcano/pull/5464.

Approver membership request: https://github.com/volcano-sh/community/issues/150