### PR TITLE
ci: limit workflow approval to fork pull requests

### DIFF
--- a/.github/workflows/workflows-approve.yaml
+++ b/.github/workflows/workflows-approve.yaml
@@ -13,6 +13,9 @@ permissions: read-all
 
 jobs:
   approve:
+    # Workflows for branches in this repository run without manual approval.
+    # This job is only needed to approve workflow runs from fork pull requests.
+    if: github.event.pull_request.head.repo.full_name != github.repository
     name: Approve workflows based on contributor status
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

When Dependabot opened many pull requests in one batch, its automatic labels triggered the approval workflow several times for each PR. These runs were unnecessary and their concurrent GitHub API requests failed with HTTP 503.

The approval workflow is used to approve `action_required` workflow runs for pull requests from forks, based on contributor history or the `ok-to-test` label. Pull requests whose branches are already in this repository, including Dependabot and Copilot pull requests, run workflows without this approval. This change therefore skips the approval job for all same-repository pull requests while preserving the existing fork behavior.

#### Which issue(s) this PR fixes:

None.

#### Special notes for your reviewer:

Validated with `actionlint` and `git diff --check`.

AI disclosure: Codex assisted with diagnosing the failed workflow runs and preparing this change.

Rhyme: Volcano workflows should quietly flow; fork approvals run, while trusted branches go.

Prompt: "Limit the approval workflow to fork pull requests and explain why Dependabot can skip it."

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
