### PR TITLE
wip: feat(scheduler): maintain per-queue allocation in cache (#5565)

### DIFF
--- a/pkg/features/volcano_features.go
+++ b/pkg/features/volcano_features.go
@@ -53,6 +53,12 @@ const (
 	// capacity, preventing cluster autoscalers from triggering unnecessary
 	// scale-ups for pods that are simply waiting for queue admission.
 	SchedulingGatesQueueAdmission featuregate.Feature = "SchedulingGatesQueueAdmission"
+
+	// CacheQueueAccounting keeps per queue allocated/request totals in the
+	// scheduler cache, updated in the pod/podgroup event handlers, instead of
+	// having queue plugins rebuild them every OnSessionOpen. While disabled (the
+	// default) it does nothing and plugins keep computing their own totals.
+	CacheQueueAccounting featuregate.Feature = "CacheQueueAccounting"
 )
 
 func init() {
@@ -70,4 +76,6 @@ var defaultVolcanoFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec
 	ResourceTopology:              {Default: true, PreRelease: featuregate.Alpha},
 	CronVolcanoJobSupport:         {Default: true, PreRelease: featuregate.Alpha},
 	SchedulingGatesQueueAdmission: {Default: false, PreRelease: featuregate.Alpha},
+	// CacheQueueAccounting is off by default until it is validated.
+	CacheQueueAccounting: {Default: false, PreRelease: featuregate.Alpha},
 }

--- a/pkg/scheduler/api/queue_info.go
+++ b/pkg/scheduler/api/queue_info.go
@@ -47,6 +47,14 @@ type QueueInfo struct {
 	// path from the root to the node itself.
 	Hierarchy string
 
+	// Allocated is the sum of Resreq over allocated tasks of all jobs in this
+	// queue. It is kept up to date by the cache when CacheQueueAccounting is on.
+	// Only jobs with a non nil PodGroup and a resolved queue are counted, which
+	// matches the jobs Snapshot exposes to plugins.
+	Allocated *Resource
+	// Request is the sum of Resreq over all tasks of all jobs in this queue.
+	Request *Resource
+
 	Queue *scheduling.Queue
 }
 
@@ -60,18 +68,31 @@ func NewQueueInfo(queue *scheduling.Queue) *QueueInfo {
 		Hierarchy: queue.Annotations[v1beta1.KubeHierarchyAnnotationKey],
 		Weights:   queue.Annotations[v1beta1.KubeHierarchyWeightAnnotationKey],
 
+		Allocated: EmptyResource(),
+		Request:   EmptyResource(),
+
 		Queue: queue,
 	}
 }
 
 // Clone is used to clone queueInfo object
 func (q *QueueInfo) Clone() *QueueInfo {
+	allocated := EmptyResource()
+	if q.Allocated != nil {
+		allocated = q.Allocated.Clone()
+	}
+	request := EmptyResource()
+	if q.Request != nil {
+		request = q.Request.Clone()
+	}
 	return &QueueInfo{
 		UID:       q.UID,
 		Name:      q.Name,
 		Weight:    q.Weight,
 		Hierarchy: q.Hierarchy,
 		Weights:   q.Weights,
+		Allocated: allocated,
+		Request:   request,
 		Queue:     q.Queue.DeepCopy(),
 	}
 }

