### PR TITLE
docs: update kubernetes version

### DIFF
--- a/docs/development/prepare-for-development.md
+++ b/docs/development/prepare-for-development.md
@@ -31,7 +31,7 @@ To leverage that you will need:
 
 ## Setting up Kubernetes
 
-We require Kubernetes version 1.24 or higher with CRD support.
+For supported Kubernetes versions and CRD support guidance, see the compatibility table in the [README](../../README.md).
 
 If you aren't sure which Kubernetes platform is right for you, see [Picking the Right Solution](https://kubernetes.io/docs/setup/).
 

--- a/docs/development/prepare-for-development.md
+++ b/docs/development/prepare-for-development.md
@@ -31,7 +31,7 @@ To leverage that you will need:
 
 ## Setting up Kubernetes
 
-We require Kubernetes version 1.12 or higher with CRD support.
+We require Kubernetes version 1.24 or higher with CRD support.
 
 If you aren't sure which Kubernetes platform is right for you, see [Picking the Right Solution](https://kubernetes.io/docs/setup/).
 


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What this PR does / why we need it:**
This PR updates the developer setup documentation to match the repository’s current Kubernetes support range. Specifically, it changes the outdated prerequisite in `prepare-for-development.md` from Kubernetes 1.12 or higher to Kubernetes 1.24 or higher so new contributors see an accurate setup requirement.

**Which issue(s) this PR fixes:**
Fixes #5608

**Special notes for your reviewer:**
N/A

**Does this PR introduce a user-facing change?**
```release-note
NONE