### PR TITLE
Use maxprocs.Set in components

### DIFF
--- a/cmd/agent-scheduler/main.go
+++ b/cmd/agent-scheduler/main.go
@@ -20,11 +20,10 @@ import (
 	"flag"
 	"fmt"
 	"os"
-	"runtime"
 	"time"
 
 	"github.com/spf13/pflag"
-	_ "go.uber.org/automaxprocs"
+	"go.uber.org/automaxprocs/maxprocs"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	cliflag "k8s.io/component-base/cli/flag"
@@ -44,8 +43,6 @@ import (
 var logFlushFreq = pflag.Duration("log-flush-frequency", 5*time.Second, "Maximum number of seconds between log flushes")
 
 func main() {
-	runtime.GOMAXPROCS(runtime.NumCPU())
-
 	klog.InitFlags(nil)
 	// Opt into the new klog behavior so that -stderrthreshold is honored even
 	// when -logtostderr=true (the default).
@@ -65,6 +62,10 @@ func main() {
 	s.RegisterOptions()
 
 	cliflag.InitFlags()
+
+	if _, err := maxprocs.Set(maxprocs.Logger(klog.Infof)); err != nil {
+		klog.Errorf("Failed to set GOMAXPROCS: %v", err)
+	}
 
 	if s.PrintVersion {
 		version.PrintVersionAndExit()

--- a/cmd/controller-manager/main.go
+++ b/cmd/controller-manager/main.go
@@ -19,12 +19,11 @@ import (
 	"flag"
 	"fmt"
 	"os"
-	"runtime"
 	"sort"
 	"time"
 
 	"github.com/spf13/pflag"
-	_ "go.uber.org/automaxprocs"
+	"go.uber.org/automaxprocs/maxprocs"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	cliflag "k8s.io/component-base/cli/flag"
@@ -52,7 +51,6 @@ import (
 var logFlushFreq = pflag.Duration("log-flush-frequency", 5*time.Second, "Maximum number of seconds between log flushes")
 
 func main() {
-	runtime.GOMAXPROCS(runtime.NumCPU())
 	klog.InitFlags(nil)
 	// Opt into the new klog behavior so that -stderrthreshold is honored even
 	// when -logtostderr=true (the default).
@@ -88,6 +86,10 @@ func main() {
 	componentbaseoptions.BindLeaderElectionFlags(&s.LeaderElection, fs)
 
 	cliflag.InitFlags()
+
+	if _, err := maxprocs.Set(maxprocs.Logger(klog.Infof)); err != nil {
+		klog.Errorf("Failed to set GOMAXPROCS: %v", err)
+	}
 
 	if s.PrintVersion {
 		version.PrintVersionAndExit()

--- a/cmd/scheduler/main.go
+++ b/cmd/scheduler/main.go
@@ -19,11 +19,10 @@ import (
 	"flag"
 	"fmt"
 	"os"
-	"runtime"
 	"time"
 
 	"github.com/spf13/pflag"
-	_ "go.uber.org/automaxprocs"
+	"go.uber.org/automaxprocs/maxprocs"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	cliflag "k8s.io/component-base/cli/flag"
@@ -46,8 +45,6 @@ import (
 var logFlushFreq = pflag.Duration("log-flush-frequency", 5*time.Second, "Maximum number of seconds between log flushes")
 
 func main() {
-	runtime.GOMAXPROCS(runtime.NumCPU())
-
 	klog.InitFlags(nil)
 	// Opt into the new klog behavior so that -stderrthreshold is honored even
 	// when -logtostderr=true (the default).
@@ -67,6 +64,10 @@ func main() {
 	s.RegisterOptions()
 
 	cliflag.InitFlags()
+
+	if _, err := maxprocs.Set(maxprocs.Logger(klog.Infof)); err != nil {
+		klog.Errorf("Failed to set GOMAXPROCS: %v", err)
+	}
 
 	if s.PrintVersion {
 		version.PrintVersionAndExit()

--- a/cmd/webhook-manager/main.go
+++ b/cmd/webhook-manager/main.go
@@ -19,11 +19,10 @@ import (
 	"flag"
 	"fmt"
 	"os"
-	"runtime"
 	"time"
 
 	"github.com/spf13/pflag"
-	_ "go.uber.org/automaxprocs"
+	"go.uber.org/automaxprocs/maxprocs"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
@@ -50,7 +49,6 @@ import (
 var logFlushFreq = pflag.Duration("log-flush-frequency", 5*time.Second, "Maximum number of seconds between log flushes")
 
 func main() {
-	runtime.GOMAXPROCS(runtime.NumCPU())
 	klog.InitFlags(nil)
 	// Opt into the new klog behavior so that -stderrthreshold is honored even
 	// when -logtostderr=true (the default).
@@ -63,6 +61,10 @@ func main() {
 	utilfeature.DefaultMutableFeatureGate.AddFlag(pflag.CommandLine)
 
 	cliflag.InitFlags()
+
+	if _, err := maxprocs.Set(maxprocs.Logger(klog.Infof)); err != nil {
+		klog.Errorf("Failed to set GOMAXPROCS: %v", err)
+	}
 
 	if config.PrintVersion {
 		version.PrintVersionAndExit()


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Uses `maxprocs.Set` in Volcano components instead of setting `GOMAXPROCS` directly with `runtime.NumCPU()`.

This keeps `GOMAXPROCS` aligned with the container CPU quota and logs any error from setting it.

#### Which issue(s) this PR fixes:

Fixes #5649

#### Special notes for your reviewer:

Updated scheduler, controller-manager, agent-scheduler, and webhook-manager since they used the same pattern.

#### Does this PR introduce a user-facing change?

```release-note
NONE