### PR TITLE
feat(metrics): add observability for gang preemption and gang reclaim scheduling actions

### DIFF
--- a/pkg/scheduler/actions/gangpreempt/gangpreempt.go
+++ b/pkg/scheduler/actions/gangpreempt/gangpreempt.go
@@ -23,6 +23,7 @@ import (
 	"volcano.sh/volcano/pkg/scheduler/api"
 	"volcano.sh/volcano/pkg/scheduler/conf"
 	"volcano.sh/volcano/pkg/scheduler/framework"
+	"volcano.sh/volcano/pkg/scheduler/metrics"
 	"volcano.sh/volcano/pkg/scheduler/util"
 )
 
@@ -119,8 +120,9 @@ func (gp *Action) Execute(ssn *framework.Session) {
 			}
 
 			preemptorJob := preemptors.Pop().(*api.JobInfo)
+			metrics.RegisterGangPreemptionAttempts()
 			stmt := framework.NewStatement(ssn)
-			subJobHyperNodes := gp.preemptJobInDomains(ssn, stmt, queue, preemptorJob)
+			subJobHyperNodes, victimsCount := gp.preemptJobInDomains(ssn, stmt, queue, preemptorJob)
 
 			// Mirror legacy commit behavior: commit only when the job becomes pipelined.
 			if ssn.JobPipelined(preemptorJob) {
@@ -128,17 +130,19 @@ func (gp *Action) Execute(ssn *framework.Session) {
 				utils.ApplySubJobNominations(preemptorJob, subJobHyperNodes)
 			} else {
 				stmt.Discard()
+				victimsCount = 0
 			}
+			metrics.UpdateGangPreemptionVictimsCount(victimsCount)
 		}
 	}
 }
 
 func (gp *Action) UnInitialize() {}
 
-func (gp *Action) preemptJobInDomains(ssn *framework.Session, stmt *framework.Statement, queue *api.QueueInfo, preemptorJob *api.JobInfo) map[api.SubJobID]string {
+func (gp *Action) preemptJobInDomains(ssn *framework.Session, stmt *framework.Statement, queue *api.QueueInfo, preemptorJob *api.JobInfo) (map[api.SubJobID]string, int) {
 	pending := utils.CollectPendingTasksForGangEviction(ssn, preemptorJob)
 	if len(pending) == 0 {
-		return nil
+		return nil, 0
 	}
 
 	jobNeed := utils.SumInitResreq(pending)
@@ -175,10 +179,10 @@ func (gp *Action) preemptJobInDomains(ssn *framework.Session, stmt *framework.St
 			if err := stmt.RecoverOperations(plan); err != nil {
 				continue
 			}
-			return subJobHyperNodes
+			return subJobHyperNodes, len(attemptVictims)
 		}
 	}
-	return nil
+	return nil, 0
 }
 
 func (gp *Action) selectDomainBundles(ssn *framework.Session, preemptorJob *api.JobInfo, pendingTasks []*api.TaskInfo, jobNeed *api.Resource, domain string) []*utils.Bundle {

--- a/pkg/scheduler/actions/gangreclaim/gangreclaim.go
+++ b/pkg/scheduler/actions/gangreclaim/gangreclaim.go
@@ -23,6 +23,7 @@ import (
 	"volcano.sh/volcano/pkg/scheduler/api"
 	"volcano.sh/volcano/pkg/scheduler/conf"
 	"volcano.sh/volcano/pkg/scheduler/framework"
+	"volcano.sh/volcano/pkg/scheduler/metrics"
 	"volcano.sh/volcano/pkg/scheduler/util"
 )
 
@@ -121,8 +122,9 @@ func (gr *Action) Execute(ssn *framework.Session) {
 				break
 			}
 			job := jobsQ.Pop().(*api.JobInfo)
+			metrics.RegisterGangReclaimAttempts()
 			stmt := framework.NewStatement(ssn)
-			subJobHyperNodes := gr.reclaimJobInDomains(ssn, stmt, queue, job)
+			subJobHyperNodes, victimsCount := gr.reclaimJobInDomains(ssn, stmt, queue, job)
 
 			// Mirror legacy commit behavior: commit only when the job becomes pipelined.
 			if ssn.JobPipelined(job) {
@@ -130,21 +132,23 @@ func (gr *Action) Execute(ssn *framework.Session) {
 				utils.ApplySubJobNominations(job, subJobHyperNodes)
 			} else {
 				stmt.Discard()
+				victimsCount = 0
 			}
+			metrics.UpdateGangReclaimVictimsCount(victimsCount)
 		}
 	}
 }
 
 func (gr *Action) UnInitialize() {}
 
