### PR TITLE
fix: restore orphan cronjob active jobs

### DIFF
--- a/pkg/controllers/cronjob/cronjob_controller_handler.go
+++ b/pkg/controllers/cronjob/cronjob_controller_handler.go
@@ -256,6 +256,12 @@ func (cc *cronjobcontroller) processCtlJobAndActiveJob(cronJob *batchv1.CronJob,
 			cc.recorder.Eventf(cronJob, corev1.EventTypeWarning, "OrphanedJob",
 				"Detected orphaned job forgotten or not managed by controller: %s (UID: %s)",
 				job.Name, job.UID)
+			jobRef, err := getRef(job)
+			if err != nil {
+				return updateStatus, err
+			}
+			cronJob.Status.Active = append(cronJob.Status.Active, *jobRef)
+			updateStatus = true
 		}
 	}
 

--- a/pkg/controllers/cronjob/cronjob_controller_test.go
+++ b/pkg/controllers/cronjob/cronjob_controller_test.go
@@ -1595,6 +1595,35 @@ func TestSyncCronJob(t *testing.T) {
 			},
 		},
 		{
+			name: "not first run, orphan active, is time, Forbid",
+			cronjob: cjSpec{
+				concurrency: "Forbid",
+			},
+			now: justTen().Add(10 * time.Minute),
+			jobs: []jobSpec{
+				{
+					status:      batchv1.Running,
+					time:        fiveMinutesAfterTen(),
+					inLister:    true,
+					inClient:    true,
+					active:      false,
+					processTime: time.Minute,
+				},
+			},
+			lastScheduleTime: &metav1.Time{Time: fiveMinutesAfterTen()},
+			expect: testExpect{
+				expectRequeueAfter:     durationPtr(5*time.Minute + nextScheduleDelta),
+				expectUpdateStatus:     true,
+				expectError:            false,
+				expectLastScheduleTime: &metav1.Time{Time: fiveMinutesAfterTen()},
+				expectInActiveNum:      1,
+				expectEventsNum:        2,
+				expectLastSuccessTime:  nil,
+				expectCreateJobNum:     0,
+				expectDeleteJobNum:     0,
+			},
+		},
+		{
 			name: "not first run, pre active, is time, Replace",
 			cronjob: cjSpec{
 				concurrency: "Replace",
@@ -1618,6 +1647,35 @@ func TestSyncCronJob(t *testing.T) {
 				expectLastScheduleTime: &metav1.Time{Time: justTen().Add(10 * time.Minute)},
 				expectInActiveNum:      1,
 				expectEventsNum:        3,
+				expectLastSuccessTime:  nil,
+				expectCreateJobNum:     1,
+				expectDeleteJobNum:     1,
+			},
+		},
+		{
+			name: "not first run, orphan active, is time, Replace",
+			cronjob: cjSpec{
+				concurrency: "Replace",
+			},
+			now: justTen().Add(10 * time.Minute),
+			jobs: []jobSpec{
+				{
+					status:      batchv1.Running,
+					time:        fiveMinutesAfterTen(),
+					inLister:    true,
+					inClient:    true,
+					active:      false,
+					processTime: time.Minute,
+				},
+			},
+			lastScheduleTime: &metav1.Time{Time: fiveMinutesAfterTen()},
+			expect: testExpect{
+				expectRequeueAfter:     durationPtr(5*time.Minute + nextScheduleDelta),
+				expectUpdateStatus:     true,
+				expectError:            false,
+				expectLastScheduleTime: &metav1.Time{Time: justTen().Add(10 * time.Minute)},
+				expectInActiveNum:      1,
+				expectEventsNum:        4,
 				expectLastSuccessTime:  nil,
 				expectCreateJobNum:     1,
 				expectDeleteJobNum:     1,


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

CronJob reconciliation already detects owned running Jobs that are missing from `status.active`, but it only recorded an event.

This restores those Jobs back into the active list during reconciliation. That keeps `Forbid` and `Replace` concurrency policy checks from ignoring an already-running owned Job.

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

Added regression coverage for `Forbid` and `Replace` when an owned running Job is missing from `status.active`.

#### Does this PR introduce a user-facing change?

```release-note
Fix Volcano CronJob concurrency handling when a running owned Job is missing from status.active.
```