### PR TITLE
Validate Ray head task

### DIFF
--- a/pkg/controllers/job/plugins/distributed-framework/ray/ray.go
+++ b/pkg/controllers/job/plugins/distributed-framework/ray/ray.go
@@ -77,6 +77,12 @@ func New(client pluginsinterface.PluginClientset, arguments []string) pluginsint
 	return &rp
 }
 
+func NewInstance(arguments []string) *rayPlugin {
+	rp := rayPlugin{rayArguments: arguments}
+	rp.addFlags()
+	return &rp
+}
+
 func (rp *rayPlugin) addFlags() {
 	flagSet := flag.NewFlagSet(rp.Name(), flag.ContinueOnError)
 	flagSet.StringVar(&rp.headName, "head", DefaultHead, "name of head node in ray cluster")
@@ -93,6 +99,10 @@ func (rp *rayPlugin) addFlags() {
 
 func (rp *rayPlugin) Name() string {
 	return RayPluginName
+}
+
+func (rp *rayPlugin) GetHeadName() string {
+	return rp.headName
 }
 
 func (rp *rayPlugin) OnPodCreate(pod *v1.Pod, job *batch.Job) error {

--- a/pkg/webhooks/admission/jobs/validate/admit_job.go
+++ b/pkg/webhooks/admission/jobs/validate/admit_job.go
@@ -40,6 +40,7 @@ import (
 	jobhelpers "volcano.sh/volcano/pkg/controllers/job/helpers"
 	"volcano.sh/volcano/pkg/controllers/job/plugins"
 	controllerMpi "volcano.sh/volcano/pkg/controllers/job/plugins/distributed-framework/mpi"
+	controllerRay "volcano.sh/volcano/pkg/controllers/job/plugins/distributed-framework/ray"
 	"volcano.sh/volcano/pkg/webhooks/router"
 	"volcano.sh/volcano/pkg/webhooks/schema"
 	"volcano.sh/volcano/pkg/webhooks/util"
@@ -137,6 +138,15 @@ func validateJobCreate(job *v1alpha1.Job, reviewResponse *admissionv1.AdmissionR
 		if masterIndex == -1 {
 			reviewResponse.Allowed = false
 			return "The specified mpi master task was not found"
+		}
+	}
+
+	if _, ok := job.Spec.Plugins[controllerRay.RayPluginName]; ok {
+		rp := controllerRay.NewInstance(job.Spec.Plugins[controllerRay.RayPluginName])
+		headIndex := jobhelpers.GetTaskIndexUnderJob(rp.GetHeadName(), job)
+		if headIndex == -1 {
+			reviewResponse.Allowed = false
+			return "The specified ray head task was not found"
 		}
 	}
 

--- a/pkg/webhooks/admission/jobs/validate/admit_job_test.go
+++ b/pkg/webhooks/admission/jobs/validate/admit_job_test.go
@@ -1814,6 +1814,42 @@ func TestValidateJobCreate(t *testing.T) {
 			ExpectErr:      true,
 		},
 		{
+			Name:                     "job-with-ray-plugin-invalid-head",
+			PodLevelResourcesEnabled: false,
+			Job: v1alpha1.Job{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "job-with-ray-plugin-invalid-head",
+					Namespace: namespace,
+				},
+				Spec: v1alpha1.JobSpec{
+					MinAvailable: 1,
+					Queue:        "default",
+					Tasks: []v1alpha1.TaskSpec{
+						{
+							Name:     "worker",
+							Replicas: 2,
+							Template: v1.PodTemplateSpec{
+								Spec: v1.PodSpec{
+									Containers: []v1.Container{
+										{
+											Name:  "worker",
+											Image: "ray:latest",
+										},
+									},
+								},
+							},
+						},
+					},
+					Plugins: map[string][]string{
+						"ray": {"--head=head"},
+					},
+				},
+			},
+			reviewResponse: admissionv1.AdmissionResponse{Allowed: false},
+			ret:            "The specified ray head task was not found",
+			ExpectErr:      true,
+		},
+		{
 			Name:                     "validate invalid-job with pod level resources less than aggregate container resources",
 			PodLevelResourcesEnabled: true,
 			Job: v1alpha1.Job{


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Validate Ray jobs during admission when the configured head task does not exist.

Without this, the job is accepted first and then fails later when the Ray plugin handles pod creation.

#### Which issue(s) this PR fixes:

Fixes #5658

#### Special notes for your reviewer:

Reuses the existing MPI plugin validation pattern.

#### Does this PR introduce a user-facing change?

```release-note
Ray jobs with a missing configured head task are now rejected during admission.