--- a/pkg/scheduler/cache/cache.go
+++ b/pkg/scheduler/cache/cache.go
@@ -142,9 +142,13 @@ type SchedulerCache struct {
 
 	Recorder record.EventRecorder
 
-	Jobs                 map[schedulingapi.JobID]*schedulingapi.JobInfo
-	Nodes                map[string]*schedulingapi.NodeInfo
-	Queues               map[schedulingapi.QueueID]*schedulingapi.QueueInfo
+	Jobs   map[schedulingapi.JobID]*schedulingapi.JobInfo
+	Nodes  map[string]*schedulingapi.NodeInfo
+	Queues map[schedulingapi.QueueID]*schedulingapi.QueueInfo
+	// jobQueueContribution records what each job currently adds to a queue's
+	// totals (see queue_allocation.go), so the totals can be updated no matter
+	// the event order. Only used when CacheQueueAccounting is on.
+	jobQueueContribution map[schedulingapi.JobID]*queueContribution
 	NodeShards           map[string]*schedulingapi.NodeShardInfo
 	PriorityClasses      map[string]*schedulingv1.PriorityClass
 	NodeList             []string

--- a/pkg/scheduler/cache/event_handlers.go
+++ b/pkg/scheduler/cache/event_handlers.go
@@ -245,6 +245,8 @@ func (sc *SchedulerCache) addTask(pi *schedulingapi.TaskInfo) error {
 	job := sc.getOrCreateJob(pi)
 	if job != nil {
 		job.AddTaskInfo(pi)
+		// Keep the job's queue totals in sync (does nothing while the gate is off).
+		sc.updateQueueForJob(job)
 	}
 
 	return nil
@@ -388,6 +390,8 @@ func (sc *SchedulerCache) deleteTask(ti *schedulingapi.TaskInfo) error {
 	if len(ti.Job) != 0 {
 		if job, found := sc.Jobs[ti.Job]; found {
 			job.DeleteTaskInfo(ti)
+			// Keep the job's queue totals in sync (does nothing while the gate is off).
+			sc.updateQueueForJob(job)
 		} else {
 			klog.Warningf("Failed to find Job <%v> for Task <%v/%v> in cache.", ti.Job, ti.Namespace, ti.Name)
 		}
@@ -864,15 +868,22 @@ func (sc *SchedulerCache) setPodGroup(ss *schedulingapi.PodGroup) error {
 		sc.Jobs[job] = schedulingapi.NewJobInfo(job)
 	}
 
-	sc.Jobs[job].SetPodGroup(ss)
+	ji := sc.Jobs[job]
+
+	ji.SetPodGroup(ss)
 
 	// TODO(k82cn): set default queue in admission.
 	if len(ss.Spec.Queue) == 0 {
-		sc.Jobs[job].Queue = schedulingapi.QueueID(sc.defaultQueue)
+		ji.Queue = schedulingapi.QueueID(sc.defaultQueue)
 	}
 
-	metrics.UpdateE2eSchedulingStartTimeByJob(sc.Jobs[job].Name, string(sc.Jobs[job].Queue), sc.Jobs[job].Namespace,
-		sc.Jobs[job].CreationTimestamp.Time)
+	// Reconcile the job's queue totals now that its PodGroup and queue are set.
+	// Handles the first assignment and a later reassignment. Does nothing while the
+	// gate is off.
+	sc.updateQueueForJob(ji)
+
+	metrics.UpdateE2eSchedulingStartTimeByJob(ji.Name, string(ji.Queue), ji.Namespace,
+		ji.CreationTimestamp.Time)
 	return nil
 }
 
@@ -890,6 +901,10 @@ func (sc *SchedulerCache) deletePodGroup(id schedulingapi.JobID) error {
 
 	// Unset SchedulingSpec
 	job.UnsetPodGroup()
+
+	// The job has no PodGroup now, so it drops out of its queue totals. Does nothing
+	// while the gate is off.
+	sc.updateQueueForJob(job)
 
 	sc.deleteJob(job)
 
@@ -1064,6 +1079,12 @@ func (sc *SchedulerCache) DeleteQueueV1beta1(obj interface{}) {
 func (sc *SchedulerCache) addQueue(queue *scheduling.Queue) {
 	qi := schedulingapi.NewQueueInfo(queue)
 	sc.Queues[qi.UID] = qi
+	// Rebuild this queue's totals. addQueue is reused by updateQueue (which
+	// replaces the QueueInfo) and a queue may be created after jobs already
+	// reference it. Does nothing while the gate is off.
+	if sc.queueAllocationEnabled() {
+		sc.reconcileQueueFromJobsLocked(qi.UID)
+	}
 }
 
 func (sc *SchedulerCache) updateQueue(queue *scheduling.Queue) {

--- a/pkg/scheduler/cache/queue_allocation.go
+++ b/pkg/scheduler/cache/queue_allocation.go
@@ -1,0 +1,232 @@
+/*
+Copyright 2026 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cache
+
+import (
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	"k8s.io/klog/v2"
+
+	"volcano.sh/volcano/pkg/features"
+	schedulingapi "volcano.sh/volcano/pkg/scheduler/api"
+)
+
+// Per queue resource accounting maintained in the scheduler cache (issue #5565).
+// Queue plugins rebuild per queue totals from scratch every OnSessionOpen. Here
+// the cache keeps those totals updated in the pod/podgroup event handlers, the
+// same way node totals are kept via node.AddTask/RemoveTask.
+//
+// The whole thing is gated by CacheQueueAccounting and does nothing while disabled.
+//
+// Invariant checked by ReconcileQueueAllocations:
+//
+//	queue.Allocated == sum(job.Allocated)    over jobs with a non nil PodGroup
+//	queue.Request   == sum(job.TotalRequest) and a resolved queue
+//
+// That job set matches what Snapshot exposes to plugins, so the cache value is
+// comparable to what plugins compute today.
+//
+// Each job's current contribution is stored in jobQueueContribution. Every event
+// calls updateQueueForJob, which removes the stored contribution and applies the
+// current one. This stays correct no matter the event order (for example a job
+// that lingers with a stale queue after its podgroup is deleted).
+//
+// The mutation helpers assume sc.Mutex is held (true in the event handlers).
+// ReconcileQueueAllocations takes the lock itself.
+
+// queueContribution is what a single job currently adds to a queue.
+type queueContribution struct {
+	queue     schedulingapi.QueueID
+	allocated *schedulingapi.Resource
+	request   *schedulingapi.Resource
+}
+
+// queueAllocationEnabled reports whether cache side queue accounting is on.
+func (sc *SchedulerCache) queueAllocationEnabled() bool {
+	return utilfeature.DefaultFeatureGate.Enabled(features.CacheQueueAccounting)
+}
+
+// jobAccountedInQueue reports whether a job currently counts towards a queue. A
+// job counts once it has a resolved PodGroup and a non empty queue id.
+func jobAccountedInQueue(job *schedulingapi.JobInfo) bool {
+	return job != nil && job.PodGroup != nil && len(job.Queue) != 0
+}
+
+// updateQueueForJob re-applies a single job's contribution to the queue totals.
+// It subtracts whatever the job contributed before and adds its current value.
+// Safe to call after any event that may change the job's totals or queue.
+func (sc *SchedulerCache) updateQueueForJob(job *schedulingapi.JobInfo) {
+	if !sc.queueAllocationEnabled() || job == nil {
+		return
+	}
+	if sc.jobQueueContribution == nil {
+		sc.jobQueueContribution = make(map[schedulingapi.JobID]*queueContribution)
+	}
+
+	if prev, ok := sc.jobQueueContribution[job.UID]; ok {
+		sc.subQueueAllocation(prev.queue, prev.allocated, prev.request)
+		delete(sc.jobQueueContribution, job.UID)
+	}
+
+	if !jobAccountedInQueue(job) {
+		return
+	}
+	allocated := schedulingapi.EmptyResource()
+	if job.Allocated != nil {
+		allocated = job.Allocated.Clone()
+	}
+	request := schedulingapi.EmptyResource()
+	if job.TotalRequest != nil {
+		request = job.TotalRequest.Clone()
+	}
+	sc.addQueueAllocation(job.Queue, allocated, request)
+	sc.jobQueueContribution[job.UID] = &queueContribution{
+		queue:     job.Queue,
+		allocated: allocated,
+		request:   request,
+	}
+}
+
+// addQueueAllocation adds the given amounts to a queue's totals. An unknown queue
+// is skipped and gets rebuilt when it is added (reconcileQueueFromJobsLocked).
+func (sc *SchedulerCache) addQueueAllocation(qid schedulingapi.QueueID, allocated, request *schedulingapi.Resource) {
+	q := sc.queueForAccounting(qid)
+	if q == nil {
+		return
+	}
+	if allocated != nil {
+		q.Allocated.Add(allocated)
+	}
+	if request != nil {
+		q.Request.Add(request)
+	}
+}
+
+// subQueueAllocation subtracts the given amounts from a queue's totals. It uses
+// SubWithoutAssert so a transient inconsistency logs instead of panicking.
+func (sc *SchedulerCache) subQueueAllocation(qid schedulingapi.QueueID, allocated, request *schedulingapi.Resource) {
+	q := sc.queueForAccounting(qid)
+	if q == nil {
+		return
+	}
+	if allocated != nil {
+		q.Allocated.SubWithoutAssert(allocated)
+	}
+	if request != nil {
+		q.Request.SubWithoutAssert(request)
+	}
+}
+
+// queueForAccounting returns the QueueInfo for qid with its total fields ready,
+// or nil when the id is empty or the queue is not in the cache.
+func (sc *SchedulerCache) queueForAccounting(qid schedulingapi.QueueID) *schedulingapi.QueueInfo {
+	if len(qid) == 0 {
+		return nil
+	}
+	q, ok := sc.Queues[qid]
+	if !ok {
+		return nil
+	}
+	if q.Allocated == nil {
+		q.Allocated = schedulingapi.EmptyResource()
+	}
+	if q.Request == nil {
+		q.Request = schedulingapi.EmptyResource()
+	}
+	return q
+}
+
+// reconcileQueueFromJobsLocked rebuilds one queue's totals from the per job
+// totals and refreshes the stored contributions for that queue. Used when a
+// queue is added, since addQueue replaces the QueueInfo with a fresh object and
+// a queue may be created after jobs already reference it. Assumes sc.Mutex held.
+func (sc *SchedulerCache) reconcileQueueFromJobsLocked(qid schedulingapi.QueueID) {
+	q := sc.queueForAccounting(qid)
+	if q == nil {
+		return
+	}
+	if sc.jobQueueContribution == nil {
+		sc.jobQueueContribution = make(map[schedulingapi.JobID]*queueContribution)
+	}
+	q.Allocated = schedulingapi.EmptyResource()
+	q.Request = schedulingapi.EmptyResource()
+	for _, job := range sc.Jobs {
+		if job.Queue != qid || !jobAccountedInQueue(job) {
+			continue
+		}
+		allocated := schedulingapi.EmptyResource()
+		if job.Allocated != nil {
+			allocated = job.Allocated.Clone()
+		}
+		request := schedulingapi.EmptyResource()
+		if job.TotalRequest != nil {
+			request = job.TotalRequest.Clone()
+		}
+		q.Allocated.Add(allocated)
+		q.Request.Add(request)
+		sc.jobQueueContribution[job.UID] = &queueContribution{
+			queue:     qid,
+			allocated: allocated,
+			request:   request,
+		}
+	}
+}
+
+// ReconcileQueueAllocations rebuilds every queue's totals from the per job totals
+// and rebuilds the contribution map. It is the ground truth used as a drift
+// safety net and by tests to check the incremental value.
+//
+// It takes sc.Mutex, so do not call it while already holding the lock.
+func (sc *SchedulerCache) ReconcileQueueAllocations() {
+	sc.Mutex.Lock()
+	defer sc.Mutex.Unlock()
+	sc.reconcileQueueAllocationsLocked()
+}
+
+// reconcileQueueAllocationsLocked is ReconcileQueueAllocations with the lock held.
+func (sc *SchedulerCache) reconcileQueueAllocationsLocked() {
+	sc.jobQueueContribution = make(map[schedulingapi.JobID]*queueContribution)
+	for _, q := range sc.Queues {
+		q.Allocated = schedulingapi.EmptyResource()
+		q.Request = schedulingapi.EmptyResource()
+	}
+	for _, job := range sc.Jobs {
+		if !jobAccountedInQueue(job) {
+			continue
+		}
+		q, ok := sc.Queues[job.Queue]
+		if !ok {
+			klog.V(5).Infof("Job <%s/%s> references queue <%s> not present in cache, skipping in reconcile",
+				job.Namespace, job.Name, job.Queue)
+			continue
+		}
+		allocated := schedulingapi.EmptyResource()
+		if job.Allocated != nil {
+			allocated = job.Allocated.Clone()
+		}
+		request := schedulingapi.EmptyResource()
+		if job.TotalRequest != nil {
+			request = job.TotalRequest.Clone()
+		}
+		q.Allocated.Add(allocated)
+		q.Request.Add(request)
+		sc.jobQueueContribution[job.UID] = &queueContribution{
+			queue:     job.Queue,
+			allocated: allocated,
+			request:   request,
+		}
+	}
+}

--- a/pkg/scheduler/cache/queue_allocation_test.go
+++ b/pkg/scheduler/cache/queue_allocation_test.go
@@ -1,0 +1,267 @@
+/*
+Copyright 2026 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cache
+
+import (
+	"fmt"
+	"math"
+	"math/rand"
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	apitypes "k8s.io/apimachinery/pkg/types"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	"k8s.io/client-go/util/workqueue"
+
+	"volcano.sh/apis/pkg/apis/scheduling"
+	"volcano.sh/apis/pkg/apis/scheduling/v1beta1"
+	schedulingapi "volcano.sh/volcano/pkg/scheduler/api"
+)
+
+const epsilon = 1e-6
+
+// newAccountingTestCache builds a minimal SchedulerCache for exercising the
+// queue accounting handlers without informers or clients.
+func newAccountingTestCache() *SchedulerCache {
+	return &SchedulerCache{
+		Jobs:   map[schedulingapi.JobID]*schedulingapi.JobInfo{},
+		Queues: map[schedulingapi.QueueID]*schedulingapi.QueueInfo{},
+		Nodes:  map[string]*schedulingapi.NodeInfo{},
+		DeletedJobs: workqueue.NewTypedRateLimitingQueue[string](
+			workqueue.DefaultTypedControllerRateLimiter[string]()),
+		defaultQueue: "default",
+	}
+}
+
+func enableQueueAccounting(t *testing.T) {
+	t.Helper()
+	if err := utilfeature.DefaultMutableFeatureGate.Set("CacheQueueAccounting=true"); err != nil {
+		t.Fatalf("failed to enable CacheQueueAccounting: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := utilfeature.DefaultMutableFeatureGate.Set("CacheQueueAccounting=false"); err != nil {
+			t.Fatalf("failed to disable CacheQueueAccounting: %v", err)
+		}
+	})
+}
+
+func addQueueToCache(sc *SchedulerCache, name string) {
+	sc.addQueue(&scheduling.Queue{ObjectMeta: metav1.ObjectMeta{Name: name}})
+}
+
+func setJobPodGroup(sc *SchedulerCache, ns, pgName, queue string) {
+	pg := &schedulingapi.PodGroup{
+		PodGroup: scheduling.PodGroup{
+			ObjectMeta: metav1.ObjectMeta{Name: pgName, Namespace: ns},
+			Spec:       scheduling.PodGroupSpec{Queue: queue, MinMember: 1},
+		},
+		Version: schedulingapi.PodGroupVersionV1Beta1,
+	}
+	if err := sc.setPodGroup(pg); err != nil {
+		panic(err)
+	}
+}
+
+// newTask builds a TaskInfo tied to podgroup pgName with the given status/resources.
+func newTask(ns, name, pgName string, status schedulingapi.TaskStatus, cpu, mem string) *schedulingapi.TaskInfo {
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			UID:         apitypes.UID(fmt.Sprintf("%s-%s", ns, name)),
+			Name:        name,
+			Namespace:   ns,
+			Annotations: map[string]string{v1beta1.KubeGroupNameAnnotationKey: pgName},
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				{Resources: v1.ResourceRequirements{Requests: schedulingapi.BuildResourceList(cpu, mem)}},
+			},
+		},
+	}
+	ti := schedulingapi.NewTaskInfo(pod)
+	ti.Status = status
+	return ti
+}
+
+// assertIncrementalMatchesReconcile snapshots the incremental queue totals, runs
+// a full reconcile as ground truth, and checks they match.
+func assertIncrementalMatchesReconcile(t *testing.T, sc *SchedulerCache, step string) {
+	t.Helper()
+
+	type agg struct{ alloc, req *schedulingapi.Resource }
+	incremental := map[schedulingapi.QueueID]agg{}
+	for qid, q := range sc.Queues {
+		incremental[qid] = agg{alloc: q.Allocated.Clone(), req: q.Request.Clone()}
+	}
+
+	// Rebuild from scratch as the ground truth.
+	sc.reconcileQueueAllocationsLocked()
+
+	for qid, q := range sc.Queues {
+		inc := incremental[qid]
+		if !resourcesEqual(inc.alloc, q.Allocated) {
+			t.Fatalf("[%s] queue %s allocated mismatch: incremental=%v reconcile=%v", step, qid, inc.alloc, q.Allocated)
+		}
+		if !resourcesEqual(inc.req, q.Request) {
+			t.Fatalf("[%s] queue %s request mismatch: incremental=%v reconcile=%v", step, qid, inc.req, q.Request)
+		}
+	}
+}
+
+func resourcesEqual(a, b *schedulingapi.Resource) bool {
+	if a == nil {
+		a = schedulingapi.EmptyResource()
+	}
+	if b == nil {
+		b = schedulingapi.EmptyResource()
+	}
+	if math.Abs(a.MilliCPU-b.MilliCPU) > epsilon || math.Abs(a.Memory-b.Memory) > epsilon {
+		return false
+	}
+	names := map[v1.ResourceName]struct{}{}
+	for n := range a.ScalarResources {
+		names[n] = struct{}{}
+	}
+	for n := range b.ScalarResources {
+		names[n] = struct{}{}
+	}
+	for n := range names {
+		if math.Abs(a.ScalarResources[n]-b.ScalarResources[n]) > epsilon {
+			return false
+		}
+	}
+	return true
+}
+
+// TestQueueAllocation_Deterministic walks the interesting orderings: podgroup
+// before tasks, tasks before podgroup, queue reassignment, queue added after
+// jobs, task deletion and podgroup deletion.
+func TestQueueAllocation_Deterministic(t *testing.T) {
+	enableQueueAccounting(t)
+	sc := newAccountingTestCache()
+	ns := "default"
+
+	addQueueToCache(sc, "q1")
+	addQueueToCache(sc, "q2")
+
+	// Case 1: PodGroup assigned before tasks are added.
+	setJobPodGroup(sc, ns, "pg1", "q1")
+	sc.addTask(newTask(ns, "pg1-a", "pg1", schedulingapi.Running, "1000m", "1Gi"))
+	sc.addTask(newTask(ns, "pg1-b", "pg1", schedulingapi.Pending, "2000m", "2Gi"))
+	assertIncrementalMatchesReconcile(t, sc, "pg1 running+pending")
+
+	// Case 2: tasks added before the PodGroup resolves the queue.
+	sc.addTask(newTask(ns, "pg2-a", "pg2", schedulingapi.Running, "500m", "512Mi"))
+	sc.addTask(newTask(ns, "pg2-b", "pg2", schedulingapi.Bound, "500m", "512Mi"))
+	// Not counted anywhere yet since there is no PodGroup, so reconcile is empty too.
+	assertIncrementalMatchesReconcile(t, sc, "pg2 tasks before podgroup")
+	setJobPodGroup(sc, ns, "pg2", "q1")
+	assertIncrementalMatchesReconcile(t, sc, "pg2 podgroup resolves queue")
+
+	// Case 3: queue reassignment moves the whole job aggregate.
+	setJobPodGroup(sc, ns, "pg2", "q2")
+	assertIncrementalMatchesReconcile(t, sc, "pg2 moved q1->q2")
+
+	// Case 4: task deletion.
+	del := newTask(ns, "pg1-a", "pg1", schedulingapi.Running, "1000m", "1Gi")
+	sc.deleteTask(del)
+	assertIncrementalMatchesReconcile(t, sc, "pg1-a deleted")
+
+	// Case 5: queue created after jobs already reference it.
+	setJobPodGroup(sc, ns, "pg3", "q3") // q3 not in cache yet
+	sc.addTask(newTask(ns, "pg3-a", "pg3", schedulingapi.Running, "4000m", "4Gi"))
+	addQueueToCache(sc, "q3") // addQueue rebuilds from existing jobs
+	assertIncrementalMatchesReconcile(t, sc, "q3 added after jobs")
+
+	// Case 6: podgroup deletion removes the job's contribution.
+	if err := sc.deletePodGroup(schedulingapi.JobID(ns + "/pg2")); err != nil {
+		t.Fatalf("deletePodGroup failed: %v", err)
+	}
+	assertIncrementalMatchesReconcile(t, sc, "pg2 podgroup deleted")
+}
+
+// TestQueueAllocation_Churn applies a random sequence of cache mutations and
+// checks after every step that the incremental per queue totals equal a full
+// recompute. This is the main correctness proof for the delta logic.
+func TestQueueAllocation_Churn(t *testing.T) {
+	enableQueueAccounting(t)
+	sc := newAccountingTestCache()
+	ns := "default"
+
+	queues := []string{"q1", "q2", "q3"}
+	for _, q := range queues {
+		addQueueToCache(sc, q)
+	}
+
+	statuses := []schedulingapi.TaskStatus{
+		schedulingapi.Running, schedulingapi.Bound, schedulingapi.Allocated,
+		schedulingapi.Pending, schedulingapi.Pipelined,
+	}
+
+	rng := rand.New(rand.NewSource(42))
+	// live tracks the tasks currently added so we can delete real ones.
+	type liveTask struct {
+		pg   string
+		task *schedulingapi.TaskInfo
+	}
+	var live []liveTask
+	pgQueue := map[string]string{} // pg to assigned queue
+
+	const steps = 2000
+	uid := 0
+	for i := 0; i < steps; i++ {
+		switch rng.Intn(5) {
+		case 0, 1: // add a task
+			uid++
+			pg := fmt.Sprintf("pg%d", rng.Intn(6))
+			st := statuses[rng.Intn(len(statuses))]
+			cpu := fmt.Sprintf("%dm", 100*(1+rng.Intn(20)))
+			mem := fmt.Sprintf("%dMi", 128*(1+rng.Intn(8)))
+			ti := newTask(ns, fmt.Sprintf("t%d", uid), pg, st, cpu, mem)
+			sc.addTask(ti)
+			live = append(live, liveTask{pg: pg, task: ti})
+		case 2: // delete a random task
+			if len(live) > 0 {
+				idx := rng.Intn(len(live))
+				sc.deleteTask(live[idx].task)
+				live = append(live[:idx], live[idx+1:]...)
+			}
+		case 3: // reassign a podgroup to a random queue
+			pg := fmt.Sprintf("pg%d", rng.Intn(6))
+			q := queues[rng.Intn(len(queues))]
+			setJobPodGroup(sc, ns, pg, q)
+			pgQueue[pg] = q
+		case 4: // delete a podgroup that exists
+			pg := fmt.Sprintf("pg%d", rng.Intn(6))
+			jobID := schedulingapi.JobID(ns + "/" + pg)
+			if _, ok := sc.Jobs[jobID]; ok {
+				_ = sc.deletePodGroup(jobID)
+				delete(pgQueue, pg)
+				// Drop live tasks of this pg since its job is gone.
+				filtered := live[:0]
+				for _, lt := range live {
+					if lt.pg != pg {
+						filtered = append(filtered, lt)
+					}
+				}
+				live = filtered
+			}
+		}
+
+		assertIncrementalMatchesReconcile(t, sc, fmt.Sprintf("churn step %d", i))
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

First step toward reducing repeated `OnSessionOpen` initialization cost (#5565). Queue-based plugins (`capacity`/`proportion`/`drf`) currently rebuild per-queue allocated/request totals from scratch every scheduling cycle. This PR maintains those totals incrementally in the scheduler cache instead.

#### Which issue(s) this PR fixes:

Part of #5565 (does not fully close it)

#### Does this PR introduce a user-facing change?

```release-note
Added a new alpha feature gate `CacheQueueAccounting` (default off) that maintains per-queue allocated/request resource totals incrementally in the scheduler cache. No behavior change while disabled.
```