### PR TITLE
fix: prevent int64 overflow in DRA device count quota accounting

### DIFF
--- a/pkg/scheduler/api/job_info.go
+++ b/pkg/scheduler/api/job_info.go
@@ -1414,7 +1414,7 @@ func (d *DRAResource) Add(other *DRAResource) {
 	if other == nil {
 		return
 	}
-	d.Count += other.Count
+	d.Count = SaturatingAdd(d.Count, other.Count)
 	if other.Capacity != nil {
 		if d.Capacity == nil {
 			d.Capacity = make(map[string]resource.Quantity)
@@ -1469,7 +1469,7 @@ func (ji *JobInfo) GetMinDRAResources() map[string]*DRAResource {
 				}
 			}
 
-			result[deviceClass].Count += request.Count * int64(times)
+			result[deviceClass].Count = SaturatingAdd(result[deviceClass].Count, SaturatingMul(request.Count, int64(times)))
 			for dim, cap := range request.Capacity {
 				totalCap := cap.DeepCopy()
 				for i := int32(0); i < times-1; i++ {

--- a/pkg/scheduler/api/saturating.go
+++ b/pkg/scheduler/api/saturating.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2026 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+import "math"
+
+// SaturatingAdd returns a + b, clamped to [math.MinInt64, math.MaxInt64] on
+// overflow instead of wrapping around.
+//
+// DRA device counts (ResourceClaim ...Exactly.Count) and gang sizes are
+// user-controlled and effectively unbounded (the apiserver only rejects
+// count <= 0), so accumulating them with a plain += can wrap a large positive
+// sum into a negative value. A negative count then defeats the "requested >
+// capability" quota check in checkDRAAllocatable, admitting a job that should
+// be rejected. Saturating keeps the running total a large positive value so
+// the quota check still rejects it.
+func SaturatingAdd(a, b int64) int64 {
+	s := a + b
+	if a > 0 && b > 0 && s < 0 {
+		return math.MaxInt64
+	}
+	if a < 0 && b < 0 && s >= 0 {
+		return math.MinInt64
+	}
+	return s
+}
+
+// SaturatingMul returns a * b, clamped to [math.MinInt64, math.MaxInt64] on
+// overflow instead of wrapping around. It guards the per-device-class
+// count * gangSize product in GetMinDRAResources.
+func SaturatingMul(a, b int64) int64 {
+	if a == 0 || b == 0 {
+		return 0
+	}
+	// math.MinInt64 * -1 overflows to math.MinInt64, and math.MinInt64 / -1 also
+	// wraps back to math.MinInt64, so the s/b overflow check below would miss it;
+	// handle that single pair explicitly.
+	if a == math.MinInt64 && b == -1 {
+		return math.MaxInt64
+	}
+	s := a * b
+	if s/b != a {
+		if (a > 0) == (b > 0) {
+			return math.MaxInt64
+		}
+		return math.MinInt64
+	}
+	return s
+}

--- a/pkg/scheduler/api/saturating_test.go
+++ b/pkg/scheduler/api/saturating_test.go
@@ -1,0 +1,71 @@
+/*
+Copyright 2026 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+import (
+	"math"
+	"testing"
+)
+
+func TestSaturatingAdd(t *testing.T) {
+	cases := []struct {
+		name string
+		a, b int64
+		want int64
+	}{
+		{"normal sum", 2, 3, 5},
+		{"positive overflow", math.MaxInt64, math.MaxInt64, math.MaxInt64},
+		{"positive overflow by one", math.MaxInt64, 1, math.MaxInt64},
+		{"negative overflow", math.MinInt64, math.MinInt64, math.MinInt64},
+		{"mixed signs", math.MaxInt64, math.MinInt64, -1},
+	}
+	for _, tc := range cases {
+		if got := SaturatingAdd(tc.a, tc.b); got != tc.want {
+			t.Errorf("%s: SaturatingAdd(%d, %d) = %d, want %d", tc.name, tc.a, tc.b, got, tc.want)
+		}
+	}
+}
+
+func TestSaturatingMul(t *testing.T) {
+	cases := []struct {
+		name string
+		a, b int64
+		want int64
+	}{
+		{"normal product", 6, 7, 42},
+		{"zero", 0, math.MaxInt64, 0},
+		{"positive overflow", math.MaxInt64, 2, math.MaxInt64},
+		{"large square", math.MaxInt64, math.MaxInt64, math.MaxInt64},
+		{"negative overflow", math.MinInt64, 2, math.MinInt64},
+		{"min times minus one saturates high", math.MinInt64, -1, math.MaxInt64},
+	}
+	for _, tc := range cases {
+		if got := SaturatingMul(tc.a, tc.b); got != tc.want {
+			t.Errorf("%s: SaturatingMul(%d, %d) = %d, want %d", tc.name, tc.a, tc.b, got, tc.want)
+		}
+	}
+}
+
+// DRAResource.Add aggregates device counts across jobs/claims into the queue's
+// inqueue/allocated totals; the sum must saturate rather than wrap negative.
+func TestDRAResourceAdd_saturates(t *testing.T) {
+	a := &DRAResource{Count: math.MaxInt64}
+	a.Add(&DRAResource{Count: math.MaxInt64})
+	if a.Count != math.MaxInt64 {
+		t.Fatalf("DRAResource.Add Count = %d, want %d (saturated, non-negative)", a.Count, int64(math.MaxInt64))
+	}
+}

--- a/pkg/scheduler/plugins/capacity/capacity.go
+++ b/pkg/scheduler/plugins/capacity/capacity.go
@@ -273,7 +273,7 @@ func checkDRAAllocatable(dra *draQuotaAttr, taskDRA map[string]*api.DRAResource,
 		klog.V(5).Infof("checkDRAAllocatable: deviceClass=%s, allocated=%d, inqueue=%d, request=%d, capability=%d",
 			deviceClass, allocatedCount, inqueueCount, request.Count, capability.Count)
 
-		if capability.Count > 0 && allocatedCount+inqueueCount+request.Count > capability.Count {
+		if capability.Count > 0 && api.SaturatingAdd(api.SaturatingAdd(allocatedCount, inqueueCount), request.Count) > capability.Count {
 			klog.V(3).Infof("checkDRAAllocatable: count exceeded for %s: allocated=%d, inqueue=%d, requested=%d, capability=%d",
 				deviceClass, allocatedCount, inqueueCount, request.Count, capability.Count)
 			return false

--- a/pkg/scheduler/plugins/capacity/capacity_test.go
+++ b/pkg/scheduler/plugins/capacity/capacity_test.go
@@ -18,6 +18,7 @@ package capacity
 
 import (
 	"fmt"
+	"math"
 	"os"
 	"testing"
 	"time"
@@ -2077,5 +2078,33 @@ func TestJobEnqueuedUpdatesDRAInqueueForDRAOnlyJob(t *testing.T) {
 	test.Run([]framework.Action{enqueue.New()})
 	if err := test.CheckAll(0); err != nil {
 		t.Fatal(err)
+	}
+}
+
+// A job whose DRA device count, summed with the queue's existing inqueue total,
+// overflows int64 must still be rejected by the capacity check. Before the fix
+// the raw sum (0 + MaxInt64 + MaxInt64) wrapped to a negative value, which is
+// not greater than the capability, so the job was wrongly admitted.
+func TestCheckDRAAllocatable_overflowRejected(t *testing.T) {
+	const dc = "gpu.example.com"
+
+	poisoned := &draQuotaAttr{
+		capability: map[string]*api.DRAResource{dc: {Count: 8}},
+		allocated:  map[string]*api.DRAResource{},
+		inqueue:    map[string]*api.DRAResource{dc: {Count: math.MaxInt64}},
+	}
+	overflowing := map[string]*api.DRAResource{dc: {Count: math.MaxInt64}}
+	if checkDRAAllocatable(poisoned, overflowing, false, true) {
+		t.Fatalf("checkDRAAllocatable admitted an overflowing request (inqueue=MaxInt64 + request=MaxInt64) against capability 8; want rejected")
+	}
+
+	// Sanity: a request within the remaining capability is still admitted.
+	fresh := &draQuotaAttr{
+		capability: map[string]*api.DRAResource{dc: {Count: 8}},
+		allocated:  map[string]*api.DRAResource{},
+		inqueue:    map[string]*api.DRAResource{},
+	}
+	if !checkDRAAllocatable(fresh, map[string]*api.DRAResource{dc: {Count: 4}}, false, true) {
+		t.Fatalf("checkDRAAllocatable rejected a valid request (4 <= 8); want admitted")
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The capacity plugin's DRA quota accounting sums user-controlled device counts on raw `int64` with no overflow guard, so an oversized count (alone multiplied by the gang size, or accumulated with the queue's existing `inqueue` total) wraps negative and is wrongly admitted by `checkDRAAllocatable`, poisoning per-queue DRA accounting for the scheduling session.

A ResourceClaim device count is an `int64` the apiserver accepts up to `math.MaxInt64` (it only rejects `count <= 0`), and the gang size (`minMember`) is user-controlled as well. This adds saturating arithmetic (`SaturatingAdd` / `SaturatingMul`, clamping at `math.MaxInt64`) at the three accumulation/comparison sites:

- `GetMinDRAResources`: `request.Count * int64(times)` and the running sum.
- `DRAResource.Add`: the count accumulation into `inqueue`/`allocated`.
- `checkDRAAllocatable`: the `allocated + inqueue + request` comparison.

An oversized request now stays a large positive value and is correctly rejected by the quota check. `DRAResource.Sub` already clamps at zero; this brings `Add` and the comparison in line.

#### Which issue(s) this PR fixes:

Fixes #5620

#### Special notes for your reviewer:

AI tools (Claude Code) were used to help prepare this change, disclosed here per the AI Guidance in contributing.md. As the author I reviewed and understand every line: I traced the overflow from a user-submitted ResourceClaim + PodGroup through `GetMinDRAResources` / `DRAResource.Add` into `checkDRAAllocatable`, and added unit tests for the saturating helpers plus regression tests for `DRAResource.Add` and `checkDRAAllocatable`. The two regression tests fail on the pre-fix code (the overflowed sum admits the job) and pass with the fix.

The change is intentionally minimal and does not touch the classic non-DRA resource paths, which use `resource.Quantity` (big.Int) and are unaffected by this `int64` overflow.

#### Does this PR introduce a user-facing change?

```release-note
Fixed an int64 overflow in the capacity plugin's DRA device-count quota accounting that could admit a job exceeding its DeviceClass quota and corrupt per-queue DRA accounting.
```
