### PR TITLE
Reject JobFlow updates in admission

### DIFF
--- a/installer/helm/chart/volcano/policy/jobflows-validating.yaml
+++ b/installer/helm/chart/volcano/policy/jobflows-validating.yaml
@@ -21,7 +21,12 @@ spec:
     - name: flowNames
       expression: "variables.flows.map(flow, flow.name)"
   validations:
-    # 1. Valid Dependency References - Dependencies must reference existing flows
+    # 1. JobFlow spec updates are not supported
+    - expression: request.operation != "UPDATE" || object.spec == oldObject.spec
+      message: "jobflow spec updates are not supported"
+      reason: Invalid
+
+    # 2. Valid Dependency References - Dependencies must reference existing flows
     - expression: |
         variables.flows.all(flow,
           !has(flow.dependsOn) ||
@@ -31,7 +36,7 @@ spec:
       message: "jobflow Flow is not DAG: vertex is not defined"
       reason: Invalid
 
-    # 2. No Self-Dependencies - A flow cannot depend on itself
+    # 3. No Self-Dependencies - A flow cannot depend on itself
     - expression: |
         variables.flows.all(flow,
           !has(flow.dependsOn) ||

--- a/installer/volcano-development-vap-map.yaml
+++ b/installer/volcano-development-vap-map.yaml
@@ -11382,7 +11382,12 @@ spec:
     - name: flowNames
       expression: "variables.flows.map(flow, flow.name)"
   validations:
-    # 1. Valid Dependency References - Dependencies must reference existing flows
+    # 1. JobFlow spec updates are not supported
+    - expression: request.operation != "UPDATE" || object.spec == oldObject.spec
+      message: "jobflow spec updates are not supported"
+      reason: Invalid
+
+    # 2. Valid Dependency References - Dependencies must reference existing flows
     - expression: |
         variables.flows.all(flow,
           !has(flow.dependsOn) ||
@@ -11392,7 +11397,7 @@ spec:
       message: "jobflow Flow is not DAG: vertex is not defined"
       reason: Invalid
 
-    # 2. No Self-Dependencies - A flow cannot depend on itself
+    # 3. No Self-Dependencies - A flow cannot depend on itself
     - expression: |
         variables.flows.all(flow,
           !has(flow.dependsOn) ||

--- a/installer/volcano-development-vap.yaml
+++ b/installer/volcano-development-vap.yaml
@@ -11382,7 +11382,12 @@ spec:
     - name: flowNames
       expression: "variables.flows.map(flow, flow.name)"
   validations:
-    # 1. Valid Dependency References - Dependencies must reference existing flows
+    # 1. JobFlow spec updates are not supported
+    - expression: request.operation != "UPDATE" || object.spec == oldObject.spec
+      message: "jobflow spec updates are not supported"
+      reason: Invalid
+
+    # 2. Valid Dependency References - Dependencies must reference existing flows
     - expression: |
         variables.flows.all(flow,
           !has(flow.dependsOn) ||
@@ -11392,7 +11397,7 @@ spec:
       message: "jobflow Flow is not DAG: vertex is not defined"
       reason: Invalid
 
-    # 2. No Self-Dependencies - A flow cannot depend on itself
+    # 3. No Self-Dependencies - A flow cannot depend on itself
     - expression: |
         variables.flows.all(flow,
           !has(flow.dependsOn) ||

--- a/pkg/webhooks/admission/jobflows/validate/validate_jobflow.go
+++ b/pkg/webhooks/admission/jobflows/validate/validate_jobflow.go
@@ -22,6 +22,7 @@ import (
 
 	admissionv1 "k8s.io/api/admission/v1"
 	whv1 "k8s.io/api/admissionregistration/v1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog/v2"
 
@@ -34,6 +35,7 @@ import (
 var (
 	VertexNotDefinedError      = errors.New("vertex is not defined")
 	FlowNotDAGError            = errors.New("jobflow Flow is not DAG")
+	JobFlowSpecUpdateError     = errors.New("jobflow spec updates are not supported")
 	OperationNotCreateOrUpdate = errors.New("expect operation to be 'CREATE' or 'UPDATE'")
 )
 
@@ -73,21 +75,27 @@ func AdmitJobFlows(ar admissionv1.AdmissionReview) *admissionv1.AdmissionRespons
 		return util.ToAdmissionResponse(err)
 	}
 
-	var msg string
 	reviewResponse := admissionv1.AdmissionResponse{}
 	reviewResponse.Allowed = true
 
 	switch ar.Request.Operation {
-	case admissionv1.Create, admissionv1.Update:
-		msg = validateJobFlowDAG(jobFlow, &reviewResponse)
+	case admissionv1.Create:
+		msg := validateJobFlowDAG(jobFlow, &reviewResponse)
+		if !reviewResponse.Allowed {
+			reviewResponse.Result = &metav1.Status{Message: strings.TrimSpace(msg)}
+		}
+	case admissionv1.Update:
+		oldJobFlow, err := schema.DecodeJobFlow(ar.Request.OldObject, ar.Request.Resource)
+		if err != nil {
+			return util.ToAdmissionResponse(err)
+		}
+		if !apiequality.Semantic.DeepEqual(jobFlow.Spec, oldJobFlow.Spec) {
+			return util.ToAdmissionResponse(JobFlowSpecUpdateError)
+		}
 	default:
-		err := OperationNotCreateOrUpdate
-		return util.ToAdmissionResponse(err)
+		return util.ToAdmissionResponse(OperationNotCreateOrUpdate)
 	}
 
-	if !reviewResponse.Allowed {
-		reviewResponse.Result = &metav1.Status{Message: strings.TrimSpace(msg)}
-	}
 	return &reviewResponse
 }
 

--- a/pkg/webhooks/admission/jobflows/validate/validate_jobflow_test.go
+++ b/pkg/webhooks/admission/jobflows/validate/validate_jobflow_test.go
@@ -17,18 +17,99 @@ limitations under the License.
 package validate
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 	"testing"
 
 	admissionv1 "k8s.io/api/admission/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 
 	flowv1alpha1 "volcano.sh/apis/pkg/apis/flow/v1alpha1"
 	schedulingv1beta2 "volcano.sh/apis/pkg/apis/scheduling/v1beta1"
 	fakeclient "volcano.sh/apis/pkg/client/clientset/versioned/fake"
 	informers "volcano.sh/apis/pkg/client/informers/externalversions"
 )
+
+func TestAdmitJobFlowsUpdate(t *testing.T) {
+	oldJobFlow := flowv1alpha1.JobFlow{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-jobflow",
+			Namespace: "test",
+		},
+		Spec: flowv1alpha1.JobFlowSpec{
+			Flows: []flowv1alpha1.Flow{
+				{Name: "a"},
+				{
+					Name: "b",
+					DependsOn: &flowv1alpha1.DependsOn{
+						Targets: []string{"a"},
+					},
+				},
+			},
+			JobRetainPolicy: flowv1alpha1.RetainPolicy("retain"),
+		},
+	}
+
+	testCases := []struct {
+		name    string
+		update  func(*flowv1alpha1.JobFlow)
+		allowed bool
+		message string
+	}{
+		{
+			name: "reject spec update",
+			update: func(jobFlow *flowv1alpha1.JobFlow) {
+				jobFlow.Spec.Flows = append(jobFlow.Spec.Flows, flowv1alpha1.Flow{Name: "c"})
+			},
+			message: "jobflow spec updates are not supported",
+		},
+		{
+			name: "allow metadata update",
+			update: func(jobFlow *flowv1alpha1.JobFlow) {
+				jobFlow.Labels = map[string]string{"test": "true"}
+			},
+			allowed: true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			jobFlow := oldJobFlow.DeepCopy()
+			testCase.update(jobFlow)
+
+			ar := admissionv1.AdmissionReview{
+				Request: &admissionv1.AdmissionRequest{
+					Resource: metav1.GroupVersionResource{
+						Group:    "flow.volcano.sh",
+						Version:  "v1alpha1",
+						Resource: "jobflows",
+					},
+					Operation: admissionv1.Update,
+					Object:    rawJobFlow(t, jobFlow),
+					OldObject: rawJobFlow(t, &oldJobFlow),
+				},
+			}
+
+			response := AdmitJobFlows(ar)
+			if response.Allowed != testCase.allowed {
+				t.Errorf("Expected Allowed %v, got %v", testCase.allowed, response.Allowed)
+			}
+			if testCase.message != "" && (response.Result == nil || !strings.Contains(response.Result.Message, testCase.message)) {
+				t.Errorf("Expected error %q, got %v", testCase.message, response.Result)
+			}
+		})
+	}
+}
+
+func rawJobFlow(t *testing.T, jobFlow *flowv1alpha1.JobFlow) runtime.RawExtension {
+	jobFlowJSON, err := json.Marshal(jobFlow)
+	if err != nil {
+		t.Fatalf("failed to marshal jobflow: %v", err)
+	}
+	return runtime.RawExtension{Raw: jobFlowJSON}
+}
 
 func TestValidateJobFlowCreate(t *testing.T) {
 	namespace := "test"

--- a/test/e2e/admission/jobflow_validation_test.go
+++ b/test/e2e/admission/jobflow_validation_test.go
@@ -188,7 +188,7 @@ var _ = ginkgo.Describe("JobFlow Validating E2E Test", func() {
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	})
 
-	ginkgo.It("Should allow jobflow update with valid DAG structure", func() {
+	ginkgo.It("Should reject jobflow spec update", func() {
 		jobFlowName := "update-valid-jobflow"
 		testCtx := util.InitTestContext(util.Options{})
 		defer util.CleanupTestContext(testCtx)
@@ -218,7 +218,10 @@ var _ = ginkgo.Describe("JobFlow Validating E2E Test", func() {
 		createdJobFlow, err := testCtx.Vcclient.FlowV1alpha1().JobFlows(testCtx.Namespace).Create(context.TODO(), jobFlow, metav1.CreateOptions{})
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-		// Update with valid DAG structure
+		createdJobFlow.Labels = map[string]string{"test": "true"}
+		createdJobFlow, err = testCtx.Vcclient.FlowV1alpha1().JobFlows(testCtx.Namespace).Update(context.TODO(), createdJobFlow, metav1.UpdateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
 		createdJobFlow.Spec.Flows = append(createdJobFlow.Spec.Flows, flowv1alpha1.Flow{
 			Name: "c",
 			DependsOn: &flowv1alpha1.DependsOn{
@@ -227,7 +230,8 @@ var _ = ginkgo.Describe("JobFlow Validating E2E Test", func() {
 		})
 
 		_, err = testCtx.Vcclient.FlowV1alpha1().JobFlows(testCtx.Namespace).Update(context.TODO(), createdJobFlow, metav1.UpdateOptions{})
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(err).To(gomega.HaveOccurred())
+		gomega.Expect(err.Error()).To(gomega.ContainSubstring("jobflow spec updates are not supported"))
 	})
 
 	ginkgo.It("Should allow jobflow creation with simple linear dependency chain", func() {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

JobFlow updates are currently accepted by admission, but the controller does not apply updated JobFlow spec changes.

The JobFlow design doc says update is not supported and should be blocked by webhook. This PR makes the webhook reject JobFlow `UPDATE` requests and adds the same check to the JobFlow validating admission policy.

#### Which issue(s) this PR fixes:

Fixes #5723

#### Special notes for your reviewer:

`UPDATE` is still registered in the webhook rule so the API server sends update requests to admission. The handler rejects them there.

#### Does this PR introduce a user-facing change?

```release-note
JobFlow spec updates are now rejected by admission because JobFlow update is not supported.