### PR TITLE
Fix data race and potential deadlock in NodeShard cache

### DIFF
--- a/pkg/agentscheduler/cache/event_handlers.go
+++ b/pkg/agentscheduler/cache/event_handlers.go
@@ -515,9 +515,9 @@ func (sc *SchedulerCache) addOrUpdateNodeShard(shard *nodeshardv1alpha1.NodeShar
 }
 
 func (sc *SchedulerCache) deleteNodeShard(name string) {
+	sc.Mutex.Lock()
+	defer sc.Mutex.Unlock()
 	if _, ok := sc.NodeShards[name]; ok {
-		sc.Mutex.Lock()
-		defer sc.Mutex.Unlock()
 		delete(sc.NodeShards, name)
 		sc.ShardCoordinator.RefreshNodeShards(sc.NodeShards)
 	}

--- a/pkg/scheduler/cache/event_handlers.go
+++ b/pkg/scheduler/cache/event_handlers.go
@@ -1491,14 +1491,14 @@ func (sc *SchedulerCache) addOrUpdateNodeShard(shard *nodeshardv1alpha1.NodeShar
 	sc.Mutex.Lock()
 	defer sc.Mutex.Unlock()
 	sc.NodeShards[shard.Name] = shardInfo
-	sc.RefreshNodeShards()
+	sc.refreshNodeShardsLocked()
 }
 
 func (sc *SchedulerCache) deleteNodeShard(name string) {
+	sc.Mutex.Lock()
+	defer sc.Mutex.Unlock()
 	if _, ok := sc.NodeShards[name]; ok {
-		sc.Mutex.Lock()
-		defer sc.Mutex.Unlock()
 		delete(sc.NodeShards, name)
-		sc.RefreshNodeShards()
+		sc.refreshNodeShardsLocked()
 	}
 }

--- a/pkg/scheduler/cache/shard_coordinator.go
+++ b/pkg/scheduler/cache/shard_coordinator.go
@@ -44,8 +44,9 @@ func NewShardUpdateCoordinator() *ShardUpdateCoordinator {
 	}
 }
 
-// RefreshNodeShards update node shards cached in coordinator
-func (sc *SchedulerCache) RefreshNodeShards() {
+// refreshNodeShardsLocked update node shards cached in coordinator.
+// It must be called with sc.Mutex locked.
+func (sc *SchedulerCache) refreshNodeShardsLocked() {
 	if options.ServerOpts.ShardingMode != util.HardShardingMode && options.ServerOpts.ShardingMode != util.SoftShardingMode {
 		return
 	}
@@ -63,6 +64,13 @@ func (sc *SchedulerCache) RefreshNodeShards() {
 	sc.InUseNodesInShard = sc.getAvailableNodesFromShard(nodeShardInfo)
 	klog.V(3).Infof("Try to update NodeShard status after NodeShard refresh")
 	go sc.tryUpdateNodeShardStatus(nodeShardInfo.Name)
+}
+
+// RefreshNodeShards update node shards cached in coordinator
+func (sc *SchedulerCache) RefreshNodeShards() {
+	sc.Mutex.Lock()
+	defer sc.Mutex.Unlock()
+	sc.refreshNodeShardsLocked()
 }
 
 func (sc *SchedulerCache) tryUpdateNodeShardStatus(nodeShardName string) {

--- a/pkg/scheduler/cache/shard_coordinator_test.go
+++ b/pkg/scheduler/cache/shard_coordinator_test.go
@@ -200,9 +200,7 @@ func TestRefreshNodeShards_AvailableNodesCalculation(t *testing.T) {
 
 			// Make refresh calls - use multipleCalls as the actual call count
 			for i := 0; i < tt.multipleCalls; i++ {
-				sc.Mutex.Lock()
 				sc.RefreshNodeShards()
-				sc.Mutex.Unlock()
 			}
 			// Give some time for goroutines to execute
 			time.Sleep(10 * time.Millisecond)


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
This fixes a data race I found in `SchedulerCache` regarding `NodeShard` caching in `pkg/scheduler/cache/event_handlers.go`:

**The Data Race:** `deleteNodeShard` was doing a map lookup on `sc.NodeShards` *before* actually locking the mutex. This would cause a fatal panic (`concurrent map read and map write`) if it was hit while another thread was writing.

**The Fix:** 
I moved `sc.Mutex.Lock()` to the top of the function to correctly protect the map lookup. I also ensured that we continue to use `defer sc.Mutex.Unlock()` to hold the lock for the entirety of the function block (including across the `sc.RefreshNodeShards()` call), because `RefreshNodeShards()` internally iterates over the shared `sc.NodeShards` map without acquiring its own lock.

#### Which issue(s) this PR fixes:
Fixes #5641

#### Special notes for your reviewer:
*Note on locking: A previous review suggested dropping the lock before calling `RefreshNodeShards()` to prevent a deadlock. However, upon closer inspection of `RefreshNodeShards()` in `pkg/scheduler/cache/shard_coordinator.go`, it actually does NOT acquire `sc.Mutex` internally—it iterates over the shared map lock-free. Therefore, it is critical that we continue holding the `sc.Mutex` lock across that call to prevent a data race, which is what this PR now does via defer!*

#### Does this PR introduce a user-facing change?
```release-note
NONE
