### PR TITLE
feat(webhook-manager): add --reconcile-admission-webhook to prune disabled webhooks

### DIFF
--- a/cmd/webhook-manager/app/options/options.go
+++ b/cmd/webhook-manager/app/options/options.go
@@ -38,23 +38,30 @@ const (
 
 // Config admission-controller server config.
 type Config struct {
-	KubeClientOptions    kube.ClientOptions
-	CertFile             string
-	KeyFile              string
-	CaCertFile           string
-	CertData             []byte
-	KeyData              []byte
-	CaCertData           []byte
-	ListenAddress        string
-	Port                 int
-	PrintVersion         bool
-	WebhookName          string
-	WebhookNamespace     string
-	SchedulerNames       []string
-	WebhookURL           string
-	ConfigPath           string
-	EnabledAdmission     string
-	GracefulShutdownTime time.Duration
+	KubeClientOptions kube.ClientOptions
+	CertFile          string
+	KeyFile           string
+	CaCertFile        string
+	CertData          []byte
+	KeyData           []byte
+	CaCertData        []byte
+	ListenAddress     string
+	Port              int
+	PrintVersion      bool
+	WebhookName       string
+	WebhookNamespace  string
+	SchedulerNames    []string
+	WebhookURL        string
+	ConfigPath        string
+	EnabledAdmission  string
+	// ReconcileAdmissionWebhook, when true, makes the webhook-manager
+	// list existing ValidatingWebhookConfigurations and
+	// MutatingWebhookConfigurations that were previously produced by
+	// this manager and delete the ones that are no longer in
+	// --enabled-admission. Off by default so existing deployments
+	// remain unchanged.
+	ReconcileAdmissionWebhook bool
+	GracefulShutdownTime      time.Duration
 
 	EnableHealthz bool
 	// HealthzBindAddress is the IP address and port for the health check server to serve on
@@ -95,6 +102,7 @@ func (c *Config) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&c.WebhookName, "webhook-service-name", "", "The name of this webhook")
 	fs.StringVar(&c.WebhookURL, "webhook-url", "", "The url of this webhook")
 	fs.StringVar(&c.EnabledAdmission, "enabled-admission", defaultEnabledAdmission, "enabled admission webhooks, if this parameter is modified, make sure corresponding webhook configurations are the same.")
+	fs.BoolVar(&c.ReconcileAdmissionWebhook, "reconcile-admission-webhook", false, "When set, on startup the webhook-manager deletes ValidatingWebhookConfigurations / MutatingWebhookConfigurations produced by this manager that are no longer listed in --enabled-admission. Off by default.")
 	fs.StringArrayVar(&c.SchedulerNames, "scheduler-name", []string{defaultSchedulerName}, "Volcano will handle pods whose .spec.SchedulerName is same as scheduler-name")
 	fs.StringVar(&c.ConfigPath, "admission-conf", "", "The configmap file of this webhook")
 	fs.BoolVar(&c.EnableHealthz, "enable-healthz", false, "Enable the health check; it is false by default")

--- a/cmd/webhook-manager/app/server.go
+++ b/cmd/webhook-manager/app/server.go
@@ -76,6 +76,18 @@ func Run(config *options.Config) error {
 
 	vClient := getVolcanoClient(restConfig)
 	kubeClient := getKubeClient(restConfig)
+
+	// Optional reconciliation: delete ValidatingWebhookConfigurations
+	// and MutatingWebhookConfigurations that were produced by this
+	// manager (name-prefix volcano-admission-service-) but that are
+	// no longer listed in --enabled-admission. Off by default.
+	if config.ReconcileAdmissionWebhook {
+		if err := SyncAdmissionWebhooks(kubeClient, config.EnabledAdmission); err != nil {
+			klog.Errorf("Failed to reconcile admission webhook configurations: %v", err)
+			return err
+		}
+	}
+
 	factory := informers.NewSharedInformerFactory(vClient, 0)
 
 	// Get the queue informer and add parent index for efficient child queue lookups

--- a/cmd/webhook-manager/app/util.go
+++ b/cmd/webhook-manager/app/util.go
@@ -168,3 +168,88 @@ func configTLS(config *options.Config, restConfig *rest.Config) *tls.Config {
 	klog.Fatal("tls: failed to find any tls config data")
 	return &tls.Config{}
 }
+
+// SyncAdmissionWebhooks reconciles Validating/Mutating webhook
+// configurations previously produced by this manager against
+// --enabled-admission. Configurations whose name matches the
+// "volcano-admission-service-*" prefix but that are not in the
+// enabled set are deleted, so operators can disable a webhook by
+// removing it from --enabled-admission without leaving orphaned
+// configurations behind.
+//
+// Only invoked when --reconcile-admission-webhook is set.
+func SyncAdmissionWebhooks(kubeClient kubernetes.Interface, enabledAdmission string) error {
+	enabledValidating := make(map[string]struct{})
+	enabledMutating := make(map[string]struct{})
+	for _, entry := range strings.Split(strings.TrimSpace(enabledAdmission), ",") {
+		entry = strings.TrimSpace(entry)
+		if entry == "" {
+			continue
+		}
+		// --enabled-admission entries have the shape "/jobs/validate";
+		// mirror addCaCertForWebhook's naming: prefix + path with "/"
+		// replaced by "-".
+		name := volcanoAdmissionPrefix + strings.ReplaceAll(entry, "/", "-")
+		if strings.HasSuffix(entry, "/validate") {
+			enabledValidating[name] = struct{}{}
+		} else if strings.HasSuffix(entry, "/mutate") {
+			enabledMutating[name] = struct{}{}
+		}
+	}
+
+	ctx := context.Background()
+	if err := deleteDisabledValidatingWebhooks(ctx, kubeClient, enabledValidating); err != nil {
+		return err
+	}
+	return deleteDisabledMutatingWebhooks(ctx, kubeClient, enabledMutating)
+}
+
+// deleteDisabledValidatingWebhooks lists ValidatingWebhookConfigurations
+// whose name has the volcano-admission-service- prefix and deletes any
+// that are not in the enabled set.
+func deleteDisabledValidatingWebhooks(ctx context.Context, kubeClient kubernetes.Interface, enabled map[string]struct{}) error {
+	client := kubeClient.AdmissionregistrationV1().ValidatingWebhookConfigurations()
+	list, err := client.List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to list ValidatingWebhookConfigurations: %v", err)
+	}
+	for i := range list.Items {
+		name := list.Items[i].Name
+		if !strings.HasPrefix(name, volcanoAdmissionPrefix) {
+			continue
+		}
+		if _, ok := enabled[name]; ok {
+			continue
+		}
+		klog.V(2).Infof("Deleting disabled ValidatingWebhookConfiguration %q", name)
+		if err := client.Delete(ctx, name, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+			return fmt.Errorf("failed to delete ValidatingWebhookConfiguration %q: %v", name, err)
+		}
+	}
+	return nil
+}
+
+// deleteDisabledMutatingWebhooks lists MutatingWebhookConfigurations
+// whose name has the volcano-admission-service- prefix and deletes any
+// that are not in the enabled set.
+func deleteDisabledMutatingWebhooks(ctx context.Context, kubeClient kubernetes.Interface, enabled map[string]struct{}) error {
+	client := kubeClient.AdmissionregistrationV1().MutatingWebhookConfigurations()
+	list, err := client.List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to list MutatingWebhookConfigurations: %v", err)
+	}
+	for i := range list.Items {
+		name := list.Items[i].Name
+		if !strings.HasPrefix(name, volcanoAdmissionPrefix) {
+			continue
+		}
+		if _, ok := enabled[name]; ok {
+			continue
+		}
+		klog.V(2).Infof("Deleting disabled MutatingWebhookConfiguration %q", name)
+		if err := client.Delete(ctx, name, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+			return fmt.Errorf("failed to delete MutatingWebhookConfiguration %q: %v", name, err)
+		}
+	}
+	return nil
+}

