### PR TITLE
fix: close int64-overflow bypass in DRA device count accounting

### DIFF
--- a/pkg/scheduler/cache/cache.go
+++ b/pkg/scheduler/cache/cache.go
@@ -1888,7 +1888,7 @@ func addDRAResource(dst map[string]*schedulingapi.DRAResource, deviceClass strin
 			dst[deviceClass].Capacity = make(map[string]resource.Quantity)
 		}
 	}
-	dst[deviceClass].Count += count
+	dst[deviceClass].Count = schedulingapi.SaturatingAdd(dst[deviceClass].Count, count)
 	for dim, reqQty := range capacity {
 		totalQty := reqQty.DeepCopy()
 		for i := int64(1); i < count; i++ {

--- a/pkg/scheduler/cache/cache_test.go
+++ b/pkg/scheduler/cache/cache_test.go
@@ -23,6 +23,7 @@ package cache
 import (
 	"context"
 	"fmt"
+	"math"
 	"reflect"
 	"sync"
 	"testing"
@@ -853,4 +854,24 @@ func TestAddUnassignedNumaPods_NilNodeValueSkips(t *testing.T) {
 		t.Fatalf("AddUnassignedNumaPods returned error: %v", err)
 	}
 	// No panic is the success condition.
+}
+
+// addDRAResource accumulates a user-controlled device count. A pod with two
+// same-deviceClass requests each near math.MaxInt64 (both individually valid:
+// the apiserver only rejects count <= 0) must not wrap the aggregate Count to a
+// negative value, which would later bypass the queue's DRA quota check.
+func TestAddDRAResource_saturates(t *testing.T) {
+	const dc = "gpu.example.com"
+	const maxInt64 = math.MaxInt64
+
+	m := make(map[string]*api.DRAResource)
+	addDRAResource(m, dc, maxInt64, nil)
+	addDRAResource(m, dc, maxInt64, nil)
+
+	if got := m[dc].Count; got < 0 {
+		t.Fatalf("addDRAResource wrapped to a negative aggregate Count (%d) for two MaxInt64 requests; want saturated non-negative", got)
+	}
+	if got := m[dc].Count; got != maxInt64 {
+		t.Fatalf("addDRAResource Count = %d for two MaxInt64 requests; want saturated to MaxInt64 (%d)", got, maxInt64)
+	}
 }

--- a/pkg/scheduler/plugins/capacity/capacity.go
+++ b/pkg/scheduler/plugins/capacity/capacity.go
@@ -273,6 +273,20 @@ func checkDRAAllocatable(dra *draQuotaAttr, taskDRA map[string]*api.DRAResource,
 		klog.V(5).Infof("checkDRAAllocatable: deviceClass=%s, allocated=%d, inqueue=%d, request=%d, capability=%d",
 			deviceClass, allocatedCount, inqueueCount, request.Count, capability.Count)
 
+		// A device count is always non-negative; a negative value here can only be
+		// the result of an upstream int64 overflow wrapping around. Reject it
+		// rather than let a poisoned negative pass the comparison below (a negative
+		// sum is not greater than the capability, so it would be wrongly admitted).
+		if request.Count < 0 || allocatedCount < 0 || inqueueCount < 0 {
+			klog.V(3).Infof("checkDRAAllocatable: negative device count for %s (allocated=%d, inqueue=%d, requested=%d); rejecting as int64 overflow",
+				deviceClass, allocatedCount, inqueueCount, request.Count)
+			return false
+		}
+
+		// For any positive capability below MaxInt64 the quota decision is exact: a
+		// sum that overflows saturates to MaxInt64, which still exceeds that
+		// capability and is rejected. A capability of MaxInt64 is effectively
+		// non-binding, since no realizable allocation reaches that many devices.
 		if capability.Count > 0 && api.SaturatingAdd(api.SaturatingAdd(allocatedCount, inqueueCount), request.Count) > capability.Count {
 			klog.V(3).Infof("checkDRAAllocatable: count exceeded for %s: allocated=%d, inqueue=%d, requested=%d, capability=%d",
 				deviceClass, allocatedCount, inqueueCount, request.Count, capability.Count)

--- a/pkg/scheduler/plugins/capacity/capacity_test.go
+++ b/pkg/scheduler/plugins/capacity/capacity_test.go
@@ -2108,3 +2108,42 @@ func TestCheckDRAAllocatable_overflowRejected(t *testing.T) {
 		t.Fatalf("checkDRAAllocatable rejected a valid request (4 <= 8); want admitted")
 	}
 }
+
+// A negative device count can only result from an upstream int64 overflow
+// wrapping around (e.g. a pod whose two same-deviceClass requests, each near
+// math.MaxInt64, are summed in the cache's addDRAResource). Such a poisoned
+// negative must never be admitted: saturating the accumulation is not enough
+// because SaturatingAdd faithfully preserves an already-negative input.
+func TestCheckDRAAllocatable_negativeCountRejected(t *testing.T) {
+	const dc = "gpu.example.com"
+
+	// Negative in the request itself.
+	negRequest := &draQuotaAttr{
+		capability: map[string]*api.DRAResource{dc: {Count: 8}},
+		allocated:  map[string]*api.DRAResource{},
+		inqueue:    map[string]*api.DRAResource{},
+	}
+	if checkDRAAllocatable(negRequest, map[string]*api.DRAResource{dc: {Count: -2}}, false, true) {
+		t.Fatalf("checkDRAAllocatable admitted a negative request.Count (-2) against capability 8; want rejected")
+	}
+
+	// Negative already poisoning the queue's inqueue total.
+	poisonedInqueue := &draQuotaAttr{
+		capability: map[string]*api.DRAResource{dc: {Count: 8}},
+		allocated:  map[string]*api.DRAResource{},
+		inqueue:    map[string]*api.DRAResource{dc: {Count: math.MinInt64}},
+	}
+	if checkDRAAllocatable(poisonedInqueue, map[string]*api.DRAResource{dc: {Count: 4}}, false, true) {
+		t.Fatalf("checkDRAAllocatable admitted a request against a poisoned negative inqueue (MinInt64); want rejected")
+	}
+
+	// Negative already poisoning the queue's allocated total.
+	poisonedAllocated := &draQuotaAttr{
+		capability: map[string]*api.DRAResource{dc: {Count: 8}},
+		allocated:  map[string]*api.DRAResource{dc: {Count: math.MinInt64}},
+		inqueue:    map[string]*api.DRAResource{},
+	}
+	if checkDRAAllocatable(poisonedAllocated, map[string]*api.DRAResource{dc: {Count: 4}}, false, true) {
+		t.Fatalf("checkDRAAllocatable admitted a request against a poisoned negative allocated (MinInt64); want rejected")
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
Follow-up to #5621. That PR added saturating arithmetic at three sites, but the DRA quota guard can still be bypassed from upstream.

`pkg/scheduler/cache/cache.go` `addDRAResource` accumulates the per-request device count with a plain `+=`. A pod whose ResourceClaims request the same DeviceClass with counts summing past `math.MaxInt64` (each `count` is individually valid; the apiserver only rejects `count <= 0`) wraps the aggregate to a negative value. That negative flows into `checkDRAAllocatable` as `request.Count`, and `SaturatingAdd(0, negative)` faithfully preserves the negative, so `sum > capability` is false and the request is wrongly admitted.

This PR adds two guards:
- `addDRAResource` accumulates with `SaturatingAdd`, so the aggregate can no longer wrap negative (it saturates to `MaxInt64`, which the quota check rejects for any queue capability below `MaxInt64`, i.e. every real quota).
- `checkDRAAllocatable` rejects a negative `allocated`/`inqueue` running total on a quota-governed DeviceClass. `getDRADelta` adjusts those totals with an unclamped subtract, so releasing an allocation an ancestor never balanced can drive one negative, and `SaturatingAdd` preserves it past the quota check.

Both regression tests (`TestAddDRAResource_saturates`, `TestCheckDRAAllocatable_negativeDeltaRejected`) fail on the pre-fix code and pass with the change.

This PR intentionally does **not** change the unbounded `for i := 1; i < count` loop in the same `addDRAResource` (an unrelated DoS concern); I'm reporting that separately so this stays focused.

#### Which issue(s) this PR fixes:
Follow-up to #5621.

#### Special notes for your reviewer:
I found this while addressing review feedback on #5621. AI assistance was used for the analysis and for drafting this change; I have reviewed and understand it and can explain and defend every part, and I will respond to review comments myself.

#### Does this PR introduce a user-facing change?
```release-note
Fixed an int64 overflow in DRA device-count accounting that could bypass the capacity plugin's DRA quota check when a pod requested the same DeviceClass with counts summing past MaxInt64.
```

