### PR TITLE
fix(cli): dedup vcctl pod list by namespace and name

### DIFF
--- a/pkg/cli/pod/pod.go
+++ b/pkg/cli/pod/pod.go
@@ -280,7 +280,9 @@ func appendIfNotExists(existing, toAppend []corev1.Pod) []corev1.Pod {
 	for _, pod := range toAppend {
 		exists := false
 		for _, existingPod := range existing {
-			if existingPod.Name == pod.Name {
+			// A pod is identified by namespace and name; two pods with the same
+			// name in different namespaces are distinct, so only skip a real duplicate.
+			if existingPod.Namespace == pod.Namespace && existingPod.Name == pod.Name {
 				exists = true
 				break
 			}

--- a/pkg/cli/pod/pod_test.go
+++ b/pkg/cli/pod/pod_test.go
@@ -224,3 +224,27 @@ func buildPod(namespace, name string, labels map[string]string, annotations map[
 		},
 	}
 }
+
+func TestAppendIfNotExists(t *testing.T) {
+	// A pod is identified by namespace and name. Two pods that share a name but
+	// live in different namespaces are distinct, so both must survive the merge;
+	// only a genuine duplicate (same namespace and name) should be dropped.
+	existing := []corev1.Pod{
+		buildPod("team-a", "worker-0", nil, nil),
+	}
+	toAppend := []corev1.Pod{
+		buildPod("team-a", "worker-0", nil, nil), // genuine duplicate, should be skipped
+		buildPod("team-b", "worker-0", nil, nil), // same name, other namespace, should be kept
+	}
+
+	got := appendIfNotExists(existing, toAppend)
+
+	var keys []string
+	for _, p := range got {
+		keys = append(keys, p.Namespace+"/"+p.Name)
+	}
+	want := []string{"team-a/worker-0", "team-b/worker-0"}
+	if !reflect.DeepEqual(keys, want) {
+		t.Errorf("expected pods %v, got %v", want, keys)
+	}
+}


### PR DESCRIPTION
/kind bug

`vcctl pod --queue` merges the label-matched and annotation-matched pods and skips duplicates, but it compared pods by name only. With `--all-namespaces` the list spans namespaces, so two distinct pods that share a name in different namespaces collapse into one and go missing from the output.

Compare namespace and name so only a real duplicate is dropped. Added a small unit test for `appendIfNotExists`.

```release-note
NONE
```