--- a/cmd/webhook-manager/app/util.go
+++ b/cmd/webhook-manager/app/util.go
@@ -179,8 +179,11 @@ func configTLS(config *options.Config, restConfig *rest.Config) *tls.Config {
 //
 // Only invoked when --reconcile-admission-webhook is set.
 func SyncAdmissionWebhooks(kubeClient kubernetes.Interface, enabledAdmission string) error {
-	enabledValidating := make(map[string]struct{})
-	enabledMutating := make(map[string]struct{})
+	// Collect the configuration names this manager would create for the
+	// enabled entries. Validating and mutating webhooks have distinct names
+	// (…-validate vs …-mutate), so a single set keyed by full name is
+	// unambiguous and does not depend on the path suffix.
+	enabledWebhooks := make(map[string]struct{})
 	for _, entry := range strings.Split(strings.TrimSpace(enabledAdmission), ",") {
 		entry = strings.TrimSpace(entry)
 		if entry == "" {
@@ -190,18 +193,22 @@ func SyncAdmissionWebhooks(kubeClient kubernetes.Interface, enabledAdmission str
 		// mirror addCaCertForWebhook's naming: prefix + path with "/"
 		// replaced by "-".
 		name := volcanoAdmissionPrefix + strings.ReplaceAll(entry, "/", "-")
-		if strings.HasSuffix(entry, "/validate") {
-			enabledValidating[name] = struct{}{}
-		} else if strings.HasSuffix(entry, "/mutate") {
-			enabledMutating[name] = struct{}{}
-		}
+		enabledWebhooks[name] = struct{}{}
+	}
+
+	// The delete path is destructive: an empty enabled set would prune every
+	// configuration this manager owns. That only happens when
+	// --enabled-admission is blank or malformed, which is a misconfiguration,
+	// not an intentional "disable everything". Refuse rather than sweep.
+	if len(enabledWebhooks) == 0 {
+		return fmt.Errorf("--reconcile-admission-webhook is set but --enabled-admission yielded no webhook names (value: %q); refusing to delete all volcano admission webhook configurations", enabledAdmission)
 	}
 
 	ctx := context.Background()
-	if err := deleteDisabledValidatingWebhooks(ctx, kubeClient, enabledValidating); err != nil {
+	if err := deleteDisabledValidatingWebhooks(ctx, kubeClient, enabledWebhooks); err != nil {
 		return err
 	}
-	return deleteDisabledMutatingWebhooks(ctx, kubeClient, enabledMutating)
+	return deleteDisabledMutatingWebhooks(ctx, kubeClient, enabledWebhooks)
 }
 
 // deleteDisabledValidatingWebhooks lists ValidatingWebhookConfigurations
@@ -215,7 +222,11 @@ func deleteDisabledValidatingWebhooks(ctx context.Context, kubeClient kubernetes
 	}
 	for i := range list.Items {
 		name := list.Items[i].Name
-		if !strings.HasPrefix(name, volcanoAdmissionPrefix) {
+		// Match the exact prefix the manager uses, including the trailing
+		// hyphen, so names like "volcano-admission-service" or
+		// "volcano-admission-serviceX" that this manager never generated are
+		// left untouched.
+		if !strings.HasPrefix(name, volcanoAdmissionPrefix+"-") {
 			continue
 		}
 		if _, ok := enabled[name]; ok {
@@ -240,7 +251,11 @@ func deleteDisabledMutatingWebhooks(ctx context.Context, kubeClient kubernetes.I
 	}
 	for i := range list.Items {
 		name := list.Items[i].Name
-		if !strings.HasPrefix(name, volcanoAdmissionPrefix) {
+		// Match the exact prefix the manager uses, including the trailing
+		// hyphen, so names like "volcano-admission-service" or
+		// "volcano-admission-serviceX" that this manager never generated are
+		// left untouched.
+		if !strings.HasPrefix(name, volcanoAdmissionPrefix+"-") {
 			continue
 		}
 		if _, ok := enabled[name]; ok {

--- a/cmd/webhook-manager/app/util_test.go
+++ b/cmd/webhook-manager/app/util_test.go
@@ -1,0 +1,132 @@
+/*
+Copyright 2026 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package app
+
+import (
+	"context"
+	"sort"
+	"testing"
+
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func validatingConfig(name string) *admissionregistrationv1.ValidatingWebhookConfiguration {
+	return &admissionregistrationv1.ValidatingWebhookConfiguration{ObjectMeta: metav1.ObjectMeta{Name: name}}
+}
+
+func mutatingConfig(name string) *admissionregistrationv1.MutatingWebhookConfiguration {
+	return &admissionregistrationv1.MutatingWebhookConfiguration{ObjectMeta: metav1.ObjectMeta{Name: name}}
+}
+
+func remainingValidating(t *testing.T, client *fake.Clientset) []string {
+	t.Helper()
+	list, err := client.AdmissionregistrationV1().ValidatingWebhookConfigurations().List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		t.Fatalf("listing validating configs: %v", err)
+	}
+	names := make([]string, 0, len(list.Items))
+	for i := range list.Items {
+		names = append(names, list.Items[i].Name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+func remainingMutating(t *testing.T, client *fake.Clientset) []string {
+	t.Helper()
+	list, err := client.AdmissionregistrationV1().MutatingWebhookConfigurations().List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		t.Fatalf("listing mutating configs: %v", err)
+	}
+	names := make([]string, 0, len(list.Items))
+	for i := range list.Items {
+		names = append(names, list.Items[i].Name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// TestSyncAdmissionWebhooksDeletesDisabled checks that only prefixed
+// configurations absent from --enabled-admission are pruned, while enabled
+// ones and configurations owned by other systems survive.
+func TestSyncAdmissionWebhooksDeletesDisabled(t *testing.T) {
+	client := fake.NewSimpleClientset(
+		validatingConfig("volcano-admission-service-jobs-validate"), // enabled, keep
+		validatingConfig("volcano-admission-service-pods-validate"), // disabled, delete
+		validatingConfig("volcano-admission-service"),               // no trailing hyphen, not ours, keep
+		validatingConfig("other-controller-validate"),               // different prefix, keep
+		mutatingConfig("volcano-admission-service-pods-mutate"),     // enabled, keep
+		mutatingConfig("volcano-admission-service-jobs-mutate"),     // disabled, delete
+	)
+
+	err := SyncAdmissionWebhooks(client, "/jobs/validate,/pods/mutate")
+	if err != nil {
+		t.Fatalf("SyncAdmissionWebhooks returned error: %v", err)
+	}
+
+	wantValidating := []string{
+		"other-controller-validate",
+		"volcano-admission-service",
+		"volcano-admission-service-jobs-validate",
+	}
+	if got := remainingValidating(t, client); !equalStrings(got, wantValidating) {
+		t.Errorf("validating configs after sync = %v, want %v", got, wantValidating)
+	}
+
+	wantMutating := []string{"volcano-admission-service-pods-mutate"}
+	if got := remainingMutating(t, client); !equalStrings(got, wantMutating) {
+		t.Errorf("mutating configs after sync = %v, want %v", got, wantMutating)
+	}
+}
+
+// TestSyncAdmissionWebhooksRefusesEmptyEnabledSet checks that a blank or
+// malformed --enabled-admission is rejected rather than deleting every
+// volcano admission webhook configuration.
+func TestSyncAdmissionWebhooksRefusesEmptyEnabledSet(t *testing.T) {
+	for _, enabled := range []string{"", "   ", ","} {
+		client := fake.NewSimpleClientset(
+			validatingConfig("volcano-admission-service-jobs-validate"),
+			mutatingConfig("volcano-admission-service-jobs-mutate"),
+		)
+
+		err := SyncAdmissionWebhooks(client, enabled)
+		if err == nil {
+			t.Errorf("enabledAdmission %q: expected error, got nil", enabled)
+		}
+		// Nothing must have been deleted.
+		if got := remainingValidating(t, client); len(got) != 1 {
+			t.Errorf("enabledAdmission %q: validating configs = %v, want the original 1 kept", enabled, got)
+		}
+		if got := remainingMutating(t, client); len(got) != 1 {
+			t.Errorf("enabledAdmission %q: mutating configs = %v, want the original 1 kept", enabled, got)
+		}
+	}
+}


### PR DESCRIPTION
<!-- AI disclosure: this PR was prepared with assistance from Claude Code, per the contributing guide's AI-guidance section.

Requested rhyme:

  A webhook once disabled stayed on the shelf,
  Rejecting requests all by itself.
  Now on startup, the manager sweeps clean —
  Volcano admits only what's meant to be seen.

Prompt: "extract the webhook-manager reconciler hunks from our downstream volcano fork's webhooks_v1.15.0.patch, port to upstream master, keep the flag opt-in with false default, prepare draft PR." -->

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Adds `--reconcile-admission-webhook` (default `false`) that makes the webhook-manager delete `ValidatingWebhookConfigurations` and `MutatingWebhookConfigurations` produced by this manager (name-prefix `volcano-admission-service-`) that are no longer listed in `--enabled-admission`.

Currently, if an operator removes a webhook from `--enabled-admission` and restarts the webhook-manager, the previously created `WebhookConfiguration` is left orphaned in the cluster. It still matches admission requests and still points at the `volcano-admission` Service, but the Service no longer routes for the disabled path, producing 404s on every matching admission call until an operator manually deletes the configuration.

This PR introduces a single-shot startup reconciliation invoked from `Run()` right after the kube-client is built. It lists all `Validating`/`MutatingWebhookConfigurations` whose name starts with `volcano-admission-service-` and deletes those whose name does not derive from an entry in `--enabled-admission`. Configurations from other systems (any name that does not begin with the well-known prefix) are untouched.

Off by default so existing deployments are unchanged. Operators who want the new behavior opt in by passing `--reconcile-admission-webhook`.

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

- The reconciliation runs **once at startup**, not continuously. That matches the shape of the existing `addCaCertForWebhook` logic in `util.go`. A continuous reconciler could be added later if operators need runtime reload without a restart.
- The name-prefix check (`strings.HasPrefix(name, volcanoAdmissionPrefix)`) is intentionally conservative — the deletion path only touches configurations this manager produced. If an operator has hand-created a webhook using the same prefix, it will be swept; the recommendation is to use a different name prefix for anything not managed here.
- No RBAC change is needed — the manager's ServiceAccount already has `delete` on `ValidatingWebhookConfigurations` and `MutatingWebhookConfigurations` because it manages them today.
- Ported from a downstream fork where the flag has been in production for several months. In that environment it eliminated recurring 404 storms from orphaned webhooks after admission-plugin trims.

#### Does this PR introduce a user-facing change?

```release-note
Add `--reconcile-admission-webhook` webhook-manager flag (default `false`). When enabled, the webhook-manager deletes at startup any `ValidatingWebhookConfiguration` or `MutatingWebhookConfiguration` with the `volcano-admission-service-` name prefix that is no longer listed in `--enabled-admission`. Operators can disable a webhook by removing it from `--enabled-admission` without leaving orphaned configurations behind.
```
