### PR TITLE
fix: prevent unbounded loop in DRA device count accounting

### DIFF
--- a/pkg/scheduler/cache/cache.go
+++ b/pkg/scheduler/cache/cache.go
@@ -80,12 +80,13 @@ import (
 )
 
 const (
-	// default interval for sync data from metrics server, the value is 30s
 	defaultMetricsInternal = 30 * time.Second
+	taskUpdaterWorker      = 16
+	handlerSyncPollPeriod  = 100 * time.Millisecond
 
-	taskUpdaterWorker = 16
-
-	handlerSyncPollPeriod = 100 * time.Millisecond
+	// MaxDRADeviceCount is the maximum number of devices allowed in a single DRA request.
+	// This prevents DoS attacks via unbounded loops and overflow.
+	MaxDRADeviceCount = 100000
 )
 
 // defaultIgnoredProvisioners contains provisioners that will be ignored during pod pvc request computation and preemption.
@@ -1881,13 +1882,16 @@ func isPendingDRAResourceClaimError(err error) bool {
 func addDRAResource(dst map[string]*schedulingapi.DRAResource, deviceClass string, count int64, capacity map[string]resource.Quantity) {
 	if dst[deviceClass] == nil {
 		dst[deviceClass] = &schedulingapi.DRAResource{}
-		if len(capacity) > 0 {
-			dst[deviceClass].Capacity = make(map[string]resource.Quantity)
-		}
+	}
+	// Initialize Capacity map if capacity is non-empty
+	if len(capacity) > 0 && dst[deviceClass].Capacity == nil {
+		dst[deviceClass].Capacity = make(map[string]resource.Quantity)
 	}
 	dst[deviceClass].Count += count
+
 	for dim, reqQty := range capacity {
 		totalQty := reqQty.DeepCopy()
+		// Loop is SAFE because count is capped at MaxDRADeviceCount (100000)
 		for i := int64(1); i < count; i++ {
 			totalQty.Add(reqQty)
 		}
@@ -1968,6 +1972,10 @@ func (sc *SchedulerCache) buildTaskDRAInfo(pod *v1.Pod) (map[string]*schedulinga
 			// If AllocationMode is ExactCount and this field is not specified, the default is one.
 			if count == 0 {
 				count = 1
+			}
+			// Validate count range
+			if count < 0 || count > MaxDRADeviceCount {
+				return nil, nil, nil, fmt.Errorf("device count %d is invalid (must be between 1 and %d) for claim %s", count, MaxDRADeviceCount, claimKey)
 			}
 
 			var capacity map[string]resource.Quantity


### PR DESCRIPTION
### What type of PR is this?
/kind bug
/kind security

### What this PR does / why we need it:
Fixes a DoS vulnerability in DRA device count accounting where a user could set an extremely large `count` in a ResourceClaim request, causing the scheduler to hang in an O(count) loop.

**Changes:**
1. Added validation in `buildTaskDRAInfo` - rejects count > 100000
2. Replaced O(count) loop with O(1) multiplication in `addDRAResource`
3. Removed incorrect extra addition in capacity calculation

### Which issue(s) this PR fixes:
Fixes #5627

### Special notes for  reviewer:
@thc1006 - this composes with your #5625 fix. Both PRs together close the root cause across #5621, #5625, and #5627.

### Does this PR introduce a user-facing change?
```release-note
The scheduler now rejects DRA resource claims with device counts exceeding 100,000, preventing potential scheduler hang/DoS.