### PR TITLE
feat(scheduler): use SSA for queue-status allocated field

### DIFF
--- a/installer/helm/chart/volcano/templates/scheduler.yaml
+++ b/installer/helm/chart/volcano/templates/scheduler.yaml
@@ -91,7 +91,7 @@ rules:
     verbs: ["get", "list", "watch", "create", "delete", "update"]
   - apiGroups: ["scheduling.incubator.k8s.io", "scheduling.volcano.sh"]
     resources: ["queues/status"]
-    verbs: ["update"]
+    verbs: ["update", "patch"]
   - apiGroups: ["scheduling.incubator.k8s.io", "scheduling.volcano.sh"]
     resources: ["podgroups"]
     verbs: ["list", "watch", "update"]

--- a/installer/volcano-development-vap-map.yaml
+++ b/installer/volcano-development-vap-map.yaml
@@ -9180,7 +9180,7 @@ rules:
     verbs: ["get", "list", "watch", "create", "delete", "update"]
   - apiGroups: ["scheduling.incubator.k8s.io", "scheduling.volcano.sh"]
     resources: ["queues/status"]
-    verbs: ["update"]
+    verbs: ["update", "patch"]
   - apiGroups: ["scheduling.incubator.k8s.io", "scheduling.volcano.sh"]
     resources: ["podgroups"]
     verbs: ["list", "watch", "update"]

--- a/installer/volcano-development-vap.yaml
+++ b/installer/volcano-development-vap.yaml
@@ -9180,7 +9180,7 @@ rules:
     verbs: ["get", "list", "watch", "create", "delete", "update"]
   - apiGroups: ["scheduling.incubator.k8s.io", "scheduling.volcano.sh"]
     resources: ["queues/status"]
-    verbs: ["update"]
+    verbs: ["update", "patch"]
   - apiGroups: ["scheduling.incubator.k8s.io", "scheduling.volcano.sh"]
     resources: ["podgroups"]
     verbs: ["list", "watch", "update"]

--- a/installer/volcano-development.yaml
+++ b/installer/volcano-development.yaml
@@ -9180,7 +9180,7 @@ rules:
     verbs: ["get", "list", "watch", "create", "delete", "update"]
   - apiGroups: ["scheduling.incubator.k8s.io", "scheduling.volcano.sh"]
     resources: ["queues/status"]
-    verbs: ["update"]
+    verbs: ["update", "patch"]
   - apiGroups: ["scheduling.incubator.k8s.io", "scheduling.volcano.sh"]
     resources: ["podgroups"]
     verbs: ["list", "watch", "update"]

