### PR TITLE
fix: remove duplicated words in vcctl and network-qos messages

### DIFF
--- a/pkg/cli/vsub/run.go
+++ b/pkg/cli/vsub/run.go
@@ -82,7 +82,7 @@ func InitRunFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVarP(&launchJobFlags.SchedulerName, "scheduler", "S", "",
 		fmt.Sprintf("the scheduler for this job, overwrite the value of '%s' (default \"%s\")",
 			SchedulerNameEnv, defaultSchedulerName))
-	cmd.Flags().StringVarP(&launchJobFlags.Command, "command", "c", "", "the command of of job")
+	cmd.Flags().StringVarP(&launchJobFlags.Command, "command", "c", "", "the command of job")
 
 	setDefaultArgs()
 }

--- a/pkg/networkqos/tc/tc_linux.go
+++ b/pkg/networkqos/tc/tc_linux.go
@@ -52,7 +52,7 @@ func (t *TCCmd) PreAddFilter(netns, ifName string) (bool, error) {
 
 		qdiscs, err := netlink.QdiscList(link)
 		if err != nil {
-			return fmt.Errorf("failed to list clsact qdiscs on on ns:ifName(%s:%s): %v", netns, ifName, err)
+			return fmt.Errorf("failed to list clsact qdiscs on ns:ifName(%s:%s): %v", netns, ifName, err)
 		}
 
 		for _, qdisc := range qdiscs {
@@ -109,7 +109,7 @@ func (t *TCCmd) AddFilter(netns, ifName string) error {
 			QdiscType: QdiscTypeClsact,
 		}
 		if err = netlink.QdiscAdd(clsact); err != nil {
-			return fmt.Errorf("failed to create clsact qdisc on on ns:ifName(%s:%s): %v", netns, ifName, err)
+			return fmt.Errorf("failed to create clsact qdisc on ns:ifName(%s:%s): %v", netns, ifName, err)
 		}
 		klog.InfoS("Successfully added qdisc", "type", QdiscTypeClsact, "netns", netns, "ifName", ifName)
 


### PR DESCRIPTION
/kind bug

While reading through the CLI and network-qos code I noticed a few user-facing strings with a duplicated word:

- the `vcctl vsub --command` help read "the command of of job"
- two network-qos qdisc errors read "on on ns:ifName(...)"

This drops the repeated word in each so they read correctly. Strings only, no behaviour change.

```release-note
NONE
```
