### PR TITLE
feat(cli): add namespace column to vcctl pod list --all-namespaces

### DIFF
--- a/pkg/cli/pod/pod.go
+++ b/pkg/cli/pod/pod.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -43,6 +44,8 @@ import (
 )
 
 const (
+	// Namespace pod namespace
+	Namespace string = "Namespace"
 	// Name pod name
 	Name string = "Name"
 	// Ready pod ready
@@ -150,54 +153,72 @@ func ListPods(ctx context.Context) error {
 		fmt.Printf("No resources found\n")
 		return nil
 	}
-	PrintPods(&pods, os.Stdout)
+	PrintPods(&pods, os.Stdout, listPodFlags.allNamespace)
 
 	return nil
 }
 
-func PrintPods(pods *corev1.PodList, writer io.Writer) {
-	maxNameLen := 0
-	maxReadyLen := 0
-	maxStatusLen := 0
-	maxRestartLen := 0
-	maxAgeLen := 0
+type podColumn struct {
+	header string
+	value  func(PodInfo) string
+}
+
+func PrintPods(pods *corev1.PodList, writer io.Writer, showNamespace bool) {
+	var columns []podColumn
+	if showNamespace {
+		columns = append(columns, podColumn{Namespace, func(p PodInfo) string { return p.Namespace }})
+	}
+	columns = append(columns,
+		podColumn{Name, func(p PodInfo) string { return p.Name }},
+		podColumn{Ready, func(p PodInfo) string { return p.ReadyContainers }},
+		podColumn{Status, func(p PodInfo) string { return p.Status }},
+		podColumn{Restart, func(p PodInfo) string { return p.Restarts }},
+		podColumn{Age, func(p PodInfo) string { return p.CreationTimestamp }},
+	)
 
 	var infoList []PodInfo
-	for _, pod := range pods.Items {
-		info := printPod(&pod)
-		infoList = append(infoList, info)
-		// update max length for each column
-		if len(info.Name) > maxNameLen {
-			maxNameLen = len(info.Name)
-		}
-		if len(info.ReadyContainers) > maxReadyLen {
-			maxReadyLen = len(info.ReadyContainers)
-		}
-		if len(info.Status) > maxStatusLen {
-			maxStatusLen = len(info.Status)
-		}
-		if len(info.Restarts) > maxRestartLen {
-			maxRestartLen = len(info.Restarts)
-		}
-		if len(info.CreationTimestamp) > maxAgeLen {
-			maxAgeLen = len(info.CreationTimestamp)
+	for i := range pods.Items {
+		infoList = append(infoList, printPod(&pods.Items[i]))
+	}
+
+	// Size each column to fit its widest value plus a fixed spacing. When the
+	// header is wider than every value, fall back to the header length plus a
+	// smaller separator so the header never touches the next column (and so an
+	// empty list still renders a readable header row).
+	const (
+		columnSpacing = 8
+		headerSpacing = 2
+	)
+	widths := make([]int, len(columns))
+	for i, col := range columns {
+		widths[i] = len(col.header) + headerSpacing
+		for _, info := range infoList {
+			if l := len(col.value(info)) + columnSpacing; l > widths[i] {
+				widths[i] = l
+			}
 		}
 	}
-	columnSpacing := 8
-	maxNameLen += columnSpacing
-	maxReadyLen += columnSpacing
-	maxStatusLen += columnSpacing
-	maxRestartLen += columnSpacing
-	maxAgeLen += columnSpacing
-	formatStr := fmt.Sprintf("%%-%ds%%-%ds%%-%ds%%-%ds%%-%ds\n", maxNameLen, maxReadyLen, maxStatusLen, maxRestartLen, maxAgeLen)
-	_, err := fmt.Fprintf(writer, formatStr, Name, Ready, Status, Restart, Age)
-	if err != nil {
+
+	formatBuilder := make([]string, len(columns))
+	for i := range columns {
+		formatBuilder[i] = fmt.Sprintf("%%-%ds", widths[i])
+	}
+	formatStr := strings.Join(formatBuilder, "") + "\n"
+
+	headerArgs := make([]interface{}, len(columns))
+	for i, col := range columns {
+		headerArgs[i] = col.header
+	}
+	if _, err := fmt.Fprintf(writer, formatStr, headerArgs...); err != nil {
 		fmt.Printf("Failed to print Pod information: %s.\n", err)
 		return
 	}
 	for _, info := range infoList {
-		_, err := fmt.Fprintf(writer, formatStr, info.Name, info.ReadyContainers, info.Status, info.Restarts, info.CreationTimestamp)
-		if err != nil {
+		rowArgs := make([]interface{}, len(columns))
+		for i, col := range columns {
+			rowArgs[i] = col.value(info)
+		}
+		if _, err := fmt.Fprintf(writer, formatStr, rowArgs...); err != nil {
 			fmt.Printf("Failed to print Pod information: %s.\n", err)
 			return
 		}
@@ -280,8 +301,6 @@ func appendIfNotExists(existing, toAppend []corev1.Pod) []corev1.Pod {
 	for _, pod := range toAppend {
 		exists := false
 		for _, existingPod := range existing {
-			// A pod is identified by namespace and name; two pods with the same
-			// name in different namespaces are distinct, so only skip a real duplicate.
 			if existingPod.Namespace == pod.Namespace && existingPod.Name == pod.Name {
 				exists = true
 				break
@@ -304,6 +323,7 @@ func translateTimestampSince(timestamp metav1.Time) string {
 
 // PodInfo holds information about a pod.
 type PodInfo struct {
+	Namespace         string
 	Name              string
 	ReadyContainers   string
 	Status            string
@@ -456,6 +476,7 @@ func printPod(pod *corev1.Pod) PodInfo {
 	}
 
 	podInfo := PodInfo{
+		Namespace:         pod.Namespace,
 		Name:              pod.Name,
 		ReadyContainers:   fmt.Sprintf("%d/%d", readyContainers, totalContainers),
 		Status:            reason,

--- a/pkg/cli/pod/pod.go
+++ b/pkg/cli/pod/pod.go
@@ -280,7 +280,9 @@ func appendIfNotExists(existing, toAppend []corev1.Pod) []corev1.Pod {
 	for _, pod := range toAppend {
 		exists := false
 		for _, existingPod := range existing {
-			if existingPod.Name == pod.Name {
+			// A pod is identified by namespace and name; two pods with the same
+			// name in different namespaces are distinct, so only skip a real duplicate.
+			if existingPod.Namespace == pod.Namespace && existingPod.Name == pod.Name {
 				exists = true
 				break
 			}

--- a/pkg/cli/pod/pod_test.go
+++ b/pkg/cli/pod/pod_test.go
@@ -224,3 +224,27 @@ func buildPod(namespace, name string, labels map[string]string, annotations map[
 		},
 	}
 }
+
+func TestAppendIfNotExists(t *testing.T) {
+	// A pod is identified by namespace and name. Two pods that share a name but
+	// live in different namespaces are distinct, so both must survive the merge;
+	// only a genuine duplicate (same namespace and name) should be dropped.
+	existing := []corev1.Pod{
+		buildPod("team-a", "worker-0", nil, nil),
+	}
+	toAppend := []corev1.Pod{
+		buildPod("team-a", "worker-0", nil, nil), // genuine duplicate, should be skipped
+		buildPod("team-b", "worker-0", nil, nil), // same name, other namespace, should be kept
+	}
+
+	got := appendIfNotExists(existing, toAppend)
+
+	var keys []string
+	for _, p := range got {
+		keys = append(keys, p.Namespace+"/"+p.Name)
+	}
+	want := []string{"team-a/worker-0", "team-b/worker-0"}
+	if !reflect.DeepEqual(keys, want) {
+		t.Errorf("expected pods %v, got %v", want, keys)
+	}
+}

--- a/pkg/cli/pod/pod_test.go
+++ b/pkg/cli/pod/pod_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package pod
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -225,16 +226,82 @@ func buildPod(namespace, name string, labels map[string]string, annotations map[
 	}
 }
 
+func TestPrintPodsAllNamespaces(t *testing.T) {
+	pods := &corev1.PodList{
+		Items: []corev1.Pod{
+			buildPod("team-a", "worker-0", nil, nil),
+			buildPod("team-b", "worker-0", nil, nil),
+		},
+	}
+
+	var buf bytes.Buffer
+	PrintPods(pods, &buf, true)
+
+	lines := strings.Split(strings.TrimRight(buf.String(), "\n"), "\n")
+	if len(lines) != 3 {
+		t.Fatalf("expected header plus 2 rows, got %d lines: %q", len(lines), buf.String())
+	}
+	if !strings.HasPrefix(lines[0], Namespace) {
+		t.Errorf("expected header to start with %q, got %q", Namespace, lines[0])
+	}
+	if !strings.HasPrefix(lines[1], "team-a") || !strings.Contains(lines[1], "worker-0") {
+		t.Errorf("expected first row for team-a/worker-0, got %q", lines[1])
+	}
+	if !strings.HasPrefix(lines[2], "team-b") || !strings.Contains(lines[2], "worker-0") {
+		t.Errorf("expected second row for team-b/worker-0, got %q", lines[2])
+	}
+}
+
+func TestPrintPodsWithoutNamespaceColumn(t *testing.T) {
+	pods := &corev1.PodList{
+		Items: []corev1.Pod{
+			buildPod("team-a", "worker-0", nil, nil),
+		},
+	}
+
+	var buf bytes.Buffer
+	PrintPods(pods, &buf, false)
+
+	out := buf.String()
+	if strings.Contains(out, Namespace) {
+		t.Errorf("did not expect a Namespace column, got %q", out)
+	}
+	if !strings.HasPrefix(out, Name) {
+		t.Errorf("expected header to start with %q, got %q", Name, out)
+	}
+}
+
+func TestPrintPodsHeaderDrivenWidth(t *testing.T) {
+	// When the header is wider than every value (a single-character namespace)
+	// or there are no rows at all, the header must still keep a separator from
+	// the next column instead of touching it.
+	cases := map[string]*corev1.PodList{
+		"single char namespace": {
+			Items: []corev1.Pod{buildPod("a", "w", nil, nil)},
+		},
+		"empty list": {},
+	}
+
+	for name, pods := range cases {
+		t.Run(name, func(t *testing.T) {
+			var buf bytes.Buffer
+			PrintPods(pods, &buf, true)
+
+			header := strings.SplitN(buf.String(), "\n", 2)[0]
+			if !strings.HasPrefix(header, Namespace+" ") {
+				t.Errorf("expected %q to be followed by a separator, got %q", Namespace, header)
+			}
+		})
+	}
+}
+
 func TestAppendIfNotExists(t *testing.T) {
-	// A pod is identified by namespace and name. Two pods that share a name but
-	// live in different namespaces are distinct, so both must survive the merge;
-	// only a genuine duplicate (same namespace and name) should be dropped.
 	existing := []corev1.Pod{
 		buildPod("team-a", "worker-0", nil, nil),
 	}
 	toAppend := []corev1.Pod{
-		buildPod("team-a", "worker-0", nil, nil), // genuine duplicate, should be skipped
-		buildPod("team-b", "worker-0", nil, nil), // same name, other namespace, should be kept
+		buildPod("team-a", "worker-0", nil, nil),
+		buildPod("team-b", "worker-0", nil, nil),
 	}
 
 	got := appendIfNotExists(existing, toAppend)


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

`vcctl pod list --all-namespaces` renders only the pod name, so pods that share a name across namespaces show up as identical, indistinguishable rows. This PR adds a leading `Namespace` column whenever `--all-namespaces` is set, matching the behaviour of `kubectl get pods --all-namespaces`. The default single-namespace output is unchanged.

`PrintPods` is reworked to build its columns dynamically so the optional `Namespace` column can be inserted without duplicating the width and formatting logic.

This PR is stacked on top of #5636. That PR fixes a related bug: `vcctl pod list --queue` compared pods by name only, so with `--all-namespaces` two distinct pods that happened to share a name in different namespaces were de-duplicated by name and one of them was silently omitted from the output. #5636 fixes the omission by comparing namespace and name, and this PR closes the remaining usability gap by making the two rows distinguishable. The first commit here is aeron-gh's unmodified dedup fix; if this PR merges, #5636 will be marked as merged too.

#### Which issue(s) this PR fixes:

Fixes #5647

#### Special notes for your reviewer:

Verification against a live cluster with two same-named pods in different namespaces (`team-a/worker-0` and `team-b/worker-0`), both tied to queue `test`:

```
./_output/bin/vcctl pod list --queue test --all-namespaces
Namespace     Name            Ready      Status                  Restart  Age
team-a        worker-0        0/1        ImagePullBackOff        0        55m
team-b        worker-0        0/1        ImagePullBackOff        0        55m
```

Before this change both rows read `worker-0` with no namespace, so they were indistinguishable. The `ImagePullBackOff` status is unrelated to this change and just reflects the `pause` test image.

Unit tests cover both directions: the `Namespace` column is present with `--all-namespaces` and absent without it.

AI disclosure: this PR was prepared with AI assistance in line with the project AI guidance.

#### Does this PR introduce a user-facing change?

```release-note
`vcctl pod list --all-namespaces` now shows a `Namespace` column so pods with the same name in different namespaces are distinguishable.
```
