### PR TITLE
feat(cli): sort vcctl pod list output by namespace and name

### DIFF
--- a/pkg/cli/pod/pod.go
+++ b/pkg/cli/pod/pod.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -153,6 +154,7 @@ func ListPods(ctx context.Context) error {
 		fmt.Printf("No resources found\n")
 		return nil
 	}
+	sortPods(pods.Items)
 	PrintPods(&pods, os.Stdout, listPodFlags.allNamespace)
 
 	return nil
@@ -311,6 +313,18 @@ func appendIfNotExists(existing, toAppend []corev1.Pod) []corev1.Pod {
 		}
 	}
 	return existing
+}
+
+// sortPods orders the pods by namespace and name. The queue path merges two
+// filtered lists, so without this the rows can come out with the namespaces
+// interleaved rather than grouped.
+func sortPods(pods []corev1.Pod) {
+	sort.Slice(pods, func(i, j int) bool {
+		if pods[i].Namespace != pods[j].Namespace {
+			return pods[i].Namespace < pods[j].Namespace
+		}
+		return pods[i].Name < pods[j].Name
+	})
 }
 
 // translateTimestampSince translates a timestamp into a human-readable string using time.Since.

--- a/pkg/cli/pod/pod_test.go
+++ b/pkg/cli/pod/pod_test.go
@@ -26,6 +26,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"reflect"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -312,7 +313,7 @@ func TestSortPods(t *testing.T) {
 		got = append(got, p.Namespace+"/"+p.Name)
 	}
 	want := []string{"team-a/worker-0", "team-a/worker-1", "team-b/worker-0", "team-b/worker-1"}
-	if !reflect.DeepEqual(got, want) {
+	if !slices.Equal(got, want) {
 		t.Errorf("expected pods in order %v, got %v", want, got)
 	}
 }

--- a/pkg/cli/pod/pod_test.go
+++ b/pkg/cli/pod/pod_test.go
@@ -295,6 +295,28 @@ func TestPrintPodsHeaderDrivenWidth(t *testing.T) {
 	}
 }
 
+func TestSortPods(t *testing.T) {
+	// Rows can turn up with the namespaces interleaved, so check they come back
+	// grouped by namespace, and by name within each one.
+	pods := []corev1.Pod{
+		buildPod("team-b", "worker-1", nil, nil),
+		buildPod("team-a", "worker-1", nil, nil),
+		buildPod("team-b", "worker-0", nil, nil),
+		buildPod("team-a", "worker-0", nil, nil),
+	}
+
+	sortPods(pods)
+
+	var got []string
+	for _, p := range pods {
+		got = append(got, p.Namespace+"/"+p.Name)
+	}
+	want := []string{"team-a/worker-0", "team-a/worker-1", "team-b/worker-0", "team-b/worker-1"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("expected pods in order %v, got %v", want, got)
+	}
+}
+
 func TestAppendIfNotExists(t *testing.T) {
 	existing := []corev1.Pod{
 		buildPod("team-a", "worker-0", nil, nil),


### PR DESCRIPTION
/kind feature

The `--queue` path merges the label matched pods with the annotation matched pods into one list, so the rows could come out with the namespaces interleaved instead of grouped. The single list paths already arrive in the API's namespace/name order, so this only showed up on the merged path.

`sortPods` orders by namespace and name before printing, so the listing stays grouped and no longer depends on how the two lists happen to merge. Added a unit test for it.

Suggested on #5648, thanks @hajnalmt for the go ahead.

Fixes #5664

```release-note
NONE
```
