### PR TITLE
scheduler: safely preserve pipelined job intent

### DIFF
--- a/pkg/scheduler/actions/allocate/allocate.go
+++ b/pkg/scheduler/actions/allocate/allocate.go
@@ -311,14 +311,27 @@ func (alloc *Action) allocateResources(actx *allocateContext) {
 			klog.V(3).InfoS("Try to allocate resource for job contains hard topology or subjob policy", "queue", queue.Name, "job", job.UID,
 				"allocatedHyperNode", job.AllocatedHyperNode, "subJobNum", jobWorksheet.subJobs.Len())
 			stmt := alloc.allocateForJob(job, jobWorksheet, ssn.HyperNodes[framework.ClusterTopHyperNode])
-			if stmt != nil && ssn.JobReady(job) { // do not commit stmt when job is pipelined
-				stmt.Commit()
-				ssn.MarkJobDirty(job.UID)
-				alloc.recorder.UpdateDecisionToJob(job, ssn.HyperNodes)
+			if stmt != nil {
+				// Every statement has already changed the session snapshot and therefore
+				// must reach exactly one terminal path:
+				//   1. Ready: commit allocations because the gang can start safely.
+				//   2. Pipelined: keep only future-node intent; rolling back Allocate
+				//      operations prevents a partially ready gang from binding early.
+				//   3. Neither: discard all speculative changes so they do not leave
+				//      phantom task states or node resource usage in this session.
+				if ssn.JobReady(job) {
+					stmt.Commit()
+					ssn.MarkJobDirty(job.UID)
+					alloc.recorder.UpdateDecisionToJob(job, ssn.HyperNodes)
 
-				// There are still left tasks that need to be allocated when min available < replicas, put the job back
-				if !jobWorksheet.Empty() {
-					jobs.Push(job)
+					// There are still left tasks that need to be allocated when min available < replicas, put the job back
+					if !jobWorksheet.Empty() {
+						jobs.Push(job)
+					}
+				} else if ssn.JobPipelined(job) {
+					stmt.CommitPipelined()
+				} else {
+					stmt.Discard()
 				}
 			}
 		} else {
@@ -340,19 +353,29 @@ func (alloc *Action) allocateResources(actx *allocateContext) {
 					stmt = alloc.allocateResourcesForTasks(subJob, tasks, framework.ClusterTopHyperNode)
 				}
 
-				if stmt != nil && ssn.JobReady(job) { // do not commit stmt when job is pipelined
-					stmt.Commit()
+				if stmt != nil {
+					// allocateResourcesForTasks mutates the session before returning.
+					// Resolve the transaction explicitly instead of dropping a non-nil
+					// statement: commit a ready gang, retain only pipeline intent for a
+					// pipelined gang, or roll the speculative result back completely.
+					if ssn.JobReady(job) {
+						stmt.Commit()
 
-					// Mirror recorder.UpdateDecisionToJob: clear the redeemed nomination.
-					if subJob.NominatedHyperNode != "" {
-						klog.V(3).InfoS("clear nominated hyperNode for committed subJob",
-							"subJob", subJob.UID, "old", subJob.NominatedHyperNode)
-						subJob.NominatedHyperNode = ""
-					}
+						// Mirror recorder.UpdateDecisionToJob: clear the redeemed nomination.
+						if subJob.NominatedHyperNode != "" {
+							klog.V(3).InfoS("clear nominated hyperNode for committed subJob",
+								"subJob", subJob.UID, "old", subJob.NominatedHyperNode)
+							subJob.NominatedHyperNode = ""
+						}
 
-					// There are still left tasks that need to be allocated when min available < replicas, put the job back
-					if tasks.Len() > 0 {
-						jobs.Push(job)
+						// There are still left tasks that need to be allocated when min available < replicas, put the job back
+						if tasks.Len() > 0 {
+							jobs.Push(job)
+						}
+					} else if ssn.JobPipelined(job) {
+						stmt.CommitPipelined()
+					} else {
+						stmt.Discard()
 					}
 				}
 			} else {

--- a/pkg/scheduler/api/job_info.go
+++ b/pkg/scheduler/api/job_info.go
@@ -869,10 +869,15 @@ func (ji *JobInfo) TaskSchedulingReason(tid TaskID) (reason, msg, nominatedNodeN
 		return PodReasonSchedulable, msg, ""
 	case Pipelined:
 		msg = fmt.Sprintf("Pod %s/%s can possibly be assigned to %s, once resource is released and minAvailable is satisfied", taskInfo.Namespace, taskInfo.Name, ctx.NodeName)
-		if ctx.EvictionOccurred {
-			nominatedNodeName = ctx.NodeName
-		}
-		return PodReasonUnschedulable, msg, nominatedNodeName
+		// A Pipelined TransactionContext is the current scheduling intent, so
+		// always expose its node as NominatedNodeName. The old behavior did this
+		// only when EvictionOccurred was true; in a later cycle the same victim
+		// could still be terminating while no new eviction occurred, causing the
+		// valid nomination to disappear. Making every Pipelined task nominate its
+		// node also gives taskUnschedulable an unambiguous contract: an empty
+		// nomination means there is no longer a pipeline decision and an old Pod
+		// status value can be safely cleared.
+		return PodReasonUnschedulable, msg, ctx.NodeName
 	case Pending:
 		if fe := ji.NodesFitErrors[tid]; fe != nil {
 			// Pod is unschedulable

--- a/pkg/scheduler/api/job_info_test.go
+++ b/pkg/scheduler/api/job_info_test.go
@@ -397,6 +397,21 @@ func TestTaskSchedulingReason(t *testing.T) {
 	}
 }
 
+func TestTaskSchedulingReasonAlwaysNominatesPipelinedTask(t *testing.T) {
+	pod := buildPod("ns1", "task-1", "", v1.PodPending, BuildResourceList("1", "1G"), nil, make(map[string]string))
+	job := NewJobInfo(JobID("job-1"))
+	task := NewTaskInfo(pod)
+	job.AddTaskInfo(task)
+
+	task.Status = Pipelined
+	task.NodeName = "node-1"
+	task.EvictionOccurred = false
+
+	reason, _, nominatedNodeName := job.TaskSchedulingReason(task.UID)
+	assert.Equal(t, PodReasonUnschedulable, reason)
+	assert.Equal(t, "node-1", nominatedNodeName)
+}
+
 func TestJobInfo(t *testing.T) {
 	newTaskFunc := func(uid, jobUid types.UID, status TaskStatus, resources *Resource) *TaskInfo {
 		isBestEffort := resources.IsEmpty()

--- a/pkg/scheduler/cache/cache.go
+++ b/pkg/scheduler/cache/cache.go
@@ -343,6 +343,8 @@ func podConditionHaveUpdate(status *v1.PodStatus, condition *v1.PodCondition) bo
 }
 
 func podNominatedNodeNameNeedUpdate(status *v1.PodStatus, nodeName string) bool {
+	// nodeName is the complete desired value, not an optional patch. In
+	// particular, an empty value is meaningful and clears a stale nomination.
 	return status.NominatedNodeName != nodeName
 }
 
@@ -1088,12 +1090,16 @@ func (sc *SchedulerCache) taskUnschedulable(task *schedulingapi.TaskInfo, reason
 
 	updateCond := podConditionHaveUpdate(&pod.Status, condition)
 
-	// only update pod's nominatedNodeName when nominatedNodeName is not empty
-	// consider this situation:
-	// 1. at session 1, the pod A preempt another lower priority pod B, and we updated A's nominatedNodeName
-	// 2. at session 2, the pod B is still terminating, so the pod A is still pipelined, but it preempt none, so
-	// the nominatedNodeName is empty, but we should not override the A's nominatedNodeName to empty
-	updateNomiNode := len(nominatedNodeName) > 0 && podNominatedNodeNameNeedUpdate(&pod.Status, nominatedNodeName)
+	// TaskSchedulingReason now guarantees that every Pipelined task reports its
+	// selected node, even when no new eviction happened in this session. Under
+	// that contract an empty nominatedNodeName means the task has no current
+	// pipeline decision, rather than "keep the previous value". Compare values
+	// directly so this path supports all required transitions:
+	//   "" -> node-a     create a nomination
+	//   node-a -> node-b move a nomination
+	//   node-a -> ""     clear a stale nomination
+	// Avoiding the old non-empty guard is what makes the last transition possible.
+	updateNomiNode := podNominatedNodeNameNeedUpdate(&pod.Status, nominatedNodeName)
 
 	if updateCond || updateNomiNode {
 		pod = pod.DeepCopy()
@@ -1102,8 +1108,9 @@ func (sc *SchedulerCache) taskUnschedulable(task *schedulingapi.TaskInfo, reason
 			klog.V(3).Infof("Updating pod condition for %s/%s to (%s==%s)", pod.Namespace, pod.Name, condition.Type, condition.Status)
 		}
 
-		// if nominatedNode field changed, we should update it to the pod status, for k8s
-		// autoscaler will check this field and ignore this pod when scale up.
+		// Apply the complete desired value, including empty string for cleanup.
+		// External components such as autoscalers observe this Pod status field,
+		// so it must reflect the current pipeline decision rather than an old one.
 		if updateNomiNode {
 			klog.V(3).Infof("Updating pod nominatedNodeName for %s/%s from (%s) to (%s)", pod.Namespace, pod.Name, pod.Status.NominatedNodeName, nominatedNodeName)
 			pod.Status.NominatedNodeName = nominatedNodeName

--- a/pkg/scheduler/cache/cache_test.go
+++ b/pkg/scheduler/cache/cache_test.go
@@ -57,6 +57,41 @@ func buildNode(name string, alloc v1.ResourceList) *v1.Node {
 	}
 }
 
+func TestTaskUnschedulableUpdatesAndClearsNominatedNodeName(t *testing.T) {
+	tests := []struct {
+		name     string
+		original string
+		desired  string
+	}{
+		{name: "persist pipeline nomination", desired: "node-1"},
+		{name: "clear stale nomination", original: "node-1"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sc := NewDefaultMockSchedulerCache("test-scheduler")
+			pod := &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "ns1", Name: "pod-1", UID: "pod-1"},
+				Status:     v1.PodStatus{NominatedNodeName: tt.original},
+			}
+			if _, err := sc.kubeClient.CoreV1().Pods(pod.Namespace).Create(context.Background(), pod.DeepCopy(), metav1.CreateOptions{}); err != nil {
+				t.Fatalf("create pod: %v", err)
+			}
+
+			task := api.NewTaskInfo(pod)
+			if err := sc.taskUnschedulable(task, api.PodReasonUnschedulable, "waiting for gang", tt.desired); err != nil {
+				t.Fatalf("taskUnschedulable: %v", err)
+			}
+
+			updated, err := sc.kubeClient.CoreV1().Pods(pod.Namespace).Get(context.Background(), pod.Name, metav1.GetOptions{})
+			if err != nil {
+				t.Fatalf("get pod: %v", err)
+			}
+			assert.Equal(t, tt.desired, updated.Status.NominatedNodeName)
+		})
+	}
+}
+
 func buildPod(ns, n, nn string,
 	p v1.PodPhase, req v1.ResourceList,
 	owner []metav1.OwnerReference, labels map[string]string) *v1.Pod {

--- a/pkg/scheduler/framework/statement.go
+++ b/pkg/scheduler/framework/statement.go
@@ -204,9 +204,6 @@ func (s *Statement) Pipeline(task *api.TaskInfo, hostname string, evictionOccurr
 	return nil
 }
 
-func (s *Statement) pipeline(task *api.TaskInfo) {
-}
-
 func (s *Statement) UnPipeline(task *api.TaskInfo) error {
 	return s.unPipeline(task)
 }
@@ -400,7 +397,12 @@ func (s *Statement) Commit() {
 				klog.Errorf("Failed to evict task: %s", err.Error())
 			}
 		case Pipeline:
-			s.pipeline(op.task)
+			// Pipeline deliberately has no cache-level resource reservation or
+			// binding side effect. The task remains Pipelined in this session, and
+			// RecordJobStatusEvent persists only its selected node as the Pod's
+			// NominatedNodeName when the session closes. The next session retries
+			// that node first without making the task compete with a stale cache
+			// reservation of its own resources.
 		case Allocate:
 			err := s.allocate(op.task)
 			if err != nil {
@@ -408,6 +410,52 @@ func (s *Statement) Commit() {
 					klog.Errorf("Failed to unallocate task <%v/%v>: %v.", op.task.Namespace, op.task.Name, e)
 				}
 				klog.Errorf("Failed to allocate task <%v/%v>: %v.", op.task.Namespace, op.task.Name, err)
+			}
+		}
+	}
+	s.operations = nil
+}
+
+// CommitPipelined resolves a statement for a job that satisfies JobPipelined
+// but not JobReady. Such a statement can contain a mixture of Allocate and
+// Pipeline operations; for example, a gang with minAvailable=4 may have two
+// Allocated tasks and two Pipelined tasks. Calling Commit in that state would
+// bind the two Allocated tasks before the complete gang is ready.
+//
+// This method therefore applies selective transaction semantics:
+//   - Pipeline is retained in the session. Its current TransactionContext is
+//     authoritative and is later reported as Pod.Status.NominatedNodeName.
+//   - Allocate is rolled back to Pending. GenerateLastTxContext preserves the
+//     successful trial placement for scheduling diagnostics without binding.
+//   - Evict is rolled back defensively. Allocate statements do not normally
+//     contain Evict, but "commit pipeline only" must not leak any other effect.
+//
+// Pipeline state intentionally reserves resources only in the current session.
+// Across sessions, the durable state is NominatedNodeName rather than a task or
+// node resource reservation in SchedulerCache. This avoids stale reservations,
+// self-competition on FutureIdle, and cache/informer consistency problems.
+func (s *Statement) CommitPipelined() {
+	klog.V(3).Info("Committing pipeline decisions and rolling back other operations ...")
+	for i := len(s.operations) - 1; i >= 0; i-- {
+		op := s.operations[i]
+		if op.name == Pipeline {
+			// The current Pipelined TransactionContext remains valid, so an older
+			// discarded transaction must not override it during status reporting.
+			op.task.ClearLastTxContext()
+			continue
+		}
+
+		// Preserve the attempted placement for TaskSchedulingReason before
+		// restoring the live TransactionContext to its pre-statement state.
+		op.task.GenerateLastTxContext()
+		switch op.name {
+		case Evict:
+			if err := s.unevict(op.task); err != nil {
+				klog.Errorf("Failed to roll back eviction while committing pipelined statement: %s", err.Error())
+			}
+		case Allocate:
+			if err := s.unallocate(op.task); err != nil {
+				klog.Errorf("Failed to roll back allocation while committing pipelined statement: %s", err.Error())
 			}
 		}
 	}

--- a/pkg/scheduler/framework/statement_test.go
+++ b/pkg/scheduler/framework/statement_test.go
@@ -394,3 +394,49 @@ func TestDiscardReversesOperations(t *testing.T) {
 		}
 	})
 }
+
+func TestCommitPipelinedPreservesOnlyPipelineOperations(t *testing.T) {
+	ssn, job, allocatedTask, node := newTestSession(t)
+
+	pipelinedTask := allocatedTask.Clone()
+	pipelinedTask.UID = api.TaskID("p2")
+	pipelinedTask.Name = "p2"
+	pipelinedTask.Pod = allocatedTask.Pod.DeepCopy()
+	pipelinedTask.Pod.UID = "p2"
+	pipelinedTask.Pod.Name = "p2"
+	pipelinedTask.TransactionContext = api.TransactionContext{Status: api.Pending}
+	pipelinedTask.LastTransaction = nil
+	job.AddTaskInfo(pipelinedTask)
+
+	stmt := NewStatement(ssn)
+	if err := stmt.Allocate(allocatedTask, node); err != nil {
+		t.Fatalf("Allocate failed: %v", err)
+	}
+	if err := stmt.Pipeline(pipelinedTask, node.Name, false); err != nil {
+		t.Fatalf("Pipeline failed: %v", err)
+	}
+
+	stmt.CommitPipelined()
+
+	if allocatedTask.Status != api.Pending || allocatedTask.NodeName != "" {
+		t.Fatalf("allocated task must be rolled back, got status %v on node %q", allocatedTask.Status, allocatedTask.NodeName)
+	}
+	if allocatedTask.LastTransaction == nil || allocatedTask.LastTransaction.Status != api.Allocated {
+		t.Fatalf("allocated task must retain its last scheduling decision for reporting, got %#v", allocatedTask.LastTransaction)
+	}
+	if pipelinedTask.Status != api.Pipelined || pipelinedTask.NodeName != node.Name {
+		t.Fatalf("pipeline decision must be retained, got status %v on node %q", pipelinedTask.Status, pipelinedTask.NodeName)
+	}
+	if pipelinedTask.LastTransaction != nil {
+		t.Fatalf("committed pipeline decision must not retain a discarded transaction, got %#v", pipelinedTask.LastTransaction)
+	}
+	if len(stmt.operations) != 0 {
+		t.Fatalf("committed statement must not retain operations, got %d", len(stmt.operations))
+	}
+	if _, found := node.Tasks[api.PodKey(allocatedTask.Pod)]; found {
+		t.Fatal("rolled-back allocated task must not remain on the session node")
+	}
+	if _, found := node.Tasks[api.PodKey(pipelinedTask.Pod)]; !found {
+		t.Fatal("pipelined task must remain on the session node until session close")
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area scheduling

#### What this PR does / why we need it:

The allocate action previously committed a statement only when `JobReady` was true. A pipelined or rejected statement could therefore be dropped without `Commit()` or `Discard()`, leaving speculative task states and node resource usage in the current session.

Directly calling `Commit()` for a pipelined job is unsafe because one statement may contain both `Allocate` and `Pipeline` operations. For example:

```text
minAvailable = 4
2 tasks Allocated + 2 tasks Pipelined
```

Committing the whole statement would bind two Pods before the gang is ready.

This PR gives every statement one explicit result:

- `JobReady`: commit all operations.
- `JobPipelined`: call `CommitPipelined()`, retain Pipeline decisions, and roll back Allocate/Evict operations.
- Otherwise: discard all speculative operations.

Rolled-back allocations keep `LastTransaction` for scheduling diagnostics. Retained Pipeline tasks publish their selected node through `Pod.Status.NominatedNodeName`, including cycles where no new eviction occurs.

Only the nomination is preserved across sessions; node resources are not reserved in `SchedulerCache`. In the next session, the Pending task retries its nominated node first. A stale nomination is cleared when there is no longer a valid Pipeline decision.

#### Which issue(s) this PR fixes:

Related to #5044

#### Special notes for your reviewer:

For the example above, `CommitPipelined()` produces:

```text
2 Allocated tasks -> rolled back to Pending, not bound
2 Pipelined tasks -> retained and nominated to their selected nodes
```

Tests cover mixed Allocate/Pipeline rollback, `LastTransaction` preservation, nomination without a new eviction, and stale nomination cleanup.

Validation:

- `go test ./pkg/scheduler/api`
- Framework, cache, and allocate tests passed as Linux test binaries under Ubuntu WSL.
- `git diff --check`

#### Does this PR introduce a user-facing change?

```release-note
Fix pipelined gang handling so partially ready jobs do not bind tasks early, while preserving nominated node intent across scheduling sessions.
```
