### PR TITLE
webhooks: validate PodGroup updates

### DIFF
--- a/installer/helm/chart/volcano/templates/webhooks.yaml
+++ b/installer/helm/chart/volcano/templates/webhooks.yaml
@@ -426,6 +426,7 @@ webhooks:
           - v1beta1
         operations:
           - CREATE
+          - UPDATE
         resources:
           - podgroups
         scope: '*'

--- a/installer/volcano-development-vap-map.yaml
+++ b/installer/volcano-development-vap-map.yaml
@@ -10728,6 +10728,7 @@ webhooks:
           - v1beta1
         operations:
           - CREATE
+          - UPDATE
         resources:
           - podgroups
         scope: '*'

--- a/installer/volcano-development-vap.yaml
+++ b/installer/volcano-development-vap.yaml
@@ -10728,6 +10728,7 @@ webhooks:
           - v1beta1
         operations:
           - CREATE
+          - UPDATE
         resources:
           - podgroups
         scope: '*'

--- a/installer/volcano-development.yaml
+++ b/installer/volcano-development.yaml
@@ -10728,6 +10728,7 @@ webhooks:
           - v1beta1
         operations:
           - CREATE
+          - UPDATE
         resources:
           - podgroups
         scope: '*'

--- a/pkg/webhooks/admission/podgroups/validate/validate_podgroup.go
+++ b/pkg/webhooks/admission/podgroups/validate/validate_podgroup.go
@@ -45,7 +45,7 @@ var service = &router.AdmissionService{
 			Name: "validatepodgroup.volcano.sh",
 			Rules: []whv1.RuleWithOperations{
 				{
-					Operations: []whv1.OperationType{whv1.Create},
+					Operations: []whv1.OperationType{whv1.Create, whv1.Update},
 					Rule: whv1.Rule{
 						APIGroups:   []string{schedulingv1beta1.SchemeGroupVersion.Group},
 						APIVersions: []string{schedulingv1beta1.SchemeGroupVersion.Version},
@@ -72,6 +72,8 @@ func Validate(ar admissionv1.AdmissionReview) *admissionv1.AdmissionResponse {
 	switch ar.Request.Operation {
 	case admissionv1.Create:
 		errMsg = validatePodGroup(podgroup)
+	case admissionv1.Update:
+		errMsg = validateNetworkTopology(podgroup.Spec.NetworkTopology, podgroup.Spec.SubGroupPolicy)
 	default:
 		errMsg = fmt.Sprintf("unsupported operation %s", ar.Request.Operation)
 	}

--- a/pkg/webhooks/admission/podgroups/validate/validate_podgroup_test.go
+++ b/pkg/webhooks/admission/podgroups/validate/validate_podgroup_test.go
@@ -36,6 +36,7 @@ func TestValidatePodGroup(t *testing.T) {
 		name        string
 		podGroup    *schedulingv1beta1.PodGroup
 		queue       *schedulingv1beta1.Queue
+		operation   admissionv1.Operation
 		expectError bool
 		// msgContains lists substrings that must all be present in the
 		// rejection message, used to assert that multiple validation errors
@@ -214,6 +215,28 @@ func TestValidatePodGroup(t *testing.T) {
 			expectError: true,
 		},
 		{
+			name: "invalid podgroup update with NetworkTopology containing HighestTierAllowed and HighestTierName",
+			podGroup: &schedulingv1beta1.PodGroup{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "PodGroup",
+					APIVersion: "scheduling.volcano.sh/v1beta1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-podgroup",
+				},
+				Spec: schedulingv1beta1.PodGroupSpec{
+					NetworkTopology: &schedulingv1beta1.NetworkTopologySpec{
+						Mode:               schedulingv1beta1.HardNetworkTopologyMode,
+						HighestTierAllowed: &highestTierAllowed,
+						HighestTierName:    "volcano.sh/hypernode",
+					},
+				},
+			},
+			queue:       &schedulingv1beta1.Queue{},
+			operation:   admissionv1.Update,
+			expectError: true,
+		},
+		{
 			name: "invalid podgroup failing both queue and networkTopology checks reports a separated message",
 			podGroup: &schedulingv1beta1.PodGroup{
 				TypeMeta: metav1.TypeMeta{
@@ -248,6 +271,10 @@ func TestValidatePodGroup(t *testing.T) {
 			assert.Nil(t, err)
 
 			pgJson, _ := json.Marshal(tt.podGroup)
+			operation := tt.operation
+			if operation == "" {
+				operation = admissionv1.Create
+			}
 			// Create an AdmissionReview object
 			ar := admissionv1.AdmissionReview{
 				TypeMeta: metav1.TypeMeta{
@@ -260,7 +287,7 @@ func TestValidatePodGroup(t *testing.T) {
 						Version: schedulingv1beta1.SchemeGroupVersion.Version,
 						Kind:    "PodGroup",
 					},
-					Operation: admissionv1.Create,
+					Operation: operation,
 					Name:      tt.podGroup.Name,
 					Object:    runtime.RawExtension{Raw: pgJson},
 					Resource: metav1.GroupVersionResource{


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

PodGroup validation rejects invalid networkTopology config, but the webhook only ran on create.

This allows a PodGroup to be updated with both highestTierAllowed and highestTierName set. This PR makes the PodGroup validating webhook handle updates too.

#### Which issue(s) this PR fixes:

NONE

#### Special notes for your reviewer:

NONE

#### Does this PR introduce a user-facing change?

```release-note
PodGroup validating webhook now rejects invalid networkTopology updates.