### PR TITLE
fix(cronjob): prune Terminated jobs with the failed history limit

### DIFF
--- a/pkg/controllers/cronjob/cronjob_controller_handler.go
+++ b/pkg/controllers/cronjob/cronjob_controller_handler.go
@@ -207,7 +207,8 @@ func (cc *cronjobcontroller) processFinishedJobs(cronJob *batchv1.CronJob, jobsB
 					updateStatus = true
 				}
 				successfulJobs = append(successfulJobs, job)
-			case batchv1.Failed:
+			case batchv1.Failed, batchv1.Terminated:
+				// A terminated job did not succeed, so it is pruned with the failed ones
 				failedJobs = append(failedJobs, job)
 			}
 		}

--- a/pkg/controllers/cronjob/cronjob_controller_test.go
+++ b/pkg/controllers/cronjob/cronjob_controller_test.go
@@ -766,6 +766,36 @@ func TestSyncCronJob(t *testing.T) {
 				expectDeleteJobNum:     1,
 			},
 		},
+		{
+			name: "not first run, terminated job, failedJobsHistoryLimit is 0",
+			now:  justTen().Add(7 * time.Minute),
+			cronjob: cjSpec{
+				concurrency:            "Allow",
+				failedJobsHistoryLimit: ptr.To[int32](0),
+			},
+			jobs: []jobSpec{
+				{
+					status:      batchv1.Terminated,
+					time:        fiveMinutesAfterTen(),
+					inLister:    true,
+					inClient:    false,
+					active:      false,
+					processTime: time.Minute,
+				},
+			},
+			lastScheduleTime: &metav1.Time{Time: fiveMinutesAfterTen()},
+			expect: testExpect{
+				expectRequeueAfter:     durationPtr(3*time.Minute + nextScheduleDelta),
+				expectUpdateStatus:     true,
+				expectError:            false,
+				expectLastScheduleTime: &metav1.Time{Time: fiveMinutesAfterTen()},
+				expectInActiveNum:      0,
+				expectEventsNum:        1,
+				expectLastSuccessTime:  nil,
+				expectCreateJobNum:     0,
+				expectDeleteJobNum:     1,
+			},
+		},
 		//TODO: 增加默认值
 		// {
 		// 	name:        "noy first run, successfulJobHistoryLimit is nil",


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

`isJobFinished` counts `Terminated` as finished, but the `switch` in `processFinishedJobs` only has cases for `Completed` and `Failed`. A Terminated job matches neither, so it never lands in `successfulJobs` or `failedJobs`, never reaches `removeOldestJobs`, and is never pruned by `successfulJobsHistoryLimit` or `failedJobsHistoryLimit`. They pile up for the lifetime of the CronJob, and the only thing that clears them today is the opt-in `ttlSecondsAfterFinished`.

This adds `Terminated` to the failed case so it ages out with the failed jobs.

#### Which issue(s) this PR fixes:

Fixes #5655

#### Special notes for your reviewer:

On the bucketing: `failedJobs` is the only option that does not need a new API field. A Terminated job is not a success, and putting it in `successfulJobs` would also move `LastSuccessfulTime`. The jobflow controller already treats Terminated the same way in `pending.go` (`FailedJobs > 0 || TerminatedJobs > 0` gives Failed), which came out of #4442.

The test asserts both halves: the Terminated job gets pruned, and `LastSuccessfulTime` stays nil. It is the first Terminated coverage in the cronjob tests.

#### Does this PR introduce a user-facing change?

```release-note
Fixed a bug where CronJob history limits never pruned jobs that ended in the Terminated phase, causing them to accumulate indefinitely.
```
