### PR TITLE
controller-manager: fix wrong error message for duplicate controllers

### DIFF
--- a/cmd/controller-manager/app/options/options.go
+++ b/cmd/controller-manager/app/options/options.go
@@ -163,12 +163,12 @@ func (s *ServerOption) checkControllers() error {
 		} else {
 			if strings.HasPrefix(c, "-") || strings.HasPrefix(c, "+") {
 				if existenceMap[c[1:]] {
-					return fmt.Errorf("controllers option %s cannot have both '-' and '+' prefixes", c)
+					return fmt.Errorf("controllers option specifies controller %q more than once", c[1:])
 				}
 				existenceMap[c[1:]] = true
 			} else {
 				if existenceMap[c] {
-					return fmt.Errorf("controllers option %s cannot have both '-' and '+' prefixes", c)
+					return fmt.Errorf("controllers option specifies controller %q more than once", c)
 				}
 				existenceMap[c] = true
 			}

--- a/cmd/controller-manager/app/options/options_test.go
+++ b/cmd/controller-manager/app/options/options_test.go
@@ -165,28 +165,43 @@ func TestCheckControllers(t *testing.T) {
 			expectErr: nil,
 		},
 		{
-			name: "fail case: use duplicate job-controller",
+			name: "fail case: same controller disabled and enabled",
 			serverOption: &ServerOption{
 				Controllers: []string{"+gc-controller", "+job-controller", "-job-controller"},
 			},
-			expectErr: fmt.Errorf("controllers option %s cannot have both '-' and '+' prefixes", "-job-controller"),
+			expectErr: fmt.Errorf("controllers option specifies controller %q more than once", "job-controller"),
 		},
 		{
-			name: "fail case: use duplicate job-controller",
+			name: "fail case: same controller with and without prefix",
 			serverOption: &ServerOption{
 				Controllers: []string{"+job-controller", "job-controller"},
 			},
-			expectErr: fmt.Errorf("controllers option %s cannot have both '-' and '+' prefixes", "job-controller"),
+			expectErr: fmt.Errorf("controllers option specifies controller %q more than once", "job-controller"),
+		},
+		{
+			name: "fail case: same controller enabled twice",
+			serverOption: &ServerOption{
+				Controllers: []string{"+job-controller", "+job-controller"},
+			},
+			expectErr: fmt.Errorf("controllers option specifies controller %q more than once", "job-controller"),
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			err := tc.serverOption.checkControllers()
-			if err != nil {
-				if err.Error() != tc.expectErr.Error() {
-					t.Errorf("test case %s failed: expected: %v, but got: %v", tc.name, tc.expectErr, err)
+			if tc.expectErr == nil {
+				if err != nil {
+					t.Errorf("test case %s failed: expected no error, but got: %v", tc.name, err)
 				}
+				return
+			}
+			if err == nil {
+				t.Errorf("test case %s failed: expected error %v, but got nil", tc.name, tc.expectErr)
+				return
+			}
+			if err.Error() != tc.expectErr.Error() {
+				t.Errorf("test case %s failed: expected: %v, but got: %v", tc.name, tc.expectErr, err)
 			}
 		})
 	}


### PR DESCRIPTION

#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
`checkControllers` validates the controller-manager's `--controllers` flag. It
keys `existenceMap` on the base (prefix-stripped) controller name, so the
`"controllers option %s cannot have both '-' and '+' prefixes"` error is returned
for *any* controller specified more than once, not only when the same name
appears with both `-` and `+`.

For inputs such as `+job-controller,job-controller` (a `+` and no prefix, zero
`-` anywhere) or `+job-controller,+job-controller` (the same prefix twice), the
message names prefixes that are not present, so it misdescribes the actual
problem. The repo's own test even pinned `+job-controller,job-controller` and
asserted the "both '-' and '+' prefixes" message, despite that input containing
no `-` at all.

This reports the real condition (the same controller is specified more than
once) using the base name in both branches, so the message is accurate for every
duplicate case and both branches agree:

```
controllers option specifies controller "job-controller" more than once
```

The enable/disable prefix logic is unchanged. Only the two (identical) error
message strings change.

#### Which issue(s) this PR fixes:
Fixes #

<!-- No existing issue; this is a code-correctness fix found by inspection. -->

#### Special notes for your reviewer:
- This is message-text only; there is no change to which flag values are accepted
  or rejected, only to the wording of the error for a duplicate/conflicting
  controller specification.
- Tests updated in the same package: the two previously identically named fail
  cases are renamed to distinct, descriptive names; a
  `+job-controller,+job-controller` case is added (the clearest case where no `-`
  prefix is present at all); and the assertion is hardened so that a missing
  expected error, or an unexpected error, now fails the test (previously an
  `err == nil` silently passed). Verified red -> green: with the old messages the
  three duplicate cases fail; with the fix they pass.
- I used an AI assistant while preparing this change. I have reviewed and tested
  every line myself and can explain each one; I will respond to review comments
  directly, without AI.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

---

## Verification run before drafting (all green)
- `go test ./cmd/controller-manager/app/options/... -run TestCheckControllers` -> ok
- `go build ./cmd/controller-manager/app/options/...` -> ok
- `go vet ./cmd/controller-manager/app/options/...` -> clean
- `gofmt -l cmd/controller-manager/app/options/` -> empty
- go1.26.4 darwin/arm64.

## Diff summary
- `cmd/controller-manager/app/options/options.go`: 2 lines (the two identical
  error strings) -> report the base name and the true "more than once" condition.
- `cmd/controller-manager/app/options/options_test.go`: rename the two duplicate
  case names, update their expected messages, add the `+job-controller,+job-controller`
  case, harden the assertion. Test-only.
- Nothing else touched. No other file references the old or new string.
