### PR TITLE
example/extender: limit HTTP request body size

### DIFF
--- a/example/extender/extender.go
+++ b/example/extender/extender.go
@@ -36,11 +36,7 @@ func onSessionOpen(w http.ResponseWriter, r *http.Request) {
 
 	content, err := io.ReadAll(r.Body)
 	if err != nil {
-		if _, ok := err.(*http.MaxBytesError); ok {
-			http.Error(w, "request body too large", http.StatusRequestEntityTooLarge)
-		} else {
-			http.Error(w, "failed to read request body", http.StatusBadRequest)
-		}
+		http.Error(w, "failed to read request body", http.StatusInternalServerError)
 		return
 	}
 
@@ -71,11 +67,7 @@ func predicate(w http.ResponseWriter, r *http.Request) {
 
 	content, err := io.ReadAll(r.Body)
 	if err != nil {
-		if _, ok := err.(*http.MaxBytesError); ok {
-			http.Error(w, "request body too large", http.StatusRequestEntityTooLarge)
-		} else {
-			http.Error(w, "failed to read request body", http.StatusBadRequest)
-		}
+		http.Error(w, "failed to read request body", http.StatusInternalServerError)
 		return
 	}
 
@@ -108,11 +100,7 @@ func prioritize(w http.ResponseWriter, r *http.Request) {
 
 	content, err := io.ReadAll(r.Body)
 	if err != nil {
-		if _, ok := err.(*http.MaxBytesError); ok {
-			http.Error(w, "request body too large", http.StatusRequestEntityTooLarge)
-		} else {
-			http.Error(w, "failed to read request body", http.StatusBadRequest)
-		}
+		http.Error(w, "failed to read request body", http.StatusInternalServerError)
 		return
 	}
 

--- a/example/extender/extender.go
+++ b/example/extender/extender.go
@@ -26,16 +26,23 @@ import (
 	"volcano.sh/volcano/pkg/scheduler/plugins/extender"
 )
 
+const maxRequestBody = 1 << 20 // 1 MiB
+
 var snapshot *api.ClusterInfo
 
 func onSessionOpen(w http.ResponseWriter, r *http.Request) {
+	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBody)
+	defer r.Body.Close()
+
 	content, err := io.ReadAll(r.Body)
 	if err != nil {
-		w.WriteHeader(http.StatusInternalServerError)
+		if _, ok := err.(*http.MaxBytesError); ok {
+			http.Error(w, "request body too large", http.StatusRequestEntityTooLarge)
+		} else {
+			http.Error(w, "failed to read request body", http.StatusBadRequest)
+		}
 		return
 	}
-
-	r.Body.Close()
 
 	req := &extender.OnSessionOpenRequest{}
 	if err := json.Unmarshal(content, req); err != nil {
@@ -50,6 +57,7 @@ func onSessionOpen(w http.ResponseWriter, r *http.Request) {
 		NamespaceInfo:  req.NamespaceInfo,
 		RevocableNodes: req.RevocableNodes,
 	}
+
 	klog.V(4).Infof("the snapshot of cluster %+v", *snapshot)
 }
 
@@ -58,13 +66,18 @@ func onSessionClose(w http.ResponseWriter, r *http.Request) {
 }
 
 func predicate(w http.ResponseWriter, r *http.Request) {
+	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBody)
+	defer r.Body.Close()
+
 	content, err := io.ReadAll(r.Body)
 	if err != nil {
-		w.WriteHeader(http.StatusInternalServerError)
+		if _, ok := err.(*http.MaxBytesError); ok {
+			http.Error(w, "request body too large", http.StatusRequestEntityTooLarge)
+		} else {
+			http.Error(w, "failed to read request body", http.StatusBadRequest)
+		}
 		return
 	}
-
-	r.Body.Close()
 
 	req := &extender.PredicateRequest{}
 	if err := json.Unmarshal(content, req); err != nil || req.Task == nil || req.Node == nil {
@@ -77,6 +90,7 @@ func predicate(w http.ResponseWriter, r *http.Request) {
 		resp.ErrorMessage = "Too many tasks on the node"
 		resp.Code = api.Unschedulable
 	}
+
 	response, err := json.Marshal(resp)
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
@@ -89,13 +103,18 @@ func predicate(w http.ResponseWriter, r *http.Request) {
 }
 
 func prioritize(w http.ResponseWriter, r *http.Request) {
+	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBody)
+	defer r.Body.Close()
+
 	content, err := io.ReadAll(r.Body)
 	if err != nil {
-		w.WriteHeader(http.StatusInternalServerError)
+		if _, ok := err.(*http.MaxBytesError); ok {
+			http.Error(w, "request body too large", http.StatusRequestEntityTooLarge)
+		} else {
+			http.Error(w, "failed to read request body", http.StatusBadRequest)
+		}
 		return
 	}
-
-	r.Body.Close()
 
 	req := &extender.PrioritizeRequest{}
 	if err := json.Unmarshal(content, req); err != nil || req.Task == nil || len(req.Nodes) == 0 {
@@ -103,7 +122,10 @@ func prioritize(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	resp := &extender.PrioritizeResponse{NodeScore: map[string]float64{}}
+	resp := &extender.PrioritizeResponse{
+		NodeScore: map[string]float64{},
+	}
+
 	for i := range req.Nodes {
 		if req.Task.BestEffort && len(req.Nodes[i].Tasks) > 5 {
 			resp.NodeScore[req.Nodes[i].Name] = 0


### PR DESCRIPTION
## What does this PR do?

Adds a maximum request body size limit for the extender example HTTP server using `http.MaxBytesReader`.


## Why is this change needed?

Although this is an example server, limiting request body size is a good security practice that helps prevent excessive memory usage from oversized requests.

## Does this introduce breaking changes?

No.