### PR TITLE
Add UUID constraints for vGPU device selection

### DIFF
--- a/docs/user-guide/how_to_use_volcano_vgpu.md
+++ b/docs/user-guide/how_to_use_volcano_vgpu.md
@@ -100,6 +100,28 @@ metadata:
 
 ---
 
+### Selecting vGPU Devices by UUID
+
+Use `volcano.sh/vgpu-use-gpuuuid` as a comma-separated allowlist of physical GPU UUIDs:
+
+```yaml
+metadata:
+  annotations:
+    volcano.sh/vgpu-use-gpuuuid: "GPU-03f69c50-207a-2038-9b45-23cac89cb67d"
+```
+
+Use `volcano.sh/vgpu-nouse-gpuuuid` to exclude physical GPU UUIDs:
+
+```yaml
+metadata:
+  annotations:
+    volcano.sh/vgpu-nouse-gpuuuid: "GPU-03f69c50-207a-2038-9b45-23cac89cb67d"
+```
+
+UUIDs are matched exactly after trimming whitespace. If no permitted device can satisfy the request, the pod remains unschedulable. When the same UUID appears in both annotations, the denylist takes precedence.
+
+---
+
 ### HAMI-core Usage
 
 * **Pod Spec**:
@@ -242,4 +264,3 @@ Metrics include GPU utilization, pod memory usage, and limits.
 
 * File bugs: [Volcano Issues](https://github.com/volcano-sh/volcano/issues)
 * Contribute: [Pull Requests Guide](https://help.github.com/articles/using-pull-requests/)
-

--- a/pkg/scheduler/api/devices/nvidia/vgpu/type.go
+++ b/pkg/scheduler/api/devices/nvidia/vgpu/type.go
@@ -22,6 +22,8 @@ const (
 
 	GPUInUse                         = "nvidia.com/use-gputype"
 	GPUNoUse                         = "nvidia.com/nouse-gputype"
+	VGPUUseUUIDAnnotation            = "volcano.sh/vgpu-use-gpuuuid"
+	VGPUNoUseUUIDAnnotation          = "volcano.sh/vgpu-nouse-gpuuuid"
 	AssignedTimeAnnotations          = "volcano.sh/vgpu-time"
 	AssignedIDsAnnotations           = "volcano.sh/vgpu-ids-new"
 	AssignedIDsToAllocateAnnotations = "volcano.sh/devices-to-allocate"

--- a/pkg/scheduler/api/devices/nvidia/vgpu/utils.go
+++ b/pkg/scheduler/api/devices/nvidia/vgpu/utils.go
@@ -19,6 +19,7 @@ package vgpu
 import (
 	"errors"
 	"fmt"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -258,6 +259,42 @@ func checkGPUtype(annos map[string]string, cardtype string) bool {
 	return true
 }
 
+type gpuUUIDFilter struct {
+	allowlist []string
+	denylist  []string
+}
+
+func newGPUUUIDFilter(annos map[string]string) gpuUUIDFilter {
+	return gpuUUIDFilter{
+		allowlist: parseGPUUUIDList(annos[VGPUUseUUIDAnnotation]),
+		denylist:  parseGPUUUIDList(annos[VGPUNoUseUUIDAnnotation]),
+	}
+}
+
+func parseGPUUUIDList(value string) []string {
+	var uuids []string
+	for _, uuid := range strings.Split(value, ",") {
+		if uuid = strings.TrimSpace(uuid); uuid != "" {
+			uuids = append(uuids, uuid)
+		}
+	}
+	return uuids
+}
+
+func (f gpuUUIDFilter) enabled() bool {
+	return len(f.allowlist) > 0 || len(f.denylist) > 0
+}
+
+func (f gpuUUIDFilter) matches(id string) bool {
+	if id == "" && f.enabled() {
+		return false
+	}
+	if len(f.allowlist) > 0 && !slices.Contains(f.allowlist, id) {
+		return false
+	}
+	return !slices.Contains(f.denylist, id)
+}
+
 func checkType(annos map[string]string, d GPUDevice, n devices.ContainerDeviceRequest) bool {
 	//General type check, NVIDIA->NVIDIA MLU->MLU
 	if !strings.Contains(d.Type, n.Type) {
@@ -397,8 +434,10 @@ func checkNodeGPUSharingPredicateAndScore(pod *v1.Pod, gssnap *GPUDevices, repli
 
 	tentativeAllocs := []tentativeAlloc{}
 	ctrdevs := []ContainerDevices{}
+	uuidFilter := newGPUUUIDFilter(pod.Annotations)
 	for _, val := range ctrReq {
 		devs := []ContainerDevice{}
+		uuidMatched := false
 		if int(val.Nums) > len(gs.Device) {
 			rollbackTentative(tentativeAllocs)
 			return false, []ContainerDevices{}, 0, fmt.Errorf("no enough gpu cards on node %s", gs.Name)
@@ -408,6 +447,10 @@ func checkNodeGPUSharingPredicateAndScore(pod *v1.Pod, gssnap *GPUDevices, repli
 		for _, i := range sortedDeviceIndicesByPolicy(gs, schedulePolicy) {
 			klog.V(3).InfoS("Scoring pod request", "memReq", val.Memreq, "memPercentageReq", val.MemPercentagereq, "coresReq", val.Coresreq, "Nums", val.Nums, "Index", i, "ID", gs.Device[i].ID)
 			klog.V(3).InfoS("Current Device", "Index", i, "TotalMemory", gs.Device[i].Memory, "UsedMemory", gs.Device[i].UsedMem, "UsedCores", gs.Device[i].UsedCore, "UsedNum", gs.Device[i].UsedNum, "Number", gs.Device[i].Number, "replicate", replicate)
+			if !uuidFilter.matches(gs.Device[i].UUID) {
+				continue
+			}
+			uuidMatched = true
 			if gs.Device[i].Number <= uint(gs.Device[i].UsedNum) {
 				continue
 			}
@@ -468,6 +511,14 @@ func checkNodeGPUSharingPredicateAndScore(pod *v1.Pod, gssnap *GPUDevices, repli
 		}
 		if val.Nums > 0 {
 			rollbackTentative(tentativeAllocs)
+			if uuidFilter.enabled() && !uuidMatched {
+				return false, []ContainerDevices{}, 0, fmt.Errorf(
+					"no GPU matches UUID constraints %s=%q, %s=%q on node %s",
+					VGPUUseUUIDAnnotation, pod.Annotations[VGPUUseUUIDAnnotation],
+					VGPUNoUseUUIDAnnotation, pod.Annotations[VGPUNoUseUUIDAnnotation],
+					gs.Name,
+				)
+			}
 			return false, []ContainerDevices{}, 0, fmt.Errorf("not enough gpu fitted on this node")
 		}
 		ctrdevs = append(ctrdevs, devs)

--- a/pkg/scheduler/api/devices/nvidia/vgpu/utils_test.go
+++ b/pkg/scheduler/api/devices/nvidia/vgpu/utils_test.go
@@ -120,6 +120,151 @@ func TestCheckGPUtype(t *testing.T) {
 	}
 }
 
+func TestCheckGPUUUID(t *testing.T) {
+	tests := []struct {
+		name        string
+		annotations map[string]string
+		id          string
+		want        bool
+	}{
+		{
+			name: "no constraint",
+			id:   "GPU-0",
+			want: true,
+		},
+		{
+			name:        "empty allowlist is ignored",
+			annotations: map[string]string{VGPUUseUUIDAnnotation: "  "},
+			id:          "GPU-0",
+			want:        true,
+		},
+		{
+			name:        "separator-only allowlist is ignored",
+			annotations: map[string]string{VGPUUseUUIDAnnotation: ", ,"},
+			id:          "GPU-0",
+			want:        true,
+		},
+		{
+			name:        "allowlist exact match",
+			annotations: map[string]string{VGPUUseUUIDAnnotation: "GPU-0, GPU-1"},
+			id:          "GPU-1",
+			want:        true,
+		},
+		{
+			name:        "allowlist ignores empty entries",
+			annotations: map[string]string{VGPUUseUUIDAnnotation: "GPU-0,, GPU-1,"},
+			id:          "GPU-1",
+			want:        true,
+		},
+		{
+			name:        "allowlist rejects partial match",
+			annotations: map[string]string{VGPUUseUUIDAnnotation: "GPU-10"},
+			id:          "GPU-1",
+			want:        false,
+		},
+		{
+			name:        "allowlist rejects empty device UUID",
+			annotations: map[string]string{VGPUUseUUIDAnnotation: "GPU-0,"},
+			id:          "",
+			want:        false,
+		},
+		{
+			name:        "denylist rejects match",
+			annotations: map[string]string{VGPUNoUseUUIDAnnotation: "GPU-0, GPU-1"},
+			id:          "GPU-1",
+			want:        false,
+		},
+		{
+			name:        "denylist constraint rejects empty device UUID",
+			annotations: map[string]string{VGPUNoUseUUIDAnnotation: "GPU-0,"},
+			id:          "",
+			want:        false,
+		},
+		{
+			name: "denylist wins over allowlist",
+			annotations: map[string]string{
+				VGPUUseUUIDAnnotation:   "GPU-1",
+				VGPUNoUseUUIDAnnotation: "GPU-1",
+			},
+			id:   "GPU-1",
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := newGPUUUIDFilter(tt.annotations).matches(tt.id); got != tt.want {
+				t.Fatalf("gpuUUIDFilter.matches() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGPUUUIDConstraints(t *testing.T) {
+	tests := []struct {
+		name        string
+		annotations map[string]string
+		wantFit     bool
+		wantUUID    string
+		wantError   string
+	}{
+		{
+			name:        "allowlist selects requested GPU",
+			annotations: map[string]string{VGPUUseUUIDAnnotation: "GPU-0000A"},
+			wantFit:     true,
+			wantUUID:    "GPU-0000A",
+		},
+		{
+			name:        "denylist excludes GPU",
+			annotations: map[string]string{VGPUNoUseUUIDAnnotation: "GPU-0000B"},
+			wantFit:     true,
+			wantUUID:    "GPU-0000A",
+		},
+		{
+			name:        "unknown allowed UUID is unschedulable",
+			annotations: map[string]string{VGPUUseUUIDAnnotation: "GPU-unknown"},
+			wantFit:     false,
+			wantError:   VGPUUseUUIDAnnotation,
+		},
+		{
+			name: "denylist excludes all GPUs",
+			annotations: map[string]string{
+				VGPUNoUseUUIDAnnotation: "GPU-0000A,GPU-0000B",
+			},
+			wantFit:   false,
+			wantError: VGPUNoUseUUIDAnnotation,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gs := makeGPUDevices("node-1", 2, 16384, 4)
+			pod := makeVGPUPod("worker", "default", "uid", 4096, false, "")
+			pod.Annotations = tt.annotations
+
+			fit, allocated, _, err := checkNodeGPUSharingPredicateAndScore(pod, gs, true, "")
+			if fit != tt.wantFit {
+				t.Fatalf("fit = %v, want %v; error: %v", fit, tt.wantFit, err)
+			}
+			if !tt.wantFit {
+				if err == nil {
+					t.Fatal("expected an allocation error")
+				}
+				if !strings.Contains(err.Error(), tt.wantError) {
+					t.Fatalf("error %q does not contain %q", err, tt.wantError)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected allocation error: %v", err)
+			}
+			if got := getDeviceUUID(allocated); got != tt.wantUUID {
+				t.Fatalf("allocated UUID = %q, want %q", got, tt.wantUUID)
+			}
+		})
+	}
+}
+
 func TestGetPodGroupKey(t *testing.T) {
 	tests := []struct {
 		name string


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Adds pod-level UUID constraints to the vGPU scheduler so workloads can select or exclude specific physical GPUs.

This is very useful for benchmarking different kind of jobs with and without colocation

- `volcano.sh/vgpu-use-gpuuuid` defines a comma-separated UUID allowlist.
- `volcano.sh/vgpu-nouse-gpuuuid` defines a comma-separated UUID denylist.
- UUIDs are matched exactly after trimming whitespace.
- The denylist takes precedence when a UUID appears in both annotations.
- Pods remain unschedulable when no permitted GPU can satisfy the resource request.

The UUID filter runs before device capacity and sharing checks, while the existing scheduler policy still chooses among permitted devices.

#### Which issue(s) this PR fixes:

NONE

#### Special notes for your reviewer:

AI-assisted contribution: GitHub Copilot CLI was used to inspect the vGPU scheduler, implement the change, add tests and documentation, and prepare this PR.

Prompt: "Add support for selecting specific GPU UUIDs in the Volcano vGPU scheduler, follow Volcano's vGPU annotation convention, update the branch from latest upstream, test it, and create a PR."

Rhyme: GPUs glow where volcanoes flow; UUIDs guide each pod where it should go.

#### Testing Done

- [x] Local code review completed
- [x] Unit tests added for UUID allowlist and denylist behavior
- [x] `go test ./pkg/scheduler/api/devices/nvidia/vgpu`
- [x] `go test ./pkg/scheduler/api/devices/...`

#### Does this PR introduce a user-facing change?

```release-note
Add `volcano.sh/vgpu-use-gpuuuid` and `volcano.sh/vgpu-nouse-gpuuuid` pod annotations for constraining vGPU allocation by physical GPU UUID.
```