### PR TITLE
queue-controller: keep closed-by-parent annotation in sync on manual re-close

### DIFF
--- a/pkg/controllers/queue/queue_controller.go
+++ b/pkg/controllers/queue/queue_controller.go
@@ -162,6 +162,7 @@ func (c *queuecontroller) Initialize(opt *framework.ControllerOption) error {
 	queuestate.SyncQueue = c.syncQueue
 	queuestate.OpenQueue = c.openQueue
 	queuestate.CloseQueue = c.closeQueue
+	queuestate.ClearClosedByParentAnnotation = c.clearClosedByParentAnnotation
 
 	c.syncHandler = c.handleQueue
 	c.syncCommandHandler = c.handleCommand
@@ -235,7 +236,7 @@ func (c *queuecontroller) handleQueue(req *apis.Request) error {
 		return fmt.Errorf("get queue %s failed for %v", req.QueueName, err)
 	}
 
-	queueState := queuestate.NewState(queue)
+	queueState := queuestate.NewState(queue, req.Event)
 	if queueState == nil {
 		return fmt.Errorf("queue %s state %s is invalid", queue.Name, queue.Status.State)
 	}

--- a/pkg/controllers/queue/queue_controller_action.go
+++ b/pkg/controllers/queue/queue_controller_action.go
@@ -174,9 +174,9 @@ func (c *queuecontroller) closeQueue(queue *schedulingv1beta1.Queue, updateState
 
 // clearClosedByParentAnnotation marks the queue as explicitly closed, so that syncHierarchicalQueue
 // no longer treats it as merely closed-by-parent and reopens it when the parent queue reopens.
-func (c *queuecontroller) clearClosedByParentAnnotation(queue *schedulingv1beta1.Queue) error {
-	_, err := c.updateQueueAnnotation(queue, ClosedByParentAnnotationKey, ClosedByParentAnnotationFalseValue)
-	return err
+// It returns the patched queue so callers can replace their stale in-memory reference.
+func (c *queuecontroller) clearClosedByParentAnnotation(queue *schedulingv1beta1.Queue) (*schedulingv1beta1.Queue, error) {
+	return c.updateQueueAnnotation(queue, ClosedByParentAnnotationKey, ClosedByParentAnnotationFalseValue)
 }
 
 // sync the state between parent and child queues

--- a/pkg/controllers/queue/queue_controller_action.go
+++ b/pkg/controllers/queue/queue_controller_action.go
@@ -172,6 +172,13 @@ func (c *queuecontroller) closeQueue(queue *schedulingv1beta1.Queue, updateState
 	return nil
 }
 
+// clearClosedByParentAnnotation marks the queue as explicitly closed, so that syncHierarchicalQueue
+// no longer treats it as merely closed-by-parent and reopens it when the parent queue reopens.
+func (c *queuecontroller) clearClosedByParentAnnotation(queue *schedulingv1beta1.Queue) error {
+	_, err := c.updateQueueAnnotation(queue, ClosedByParentAnnotationKey, ClosedByParentAnnotationFalseValue)
+	return err
+}
+
 // sync the state between parent and child queues
 func (c *queuecontroller) syncHierarchicalQueue(queue *schedulingv1beta1.Queue) error {
 	if queue.Name == "root" {

--- a/pkg/controllers/queue/queue_controller_test.go
+++ b/pkg/controllers/queue/queue_controller_test.go
@@ -321,7 +321,7 @@ func TestClearClosedByParentAnnotation(t *testing.T) {
 	_, err := c.vcClient.SchedulingV1beta1().Queues().Create(context.TODO(), queue, metav1.CreateOptions{})
 	assert.NoError(t, err)
 
-	err = c.clearClosedByParentAnnotation(queue)
+	_, err = c.clearClosedByParentAnnotation(queue)
 	assert.NoError(t, err)
 
 	item, err := c.vcClient.SchedulingV1beta1().Queues().Get(context.TODO(), queue.Name, metav1.GetOptions{})

--- a/pkg/controllers/queue/queue_controller_test.go
+++ b/pkg/controllers/queue/queue_controller_test.go
@@ -308,6 +308,27 @@ func TestSyncQueue(t *testing.T) {
 	}
 }
 
+func TestClearClosedByParentAnnotation(t *testing.T) {
+	queue := &schedulingv1beta1.Queue{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "child",
+			Annotations: map[string]string{ClosedByParentAnnotationKey: ClosedByParentAnnotationTrueValue},
+		},
+		Status: schedulingv1beta1.QueueStatus{State: schedulingv1beta1.QueueStateClosed},
+	}
+
+	c := newFakeController()
+	_, err := c.vcClient.SchedulingV1beta1().Queues().Create(context.TODO(), queue, metav1.CreateOptions{})
+	assert.NoError(t, err)
+
+	err = c.clearClosedByParentAnnotation(queue)
+	assert.NoError(t, err)
+
+	item, err := c.vcClient.SchedulingV1beta1().Queues().Get(context.TODO(), queue.Name, metav1.GetOptions{})
+	assert.NoError(t, err)
+	assert.Equal(t, ClosedByParentAnnotationFalseValue, item.Annotations[ClosedByParentAnnotationKey])
+}
+
 func TestProcessNextWorkItem(t *testing.T) {
 	testCases := []struct {
 		Name        string

--- a/pkg/controllers/queue/state/closed.go
+++ b/pkg/controllers/queue/state/closed.go
@@ -23,6 +23,7 @@ import (
 
 type closedState struct {
 	queue *v1beta1.Queue
+	event v1alpha1.Event
 }
 
 func (cs *closedState) Execute(action v1alpha1.Action) error {
@@ -32,6 +33,14 @@ func (cs *closedState) Execute(action v1alpha1.Action) error {
 			status.State = v1beta1.QueueStateOpen
 		})
 	case v1alpha1.CloseQueueAction:
+		// A user-issued close command re-targeting an already closed queue means the user
+		// explicitly wants it closed, regardless of why it was closed before. Mark it as no
+		// longer merely closed-by-parent so it isn't auto-reopened when the parent reopens.
+		if cs.event == v1alpha1.CommandIssuedEvent {
+			if err := ClearClosedByParentAnnotation(cs.queue); err != nil {
+				return err
+			}
+		}
 		return SyncQueue(cs.queue, func(status *v1beta1.QueueStatus, podGroupList []string) {
 			status.State = v1beta1.QueueStateClosed
 		})

--- a/pkg/controllers/queue/state/closed.go
+++ b/pkg/controllers/queue/state/closed.go
@@ -37,9 +37,11 @@ func (cs *closedState) Execute(action v1alpha1.Action) error {
 		// explicitly wants it closed, regardless of why it was closed before. Mark it as no
 		// longer merely closed-by-parent so it isn't auto-reopened when the parent reopens.
 		if cs.event == v1alpha1.CommandIssuedEvent {
-			if err := ClearClosedByParentAnnotation(cs.queue); err != nil {
+			updatedQueue, err := ClearClosedByParentAnnotation(cs.queue)
+			if err != nil {
 				return err
 			}
+			cs.queue = updatedQueue
 		}
 		return SyncQueue(cs.queue, func(status *v1beta1.QueueStatus, podGroupList []string) {
 			status.State = v1beta1.QueueStateClosed

--- a/pkg/controllers/queue/state/closed_test.go
+++ b/pkg/controllers/queue/state/closed_test.go
@@ -119,12 +119,12 @@ func TestClosedState_CloseQueueAction(t *testing.T) {
 				return nil
 			}
 			clearCalled := false
-			ClearClosedByParentAnnotation = func(queue *schedulingv1beta1.Queue) error {
+			ClearClosedByParentAnnotation = func(queue *schedulingv1beta1.Queue) (*schedulingv1beta1.Queue, error) {
 				if queue != tc.queue {
 					t.Errorf("expected queue %v, got %v", tc.queue, queue)
 				}
 				clearCalled = true
-				return nil
+				return queue, nil
 			}
 			s := &closedState{queue: tc.queue, event: tc.event}
 			err := s.Execute(busv1alpha1.CloseQueueAction)

--- a/pkg/controllers/queue/state/closed_test.go
+++ b/pkg/controllers/queue/state/closed_test.go
@@ -72,23 +72,42 @@ func TestClosedState_CloseQueueAction(t *testing.T) {
 	testcases := []struct {
 		name          string
 		queue         *schedulingv1beta1.Queue
+		event         busv1alpha1.Event
 		podGroups     []string
 		expectedState schedulingv1beta1.QueueState
+		expectClear   bool
 	}{
 		{
-			name: "CloseQueueAction: Closed queue",
+			name: "CloseQueueAction: manual re-close of a closed queue clears closed-by-parent",
 			queue: &schedulingv1beta1.Queue{
 				ObjectMeta: metav1.ObjectMeta{Name: "test-queue"},
 				Status:     schedulingv1beta1.QueueStatus{State: schedulingv1beta1.QueueStateClosed},
 			},
+			event:         busv1alpha1.CommandIssuedEvent,
 			podGroups:     []string{},
 			expectedState: schedulingv1beta1.QueueStateClosed,
+			expectClear:   true,
+		},
+		{
+			name: "CloseQueueAction: automatic cascade re-targeting a closed queue leaves closed-by-parent untouched",
+			queue: &schedulingv1beta1.Queue{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-queue"},
+				Status:     schedulingv1beta1.QueueStatus{State: schedulingv1beta1.QueueStateClosed},
+			},
+			event:         "",
+			podGroups:     []string{},
+			expectedState: schedulingv1beta1.QueueStateClosed,
+			expectClear:   false,
 		},
 	}
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
 			origSyncQueue := SyncQueue
-			t.Cleanup(func() { SyncQueue = origSyncQueue })
+			origClearClosedByParentAnnotation := ClearClosedByParentAnnotation
+			t.Cleanup(func() {
+				SyncQueue = origSyncQueue
+				ClearClosedByParentAnnotation = origClearClosedByParentAnnotation
+			})
 			var capturedState schedulingv1beta1.QueueState
 			SyncQueue = func(queue *schedulingv1beta1.Queue, fn UpdateQueueStatusFn) error {
 				if queue != tc.queue {
@@ -99,13 +118,24 @@ func TestClosedState_CloseQueueAction(t *testing.T) {
 				capturedState = fakeStatus.State
 				return nil
 			}
-			s := &closedState{queue: tc.queue}
+			clearCalled := false
+			ClearClosedByParentAnnotation = func(queue *schedulingv1beta1.Queue) error {
+				if queue != tc.queue {
+					t.Errorf("expected queue %v, got %v", tc.queue, queue)
+				}
+				clearCalled = true
+				return nil
+			}
+			s := &closedState{queue: tc.queue, event: tc.event}
 			err := s.Execute(busv1alpha1.CloseQueueAction)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
 			if capturedState != tc.expectedState {
 				t.Errorf("expected state %q got %q", tc.expectedState, capturedState)
+			}
+			if clearCalled != tc.expectClear {
+				t.Errorf("expected ClearClosedByParentAnnotation called=%v, got %v", tc.expectClear, clearCalled)
 			}
 		})
 	}

--- a/pkg/controllers/queue/state/closing.go
+++ b/pkg/controllers/queue/state/closing.go
@@ -23,6 +23,7 @@ import (
 
 type closingState struct {
 	queue *v1beta1.Queue
+	event v1alpha1.Event
 }
 
 func (cs *closingState) Execute(action v1alpha1.Action) error {
@@ -32,6 +33,14 @@ func (cs *closingState) Execute(action v1alpha1.Action) error {
 			status.State = v1beta1.QueueStateOpen
 		})
 	case v1alpha1.CloseQueueAction:
+		// A user-issued close command re-targeting an already closing queue means the user
+		// explicitly wants it closed, regardless of why it was closing before. Mark it as no
+		// longer merely closed-by-parent so it isn't auto-reopened when the parent reopens.
+		if cs.event == v1alpha1.CommandIssuedEvent {
+			if err := ClearClosedByParentAnnotation(cs.queue); err != nil {
+				return err
+			}
+		}
 		return SyncQueue(cs.queue, func(status *v1beta1.QueueStatus, podGroupList []string) {
 			if len(podGroupList) == 0 {
 				status.State = v1beta1.QueueStateClosed

--- a/pkg/controllers/queue/state/closing.go
+++ b/pkg/controllers/queue/state/closing.go
@@ -37,9 +37,11 @@ func (cs *closingState) Execute(action v1alpha1.Action) error {
 		// explicitly wants it closed, regardless of why it was closing before. Mark it as no
 		// longer merely closed-by-parent so it isn't auto-reopened when the parent reopens.
 		if cs.event == v1alpha1.CommandIssuedEvent {
-			if err := ClearClosedByParentAnnotation(cs.queue); err != nil {
+			updatedQueue, err := ClearClosedByParentAnnotation(cs.queue)
+			if err != nil {
 				return err
 			}
+			cs.queue = updatedQueue
 		}
 		return SyncQueue(cs.queue, func(status *v1beta1.QueueStatus, podGroupList []string) {
 			if len(podGroupList) == 0 {

--- a/pkg/controllers/queue/state/closing_test.go
+++ b/pkg/controllers/queue/state/closing_test.go
@@ -75,33 +75,43 @@ func TestClosingState_CloseQueueAction(t *testing.T) {
 	testcases := []struct {
 		name          string
 		queue         *schedulingv1beta1.Queue
+		event         busv1alpha1.Event
 		podGroups     []string
 		expectedState schedulingv1beta1.QueueState
+		expectClear   bool
 	}{
 		{
-			name: "CloseQueueAction: Closing queue with no podgroup",
+			name: "CloseQueueAction: manual re-close of a closing queue clears closed-by-parent",
 			queue: &schedulingv1beta1.Queue{
 				ObjectMeta: metav1.ObjectMeta{Name: "test-queue"},
 				Status:     schedulingv1beta1.QueueStatus{State: schedulingv1beta1.QueueStateClosing},
 			},
+			event:         busv1alpha1.CommandIssuedEvent,
 			podGroups:     []string{},
 			expectedState: schedulingv1beta1.QueueStateClosed,
+			expectClear:   true,
 		},
 		{
-			name: "CloseQueueAction: Closing queue with running podgroup",
+			name: "CloseQueueAction: automatic cascade re-targeting a closing queue leaves closed-by-parent untouched",
 			queue: &schedulingv1beta1.Queue{
 				ObjectMeta: metav1.ObjectMeta{Name: "test-queue"},
 				Status:     schedulingv1beta1.QueueStatus{State: schedulingv1beta1.QueueStateClosing},
 			},
+			event:         "",
 			podGroups:     []string{"pg1"},
 			expectedState: schedulingv1beta1.QueueStateClosing,
+			expectClear:   false,
 		},
 	}
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
 			origSyncQueue := SyncQueue
-			t.Cleanup(func() { SyncQueue = origSyncQueue })
+			origClearClosedByParentAnnotation := ClearClosedByParentAnnotation
+			t.Cleanup(func() {
+				SyncQueue = origSyncQueue
+				ClearClosedByParentAnnotation = origClearClosedByParentAnnotation
+			})
 
 			var capturedState schedulingv1beta1.QueueState
 			SyncQueue = func(queue *schedulingv1beta1.Queue, fn UpdateQueueStatusFn) error {
@@ -113,8 +123,16 @@ func TestClosingState_CloseQueueAction(t *testing.T) {
 				capturedState = fakeStatus.State
 				return nil
 			}
+			clearCalled := false
+			ClearClosedByParentAnnotation = func(queue *schedulingv1beta1.Queue) error {
+				if queue != tc.queue {
+					t.Errorf("expected queue %v, got %v", tc.queue, queue)
+				}
+				clearCalled = true
+				return nil
+			}
 
-			s := &closingState{queue: tc.queue}
+			s := &closingState{queue: tc.queue, event: tc.event}
 			err := s.Execute(busv1alpha1.CloseQueueAction)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
@@ -122,6 +140,9 @@ func TestClosingState_CloseQueueAction(t *testing.T) {
 
 			if capturedState != tc.expectedState {
 				t.Errorf("expected state %q got %q", tc.expectedState, capturedState)
+			}
+			if clearCalled != tc.expectClear {
+				t.Errorf("expected ClearClosedByParentAnnotation called=%v, got %v", tc.expectClear, clearCalled)
 			}
 		})
 	}

--- a/pkg/controllers/queue/state/closing_test.go
+++ b/pkg/controllers/queue/state/closing_test.go
@@ -124,12 +124,12 @@ func TestClosingState_CloseQueueAction(t *testing.T) {
 				return nil
 			}
 			clearCalled := false
-			ClearClosedByParentAnnotation = func(queue *schedulingv1beta1.Queue) error {
+			ClearClosedByParentAnnotation = func(queue *schedulingv1beta1.Queue) (*schedulingv1beta1.Queue, error) {
 				if queue != tc.queue {
 					t.Errorf("expected queue %v, got %v", tc.queue, queue)
 				}
 				clearCalled = true
-				return nil
+				return queue, nil
 			}
 
 			s := &closingState{queue: tc.queue, event: tc.event}

--- a/pkg/controllers/queue/state/factory.go
+++ b/pkg/controllers/queue/state/factory.go
@@ -41,8 +41,9 @@ var (
 	// CloseQueue will set state of queue to close
 	CloseQueue QueueActionFn
 	// ClearClosedByParentAnnotation marks the queue as explicitly closed, so
-	// it is not automatically reopened when its parent queue reopens.
-	ClearClosedByParentAnnotation func(queue *v1beta1.Queue) error
+	// it is not automatically reopened when its parent queue reopens. It
+	// returns the patched queue so callers can replace their stale reference.
+	ClearClosedByParentAnnotation func(queue *v1beta1.Queue) (*v1beta1.Queue, error)
 )
 
 // NewState gets the state from queue status. event is the event of the request that

--- a/pkg/controllers/queue/state/factory.go
+++ b/pkg/controllers/queue/state/factory.go
@@ -40,17 +40,23 @@ var (
 	OpenQueue QueueActionFn
 	// CloseQueue will set state of queue to close
 	CloseQueue QueueActionFn
+	// ClearClosedByParentAnnotation marks the queue as explicitly closed, so
+	// it is not automatically reopened when its parent queue reopens.
+	ClearClosedByParentAnnotation func(queue *v1beta1.Queue) error
 )
 
-// NewState gets the state from queue status.
-func NewState(queue *v1beta1.Queue) State {
+// NewState gets the state from queue status. event is the event of the request that
+// triggered this action, used to tell an explicit user command (v1alpha1.CommandIssuedEvent)
+// apart from an action the controller cascaded automatically (e.g. closing a child queue
+// because its parent closed).
+func NewState(queue *v1beta1.Queue, event v1alpha1.Event) State {
 	switch queue.Status.State {
 	case "", v1beta1.QueueStateOpen:
 		return &openState{queue: queue}
 	case v1beta1.QueueStateClosed:
-		return &closedState{queue: queue}
+		return &closedState{queue: queue, event: event}
 	case v1beta1.QueueStateClosing:
-		return &closingState{queue: queue}
+		return &closingState{queue: queue, event: event}
 	case v1beta1.QueueStateUnknown:
 		return &unknownState{queue: queue}
 	}

--- a/pkg/controllers/queue/state/factory_test.go
+++ b/pkg/controllers/queue/state/factory_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	busv1alpha1 "volcano.sh/apis/pkg/apis/bus/v1alpha1"
 	schedulingv1beta1 "volcano.sh/apis/pkg/apis/scheduling/v1beta1"
 )
 
@@ -71,7 +72,7 @@ func TestNewState(t *testing.T) {
 				},
 			}
 
-			s := NewState(queue)
+			s := NewState(queue, busv1alpha1.CommandIssuedEvent)
 
 			var actualType string
 			if s == nil {


### PR DESCRIPTION
What type of PR is this?
/kind bug

What this PR does / why we need it:
When a parent queue closes, the controller cascades the close to its child
queues and tags each child with the annotation `volcano.sh/closed-by-parent:
"true"`, so that reopening the parent auto-reopens the child. If an admin
then explicitly closes that same child queue directly (e.g. `vcctl queue
operate --action close`) while it is already Closed/Closing, the request was
previously routed to a code path that never touched the annotation. So when
the parent is later reopened, the controller still sees
`closed-by-parent: "true"` and silently auto-reopens the child, overriding
the admin's explicit close. This is a pure queue open/close state-machine
bug: the child queue ends up unexpectedly reopened; it is not a crash or
data loss.

Approach:
- Added `state.ClearClosedByParentAnnotation`, wired to a new
  `queuecontroller.clearClosedByParentAnnotation` that patches the
  `closed-by-parent` annotation to `"false"`.
- `closedState.Execute`/`closingState.Execute` (pkg/controllers/queue/state)
  now call it when a `CloseQueueAction` re-targets an already
  Closed/Closing queue.
- To avoid misfiring on a duplicate/retried automatic cascade request that
  happens to reach an already-Closed/Closing queue (the workqueue dedupes
  `*apis.Request` by pointer identity, not value, so this can occur when the
  parent's own close is retried after a failed status update, or on
  concurrent resyncs), the annotation is only cleared when the request's
  `Event` is `busv1alpha1.CommandIssuedEvent` - the signal already set by
  `handleCommand` exclusively for user-issued `vcctl`/Command-CR actions,
  never by the automatic parent<->child cascade paths
  (`closeHierarchicalQueue`, `syncHierarchicalQueue`). `state.NewState` now
  takes the triggering event so this signal is available where needed.

Which issue(s) this PR fixes:
Fixes #5681

Special notes for your reviewer:
AI tools were used to help investigate, implement, and adversarially review
this change (multiple rounds of self-review before submission); I have
reviewed and understand the diff.

Does this PR introduce a user-facing change?
```release-note
Fixed a bug where manually closing a child queue while its parent queue was
already closed did not clear the `volcano.sh/closed-by-parent` annotation,
causing the child queue to be unexpectedly auto-reopened when the parent
queue was later reopened.
```

Validation:
go build ./pkg/controllers/queue/...
go test ./pkg/controllers/queue/... -v
All existing and new tests pass.

Signed-off-by: Pujitha Paladugu <10557236+pujitha24@users.noreply.github.com>