--- a/pkg/scheduler/cache/cache.go
+++ b/pkg/scheduler/cache/cache.go
@@ -62,6 +62,7 @@ import (
 	"volcano.sh/apis/pkg/apis/scheduling"
 	schedulingscheme "volcano.sh/apis/pkg/apis/scheduling/scheme"
 	vcv1beta1 "volcano.sh/apis/pkg/apis/scheduling/v1beta1"
+	v1beta1apply "volcano.sh/apis/pkg/client/applyconfiguration/scheduling/v1beta1"
 	vcclient "volcano.sh/apis/pkg/client/clientset/versioned"
 	"volcano.sh/apis/pkg/client/clientset/versioned/scheme"
 	vcinformer "volcano.sh/apis/pkg/client/informers/externalversions"
@@ -75,6 +76,7 @@ import (
 	schedulingapi "volcano.sh/volcano/pkg/scheduler/api"
 	"volcano.sh/volcano/pkg/scheduler/metrics"
 	"volcano.sh/volcano/pkg/scheduler/metrics/source"
+	schedulerutil "volcano.sh/volcano/pkg/scheduler/util"
 	schedulercache "volcano.sh/volcano/pkg/schedulercommon/cache"
 	"volcano.sh/volcano/pkg/util"
 )
@@ -383,8 +385,15 @@ func (su *defaultStatusUpdater) UpdateQueueStatus(queue *schedulingapi.QueueInfo
 		return err
 	}
 
-	_, err := su.vcclient.SchedulingV1beta1().Queues().UpdateStatus(context.TODO(), newQueue, metav1.UpdateOptions{})
-	if err != nil {
+	// Use Server-Side Apply and own only .status.allocated with the
+	// scheduler's FieldManager. The queue-controller owns .status.state
+	// via its own FieldManager (see pkg/controllers/queue/…).
+	// UpdateStatus with a full-object body used to stomp the state field
+	// on every apply, forcing the queue controller to re-write it and
+	// producing a flap between the two writers.
+	queueStatusApply := v1beta1apply.QueueStatus().WithAllocated(newQueue.Status.Allocated)
+	queueApply := v1beta1apply.Queue(newQueue.Name).WithStatus(queueStatusApply)
+	if _, err := su.vcclient.SchedulingV1beta1().Queues().ApplyStatus(context.TODO(), queueApply, metav1.ApplyOptions{FieldManager: schedulerutil.DefaultComponentName, Force: true}); err != nil {
 		klog.Errorf("error occurred in updating Queue <%s>: %s", newQueue.Name, err.Error())
 		return err
 	}

--- a/pkg/scheduler/cache/cache.go
+++ b/pkg/scheduler/cache/cache.go
@@ -379,22 +379,20 @@ func (su *defaultStatusUpdater) UpdatePodGroup(pg *schedulingapi.PodGroup) (*sch
 
 // UpdateQueueStatus will update the status of queue
 func (su *defaultStatusUpdater) UpdateQueueStatus(queue *schedulingapi.QueueInfo) error {
-	newQueue := &vcv1beta1.Queue{}
-	if err := schedulingscheme.Scheme.Convert(queue.Queue, newQueue, nil); err != nil {
-		klog.Errorf("error occurred in converting scheduling.Queue to v1beta1.Queue: %s", err.Error())
-		return err
-	}
-
 	// Use Server-Side Apply and own only .status.allocated with the
 	// scheduler's FieldManager. The queue-controller owns .status.state
 	// via its own FieldManager (see pkg/controllers/queue/…).
 	// UpdateStatus with a full-object body used to stomp the state field
 	// on every apply, forcing the queue controller to re-write it and
 	// producing a flap between the two writers.
-	queueStatusApply := v1beta1apply.QueueStatus().WithAllocated(newQueue.Status.Allocated)
-	queueApply := v1beta1apply.Queue(newQueue.Name).WithStatus(queueStatusApply)
+	//
+	// The apply payload is built directly from QueueInfo: Name is already
+	// a string and the internal Status.Allocated is already a
+	// v1.ResourceList, so no scheme conversion is needed.
+	queueStatusApply := v1beta1apply.QueueStatus().WithAllocated(queue.Queue.Status.Allocated)
+	queueApply := v1beta1apply.Queue(queue.Name).WithStatus(queueStatusApply)
 	if _, err := su.vcclient.SchedulingV1beta1().Queues().ApplyStatus(context.TODO(), queueApply, metav1.ApplyOptions{FieldManager: schedulerutil.DefaultComponentName, Force: true}); err != nil {
-		klog.Errorf("error occurred in updating Queue <%s>: %s", newQueue.Name, err.Error())
+		klog.Errorf("error occurred in updating Queue <%s>: %s", queue.Name, err.Error())
 		return err
 	}
 	return nil

--- a/pkg/scheduler/cache/cache_test.go
+++ b/pkg/scheduler/cache/cache_test.go
@@ -22,6 +22,7 @@ package cache
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"reflect"
 	"sync"
@@ -38,6 +39,7 @@ import (
 	kcache "k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 
+	"volcano.sh/apis/pkg/apis/scheduling"
 	vcv1beta1 "volcano.sh/apis/pkg/apis/scheduling/v1beta1"
 	vcclient "volcano.sh/apis/pkg/client/clientset/versioned"
 	vcclientfake "volcano.sh/apis/pkg/client/clientset/versioned/fake"
@@ -853,4 +855,68 @@ func TestAddUnassignedNumaPods_NilNodeValueSkips(t *testing.T) {
 		t.Fatalf("AddUnassignedNumaPods returned error: %v", err)
 	}
 	// No panic is the success condition.
+}
+
+// TestUpdateQueueStatusUsesServerSideApply pins the wire behavior of the
+// scheduler queue-status writer: it must issue a single Server-Side Apply
+// patch under the "vc-scheduler" field manager that carries only
+// status.allocated (not status.state, which the queue-controller owns).
+// If someone reverts this to a full-object UpdateStatus write, this test
+// fails instead of a busy cluster flapping between the two writers.
+func TestUpdateQueueStatusUsesServerSideApply(t *testing.T) {
+	// Seed the queue so the fake clientset's apply reactor finds an object
+	// to patch (the fake does not create-on-apply).
+	fakeClient := vcclientfake.NewSimpleClientset(&vcv1beta1.Queue{
+		ObjectMeta: metav1.ObjectMeta{Name: "q1"},
+	})
+	su := &defaultStatusUpdater{
+		vcclient: fakeClient,
+	}
+
+	queue := &api.QueueInfo{
+		Name: "q1",
+		Queue: &scheduling.Queue{
+			ObjectMeta: metav1.ObjectMeta{Name: "q1"},
+			Status: scheduling.QueueStatus{
+				State:     scheduling.QueueStateOpen,
+				Allocated: api.BuildResourceList("2", "1G"),
+			},
+		},
+	}
+
+	err := su.UpdateQueueStatus(queue)
+	assert.NoError(t, err)
+
+	actions := fakeClient.Actions()
+	if !assert.Len(t, actions, 1, "expected exactly one apiserver action") {
+		return
+	}
+
+	patchAction, ok := actions[0].(kubetesting.PatchAction)
+	if !assert.True(t, ok, "expected a patch action, got %T", actions[0]) {
+		return
+	}
+
+	// Must be a Server-Side Apply patch on the status subresource of q1,
+	// under the vc-scheduler field manager, with Force set.
+	assert.Equal(t, types.ApplyPatchType, patchAction.GetPatchType(), "must be a server-side apply patch")
+	assert.Equal(t, "q1", patchAction.GetName())
+	assert.Equal(t, "status", patchAction.GetSubresource())
+	assert.Equal(t, util.DefaultComponentName, patchAction.(kubetesting.PatchActionImpl).PatchOptions.FieldManager)
+	if force := patchAction.(kubetesting.PatchActionImpl).PatchOptions.Force; assert.NotNil(t, force) {
+		assert.True(t, *force, "apply must set Force so ownership transfers from a legacy full-object writer")
+	}
+
+	// The applied status must contain allocated and must NOT contain
+	// state (owned by the queue-controller under its own field manager).
+	var payload map[string]interface{}
+	assert.NoError(t, json.Unmarshal(patchAction.GetPatch(), &payload))
+	status, ok := payload["status"].(map[string]interface{})
+	if !assert.True(t, ok, "apply payload must have a status object") {
+		return
+	}
+	_, hasAllocated := status["allocated"]
+	_, hasState := status["state"]
+	assert.True(t, hasAllocated, "apply must include status.allocated")
+	assert.False(t, hasState, "apply must NOT include status.state; that field is owned by the queue-controller")
 }


### PR DESCRIPTION
<!-- AI disclosure: this PR was prepared with assistance from Claude Code, per the contributing guide's AI-guidance section.

Requested rhyme:

  Two writers on a queue's small page,
  the old full write picked a stale page.
  409 came back, a retry to send,
  now each owns its field and the conflicts end. -->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Switches the scheduler's `Queue` status writer from a full-object `UpdateStatus` to a Server-Side Apply that owns only `.status.allocated` under the FieldManager `"vc-scheduler"`.

The queue-controller has already been using SSA under FieldManager `"queue-controller"` for `.status.state` (see [`pkg/controllers/queue/queue_controller_action.go`](https://github.com/volcano-sh/volcano/blob/master/pkg/controllers/queue/queue_controller_action.go)). On the scheduler side, `UpdateStatus` sends the full `Queue` object.

The scheduler only writes when `.status.allocated` actually changes (session.go guards the call with a DeepEqual). The problem is the write itself: the full-object `UpdateStatus` carries the snapshot's `resourceVersion`, so when the queue-controller has written `.status.state` since that snapshot, the scheduler's update comes back 409 Conflict and retries. On busy queues that is steady 409 + retry noise, not a silent overwrite of `.state`.

After this change the two writers touch disjoint field sets under distinct managers, so there is no shared field to conflict on:

| Field manager | Owns |
|---|---|
| `"vc-scheduler"` | `.status.allocated` |
| `"queue-controller"` | `.status.state` |

`Force: true` is set on the scheduler-side apply so a v1.15 upgrade from a prior scheduler version that still owned `.status.allocated` under the legacy `UpdateStatus` manager cleanly transfers ownership.

No API changes, no new flags. Existing tests remain green (`go test ./pkg/scheduler/... ./pkg/controllers/queue/...`).

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

- RBAC: the scheduler ClusterRole now grants `patch` on `queues/status` (kept `update` for upgrade skew). Server-Side Apply is sent as a PATCH, so without it `ApplyStatus` 403s in a real cluster. Installer manifests regenerated with `make generate-yaml`.
- The controller-side `ApplyStatus` calls in `queue_controller_action.go` are **intentionally left alone**. They already work, and since the scheduler now owns a disjoint field, there is no conflict for `Force: true` to resolve on the controller side.
- The scheduler change is confined to one function in `pkg/scheduler/cache/cache.go` (`defaultStatusUpdater.UpdateQueueStatus`).
- Symptom this fixes in the wild: on high-throughput deployments the scheduler's status write raced the controller's `.state` write and came back 409, retrying on the next cycle. After the change the two managers own disjoint fields, so those conflicts go away.

#### Does this PR introduce a user-facing change?

```release-note
The scheduler now uses Server-Side Apply to write `Queue.status.allocated` under the FieldManager `"vc-scheduler"`, taking ownership of only that field instead of writing the whole object. This removes the 409 conflict-and-retry churn between the scheduler and the queue-controller (which owns `Queue.status.state`) on busy queues. The scheduler ClusterRole now also grants `patch` on `queues/status`, required because Server-Side Apply is sent as a PATCH.
```
