### PR TITLE
Fix nil pointer dereference risk when listing events in vcctl

### DIFF
--- a/pkg/cli/job/view.go
+++ b/pkg/cli/job/view.go
@@ -242,7 +242,11 @@ func GetEvents(ctx context.Context, config *rest.Config, job *v1alpha1.Job) []co
 		fmt.Printf("%v\n", err)
 		return nil
 	}
-	events, _ := kubernetes.CoreV1().Events(viewJobFlags.Namespace).List(ctx, metav1.ListOptions{})
+	events, err := kubernetes.CoreV1().Events(viewJobFlags.Namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to list events: %v\n", err)
+		return nil
+	}
 	var jobEvents []coreV1.Event
 	for _, v := range events.Items {
 		if strings.HasPrefix(v.ObjectMeta.Name, job.Name+".") {

--- a/pkg/cli/vjobs/view.go
+++ b/pkg/cli/vjobs/view.go
@@ -275,7 +275,11 @@ func GetEvents(ctx context.Context, config *rest.Config, job *v1alpha1.Job) []co
 		fmt.Printf("%v\n", err)
 		return nil
 	}
-	events, _ := kubernetes.CoreV1().Events(viewJobFlags.Namespace).List(ctx, metav1.ListOptions{})
+	events, err := kubernetes.CoreV1().Events(viewJobFlags.Namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to list events: %v\n", err)
+		return nil
+	}
 	var jobEvents []coreV1.Event
 	for _, v := range events.Items {
 		if strings.HasPrefix(v.ObjectMeta.Name, job.Name+".") {


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
In `pkg/cli/job/view.go` and `pkg/cli/vjobs/view.go`, the `GetEvents()` function was silently ignoring the error from `kubernetes.CoreV1().Events().List()`. 

If this API call failed (for instance, due to missing RBAC permissions, network timeouts, or APIServer unavailability), the `events` list would be `nil`. The very next line would then attempt to iterate over `events.Items`, resulting in a runtime panic and crashing the `vcctl` tool.

This PR adds standard error handling so that if the `List()` call fails, `vcctl` prints an error message and gracefully skips event processing instead of crashing.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Notice that do not add `Fixes` if the issue is associated with multiple PRs.
-->
Fixes #5652 

#### Special notes for your reviewer:


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
Fix a bug where `vcctl job view` and `vcctl vjobs view` would crash with a nil pointer dereference if listing Kubernetes events failed.
