### PR TITLE
docs: clarify how to join the Volcano Slack community

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ If you have any question, feel free to reach out to us in the following ways:
 > [!TIP]
 > New to the Volcano community? First, join the CNCF Slack workspace using the **Join CNCF Slack** link below. After signing in, search for the `#volcano` channel in the CNCF Slack workspace and join it to participate in community discussions.
 
-**CNCF Slack Workspace:** [Join CNCF Slack](https://slack.cncf.io/)
+**CNCF Slack Workspace Signup:** [Domain Signup](https://cloud-native.slack.com/signup#/domain-signup) or [Community Inviter](https://communityinviter.com/apps/cloud-native/cncf)
 
 **Volcano Slack Channel:** [#volcano](https://cloud-native.slack.com/archives/C011GJDQS0N)
 

--- a/README.md
+++ b/README.md
@@ -222,23 +222,18 @@ Resources:
 - [Meeting link](https://zoom.us/j/91804791393)
 - [Meeting Calendar](https://calendar.google.com/calendar/b/1/embed?src=volcano.sh.bot@gmail.com) | [Subscribe](https://calendar.google.com/calendar/b/1?cid=dm9sY2Fuby5zaC5ib3RAZ21haWwuY29t)
 
-
 ## Contact
 
 If you have any question, feel free to reach out to us in the following ways:
 
 > [!TIP]
-> New to the Volcano community? Follow these steps to join the Slack community:
->
-> 1. Join the CNCF Slack workspace using the **Join CNCF Slack** link below.
-> 2. Sign in to the CNCF Slack workspace.
-> 3. Search for the `#volcano` channel and join it to participate in community discussions.
+> New to the Volcano community? First, join the CNCF Slack workspace using the **Join CNCF Slack** link below. After signing in, search for the `#volcano` channel in the CNCF Slack workspace and join it to participate in community discussions.
 
 **CNCF Slack Workspace:** [Join CNCF Slack](https://slack.cncf.io/)
 
-**Volcano Slack Channel:** https://cloud-native.slack.com/archives/C011GJDQS0N
+**Volcano Slack Channel:** [#volcano](https://cloud-native.slack.com/archives/C011GJDQS0N)
 
-**Mailing List:** https://groups.google.com/forum/#!forum/volcano-sh
+**Mailing List:** [volcano-sh Google Group](https://groups.google.com/forum/#!forum/volcano-sh)
 
-WeChat: Please add WeChat account `k8s2222` and request an invitation to the group chat.
+**WeChat:** Please add WeChat account `k8s2222` and request an invitation to the group chat.
 

--- a/README.md
+++ b/README.md
@@ -222,12 +222,23 @@ Resources:
 - [Meeting link](https://zoom.us/j/91804791393)
 - [Meeting Calendar](https://calendar.google.com/calendar/b/1/embed?src=volcano.sh.bot@gmail.com) | [Subscribe](https://calendar.google.com/calendar/b/1?cid=dm9sY2Fuby5zaC5ib3RAZ21haWwuY29t)
 
+
 ## Contact
 
 If you have any question, feel free to reach out to us in the following ways:
 
-[Volcano Slack Channel](https://cloud-native.slack.com/archives/C011GJDQS0N) | [Join](https://slack.cncf.io/)
+> [!TIP]
+> New to the Volcano community? Follow these steps to join the Slack community:
+>
+> 1. Join the CNCF Slack workspace using the **Join CNCF Slack** link below.
+> 2. Sign in to the CNCF Slack workspace.
+> 3. Search for the `#volcano` channel and join it to participate in community discussions.
 
-[Mailing List](https://groups.google.com/forum/#!forum/volcano-sh)
+**CNCF Slack Workspace:** [Join CNCF Slack](https://slack.cncf.io/)
+
+**Volcano Slack Channel:** https://cloud-native.slack.com/archives/C011GJDQS0N
+
+**Mailing List:** https://groups.google.com/forum/#!forum/volcano-sh
 
 WeChat: Please add WeChat account `k8s2222` and request an invitation to the group chat.
+


### PR DESCRIPTION
## Summary

Clarify how new contributors can join the Volcano Slack community.

## Motivation

While joining the Volcano community, I noticed that the README provides a direct Slack channel link and a CNCF Slack join link, but it does not explicitly mention that contributors should first join the CNCF Slack workspace before accessing the channel.

This clarification improves the onboarding experience for first-time contributors.

## Changes

- Added a short note explaining the CNCF Slack workspace requirement.
- Clarified the steps to find and join the `#volcano` channel.

## Type of Change

- [x] Documentation