-func (gr *Action) reclaimJobInDomains(ssn *framework.Session, stmt *framework.Statement, queue *api.QueueInfo, job *api.JobInfo) map[api.SubJobID]string {
+func (gr *Action) reclaimJobInDomains(ssn *framework.Session, stmt *framework.Statement, queue *api.QueueInfo, job *api.JobInfo) (map[api.SubJobID]string, int) {
 	pending := utils.CollectPendingTasksForGangEviction(ssn, job)
 	if len(pending) == 0 {
-		return nil
+		return nil, 0
 	}
 	if queue != nil && !ssn.Preemptive(queue, pending) {
 		klog.V(3).Infof("Queue <%s> cannot reclaim for job <%s/%s>, skip", queue.Name, job.Namespace, job.Name)
-		return nil
+		return nil, 0
 	}
 	jobNeed := utils.SumInitResreq(pending)
 	domains := utils.GetCandidateDomains(ssn, job, gr.maxDomains)
@@ -180,10 +184,10 @@ func (gr *Action) reclaimJobInDomains(ssn *framework.Session, stmt *framework.St
 			if err := stmt.RecoverOperations(plan); err != nil {
 				continue
 			}
-			return subJobHyperNodes
+			return subJobHyperNodes, len(attemptVictims)
 		}
 	}
-	return nil
+	return nil, 0
 }
 
 func (gr *Action) selectDomainBundles(ssn *framework.Session, lessQueueFn func(l, r *api.QueueInfo) bool, reclaimerJob *api.JobInfo, pendingTasks []*api.TaskInfo, jobNeed *api.Resource, domain string) []*utils.Bundle {

--- a/pkg/scheduler/metrics/gang_metrics_test.go
+++ b/pkg/scheduler/metrics/gang_metrics_test.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2026 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGangPreemptionMetrics(t *testing.T) {
+	// Simulate an attempt
+	RegisterGangPreemptionAttempts()
+
+	// Read the metric from memory
+	attempts := testutil.ToFloat64(gangPreemptionAttempts)
+	assert.Equal(t, float64(1), attempts, "gangPreemptionAttempts should be 1 after one registration")
+
+	// Simulate selecting 5 victims
+	UpdateGangPreemptionVictimsCount(5)
+
+	// Read the gauge from memory
+	victims := testutil.ToFloat64(gangPreemptionVictims)
+	assert.Equal(t, float64(5), victims, "gangPreemptionVictims should be 5 after update")
+}
+
+func TestGangReclaimMetrics(t *testing.T) {
+	// Simulate an attempt
+	RegisterGangReclaimAttempts()
+
+	// Read the metric from memory
+	attempts := testutil.ToFloat64(gangReclaimAttempts)
+	assert.Equal(t, float64(1), attempts, "gangReclaimAttempts should be 1 after one registration")
+
+	// Simulate selecting 3 victims
+	UpdateGangReclaimVictimsCount(3)
+
+	// Read the gauge from memory
+	victims := testutil.ToFloat64(gangReclaimVictims)
+	assert.Equal(t, float64(3), victims, "gangReclaimVictims should be 3 after update")
+}

--- a/pkg/scheduler/metrics/metrics.go
+++ b/pkg/scheduler/metrics/metrics.go
@@ -163,6 +163,38 @@ var (
 		},
 	)
 
