### PR TITLE
Validate CronJob job template

### DIFF
--- a/pkg/webhooks/admission/cronjobs/validate/admit_cronjob.go
+++ b/pkg/webhooks/admission/cronjobs/validate/admit_cronjob.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/kubernetes/pkg/capabilities"
 
 	"volcano.sh/apis/pkg/apis/batch/v1alpha1"
+	schedulingv1beta1 "volcano.sh/apis/pkg/apis/scheduling/v1beta1"
 
 	"volcano.sh/volcano/pkg/webhooks/router"
 	"volcano.sh/volcano/pkg/webhooks/schema"
@@ -129,8 +130,37 @@ func validateCronJob(cronjob *v1alpha1.CronJob) string {
 	if msg := strings.TrimSpace(validateCronJobName(cronjob.Name)); msg != "" {
 		errs = append(errs, msg)
 	}
+	if msg := strings.TrimSpace(validateJobTemplate(&cronjob.Spec.JobTemplate.Spec)); msg != "" {
+		errs = append(errs, msg)
+	}
 	return strings.Join(errs, "; ")
 }
+
+func validateJobTemplate(spec *v1alpha1.JobSpec) string {
+	if len(spec.Tasks) == 0 {
+		return "No task specified in job spec"
+	}
+
+	queue, err := config.QueueLister.Get(spec.Queue)
+	if err != nil {
+		return fmt.Sprintf("unable to find job queue: %v", err)
+	}
+	if queue.Status.State != schedulingv1beta1.QueueStateOpen {
+		return fmt.Sprintf("can only submit job to queue with state `Open`, queue `%s` status is `%s`", queue.Name, queue.Status.State)
+	}
+	if queue.Name == "root" {
+		return "can not submit job to root queue"
+	}
+	childQueues, err := config.GetQueuesByParent(queue.Name)
+	if err != nil {
+		return fmt.Sprintf("failed to get child queues for queue %s: %v", queue.Name, err)
+	}
+	if len(childQueues) != 0 {
+		return fmt.Sprintf("can only submit job to leaf queue, queue `%s` has %d child queues", queue.Name, len(childQueues))
+	}
+	return ""
+}
+
 func validateCronjobSpec(spec *v1alpha1.CronJobSpec, nameSpace string) string {
 	var msg string
 	if len(spec.Schedule) == 0 {

--- a/pkg/webhooks/admission/cronjobs/validate/admit_cronjob.go
+++ b/pkg/webhooks/admission/cronjobs/validate/admit_cronjob.go
@@ -141,7 +141,11 @@ func validateJobTemplate(spec *v1alpha1.JobSpec) string {
 		return "No task specified in job spec"
 	}
 
-	queue, err := config.QueueLister.Get(spec.Queue)
+	queueName := spec.Queue
+	if queueName == "" {
+		queueName = schedulingv1beta1.DefaultQueue
+	}
+	queue, err := config.QueueLister.Get(queueName)
 	if err != nil {
 		return fmt.Sprintf("unable to find job queue: %v", err)
 	}

--- a/pkg/webhooks/admission/cronjobs/validate/admit_cronjob_test.go
+++ b/pkg/webhooks/admission/cronjobs/validate/admit_cronjob_test.go
@@ -379,6 +379,31 @@ func getJobTemplate() v1alpha1.JobSpec {
 		},
 	}
 }
+func TestValidateCronJobTemplateDefaultQueue(t *testing.T) {
+	stopCh := setupDefaultQueue()
+	defer close(stopCh)
+
+	jobTemplate := getJobTemplate()
+	jobTemplate.Queue = ""
+	cronjob := &v1alpha1.CronJob{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cronvcjob",
+			Namespace: metav1.NamespaceDefault,
+		},
+		Spec: v1alpha1.CronJobSpec{
+			Schedule:          "* * * * *",
+			ConcurrencyPolicy: v1alpha1.AllowConcurrent,
+			JobTemplate: v1alpha1.JobTemplateSpec{
+				Spec: jobTemplate,
+			},
+		},
+	}
+
+	if msg := validateCronJob(cronjob); msg != "" {
+		t.Errorf("Expect no error, but got error %v", msg)
+	}
+}
+
 func TestValidateCronJobTemplate(t *testing.T) {
 	stopCh := setupDefaultQueue()
 	defer close(stopCh)

--- a/pkg/webhooks/admission/cronjobs/validate/admit_cronjob_test.go
+++ b/pkg/webhooks/admission/cronjobs/validate/admit_cronjob_test.go
@@ -299,6 +299,27 @@ func TestValidateCronjobSpec(t *testing.T) {
 			ret:       " invalid timeZone",
 		},
 	}
