### PR TITLE
Validate controller-manager worker counts to prevent divide-by-zero panics

### DIFF
--- a/cmd/controller-manager/app/options/options.go
+++ b/cmd/controller-manager/app/options/options.go
@@ -145,6 +145,10 @@ func (s *ServerOption) CheckOptionOrDie() error {
 		allErrors = append(allErrors, err)
 	}
 
+	if err := s.validateWorkerThreads(); err != nil {
+		allErrors = append(allErrors, err)
+	}
+
 	// Check leader election flag when LeaderElection is enabled.
 	leaderElectionErr := componentbaseconfigvalidation.ValidateLeaderElectionConfiguration(
 		&s.LeaderElection, field.NewPath("leaderElection")).ToAggregate()
@@ -175,6 +179,27 @@ func (s *ServerOption) checkControllers() error {
 		}
 	}
 	return nil
+}
+
+func (s *ServerOption) validateWorkerThreads() error {
+	workerThreads := []struct {
+		name  string
+		value uint32
+	}{
+		{name: "worker-threads", value: s.WorkerThreads},
+		{name: "worker-threads-for-cronjob", value: s.WorkerThreadsForCronJob},
+		{name: "worker-threads-for-podgroup", value: s.WorkerThreadsForPG},
+		{name: "worker-threads-for-queue", value: s.WorkerThreadsForQueue},
+		{name: "worker-threads-for-gc", value: s.WorkerThreadsForGC},
+	}
+
+	var allErrors []error
+	for _, workerThread := range workerThreads {
+		if workerThread.value <= 0 {
+			allErrors = append(allErrors, fmt.Errorf("%s must be greater than 0", workerThread.name))
+		}
+	}
+	return errors.NewAggregate(allErrors)
 }
 
 // readCAFiles read data from ca file path

--- a/cmd/controller-manager/app/options/options_test.go
+++ b/cmd/controller-manager/app/options/options_test.go
@@ -191,3 +191,90 @@ func TestCheckControllers(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateWorkerThreads(t *testing.T) {
+	validOptions := &ServerOption{
+		WorkerThreads:           defaultWorkers,
+		WorkerThreadsForCronJob: defaultCronJobWorkers,
+		WorkerThreadsForPG:      defaultPodGroupWorkers,
+		WorkerThreadsForQueue:   defaultQueueWorkers,
+		WorkerThreadsForGC:      defaultGCWorkers,
+	}
+
+	testCases := []struct {
+		name        string
+		configure   func(*ServerOption)
+		expectedErr string
+	}{
+		{
+			name: "all worker threads are positive",
+			configure: func(*ServerOption) {
+			},
+		},
+		{
+			name: "worker-threads is zero",
+			configure: func(option *ServerOption) {
+				option.WorkerThreads = 0
+			},
+			expectedErr: "worker-threads must be greater than 0",
+		},
+		{
+			name: "worker-threads-for-cronjob is zero",
+			configure: func(option *ServerOption) {
+				option.WorkerThreadsForCronJob = 0
+			},
+			expectedErr: "worker-threads-for-cronjob must be greater than 0",
+		},
+		{
+			name: "worker-threads-for-podgroup is zero",
+			configure: func(option *ServerOption) {
+				option.WorkerThreadsForPG = 0
+			},
+			expectedErr: "worker-threads-for-podgroup must be greater than 0",
+		},
+		{
+			name: "worker-threads-for-queue is zero",
+			configure: func(option *ServerOption) {
+				option.WorkerThreadsForQueue = 0
+			},
+			expectedErr: "worker-threads-for-queue must be greater than 0",
+		},
+		{
+			name: "worker-threads-for-gc is zero",
+			configure: func(option *ServerOption) {
+				option.WorkerThreadsForGC = 0
+			},
+			expectedErr: "worker-threads-for-gc must be greater than 0",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			option := *validOptions
+			testCase.configure(&option)
+
+			err := option.validateWorkerThreads()
+			if testCase.expectedErr == "" {
+				assert.NoError(t, err)
+				return
+			}
+			assert.EqualError(t, err, testCase.expectedErr)
+		})
+	}
+}
+
+func TestCheckOptionOrDieRejectsZeroWorkerThreads(t *testing.T) {
+	s := &ServerOption{
+		WorkerThreads:           defaultWorkers,
+		WorkerThreadsForCronJob: defaultCronJobWorkers,
+		WorkerThreadsForPG:      defaultPodGroupWorkers,
+		WorkerThreadsForQueue:   defaultQueueWorkers,
+		WorkerThreadsForGC:      defaultGCWorkers,
+	}
+	commonutil.LeaderElectionDefault(&s.LeaderElection)
+	s.LeaderElection.ResourceName = "vc-controller-manager"
+	s.WorkerThreads = 0
+
+	err := s.CheckOptionOrDie()
+	assert.EqualError(t, err, "worker-threads must be greater than 0")
+}


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
This PR validates all controller-manager worker-thread flags during startup:

- `--worker-threads`
- `--worker-threads-for-cronjob`
- `--worker-threads-for-podgroup`
- `--worker-threads-for-queue`
- `--worker-threads-for-gc`

Previously, setting a worker count to `0` could cause the controller-manager to panic with `integer divide by zero` when processing a Job. The validation now rejects invalid values before startup and includes unit tests.

#### Which issue(s) this PR fixes:
Fixes #5673

#### Special notes for your reviewer:
- Added centralized worker-thread validation.
- Added test coverage for zero worker-thread values.
- Verified with:
  `go test ./cmd/controller-manager/app/options`

#### Does this PR introduce a user-facing change?
Yes. The controller-manager now fails startup with a clear validation error when a worker-thread count is zero.

```release-note
Controller-manager now validates worker-thread counts during startup and rejects zero values.
```