### PR TITLE
fix(webhook): separate CronJob validation errors with "; "

### DIFF
--- a/pkg/webhooks/admission/cronjobs/validate/admit_cronjob.go
+++ b/pkg/webhooks/admission/cronjobs/validate/admit_cronjob.go
@@ -105,21 +105,31 @@ func AdmitCronjobs(ar admissionv1.AdmissionReview) *admissionv1.AdmissionRespons
 	return &reviewResponse
 }
 func validateCronJobCreate(cronjob *v1alpha1.CronJob, reviewResponse *admissionv1.AdmissionResponse) string {
-	msg := validateCronjobSpec(&cronjob.Spec, cronjob.Namespace)
-	msg += validateCronJobName(cronjob.Name)
+	msg := validateCronJob(cronjob)
 	if msg != "" {
 		reviewResponse.Allowed = false
 	}
 	return msg
 }
 func validateCronJobUpdate(new *v1alpha1.CronJob) error {
-	msg := validateCronjobSpec(&new.Spec, new.Namespace)
-	msg += validateCronJobName(new.Name)
-
-	if msg != "" {
+	if msg := validateCronJob(new); msg != "" {
 		return errors.New(msg)
 	}
 	return nil
+}
+
+// validateCronJob runs the validators and joins their non-empty messages with
+// "; " so that multiple failures don't run together in a single line. Each
+// message is trimmed so the result has no stray leading or trailing spaces.
+func validateCronJob(cronjob *v1alpha1.CronJob) string {
+	var errs []string
+	if msg := strings.TrimSpace(validateCronjobSpec(&cronjob.Spec, cronjob.Namespace)); msg != "" {
+		errs = append(errs, msg)
+	}
+	if msg := strings.TrimSpace(validateCronJobName(cronjob.Name)); msg != "" {
+		errs = append(errs, msg)
+	}
+	return strings.Join(errs, "; ")
 }
 func validateCronjobSpec(spec *v1alpha1.CronJobSpec, nameSpace string) string {
 	var msg string

--- a/pkg/webhooks/admission/cronjobs/validate/admit_cronjob_test.go
+++ b/pkg/webhooks/admission/cronjobs/validate/admit_cronjob_test.go
@@ -412,3 +412,54 @@ func TestValidateCronJobName(t *testing.T) {
 		})
 	}
 }
+
+// When several checks fail at once, the messages should be separated by "; ".
+func TestValidateCronJobSeparatesMultipleErrors(t *testing.T) {
+	cronjob := &v1alpha1.CronJob{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      strings.Repeat("a", 53),
+			Namespace: metav1.NamespaceDefault,
+		},
+		Spec: v1alpha1.CronJobSpec{
+			Schedule:          "error schedule",
+			ConcurrencyPolicy: v1alpha1.AllowConcurrent,
+			JobTemplate: v1alpha1.JobTemplateSpec{
+				Spec: getJobTemplate(),
+			},
+		},
+	}
+
+	msg := validateCronJob(cronjob)
+
+	for _, want := range []string{"schedule is not a valid cron expression", "; ", "must be no more than 52 characters"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("expected %q in combined message, got %q", want, msg)
+		}
+	}
+}
+
+// A single failing check should come back on its own, with no separator.
+func TestValidateCronJobSingleErrorHasNoSeparator(t *testing.T) {
+	cronjob := &v1alpha1.CronJob{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "valid-cronjob",
+			Namespace: metav1.NamespaceDefault,
+		},
+		Spec: v1alpha1.CronJobSpec{
+			Schedule:          "",
+			ConcurrencyPolicy: v1alpha1.AllowConcurrent,
+			JobTemplate: v1alpha1.JobTemplateSpec{
+				Spec: getJobTemplate(),
+			},
+		},
+	}
+
+	msg := validateCronJob(cronjob)
+
+	if want := "schedule is required, but got empty"; msg != want {
+		t.Errorf("expected single-error message %q, got %q", want, msg)
+	}
+	if strings.Contains(msg, "; ") {
+		t.Errorf("single-error message should not contain %q, got %q", "; ", msg)
+	}
+}


### PR DESCRIPTION
/kind bug

When a CronJob fails more than one check at once (say a bad schedule and a name over the length limit), the webhook joined the messages with no separator, so the rejection came out as one run-on line. This trims each validator message and joins the non-empty ones with "; " so each error reads on its own.

It's the CronJob version of the PodGroup fix in #5487 (same collect-and-join, with the leading/trailing whitespace trimmed for a clean result). Going by @hajnalmt's grep on that PR, this was the last spot left with the pattern. It's one `validateCronJob` helper shared by the create and update paths, plus a couple of tests.

Scoped to the CronJob webhook. The `admit_job.go` cleanup the issue mentions uses a different convention (its own leading-space / trailing-`;` style), so it's better kept as a separate change.

Thanks @anxkhn for starting this off in #5533. I opened this since it's issue (#5489) and I already had the same pattern from #5487.

Fixes #5489

```release-note
NONE
```
