### PR TITLE
fix: refresh affinity lists on snapshot update

### DIFF
--- a/pkg/scheduler/plugins/util/k8s/snapshot.go
+++ b/pkg/scheduler/plugins/util/k8s/snapshot.go
@@ -249,14 +249,17 @@ func (s *Snapshot) RemoveDeletedNodesFromSnapshot(currentNodeNames map[string]bo
 // updateAffinityList updates an affinity list based on node changes
 func (s *Snapshot) updateAffinityList(nodeName string) {
 	hasAffinity := len(s.fwkInfo.nodeInfoMap[nodeName].GetPodsWithAffinity()) > 0
-	_, exists := s.affinityNodeIndex[nodeName]
+	idx, exists := s.affinityNodeIndex[nodeName]
 
 	switch {
 	case hasAffinity && !exists:
-		idx := len(s.fwkInfo.havePodsWithAffinityNodeInfoList)
+		idx = len(s.fwkInfo.havePodsWithAffinityNodeInfoList)
 		s.fwkInfo.havePodsWithAffinityNodeInfoList =
 			append(s.fwkInfo.havePodsWithAffinityNodeInfoList, s.fwkInfo.nodeInfoMap[nodeName])
 		s.affinityNodeIndex[nodeName] = idx
+
+	case hasAffinity && exists:
+		s.fwkInfo.havePodsWithAffinityNodeInfoList[idx] = s.fwkInfo.nodeInfoMap[nodeName]
 
 	case !hasAffinity && exists:
 		s.removeNodeFromAffinityList(nodeName)
@@ -266,14 +269,17 @@ func (s *Snapshot) updateAffinityList(nodeName string) {
 // updateAffinityList updates an affinity list based on node changes
 func (s *Snapshot) updateRequiredAntiAffinity(nodeName string) {
 	hasRequiredAntiAffinity := len(s.fwkInfo.nodeInfoMap[nodeName].GetPodsWithRequiredAntiAffinity()) > 0
-	_, exists := s.antiAffinityNodeIndex[nodeName]
+	idx, exists := s.antiAffinityNodeIndex[nodeName]
 
 	switch {
 	case hasRequiredAntiAffinity && !exists:
-		idx := len(s.fwkInfo.havePodsWithRequiredAntiAffinityNodeInfoList)
+		idx = len(s.fwkInfo.havePodsWithRequiredAntiAffinityNodeInfoList)
 		s.fwkInfo.havePodsWithRequiredAntiAffinityNodeInfoList =
 			append(s.fwkInfo.havePodsWithRequiredAntiAffinityNodeInfoList, s.fwkInfo.nodeInfoMap[nodeName])
 		s.antiAffinityNodeIndex[nodeName] = idx
+
+	case hasRequiredAntiAffinity && exists:
+		s.fwkInfo.havePodsWithRequiredAntiAffinityNodeInfoList[idx] = s.fwkInfo.nodeInfoMap[nodeName]
 
 	case !hasRequiredAntiAffinity && exists:
 		s.removeNodeFromAntiAffinityList(nodeName)

--- a/pkg/scheduler/plugins/util/k8s/snapshot_test.go
+++ b/pkg/scheduler/plugins/util/k8s/snapshot_test.go
@@ -352,6 +352,64 @@ func TestSnapshot_AddOrUpdateNodes(t *testing.T) {
 	}
 }
 
+func TestSnapshot_UpdateAffinityLists(t *testing.T) {
+	affinity := &v1.Affinity{
+		PodAffinity: &v1.PodAffinity{
+			RequiredDuringSchedulingIgnoredDuringExecution: []v1.PodAffinityTerm{
+				{
+					LabelSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{"app": "test"},
+					},
+					TopologyKey: "kubernetes.io/hostname",
+				},
+			},
+		},
+		PodAntiAffinity: &v1.PodAntiAffinity{
+			RequiredDuringSchedulingIgnoredDuringExecution: []v1.PodAffinityTerm{
+				{
+					LabelSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{"app": "test"},
+					},
+					TopologyKey: "kubernetes.io/hostname",
+				},
+			},
+		},
+	}
+	newNodeInfo := func(podName string) *api.NodeInfo {
+		node := api.NewNodeInfo(util.BuildNode("node-1", api.BuildResourceList("4", "8Gi"), nil))
+		pod := util.BuildPodWithAffinity("default", podName, "node-1", v1.PodPending,
+			api.BuildResourceList("100m", "100Mi"), "pg1", nil, nil, affinity)
+		node.AddTask(api.NewTaskInfo(pod))
+		return node
+	}
+
+	snapshot := NewEmptySnapshot()
+	snapshot.addOrUpdateNode(newNodeInfo("pod-old"))
+	snapshot.addOrUpdateNode(newNodeInfo("pod-new"))
+
+	affinityList, err := snapshot.HavePodsWithAffinityList()
+	if err != nil {
+		t.Fatalf("unexpected affinity list error: %v", err)
+	}
+	if len(affinityList) != 1 {
+		t.Fatalf("expected 1 affinity node info, got %d", len(affinityList))
+	}
+	if got := affinityList[0].GetPods()[0].GetPod().Name; got != "pod-new" {
+		t.Fatalf("expected updated affinity pod pod-new, got %s", got)
+	}
+
+	antiAffinityList, err := snapshot.HavePodsWithRequiredAntiAffinityList()
+	if err != nil {
+		t.Fatalf("unexpected anti-affinity list error: %v", err)
+	}
+	if len(antiAffinityList) != 1 {
+		t.Fatalf("expected 1 anti-affinity node info, got %d", len(antiAffinityList))
+	}
+	if got := antiAffinityList[0].GetPods()[0].GetPod().Name; got != "pod-new" {
+		t.Fatalf("expected updated anti-affinity pod pod-new, got %s", got)
+	}
+}
+
 func TestSnapshot_DeleteNode(t *testing.T) {
 	tests := []struct {
 		name        string


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The incremental scheduler snapshot updates the main node info map/list, but the affinity helper lists were only handling add/remove cases.

If a node was updated and still had affinity or required anti-affinity pods, those helper lists could keep the old `NodeInfo`.

This PR refreshes the existing list entry on update and adds a small regression test.

#### Which issue(s) this PR fixes:

Fixes #5637

#### Special notes for your reviewer:

`go test ./pkg/scheduler/plugins/util/k8s` does not compile on my Windows env because `pkg/util/socket.go` uses `unix.Umask`.

#### Does this PR introduce a user-facing change?

```release-note
NONE