### PR TITLE
agent-scheduler: validate scheduler-worker-count is greater than zero

### DIFF
--- a/cmd/agent-scheduler/app/options/options.go
+++ b/cmd/agent-scheduler/app/options/options.go
@@ -128,6 +128,9 @@ func (s *ServerOption) AddFlags(fs *pflag.FlagSet) {
 func (s *ServerOption) CheckOptionOrDie() error {
 	s.ServerOption.ShardingMode = s.ShardingMode
 	s.ServerOption.ShardName = s.ShardName
+	if s.ScheduleWorkerCount == 0 {
+		return fmt.Errorf("scheduler-worker-count must be greater than 0")
+	}
 	return componentbaseconfigvalidation.ValidateLeaderElectionConfiguration(&s.LeaderElection, field.NewPath("leaderElection")).ToAggregate()
 }
 

--- a/cmd/agent-scheduler/app/options/options.go
+++ b/cmd/agent-scheduler/app/options/options.go
@@ -128,7 +128,12 @@ func (s *ServerOption) AddFlags(fs *pflag.FlagSet) {
 func (s *ServerOption) CheckOptionOrDie() error {
 	s.ServerOption.ShardingMode = s.ShardingMode
 	s.ServerOption.ShardName = s.ShardName
-	if s.ScheduleWorkerCount == 0 {
+	return s.validateOptions()
+}
+
+// validateOptions validates agent scheduler-specific options.
+func (s *ServerOption) validateOptions() error {
+	if s.ScheduleWorkerCount <= 0 {
 		return fmt.Errorf("scheduler-worker-count must be greater than 0")
 	}
 	return componentbaseconfigvalidation.ValidateLeaderElectionConfiguration(&s.LeaderElection, field.NewPath("leaderElection")).ToAggregate()

--- a/cmd/agent-scheduler/app/options/options_test.go
+++ b/cmd/agent-scheduler/app/options/options_test.go
@@ -124,3 +124,18 @@ func TestCheckOptionOrDieSyncsAgentShardingOptions(t *testing.T) {
 	assert.Equal(t, commonutil.HardShardingMode, s.ServerOption.ShardingMode)
 	assert.Equal(t, defaultShardName, s.ServerOption.ShardName)
 }
+
+func TestCheckOptionOrDieRejectsZeroScheduleWorkerCount(t *testing.T) {
+	fs := pflag.NewFlagSet("worker-count-test", pflag.ExitOnError)
+	s := NewServerOption()
+	commonutil.LeaderElectionDefault(&s.LeaderElection)
+	componentbaseoptions.BindLeaderElectionFlags(&s.LeaderElection, fs)
+	s.AddFlags(fs)
+	s.LeaderElection.ResourceName = commonutil.GenerateComponentName([]string{s.SchedulerName})
+
+	err := fs.Parse([]string{"--scheduler-worker-count=0"})
+	assert.NoError(t, err)
+
+	err = s.CheckOptionOrDie()
+	assert.EqualError(t, err, "scheduler-worker-count must be greater than 0")
+}

--- a/cmd/agent-scheduler/app/options/options_test.go
+++ b/cmd/agent-scheduler/app/options/options_test.go
@@ -125,7 +125,7 @@ func TestCheckOptionOrDieSyncsAgentShardingOptions(t *testing.T) {
 	assert.Equal(t, defaultShardName, s.ServerOption.ShardName)
 }
 
-func TestCheckOptionOrDieRejectsZeroScheduleWorkerCount(t *testing.T) {
+func TestCheckOptionOrDieRejectsNonPositiveScheduleWorkerCount(t *testing.T) {
 	fs := pflag.NewFlagSet("worker-count-test", pflag.ExitOnError)
 	s := NewServerOption()
 	commonutil.LeaderElectionDefault(&s.LeaderElection)


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:

This PR validates `--scheduler-worker-count` during agent-scheduler startup.

Previously, setting the value to `0` was accepted. The scheduler started successfully but launched no scheduling workers, leaving pods assigned to `agent-scheduler` in the `Pending` state indefinitely.

This change rejects zero with a clear validation error:

```text
scheduler-worker-count must be greater than 0
```

A regression test was added to verify the behavior.

#### Which issue(s) this PR fixes:

Fixes #5666 

#### Special notes for your reviewer:

- The default worker count remains unchanged at `1`.
- Positive worker counts continue to work as before.
- The targeted options package tests pass.

#### Does this PR introduce a user-facing change?

Yes. Invalid configurations using `--scheduler-worker-count=0` now fail during startup instead of silently disabling scheduling.

```release-note
agent-scheduler now rejects scheduler-worker-count values of 0 during startup.
```