### PR TITLE
refactor(scheduler): make enabled actions session-scoped instead of a global map

### DIFF
--- a/pkg/scheduler/actions/allocate/allocate.go
+++ b/pkg/scheduler/actions/allocate/allocate.go
@@ -152,7 +152,7 @@ func (alloc *Action) buildAllocateContext() *allocateContext {
 	for _, job := range ssn.Jobs {
 		// If not config enqueue action, change Pending pg into Inqueue state to avoid blocking job scheduling.
 		if job.IsPending() {
-			if conf.EnabledActionMap["enqueue"] {
+			if ssn.EnabledActions["enqueue"] {
 				klog.V(4).Infof("Job <%s/%s> Queue <%s> skip allocate, reason: job status is pending.",
 					job.Namespace, job.Name, job.Queue)
 				continue

--- a/pkg/scheduler/conf/scheduler_conf.go
+++ b/pkg/scheduler/conf/scheduler_conf.go
@@ -21,9 +21,6 @@ limitations under the License.
 
 package conf
 
-// EnabledActionMap check if a action exist in scheduler configmap. If not exist the value is false.
-var EnabledActionMap map[string]bool
-
 // SchedulerConfiguration defines the configuration of scheduler.
 type SchedulerConfiguration struct {
 	// Actions defines the actions list of scheduler in order

--- a/pkg/scheduler/framework/session.go
+++ b/pkg/scheduler/framework/session.go
@@ -99,6 +99,10 @@ type Session struct {
 	Tiers          []conf.Tier
 	Configurations []conf.Configuration
 	NodeList       []*api.NodeInfo
+	// EnabledActions records which actions are configured to run in this scheduling
+	// session. It is populated once by the caller after the session is opened and
+	// must not be mutated afterward.
+	EnabledActions map[string]bool
 	// HyperNodes stores the HyperNodeInfo of each HyperNode
 	HyperNodes           api.HyperNodeInfoMap
 	HyperNodeTierNameMap api.HyperNodeTierNameMap
@@ -186,6 +190,7 @@ func openSession(cache cache.Cache) *Session {
 		CSINodesStatus: map[string]*api.CSINodeStatusInfo{},
 		RevocableNodes: map[string]*api.NodeInfo{},
 		Queues:         map[api.QueueID]*api.QueueInfo{},
+		EnabledActions: map[string]bool{},
 
 		plugins:                       map[string]Plugin{},
 		jobOrderFns:                   map[string]api.CompareFn{},

--- a/pkg/scheduler/plugins/capacity/capacity_test.go
+++ b/pkg/scheduler/plugins/capacity/capacity_test.go
@@ -1450,10 +1450,6 @@ func Test_buildHierarchicalQueueAttrs_nilSafety(t *testing.T) {
 func TestNoDoubleCountingForInqueueJobWithBindingTasks(t *testing.T) {
 	options.Default()
 
-	prevEnabledActionMap := conf.EnabledActionMap
-	conf.EnabledActionMap = map[string]bool{"enqueue": true}
-	defer func() { conf.EnabledActionMap = prevEnabledActionMap }()
-
 	trueValue := true
 	plugins := map[string]framework.PluginBuilder{PluginName: New}
 	uthelper.RegisterPlugins(plugins)
@@ -1514,6 +1510,7 @@ func TestNoDoubleCountingForInqueueJobWithBindingTasks(t *testing.T) {
 	// Cycle 1: allocate jobA. After this pA1/pA2/pA3 are Binding in cache,
 	// pgA stays Inqueue (Binding ∉ ScheduledStatus).
 	ssn1 := framework.OpenSession(sc, tiers, nil)
+	ssn1.EnabledActions = map[string]bool{"enqueue": true}
 	allocate.New().Execute(ssn1)
 	framework.CloseSession(ssn1)
 
@@ -1532,6 +1529,7 @@ func TestNoDoubleCountingForInqueueJobWithBindingTasks(t *testing.T) {
 	// Correct (fix applied):  allocated=3CPU, inqueue=max(0,3-3)=0 → 1+3+0=4 ≤ 4 → jobB bound.
 	// Buggy (pre-fix):        allocated=3CPU, inqueue=3CPU         → 1+3+3=7 > 4 → jobB rejected.
 	ssn2 := framework.OpenSession(sc, tiers, nil)
+	ssn2.EnabledActions = map[string]bool{"enqueue": true}
 	enqueue.New().Execute(ssn2)
 	allocate.New().Execute(ssn2)
 	framework.CloseSession(ssn2)

--- a/pkg/scheduler/plugins/proportion/proportion_test.go
+++ b/pkg/scheduler/plugins/proportion/proportion_test.go
@@ -523,12 +523,6 @@ func TestAllocate(t *testing.T) {
 func TestNoDoubleCountingForInqueueJobWithBindingTasks(t *testing.T) {
 	options.Default()
 
-	// Tell the allocate action that the enqueue action is active, so it will
-	// not bypass the queue-capacity check by promoting Pending→Inqueue itself.
-	prevEnabledActionMap := conf.EnabledActionMap
-	conf.EnabledActionMap = map[string]bool{"enqueue": true}
-	defer func() { conf.EnabledActionMap = prevEnabledActionMap }()
-
 	trueValue := true
 	plugins := map[string]framework.PluginBuilder{PluginName: New}
 	uthelper.RegisterPlugins(plugins)
@@ -595,6 +589,9 @@ func TestNoDoubleCountingForInqueueJobWithBindingTasks(t *testing.T) {
 	// After this cycle, pA1/pA2/pA3 are in Binding state in the scheduler cache.
 	// pgA remains Inqueue because Binding ∉ ScheduledStatus.
 	ssn1 := framework.OpenSession(sc, tiers, nil)
+	// Tell the allocate action that the enqueue action is active, so it will
+	// not bypass the queue-capacity check by promoting Pending→Inqueue itself.
+	ssn1.EnabledActions = map[string]bool{"enqueue": true}
 	allocate.New().Execute(ssn1)
 	framework.CloseSession(ssn1)
 
@@ -618,6 +615,7 @@ func TestNoDoubleCountingForInqueueJobWithBindingTasks(t *testing.T) {
 	// Buggy behaviour (pre-fix): attr.allocated=3CPU, attr.inqueue=3CPU (full minResources)
 	//   → jobB.minReq(1CPU) + 3CPU + 3CPU = 7CPU > capacity(4CPU) → jobB rejected.
 	ssn2 := framework.OpenSession(sc, tiers, nil)
+	ssn2.EnabledActions = map[string]bool{"enqueue": true}
 	enqueue.New().Execute(ssn2)
 	allocate.New().Execute(ssn2)
 	framework.CloseSession(ssn2)

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -132,13 +132,14 @@ func (pc *Scheduler) runOnce() {
 	configurations := pc.configurations
 	pc.mutex.Unlock()
 
-	// Load ConfigMap to check which action is enabled.
-	conf.EnabledActionMap = make(map[string]bool)
+	// Record which actions are enabled so it can be checked during this scheduling cycle.
+	enabledActions := make(map[string]bool, len(actions))
 	for _, action := range actions {
-		conf.EnabledActionMap[action.Name()] = true
+		enabledActions[action.Name()] = true
 	}
 
 	ssn := framework.OpenSession(pc.cache, plugins, configurations)
+	ssn.EnabledActions = enabledActions
 	ssn.SetSchGateManager(pc.schGateManager)
 	defer func() {
 		framework.CloseSession(ssn)

--- a/pkg/scheduler/uthelper/helper.go
+++ b/pkg/scheduler/uthelper/helper.go
@@ -216,11 +216,12 @@ func (test *TestCommonStruct) Run(actions []framework.Action) {
 		panic("no actions provided, please specify a list of actions to execute")
 	}
 
-	// registry actions in conf variables
-	conf.EnabledActionMap = make(map[string]bool, len(actions))
+	// record which actions are enabled on the session for this run
+	enabledActions := make(map[string]bool, len(actions))
 	for _, action := range actions {
-		conf.EnabledActionMap[action.Name()] = true
+		enabledActions[action.Name()] = true
 	}
+	test.ssn.EnabledActions = enabledActions
 
 	for _, action := range actions {
 		action.Initialize()


### PR DESCRIPTION
## What type of PR is this?

/kind cleanup

## What this PR does / why we need it

This PR removes the package-level mutable global `conf.EnabledActionMap` and moves the enabled action set into the scheduler session.

Currently, the scheduler executes scheduling sessions serially, so this change does not fix a user-visible concurrency issue. Instead, it scopes the enabled action state to the object that owns it (`framework.Session`), making ownership explicit, improving test isolation, and removing unnecessary mutable global state.

This preserves the existing scheduling behavior while making the design easier to reason about and less dependent on process-wide state.

## Which issue(s) this PR fixes

Fixes #5674

## Special notes for your reviewer

### Changes

- Added `EnabledActions map[string]bool` to `framework.Session`.
- Removed the package-level `conf.EnabledActionMap`.
- Built the enabled action map locally in `scheduler.runOnce()`.
- Assigned the map to `ssn.EnabledActions` after opening the session.
- Replaced `conf.EnabledActionMap` lookups with `ssn.EnabledActions`.
- Updated the scheduler test helper to initialize `EnabledActions` on the session.
- Updated capacity and proportion plugin tests to use session-scoped state instead of swapping a global variable.

### Verification

- `grep -R "EnabledActionMap" .` returns zero matches.
- `go test ./pkg/scheduler/...` passes.
- `go test -race ./pkg/scheduler/...` passes.
- `go build ./pkg/scheduler/...` succeeds.
- `gofmt` clean on all modified files.

### Behavior

- No scheduling logic changes.
- No action ordering changes.
- No plugin behavior changes.
- Moves enabled action state from global scope to session scope.
- Improves state ownership and test isolation by removing mutable global state.

## Does this PR introduce a user-facing change?

```release-note
NONE
```