### PR TITLE
fix(webhook): report the right index for init containers in topology validation

### DIFF
--- a/pkg/webhooks/admission/jobs/validate/admit_job.go
+++ b/pkg/webhooks/admission/jobs/validate/admit_job.go
@@ -395,11 +395,21 @@ func validateTaskTopoPolicy(task v1alpha1.TaskSpec, index int) string {
 		}
 	}
 
-	for id, container := range append(template.Spec.Containers, template.Spec.InitContainers...) {
-		requestNum := guaranteedCPUs(container)
-		if requestNum == 0 {
-			return fmt.Sprintf("the cpu request isn't an integer in spec.task[%d] container[%d].",
-				index, id)
+	if msg := validateIntegerCPU(template.Spec.Containers, "container", index); msg != "" {
+		return msg
+	}
+
+	return validateIntegerCPU(template.Spec.InitContainers, "initContainer", index)
+}
+
+// validateIntegerCPU checks that every container asks for a whole number of CPUs,
+// which is what the topology policy needs. field names the spec field in the
+// message, so "container" or "initContainer".
+func validateIntegerCPU(containers []v1.Container, field string, taskIndex int) string {
+	for id, container := range containers {
+		if guaranteedCPUs(container) == 0 {
+			return fmt.Sprintf("the cpu request isn't an integer in spec.task[%d] %s[%d].",
+				taskIndex, field, id)
 		}
 	}
 

--- a/pkg/webhooks/admission/jobs/validate/admit_job_test.go
+++ b/pkg/webhooks/admission/jobs/validate/admit_job_test.go
@@ -2478,6 +2478,41 @@ func TestValidateTaskTopoPolicy(t *testing.T) {
 			},
 			expect: "the cpu request isn't an integer",
 		},
+		{
+			// The init container is the one at fault here, so the message should
+			// point at initContainer[0] and not at a container index that the
+			// task does not even have.
+			name: "test-3",
+			taskSpec: v1alpha1.TaskSpec{
+				Name:           "task-3",
+				TopologyPolicy: v1alpha1.Restricted,
+				Template: v1.PodTemplateSpec{
+					Spec: v1.PodSpec{
+						InitContainers: []v1.Container{
+							{
+								Resources: v1.ResourceRequirements{
+									Limits: v1.ResourceList{
+										v1.ResourceCPU:    *resource.NewMilliQuantity(500, resource.DecimalSI),
+										v1.ResourceMemory: *resource.NewQuantity(2000, resource.BinarySI),
+									},
+								},
+							},
+						},
+						Containers: []v1.Container{
+							{
+								Resources: v1.ResourceRequirements{
+									Limits: v1.ResourceList{
+										v1.ResourceCPU:    *resource.NewQuantity(1, ""),
+										v1.ResourceMemory: *resource.NewQuantity(2000, resource.BinarySI),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expect: "spec.task[0] initContainer[0]",
+		},
 	}
 
 	for _, testcase := range testCases {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

`validateTaskTopoPolicy` walks the containers and the init containers as one appended slice, and every message it builds is hardcoded to say `container[%d]`, so an init container is reported under the combined index:

https://github.com/volcano-sh/volcano/blob/26f0052d47deecfbe922b74e48439cccf55636e0/pkg/webhooks/admission/jobs/validate/admit_job.go#L398-L404

For a task with one container and one init container, a fractional cpu request on the init container comes back as `spec.task[0] container[1]`. That task has no `container[1]`, so the message points at a container that does not exist and never mentions the init container.

**Affected versions**

The combined loop has been there since the cpu topology feature was added in [54c2c9ee](https://github.com/volcano-sh/volcano/commit/54c2c9eee8ad1635781b5080e2201c3dfce9397d) (June 2021) and is unchanged on master, so every release since then reports the wrong location.

**User path to the failure**

Both halves of the input are ordinary. `topologyPolicy` is the documented way to ask for NUMA alignment, and a fractional cpu request on a short-lived init container is a normal thing to write.

```yaml
apiVersion: batch.volcano.sh/v1alpha1
kind: Job
metadata:
  name: numa-job
spec:
  minAvailable: 1
  queue: default
  tasks:
    - name: worker
      replicas: 1
      topologyPolicy: single-numa-node
      template:
        spec:
          initContainers:
            - name: prepare
              image: busybox
              resources:
                requests:
                  cpu: 500m
                  memory: 256Mi
          containers:
            - name: main
              image: nginx
              resources:
                requests:
                  cpu: "2"
                  memory: 1Gi
```

`kubectl apply` of that job reaches the message through the admission path:

[`AdmitJobs`](https://github.com/volcano-sh/volcano/blob/26f0052d47deecfbe922b74e48439cccf55636e0/pkg/webhooks/admission/jobs/validate/admit_job.go#L86) takes the [Create branch](https://github.com/volcano-sh/volcano/blob/26f0052d47deecfbe922b74e48439cccf55636e0/pkg/webhooks/admission/jobs/validate/admit_job.go#L98-L99) into `validateJobCreate`, which [calls `validateTaskTemplate`](https://github.com/volcano-sh/volcano/blob/26f0052d47deecfbe922b74e48439cccf55636e0/pkg/webhooks/admission/jobs/validate/admit_job.go#L174) per task, which [calls `validateTaskTopoPolicy`](https://github.com/volcano-sh/volcano/blob/26f0052d47deecfbe922b74e48439cccf55636e0/pkg/webhooks/admission/jobs/validate/admit_job.go#L361), which runs the loop above.

**Evidence**

Handing that job to `AdmitJobs`, the same entry point the API server calls on a Create, gives this on master at `26f0052d4`:

```
allowed = false
message = "the cpu request isn't an integer in spec.task[0] container[1]."
```

The task has one container, `main`, at index 0, so there is no `container[1]` to go and look at. The fractional request is on the init container `prepare`.

With this PR the same job reports:

```
allowed = false
message = "the cpu request isn't an integer in spec.task[0] initContainer[0]."
```

The rejection itself is right either way, the topology policy does need whole cpus. Only the place the message names is wrong.

I have not hit this on a live cluster. I found it by reading the code and then reproduced it at the admission handler with the job above.

#### Which issue(s) this PR fixes:

None, the evidence is in this PR.

#### Special notes for your reviewer:

The two lists are walked separately through a small helper rather than being appended together, so each reports its own index and the init containers are named as such.

Added a test for the init container case, which had no coverage before.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
