### PR TITLE
docs: update Go version instructions to be version-agnostic

### DIFF
--- a/docs/development/prepare-for-development.md
+++ b/docs/development/prepare-for-development.md
@@ -18,7 +18,7 @@ To build, you'll need a Go development environment. If you haven't set up a Go d
 environment, please follow [these instructions](https://golang.org/doc/install)
 to install the Go tools.
 
-Volcano currently builds with Go 1.14
+Volcano requires the Go version specified in the [`go.mod`](../../go.mod) file at the root of the repository.
 
 ## Setting up Docker
 


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What this PR does / why we need it:**
This PR updates the developer setup documentation to be version-agnostic. The docs previously instructed developers to install Go 1.14, but the project now requires a newer version (as specified in `go.mod`). 

**Which issue(s) this PR fixes:**
Fixes #5598

**Special notes for your reviewer:**
N/A

**Does this PR introduce a user-facing change?**
```release-note
NONE