+	stopCh := setupDefaultQueue()
+	defer close(stopCh)
+
+	for _, testCase := range testCases {
+		t.Run(testCase.Name, func(t *testing.T) {
+			ret := validateCronjobSpec(&testCase.CronJob.Spec, testCase.CronJob.Namespace)
+			//fmt.Printf("test-case name:%s, ret:%v  testCase.reviewResponse:%v \n", testCase.Name, ret,testCase.reviewResponse)
+			if testCase.ExpectErr == true && ret == "" {
+				t.Errorf("Expect error msg :%s, but got nil.", testCase.ret)
+			}
+			if testCase.ExpectErr == true && !strings.Contains(ret, testCase.ret) {
+				t.Errorf("Expect error msg :%s, but got diff error %v", testCase.ret, ret)
+			}
+			if testCase.ExpectErr == false && ret != "" {
+				t.Errorf("Expect no error, but got error %v", ret)
+			}
+		})
+	}
+}
+
+func setupDefaultQueue() chan struct{} {
 	defaultqueue := &schedulingv1beta2.Queue{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "default",
@@ -324,24 +345,9 @@ func TestValidateCronjobSpec(t *testing.T) {
 			panic(fmt.Errorf("failed to sync cache: %v", informerType))
 		}
 	}
-	defer close(stopCh)
-
-	for _, testCase := range testCases {
-		t.Run(testCase.Name, func(t *testing.T) {
-			ret := validateCronjobSpec(&testCase.CronJob.Spec, testCase.CronJob.Namespace)
-			//fmt.Printf("test-case name:%s, ret:%v  testCase.reviewResponse:%v \n", testCase.Name, ret,testCase.reviewResponse)
-			if testCase.ExpectErr == true && ret == "" {
-				t.Errorf("Expect error msg :%s, but got nil.", testCase.ret)
-			}
-			if testCase.ExpectErr == true && !strings.Contains(ret, testCase.ret) {
-				t.Errorf("Expect error msg :%s, but got diff error %v", testCase.ret, ret)
-			}
-			if testCase.ExpectErr == false && ret != "" {
-				t.Errorf("Expect no error, but got error %v", ret)
-			}
-		})
-	}
+	return stopCh
 }
+
 func getJobTemplate() v1alpha1.JobSpec {
 	return v1alpha1.JobSpec{
 		MinAvailable: 1,
@@ -373,6 +379,32 @@ func getJobTemplate() v1alpha1.JobSpec {
 		},
 	}
 }
+func TestValidateCronJobTemplate(t *testing.T) {
+	stopCh := setupDefaultQueue()
+	defer close(stopCh)
+
+	jobTemplate := getJobTemplate()
+	jobTemplate.Queue = "missing-queue"
+	cronjob := &v1alpha1.CronJob{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cronvcjob",
+			Namespace: metav1.NamespaceDefault,
+		},
+		Spec: v1alpha1.CronJobSpec{
+			Schedule:          "* * * * *",
+			ConcurrencyPolicy: v1alpha1.AllowConcurrent,
+			JobTemplate: v1alpha1.JobTemplateSpec{
+				Spec: jobTemplate,
+			},
+		},
+	}
+
+	msg := validateCronJob(cronjob)
+	if want := "unable to find job queue"; !strings.Contains(msg, want) {
+		t.Errorf("expected %q in error, got %q", want, msg)
+	}
+}
+
 func TestValidateCronJobName(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -415,6 +447,9 @@ func TestValidateCronJobName(t *testing.T) {
 
 // When several checks fail at once, the messages should be separated by "; ".
 func TestValidateCronJobSeparatesMultipleErrors(t *testing.T) {
+	stopCh := setupDefaultQueue()
+	defer close(stopCh)
+
 	cronjob := &v1alpha1.CronJob{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      strings.Repeat("a", 53),
@@ -440,6 +475,9 @@ func TestValidateCronJobSeparatesMultipleErrors(t *testing.T) {
 
 // A single failing check should come back on its own, with no separator.
 func TestValidateCronJobSingleErrorHasNoSeparator(t *testing.T) {
+	stopCh := setupDefaultQueue()
+	defer close(stopCh)
+
 	cronjob := &v1alpha1.CronJob{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "valid-cronjob",


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

CronJob admission can accept an invalid jobTemplate and fail later when creating the Job. This adds scoped validation for task presence and queue validity.

#### Which issue(s) this PR fixes:

Fixes #5669

#### Special notes for your reviewer:

This intentionally does not duplicate full Job admission logic.

#### Does this PR introduce a user-facing change?

```release-note
CronJob admission now rejects jobTemplate specs with missing tasks or invalid queues.