### PR TITLE
fix(hypernode): stop discovery workers cleanly on shutdown

### DIFF
--- a/pkg/controllers/hypernode/discovery/manager.go
+++ b/pkg/controllers/hypernode/discovery/manager.go
@@ -58,7 +58,11 @@ type Manager interface {
 
 // manager manages network topology discovery processes
 type manager struct {
-	mutex sync.Mutex
+	mutex    sync.Mutex
+	stopOnce sync.Once
+	stopped  bool
+	workerWG sync.WaitGroup
+	resultWG sync.WaitGroup
 
 	configLoader config.Loader
 	config       *api.NetworkTopologyConfig
@@ -99,7 +103,11 @@ func (m *manager) Start() error {
 		m.config = cfg
 	}
 
-	go m.worker()
+	m.workerWG.Add(1)
+	go func() {
+		defer m.workerWG.Done()
+		m.worker()
+	}()
 
 	klog.InfoS("Network topology discovery manager started")
 	return nil
@@ -107,9 +115,19 @@ func (m *manager) Start() error {
 
 // Stop halts all discovery processes
 func (m *manager) Stop() {
-	close(m.stopCh)
-	m.stopAllDiscoverers()
-	klog.InfoS("Network topology discovery manager stopped")
+	m.stopOnce.Do(func() {
+		m.mutex.Lock()
+		m.stopped = true
+		close(m.stopCh)
+		m.mutex.Unlock()
+
+		m.workQueue.ShutDown()
+		m.stopAllDiscoverers()
+		m.workerWG.Wait()
+		m.resultWG.Wait()
+		close(m.resultCh)
+		klog.InfoS("Network topology discovery manager stopped")
+	})
 }
 
 // ResultSynced every time the Result in ResultChannel are processed, this method must be called to notify network topology discover
@@ -150,7 +168,11 @@ func (m *manager) startSingleDiscoverer(source string) error {
 		return fmt.Errorf("failed to start discoverer: %v", err)
 	}
 
-	go m.processTopology(source, outputCh)
+	m.resultWG.Add(1)
+	go func() {
+		defer m.resultWG.Done()
+		m.processTopology(source, outputCh)
+	}()
 
 	klog.InfoS("Started network topology discoverer", "source", source)
 	return nil
@@ -232,6 +254,9 @@ func (m *manager) syncHandler(key string) error {
 
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
+	if m.stopped {
+		return nil
+	}
 
 	err = m.handleRemovedSources(newConfig)
 	if err != nil {
@@ -287,9 +312,14 @@ func (m *manager) processTopology(source string, topologyCh <-chan []*topologyv1
 				return
 			}
 
-			m.resultCh <- Result{
+			result := Result{
 				HyperNodes: hyperNodes,
 				Source:     source,
+			}
+			select {
+			case m.resultCh <- result:
+			case <-m.stopCh:
+				return
 			}
 			klog.V(3).InfoS("Forwarded discovery results to unified channel",
 				"source", source,

--- a/pkg/controllers/hypernode/discovery/manager_test.go
+++ b/pkg/controllers/hypernode/discovery/manager_test.go
@@ -172,3 +172,37 @@ func TestManager_syncHandler(t *testing.T) {
 	// Stop the manager
 	m.Stop()
 }
+
+func TestManagerStopShutsDownWorkerAndClosesResultChannel(t *testing.T) {
+	const source = "shutdown-test-source"
+
+	constructor := api.DiscovererConstructor(func(cfg api.DiscoveryConfig, kubeClient clientset.Interface, vcClient vcclientset.Interface) api.Discoverer {
+		return fakedisc.NewFakeDiscoverer(nil, cfg)
+	})
+	api.RegisterDiscoverer(source, constructor)
+
+	loader := config.NewFakeLoader(&api.NetworkTopologyConfig{
+		NetworkTopologyDiscovery: []api.DiscoveryConfig{{
+			Source:  source,
+			Enabled: true,
+		}},
+	})
+	queue := workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[string]())
+	discoveryManager := NewManager(loader, queue, fake.NewSimpleClientset(), fakevcclientset.NewSimpleClientset())
+
+	if !assert.NoError(t, discoveryManager.Start()) {
+		return
+	}
+
+	mgr := discoveryManager.(*manager)
+	if !assert.NoError(t, mgr.startSingleDiscoverer(source)) {
+		return
+	}
+
+	discoveryManager.Stop()
+	discoveryManager.Stop()
+
+	assert.True(t, queue.ShuttingDown())
+	_, ok := <-discoveryManager.ResultChannel()
+	assert.False(t, ok)
+}


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
Fixes HyperNode discovery manager shutdown so all background goroutines can exit cleanly.

Previously, `Stop()` closed the stop channel and stopped discoverers, but did not shut down the ConfigMap work queue. The worker could remain blocked in `workQueue.Get()`. The discovery result channel also remained open, leaving the controller result watcher blocked.

This PR:
- Shuts down the work queue during manager shutdown.
- Waits for the worker and result-forwarding goroutines to exit.
- Closes the result channel only after its senders have stopped.
- Adds a regression test for queue shutdown and result-channel closure.

**SS:**
<img width="875" height="125" alt="image" src="https://github.com/user-attachments/assets/a3beda46-a780-4454-b936-9ebaace9e43e" />


#### Which issue(s) this PR fixes:
Fixes #5688

#### Special notes for your reviewer:
- Validated with `go test ./pkg/controllers/hypernode/discovery`.

#### Does this PR introduce a user-facing change?
```release-note
NONE