+	gangPreemptionVictims = promauto.NewGauge(
+		prometheus.GaugeOpts{
+			Subsystem: VolcanoSubSystemName,
+			Name:      "pod_gang_preemption_victims",
+			Help:      "Number of selected gang preemption victims",
+		},
+	)
+
+	gangPreemptionAttempts = promauto.NewCounter(
+		prometheus.CounterOpts{
+			Subsystem: VolcanoSubSystemName,
+			Name:      "total_gang_preemption_attempts",
+			Help:      "Total gang preemption attempts in the cluster till now",
+		},
+	)
+
+	gangReclaimVictims = promauto.NewGauge(
+		prometheus.GaugeOpts{
+			Subsystem: VolcanoSubSystemName,
+			Name:      "pod_gang_reclaim_victims",
+			Help:      "Number of selected gang reclaim victims",
+		},
+	)
+
+	gangReclaimAttempts = promauto.NewCounter(
+		prometheus.CounterOpts{
+			Subsystem: VolcanoSubSystemName,
+			Name:      "total_gang_reclaim_attempts",
+			Help:      "Total gang reclaim attempts in the cluster till now",
+		},
+	)
+
 	unscheduleTaskCount = promauto.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Subsystem: VolcanoSubSystemName,
@@ -252,6 +284,26 @@ func UpdatePreemptionVictimsCount(victimsCount int) {
 // RegisterPreemptionAttempts records number of attempts for preemtion
 func RegisterPreemptionAttempts() {
 	preemptionAttempts.Inc()
+}
+
+// UpdateGangPreemptionVictimsCount updates count of gang preemption victims
+func UpdateGangPreemptionVictimsCount(victimsCount int) {
+	gangPreemptionVictims.Set(float64(victimsCount))
+}
+
+// RegisterGangPreemptionAttempts records number of attempts for gang preemption
+func RegisterGangPreemptionAttempts() {
+	gangPreemptionAttempts.Inc()
+}
+
+// UpdateGangReclaimVictimsCount updates count of gang reclaim victims
+func UpdateGangReclaimVictimsCount(victimsCount int) {
+	gangReclaimVictims.Set(float64(victimsCount))
+}
+
+// RegisterGangReclaimAttempts records number of attempts for gang reclaim
+func RegisterGangReclaimAttempts() {
+	gangReclaimAttempts.Inc()
 }
 
 // UpdateUnscheduleTaskCount records total number of unscheduleable tasks


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

The `gangpreempt` and `gangreclaim` scheduler actions currently have no Prometheus metrics, making it impossible for cluster administrators to monitor gang-level eviction activity.

The existing `preempt` and `reclaim` actions already expose metrics like `total_preemption_attempts` (Counter) and `pod_preemption_victims` (Gauge), but their gang counterparts have no equivalent observability.

This PR adds four new Prometheus metrics following the existing pattern:

| Metric | Type | Description |
|---|---|---|
| `volcano_total_gang_preemption_attempts` | Counter | Total gang preemption attempts |
| `volcano_pod_gang_preemption_victims` | Gauge | Number of selected gang preemption victims |
| `volcano_total_gang_reclaim_attempts` | Counter | Total gang reclaim attempts |
| `volcano_pod_gang_reclaim_victims` | Gauge | Number of selected gang reclaim victims |

Changes:
- Added metric variable definitions and helper functions in `pkg/scheduler/metrics/metrics.go`
- Instrumented `gangpreempt` action in `pkg/scheduler/actions/gangpreempt/gangpreempt.go`
- Instrumented `gangreclaim` action in `pkg/scheduler/actions/gangreclaim/gangreclaim.go`
- Added unit tests in `pkg/scheduler/metrics/gang_metrics_test.go`

#### Which issue(s) this PR fixes:

Fixes #5661 

#### Special notes for your reviewer:

This follows the exact same pattern used by the existing preempt/reclaim metrics. All unit tests pass locally.

#### Does this PR introduce a user-facing change?

```release-note
Added Prometheus metrics for gangpreempt and gangreclaim scheduler actions to improve observability for gang-level scheduling.
