### PR TITLE
docs: add unschedulable job cache design proposal

### DIFF
--- a/docs/design/images/kube-scheduler-queueing-hint-workflow.svg
+++ b/docs/design/images/kube-scheduler-queueing-hint-workflow.svg
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 940 620" width="940" height="620">
+  <style>
+    text { font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; fill: #111827; }
+    .title { font-size: 20px; font-weight: 700; }
+    .queue { font-size: 16px; font-weight: 700; fill: #1e3a8a; }
+    .queue-sub { font-size: 12px; fill: #475569; }
+    .queue-item { font-size: 12px; fill: #334155; }
+    .box { font-size: 14px; font-weight: 600; fill: #111827; }
+    .diamond-title { font-size: 14px; font-weight: 700; fill: #1e3a8a; }
+    .diamond-sub { font-size: 11px; fill: #475569; }
+    .label { font-size: 12px; font-weight: 600; fill: #334155; }
+    .label-sub { font-size: 11px; fill: #475569; }
+    .label-green { font-size: 12px; font-weight: 700; fill: #047857; }
+    .label-green-sub { font-size: 11px; fill: #047857; }
+    .legend { font-size: 12px; fill: #475569; }
+  </style>
+  <defs>
+    <marker id="k-arrow" markerWidth="10" markerHeight="8" refX="9" refY="4" orient="auto">
+      <polygon points="0 0,10 4,0 8" fill="#334155"/>
+    </marker>
+    <marker id="k-wake" markerWidth="10" markerHeight="8" refX="9" refY="4" orient="auto">
+      <polygon points="0 0,10 4,0 8" fill="#047857"/>
+    </marker>
+  </defs>
+
+  <rect width="940" height="620" fill="#ffffff"/>
+  <text x="470" y="28" text-anchor="middle" class="title">kube-scheduler: pod queues and event-driven wake-up</text>
+
+  <!-- Top boxes: Scheduler over activeQ, Cluster event over backoffQ -->
+  <rect x="80" y="46" width="140" height="50" rx="8" fill="#f8fafc" stroke="#334155" stroke-width="1.5"/>
+  <text x="150" y="77" text-anchor="middle" class="box">Scheduler</text>
+
+  <rect x="670" y="46" width="180" height="50" rx="8" fill="#f8fafc" stroke="#334155" stroke-width="1.5"/>
+  <text x="760" y="77" text-anchor="middle" class="box">Cluster event</text>
+
+  <!-- activeQ -->
+  <circle cx="150" cy="280" r="70" fill="#dbeafe" stroke="#1e40af" stroke-width="2"/>
+  <text x="150" y="276" text-anchor="middle" class="queue">activeQ</text>
+  <text x="150" y="298" text-anchor="middle" class="queue-sub">ready to schedule</text>
+
+  <!-- backoffQ -->
+  <circle cx="760" cy="280" r="70" fill="#dbeafe" stroke="#1e40af" stroke-width="2"/>
+  <text x="760" y="276" text-anchor="middle" class="queue">backoffQ</text>
+  <text x="760" y="298" text-anchor="middle" class="queue-sub">still in backoff</text>
+
+  <!-- Diamond: QueueingHintFn decision -->
+  <polygon points="455,205 570,280 455,355 340,280" fill="#ffffff" stroke="#334155" stroke-width="2"/>
+  <text x="455" y="277" text-anchor="middle" class="diamond-title">QueueingHintFn?</text>
+  <text x="455" y="294" text-anchor="middle" class="diamond-sub">run on each entry</text>
+
+  <!-- unschedulablePods -->
+  <circle cx="455" cy="460" r="70" fill="#dbeafe" stroke="#1e40af" stroke-width="2"/>
+  <text x="455" y="456" text-anchor="middle" class="queue">unschedulablePods</text>
+  <text x="455" y="478" text-anchor="middle" class="queue-sub">waiting for a hint</text>
+
+  <!-- Arrow 1: activeQ -> Scheduler (pop) -->
+  <path d="M 150 210 L 150 96" stroke="#334155" stroke-width="1.8" fill="none" marker-end="url(#k-arrow)"/>
+  <rect x="163" y="142" width="34" height="18" rx="4" fill="#ffffff"/>
+  <text x="180" y="155" text-anchor="middle" class="label">pop</text>
+
+  <!-- Arrow 2: Scheduler -> unschedulablePods (curved on far left, bypassing activeQ) -->
+  <path d="M 100 96 C 25 250, 25 460, 385 460" stroke="#334155" stroke-width="1.8" fill="none" marker-end="url(#k-arrow)"/>
+  <rect x="8" y="278" width="88" height="34" rx="4" fill="#ffffff"/>
+  <text x="52" y="292" text-anchor="middle" class="label">reject</text>
+  <text x="52" y="306" text-anchor="middle" class="label-sub">record entry</text>
+
+  <!-- Arrow 3: Cluster event -> Diamond top vertex -->
+  <path d="M 700 96 L 460 202" stroke="#334155" stroke-width="1.8" fill="none" marker-end="url(#k-arrow)"/>
+  <rect x="562" y="138" width="54" height="18" rx="4" fill="#ffffff"/>
+  <text x="589" y="151" text-anchor="middle" class="label">trigger</text>
+
+  <!-- Arrow 4: Diamond left vertex -> activeQ right edge (Queue, backoff expired) -->
+  <path d="M 340 280 L 223 280" stroke="#047857" stroke-width="2" fill="none" marker-end="url(#k-wake)"/>
+  <rect x="238" y="286" width="88" height="30" rx="4" fill="#ffffff"/>
+  <text x="282" y="298" text-anchor="middle" class="label-green">Queue</text>
+  <text x="282" y="311" text-anchor="middle" class="label-green-sub">backoff expired</text>
+
+  <!-- Arrow 5: Diamond right vertex -> backoffQ left edge (Queue, backoff pending) -->
+  <path d="M 570 280 L 687 280" stroke="#047857" stroke-width="2" fill="none" marker-end="url(#k-wake)"/>
+  <rect x="583" y="286" width="88" height="30" rx="4" fill="#ffffff"/>
+  <text x="627" y="298" text-anchor="middle" class="label-green">Queue</text>
+  <text x="627" y="311" text-anchor="middle" class="label-green-sub">backoff pending</text>
+
+  <!-- Arrow 6: Diamond bottom -> unschedulablePods (QueueSkip, side-labeled) -->
+  <path d="M 455 355 L 455 388" stroke="#334155" stroke-width="1.8" fill="none" marker-end="url(#k-arrow)"/>
+  <rect x="467" y="352" width="90" height="30" rx="4" fill="#ffffff"/>
+  <text x="512" y="364" text-anchor="middle" class="label">QueueSkip</text>
+  <text x="512" y="377" text-anchor="middle" class="label-sub">stay in queue</text>
+
+  <!-- Legend -->
+  <line x1="290" y1="602" x2="335" y2="602" stroke="#334155" stroke-width="1.8"/>
+  <text x="342" y="606" class="legend">normal flow</text>
+
+  <line x1="500" y1="602" x2="545" y2="602" stroke="#047857" stroke-width="2"/>
+  <text x="552" y="606" class="legend">hint returns Queue (wake)</text>
+</svg>

--- a/docs/design/images/unschedulable-job-cache.svg
+++ b/docs/design/images/unschedulable-job-cache.svg
@@ -1,0 +1,173 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1040 800" width="1040" height="800">
+  <style>
+    text { font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; fill: #111827; }
+    .title { font-size: 22px; font-weight: 700; }
+    .strip { font-size: 15px; font-weight: 700; fill: #4c1d95; }
+    .box-title { font-size: 17px; font-weight: 700; fill: #4c1d95; }
+    .pill { font-size: 12px; font-weight: 600; fill: #1f2937; }
+    .pill-green { font-size: 12px; font-weight: 600; fill: #065f46; }
+    .diamond-text { font-size: 12px; font-weight: 700; fill: #1e3a8a; }
+    .branch { font-size: 11px; font-weight: 700; fill: #475569; }
+    .cache-title { font-size: 19px; font-weight: 700; fill: #065f46; }
+    .cache-body { font-size: 13px; fill: #065f46; }
+    .cache-item { font-size: 13px; fill: #065f46; }
+    .aux-title { font-size: 16px; font-weight: 700; fill: #334155; }
+    .aux-body { font-size: 13px; fill: #1f2937; }
+    .label { font-size: 13px; font-weight: 600; fill: #334155; }
+    .legend { font-size: 13px; fill: #475569; }
+  </style>
+  <defs>
+    <marker id="v-arrow" markerWidth="10" markerHeight="8" refX="9" refY="4" orient="auto">
+      <polygon points="0 0,10 4,0 8" fill="#334155"/>
+    </marker>
+    <marker id="v-arrow-sm" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto">
+      <polygon points="0 0,8 3,0 6" fill="#334155"/>
+    </marker>
+  </defs>
+
+  <rect width="1040" height="800" fill="#ffffff"/>
+  <text x="520" y="40" text-anchor="middle" class="title">Volcano: session loop with UnschedulableJobCache</text>
+
+  <!-- Session strip -->
+  <rect x="30" y="70" width="980" height="270" rx="12" fill="#f5f3ff" stroke="#7c3aed" stroke-width="2"/>
+  <text x="50" y="96" class="strip">Scheduler session (runs every schedule period)</text>
+
+  <!-- ========== Sub-box 1: OpenSession ========== -->
+  <rect x="50" y="110" width="300" height="220" rx="8" fill="#ffffff" stroke="#a78bfa" stroke-width="1.5"/>
+  <text x="200" y="138" text-anchor="middle" class="box-title">OpenSession</text>
+
+  <rect x="160" y="160" width="80" height="24" rx="6" fill="#eef2ff" stroke="#4338ca" stroke-width="1.2"/>
+  <text x="200" y="177" text-anchor="middle" class="pill">pending Job</text>
+
+  <path d="M 200 184 L 200 197" stroke="#334155" stroke-width="1.5" fill="none" marker-end="url(#v-arrow-sm)"/>
+
+  <polygon points="200,200 245,225 200,250 155,225" fill="#ffffff" stroke="#334155" stroke-width="1.5"/>
+  <text x="200" y="229" text-anchor="middle" class="diamond-text">in cache?</text>
+
+  <path d="M 165 232 L 132 273" stroke="#334155" stroke-width="1.5" fill="none" marker-end="url(#v-arrow-sm)"/>
+  <text x="128" y="252" class="branch">hit</text>
+
+  <path d="M 235 232 L 268 273" stroke="#334155" stroke-width="1.5" fill="none" marker-end="url(#v-arrow-sm)"/>
+  <text x="252" y="252" class="branch">miss</text>
+
+  <rect x="75" y="278" width="115" height="24" rx="6" fill="#ecfdf5" stroke="#059669" stroke-width="1.2"/>
+  <text x="132" y="295" text-anchor="middle" class="pill-green">set SkipPredicate</text>
+
+  <rect x="210" y="278" width="115" height="24" rx="6" fill="#f8fafc" stroke="#334155" stroke-width="1.2"/>
+  <text x="267" y="295" text-anchor="middle" class="pill">evaluate normally</text>
+
+  <!-- ========== Sub-box 2: Scheduler actions ========== -->
+  <rect x="370" y="110" width="300" height="220" rx="8" fill="#ffffff" stroke="#a78bfa" stroke-width="1.5"/>
+  <text x="520" y="138" text-anchor="middle" class="box-title">Scheduler actions</text>
+
+  <!-- Row 1: enqueue / allocate / backfill -> skip if tagged -->
+  <rect x="386" y="158" width="76" height="20" rx="5" fill="#eef2ff" stroke="#4338ca" stroke-width="1"/>
+  <text x="424" y="173" text-anchor="middle" class="pill">enqueue</text>
+  <rect x="386" y="181" width="76" height="20" rx="5" fill="#eef2ff" stroke="#4338ca" stroke-width="1"/>
+  <text x="424" y="196" text-anchor="middle" class="pill">allocate</text>
+  <rect x="386" y="204" width="76" height="20" rx="5" fill="#eef2ff" stroke="#4338ca" stroke-width="1"/>
+  <text x="424" y="219" text-anchor="middle" class="pill">backfill</text>
+
+  <path d="M 462 168 L 482 191" stroke="#334155" stroke-width="1.2" fill="none"/>
+  <path d="M 462 191 L 482 191" stroke="#334155" stroke-width="1.2" fill="none"/>
+  <path d="M 462 214 L 482 191" stroke="#334155" stroke-width="1.2" fill="none"/>
+  <path d="M 482 191 L 552 191" stroke="#334155" stroke-width="1.5" fill="none" marker-end="url(#v-arrow-sm)"/>
+
+  <rect x="555" y="179" width="105" height="24" rx="6" fill="#ecfdf5" stroke="#059669" stroke-width="1.2"/>
+  <text x="607" y="196" text-anchor="middle" class="pill-green">skip if tagged</text>
+
+  <!-- Row 2: preempt / reclaim -> evaluate every Job -->
+  <rect x="386" y="245" width="76" height="20" rx="5" fill="#eef2ff" stroke="#4338ca" stroke-width="1"/>
+  <text x="424" y="260" text-anchor="middle" class="pill">preempt</text>
+  <rect x="386" y="268" width="76" height="20" rx="5" fill="#eef2ff" stroke="#4338ca" stroke-width="1"/>
+  <text x="424" y="283" text-anchor="middle" class="pill">reclaim</text>
+
+  <path d="M 462 255 L 482 266" stroke="#334155" stroke-width="1.2" fill="none"/>
+  <path d="M 462 278 L 482 266" stroke="#334155" stroke-width="1.2" fill="none"/>
+  <path d="M 482 266 L 552 266" stroke="#334155" stroke-width="1.5" fill="none" marker-end="url(#v-arrow-sm)"/>
+
+  <rect x="555" y="254" width="105" height="24" rx="6" fill="#f8fafc" stroke="#334155" stroke-width="1.2"/>
+  <text x="607" y="271" text-anchor="middle" class="pill">evaluate every Job</text>
+
+  <!-- ========== Sub-box 3: CloseSession ========== -->
+  <rect x="690" y="110" width="300" height="220" rx="8" fill="#ffffff" stroke="#a78bfa" stroke-width="1.5"/>
+  <text x="840" y="138" text-anchor="middle" class="box-title">CloseSession</text>
+
+  <rect x="795" y="160" width="90" height="24" rx="6" fill="#eef2ff" stroke="#4338ca" stroke-width="1.2"/>
+  <text x="840" y="177" text-anchor="middle" class="pill">evaluated Job</text>
+
+  <path d="M 840 184 L 840 197" stroke="#334155" stroke-width="1.5" fill="none" marker-end="url(#v-arrow-sm)"/>
+
+  <polygon points="840,200 900,225 840,250 780,225" fill="#ffffff" stroke="#334155" stroke-width="1.5"/>
+  <text x="840" y="229" text-anchor="middle" class="diamond-text">still pending?</text>
+
+  <path d="M 797 232 L 772 273" stroke="#334155" stroke-width="1.5" fill="none" marker-end="url(#v-arrow-sm)"/>
+  <text x="770" y="252" class="branch">no</text>
+
+  <path d="M 883 232 L 908 273" stroke="#334155" stroke-width="1.5" fill="none" marker-end="url(#v-arrow-sm)"/>
+  <text x="895" y="252" class="branch">yes</text>
+
+  <rect x="715" y="278" width="115" height="24" rx="6" fill="#f8fafc" stroke="#334155" stroke-width="1.2"/>
+  <text x="772" y="295" text-anchor="middle" class="pill">Forget(job)</text>
+
+  <rect x="850" y="278" width="115" height="24" rx="6" fill="#ecfdf5" stroke="#059669" stroke-width="1.2"/>
+  <text x="907" y="295" text-anchor="middle" class="pill-green">Record(job)</text>
+
+  <!-- ========== Informer aux box ========== -->
+  <rect x="30" y="470" width="240" height="160" rx="10" fill="#f8fafc" stroke="#334155" stroke-width="1.5"/>
+  <text x="150" y="500" text-anchor="middle" class="aux-title">Informer events</text>
+  <rect x="45" y="525" width="90" height="22" rx="5" fill="#ffffff" stroke="#334155" stroke-width="1"/>
+  <text x="90" y="540" text-anchor="middle" class="pill">handler</text>
+  <path d="M 135 536 L 160 536" stroke="#334155" stroke-width="1.5" fill="none" marker-end="url(#v-arrow-sm)"/>
+  <rect x="160" y="525" width="95" height="22" rx="5" fill="#ffffff" stroke="#334155" stroke-width="1"/>
+  <text x="207" y="540" text-anchor="middle" class="pill">ClusterEvent</text>
+  <path d="M 150 555 L 150 578" stroke="#334155" stroke-width="1.5" fill="none" marker-end="url(#v-arrow-sm)"/>
+  <text x="150" y="600" text-anchor="middle" class="aux-body">cache.OnEvent(evt)</text>
+
+  <!-- ========== Watchdog aux box ========== -->
+  <rect x="770" y="470" width="240" height="160" rx="10" fill="#f8fafc" stroke="#334155" stroke-width="1.5"/>
+  <text x="890" y="500" text-anchor="middle" class="aux-title">Watchdog goroutine</text>
+  <circle cx="815" cy="545" r="16" fill="#ffffff" stroke="#334155" stroke-width="1.5"/>
+  <line x1="815" y1="545" x2="815" y2="533" stroke="#334155" stroke-width="1.4"/>
+  <line x1="815" y1="545" x2="825" y2="550" stroke="#334155" stroke-width="1.4"/>
+  <path d="M 838 545 L 862 545" stroke="#334155" stroke-width="1.5" fill="none" marker-end="url(#v-arrow-sm)"/>
+  <text x="937" y="541" text-anchor="middle" class="aux-body">drop records with</text>
+  <text x="937" y="559" text-anchor="middle" class="aux-body">expired RetryAfter</text>
+  <text x="890" y="600" text-anchor="middle" class="aux-body">(safety net for missed hints)</text>
+
+  <!-- ========== Cache circle ========== -->
+  <circle cx="520" cy="560" r="140" fill="#ecfdf5" stroke="#059669" stroke-width="2"/>
+  <text x="520" y="525" text-anchor="middle" class="cache-title">UnschedulableJobCache</text>
+  <text x="520" y="555" text-anchor="middle" class="cache-body">one record per Job:</text>
+  <text x="520" y="580" text-anchor="middle" class="cache-item">• plugin rejections</text>
+  <text x="520" y="601" text-anchor="middle" class="cache-item">• subscribed cluster events</text>
+  <text x="520" y="622" text-anchor="middle" class="cache-item">• RetryAfter timestamp</text>
+
+  <!-- Arrow: OpenSession -> Cache (read, dashed) -->
+  <path d="M 200 330 L 406.3 478.2" stroke="#334155" stroke-width="1.8" stroke-dasharray="6,5" fill="none" marker-end="url(#v-arrow)"/>
+  <rect x="267" y="393" width="72" height="22" rx="4" fill="#ffffff"/>
+  <text x="303" y="409" text-anchor="middle" class="label">check</text>
+
+  <!-- Arrow: CloseSession -> Cache (write, solid) -->
+  <path d="M 840 330 L 633.7 478.2" stroke="#334155" stroke-width="1.8" fill="none" marker-end="url(#v-arrow)"/>
+  <rect x="678" y="393" width="118" height="22" rx="4" fill="#ffffff"/>
+  <text x="737" y="409" text-anchor="middle" class="label">record / forget</text>
+
+  <!-- Arrow: Informer -> Cache -->
+  <path d="M 270 560 L 380 560" stroke="#334155" stroke-width="1.8" fill="none" marker-end="url(#v-arrow)"/>
+  <rect x="292" y="534" width="66" height="20" rx="4" fill="#ffffff"/>
+  <text x="325" y="549" text-anchor="middle" class="label">OnEvent</text>
+
+  <!-- Arrow: Watchdog -> Cache -->
+  <path d="M 770 560 L 660 560" stroke="#334155" stroke-width="1.8" fill="none" marker-end="url(#v-arrow)"/>
+  <rect x="682" y="534" width="52" height="20" rx="4" fill="#ffffff"/>
+  <text x="708" y="549" text-anchor="middle" class="label">flush</text>
+
+  <!-- Legend -->
+  <line x1="280" y1="750" x2="332" y2="750" stroke="#334155" stroke-width="1.8"/>
+  <text x="342" y="754" class="legend">writes / mutates cache</text>
+
+  <line x1="560" y1="750" x2="612" y2="750" stroke="#334155" stroke-width="1.8" stroke-dasharray="6,5"/>
+  <text x="622" y="754" class="legend">reads cache</text>
+</svg>

--- a/docs/design/unschedulable-job-cache.md
+++ b/docs/design/unschedulable-job-cache.md
@@ -1,0 +1,993 @@
+# Unschedulable Job Cache for Volcano Scheduler
+
+<!-- toc -->
+- [Summary](#summary)
+- [Motivation](#motivation)
+  - [Goals](#goals)
+  - [Non-Goals](#non-goals)
+- [Proposal](#proposal)
+  - [User Stories](#user-stories)
+  - [Architecture](#architecture)
+- [Design Details](#design-details)
+  - [1. Plugin Extension Point](#1-plugin-extension-point)
+  - [2. Failure Recording](#2-failure-recording)
+  - [3. UnschedulableJobCache](#3-unschedulablejobcache)
+  - [4. Event Dispatch](#4-event-dispatch)
+  - [5. Scheduler Action Changes](#5-scheduler-action-changes)
+  - [6. kube-scheduler QueueingHint Adapter](#6-kube-scheduler-queueinghint-adapter)
+  - [7. Initial Plugin Coverage](#7-initial-plugin-coverage)
+- [Risks and Mitigations](#risks-and-mitigations)
+- [Alternatives Considered](#alternatives-considered)
+- [Test Plan](#test-plan)
+- [Related Issues](#related-issues)
+<!-- /toc -->
+
+## Summary
+
+Volcano opens a new scheduling session every second. In each session, it re-runs the
+full filter path for every pending Job, even when nothing has changed for that Job
+since the previous session. In clusters with thousands of pending Pods, this repeated
+work takes up most of the `allocate` action's time and delays newly submitted Jobs.
+
+This proposal adds an event-driven retry mechanism. Each plugin declares which
+cluster events could change its previous unschedulable decision. When a Job stays
+unschedulable at the end of a session, Volcano records the plugins that rejected it
+and skips their checks in later sessions. When one of the declared events arrives,
+the record is dropped and the Job is evaluated normally in the next session.
+
+## Motivation
+
+Volcano's scheduler runs a periodic loop. It opens a new session roughly every second.
+Each session takes a snapshot of the cluster, iterates every pending Job, and runs the
+enabled actions end-to-end. The failure reasons produced in a session are kept only
+for that session and are discarded when the session closes.
+
+As a result, a Job that failed because no node carries the required label is
+re-evaluated against every node in the next session, and in every session after that,
+until either the Job or the cluster changes. When thousands of Jobs are stuck on
+conditions that have not changed, `allocate` spends most of its time producing the
+same negative answers it produced a second ago. This increases the `allocate`
+action's scheduling latency, and newly submitted Jobs that could be scheduled are
+delayed as well.
+
+The session loop itself is not the problem. Two things are missing around it. First,
+each session needs a way to know that nothing relevant has changed for a Job, so the
+retry can be skipped. Second, Volcano needs a way to notice when something relevant
+does change, so the Job can be retried immediately.
+
+### Goals
+
+- Stop re-running the full filter path each session for Jobs whose blocking condition
+  has not changed.
+- Retry a blocked Job promptly when a cluster change happens that could make it
+  schedulable, without waiting for a timeout.
+- Give plugins a first-class way to declare which cluster events are relevant to their
+  unschedulable decisions, so different rejection causes wake on different signals.
+- Preserve fairness and ordering. Only the redundant filter work is skipped; a
+  cached Job still counts as pending demand so DRF shares, queue capacity, and gang
+  `minAvailable` are computed against the same workload as before.
+
+### Non-Goals
+
+- Persisting unschedulable state across scheduler restarts. Records live in memory and
+  are rebuilt from the first post-restart session.
+- Providing hint coverage for every plugin in the first release. Plugins without a
+  hint fall back to per-session evaluation.
+
+## Proposal
+
+The design adds two pieces around Volcano's session loop. Plugins declare a set of
+cluster events that may invalidate their previous rejection. The scheduler cache
+keeps a per-Job record of which plugins blocked the Job in the last session, and
+later sessions skip those plugins' checks until one of the subscribed events arrives.
+When such an event arrives, the record is dropped and the Job is evaluated normally
+in the next session.
+
+### User Stories
+
+- **Queue is temporarily full.** A queue reaches its resource limit and every Job in
+  it fails the `capacity` check. Volcano stops retrying these Jobs each session. They
+  wake up when another Job in the queue finishes or an operator raises the limit.
+
+- **Job requires a node that does not exist yet.** A Job needs a GPU node label that
+  no current node carries. Today Volcano gets the same negative answer from every
+  node in every session. With the unschedulable-job cache, the Job is set aside after
+  the first check and woken up when a new node is added or an existing node's labels
+  change.
+
+- **Gang Job is waiting for enough capacity.** A gang Job needs `minAvailable` tasks
+  to fit at once, but the cluster cannot place enough of them. Volcano stops retrying
+  the Job until capacity may have grown: a task from another Job completes, a Pod is
+  deleted, or a new node joins. A `PodGroup` spec update wakes it as well.
+
+### Architecture
+
+kube-scheduler already avoids retrying unchanged unschedulable Pods with an
+event-driven queueing-hint mechanism, which is a useful reference for this design.
+Its scheduling queue keeps three buckets and moves Pods between them:
+
+![kube-scheduler queueing-hint reference](images/kube-scheduler-queueing-hint-workflow.svg)
+
+`activeQ` holds Pods ready to schedule, and the scheduler pops from it. When a Pod
+fails its filters, it is moved to `unschedulablePods` together with the names of the
+plugins that rejected it. Cluster events trigger the failed plugins' `QueueingHintFn`.
+If a hint returns `Queue`, the Pod moves to `backoffQ` if it is still inside its
+backoff window, or directly to `activeQ` if the backoff has already expired. If every
+subscribed hint returns `QueueSkip`, the Pod stays in `unschedulablePods`. A periodic
+watchdog also releases Pods that have been stuck there for too long.
+
+Volcano applies the same idea to its session-based, Job-level scheduling. There are
+no per-Pod queue buckets. Instead, a single `UnschedulableJobCache` lives beside the
+scheduling loop, and is updated from three sources: the session itself, informer
+handlers, and a background watchdog.
+
+![UnschedulableJobCache architecture](images/unschedulable-job-cache.svg)
+
+The scheduler session drives most of the interaction. `OpenSession` asks the cache
+which Jobs to skip and copies the cached rejections onto their `JobInfo`. `CloseSession` writes new
+records for Jobs that stayed unschedulable, and forgets records for Jobs that were
+allocated or pipelined.
+
+Informer handlers translate cluster changes into `ClusterEvent`s and call `OnEvent`.
+The cache then runs each subscribed Job's hints and forgets records whose hint
+returns `HintWakeup`. A background watchdog forgets records whose `RetryAfter` has
+passed, which prevents a Job from staying cached forever if a hint is ever missed.
+
+## Design Details
+
+### 1. Plugin Extension Point
+
+`HintProvider` is an optional interface that a plugin implements to declare the
+cluster events that could invalidate its previous unschedulable decisions. Each
+declaration is a `ClusterEventWithHint`, which is a `(ClusterEvent, JobHintFn)` pair.
+`ClusterEvent` names the change to watch, and `JobHintFn` decides, for a given Job,
+whether a particular occurrence of that event may make the Job schedulable. If
+`JobHintFn` is `nil`, every occurrence of the event wakes Jobs blocked by this
+plugin.
+
+#### Types
+
+```go
+// ClusterEvent identifies one category of cluster change a plugin subscribes to.
+type ClusterEvent struct {
+    // Resource is the object type whose change may affect scheduling: Node, Pod,
+    // PVC/PV, StorageClass, CSINode, PodGroup, Queue, HyperNode, NumaInfo.
+    Resource   EventResource
+
+    // ActionType names the kind of change. Besides generic Add/Update/Delete,
+    // node updates are split into label, taint, allocatable and condition
+    // variants so a taint-only change does not wake Jobs blocked on labels.
+    ActionType ActionType
+}
+
+// HintResult is the decision a JobHintFn returns for one Job on one event.
+type HintResult int
+
+const (
+    HintSkip   HintResult = iota // event cannot unblock this Job; keep it cached.
+    HintWakeup                   // event may unblock this Job; drop the record.
+)
+
+// JobHintFn is invoked when a subscribed cluster event fires for a Job that the
+// plugin previously rejected. It answers one question: could this particular
+// event make the Job schedulable this time?
+//
+//   @param logger    logger scoped to this hint invocation.
+//   @param job       the cached Job under evaluation.
+//   @param rejection the plugin's own rejection from the previous session; for
+//                    predicate sources it also carries the task IDs that failed
+//                    (see §2), which lets per-task hints replay only those tasks.
+//   @param oldObj    object state before the change; nil on Add events.
+//   @param newObj    object state after the change; nil on Delete events.
+//   @return HintResult  HintSkip to keep the record, HintWakeup to drop it and
+//                       let the next session evaluate the Job normally.
+//   @return error       a non-nil error is treated as HintWakeup by the caller,
+//                       so a broken hint cannot keep a Job cached forever.
+type JobHintFn func(
+    logger klog.Logger,
+    job *JobInfo,
+    rejection Rejection,
+    oldObj, newObj any,
+) (HintResult, error)
+
+// ClusterEventWithHint pairs one cluster event a plugin cares about with the
+// callback used to check whether that event may help a specific Job. A nil
+// HintFn means every occurrence of Event wakes Jobs blocked by this plugin.
+type ClusterEventWithHint struct {
+    Event  ClusterEvent
+    HintFn JobHintFn
+}
+
+// HintProvider lets a plugin declare the events that can change its previous
+// unschedulable decisions.
+type HintProvider interface {
+    // EventsToRegister returns every (event, hint) pair this plugin subscribes
+    // to. It is called once per registration; the result is stored verbatim.
+    EventsToRegister(ctx context.Context) ([]ClusterEventWithHint, error)
+}
+```
+
+#### Example
+
+A `NodeAffinity` hint registered for `Node/UpdateNodeLabel` compares `oldObj` and
+`newObj` node labels against the Job's node selector. It returns `HintWakeup`
+only when the new labels may satisfy the selector, and `HintSkip` otherwise.
+
+#### Registration
+
+Plugins register during `OpenSession`:
+
+```go
+// AddHintProvider forwards a session-scoped plugin's HintProvider into the
+// cache-scoped HintRegistry so it keeps working after the session tears down.
+//
+//   @param pluginName plugin identity later matched against Rejection.Plugin at
+//                     Record time; must be stable across sessions.
+//   @param p          the HintProvider; typically the plugin itself when it
+//                     also implements the interface.
+func (ssn *Session) AddHintProvider(pluginName string, p HintProvider)
+```
+
+Plugin objects are session-scoped, but the informer handlers and
+`UnschedulableJobCache` run at scheduler-cache scope and keep firing after the
+session ends. To cross this lifetime gap, `AddHintProvider` copies the plugin's
+`ClusterEventWithHint`s into a cache-owned `HintRegistry`. The `HintRegistry` lives
+next to `BinderRegistry` in `pkg/scheduler/cache/factory.go`, which follows the same
+pattern Volcano already uses for `PreBinder`:
+
+```go
+// pkg/scheduler/cache/factory.go
+
+type HintRegistry struct {
+    mu             sync.RWMutex
+    eventsByPlugin map[string][]ClusterEventWithHint
+}
+
+// Register calls p.EventsToRegister(ctx) once, then stores the returned slice
+// under name, overwriting any previous entry for the same plugin.
+//
+//   @param name plugin name used as the map key; must match Rejection.Plugin so
+//               Record can look the hints up by rejecting plugin.
+//   @param p    the HintProvider whose events are being registered.
+func (r *HintRegistry) Register(name string, p HintProvider) { /* ... */ }
+```
+
+Overwriting matches `BinderRegistry`'s replacement behavior. `HintRegistry` and
+`BinderRegistry` are kept as separate types instead of merged into one shared
+registry, so that each extension point keeps its own registration signature, and the
+cache still has a single place to hold every session-to-cache extension.
+
+`HintRegistry` is the only bridge from session-scoped plugins to cache-scoped
+dispatch. §3 covers how `Record` reads from it at `CloseSession`, and §4 covers how
+informer handlers reach the cache through it.
+
+### 2. Failure Recording
+
+The cache stores one `Rejection` per plugin that rejected a Job. Volcano does
+not short-circuit at the Job level: a session iterates every task and every
+plugin that guards the extension points along the way, so different tasks of
+the same Job can be rejected by different plugins. For example, if one task
+fails `predicates/nodeaffinity` because no node carries its required label and
+another task fails `predicates/tainttoleration` because all remaining nodes are
+tainted, the Job accumulates two rejections in the same session.
+
+```go
+// Rejection describes one plugin decision that made a Job unschedulable in a session.
+type Rejection struct {
+    Plugin string          // registered HintProvider name, e.g. "predicates/nodeaffinity".
+    Source RejectionSource // extension point that emitted the rejection.
+    Tasks  []TaskID        // failed task IDs; nil only for RejectionEnqueue.
+}
+
+type RejectionSource string
+
+const (
+    RejectionPredicate   RejectionSource = "predicate"   // PredicateFn / PrePredicateFn
+    RejectionAllocatable RejectionSource = "allocatable" // Allocatable
+    RejectionEnqueue     RejectionSource = "enqueue"     // JobEnqueueable
+)
+```
+
+Both `RejectionPredicate` and `RejectionAllocatable` carry `Tasks`, because
+their extension points run per task and can fail for a subset of a Job's tasks.
+A large-request task can fail queue capacity while a smaller task of the same
+Job passes, and one task can fail predicates on every node while another task
+of the same Job fits. Only `RejectionEnqueue` is Job-level: `JobEnqueueable`
+returns one decision for the whole `PodGroup`, so no task list is stored.
+
+`Plugin` is used to look up the plugin's registered hints when the record is
+built, so the Job only subscribes to events from plugins that actually rejected
+it. `Source` is kept on `Rejection` rather than on the Job, because a
+`RejectionPredicate` and a `RejectionAllocatable` can both occur in one
+`allocate` pass. For example, one task fails predicates on all nodes while
+another passes predicates but exceeds queue quota. `RejectionEnqueue` does not
+appear together with the others, since a Job that fails `JobEnqueueable` does
+not reach `allocate` in that session.
+
+#### Extension point coverage
+
+| Extension point | Source | `Tasks` | Typical plugins |
+|---|---|---|---|
+| `PredicateFn` / `PrePredicateFn`, and `allocate`'s inline node-fit check | `RejectionPredicate` | yes | `predicates/*`, `predicates/noderesources` |
+| `Allocatable` | `RejectionAllocatable` | yes | `capacity`, `proportion` |
+| `JobEnqueueable` | `RejectionEnqueue` | — | `capacity`, `proportion`, `overcommit` |
+
+`allocate` runs a resource-fit check inline (`task.InitResreq` against
+`node.FutureIdle`) before calling `PredicateFn`, so pure capacity shortfalls
+never reach a real predicate plugin. Volcano attributes those failures to a
+synthetic plugin name `predicates/noderesources` and records them as
+`RejectionPredicate` on the same footing as any other per-task predicate
+failure. The synthetic plugin registers hints on capacity-changing events
+(`Node/Add`, `Node/UpdateNodeAllocatable`, `Pod/Delete`) so the wake path
+works the same way as other predicates.
+
+#### Recording rejections
+
+Rejections accumulate on a session-scoped `jobRejections` map keyed by Job ID
+and are drained at `CloseSession` into per-Job `Record` calls. Each source is
+appended at a different point in the flow:
+
+- `RejectionPredicate` reuses the existing per-task fit-error tracking. When
+  `allocate` filters a task against every node, both the inline resource-fit
+  check and each `PredicateFn` failure land on `JobInfo.NodesFitErrors` as they
+  do today. The synthetic `predicates/noderesources` name is used for the
+  inline check so the two paths look the same to the cache. At `CloseSession`,
+  Volcano walks each pending Job's `NodesFitErrors`, groups the failed tasks
+  by plugin, and appends one `RejectionPredicate{Plugin, Tasks}` per plugin.
+- `RejectionAllocatable` is appended when the `Allocatable` extension point
+  returns false for a task, attributed to the plugin whose registered
+  `AllocatableFn(queue, task)` returned false and carrying that task's ID.
+- `RejectionEnqueue` is appended when `JobEnqueueable` rejects the Job,
+  attributed to the plugin whose callback returned the reject decision.
+
+`gang.JobReadyFn` does not produce a rejection. If a gang shortfall is caused
+by real per-task failures, those failures already surface as
+`RejectionPredicate` or `RejectionAllocatable` on the specific tasks that
+could not be placed, and §2's [Skip granularity](#skip-granularity) turns the
+shortfall into either a task-subset or a whole-Job skip in the next session.
+Gang's role stays session-internal: it decides whether the pipelined tasks
+form a viable Job and rolls them back if not.
+
+A Job whose rejection list is empty after this pass is not cached. Either it
+was placed, or all of its failures came from plugins without a `HintProvider`
+(see [Rejections from plugins without hints](#rejections-from-plugins-without-hints)).
+
+#### Skip granularity
+
+Rejections say which tasks failed which plugin; they do not say how much of
+the Job should be skipped next session. That decision is derived at
+`OpenSession` from the rejections plus the Job's gang topology, and stored on
+`JobInfo.Skip`:
+
+```go
+// SkipDecision is computed once per pending Job at OpenSession from the
+// cached rejections and the Job's gang topology. Each field names the piece
+// of work an action should skip for this Job in this session.
+type SkipDecision struct {
+    // Enqueue skips enqueue's JobEnqueueable re-check for this Job.
+    // Set when RejectionEnqueue was cached.
+    Enqueue bool
+
+    // Allocate skips the allocate and backfill actions entirely for this
+    // Job (no tasks popped, no gang JobReadyFn call). Set when the Job
+    // cannot reach its gang criterion after excluding the per-task
+    // rejections.
+    Allocate bool
+
+    // Tasks lists task IDs that allocate and backfill should treat as
+    // unschedulable this session. Consulted only when Allocate is false;
+    // nil otherwise.
+    Tasks map[TaskID]struct{}
+}
+```
+
+For the two per-task sources (`RejectionPredicate`, `RejectionAllocatable`),
+Volcano picks between two modes:
+
+1. **Task-subset skip.** `Skip.Tasks` is populated from the union of
+   `Rejection.Tasks`; `Skip.Allocate` stays false. `allocate` and `backfill`
+   still pop the Job's other tasks and evaluate them normally, but any task
+   in `Skip.Tasks` is treated as unschedulable this session (predicate and
+   allocatable loops are skipped for it). This is the mode used when the Job
+   can still reach its gang criterion after excluding the skipped tasks. For
+   example, an elastic gang Job whose `minAvailable` is already met by
+   running tasks, with only extras cached as failed.
+
+2. **Whole-Job skip.** `Skip.Allocate` is true. No task of the Job is popped
+   this session, and gang's `JobReadyFn` is never called. This is the mode
+   used when excluding the skipped tasks makes some level of the gang
+   hierarchy fall below its own threshold. For example, a gang with
+   `minAvailable=8`, five tasks running, three tasks previously rejected on
+   capacity, and nothing left to try.
+
+`Skip.Enqueue` is orthogonal: it is set from `RejectionEnqueue` alone, and
+since a Job that failed `JobEnqueueable` never reached `allocate` in the
+previous session, it cannot coexist with per-task rejections in the same
+record.
+
+The whole-Job/task-subset choice comes from a recursive check against the
+Job's `SubJob` tree. Each `SubJob` has its own `minAvailable` (on its leaf
+tasks) and its own `minSubgroups` (on its child SubJobs), so an internal node
+can still reach its gang criterion when only `minSubgroups` of its children
+are viable:
+
+```go
+// canReach reports whether sj can still reach its gang criterion after
+// excluding the skipped tasks. A leaf SubJob checks its own minAvailable
+// against the tasks that are still schedulable; an internal SubJob checks
+// how many of its children can themselves reach their criterion against
+// minSubgroups.
+func canReach(sj *SubJobInfo, skipped map[TaskID]struct{}) bool {
+    if len(sj.Children) == 0 {
+        remaining := 0
+        for _, t := range sj.PendingTasks {
+            if _, s := skipped[t.UID]; !s {
+                remaining++
+            }
+        }
+        if sj.IsGang && remaining+sj.NumRunning+sj.NumAllocated < sj.MinAvailable {
+            return false
+        }
+        return true
+    }
+    reachable := 0
+    for _, child := range sj.Children {
+        if canReach(child, skipped) {
+            reachable++
+        }
+    }
+    return reachable >= sj.MinSubgroups
+}
+
+func computeSkip(job *JobInfo, rejections []Rejection) SkipDecision {
+    var d SkipDecision
+    tasks := map[TaskID]struct{}{}
+    for _, r := range rejections {
+        if r.Source == RejectionEnqueue {
+            d.Enqueue = true
+            continue
+        }
+        for _, t := range r.Tasks {
+            tasks[t] = struct{}{}
+        }
+    }
+    if !canReach(job.RootSubJob, tasks) {
+        d.Allocate = true
+        return d
+    }
+    d.Tasks = tasks
+    return d
+}
+```
+
+Either way the wake behavior is the same: any `HintWakeup` from the plugins
+that produced the cached rejections drops the whole record, and the next
+`OpenSession` recomputes `SkipDecision` from scratch. There is no partial
+wake that lifts only some cached task-level skips.
+
+#### How actions apply cached rejections
+
+At `OpenSession`, Volcano fetches each pending Job's rejections from the
+cache and derives `JobInfo.Skip` from them (see §5). Actions consult `Skip`
+only. Each field names the piece of work to skip:
+
+- **`enqueue`** skips its `JobEnqueueable` re-check when `Skip.Enqueue` is
+  true. Only the `RejectionEnqueue` source sets this flag.
+- **`allocate`** short-circuits the Job when `Skip.Allocate` is true: no task
+  is popped and gang's `JobReadyFn` is not called. Otherwise, for each popped
+  task, a lookup in `Skip.Tasks` decides whether to skip the predicate and
+  allocatable loops for that task. Other tasks of the same Job continue
+  normally, so elastic gang Jobs can still push past `minAvailable` when a
+  new task becomes placeable.
+- **`backfill`** reads `Skip` the same way `allocate` does.
+- **`preempt`** and **`reclaim`** ignore `Skip`. They exist to free
+  resources for Jobs the other actions could not place, so a cached Job must
+  still be a preemption candidate.
+
+#### Rejections from plugins without hints
+
+A rejection is only useful if its plugin has a `HintProvider`. If the rejecting
+plugin has no registered hints, there is no cluster event that could wake the
+Job for that failure. The cache leaves such Jobs out entirely and lets them go
+through the normal filter path every session, which matches today's behavior.
+
+### 3. UnschedulableJobCache
+
+`UnschedulableJobCache` lives on `SchedulerCache`. It records unschedulable Jobs by
+`JobID`, together with the rejection list collected at `CloseSession` and the hint
+callbacks copied from `HintRegistry`.
+
+The normal retry lifecycle is:
+
+1. `CloseSession` calls `Record(job, rejections)` for Jobs that were evaluated and
+   still failed.
+2. The next `OpenSession` calls `GetCachedRejections(job)` for each pending Job.
+3. If the call returns a non-nil slice, Volcano derives `JobInfo.Skip` from it (see
+   §2's [Skip granularity](#skip-granularity)), and `enqueue`, `allocate` and
+   `backfill` bypass either the whole Job, specific tasks, or the enqueue re-check
+   accordingly.
+4. A matching informer event calls `OnEvent`; if a hint says the Job may need retry,
+   the cache calls `Forget(job.UID)` and the next session evaluates it normally.
+5. If no relevant event arrives before `RetryAfter`, a background watchdog goroutine
+   `Forget`s the record, and the next session evaluates the Job normally.
+
+Recovery actions (`preempt` and `reclaim`) do not consult `GetCachedRejections`.
+They scan pending Jobs from `ssn.Jobs` directly, because Volcano cannot know in
+advance which Job becomes schedulable after victims are selected. Once they
+pipeline a Job's tasks onto victims, that Job is making progress through
+preemption. `GetCachedRejections` returns nil for it, `allocate` keeps placing
+its remaining tasks as resources free, and `CloseSession` drops any existing
+record instead of re-caching it (see §5).
+
+A Job therefore moves between three states across sessions:
+
+```mermaid
+stateDiagram-v2
+    [*] --> Evaluating: OpenSession, no record
+    Evaluating --> Progressing: allocated / pipelined
+    Evaluating --> Cached: CloseSession Record
+    Cached --> Cached: GetCachedRejections applied
+    Cached --> Cached: hint = HintSkip
+    Cached --> Evaluating: Forget (hint / PodGroup / watchdog)
+    Progressing --> [*]
+```
+
+The three states are:
+
+- **Evaluating** — no record (or the record is being bypassed); actions run predicates
+  and resource fit for the Job normally.
+- **Cached** — a record exists and `now < RetryAfter`; `enqueue`/`allocate`/`backfill`
+  apply the derived `Skip` (the enqueue re-check, the whole Job, or a subset of its
+  tasks, depending on the record). `preempt`/`reclaim` still evaluate it (they ignore
+  the cache).
+- **Progressing** — the Job allocated or was pipelined this session, so it holds no
+  record and leaves the cache's scope.
+
+A Job enters **Cached** only from `CloseSession → Record`. It leaves **Cached** back to
+**Evaluating** through three paths, all of which `Forget` (delete) the record so the
+next `OpenSession` finds none and evaluates the Job normally:
+
+1. **Hint wake-up (event-driven).** An informer fires `OnEvent`; the cache runs the
+   Job's subscribed hints. If any returns `HintWakeup`, the cache `Forget`s the record.
+   If every hint returns `HintSkip`, the record is kept and the Job stays **Cached**
+   (the `Cached → Cached` self-loop). This is the primary path, since a real cluster
+   change plausibly fixes the earlier rejection.
+2. **PodGroup change (invalidation).** A `PodGroup Update`/`Delete` informer handler
+   `Forget`s the record directly, without consulting any hint: the Job's own spec or
+   lifecycle changed, so the previous rejection may no longer describe it and the record
+   must not be trusted.
+3. **RetryAfter watchdog (safety net).** A background goroutine runs on a fixed
+   interval and `Forget`s any record whose `RetryAfter` has passed. It runs off the
+   scheduling path, so it does not add scanning work to `OpenSession`, and it
+   guarantees a Job is never cached forever when a hint is missed or an informer
+   edge case drops an event.
+
+#### Interface
+
+```go
+type UnschedulableJobCache interface {
+    // Record inserts (or replaces) the Job with the rejections observed at
+    // CloseSession and copies the matching hint callbacks out of sc.hintRegistry.
+    // Returns without inserting if any rejection's plugin has no HintProvider
+    // (see §2 fallback).
+    Record(job *api.JobInfo, rejections []Rejection)
+
+    // GetCachedRejections is called during OpenSession. It returns the
+    // rejections recorded for job in the previous session, or nil when the
+    // caller should evaluate the Job normally. Nil is returned in two cases
+    // the caller treats the same way:
+    //   1. no record exists for the Job;
+    //   2. the Job has pipelined tasks from a prior preempt/reclaim, so
+    //      preemption progress must not be suppressed.
+    // Expired records are removed off-path by the watchdog goroutine, not
+    // here. The caller derives JobInfo.Skip from the returned slice via
+    // computeSkip (see §2's Skip granularity).
+    GetCachedRejections(job *api.JobInfo) []Rejection
+
+    // Forget drops the record.
+    Forget(jobID api.JobID)
+
+    // OnEvent is invoked by the informer dispatchers wired in §4. It runs the
+    // hints subscribed to `ev` and Forgets any Job whose hint returns HintWakeup.
+    OnEvent(ev ClusterEvent, oldObj, newObj any)
+}
+```
+
+#### Cache state
+
+The cache keeps one record per Job, plus a reverse index so `OnEvent` can find
+the affected Jobs without scanning every record:
+
+```go
+type UnschedulableJobCache struct {
+    mu sync.RWMutex
+
+    // records is the primary store: one entry per cached Job.
+    records map[api.JobID]*UnschedulableRecord
+
+    // byEvent is the reverse index OnEvent uses: for each subscribed event, the
+    // Jobs whose hints want it. wildcard holds Jobs subscribed with a nil HintFn
+    // (any occurrence of a subscribed event wakes them).
+    byEvent  map[ClusterEvent]sets.Set[api.JobID]
+    wildcard sets.Set[api.JobID]
+}
+
+type UnschedulableRecord struct {
+    JobID      api.JobID
+    Rejections []Rejection // populated at Record; drives Skip derivation on the next OpenSession.
+
+    LastFailedAt time.Time
+    RetryAfter   time.Time // LastFailedAt + DefaultMaxSkipDuration
+
+    // Subscriptions is this Job's private routing table: for every event that
+    // could wake it, the hint callbacks to run. It is a snapshot (see below),
+    // not a reference to the global registry.
+    Subscriptions map[ClusterEvent][]HintSubscription
+}
+
+// HintSubscription pairs a plugin name with its hint callback, plus the plugin's
+// own Rejection so the callback can inspect the exact decision it made in the
+// previous session.
+type HintSubscription struct {
+    Plugin    string
+    Rejection Rejection
+    HintFn    JobHintFn
+}
+```
+
+`Subscriptions` holds the same `(event, hintFn)` pairs a plugin declares through
+`ClusterEventWithHint` (§1), narrowed to the plugins that rejected this Job and
+re-keyed by event for fast `OnEvent` lookup. `Record` builds it by looking each
+rejection's plugin up in the cache's global `HintRegistry` and copying the matching
+entries.
+
+It is a **snapshot** rather than a live reference to `HintRegistry`. A Job
+cached in an earlier session must keep waking the same way it was recorded,
+even if a plugin re-registers different events later. Copying at `Record` time
+also keeps the cache working after the session that produced the hints is torn
+down.
+
+#### Cache updates
+
+| Call site | Cache call | Meaning |
+|---|---|---|
+| `CloseSession`, evaluated Job still pending | `Record(job, rejections)` | Store or replace the record and rebuild event subscriptions. |
+| `OpenSession`, pending Job | `GetCachedRejections(job)` | Return the previous session's rejections, or nil to evaluate the Job normally. |
+| `CloseSession`, Job became allocated | `Forget(job.UID)` | Remove the record. |
+| PodGroup update/delete informer | `Forget(jobID)` | Job spec/lifecycle changed; evaluate it again. |
+| Subscribed cluster event (informer) | `OnEvent(ev, oldObj, newObj)` | Run matching hints and wake Jobs that may need retry. |
+| Watchdog goroutine, `now >= RetryAfter` | `Forget(jobID)` | Off-path cleanup of stale records so a Job is never cached forever. |
+
+`GetCachedRejections(job)` returns nil when there is no record, or the Job
+currently has pipelined tasks from a prior `preempt`/`reclaim`. In that case
+the normal actions evaluate the Job again; if it still fails, `Record`
+refreshes the cache at `CloseSession`. Expired records are removed by the
+watchdog goroutine (below), so `GetCachedRejections` never scans for timeouts
+on the scheduling path.
+
+There is no per-Job timer and no exponential backoff. A single background
+goroutine runs on a fixed interval, scans the records, and `Forget`s any
+whose `RetryAfter` has passed. Keeping expiry off the scheduling path means
+`OpenSession` and `GetCachedRejections` only read a record. Events remain the
+normal wake-up path, and the timestamp is a safety net for missed hints or
+informer edge cases.
+
+#### Per-session overhead
+
+For a Job with no cached record, `GetCachedRejections` is a single map
+lookup under a read lock, so the `OpenSession` pass adds constant time per
+pending Job. For a Job with a record, `computeSkip` walks the Job's SubJob
+tree once and does a map lookup per pending task, all without touching the
+cluster snapshot. This is orders of magnitude cheaper than the per-node
+predicate loop the skip is designed to avoid, so the derivation cost never
+exceeds the work it saves.
+
+#### Invalidation
+
+A record is removed or bypassed by these triggers:
+
+| Trigger | Effect |
+|---|---|
+| A subscribed cluster event whose hint returns `HintWakeup` or errors | `Forget` (via `OnEvent`) |
+| `PodGroup Update` / `Delete` | `Forget` (from the cache's informer handler) |
+| `now >= RetryAfter` | the watchdog goroutine `Forget`s the record; the next session re-evaluates the Job |
+
+`Record` sets retry timing like this:
+
+```
+LastFailedAt = now
+RetryAfter   = now + DefaultMaxSkipDuration // 5m
+```
+
+`OnEvent` is described in §4 together with the informer dispatch path.
+
+### 4. Event Dispatch
+
+
+The dispatch layer connects cluster events to `UnschedulableJobCache`. Plugins
+declare which events they care about through `HintRegistry` (§1). The layer
+attaches informer handlers for exactly those events and delivers them into the
+cache through `OnEvent`.
+
+#### Subscribed event set
+
+After each `OpenSession`, the cache takes the union of the `(resource, action)`
+pairs declared in `HintRegistry`. Only those events are forwarded to the cache;
+an event no plugin subscribes to never runs any hint. Node updates are split
+into finer actions (`UpdateNodeLabel`, `UpdateNodeTaint`, `UpdateNodeAllocatable`,
+`UpdateNodeCondition`) while other resources use a generic `Update`, so a
+taint-only change does not wake Jobs blocked only by node labels.
+
+#### Handler registration
+
+Volcano installs a handler that dispatches into `UnschedulableJobCache` beside
+the existing cache-update handlers on the subscribed informers. Each handler
+normalizes the informer callback into a `ClusterEvent` and calls
+`UnschedulableJobCache.OnEvent(ev, oldObj, newObj)`.
+
+#### Delivery
+
+`OnEvent` uses the `byEvent` / `wildcard` index (§3) to find the records
+subscribed to the event, runs each Job's matching hints, and `Forget`s a Job as
+soon as one hint returns `HintWakeup`. A hint that returns an error is treated
+as `HintWakeup` too, so a broken hint can never keep a Job cached forever. Jobs
+whose hints all return `HintSkip` stay cached until another event fires or the
+`RetryAfter` watchdog (§3) lets them retry.
+
+```mermaid
+sequenceDiagram
+    participant Informer as SharedInformer
+    participant Dispatch as Event Handler
+    participant UJC as UnschedulableJobCache
+
+    Informer->>Dispatch: Add / Update / Delete object
+    Dispatch->>Dispatch: normalize to ClusterEvent
+    Dispatch->>UJC: OnEvent(ev, oldObj, newObj)
+    UJC->>UJC: look up subscribed records via byEvent / wildcard
+    UJC->>UJC: run each Job's matching hints
+    UJC-->>UJC: Forget Job on HintWakeup / error
+```
+
+`OnEvent` decides per record:
+
+```mermaid
+flowchart TD
+    A[OnEvent receives ClusterEvent] --> B[Find subscribed records via byEvent / wildcard]
+    B --> C{Job still pending in SchedulerCache?}
+    C -- no --> D[Forget record]
+    C -- yes --> E[Run the Job's matching hints]
+    E --> F{Any hint returns HintWakeup or errors?}
+    F -- yes --> D
+    F -- no --> G[Keep record cached]
+```
+
+Any subscribed plugin can wake the Job. Waking only lifts the cached skip. The
+next scheduling session still runs the normal Volcano checks before the Job can
+be placed.
+
+### 5. Scheduler Action Changes
+
+Two hooks in the session lifecycle wire the cache into the scheduler. `OpenSession`
+derives each pending Job's `Skip` decision from the cache, and `CloseSession`
+writes updated records back. §2 describes what the actions do with `Skip`; this
+section covers the two hooks and how `CloseSession` reconciles the cache with what
+the session actually did.
+
+#### Tagging pending Jobs
+
+`OpenSession` builds the session as usual. Once plugins have registered, Volcano
+calls `GetCachedRejections` for every pending Job. If the call returns a non-nil
+slice, `computeSkip` (§2) turns it into a `SkipDecision` that is stored on
+`JobInfo`:
+
+```go
+type JobInfo struct {
+    // existing fields omitted
+
+    // Skip is derived from the cache's rejections and the Job's SubJob
+    // topology at OpenSession. enqueue reads Skip.Enqueue; allocate and
+    // backfill read Skip.Allocate and Skip.Tasks. Zero value means the
+    // Job is evaluated normally this session. See §2's Skip granularity.
+    Skip SkipDecision
+}
+```
+
+The raw `[]Rejection` slice stays on the cache record. Actions never need it,
+and duplicating it on `JobInfo` would add pointer traffic without a reader.
+
+Skipped Jobs are *not* dropped from the snapshot. They stay in `ssn.Jobs` and
+in every action's queue so DRF, capacity, proportion and gang accounting still
+see the full pending demand; `Skip` only gates the expensive retry work.
+
+#### Reconciling the cache at `CloseSession`
+
+Each pending Job's record is updated to match what actually happened to it:
+
+- If the Job was allocated, or `preempt`/`reclaim` pipelined some of its tasks onto
+  victims, it is making progress, so any record is dropped (or never written).
+- If the Job was skipped and never re-evaluated, its record is left untouched, still
+  waiting for an event or the watchdog.
+- If the Job was actually evaluated and still produced rejections, the record is written
+  or replaced with those fresh rejections.
+
+A pipelined Job is deliberately kept out of the cache. Its victims are still being
+evicted, so the next `allocate` may keep rejecting those tasks until their resources
+are freed. Caching the Job as unschedulable would suppress the retries that let the
+preemption finish.
+
+### 6. kube-scheduler QueueingHint Adapter
+
+Most of the value in the first release comes from reusing kube-scheduler's
+existing `QueueingHintFn`s for its filter plugins. Volcano's `predicates/*`
+plugins already wrap those upstream plugins, so the adapter only has to expose
+their hints and turn each per-Pod answer into a per-Job answer.
+
+#### Exposed upstream hints
+
+The following upstream plugins implement `fwk.EnqueueExtensions` and expose
+their hint list through `EventsToRegister(ctx) ([]fwk.ClusterEventWithHint, error)`:
+
+- `nodeaffinity`, `nodeports`
+- `tainttoleration`
+- `interpodaffinity`, `podtopologyspread`
+- `nodevolumelimits.CSILimits`, `volumezone`, `vbcap.VolumeBinding`
+- `dynamicresources.DynamicResources`
+
+Both the return type and its `QueueingHintFn` field are exported, so Volcano
+can invoke the upstream hints directly without reimplementing them. Volcano's
+`predicates` plugin publishes one `ClusterEventWithHint` per upstream event and
+tags each with a stable plugin name (`predicates/<filter>`). `Record` uses that
+name to copy only the hints for filters that actually rejected the Job.
+
+#### From per-Pod to per-Job
+
+The upstream `QueueingHintFn` is Pod-level. It answers "could this event make
+this one Pod schedulable?":
+
+```go
+func(logger klog.Logger, pod *v1.Pod, oldObj, newObj any) (fwk.QueueingHint, error)
+```
+
+Volcano's `JobHintFn` asks the same question for a whole Job. `wrapPodHint`
+turns the per-Pod callback into a per-Job one. `Rejection.Tasks` (§2) records
+exactly the task IDs that failed this filter in the previous session, so the
+wrapper runs the upstream hint only for those Pods — other tasks passed the
+filter and cannot be why the Job is blocked on it.
+
+The wrapper returns `HintWakeup` as soon as one failed task's upstream hint
+returns `Queue`. Waking on a single Pod is safe:
+
+- `HintWakeup` does not place anything. It asks Volcano to run the normal
+  evaluation again, where full predicates re-run for every task. A useless
+  wake costs one session's evaluation and nothing more.
+- Wakes are whole-record. Even though `RejectionPredicate` carries a `Tasks`
+  list, one Pod turning schedulable drops the whole record, and the next
+  session re-evaluates every task from scratch. There is no partial wake that
+  lifts only some of the cached task-level skips.
+- For a gang Job, a single task becoming placeable can be the marginal task
+  that finally satisfies `minAvailable`, so one Pod's improvement must be
+  able to unblock the Job.
+
+A missed wake is the more expensive failure — the Job stays cached until the
+watchdog — so any upstream hint that errors is also treated as `HintWakeup`.
+
+```mermaid
+flowchart TD
+    A[Cluster event reaches wrapPodHint] --> B[Load failed tasks from Rejection.Tasks]
+    B --> C[Run upstream QueueingHintFn for each failed Pod]
+    C --> D{Any Pod returns Queue or error?}
+    D -- yes --> W[HintWakeup: drop record, next session evaluates normally]
+    D -- no --> S[HintSkip: keep cached]
+```
+
+### 7. Initial Plugin Coverage
+
+Coverage lands in tiers so the first release focuses on the plugins that
+drive the most redundant work today. The kube-scheduler upstream already
+ships hint logic for every `predicates/*` plugin, so the predicate tier is
+almost entirely adapter code and lands in P0. Native queue plugins are also
+P0 because `capacity`/`proportion` are the most common source of blocked
+Jobs. Everything else follows as its rejection path is wired up.
+
+**P0 — first release**
+
+| Plugin | Category | Event source | Notes |
+|---|---|---|---|
+| `predicates/nodeaffinity`, `predicates/nodeports` | NodeAffinity | adapter | `Node/Add`, `Node/UpdateNodeLabel` |
+| `predicates/tainttoleration`, `predicates/nodeunschedulable` | Taint | adapter | `Node/Add`, `Node/UpdateNodeTaint` |
+| `predicates/interpodaffinity`, `predicates/podtopologyspread` | PodTopology | adapter | `Pod/Add`, `Pod/Delete`, `Node/UpdateNodeLabel` |
+| `predicates/nodevolumelimits`, `predicates/volumezone`, `predicates/volumebinding` | Storage | adapter | PVC/PV/StorageClass/CSINode events |
+| `predicates/dynamicresources` | Device | adapter | ResourceClaim/DeviceClass/Node allocatable events |
+| `predicates/noderesources` | Resource | native (synthetic) | §2 synthetic name for `allocate`'s inline node-fit check; `Node/Add`, `Node/UpdateNodeAllocatable`, `Pod/Delete` |
+| `capacity`, `proportion` | Queue | native | Queue, PodGroup completion/deletion, Pod deletion |
+
+**P1 — follow-up**
+
+| Plugin | Category | Event source | Notes |
+|---|---|---|---|
+| `overcommit` | Queue | native | Queue, PodGroup completion/deletion |
+| `numaaware` | NUMA | native | NumaInfo, Node add |
+| `deviceshare` | Device | native | Node allocatable, PodGroup deletion |
+| `resource-strategy-fit` | Resource | native | Node add/allocatable, Pod deletion |
+
+**P2 — later**
+
+| Plugin | Category | Event source | Notes |
+|---|---|---|---|
+| `network-topology-aware` | HyperNode | native | HyperNode, node label events |
+
+**No `HintProvider` (fallback)**
+
+`extender`, and any other plugin that does not implement `HintProvider`, keep
+today's behavior: Jobs they reject are not cached and go through the normal
+filter path every session.
+
+## Risks and Mitigations
+
+| Risk | Mitigation |
+|---|---|
+| A hint misses a relevant event, keeping a Job cached too long. | Fail open on hint errors; the `RetryAfter` watchdog `Forget`s the record; rejections from plugins without a `HintProvider` are not cached at all (§7). |
+| Stale plugin registrations after a re-register. | `Record` snapshots the hints at cache-write time; later registrations only apply to new records, and old records are bounded by the watchdog. |
+| Fairness drift from skipping Jobs. | Cached Jobs stay in `ssn.Jobs`; DRF, capacity, proportion and gang accounting see the full pending demand (§5). |
+| Hot `Pod` event path spending time on unrelated Jobs. | `byEvent` / `wildcard` index dispatches only to records subscribed to the event; hints for others never run. |
+| Preemption progress suppressed by the cache. | Jobs with pipelined tasks are excluded from the cache (§3, §5), so `preempt`/`reclaim` retries are never skipped. |
+
+## Alternatives Considered
+
+- **All-plugins-must-return-`HintWakeup` policy.** Rejected. Needs per-plugin wake state on each record, and one missed hint leaves the Job stuck until the watchdog.
+- **Drop unschedulable Jobs from `ssn.Jobs`.** Rejected. DRF, capacity and proportion need to see pending demand or fairness drifts.
+- **Persist records in PodGroup status or annotations.** Rejected. Adds API-server writes on every rejection and races with user updates. Records live in memory and rebuild from the first post-restart session.
+- **Reimplement kube-scheduler hints in Volcano.** Rejected. The upstream callback API is public and already captures plugin-specific logic; wrapping it costs adapter code once.
+- **Task-granularity cache records.** Rejected as the cache key, though task-level
+  detail is still kept inside each Job record. Volcano schedules and gates at
+  Job/PodGroup granularity, so `GetCachedRejections`, gang thresholds and the action
+  loops all decide per Job. A per-task record would have to be rolled up to that
+  same Job-level answer, which the §6 OR already produces. A Job's tasks are also
+  typically homogeneous and fail the same filter for the same reason, so per-task
+  records would store many near-duplicate entries and scale with total pending Pods
+  instead of pending PodGroups. Task-level precision matters only when replaying the
+  upstream per-Pod hint, and `Rejection.Tasks` inside the Job record already provides
+  it.
+
+## Test Plan
+
+**Unit tests**
+
+Standard package-level unit tests cover the core logic: `HintRegistry` lifecycle
+and re-registration; rejection recording at each extension point (`PredicateFn`,
+`Allocatable`, `JobEnqueueable`, plus the synthetic `predicates/noderesources`);
+`UnschedulableJobCache` operations (`Record`, `GetCachedRejections`, `Forget`,
+`OnEvent`, watchdog expiry, `byEvent` / `wildcard` dispatch, hint-error fail-open);
+`computeSkip` against SubJob trees with and without `minSubgroups`; and the
+`predicates` adapter's per-Pod-to-per-Job aggregation.
+
+**Benchmarks**
+
+`benchmark/testcases/unschedulable-job-cache/`: 5,000 pending PodGroups with mixed
+rejection sources. Compare `allocate` latency, session duration, bind throughput,
+and cache memory before and after the cache is enabled.
+
+**End-to-end**
+
+- **Wake on a matching cluster event.** A Job blocked on a node label is
+  cached after the first session; adding a node with the matching label
+  drops the record and places the Job in the next session.
+- **Gang whole-Job skip.** A gang Job whose `minAvailable` is unreachable in
+  the current cluster is cached; no task is popped for it until a `Pod/Delete`
+  frees enough capacity, at which point the record wakes and the Job is
+  placed.
+- **Task-subset skip.** An elastic gang Job whose `minAvailable` is already met
+  by running tasks has extra tasks rejected on capacity; later sessions skip
+  only those cached tasks and keep evaluating the Job's other tasks normally.
+- **Preemption is not suppressed.** A cached Job is chosen as a preemption
+  target; `preempt` selects victims, `allocate` pipelines the Job's tasks, and
+  the record is dropped instead of refreshed.
+- **Watchdog safety net.** A cached Job whose subscribed events never fire is
+  re-evaluated after `DefaultMaxSkipDuration`.
+
+## Related Issues
+
+- [#5551 Reduce repeated scheduling attempts for unchanged unschedulable jobs](https://github.com/volcano-sh/volcano/issues/5551)
+- [#5494 [Umbrella] Track Volcano performance and scalability work](https://github.com/volcano-sh/volcano/issues/5494)
+- [#5537 Explore signature-based batching for homogeneous gang workloads](https://github.com/volcano-sh/volcano/issues/5537)
+- Upstream: [KEP-4247 QueueingHint](https://kep.k8s.io/4247)

--- a/docs/design/unschedulable-job-cache.md
+++ b/docs/design/unschedulable-job-cache.md
@@ -142,11 +142,21 @@ passed, which prevents a Job from staying cached forever if a hint is ever misse
 
 `HintProvider` is an optional interface that a plugin implements to declare the
 cluster events that could invalidate its previous unschedulable decisions. Each
-declaration is a `ClusterEventWithHint`, which is a `(ClusterEvent, JobHintFn)` pair.
-`ClusterEvent` names the change to watch, and `JobHintFn` decides, for a given Job,
-whether a particular occurrence of that event may make the Job schedulable. If
-`JobHintFn` is `nil`, every occurrence of the event wakes Jobs blocked by this
-plugin.
+declaration is a `ClusterEventWithHint`. `ClusterEvent` identifies the change to
+watch, and `JobHintFn` decides whether one occurrence of that change may make a
+previously rejected Job schedulable. If `JobHintFn` is nil, every occurrence of
+the declared event wakes Jobs rejected by that plugin.
+
+A declaration may also provide a secondary index: a cache-maintained map from
+plugin-defined `HintKey`s to cached Job IDs. Without a secondary index, an event
+checks every cached Job rejected by the same plugin for the same resource and
+action. The cache represents that classification as a **plugin/action index**
+under the event resource. With secondary HintKeys, it selects only Jobs that
+share a `HintKey` with the event. A Job selected for the final `JobHintFn`
+evaluation is a **candidate Job**. The key match only reduces the candidate set;
+it never decides whether a Job wakes. Jobs for which `JobKeysFn` cannot provide
+usable keys are stored explicitly in `jobIDsWithoutHintKeys` and remain candidate
+Jobs for every matching event.
 
 #### Types
 
@@ -195,28 +205,100 @@ type JobHintFn func(
     oldObj, newObj any,
 ) (HintResult, error)
 
-// ClusterEventWithHint pairs one cluster event a plugin cares about with the
-// callback used to check whether that event may help a specific Job. A nil
-// HintFn means every occurrence of Event wakes Jobs blocked by this plugin.
+// HintKey identifies one scheduling condition that both a rejected Job and a
+// later cluster event can name. The plugin that owns the index defines the key
+// format and meaning.
+type HintKey string
+
+// MaxHintKeysPerPluginEvent bounds the key set returned for one Job or event
+// handled by one plugin. Larger Job key sets make that Job use dispatch without
+// HintKeys; larger event key sets select every Job in the plugin/action index.
+const MaxHintKeysPerPluginEvent = 256
+
+// JobKeysFn returns every HintKey that may be relevant to one rejected Job for
+// one event declaration. job is the immutable Job snapshot retained from the
+// completed session, and rejection is the declaring plugin's rejection from that
+// session. For correctness, any event that can make HintFn return HintWakeup must
+// share at least one key with this result.
+//
+// Returning an error, no keys, or more than MaxHintKeysPerPluginEvent keys
+// disables secondary-index selection for this Job and event declaration. The
+// cache then evaluates the Job for every matching event.
+type JobKeysFn func(job *JobInfo, rejection Rejection) ([]HintKey, error)
+
+// EventKeysFn returns every HintKey affected by one occurrence of a declared
+// cluster event. oldObj is nil for Add, and newObj is nil for Delete. For
+// correctness, this result must share at least one key with every rejected Job
+// that the event can make schedulable.
+//
+// A zero-length result with a nil error, whether the slice itself is nil or
+// non-nil, means that this event affects no indexed Job; the cache still evaluates
+// Jobs without HintKeys. A function that cannot determine complete event keys must
+// return an error. An error or more than
+// MaxHintKeysPerPluginEvent keys makes the cache evaluate every Job in the
+// matching plugin/action index.
+type EventKeysFn func(oldObj, newObj any) ([]HintKey, error)
+
+// ClusterEventWithHint describes how one plugin reacts to one cluster event.
 type ClusterEventWithHint struct {
-    Event  ClusterEvent
+    // Event identifies the cluster change that can affect the plugin's previous
+    // rejection.
+    Event ClusterEvent
+
+    // JobKeysFn follows the JobKeysFn contract above. It runs when a Job record
+    // is inserted. A nil value records the Job without HintKeys and requires
+    // EventKeysFn to be nil too.
+    JobKeysFn JobKeysFn
+
+    // EventKeysFn follows the EventKeysFn contract above. It runs once for each
+    // matching plugin/action index. A nil value requires JobKeysFn to be nil too.
+    EventKeysFn EventKeysFn
+
+    // HintFn follows the JobHintFn contract above and makes the final decision
+    // for each candidate Job. A nil value means every matching event wakes the
+    // Job, so the declaration cannot use secondary-index selection.
     HintFn JobHintFn
 }
 
 // HintProvider lets a plugin declare the events that can change its previous
 // unschedulable decisions.
 type HintProvider interface {
-    // EventsToRegister returns every (event, hint) pair this plugin subscribes
-    // to. It is called once per registration; the result is stored verbatim.
+    // EventsToRegister returns every event declaration owned by this plugin.
+    // It is called once per registration; the result is stored verbatim.
     EventsToRegister(ctx context.Context) ([]ClusterEventWithHint, error)
 }
 ```
 
-#### Example
+`JobKeysFn` and `EventKeysFn` are optional and must be provided together. The two
+functions must satisfy one rule: if an event can make a rejected Job schedulable,
+their results must have at least one key in common. A Job may be omitted from the
+candidate set only when `JobKeysFn` returned a complete key set for that Job. If
+`JobKeysFn` is absent, returns an error, returns no keys, or returns more than 256
+keys, that Job is recorded in `jobIDsWithoutHintKeys` and is evaluated for every matching event. If
+`EventKeysFn` errors or returns more than 256 keys, the cache evaluates the full
+plugin/action index. A zero-length result with a nil error means the event affects
+no indexed Jobs, so the cache evaluates only `jobIDsWithoutHintKeys`. A
+declaration with a nil `HintFn` records every Job without HintKeys because every
+matching event must wake them.
+
+#### Examples
 
 A `NodeAffinity` hint registered for `Node/UpdateNodeLabel` compares `oldObj` and
 `newObj` node labels against the Job's node selector. It returns `HintWakeup`
 only when the new labels may satisfy the selector, and `HintSkip` otherwise.
+
+Resource Fit shows how the optional index narrows that final evaluation:
+
+1. A task requests CPU and fails Resource Fit on `node-a`. The rejection records
+   the key `pod-release/node-a/cpu`.
+2. Deleting a memory-only Pod on `node-a` produces
+   `pod-release/node-a/memory`. The keys do not match, so the rejected Job is not
+   a candidate for this event.
+3. Deleting a CPU-consuming Pod on `node-a` produces
+   `pod-release/node-a/cpu`. The key matches, so the cache runs Resource Fit's
+   `JobHintFn` for the Job.
+4. `JobHintFn`, not the key match, makes the final `HintWakeup` or `HintSkip`
+   decision.
 
 #### Registration
 
@@ -247,8 +329,10 @@ type HintRegistry struct {
     eventsByPlugin map[string][]ClusterEventWithHint
 }
 
-// Register calls p.EventsToRegister(context.TODO()) once. A successful non-empty
-// result replaces the plugin entry; an error or empty result removes it.
+// Register calls p.EventsToRegister(context.TODO()) once. A successful, non-empty,
+// and valid result replaces the plugin entry. An error, an empty result, or
+// duplicate declarations for one ClusterEvent remove the plugin entry and log the
+// registration failure.
 //
 //   @param name plugin name used as the map key; must match Rejection.Plugin so
 //               RecordUnschedulable can look the hints up by rejecting plugin.
@@ -261,6 +345,18 @@ Overwriting matches `BinderRegistry`'s replacement behavior. `HintRegistry` and
 registry, so that each extension point keeps its own registration signature, and the
 cache still has a single place to hold every session-to-cache extension.
 
+One plugin may register at most one declaration for the same `ClusterEvent`. If a
+registration contains duplicates, the registry logs the error and removes that
+plugin's registry entry; already-recorded Jobs keep their copied declarations.
+Across later registrations under the same plugin name, `JobKeysFn`, `EventKeysFn`, and the
+`HintKey` format for an existing event must keep the same meaning. This
+scheduler-lifetime stability rule lets old and new records safely share one event
+plugin/action index without a generation identifier. The registry rejects a
+re-registration that switches an existing event between indexed and non-indexed
+handling. A plugin that needs to change its key meaning must use a new plugin name
+or restart the scheduler. `HintFn` may be replaced because each Job record keeps
+the version copied when that record was created.
+
 `HintRegistry` is the only bridge from session-scoped plugins to cache-scoped
 dispatch. §3 covers how `RecordUnschedulable` reads from it at `CloseSession`, and §4 covers how
 informer handlers reach the cache through it.
@@ -268,17 +364,29 @@ informer handlers reach the cache through it.
 ### 2. Failure Recording
 
 The cache stores one `Rejection` per plugin and extension point that rejected a
-Job. Repeated failures merge their task IDs. Different tasks can therefore
-accumulate different predicate rejections, while `Allocatable` and
-`JobEnqueueable` record the first rejecting plugin in their callback chain.
+Job. Repeated failures merge their task IDs and secondary-index keys. Different
+tasks can therefore accumulate different predicate rejections, while
+`Allocatable` and `JobEnqueueable` record the first rejecting plugin in their
+registered function chain.
 
 ```go
 // Rejection describes one plugin decision that made a Job unschedulable in a session.
 type Rejection struct {
-    Plugin string          // registered HintProvider name, e.g. "NodeAffinity".
-    Source RejectionSource // extension point that emitted the rejection.
-    Tasks  []TaskID        // failed task IDs; nil only for RejectionEnqueue.
-    Queues []QueueID       // Job Queue followed by its known ancestors.
+    // Plugin is the registered HintProvider name, for example "NodeAffinity".
+    Plugin string
+
+    // Source is the extension point that emitted the rejection.
+    Source RejectionSource
+
+    // Tasks contains the rejected task IDs. It is nil only for RejectionEnqueue.
+    Tasks []TaskID
+
+    // Queues contains the Job's Queue followed by its known ancestors.
+    Queues []QueueID
+
+    // HintKeys contains the complete secondary-index keys collected while this
+    // rejection was produced. It is nil when complete keys are unavailable.
+    HintKeys []HintKey
 }
 
 type RejectionSource string
@@ -289,6 +397,20 @@ const (
     RejectionEnqueue     RejectionSource = "enqueue"     // JobEnqueueable
 )
 ```
+
+The scheduler records `Rejection.HintKeys` at the point where a failure occurs,
+because that code still has the rejected task, rejected node, and insufficient
+resource dimensions. Repeated rejections for the same `(Plugin, Source)` merge
+and deduplicate both `Tasks` and `HintKeys`. The 256-key limit applies after the
+merge. If any merged rejection lacks complete keys, or if the merged result
+exceeds the limit, `HintKeys` becomes nil. The cache then evaluates this Job for
+every event in each matching plugin/action index.
+
+When the cache records the Job, each event declaration runs its `JobKeysFn` to
+validate the rejection keys and select only the keys relevant to that event. For
+example, the Resource Fit declaration for `Pod/Delete` selects Pod-release keys
+and ignores Node-growth keys. `JobKeysFn` cannot make incomplete rejection data
+complete; it must return an error or no keys instead.
 
 Both `RejectionPredicate` and `RejectionAllocatable` carry `Tasks`, because
 their extension points run per task and can fail for a subset of a Job's tasks.
@@ -321,7 +443,16 @@ synthetic plugin name `predicates-resource-fit` and records them as
 `RejectionPredicate` on the same footing as any other per-task predicate
 failure. The synthetic plugin registers hints on capacity-changing events
 (`Node/Add`, `Node/UpdateNodeAllocatable`, `Pod/Delete`) so the wake path
-works the same way as other predicates.
+works the same way as other predicates. It also records the rejected node and
+insufficient resource dimensions as secondary-index keys for every candidate node
+that failed Resource Fit in the completed scheduling attempt. Deleting a
+CPU-consuming Pod on `node-a` therefore selects every Job whose complete failure
+set contains a CPU shortage on `node-a`, including Jobs that also failed on other
+nodes. It does not select a Job when its complete Resource Fit failure set contains
+no CPU shortage on `node-a`; if the scheduler cannot build that complete set, the
+Job is dispatched without HintKeys instead of using precise selection. `Node/Add` uses
+resource-dimension keys without an old node name, so a newly added node can still
+reach every Job whose requested dimensions it may satisfy.
 
 #### Recording rejections
 
@@ -434,7 +565,7 @@ through the normal filter path every session, which matches today's behavior.
 
 `UnschedulableJobCache` lives on `SchedulerCache`. It records unschedulable Jobs by
 `JobID`, together with the rejection list collected at `CloseSession` and the hint
-callbacks copied from `HintRegistry`.
+functions copied from `HintRegistry`.
 
 The normal retry lifecycle is:
 
@@ -467,7 +598,7 @@ stateDiagram-v2
     Evaluating --> Cached: CloseSession RecordUnschedulable
     Cached --> Cached: GetCachedRejections applied
     Cached --> Cached: hint = HintSkip
-    Cached --> Evaluating: ForgetUnschedulable (hint / PodGroup / watchdog)
+    Cached --> Evaluating: ForgetUnschedulable (hint / workload / watchdog)
     Progressing --> [*]
 ```
 
@@ -491,8 +622,9 @@ so the next `OpenSession` finds none and evaluates the Job normally:
    If every hint returns `HintSkip`, the record is kept and the Job stays **Cached**
    (the `Cached → Cached` self-loop). This is the primary path, since a real cluster
    change plausibly fixes the earlier rejection.
-2. **PodGroup change (invalidation).** A spec update or delete forgets the record
-   directly; status-only updates remain hint events.
+2. **Workload change (snapshot invalidation).** A Pod add, scheduling-input
+   update, or delete forgets the record for that Pod's Job. A PodGroup spec update
+   or delete does the same. PodGroup status-only updates remain hint events.
 3. **RetryAfter watchdog (safety net).** A background goroutine runs on a fixed
    interval and forgets any record whose `RetryAfter` has passed. It runs off the
    scheduling path, so it does not add scanning work to `OpenSession`, and it
@@ -505,8 +637,12 @@ so the next `OpenSession` finds none and evaluates the Job normally:
 // UnschedulableCache stores Jobs rejected in previous scheduling sessions and
 // exposes the operations needed by scheduler sessions.
 type UnschedulableCache interface {
-    // AddHintProvider registers a plugin's event subscriptions and hint callbacks.
+    // AddHintProvider registers the events and hint functions declared by a plugin.
     AddHintProvider(name string, p api.HintProvider)
+
+    // BeginSession records the freshness boundary immediately before the
+    // scheduler takes the session snapshot.
+    BeginSession()
 
     // RecordUnschedulable stores the plugin rejections observed for a Job in the
     // current session.
@@ -526,29 +662,83 @@ type UnschedulableCache interface {
 
 #### Cache state
 
-The cache keeps one record per Job, plus a reverse index so `OnEvent` can find
-the affected Jobs without scanning every record:
+The cache keeps one primary record per Job. Its event index first classifies Jobs
+by `EventResource`, then uses the plugin name and `ActionType` to distinguish how
+different plugins handle events of the same resource. The plugin name must be in
+the second-level key because two plugins can use different HintKey meanings and
+different `EventKeysFn` implementations for the same resource and action.
+
+Each plugin/action index stores all of its Job IDs for extraction-error fail-open,
+the Job IDs for which complete HintKeys were unavailable, and precise Job-ID sets
+for each HintKey. The field names describe the contents directly instead of
+encoding the dispatch policy in names such as `bucket` or `fallback`.
 
 ```go
-// UnschedulableJobCache stores rejected Jobs and routes matching cluster events
-// to their captured hint callbacks.
+// eventIndex first classifies indexes by EventResource, then by plugin/action.
+type eventIndex struct {
+  jobIndexesByResource map[fwk.EventResource]map[pluginActionKey]*pluginActionIndex
+  wildcardJobIndexes   map[pluginActionKey]*pluginActionIndex
+}
+
+// pluginActionKey further classifies one EventResource. pluginName separates
+// plugin-owned HintKey spaces and actionType identifies the handled change.
+type pluginActionKey struct {
+  pluginName string
+  actionType fwk.ActionType
+}
+
+// pluginActionIndex pairs event-side key extraction with indexed Job IDs.
+type pluginActionIndex struct {
+  eventHintKeysFn api.EventKeysFn
+  jobs            jobHintKeyIndex
+}
+
+type jobHintKeyIndex struct {
+  // allJobIDs supports fail-open dispatch when event key extraction fails.
+  allJobIDs sets.Set[api.JobID]
+
+  // jobIDsWithoutHintKeys contains Jobs for which complete keys are unavailable.
+  jobIDsWithoutHintKeys sets.Set[api.JobID]
+
+  // jobIDsByHintKey selects Jobs sharing a necessary-condition key.
+  jobIDsByHintKey map[api.HintKey]sets.Set[api.JobID]
+}
+
+// jobIndexLocation identifies one index location containing a Job. It lets
+// replacement and deletion remove the Job without scanning every index. An
+// empty hintKeys slice means the Job is in jobIDsWithoutHintKeys.
+type jobIndexLocation struct {
+  resource        fwk.EventResource
+  pluginActionKey pluginActionKey
+  hintKeys        []api.HintKey
+}
+
+// freshnessTracker rejects stale session conclusions. All methods run while
+// UnschedulableJobCache.mu is held.
+type freshnessTracker struct {
+  currentGeneration   uint64
+  sessionGeneration   uint64
+  sessionStarted      bool
+  lastEventGeneration map[api.ClusterEvent]uint64
+  lastJobInvalidation map[api.JobID]uint64
+}
+
+// UnschedulableJobCache stores rejected Jobs and finds the Jobs that must
+// evaluate each incoming cluster event.
 type UnschedulableJobCache struct {
     mu sync.RWMutex
 
     // records is the primary store: one entry per cached Job.
     records map[api.JobID]*unschedulableRecord
 
-    // byResource narrows event dispatch to Jobs interested in a resource.
-    // wildcard holds Jobs subscribed to fwk.WildCard as the resource.
-    byResource map[fwk.EventResource]sets.Set[api.JobID]
-    wildcard sets.Set[api.JobID]
+    // eventIndex narrows an incoming resource/plugin/action event to candidates.
+    eventIndex eventIndex
 
     // registry provides the latest plugin hint declarations for new records.
     registry *HintRegistry
 
-    // jobGetter returns a cloned JobInfo snapshot under the SchedulerCache lock,
-    // or nil when the Job is gone.
-    jobGetter func(api.JobID) *api.JobInfo
+    // freshness prevents caching results computed from an outdated snapshot.
+    freshness freshnessTracker
 
     // maxSkipDuration bounds how long a record can suppress retries.
     maxSkipDuration time.Duration
@@ -556,37 +746,65 @@ type UnschedulableJobCache struct {
 
 // unschedulableRecord is the cached state for one Job.
 type unschedulableRecord struct {
-    // jobID identifies the cached Job; rejections drive Skip derivation in the
-    // next OpenSession.
-    jobID      api.JobID
+    // jobID identifies the cached Job.
+    jobID api.JobID
+
+    // job is the immutable JobInfo from the completed scheduling session.
+    // A workload update invalidates the record before this value can become stale.
+    job *api.JobInfo
+
+    // rejections contains the plugin decisions reused by the next session.
     rejections []api.Rejection
 
     // lastFailedAt and retryAfter define the watchdog retry window.
     lastFailedAt time.Time
     retryAfter   time.Time
 
-    // subscriptions and resources are snapshots, not references to the registry.
-    subscriptions []hintSubscription
-    resources     sets.Set[fwk.EventResource]
+    // eventHints contains plugin event handlers copied when the Job is recorded.
+    eventHints []pluginEventHint
+
+    // indexLocations records every index location containing this Job.
+    indexLocations []jobIndexLocation
 }
 
-// hintSubscription pairs a plugin name with its hint callback, plus the plugin's
-// own Rejection so the callback can inspect the exact decision it made in the
-// previous session.
-type hintSubscription struct {
-    plugin    string
-    event     api.ClusterEvent
+  // pluginEventHint is one event handler copied for one plugin rejection.
+  type pluginEventHint struct {
+    pluginName string
+
+    // event identifies the cluster change that can affect the rejection.
+    event api.ClusterEvent
+
+    // rejection is the plugin decision from the completed session.
     rejection api.Rejection
-    hintFn    api.JobHintFn
+
+    // jobHintKeysFn produces the Job's necessary-condition keys at insertion.
+    jobHintKeysFn api.JobKeysFn
+
+    // eventHintKeysFn produces the keys carried by an incoming event.
+    eventHintKeysFn api.EventKeysFn
+
+    // jobHintFn makes the final decision for this Job.
+    jobHintFn api.JobHintFn
 }
 ```
 
-`subscriptions` holds the same `(event, hintFn)` pairs a plugin declares through
-`ClusterEventWithHint` (§1), narrowed to the plugins that rejected this Job and
-indexed by resource for fast candidate lookup. A nil `HintFn` wakes only after its
-event matches; it is unrelated to the resource wildcard. `RecordUnschedulable`
-builds it by looking each rejection's plugin up in the cache's global
-`HintRegistry` and copying the matching entries.
+`RecordUnschedulable` looks up each rejecting plugin in `HintRegistry` and copies
+that plugin's event declarations into `eventHints`. It then creates one
+`jobIndexLocation` for each copied declaration. If both key functions are
+present and `JobKeysFn` returns a complete key set, the location records those
+keys. Otherwise its `hintKeys` is empty and the Job is inserted into
+  `jobIDsWithoutHintKeys`. A declaration with a nil `HintFn` also records the Job
+  without HintKeys because every matching event must wake it.
+
+`freshnessTracker` handles a separate correctness problem: an event can arrive
+after the scheduler takes its session snapshot but before `CloseSession` records
+the rejection. There is no record to wake when that event arrives. `BeginSession`
+therefore captures `sessionGeneration`; every external event and direct Job
+invalidation advances `currentGeneration`. Before insertion,
+`RecordUnschedulable` rejects the stale conclusion if the Job changed after the
+boundary or if any registered event matching `eventHints` occurred after it.
+Grouping these fields in `freshnessTracker` keeps snapshot freshness independent
+from candidate indexing.
 
 It is a **snapshot** rather than a live reference to `HintRegistry`. A Job
 cached in an earlier session must keep waking the same way it was recorded,
@@ -598,10 +816,10 @@ down.
 
 | Call site | Cache call | Meaning |
 |---|---|---|
-| `CloseSession`, evaluated Job still pending | `RecordUnschedulable(job, rejections)` | Store or replace the record and rebuild event subscriptions. |
+| `CloseSession`, evaluated Job still pending | `RecordUnschedulable(job, rejections)` | Store or replace the record and rebuild its plugin event hints. |
 | `OpenSession`, pending Job | `GetCachedRejections(job)` | Return the previous session's rejections, or nil to evaluate the Job normally. |
 | `CloseSession`, Job became ready or gained a pipelined task | `ForgetUnschedulable(job.UID)` | Remove the record. |
-| PodGroup spec update/delete informer | `ForgetUnschedulable(jobID)` | Job spec/lifecycle changed; evaluate it again. |
+| Pod add/update/delete or PodGroup scheduling-input update/delete informer | `ForgetUnschedulable(jobID)` | The cached session snapshot may be stale; evaluate the current Job again. |
 | Subscribed cluster event (informer) | `OnEvent(ev, oldObj, newObj)` | Run matching hints and wake Jobs that may need retry. |
 | Watchdog goroutine, `now >= RetryAfter` | `ForgetUnschedulable(jobID)` | Off-path cleanup of stale records so a Job is never cached forever. |
 
@@ -630,7 +848,8 @@ A record is removed or bypassed by these triggers:
 | Trigger | Effect |
 |---|---|
 | A subscribed cluster event whose hint returns `HintWakeup` or errors | `ForgetUnschedulable` (via `OnEvent`) |
-| `PodGroup` spec update or delete | `ForgetUnschedulable` (from the informer handler) |
+| A Pod add, scheduling-input update, or deletion belonging to the Job | `ForgetUnschedulable` directly; the event is still delivered to other Jobs' hints |
+| `PodGroup` spec update or delete | `ForgetUnschedulable` directly |
 | `now >= RetryAfter` | the watchdog calls `ForgetUnschedulable`; the next session re-evaluates the Job |
 
 `RecordUnschedulable` sets retry timing like this:
@@ -650,34 +869,135 @@ declare which events they care about through `HintRegistry` (§1). Scheduler-cac
 informer handlers are installed when the cache is constructed and deliver supported
 events through `OnEvent`.
 
-#### Subscribed event set
+#### Registered event set
 
-`OnEvent` finds candidate records by resource and then matches the action on each
-subscription. Node and Pod updates use kube-scheduler's classified actions. A Pod
-transitioning to a terminal phase is treated as `Pod/Delete` because it releases
-its node resources.
+`OnEvent` first selects `jobIndexesByResource[ev.Resource]`, then checks whether
+`ev.ActionType` matches each `pluginActionKey.actionType`. It also checks
+`wildcardJobIndexes`. This can select multiple plugin/action indexes for one
+incoming event. Node and Pod updates use kube-scheduler's classified actions. A
+Pod transitioning to a terminal phase is treated as `Pod/Delete` because it
+releases its node resources.
 
 #### Handler registration
 
 Volcano dispatches into `UnschedulableJobCache` beside the existing cache-update
-handlers on supported informers. Each handler
-normalizes the informer callback into a `ClusterEvent` and calls
+handlers on supported informers. Each handler converts an informer notification
+into a `ClusterEvent` and calls
 `UnschedulableJobCache.OnEvent(ev, oldObj, newObj)`. PodGroup spec updates and
 deletes invalidate the Job directly, while status updates are delivered to hints.
+Pod add, scheduling-input update, and delete handlers also invalidate the Pod's own
+Job directly before delivering the event to other Jobs, because the retained
+session snapshot no longer represents that Job.
 
 #### Delivery
 
-`OnEvent` uses the `byResource` / `wildcard` index (§3) to find candidate records
-subscribed to the event, runs each Job's matching hints, and forgets a Job as
-soon as one hint returns `HintWakeup`. A hint that returns an error is treated
-as `HintWakeup` too, so a broken hint can never keep a Job cached forever. Jobs
-whose hints all return `HintSkip` stay cached until another event fires or the
-`RetryAfter` watchdog (§3) lets them retry.
+`OnEvent` processes each matching plugin/action index in four steps:
 
-The cache lock is held only while copying candidate IDs and immutable subscription
-snapshots. `JobHintFn` callbacks run after the lock is released, so plugin code cannot
-block cache reads/writes or create lock-order cycles. Delete handlers unwrap
+1. If the index has an `EventKeysFn`, run it once for the incoming event.
+2. If it returns one or more keys, select the union of Jobs stored under those
+  keys in `jobIDsByHintKey` and Jobs in `jobIDsWithoutHintKeys`. If it returns
+  zero keys with no error, select only `jobIDsWithoutHintKeys`. If it errors or
+  exceeds the key limit, select every Job in `allJobIDs`. The selected records
+  are the candidate Jobs.
+3. Run the matching `JobHintFn` for each candidate Job.
+4. Forget a Job as soon as one hint returns `HintWakeup` or an error. Keep the Job
+   cached if every matching hint returns `HintSkip`.
+
+Treating a hint error as `HintWakeup` prevents a faulty hint from keeping a Job
+cached forever. A Job whose hints all return `HintSkip` remains cached until
+another event fires or the `RetryAfter` watchdog (§3) lets it retry.
+
+The cache lock is held only while copying candidate IDs and immutable plugin
+event snapshots. `JobHintFn` functions run after the lock is released, so plugin code
+cannot block cache reads/writes or create lock-order cycles. Delete handlers unwrap
 `cache.DeletedFinalStateUnknown` before dispatching the concrete object to hints.
+
+#### Dispatch cost model
+
+High-rate events need a different cost analysis from `OpenSession`. The equations
+below describe one matching plugin/action index, which is the Resource Fit
+benchmark configuration. When one event matches multiple indexes, event-key
+extraction costs are summed across those indexes, candidate Job IDs are
+deduplicated, and a candidate may run more than one matching `JobHintFn` until one
+wakes it. For example,
+Resource Fit subscribes to `Pod/Delete`, so a busy cluster may deliver many events
+between two scheduling sessions. The cache narrows the work in two stages:
+
+```text
+J: all cached Jobs
+  -> EventResource, then pluginName + ActionType lookup
+N: Jobs in matching pluginActionIndex.jobs.allJobIDs
+  -> jobIDsByHintKey matches union jobIDsWithoutHintKeys
+K: candidate Jobs whose final HintFn runs
+```
+
+The EventResource and `pluginActionKey` lookup makes the first reduction from `J`
+to `N`: Jobs rejected by another plugin or registered for another action are not
+considered. HintKey lookup makes the second reduction from `N` to `K`. `K`
+includes both precise key matches and `jobIDsWithoutHintKeys`, with duplicates
+removed, so `K <= N`.
+
+Let `R` be the event rate and `T_hint` the cost of one final `HintFn` evaluation.
+Without secondary keys, every event evaluates all Jobs in the matching
+plugin/action index:
+
+```text
+event cost per second = R * N * T_hint
+```
+
+With secondary keys, let `T_index` be the cost of creating the event keys and
+looking them up:
+
+```text
+event cost per second = R * (T_index + K * T_hint)
+```
+
+This addresses only event handling. To decide whether the cache is beneficial as
+a whole, compare it with the redundant scheduling work it removes. Let `S` be the
+scheduling-session rate, `T_filter` the filter work for one unchanged
+unschedulable Job in one session, and `W` the number of cached Jobs per second
+returned to normal filtering by hint wake-ups, hint errors, direct workload
+invalidation, or watchdog expiry. The following comparison isolates the filter and
+event-dispatch terms raised by high `Pod/Delete` churn; benchmarks measure record
+insertion, cache lookup, and removal costs separately:
+
+```text
+cache disabled: S * N * T_filter
+cache enabled:  R * (T_index + K * T_hint) + W * T_filter
+```
+
+The cache is a net CPU win when the enabled cost is lower than the disabled cost.
+If there is no secondary index, then `K = N`. Ignoring `T_index` and `W` shows the
+high-churn concern directly:
+
+```text
+T_hint < (S / R) * T_filter
+```
+
+At one session per second and 50 events per second, each hint would need to be
+about 50 times cheaper than the avoided filter work. The secondary index changes
+that threshold. Let `p = K / N` be the fraction of the plugin/action index selected for
+final hint evaluation:
+
+```text
+T_hint < (S / (R * p)) * T_filter
+```
+
+This threshold applies when `p > 0`; the required cost ratio is relaxed by
+`N / K`. When `K = 0`, no final hint runs and the event term is only `R * T_index`.
+This is the reason for adding the Resource Fit index: a Pod deletion normally
+names one node and the resource dimensions it releases, so unrelated Resource Fit
+rejections stay out of `K`. The model does not assume that `K` is always small. If
+all Jobs share a key, or many Jobs are in `jobIDsWithoutHintKeys`, `K` approaches
+`N` and the index provides little benefit.
+
+The index adds memory as well as CPU work. If `H` is the total number of Job-key
+entries in a plugin/action index, `jobIDsByHintKey` uses `O(H)` additional
+entries alongside `allJobIDs` and `jobIDsWithoutHintKeys`. The 256-key limit
+bounds one Job's contribution. An absent, failing, empty, or over-limit
+`JobKeysFn` records that Job in `jobIDsWithoutHintKeys`. A failing or over-limit
+`EventKeysFn` selects `allJobIDs`. These fail-open paths cannot suppress a wake-up
+that the final `HintFn` could produce.
 
 ```mermaid
 sequenceDiagram
@@ -688,7 +1008,7 @@ sequenceDiagram
     Informer->>Dispatch: Add / Update / Delete object
     Dispatch->>Dispatch: normalize to ClusterEvent
     Dispatch->>UJC: OnEvent(ev, oldObj, newObj)
-    UJC->>UJC: look up candidates via byResource / wildcard
+    UJC->>UJC: look up resource/plugin/action indexes and optional HintKeys
     UJC->>UJC: run each Job's matching hints
     UJC-->>UJC: Forget Job on HintWakeup / error
 ```
@@ -697,13 +1017,12 @@ sequenceDiagram
 
 ```mermaid
 flowchart TD
-    A[OnEvent receives ClusterEvent] --> B[Find candidates via byResource / wildcard]
-    B --> C{Job still pending in SchedulerCache?}
-    C -- no --> D[Forget record]
-    C -- yes --> E[Run the Job's matching hints]
-    E --> F{Any hint returns HintWakeup or errors?}
-    F -- yes --> D
-    F -- no --> G[Keep record cached]
+    A[OnEvent receives ClusterEvent] --> B[Find resource then plugin/action indexes]
+  B --> C[Select and deduplicate candidate Job records]
+  C --> D[Run each candidate Job's matching hints]
+  D --> E{Any hint returns HintWakeup or errors?}
+  E -- yes --> F[Forget record]
+  E -- no --> G[Keep record cached]
 ```
 
 Any subscribed plugin can wake the Job. Waking only lifts the cached skip. The
@@ -784,6 +1103,12 @@ can invoke the upstream hints directly without reimplementing them. Volcano's
 uses the upstream plugin name (for example, `NodeAffinity`) as its stable identity.
 `RecordUnschedulable` uses that name to copy only the hints for filters that actually rejected the Job.
 
+The adapter intentionally does not duplicate upstream plugin semantics in
+secondary-index key functions in the Alpha release. Wrapped plugins therefore
+evaluate every Job in the matching plugin/action index with their upstream
+`QueueingHintFn`. A wrapped plugin can add a secondary index later without
+changing the cache API.
+
 #### From per-Pod to per-Job
 
 The upstream `QueueingHintFn` is Pod-level. It answers "could this event make
@@ -794,7 +1119,7 @@ func(logger klog.Logger, pod *v1.Pod, oldObj, newObj any) (fwk.QueueingHint, err
 ```
 
 Volcano's `JobHintFn` asks the same question for a whole Job. `wrapPodHint`
-turns the per-Pod callback into a per-Job one. `Rejection.Tasks` (§2) records
+turns the per-Pod hint function into a per-Job hint function. `Rejection.Tasks` (§2) records
 exactly the task IDs that failed this filter in the previous session, so the
 wrapper runs the upstream hint only for those Pods — other tasks passed the
 filter and cannot be why the Job is blocked on it.
@@ -843,8 +1168,14 @@ Jobs. Everything else follows as its rejection path is wired up.
 | `InterPodAffinity`, `PodTopologySpread` | PodTopology | adapter | `Pod/Add`, `Pod/Delete`, `Node/UpdateNodeLabel` |
 | `NodeVolumeLimits`, `VolumeZone`, `VolumeBinding` | Storage | adapter | PVC/PV/StorageClass/CSINode events |
 | `DynamicResources` | Device | adapter | ResourceClaim/DeviceClass/Node allocatable events |
-| `predicates-resource-fit` | Resource | native (synthetic) | §2 synthetic name for `allocate`'s inline node-fit check; `Node/Add`, `Node/UpdateNodeAllocatable`, `Pod/Delete` |
+| `predicates-resource-fit` | Resource | native (synthetic, indexed) | §2 synthetic name for `allocate`'s inline node-fit check; indexed by rejected task, node, and insufficient resource dimension |
 | `capacity`, `proportion` | Queue | native | Queue, PodGroup completion/deletion, Pod deletion |
+
+P0 describes HintProvider coverage, not secondary-index coverage. Resource Fit
+is the only provider-specific secondary index in the Alpha implementation. The
+other native and adapted providers initially evaluate every Job in the matching
+plugin/action index with their final `HintFn`. Selective indexes can be added independently
+after measuring their event rates and the number of Jobs evaluated per event.
 
 **P1 — follow-up**
 
@@ -861,7 +1192,7 @@ Jobs. Everything else follows as its rejection path is wired up.
 |---|---|---|---|
 | `network-topology-aware` | HyperNode | native | HyperNode, node label events |
 
-**No `HintProvider` (fallback)**
+**Plugins without `HintProvider`**
 
 `extender`, and any other plugin that does not implement `HintProvider`, keep
 today's behavior: Jobs they reject are not cached and go through the normal
@@ -871,10 +1202,10 @@ filter path every session.
 
 | Risk | Mitigation |
 |---|---|
-| A hint misses a relevant event, keeping a Job cached too long. | Fail open on hint errors; the `RetryAfter` watchdog forgets the record; rejections from plugins without a `HintProvider` are not cached at all (§7). |
-| Stale plugin registrations after a re-register. | `RecordUnschedulable` snapshots the hints at cache-write time; later registrations only apply to new records, and old records are bounded by the watchdog. |
+| A hint misses a relevant event, keeping a Job cached too long. | Treat hint errors as `HintWakeup`; the `RetryAfter` watchdog forgets the record; rejections from plugins without a `HintProvider` are not cached at all (§7). |
+| A plugin changes its secondary-index meaning after Jobs have been recorded. | A plugin's key functions and key format must remain stable for the scheduler process lifetime; changing them requires a new plugin name or scheduler restart. Each record still snapshots its final `HintFn`. |
 | Fairness drift from skipping Jobs. | Cached Jobs stay in `ssn.Jobs`; DRF, capacity, proportion and gang accounting see the full pending demand (§5). |
-| Hot `Pod` event path spending time on unrelated Jobs. | `byResource` / `wildcard` index dispatches only to records subscribed to the event; hints for others never run. |
+| Hot `Pod` event path spending time on unrelated Jobs. | Resource/plugin/action indexes exclude unrelated Jobs; optional necessary-condition keys further reduce the Jobs that need final hint evaluation. Incomplete keys safely select every Job ID in the matching index. |
 | Preemption progress suppressed by the cache. | Jobs with pipelined tasks are excluded from the cache (§3, §5), so `preempt`/`reclaim` retries are never skipped. |
 
 ## Alternatives Considered
@@ -882,7 +1213,7 @@ filter path every session.
 - **All-plugins-must-return-`HintWakeup` policy.** Rejected. Needs per-plugin wake state on each record, and one missed hint leaves the Job stuck until the watchdog.
 - **Drop unschedulable Jobs from `ssn.Jobs`.** Rejected. DRF, capacity and proportion need to see pending demand or fairness drifts.
 - **Persist records in PodGroup status or annotations.** Rejected. Adds API-server writes on every rejection and races with user updates. Records live in memory and rebuild from the first post-restart session.
-- **Reimplement kube-scheduler hints in Volcano.** Rejected. The upstream callback API is public and already captures plugin-specific logic; wrapping it costs adapter code once.
+- **Reimplement kube-scheduler hints in Volcano.** Rejected. The upstream hint API is public and already captures plugin-specific logic; wrapping it costs adapter code once.
 - **Task-granularity cache records.** Rejected as the cache key, though task-level
   detail is still kept inside each Job record. Volcano schedules and gates at
   Job/PodGroup granularity, so `GetCachedRejections`, gang thresholds and the action
@@ -896,40 +1227,36 @@ filter path every session.
 
 ## Test Plan
 
-**Unit tests**
+The unit tests cover internal safety rules. End-to-end tests focus on common user
+workflows rather than repeating every internal fail-open variant.
 
-Standard package-level unit tests cover the core logic: `HintRegistry` lifecycle
-and re-registration; rejection recording at each extension point (`PredicateFn`,
-`Allocatable`, `JobEnqueueable`, plus the synthetic `predicates-resource-fit`);
-`UnschedulableJobCache` operations (`RecordUnschedulable`, `GetCachedRejections`,
-`ForgetUnschedulable`, `OnEvent`, watchdog expiry, `byResource` / `wildcard`
-dispatch, hint-error fail-open); `ComputeSkip` against Job, role, and flat SubJob
-thresholds; and the
-`predicates` adapter's per-Pod-to-per-Job aggregation.
+### Unit tests
 
-**Benchmarks**
+| Area | Core coverage |
+|---|---|
+| Registration and recording | `HintRegistry` lifecycle; duplicate-event rejection; rejections from `PredicateFn`, `Allocatable`, `JobEnqueueable`, and `predicates-resource-fit`; merging task IDs and keys. |
+| Cache lifecycle | Record, read, replace, forget, event wake-up, watchdog expiry, and direct Pod/PodGroup invalidation. |
+| Secondary-index safety | Matching and non-matching keys; mixed indexed Jobs and Jobs without HintKeys; empty, erroneous, incomplete, and over-limit keys; index cleanup after replacement and removal. |
+| Resource Fit | Keys for every node and insufficient resource dimension; a Pod deletion on any recorded node selects the Job; a release on an unrelated node or dimension does not. |
+| Scheduling behavior | Whole-Job and task-subset `ComputeSkip`; per-Pod to per-Job upstream hint aggregation; hint errors treated as `HintWakeup`; nil hints select all Job IDs in the matching plugin/action index. |
 
-`benchmark/testcases/unschedulable-job-cache/`: 5,000 pending PodGroups with mixed
-rejection sources. Compare `allocate` latency, session duration, bind throughput,
-and cache memory before and after the cache is enabled.
+### Benchmarks
 
-**End-to-end**
+| Workload | Comparison | Main measurements |
+|---|---|---|
+| Continuous schedulable Job arrivals behind unchanged unschedulable Jobs | Cache disabled vs enabled | Job/Pod throughput, session latency, predicate calls, scheduler CPU. |
+| Sustained `Pod/Delete` churn | Cache disabled vs all-Job-ID dispatch vs Resource Fit indexing | Event CPU, `N`, `K/N`, hint evaluations, wake-ups, session latency, and retained memory. |
+| Dispatch microbenchmark | All-Job-ID dispatch vs indexed dispatch at several `K/N` values | Time and allocations per event; record/replace cost at the key limit. |
 
-- **Wake on a matching cluster event.** A Job blocked on a node label is
-  cached after the first session; adding a node with the matching label
-  drops the record and places the Job in the next session.
-- **Gang whole-Job skip.** A gang Job whose `minAvailable` is unreachable in
-  the current cluster is cached; no task is popped for it until a `Pod/Delete`
-  frees enough capacity, at which point the record wakes and the Job is
-  placed.
-- **Task-subset skip.** An elastic gang Job whose `minAvailable` is already met
-  by running tasks has extra tasks rejected on capacity; later sessions skip
-  only those cached tasks and keep evaluating the Job's other tasks normally.
-- **Preemption is not suppressed.** A cached Job is chosen as a preemption
-  target; `preempt` selects victims, `allocate` pipelines the Job's tasks, and
-  the record is dropped instead of refreshed.
-- **Watchdog safety net.** A cached Job whose subscribed events never fire is
-  re-evaluated after the configured maximum skip duration.
+### End-to-end tests
+
+| User scenario | Setup and action | Expected result |
+|---|---|---|
+| Resource shortage recovers | A multi-replica gang Job cannot reach `minAvailable`; deleting a resource-consuming Pod on any candidate node frees enough capacity. | The Job stays cached before the deletion, wakes on the matching `Pod/Delete`, and reaches `minAvailable`. |
+| New capacity appears | A Job is blocked by node resources or labels; add a suitable Node or update the relevant Node property. | The matching hint wakes the Job and normal scheduling places it on the newly suitable Node. |
+| Schedulable Jobs continue to make progress | Keep high-priority, multi-replica unschedulable Jobs pending while continuously submitting lower-priority Jobs that fit. | Cached Jobs do not repeatedly consume the allocation loop, and newly submitted schedulable Jobs continue to bind. |
+| Workload changes while cached | Add, update, or delete a Pod belonging to a cached Job, or update/delete its PodGroup. | The stale record is removed and the next session evaluates the current workload state. |
+| Preemption remains available | A cached high-priority Job can become schedulable by preempting lower-priority tasks. | Preemption still selects victims; a pipelined task removes the cached record and allocation continues normally. |
 
 ## Related Issues
 

--- a/docs/design/unschedulable-job-cache.md
+++ b/docs/design/unschedulable-job-cache.md
@@ -1,0 +1,939 @@
+# Unschedulable Job Cache for Volcano Scheduler
+
+<!-- toc -->
+- [Summary](#summary)
+- [Motivation](#motivation)
+  - [Goals](#goals)
+  - [Non-Goals](#non-goals)
+- [Proposal](#proposal)
+  - [User Stories](#user-stories)
+  - [Architecture](#architecture)
+- [Design Details](#design-details)
+  - [1. Plugin Extension Point](#1-plugin-extension-point)
+  - [2. Failure Recording](#2-failure-recording)
+  - [3. UnschedulableJobCache](#3-unschedulablejobcache)
+  - [4. Event Dispatch](#4-event-dispatch)
+  - [5. Scheduler Action Changes](#5-scheduler-action-changes)
+  - [6. kube-scheduler QueueingHint Adapter](#6-kube-scheduler-queueinghint-adapter)
+  - [7. Initial Plugin Coverage](#7-initial-plugin-coverage)
+- [Risks and Mitigations](#risks-and-mitigations)
+- [Alternatives Considered](#alternatives-considered)
+- [Test Plan](#test-plan)
+- [Related Issues](#related-issues)
+<!-- /toc -->
+
+## Summary
+
+Volcano opens a new scheduling session every second. In each session, it re-runs the
+full filter path for every pending Job, even when nothing has changed for that Job
+since the previous session. In clusters with thousands of pending Pods, this repeated
+work takes up most of the `allocate` action's time and delays newly submitted Jobs.
+
+This proposal adds an event-driven retry mechanism. Each plugin declares which
+cluster events could change its previous unschedulable decision. When a Job stays
+unschedulable at the end of a session, Volcano records the plugins that rejected it
+and later sessions derive enqueue, whole-Job, or task skips from those rejections.
+When one of the declared events arrives, the record is dropped and the Job is
+evaluated normally in the next session.
+
+The first version caches a Job only when every recorded rejection has a registered
+`HintProvider`; otherwise the whole Job follows the normal per-session path.
+
+## Motivation
+
+Volcano's scheduler runs a periodic loop. It opens a new session roughly every second.
+Each session takes a snapshot of the cluster, iterates every pending Job, and runs the
+enabled actions end-to-end. The failure reasons produced in a session are kept only
+for that session and are discarded when the session closes.
+
+As a result, a Job that failed because no node carries the required label is
+re-evaluated against every node in the next session, and in every session after that,
+until either the Job or the cluster changes. When thousands of Jobs are stuck on
+conditions that have not changed, `allocate` spends most of its time producing the
+same negative answers it produced a second ago. This increases the `allocate`
+action's scheduling latency, and newly submitted Jobs that could be scheduled are
+delayed as well.
+
+The session loop itself is not the problem. Two things are missing around it. First,
+each session needs a way to know that nothing relevant has changed for a Job, so the
+retry can be skipped. Second, Volcano needs a way to notice when something relevant
+does change, so the Job can be retried immediately.
+
+### Goals
+
+- Stop re-running the full filter path each session for Jobs whose blocking condition
+  has not changed.
+- Retry a blocked Job promptly when a cluster change happens that could make it
+  schedulable, without waiting for a timeout.
+- Give plugins a first-class way to declare which cluster events are relevant to their
+  unschedulable decisions, so different rejection causes wake on different signals.
+- Preserve fairness and ordering. Only the redundant filter work is skipped; a
+  cached Job still counts as pending demand so DRF shares, queue capacity, and gang
+  `minAvailable` are computed against the same workload as before.
+
+### Non-Goals
+
+- Persisting unschedulable state across scheduler restarts. Records live in memory and
+  are rebuilt from the first post-restart session.
+- Providing hint coverage for every plugin in the first release. Plugins without a
+  hint fall back to per-session evaluation.
+
+## Proposal
+
+The design adds two pieces around Volcano's session loop. Plugins declare a set of
+cluster events that may invalidate their previous rejection. The scheduler cache
+keeps a per-Job record of which plugins blocked the Job in the last session, and
+later sessions derive enqueue, whole-Job, or task skips until one of the subscribed events arrives.
+When such an event arrives, the record is dropped and the Job is evaluated normally
+in the next session.
+
+### User Stories
+
+- **Queue is temporarily full.** A queue reaches its resource limit and every Job in
+  it fails the `capacity` check. Volcano stops retrying these Jobs each session. They
+  wake up when another Job in the queue finishes or an operator raises the limit.
+
+- **Job requires a node that does not exist yet.** A Job needs a GPU node label that
+  no current node carries. Today Volcano gets the same negative answer from every
+  node in every session. With the unschedulable-job cache, the Job is set aside after
+  the first check and woken up when a new node is added or an existing node's labels
+  change.
+
+- **Gang Job is waiting for enough capacity.** A gang Job needs `minAvailable` tasks
+  to fit at once, but the cluster cannot place enough of them. Volcano stops retrying
+  the Job until capacity may have grown: a task from another Job completes, a Pod is
+  deleted, or a new node joins. A `PodGroup` spec update wakes it as well.
+
+### Architecture
+
+kube-scheduler already avoids retrying unchanged unschedulable Pods with an
+event-driven queueing-hint mechanism, which is a useful reference for this design.
+Its scheduling queue keeps three buckets and moves Pods between them:
+
+![kube-scheduler queueing-hint reference](images/kube-scheduler-queueing-hint-workflow.svg)
+
+`activeQ` holds Pods ready to schedule, and the scheduler pops from it. When a Pod
+fails its filters, it is moved to `unschedulablePods` together with the names of the
+plugins that rejected it. Cluster events trigger the failed plugins' `QueueingHintFn`.
+If a hint returns `Queue`, the Pod moves to `backoffQ` if it is still inside its
+backoff window, or directly to `activeQ` if the backoff has already expired. If every
+subscribed hint returns `QueueSkip`, the Pod stays in `unschedulablePods`. A periodic
+watchdog also releases Pods that have been stuck there for too long.
+
+Volcano applies the same idea to its session-based, Job-level scheduling. There are
+no per-Pod queue buckets. Instead, a single `UnschedulableJobCache` lives beside the
+scheduling loop, and is updated from three sources: the session itself, informer
+handlers, and a background watchdog.
+
+![UnschedulableJobCache architecture](images/unschedulable-job-cache.svg)
+
+The scheduler session drives most of the interaction. `OpenSession` derives
+`JobInfo.Skip` from cached rejections. `CloseSession` records unschedulable Jobs and
+forgets records for Jobs that are ready or pipelined.
+
+Informer handlers translate cluster changes into `ClusterEvent`s and call `OnEvent`.
+The cache then runs each subscribed Job's hints and forgets records whose hint
+returns `HintWakeup`. A background watchdog forgets records whose `RetryAfter` has
+passed, which prevents a Job from staying cached forever if a hint is ever missed.
+
+## Design Details
+
+### 1. Plugin Extension Point
+
+`HintProvider` is an optional interface that a plugin implements to declare the
+cluster events that could invalidate its previous unschedulable decisions. Each
+declaration is a `ClusterEventWithHint`, which is a `(ClusterEvent, JobHintFn)` pair.
+`ClusterEvent` names the change to watch, and `JobHintFn` decides, for a given Job,
+whether a particular occurrence of that event may make the Job schedulable. If
+`JobHintFn` is `nil`, every occurrence of the event wakes Jobs blocked by this
+plugin.
+
+#### Types
+
+The shared hint, event, rejection, and skip types live in `pkg/scheduler/api`, which
+both `framework` and `cache` can import without creating a package cycle.
+
+```go
+// ClusterEvent identifies one category of cluster change a plugin subscribes to.
+type ClusterEvent struct {
+    // Resource is the object type whose change may affect scheduling: Node, Pod,
+    // PVC/PV, StorageClass, CSINode, ResourceClaim, ResourceSlice, DeviceClass,
+    // PodGroup, Queue, HyperNode, or NumaInfo.
+    Resource fwk.EventResource
+
+    // ActionType names the kind of change. Besides generic Add/Update/Delete,
+    // node updates are split into label, taint, allocatable and condition
+    // variants so a taint-only change does not wake Jobs blocked on labels.
+    ActionType fwk.ActionType
+}
+
+// HintResult is the decision a JobHintFn returns for one Job on one event.
+type HintResult int
+
+const (
+    HintSkip   HintResult = iota // event cannot unblock this Job; keep it cached.
+    HintWakeup                   // event may unblock this Job; drop the record.
+)
+
+// JobHintFn is invoked when a subscribed cluster event fires for a Job that the
+// plugin previously rejected. It answers one question: could this particular
+// event make the Job schedulable this time?
+//
+//   @param job       the cached Job under evaluation.
+//   @param rejection the plugin's own rejection from the previous session; for
+//                    predicate sources it also carries the task IDs that failed
+//                    (see §2), which lets per-task hints replay only those tasks.
+//   @param oldObj    object state before the change; nil on Add events.
+//   @param newObj    object state after the change; nil on Delete events.
+//   @return HintResult  HintSkip to keep the record, HintWakeup to drop it and
+//                       let the next session evaluate the Job normally.
+//   @return error       a non-nil error is treated as HintWakeup by the caller,
+//                       so a broken hint cannot keep a Job cached forever.
+type JobHintFn func(
+    job *JobInfo,
+    rejection Rejection,
+    oldObj, newObj any,
+) (HintResult, error)
+
+// ClusterEventWithHint pairs one cluster event a plugin cares about with the
+// callback used to check whether that event may help a specific Job. A nil
+// HintFn means every occurrence of Event wakes Jobs blocked by this plugin.
+type ClusterEventWithHint struct {
+    Event  ClusterEvent
+    HintFn JobHintFn
+}
+
+// HintProvider lets a plugin declare the events that can change its previous
+// unschedulable decisions.
+type HintProvider interface {
+    // EventsToRegister returns every (event, hint) pair this plugin subscribes
+    // to. It is called once per registration; the result is stored verbatim.
+    EventsToRegister(ctx context.Context) ([]ClusterEventWithHint, error)
+}
+```
+
+#### Example
+
+A `NodeAffinity` hint registered for `Node/UpdateNodeLabel` compares `oldObj` and
+`newObj` node labels against the Job's node selector. It returns `HintWakeup`
+only when the new labels may satisfy the selector, and `HintSkip` otherwise.
+
+#### Registration
+
+Plugins register during `OpenSession`:
+
+```go
+// AddHintProvider forwards a session-scoped plugin's HintProvider into the
+// cache-scoped HintRegistry so it keeps working after the session tears down.
+//
+//   @param pluginName plugin identity later matched against Rejection.Plugin at
+//                     RecordUnschedulable time; must be stable across sessions.
+//   @param p          the HintProvider; typically the plugin itself when it
+//                     also implements the interface.
+func (ssn *Session) AddHintProvider(pluginName string, p HintProvider)
+```
+
+Plugin objects are session-scoped, but the informer handlers and
+`UnschedulableJobCache` run at scheduler-cache scope and keep firing after the
+session ends. To cross this lifetime gap, `AddHintProvider` copies the plugin's
+`ClusterEventWithHint`s into a cache-owned `HintRegistry`. `HintRegistry` is defined
+in `pkg/scheduler/cache/hint_registry.go` and owned by `SchedulerCache`:
+
+```go
+// pkg/scheduler/cache/hint_registry.go
+
+type HintRegistry struct {
+    mu             sync.RWMutex
+    eventsByPlugin map[string][]ClusterEventWithHint
+}
+
+// Register calls p.EventsToRegister(context.TODO()) once. A successful non-empty
+// result replaces the plugin entry; an error or empty result removes it.
+//
+//   @param name plugin name used as the map key; must match Rejection.Plugin so
+//               RecordUnschedulable can look the hints up by rejecting plugin.
+//   @param p    the HintProvider whose events are being registered.
+func (r *HintRegistry) Register(name string, p HintProvider) { /* ... */ }
+```
+
+Overwriting matches `BinderRegistry`'s replacement behavior. `HintRegistry` and
+`BinderRegistry` are kept as separate types instead of merged into one shared
+registry, so that each extension point keeps its own registration signature, and the
+cache still has a single place to hold every session-to-cache extension.
+
+`HintRegistry` is the only bridge from session-scoped plugins to cache-scoped
+dispatch. §3 covers how `RecordUnschedulable` reads from it at `CloseSession`, and §4 covers how
+informer handlers reach the cache through it.
+
+### 2. Failure Recording
+
+The cache stores one `Rejection` per plugin and extension point that rejected a
+Job. Repeated failures merge their task IDs. Different tasks can therefore
+accumulate different predicate rejections, while `Allocatable` and
+`JobEnqueueable` record the first rejecting plugin in their callback chain.
+
+```go
+// Rejection describes one plugin decision that made a Job unschedulable in a session.
+type Rejection struct {
+    Plugin string          // registered HintProvider name, e.g. "NodeAffinity".
+    Source RejectionSource // extension point that emitted the rejection.
+    Tasks  []TaskID        // failed task IDs; nil only for RejectionEnqueue.
+    Queues []QueueID       // Job Queue followed by its known ancestors.
+}
+
+type RejectionSource string
+
+const (
+    RejectionPredicate   RejectionSource = "predicate"   // PredicateFn / PrePredicateFn
+    RejectionAllocatable RejectionSource = "allocatable" // Allocatable
+    RejectionEnqueue     RejectionSource = "enqueue"     // JobEnqueueable
+)
+```
+
+Both `RejectionPredicate` and `RejectionAllocatable` carry `Tasks`, because
+their extension points run per task and can fail for a subset of a Job's tasks.
+A large-request task can fail queue capacity while a smaller task of the same
+Job passes, and one task can fail predicates on every node while another task
+of the same Job fits. Only `RejectionEnqueue` is Job-level: `JobEnqueueable`
+returns one decision for the whole `PodGroup`, so no task list is stored.
+
+`Plugin` is used to look up the plugin's registered hints when the record is
+built, so the Job only subscribes to events from plugins that actually rejected
+it. `Source` is kept on `Rejection` rather than on the Job, because a
+`RejectionPredicate` and a `RejectionAllocatable` can both occur in one
+`allocate` pass. For example, one task fails predicates on all nodes while
+another passes predicates but exceeds queue quota. `RejectionEnqueue` does not
+appear together with the others, since a Job that fails `JobEnqueueable` does
+not reach `allocate` in that session.
+
+#### Extension point coverage
+
+| Extension point | Source | `Tasks` | Typical plugins |
+|---|---|---|---|
+| `PredicateFn` / `PrePredicateFn`, and `allocate`'s inline node-fit check | `RejectionPredicate` | yes | wrapped predicate plugin names, `predicates-resource-fit` |
+| `Allocatable` | `RejectionAllocatable` | yes | `capacity`, `proportion` |
+| `JobEnqueueable` | `RejectionEnqueue` | — | `capacity`, `proportion`, `overcommit` |
+
+`allocate` runs a resource-fit check inline (`task.InitResreq` against
+`node.FutureIdle`) before calling `PredicateFn`, so pure capacity shortfalls
+never reach a real predicate plugin. Volcano attributes those failures to a
+synthetic plugin name `predicates-resource-fit` and records them as
+`RejectionPredicate` on the same footing as any other per-task predicate
+failure. The synthetic plugin registers hints on capacity-changing events
+(`Node/Add`, `Node/UpdateNodeAllocatable`, `Pod/Delete`) so the wake path
+works the same way as other predicates.
+
+#### Recording rejections
+
+`AddRejection` records each extension-point failure immediately. `CloseSession`
+deduplicates the accumulated rejections and drains them into the cache.
+
+`gang.JobReadyFn` does not produce a rejection. If a gang shortfall is caused
+by real per-task failures, those failures already surface as
+`RejectionPredicate` or `RejectionAllocatable` on the specific tasks that
+could not be placed, and §2's [Skip granularity](#skip-granularity) turns the
+shortfall into either a task-subset or a whole-Job skip in the next session.
+Gang's role stays session-internal: it decides whether the pipelined tasks
+form a viable Job and rolls them back if not.
+
+A Job whose rejection list is empty after this pass is not cached because no
+instrumented extension point reported a stable rejection. Rejections from plugins
+without hints are still recorded, but `RecordUnschedulable` rejects the complete set
+and leaves the Job uncached (see
+[Rejections from plugins without hints](#rejections-from-plugins-without-hints)).
+
+#### Skip granularity
+
+Rejections say which tasks failed which plugin; they do not say how much of
+the Job should be skipped next session. That decision is derived at
+`OpenSession` from the rejections plus the Job's gang topology, and stored on
+`JobInfo.Skip`:
+
+```go
+// SkipDecision is computed once per pending Job at OpenSession from the
+// cached rejections and the Job's gang topology. Each field names the piece
+// of work an action should skip for this Job in this session.
+type SkipDecision struct {
+    // Enqueue skips enqueue's JobEnqueueable re-check for this Job.
+    // Set when RejectionEnqueue was cached.
+    Enqueue bool
+
+    // Allocate skips the allocate and backfill actions entirely for this
+    // Job (no tasks popped, no gang JobReadyFn call). Set when the Job
+    // cannot reach its gang criterion after excluding the per-task
+    // rejections.
+    Allocate bool
+
+    // Tasks lists task IDs that allocate and backfill should treat as
+    // unschedulable this session. Consulted only when Allocate is false;
+    // nil otherwise.
+    Tasks map[TaskID]struct{}
+}
+```
+
+For the two per-task sources (`RejectionPredicate`, `RejectionAllocatable`),
+Volcano picks between two modes:
+
+1. **Task-subset skip.** `Skip.Tasks` is populated from the union of
+   `Rejection.Tasks`; `Skip.Allocate` stays false. `allocate` and `backfill`
+   still pop the Job's other tasks and evaluate them normally, but any task
+   in `Skip.Tasks` is treated as unschedulable this session (predicate and
+   allocatable loops are skipped for it). This is the mode used when the Job
+   can still reach its gang criterion after excluding the skipped tasks. For
+   example, an elastic gang Job whose `minAvailable` is already met by
+   running tasks, with only extras cached as failed.
+
+2. **Whole-Job skip.** `Skip.Allocate` is true. No task of the Job is popped
+   this session, and gang's `JobReadyFn` is never called. This is the mode
+   used when excluding the skipped tasks makes some level of the gang
+   hierarchy fall below its own threshold. For example, a gang with
+   `minAvailable=8`, five tasks running, three tasks previously rejected on
+   capacity, and nothing left to try.
+
+`Skip.Enqueue` is orthogonal: it is set from `RejectionEnqueue` alone, and
+since a Job that failed `JobEnqueueable` never reached `allocate` in the
+previous session, it cannot coexist with per-task rejections in the same
+record.
+
+`ComputeSkip` follows Volcano's current flat gang model. It checks Job
+`MinAvailable`, role `TaskMinAvailable` when configured, flat SubJob
+`MinAvailable`/`MinSubJobs`, and tasks that have already progressed.
+
+Either way the wake behavior is the same: any `HintWakeup` from the plugins
+that produced the cached rejections drops the whole record, and the next
+`OpenSession` recomputes `SkipDecision` from scratch. There is no partial
+wake that lifts only some cached task-level skips.
+
+#### How actions apply cached rejections
+
+At `OpenSession`, Volcano fetches each pending Job's rejections from the
+cache and derives `JobInfo.Skip` from them (see §5). Actions consult `Skip`
+only. Each field names the piece of work to skip:
+
+- **`enqueue`** skips its `JobEnqueueable` re-check when `Skip.Enqueue` is
+  true. Only the `RejectionEnqueue` source sets this flag.
+- **`allocate`** short-circuits the Job when `Skip.Allocate` is true: no task
+  is popped and gang's `JobReadyFn` is not called. Otherwise, for each popped
+  task, a lookup in `Skip.Tasks` decides whether to skip the predicate and
+  allocatable loops for that task. Other tasks of the same Job continue
+  normally, so elastic gang Jobs can still push past `minAvailable` when a
+  new task becomes placeable.
+- **`backfill`** reads `Skip` the same way `allocate` does.
+- **`preempt`** and **`reclaim`** ignore `Skip`. They exist to free
+  resources for Jobs the other actions could not place, so a cached Job must
+  still be a preemption candidate.
+
+#### Rejections from plugins without hints
+
+A rejection is only useful if its plugin has a `HintProvider`. If the rejecting
+plugin has no registered hints, there is no cluster event that could wake the
+Job for that failure. The cache leaves such Jobs out entirely and lets them go
+through the normal filter path every session, which matches today's behavior.
+
+### 3. UnschedulableJobCache
+
+`UnschedulableJobCache` lives on `SchedulerCache`. It records unschedulable Jobs by
+`JobID`, together with the rejection list collected at `CloseSession` and the hint
+callbacks copied from `HintRegistry`.
+
+The normal retry lifecycle is:
+
+1. `CloseSession` calls `RecordUnschedulable(job, rejections)` for Jobs that were
+  evaluated and still failed.
+2. The next `OpenSession` calls `GetCachedRejections(job)` for each pending Job.
+3. If the call returns a non-nil slice, Volcano derives `JobInfo.Skip` from it (see
+   §2's [Skip granularity](#skip-granularity)), and `enqueue`, `allocate` and
+   `backfill` bypass either the whole Job, specific tasks, or the enqueue re-check
+   accordingly.
+4. A matching informer event calls `OnEvent`; if a hint says the Job may need retry,
+   the cache calls `ForgetUnschedulable(job.UID)` and the next session evaluates it
+   normally.
+5. If no relevant event arrives before `RetryAfter`, a background watchdog goroutine
+   forgets the record, and the next session evaluates the Job normally.
+
+Recovery actions (`preempt` and `reclaim`) do not consult `GetCachedRejections`.
+They scan pending Jobs from `ssn.Jobs` directly, because Volcano cannot know in
+advance which Job becomes schedulable after victims are selected. Once they
+pipeline a Job's tasks onto victims, that Job is making progress through
+preemption. `CloseSession` drops any existing record instead of re-caching it
+(see §5); `GetCachedRejections` itself remains a plain lookup.
+
+A Job therefore moves between three states across sessions:
+
+```mermaid
+stateDiagram-v2
+    [*] --> Evaluating: OpenSession, no record
+    Evaluating --> Progressing: ready / pipelined
+    Evaluating --> Cached: CloseSession RecordUnschedulable
+    Cached --> Cached: GetCachedRejections applied
+    Cached --> Cached: hint = HintSkip
+    Cached --> Evaluating: ForgetUnschedulable (hint / PodGroup / watchdog)
+    Progressing --> [*]
+```
+
+The three states are:
+
+- **Evaluating** — no record (or the record is being bypassed); actions run predicates
+  and resource fit for the Job normally.
+- **Cached** — a record exists; `enqueue`/`allocate`/`backfill`
+  apply the derived `Skip` (the enqueue re-check, the whole Job, or a subset of its
+  tasks, depending on the record). `preempt`/`reclaim` still evaluate it (they ignore
+  the cache).
+- **Progressing** — the Job became ready or gained a pipelined task, so it holds no
+  record and leaves the cache's scope.
+
+A Job enters **Cached** only from `CloseSession → RecordUnschedulable`. It leaves
+**Cached** back to **Evaluating** through three paths, all of which delete the record
+so the next `OpenSession` finds none and evaluates the Job normally:
+
+1. **Hint wake-up (event-driven).** An informer fires `OnEvent`; the cache runs the
+  Job's subscribed hints. If any returns `HintWakeup`, the cache forgets the record.
+   If every hint returns `HintSkip`, the record is kept and the Job stays **Cached**
+   (the `Cached → Cached` self-loop). This is the primary path, since a real cluster
+   change plausibly fixes the earlier rejection.
+2. **PodGroup change (invalidation).** A spec update or delete forgets the record
+   directly; status-only updates remain hint events.
+3. **RetryAfter watchdog (safety net).** A background goroutine runs on a fixed
+   interval and forgets any record whose `RetryAfter` has passed. It runs off the
+   scheduling path, so it does not add scanning work to `OpenSession`, and it
+   guarantees a Job is never cached forever when a hint is missed or an informer
+   edge case drops an event.
+
+#### Interface
+
+```go
+// UnschedulableCache stores Jobs rejected in previous scheduling sessions and
+// exposes the operations needed by scheduler sessions.
+type UnschedulableCache interface {
+    // AddHintProvider registers a plugin's event subscriptions and hint callbacks.
+    AddHintProvider(name string, p api.HintProvider)
+
+    // RecordUnschedulable stores the plugin rejections observed for a Job in the
+    // current session.
+    RecordUnschedulable(job *api.JobInfo, rejections []api.Rejection)
+
+    // GetCachedRejections returns the rejections that may be reused to skip work
+    // for the Job in the current session.
+    GetCachedRejections(job *api.JobInfo) []api.Rejection
+
+    // ForgetUnschedulable removes the cached record for the Job.
+    ForgetUnschedulable(jobID api.JobID)
+}
+```
+
+`OnEvent` and `StartWatchdog` are methods on the concrete
+`*UnschedulableJobCache`; informer dispatch and cache startup call them directly.
+
+#### Cache state
+
+The cache keeps one record per Job, plus a reverse index so `OnEvent` can find
+the affected Jobs without scanning every record:
+
+```go
+// UnschedulableJobCache stores rejected Jobs and routes matching cluster events
+// to their captured hint callbacks.
+type UnschedulableJobCache struct {
+    mu sync.RWMutex
+
+    // records is the primary store: one entry per cached Job.
+    records map[api.JobID]*unschedulableRecord
+
+    // byResource narrows event dispatch to Jobs interested in a resource.
+    // wildcard holds Jobs subscribed to fwk.WildCard as the resource.
+    byResource map[fwk.EventResource]sets.Set[api.JobID]
+    wildcard sets.Set[api.JobID]
+
+    // registry provides the latest plugin hint declarations for new records.
+    registry *HintRegistry
+
+    // jobGetter returns a cloned JobInfo snapshot under the SchedulerCache lock,
+    // or nil when the Job is gone.
+    jobGetter func(api.JobID) *api.JobInfo
+
+    // maxSkipDuration bounds how long a record can suppress retries.
+    maxSkipDuration time.Duration
+}
+
+// unschedulableRecord is the cached state for one Job.
+type unschedulableRecord struct {
+    // jobID identifies the cached Job; rejections drive Skip derivation in the
+    // next OpenSession.
+    jobID      api.JobID
+    rejections []api.Rejection
+
+    // lastFailedAt and retryAfter define the watchdog retry window.
+    lastFailedAt time.Time
+    retryAfter   time.Time
+
+    // subscriptions and resources are snapshots, not references to the registry.
+    subscriptions []hintSubscription
+    resources     sets.Set[fwk.EventResource]
+}
+
+// hintSubscription pairs a plugin name with its hint callback, plus the plugin's
+// own Rejection so the callback can inspect the exact decision it made in the
+// previous session.
+type hintSubscription struct {
+    plugin    string
+    event     api.ClusterEvent
+    rejection api.Rejection
+    hintFn    api.JobHintFn
+}
+```
+
+`subscriptions` holds the same `(event, hintFn)` pairs a plugin declares through
+`ClusterEventWithHint` (§1), narrowed to the plugins that rejected this Job and
+indexed by resource for fast candidate lookup. A nil `HintFn` wakes only after its
+event matches; it is unrelated to the resource wildcard. `RecordUnschedulable`
+builds it by looking each rejection's plugin up in the cache's global
+`HintRegistry` and copying the matching entries.
+
+It is a **snapshot** rather than a live reference to `HintRegistry`. A Job
+cached in an earlier session must keep waking the same way it was recorded,
+even if a plugin re-registers different events later. Copying at record time
+also keeps the cache working after the session that produced the hints is torn
+down.
+
+#### Cache updates
+
+| Call site | Cache call | Meaning |
+|---|---|---|
+| `CloseSession`, evaluated Job still pending | `RecordUnschedulable(job, rejections)` | Store or replace the record and rebuild event subscriptions. |
+| `OpenSession`, pending Job | `GetCachedRejections(job)` | Return the previous session's rejections, or nil to evaluate the Job normally. |
+| `CloseSession`, Job became ready or gained a pipelined task | `ForgetUnschedulable(job.UID)` | Remove the record. |
+| PodGroup spec update/delete informer | `ForgetUnschedulable(jobID)` | Job spec/lifecycle changed; evaluate it again. |
+| Subscribed cluster event (informer) | `OnEvent(ev, oldObj, newObj)` | Run matching hints and wake Jobs that may need retry. |
+| Watchdog goroutine, `now >= RetryAfter` | `ForgetUnschedulable(jobID)` | Off-path cleanup of stale records so a Job is never cached forever. |
+
+`GetCachedRejections(job)` is a map lookup by Job ID. Progress is reconciled at
+`CloseSession`, and expiry is handled by the watchdog.
+
+There is no per-Job timer and no exponential backoff. A single background
+goroutine runs on a fixed interval, scans the records, and forgets any
+whose `RetryAfter` has passed. Keeping expiry off the scheduling path means
+`OpenSession` and `GetCachedRejections` only read a record. Events remain the
+normal wake-up path, and the timestamp is a safety net for missed hints or
+informer edge cases.
+
+#### Per-session overhead
+
+For a Job with no cached record, `GetCachedRejections` is a single map
+lookup under a read lock, so the `OpenSession` pass adds constant time per
+pending Job. For a cached Job, `ComputeSkip` checks gang thresholds without
+touching the cluster snapshot, which is much cheaper than the per-node predicate
+loop the skip avoids.
+
+#### Invalidation
+
+A record is removed or bypassed by these triggers:
+
+| Trigger | Effect |
+|---|---|
+| A subscribed cluster event whose hint returns `HintWakeup` or errors | `ForgetUnschedulable` (via `OnEvent`) |
+| `PodGroup` spec update or delete | `ForgetUnschedulable` (from the informer handler) |
+| `now >= RetryAfter` | the watchdog calls `ForgetUnschedulable`; the next session re-evaluates the Job |
+
+`RecordUnschedulable` sets retry timing like this:
+
+```
+LastFailedAt = now
+RetryAfter   = now + maxSkipDuration // configurable; defaults to 5m
+```
+
+`OnEvent` is described in §4 together with the informer dispatch path.
+
+### 4. Event Dispatch
+
+
+The dispatch layer connects cluster events to `UnschedulableJobCache`. Plugins
+declare which events they care about through `HintRegistry` (§1). Scheduler-cache
+informer handlers are installed when the cache is constructed and deliver supported
+events through `OnEvent`.
+
+#### Subscribed event set
+
+`OnEvent` finds candidate records by resource and then matches the action on each
+subscription. Node and Pod updates use kube-scheduler's classified actions. A Pod
+transitioning to a terminal phase is treated as `Pod/Delete` because it releases
+its node resources.
+
+#### Handler registration
+
+Volcano dispatches into `UnschedulableJobCache` beside the existing cache-update
+handlers on supported informers. Each handler
+normalizes the informer callback into a `ClusterEvent` and calls
+`UnschedulableJobCache.OnEvent(ev, oldObj, newObj)`. PodGroup spec updates and
+deletes invalidate the Job directly, while status updates are delivered to hints.
+
+#### Delivery
+
+`OnEvent` uses the `byResource` / `wildcard` index (§3) to find candidate records
+subscribed to the event, runs each Job's matching hints, and forgets a Job as
+soon as one hint returns `HintWakeup`. A hint that returns an error is treated
+as `HintWakeup` too, so a broken hint can never keep a Job cached forever. Jobs
+whose hints all return `HintSkip` stay cached until another event fires or the
+`RetryAfter` watchdog (§3) lets them retry.
+
+The cache lock is held only while copying candidate IDs and immutable subscription
+snapshots. `JobHintFn` callbacks run after the lock is released, so plugin code cannot
+block cache reads/writes or create lock-order cycles. Delete handlers unwrap
+`cache.DeletedFinalStateUnknown` before dispatching the concrete object to hints.
+
+```mermaid
+sequenceDiagram
+    participant Informer as SharedInformer
+    participant Dispatch as Event Handler
+    participant UJC as UnschedulableJobCache
+
+    Informer->>Dispatch: Add / Update / Delete object
+    Dispatch->>Dispatch: normalize to ClusterEvent
+    Dispatch->>UJC: OnEvent(ev, oldObj, newObj)
+    UJC->>UJC: look up candidates via byResource / wildcard
+    UJC->>UJC: run each Job's matching hints
+    UJC-->>UJC: Forget Job on HintWakeup / error
+```
+
+`OnEvent` decides per record:
+
+```mermaid
+flowchart TD
+    A[OnEvent receives ClusterEvent] --> B[Find candidates via byResource / wildcard]
+    B --> C{Job still pending in SchedulerCache?}
+    C -- no --> D[Forget record]
+    C -- yes --> E[Run the Job's matching hints]
+    E --> F{Any hint returns HintWakeup or errors?}
+    F -- yes --> D
+    F -- no --> G[Keep record cached]
+```
+
+Any subscribed plugin can wake the Job. Waking only lifts the cached skip. The
+next scheduling session still runs the normal Volcano checks before the Job can
+be placed.
+
+### 5. Scheduler Action Changes
+
+Two hooks in the session lifecycle wire the cache into the scheduler. `OpenSession`
+derives each pending Job's `Skip` decision from the cache, and `CloseSession`
+writes updated records back. §2 describes what the actions do with `Skip`; this
+section covers the two hooks and how `CloseSession` reconciles the cache with what
+the session actually did.
+
+#### Tagging pending Jobs
+
+`OpenSession` builds the session as usual. Once plugins have registered, Volcano
+calls `GetCachedRejections` for every pending Job. If the call returns a non-nil
+slice, `ComputeSkip` (§2) turns it into a `SkipDecision` that is stored on
+`JobInfo`:
+
+```go
+type JobInfo struct {
+    // existing fields omitted
+
+    // Skip is derived from cached rejections and the Job's gang constraints.
+    // enqueue reads Skip.Enqueue; allocate and
+    // backfill read Skip.Allocate and Skip.Tasks. Zero value means the
+    // Job is evaluated normally this session. See §2's Skip granularity.
+    Skip SkipDecision
+}
+```
+
+The raw `[]Rejection` slice stays on the cache record. Actions never need it,
+and duplicating it on `JobInfo` would add pointer traffic without a reader.
+
+Skipped Jobs stay in `ssn.Jobs` so plugin accounting still sees pending demand.
+Whole-Job skips may be omitted from action-local queues; `Skip` only gates the
+expensive retry work.
+
+#### Reconciling the cache at `CloseSession`
+
+Each pending Job's record is updated to match what actually happened to it:
+
+- If the Job is ready, or `preempt`/`reclaim` pipelined any task onto
+  victims, it is making progress, so any record is dropped (or never written).
+- If the Job was skipped and never re-evaluated, its record is left untouched, still
+  waiting for an event or the watchdog.
+- If the Job was actually evaluated and still produced rejections, the record is written
+  or replaced with those fresh rejections.
+
+A pipelined Job is deliberately kept out of the cache. Its victims are still being
+evicted, so the next `allocate` may keep rejecting those tasks until their resources
+are freed. Caching the Job as unschedulable would suppress the retries that let the
+preemption finish.
+
+### 6. kube-scheduler QueueingHint Adapter
+
+Most of the value in the first release comes from reusing kube-scheduler's
+existing `QueueingHintFn`s for its filter plugins. Volcano's `predicates`
+plugin already wraps those upstream plugins, so the adapter only has to expose
+their hints and turn each per-Pod answer into a per-Job answer.
+
+#### Exposed upstream hints
+
+The following upstream plugins implement `fwk.EnqueueExtensions` and expose
+their hint list through `EventsToRegister(ctx) ([]fwk.ClusterEventWithHint, error)`:
+
+- `nodeaffinity`, `nodeports`
+- `tainttoleration`
+- `interpodaffinity`, `podtopologyspread`
+- `nodevolumelimits.CSILimits`, `volumezone`, `volumebinding.VolumeBinding`
+- `dynamicresources.DynamicResources`
+
+Both the return type and its `QueueingHintFn` field are exported, so Volcano
+can invoke the upstream hints directly without reimplementing them. Volcano's
+`predicates` plugin publishes one `ClusterEventWithHint` per upstream event and
+uses the upstream plugin name (for example, `NodeAffinity`) as its stable identity.
+`RecordUnschedulable` uses that name to copy only the hints for filters that actually rejected the Job.
+
+#### From per-Pod to per-Job
+
+The upstream `QueueingHintFn` is Pod-level. It answers "could this event make
+this one Pod schedulable?":
+
+```go
+func(logger klog.Logger, pod *v1.Pod, oldObj, newObj any) (fwk.QueueingHint, error)
+```
+
+Volcano's `JobHintFn` asks the same question for a whole Job. `wrapPodHint`
+turns the per-Pod callback into a per-Job one. `Rejection.Tasks` (§2) records
+exactly the task IDs that failed this filter in the previous session, so the
+wrapper runs the upstream hint only for those Pods — other tasks passed the
+filter and cannot be why the Job is blocked on it.
+
+The wrapper returns `HintWakeup` as soon as one failed task's upstream hint
+returns `Queue`. Waking on a single Pod is safe:
+
+- `HintWakeup` does not place anything. It asks Volcano to run the normal
+  evaluation again, where full predicates re-run for every task. A useless
+  wake costs one session's evaluation and nothing more.
+- Wakes are whole-record. Even though `RejectionPredicate` carries a `Tasks`
+  list, one Pod turning schedulable drops the whole record, and the next
+  session re-evaluates every task from scratch. There is no partial wake that
+  lifts only some of the cached task-level skips.
+- For a gang Job, a single task becoming placeable can be the marginal task
+  that finally satisfies `minAvailable`, so one Pod's improvement must be
+  able to unblock the Job.
+
+A missed wake is the more expensive failure — the Job stays cached until the
+watchdog — so any upstream hint that errors is also treated as `HintWakeup`.
+
+```mermaid
+flowchart TD
+    A[Cluster event reaches wrapPodHint] --> B[Load failed tasks from Rejection.Tasks]
+    B --> C[Run upstream QueueingHintFn for each failed Pod]
+    C --> D{Any Pod returns Queue or error?}
+    D -- yes --> W[HintWakeup: drop record, next session evaluates normally]
+    D -- no --> S[HintSkip: keep cached]
+```
+
+### 7. Initial Plugin Coverage
+
+Coverage lands in tiers so the first release focuses on the plugins that
+drive the most redundant work today. The kube-scheduler upstream already
+ships hint logic for the wrapped predicate plugins, so the predicate tier is
+almost entirely adapter code and lands in P0. Native queue plugins are also
+P0 because `capacity`/`proportion` are the most common source of blocked
+Jobs. Everything else follows as its rejection path is wired up.
+
+**P0 — first release**
+
+| Plugin | Category | Event source | Notes |
+|---|---|---|---|
+| `NodeAffinity`, `NodePorts` | NodeAffinity | adapter | `Node/Add`, `Node/UpdateNodeLabel` |
+| `TaintToleration`, `NodeUnschedulable` | Taint | adapter | `Node/Add`, `Node/UpdateNodeTaint` |
+| `InterPodAffinity`, `PodTopologySpread` | PodTopology | adapter | `Pod/Add`, `Pod/Delete`, `Node/UpdateNodeLabel` |
+| `NodeVolumeLimits`, `VolumeZone`, `VolumeBinding` | Storage | adapter | PVC/PV/StorageClass/CSINode events |
+| `DynamicResources` | Device | adapter | ResourceClaim/DeviceClass/Node allocatable events |
+| `predicates-resource-fit` | Resource | native (synthetic) | §2 synthetic name for `allocate`'s inline node-fit check; `Node/Add`, `Node/UpdateNodeAllocatable`, `Pod/Delete` |
+| `capacity`, `proportion` | Queue | native | Queue, PodGroup completion/deletion, Pod deletion |
+
+**P1 — follow-up**
+
+| Plugin | Category | Event source | Notes |
+|---|---|---|---|
+| `overcommit` | Queue | native | Queue, PodGroup completion/deletion |
+| `numaaware` | NUMA | native | NumaInfo, Node add |
+| `deviceshare` | Device | native | Node allocatable, PodGroup deletion |
+| `resource-strategy-fit` | Resource | native | Node add/allocatable, Pod deletion |
+
+**P2 — later**
+
+| Plugin | Category | Event source | Notes |
+|---|---|---|---|
+| `network-topology-aware` | HyperNode | native | HyperNode, node label events |
+
+**No `HintProvider` (fallback)**
+
+`extender`, and any other plugin that does not implement `HintProvider`, keep
+today's behavior: Jobs they reject are not cached and go through the normal
+filter path every session.
+
+## Risks and Mitigations
+
+| Risk | Mitigation |
+|---|---|
+| A hint misses a relevant event, keeping a Job cached too long. | Fail open on hint errors; the `RetryAfter` watchdog forgets the record; rejections from plugins without a `HintProvider` are not cached at all (§7). |
+| Stale plugin registrations after a re-register. | `RecordUnschedulable` snapshots the hints at cache-write time; later registrations only apply to new records, and old records are bounded by the watchdog. |
+| Fairness drift from skipping Jobs. | Cached Jobs stay in `ssn.Jobs`; DRF, capacity, proportion and gang accounting see the full pending demand (§5). |
+| Hot `Pod` event path spending time on unrelated Jobs. | `byResource` / `wildcard` index dispatches only to records subscribed to the event; hints for others never run. |
+| Preemption progress suppressed by the cache. | Jobs with pipelined tasks are excluded from the cache (§3, §5), so `preempt`/`reclaim` retries are never skipped. |
+
+## Alternatives Considered
+
+- **All-plugins-must-return-`HintWakeup` policy.** Rejected. Needs per-plugin wake state on each record, and one missed hint leaves the Job stuck until the watchdog.
+- **Drop unschedulable Jobs from `ssn.Jobs`.** Rejected. DRF, capacity and proportion need to see pending demand or fairness drifts.
+- **Persist records in PodGroup status or annotations.** Rejected. Adds API-server writes on every rejection and races with user updates. Records live in memory and rebuild from the first post-restart session.
+- **Reimplement kube-scheduler hints in Volcano.** Rejected. The upstream callback API is public and already captures plugin-specific logic; wrapping it costs adapter code once.
+- **Task-granularity cache records.** Rejected as the cache key, though task-level
+  detail is still kept inside each Job record. Volcano schedules and gates at
+  Job/PodGroup granularity, so `GetCachedRejections`, gang thresholds and the action
+  loops all decide per Job. A per-task record would have to be rolled up to that
+  same Job-level answer, which the §6 OR already produces. A Job's tasks are also
+  typically homogeneous and fail the same filter for the same reason, so per-task
+  records would store many near-duplicate entries and scale with total pending Pods
+  instead of pending PodGroups. Task-level precision matters only when replaying the
+  upstream per-Pod hint, and `Rejection.Tasks` inside the Job record already provides
+  it.
+
+## Test Plan
+
+**Unit tests**
+
+Standard package-level unit tests cover the core logic: `HintRegistry` lifecycle
+and re-registration; rejection recording at each extension point (`PredicateFn`,
+`Allocatable`, `JobEnqueueable`, plus the synthetic `predicates-resource-fit`);
+`UnschedulableJobCache` operations (`RecordUnschedulable`, `GetCachedRejections`,
+`ForgetUnschedulable`, `OnEvent`, watchdog expiry, `byResource` / `wildcard`
+dispatch, hint-error fail-open); `ComputeSkip` against Job, role, and flat SubJob
+thresholds; and the
+`predicates` adapter's per-Pod-to-per-Job aggregation.
+
+**Benchmarks**
+
+`benchmark/testcases/unschedulable-job-cache/`: 5,000 pending PodGroups with mixed
+rejection sources. Compare `allocate` latency, session duration, bind throughput,
+and cache memory before and after the cache is enabled.
+
+**End-to-end**
+
+- **Wake on a matching cluster event.** A Job blocked on a node label is
+  cached after the first session; adding a node with the matching label
+  drops the record and places the Job in the next session.
+- **Gang whole-Job skip.** A gang Job whose `minAvailable` is unreachable in
+  the current cluster is cached; no task is popped for it until a `Pod/Delete`
+  frees enough capacity, at which point the record wakes and the Job is
+  placed.
+- **Task-subset skip.** An elastic gang Job whose `minAvailable` is already met
+  by running tasks has extra tasks rejected on capacity; later sessions skip
+  only those cached tasks and keep evaluating the Job's other tasks normally.
+- **Preemption is not suppressed.** A cached Job is chosen as a preemption
+  target; `preempt` selects victims, `allocate` pipelines the Job's tasks, and
+  the record is dropped instead of refreshed.
+- **Watchdog safety net.** A cached Job whose subscribed events never fire is
+  re-evaluated after the configured maximum skip duration.
+
+## Related Issues
+
+- [#5551 Reduce repeated scheduling attempts for unchanged unschedulable jobs](https://github.com/volcano-sh/volcano/issues/5551)
+- [#5494 [Umbrella] Track Volcano performance and scalability work](https://github.com/volcano-sh/volcano/issues/5494)
+- [#5537 Explore signature-based batching for homogeneous gang workloads](https://github.com/volcano-sh/volcano/issues/5537)
+- Upstream: [KEP-4247 QueueingHint](https://kep.k8s.io/4247)


### PR DESCRIPTION
#### What type of PR is this?

/kind design
/kind documentation

#### What this PR does / why we need it:

Adds a design proposal for an event-driven unschedulable Job cache in the Volcano scheduler.

Volcano opens a new scheduling session roughly every second and currently repeats the full filter path for pending Jobs even when their blockers have not changed. At scale, this redundant work delays newly submitted schedulable Jobs.

The proposal introduces:

- An optional `HintProvider` extension point. A plugin declares the cluster events that can change its previous rejection and a `JobHintFn` that makes the final wake-or-keep decision.
- An `UnschedulableJobCache` owned by `SchedulerCache`. `CloseSession` records rejected Jobs, and the next `OpenSession` derives a `SkipDecision` that lets `enqueue`, `allocate`, and `backfill` skip unchanged work at whole-Job or task-subset granularity.
- Event-driven retries. Informer events run only the hints registered by plugins that rejected the Job. Any `HintWakeup` or hint error removes the record, while a watchdog provides a bounded retry safety net.
- Reuse of kube-scheduler QueueingHint functions for supported predicate plugins through a per-Pod to per-Job adapter.
- Optional secondary candidate indexing. The cache first classifies by `EventResource`, then by plugin name and `ActionType`. Within each plugin/action index, `JobKeysFn` and `EventKeysFn` select `jobIDsByHintKey`; Jobs without complete keys remain in `jobIDsWithoutHintKeys`, and event-key extraction failure selects `allJobIDs`. `JobHintFn` remains the final correctness check.
- A dedicated freshness tracker. It prevents a rejection computed from an old session snapshot from being cached after a relevant event or direct Job invalidation has already occurred.

To keep the Alpha scope focused, Resource Fit is the only provider-specific secondary index. It uses the rejected node and insufficient resource dimensions to reduce work on the high-frequency `Pod/Delete` path. `capacity`, `proportion`, and wrapped kube-scheduler plugins initially dispatch all Job IDs in their matching resource/plugin/action indexes to their existing hint functions; selective indexes can be added later when a safe key and measured event fan-out justify them.

The proposal also defines stale Job snapshot invalidation, preemption safety, the `Pod/Delete` dispatch cost model, index memory bounds, and a test plan centered on common end-to-end workflows.

Full design, interfaces, lifecycle diagrams, plugin coverage, risks, cost analysis, and test plan are in [docs/design/unschedulable-job-cache.md](docs/design/unschedulable-job-cache.md).

#### Which issue(s) this PR fixes:

Fixes #5551

#### Special notes for your reviewer:

For AI Assistance, I mainly use copilot for helping finish this proposal design, but I have carefully reviewed it.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
