### PR TITLE
Fix missing session state rollback on RecoverOperations failure

### DIFF
--- a/pkg/scheduler/actions/allocate/allocate.go
+++ b/pkg/scheduler/actions/allocate/allocate.go
@@ -446,6 +446,7 @@ func (alloc *Action) allocateForJob(job *api.JobInfo, jobWorksheet *JobWorksheet
 		finalStmt := framework.NewStatement(ssn)
 		if err = finalStmt.RecoverOperations(bestStmt); err != nil {
 			klog.ErrorS(err, "Failed to recover operations", "job", job.UID, "hyperNode", bestHyperNode)
+			finalStmt.Discard()
 			return nil
 		}
 
@@ -519,6 +520,7 @@ func (alloc *Action) allocateForSubJob(subJob *api.SubJobInfo, subJobWorksheet *
 		finalStmt := framework.NewStatement(ssn)
 		if err = finalStmt.RecoverOperations(bestStmt); err != nil {
 			klog.ErrorS(err, "Failed to recover operations", "subJob", subJob.UID, "hyperNode", bestHyperNode)
+			finalStmt.Discard()
 			return nil, 0
 		}
 		newAllocatedHyperNode := ssn.HyperNodes.GetLCAHyperNode(subJob.AllocatedHyperNode, bestHyperNode)

--- a/pkg/scheduler/actions/gangpreempt/gangpreempt.go
+++ b/pkg/scheduler/actions/gangpreempt/gangpreempt.go
@@ -173,6 +173,7 @@ func (gp *Action) preemptJobInDomains(ssn *framework.Session, stmt *framework.St
 				continue
 			}
 			if err := stmt.RecoverOperations(plan); err != nil {
+				stmt.Discard()
 				continue
 			}
 			return subJobHyperNodes

--- a/pkg/scheduler/actions/gangreclaim/gangreclaim.go
+++ b/pkg/scheduler/actions/gangreclaim/gangreclaim.go
@@ -178,6 +178,7 @@ func (gr *Action) reclaimJobInDomains(ssn *framework.Session, stmt *framework.St
 				continue
 			}
 			if err := stmt.RecoverOperations(plan); err != nil {
+				stmt.Discard()
 				continue
 			}
 			return subJobHyperNodes

--- a/pkg/scheduler/framework/statement_recover_test.go
+++ b/pkg/scheduler/framework/statement_recover_test.go
@@ -77,3 +77,107 @@ func TestRecoverOperations_PipelinePreservesEvictionFlag(t *testing.T) {
 		assert.True(t, recoveredTask.EvictionOccurred)
 	}
 }
+
+// TestRecoverOperations_DiscardRollsBackOnPartialFailure is a regression test for
+// issue #5362 (and similar in gangpreempt/gangreclaim): when RecoverOperations fails partway through
+// replaying operations (e.g. an Evict succeeds but a subsequent Pipeline fails because the target node
+// is not present in the session), the caller must call Discard() on the partially-populated
+// statement to roll back the already-applied session mutations.
+func TestRecoverOperations_DiscardRollsBackOnPartialFailure(t *testing.T) {
+	jobID := api.JobID("ns/job-partial")
+
+	// victim: a running task that will be evicted in the saved plan.
+	victim := &api.TaskInfo{
+		UID:       "victim",
+		Job:       jobID,
+		Name:      "victim",
+		Namespace: "ns",
+		Resreq:    (&api.Resource{MilliCPU: 500}).Clone(),
+		InitResreq: (&api.Resource{
+			MilliCPU: 500,
+		}).Clone(),
+		Pod: &v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "victim",
+				Namespace: "ns",
+				UID:       types.UID("victim"),
+			},
+		},
+		NumaInfo: &api.TopologyInfo{ResMap: map[int]v1.ResourceList{}},
+		TransactionContext: api.TransactionContext{
+			Status:   api.Running,
+			NodeName: "n1",
+		},
+	}
+
+	// preemptor: a pending task that will be pipelined to a node that does NOT
+	// exist in the recovery session, forcing RecoverOperations to return an error.
+	preemptor := &api.TaskInfo{
+		UID:       "preemptor",
+		Job:       jobID,
+		Name:      "preemptor",
+		Namespace: "ns",
+		Resreq:    (&api.Resource{MilliCPU: 500}).Clone(),
+		InitResreq: (&api.Resource{
+			MilliCPU: 500,
+		}).Clone(),
+		Pod: &v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "preemptor",
+				Namespace: "ns",
+				UID:       types.UID("preemptor"),
+			},
+		},
+		NumaInfo: &api.TopologyInfo{ResMap: map[int]v1.ResourceList{}},
+		TransactionContext: api.TransactionContext{
+			Status:   api.Pending,
+			NodeName: "ghost-node", // node absent from session — Pipeline will fail
+		},
+	}
+
+	job := api.NewJobInfo(jobID, victim, preemptor)
+
+	// Only n1 is in the session; ghost-node is intentionally absent.
+	n1 := api.NewNodeInfo(nil)
+	n1.Name = "n1"
+	n1.Idle = (&api.Resource{MilliCPU: 1000}).Clone()
+	n1.Releasing = api.EmptyResource()
+	n1.Pipelined = api.EmptyResource()
+	assert.NoError(t, n1.AddTask(victim))
+
+	ssn := &Session{
+		Jobs:  map[api.JobID]*api.JobInfo{jobID: job},
+		Nodes: map[string]*api.NodeInfo{"n1": n1},
+	}
+
+	// Build a saved plan that first evicts the victim then pipelines the preemptor
+	// to a node that does not exist in the session.
+	plan := &Statement{
+		operations: []operation{
+			{name: Evict, task: victim.Clone(), reason: "preempt"},
+			{name: Pipeline, task: preemptor.Clone(), reason: ""},
+		},
+	}
+
+	// Apply the plan. The Evict succeeds (victim -> Releasing) but the Pipeline
+	// fails because "ghost-node" is absent, so RecoverOperations returns an error.
+	finalStmt := NewStatement(ssn)
+	err := finalStmt.RecoverOperations(plan)
+	assert.Error(t, err, "RecoverOperations should fail because ghost-node is missing")
+
+	// Verify the session is dirty before Discard
+	releasingVictim := job.TaskStatusIndex[api.Releasing][victim.UID]
+	assert.NotNil(t, releasingVictim, "victim must be in Releasing state before Discard")
+
+	// Discard() reverses the eviction, restoring victim to Running.
+	finalStmt.Discard()
+
+	// The victim must be back in the Running state after Discard().
+	restoredVictim := job.TaskStatusIndex[api.Running][victim.UID]
+	assert.NotNil(t, restoredVictim,
+		"victim must be in Running state after Discard() rolls back the partial eviction")
+
+	// The victim must NOT remain in the Releasing state.
+	assert.Nil(t, job.TaskStatusIndex[api.Releasing][victim.UID],
+		"victim must not remain in Releasing state after Discard()")
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

This PR adds rollback on the error paths following `RecoverOperations()`.

`RecoverOperations()` replays operations sequentially. If it returns an error after partially replaying operations, the caller currently returns (or retries) without explicitly discarding the successfully replayed operations.

This change calls `Discard()` before those error exits so that any partially replayed operations are rolled back before returning or retrying.

A regression test has been added to verify the rollback behavior.

#### Which issue(s) this PR fixes:

Fixes #5684 

#### Special notes for your reviewer:

`Discard()` only reverses operations that have already been successfully recorded in the statement. Since operations are appended during successful replay, calling `Discard()` on the error path rolls back only the operations that were applied before the failure and does not affect the successful execution path.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```