### PR TITLE
feat(predicates): support DRA score normalization

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -224,7 +224,7 @@ e2e-test-cronjob: images
 	E2E_TYPE=CRONJOB ./hack/run-e2e-kind.sh
 
 e2e-test-dra: images
-	E2E_TYPE=DRA FEATURE_GATES="DynamicResourceAllocation=true,DRAConsumableCapacity=true" ./hack/run-e2e-kind.sh
+	E2E_TYPE=DRA FEATURE_GATES="DynamicResourceAllocation=true,DRAConsumableCapacity=true,DRAPrioritizedList=true" ./hack/run-e2e-kind.sh
 
 e2e-test-hypernode: images
 	E2E_TYPE=HYPERNODE ./hack/run-e2e-kind.sh

--- a/docs/user-guide/how_to_enable_dra.md
+++ b/docs/user-guide/how_to_enable_dra.md
@@ -44,6 +44,16 @@ When you directly use `kubectl apply -f` to install Volcano, you need to add or 
 --feature-gates=DynamicResourceAllocation=true
 ```
 
+### Enable prioritized device requests (optional)
+
+Kubernetes v1.36 introduces prioritized DRA device requests through the `FirstAvailable` field. When Pods use this field, enable the `DRAPrioritizedList` feature gate together with `DynamicResourceAllocation`:
+
+```yaml
+--feature-gates=DynamicResourceAllocation=true,DRAPrioritizedList=true
+```
+
+Volcano uses the Kubernetes DRA score to prefer nodes that satisfy an earlier device request alternative. No additional Volcano scheduler configuration is required.
+
 ## 3. Configure Volcano Scheduler Plugins
 After installing Volcano, you need to configure the Volcano scheduler's plugin configuration to enable the DRA plugin within the predicates plugin arguments.
 
@@ -73,4 +83,3 @@ For example, you can refer to the [kubernetes-sigs/dra-example-driver](https://g
 For some DRA Drivers which have already been used in actual production, you can refer to:
 - [NVIDIA/k8s-dra-driver-gpu](https://github.com/NVIDIA/k8s-dra-driver-gpu)
 - [intel/intel-resource-drivers-for-kubernetes](https://github.com/intel/intel-resource-drivers-for-kubernetes)
-

--- a/pkg/scheduler/plugins/nodeorder/nodeorder.go
+++ b/pkg/scheduler/plugins/nodeorder/nodeorder.go
@@ -365,6 +365,16 @@ func (pp *NodeOrderPlugin) BatchNodeOrderFn(task *api.TaskInfo, nodes []*api.Nod
 	nodeScores := make(map[string]float64, len(nodes))
 
 	for name, entry := range pp.ScorePlugins {
+		if preScorePlugin, ok := entry.plugin.(fwk.PreScorePlugin); ok {
+			skipScore, err := nodescore.RunPreScorePlugin(preScorePlugin, state, task.Pod, nodeInfos)
+			if err != nil {
+				return nil, err
+			}
+			if skipScore {
+				continue
+			}
+		}
+
 		scores, err := nodescore.CalculatePluginScore(name, entry.plugin, state, task.Pod, nodeInfos, entry.weight)
 		if err != nil {
 			return nil, err

--- a/pkg/scheduler/plugins/nodeorder/nodeorder.go
+++ b/pkg/scheduler/plugins/nodeorder/nodeorder.go
@@ -75,12 +75,10 @@ type NodeOrderPlugin struct {
 	NodeOrderScorePlugins map[string]ScorePluginWithWeight
 }
 
-// scorePluginEntry contains a plugin that has both PreScore and Score extension points.
-// If all score plugins support PreScore in the future, ScorePluginWithWeight can be replaced by scorePluginEntry.
+// scorePluginEntry contains a score plugin used by BatchNodeOrderFn.
 type scorePluginEntry struct {
-	plugin     nodescore.BaseScorePlugin
-	normalizer fwk.ScoreExtensions // If the plugin implements ScoreExtensions, normalizer is the plugin itself; otherwise, it can be EmptyNormalizer.
-	weight     int
+	plugin nodescore.BaseScorePlugin
+	weight int
 }
 
 type ScorePluginWithWeight struct {
@@ -222,9 +220,8 @@ func (pp *NodeOrderPlugin) InitPlugin() {
 		if p, err := noderesources.NewFit(context.TODO(), leastAllocatedArgs, pp.Handle, fts); err == nil {
 			leastAllocated := p.(*noderesources.Fit)
 			scorePlugins[leastAllocated.Name()+"_LeastAllocated"] = scorePluginEntry{
-				plugin:     leastAllocated,
-				normalizer: &nodescore.EmptyNormalizer{},
-				weight:     pp.weight.leastReqWeight,
+				plugin: leastAllocated,
+				weight: pp.weight.leastReqWeight,
 			}
 		} else {
 			klog.Errorf("Failed to init Least Allocated plugin %v", err)
@@ -242,9 +239,8 @@ func (pp *NodeOrderPlugin) InitPlugin() {
 		if p, err := noderesources.NewFit(context.TODO(), mostAllocatedArgs, pp.Handle, fts); err == nil {
 			mostAllocation := p.(*noderesources.Fit)
 			scorePlugins[mostAllocation.Name()+"_MostAllocated"] = scorePluginEntry{
-				plugin:     mostAllocation,
-				normalizer: &nodescore.EmptyNormalizer{},
-				weight:     pp.weight.mostReqWeight,
+				plugin: mostAllocation,
+				weight: pp.weight.mostReqWeight,
 			}
 		} else {
 			klog.Errorf("Failed to init Most Allocated plugin %v", err)
@@ -263,9 +259,8 @@ func (pp *NodeOrderPlugin) InitPlugin() {
 		if p, err := noderesources.NewBalancedAllocation(context.TODO(), blArgs, pp.Handle, fts); err == nil {
 			balancedAllocation := p.(*noderesources.BalancedAllocation)
 			scorePlugins[balancedAllocation.Name()] = scorePluginEntry{
-				plugin:     balancedAllocation,
-				normalizer: &nodescore.EmptyNormalizer{},
-				weight:     pp.weight.balancedResourceWeight,
+				plugin: balancedAllocation,
+				weight: pp.weight.balancedResourceWeight,
 			}
 		} else {
 			klog.Errorf("Failed to init Balanced Resource Allocation plugin %v", err)
@@ -280,9 +275,8 @@ func (pp *NodeOrderPlugin) InitPlugin() {
 		if p, err := nodeaffinity.New(context.TODO(), naArgs, pp.Handle, fts); err == nil {
 			nodeAffinity := p.(*nodeaffinity.NodeAffinity)
 			scorePlugins[nodeAffinity.Name()] = scorePluginEntry{
-				plugin:     nodeAffinity,
-				normalizer: nodeAffinity,
-				weight:     pp.weight.nodeAffinityWeight,
+				plugin: nodeAffinity,
+				weight: pp.weight.nodeAffinityWeight,
 			}
 		} else {
 			klog.Errorf("Failed to init Node Affinity plugin %v", err)
@@ -305,9 +299,8 @@ func (pp *NodeOrderPlugin) InitPlugin() {
 		if p, err := interpodaffinity.New(context.TODO(), plArgs, pp.Handle, fts); err == nil {
 			interPodAffinity := p.(*interpodaffinity.InterPodAffinity)
 			scorePlugins[interpodaffinity.Name] = scorePluginEntry{
-				plugin:     interPodAffinity,
-				normalizer: interPodAffinity,
-				weight:     pp.weight.podAffinityWeight,
+				plugin: interPodAffinity,
+				weight: pp.weight.podAffinityWeight,
 			}
 		} else {
 			klog.Errorf("Failed to init InterPodAffinity plugin %v", err)
@@ -319,9 +312,8 @@ func (pp *NodeOrderPlugin) InitPlugin() {
 		if p, err := tainttoleration.New(context.TODO(), nil, pp.Handle, fts); err == nil {
 			taintToleration := p.(*tainttoleration.TaintToleration)
 			scorePlugins[tainttoleration.Name] = scorePluginEntry{
-				plugin:     taintToleration,
-				normalizer: taintToleration,
-				weight:     pp.weight.taintTolerationWeight,
+				plugin: taintToleration,
+				weight: pp.weight.taintTolerationWeight,
 			}
 		} else {
 			klog.Errorf("Failed to init TaintToleration plugin %v", err)
@@ -336,9 +328,8 @@ func (pp *NodeOrderPlugin) InitPlugin() {
 		if p, err := podtopologyspread.New(context.TODO(), ptsArgs, pp.Handle, fts); err == nil {
 			podTopologySpread := p.(*podtopologyspread.PodTopologySpread)
 			scorePlugins[podtopologyspread.Name] = scorePluginEntry{
-				plugin:     podTopologySpread,
-				normalizer: podTopologySpread,
-				weight:     pp.weight.podTopologySpreadWeight,
+				plugin: podTopologySpread,
+				weight: pp.weight.podTopologySpreadWeight,
 			}
 		} else {
 			klog.Errorf("Failed to init PodTopologySpread plugin %v", err)
@@ -374,7 +365,7 @@ func (pp *NodeOrderPlugin) BatchNodeOrderFn(task *api.TaskInfo, nodes []*api.Nod
 	nodeScores := make(map[string]float64, len(nodes))
 
 	for name, entry := range pp.ScorePlugins {
-		scores, err := nodescore.CalculatePluginScore(name, entry.plugin, entry.normalizer, state, task.Pod, nodeInfos, entry.weight)
+		scores, err := nodescore.CalculatePluginScore(name, entry.plugin, state, task.Pod, nodeInfos, entry.weight)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/scheduler/plugins/nodeorder/nodeorder.go
+++ b/pkg/scheduler/plugins/nodeorder/nodeorder.go
@@ -76,6 +76,7 @@ type NodeOrderPlugin struct {
 }
 
 // scorePluginEntry contains a score plugin used by BatchNodeOrderFn.
+// If all score plugins support PreScore in the future, ScorePluginWithWeight can be replaced by scorePluginEntry
 type scorePluginEntry struct {
 	plugin nodescore.BaseScorePlugin
 	weight int

--- a/pkg/scheduler/plugins/predicates/predicates.go
+++ b/pkg/scheduler/plugins/predicates/predicates.go
@@ -634,6 +634,7 @@ func (pp *PredicatesPlugin) InitPlugin() {
 		addPreFilterPlugin(dynamicresources.Name, dynamicResourceAllocationPlugin)
 		addReservePlugin(dynamicresources.Name, dynamicResourceAllocationPlugin)
 		addPreBindPlugin(dynamicresources.Name, dynamicResourceAllocationPlugin)
+		addScorePlugin(dynamicresources.Name, dynamicResourceAllocationPlugin, 1)
 	}
 
 	pp.FilterPlugins = filterPlugins
@@ -771,9 +772,6 @@ func (pp *PredicatesPlugin) BatchNodeOrder(task *api.TaskInfo, nodes []fwk.NodeI
 		if !exists {
 			continue
 		}
-		// Get normalizer (most plugins don't need normalization, use EmptyNormalizer by default)
-		normalizer := &nodescore.EmptyNormalizer{}
-
 		// Get weight from ScoreWeights map, default to 1 if not set
 		weight := 1
 		if w, exists := pp.ScoreWeights[name]; exists {
@@ -781,7 +779,7 @@ func (pp *PredicatesPlugin) BatchNodeOrder(task *api.TaskInfo, nodes []fwk.NodeI
 		}
 
 		// Calculate score using the helper function
-		pluginScores, err := nodescore.CalculatePluginScore(name, plugin, normalizer, state, task.Pod, nodes, weight)
+		pluginScores, err := nodescore.CalculatePluginScore(name, plugin, state, task.Pod, nodes, weight)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/scheduler/plugins/predicates/predicates.go
+++ b/pkg/scheduler/plugins/predicates/predicates.go
@@ -105,6 +105,7 @@ type PredicatesPlugin struct {
 	FilterPlugins       map[string]fwk.FilterPlugin
 	StableFilterPlugins map[string]fwk.FilterPlugin // Subset of FilterPlugins for cache-stable filters
 	PreFilterPlugins    map[string]fwk.PreFilterPlugin
+	PreScorePlugins     map[string]fwk.PreScorePlugin
 	ReservePlugins      map[string]fwk.ReservePlugin
 	PreBindPlugins      map[string]fwk.PreBindPlugin
 	ScorePlugins        map[string]nodescore.BaseScorePlugin
@@ -112,6 +113,7 @@ type PredicatesPlugin struct {
 	FilterOrder         []string
 	StableFilterOrder   []string
 	PreFilterOrder      []string
+	PreScoreOrder       []string
 	ReserveOrder        []string
 	PreBindOrder        []string
 	ScoreOrder          []string
@@ -473,6 +475,7 @@ func (pp *PredicatesPlugin) InitPlugin() {
 	filterPlugins := map[string]fwk.FilterPlugin{}
 	stableFilterPlugins := map[string]fwk.FilterPlugin{} // Subset for cache-stable filters
 	prefilterPlugins := map[string]fwk.PreFilterPlugin{}
+	preScorePlugins := map[string]fwk.PreScorePlugin{}
 	reservePlugins := map[string]fwk.ReservePlugin{}
 	scorePlugins := map[string]nodescore.BaseScorePlugin{}
 	preBindPlugins := map[string]fwk.PreBindPlugin{}
@@ -480,6 +483,7 @@ func (pp *PredicatesPlugin) InitPlugin() {
 	var filterOrder []string
 	var stableFilterOrder []string
 	var preFilterOrder []string
+	var preScoreOrder []string
 	var reserveOrder []string
 	var preBindOrder []string
 	var scoreOrder []string
@@ -495,6 +499,10 @@ func (pp *PredicatesPlugin) InitPlugin() {
 	addPreFilterPlugin := func(name string, plugin fwk.PreFilterPlugin) {
 		prefilterPlugins[name] = plugin
 		preFilterOrder = append(preFilterOrder, name)
+	}
+	addPreScorePlugin := func(name string, plugin fwk.PreScorePlugin) {
+		preScorePlugins[name] = plugin
+		preScoreOrder = append(preScoreOrder, name)
 	}
 	addReservePlugin := func(name string, plugin fwk.ReservePlugin) {
 		reservePlugins[name] = plugin
@@ -619,6 +627,7 @@ func (pp *PredicatesPlugin) InitPlugin() {
 		addPreFilterPlugin(volumebinding.Name, volumeBindingPluginInstance)
 		addReservePlugin(volumebinding.Name, volumeBindingPluginInstance)
 		addPreBindPlugin(volumebinding.Name, volumeBindingPluginInstance)
+		addPreScorePlugin(volumebinding.Name, volumeBindingPluginInstance)
 		addScorePlugin(volumebinding.Name, volumeBindingPluginInstance, vbArgs.Weight)
 	}
 	// 10. DRA
@@ -640,6 +649,7 @@ func (pp *PredicatesPlugin) InitPlugin() {
 	pp.FilterPlugins = filterPlugins
 	pp.StableFilterPlugins = stableFilterPlugins
 	pp.PreFilterPlugins = prefilterPlugins
+	pp.PreScorePlugins = preScorePlugins
 	pp.ReservePlugins = reservePlugins
 	pp.PreBindPlugins = preBindPlugins
 	pp.ScorePlugins = scorePlugins
@@ -647,6 +657,7 @@ func (pp *PredicatesPlugin) InitPlugin() {
 	pp.FilterOrder = filterOrder
 	pp.StableFilterOrder = stableFilterOrder
 	pp.PreFilterOrder = preFilterOrder
+	pp.PreScoreOrder = preScoreOrder
 	pp.ReserveOrder = reserveOrder
 	pp.PreBindOrder = preBindOrder
 	pp.ScoreOrder = scoreOrder
@@ -765,9 +776,28 @@ func (pp *PredicatesPlugin) Predicate(task *api.TaskInfo, node *api.NodeInfo, st
 // BatchNodeOrder runs all Score plugins for the given task and nodes.
 func (pp *PredicatesPlugin) BatchNodeOrder(task *api.TaskInfo, nodes []fwk.NodeInfo, state *k8sframework.CycleState) (map[string]float64, error) {
 	nodeScores := make(map[string]float64, len(nodes))
+	skippedScorePlugins := map[string]struct{}{}
+
+	for _, name := range pp.PreScoreOrder {
+		plugin, exists := pp.PreScorePlugins[name]
+		if !exists {
+			continue
+		}
+
+		skipScore, err := nodescore.RunPreScorePlugin(plugin, state, task.Pod, nodes)
+		if err != nil {
+			return nil, fmt.Errorf("pre-score plugin %s failed: %w", name, err)
+		}
+		if skipScore {
+			skippedScorePlugins[name] = struct{}{}
+		}
+	}
 
 	// Run all Score plugins
 	for _, name := range pp.ScoreOrder {
+		if _, skipped := skippedScorePlugins[name]; skipped {
+			continue
+		}
 		plugin, exists := pp.ScorePlugins[name]
 		if !exists {
 			continue

--- a/pkg/scheduler/plugins/predicates/predicates_test.go
+++ b/pkg/scheduler/plugins/predicates/predicates_test.go
@@ -54,6 +54,7 @@ import (
 	"volcano.sh/volcano/pkg/scheduler/plugins/gang"
 	"volcano.sh/volcano/pkg/scheduler/plugins/priority"
 	"volcano.sh/volcano/pkg/scheduler/plugins/util/k8s"
+	"volcano.sh/volcano/pkg/scheduler/plugins/util/nodescore"
 	"volcano.sh/volcano/pkg/scheduler/uthelper"
 	"volcano.sh/volcano/pkg/scheduler/util"
 )
@@ -88,6 +89,29 @@ func (p *fakeTrackingFilterPlugin) Filter(_ context.Context, _ k8sframework.Cycl
 type fakeReservePlugin struct {
 	name  string
 	calls *[]string
+}
+
+type fakePreScorePlugin struct {
+	name           string
+	preScoreStatus *k8sframework.Status
+	preScoreCalls  int
+}
+
+func (p *fakePreScorePlugin) Name() string {
+	return p.name
+}
+
+func (p *fakePreScorePlugin) PreScore(_ context.Context, _ k8sframework.CycleState, _ *apiv1.Pod, _ []k8sframework.NodeInfo) *k8sframework.Status {
+	p.preScoreCalls++
+	return p.preScoreStatus
+}
+
+func (p *fakePreScorePlugin) Score(_ context.Context, _ k8sframework.CycleState, _ *apiv1.Pod, _ k8sframework.NodeInfo) (int64, *k8sframework.Status) {
+	return 50, k8sframework.NewStatus(k8sframework.Success)
+}
+
+func (p *fakePreScorePlugin) ScoreExtensions() k8sframework.ScoreExtensions {
+	return nil
 }
 
 func (p *fakeReservePlugin) Name() string {
@@ -432,10 +456,12 @@ func TestInitPlugin(t *testing.T) {
 		expectInFilter          []string
 		expectInStableFilter    []string
 		expectInPrefilter       []string
+		expectInPreScore        []string
 		expectInReserve         []string
 		expectInPreBind         []string
 		expectInScore           []string
 		expectNotInFilter       []string
+		expectNotInPreScore     []string
 		expectNotInReserve      []string
 		expectNotInPreBind      []string
 		expectNotInScore        []string
@@ -454,6 +480,7 @@ func TestInitPlugin(t *testing.T) {
 			expectInFilter:          []string{nodeunschedulable.Name, nodeaffinity.Name, nodeports.Name, tainttoleration.Name, interpodaffinity.Name, nodevolumelimits.CSIName, volumezone.Name, podtopologyspread.Name},
 			expectInStableFilter:    []string{nodeunschedulable.Name, nodeaffinity.Name, tainttoleration.Name},
 			expectInPrefilter:       []string{nodeaffinity.Name, nodeports.Name, interpodaffinity.Name, nodevolumelimits.CSIName, volumezone.Name, podtopologyspread.Name},
+			expectNotInPreScore:     []string{volumebinding.Name, dynamicresources.Name},
 			expectInReserve:         []string{},
 			expectInPreBind:         []string{},
 			expectInScore:           []string{},
@@ -476,6 +503,8 @@ func TestInitPlugin(t *testing.T) {
 			expectInFilter:          []string{nodeunschedulable.Name, nodeaffinity.Name, tainttoleration.Name, volumebinding.Name},
 			expectInStableFilter:    []string{nodeunschedulable.Name, nodeaffinity.Name, tainttoleration.Name},
 			expectInPrefilter:       []string{volumebinding.Name},
+			expectInPreScore:        []string{volumebinding.Name},
+			expectNotInPreScore:     []string{dynamicresources.Name},
 			expectInReserve:         []string{volumebinding.Name},
 			expectInPreBind:         []string{volumebinding.Name},
 			expectInScore:           []string{volumebinding.Name},
@@ -497,6 +526,7 @@ func TestInitPlugin(t *testing.T) {
 			expectInFilter:          []string{nodeunschedulable.Name, nodeaffinity.Name, tainttoleration.Name, dynamicresources.Name},
 			expectInStableFilter:    []string{nodeunschedulable.Name, nodeaffinity.Name, tainttoleration.Name},
 			expectInPrefilter:       []string{nodeaffinity.Name, dynamicresources.Name},
+			expectNotInPreScore:     []string{volumebinding.Name, dynamicresources.Name},
 			expectInReserve:         []string{dynamicresources.Name},
 			expectInPreBind:         []string{dynamicresources.Name},
 			expectInScore:           []string{dynamicresources.Name},
@@ -519,6 +549,8 @@ func TestInitPlugin(t *testing.T) {
 			expectInFilter:          []string{nodeunschedulable.Name, nodeaffinity.Name, nodeports.Name, tainttoleration.Name, interpodaffinity.Name, nodevolumelimits.CSIName, volumezone.Name, podtopologyspread.Name, volumebinding.Name, dynamicresources.Name},
 			expectInStableFilter:    []string{nodeunschedulable.Name, nodeaffinity.Name, tainttoleration.Name},
 			expectInPrefilter:       []string{nodeports.Name, interpodaffinity.Name, podtopologyspread.Name, volumebinding.Name, dynamicresources.Name},
+			expectInPreScore:        []string{volumebinding.Name},
+			expectNotInPreScore:     []string{dynamicresources.Name},
 			expectInReserve:         []string{volumebinding.Name, dynamicresources.Name},
 			expectInPreBind:         []string{volumebinding.Name, dynamicresources.Name},
 			expectInScore:           []string{volumebinding.Name, dynamicresources.Name},
@@ -578,6 +610,17 @@ func TestInitPlugin(t *testing.T) {
 				}
 			}
 
+			for _, pluginName := range tt.expectInPreScore {
+				if _, exists := pp.PreScorePlugins[pluginName]; !exists {
+					t.Errorf("expected %s in PreScorePlugins, but not found", pluginName)
+				}
+			}
+			for _, pluginName := range tt.expectNotInPreScore {
+				if _, exists := pp.PreScorePlugins[pluginName]; exists {
+					t.Errorf("expected %s not in PreScorePlugins, but found", pluginName)
+				}
+			}
+
 			// Verify ReservePlugins
 			for _, pluginName := range tt.expectInReserve {
 				if _, exists := pp.ReservePlugins[pluginName]; !exists {
@@ -624,6 +667,70 @@ func TestInitPlugin(t *testing.T) {
 				if weight, exists := pp.ScoreWeights[dynamicresources.Name]; !exists || weight != 1 {
 					t.Errorf("expected DynamicResources to have weight 1 in ScoreWeights")
 				}
+			}
+		})
+	}
+}
+
+func TestBatchNodeOrderRunsPreScorePlugins(t *testing.T) {
+	tests := []struct {
+		name          string
+		preScoreState *k8sframework.Status
+		wantScore     bool
+		wantError     bool
+	}{
+		{
+			name:          "runs score after successful pre-score",
+			preScoreState: k8sframework.NewStatus(k8sframework.Success),
+			wantScore:     true,
+		},
+		{
+			name:          "skips matching score when pre-score skips",
+			preScoreState: k8sframework.NewStatus(k8sframework.Skip),
+		},
+		{
+			name:          "returns pre-score error",
+			preScoreState: k8sframework.NewStatus(k8sframework.Error, "pre-score failed"),
+			wantError:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			plugin := &fakePreScorePlugin{
+				name:           "test-pre-score-plugin",
+				preScoreStatus: tt.preScoreState,
+			}
+			pp := &PredicatesPlugin{
+				PreScorePlugins: map[string]k8sframework.PreScorePlugin{plugin.Name(): plugin},
+				PreScoreOrder:   []string{plugin.Name()},
+				ScorePlugins:    map[string]nodescore.BaseScorePlugin{plugin.Name(): plugin},
+				ScoreWeights:    map[string]int{plugin.Name(): 1},
+				ScoreOrder:      []string{plugin.Name()},
+			}
+			nodeInfo := schedframework.NewNodeInfo()
+			nodeInfo.SetNode(&apiv1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-a"}})
+
+			scores, err := pp.BatchNodeOrder(
+				&api.TaskInfo{Pod: &apiv1.Pod{}},
+				[]k8sframework.NodeInfo{nodeInfo},
+				schedframework.NewCycleState(),
+			)
+			if tt.wantError {
+				if err == nil {
+					t.Fatal("expected pre-score error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("BatchNodeOrder returned an error: %v", err)
+			}
+			if plugin.preScoreCalls != 1 {
+				t.Errorf("expected PreScore to be called once, got %d", plugin.preScoreCalls)
+			}
+			_, scored := scores["node-a"]
+			if scored != tt.wantScore {
+				t.Errorf("expected node score presence to be %t, got %t", tt.wantScore, scored)
 			}
 		})
 	}

--- a/pkg/scheduler/plugins/predicates/predicates_test.go
+++ b/pkg/scheduler/plugins/predicates/predicates_test.go
@@ -460,7 +460,7 @@ func TestInitPlugin(t *testing.T) {
 			expectNotInFilter:       []string{volumebinding.Name, dynamicresources.Name},
 			expectNotInReserve:      []string{volumebinding.Name, dynamicresources.Name},
 			expectNotInPreBind:      []string{volumebinding.Name, dynamicresources.Name},
-			expectNotInScore:        []string{volumebinding.Name},
+			expectNotInScore:        []string{dynamicresources.Name, volumebinding.Name},
 		},
 		{
 			name:                    "volume binding enabled",
@@ -499,11 +499,11 @@ func TestInitPlugin(t *testing.T) {
 			expectInPrefilter:       []string{nodeaffinity.Name, dynamicresources.Name},
 			expectInReserve:         []string{dynamicresources.Name},
 			expectInPreBind:         []string{dynamicresources.Name},
-			expectInScore:           []string{},
+			expectInScore:           []string{dynamicresources.Name},
 			expectNotInFilter:       []string{volumebinding.Name},
 			expectNotInReserve:      []string{volumebinding.Name},
 			expectNotInPreBind:      []string{volumebinding.Name},
-			expectNotInScore:        []string{dynamicresources.Name, volumebinding.Name},
+			expectNotInScore:        []string{volumebinding.Name},
 		},
 		{
 			name:                    "both volume binding and dra enabled",
@@ -521,8 +521,7 @@ func TestInitPlugin(t *testing.T) {
 			expectInPrefilter:       []string{nodeports.Name, interpodaffinity.Name, podtopologyspread.Name, volumebinding.Name, dynamicresources.Name},
 			expectInReserve:         []string{volumebinding.Name, dynamicresources.Name},
 			expectInPreBind:         []string{volumebinding.Name, dynamicresources.Name},
-			expectInScore:           []string{volumebinding.Name},
-			expectNotInScore:        []string{dynamicresources.Name},
+			expectInScore:           []string{volumebinding.Name, dynamicresources.Name},
 		},
 	}
 
@@ -619,6 +618,11 @@ func TestInitPlugin(t *testing.T) {
 			if tt.enableVolumeBinding {
 				if weight, exists := pp.ScoreWeights[volumebinding.Name]; !exists || weight == 0 {
 					t.Errorf("expected VolumeBinding to have non-zero weight in ScoreWeights")
+				}
+			}
+			if tt.enableDRA {
+				if weight, exists := pp.ScoreWeights[dynamicresources.Name]; !exists || weight != 1 {
+					t.Errorf("expected DynamicResources to have weight 1 in ScoreWeights")
 				}
 			}
 		})

--- a/pkg/scheduler/plugins/util/nodescore/score_helper.go
+++ b/pkg/scheduler/plugins/util/nodescore/score_helper.go
@@ -29,16 +29,7 @@ import (
 )
 
 type BaseScorePlugin interface {
-	fwk.PreScorePlugin
 	fwk.ScorePlugin
-}
-
-// EmptyNormalizer is a no-op normalizer that does nothing. For plugins that do not implement the ScoreExtensions interface,
-// such as VolumeBinding, ExampleNormalizer can be used, indicating that there is no need to normalize the score
-type EmptyNormalizer struct{}
-
-func (e *EmptyNormalizer) NormalizeScore(ctx context.Context, state fwk.CycleState, p *v1.Pod, scores fwk.NodeScoreList) *fwk.Status {
-	return nil
 }
 
 func NodeInfosForCandidateNodes(nodes []*api.NodeInfo, nodeMap map[string]fwk.NodeInfo) []fwk.NodeInfo {
@@ -57,19 +48,20 @@ func NodeInfosForCandidateNodes(nodes []*api.NodeInfo, nodeMap map[string]fwk.No
 func CalculatePluginScore(
 	pluginName string,
 	plugin BaseScorePlugin,
-	normalizer fwk.ScoreExtensions,
 	cycleState fwk.CycleState,
 	pod *v1.Pod,
 	nodeInfos []fwk.NodeInfo,
 	weight int,
 ) (map[string]float64, error) {
-	preScoreStatus := plugin.PreScore(context.TODO(), cycleState, pod, nodeInfos)
-	if preScoreStatus.IsSkip() {
-		// Skip Score
-		return map[string]float64{}, nil
-	}
-	if !preScoreStatus.IsSuccess() {
-		return nil, preScoreStatus.AsError()
+	if preScorePlugin, ok := plugin.(fwk.PreScorePlugin); ok {
+		preScoreStatus := preScorePlugin.PreScore(context.TODO(), cycleState, pod, nodeInfos)
+		if preScoreStatus.IsSkip() {
+			// Skip Score
+			return map[string]float64{}, nil
+		}
+		if !preScoreStatus.IsSuccess() {
+			return nil, preScoreStatus.AsError()
+		}
 	}
 
 	nodeScoreList := make(fwk.NodeScoreList, len(nodeInfos))
@@ -106,7 +98,12 @@ func CalculatePluginScore(
 	default:
 	}
 
-	normalizer.NormalizeScore(context.TODO(), cycleState, pod, nodeScoreList)
+	if extensions := plugin.ScoreExtensions(); extensions != nil {
+		normalizeStatus := extensions.NormalizeScore(context.TODO(), cycleState, pod, nodeScoreList)
+		if !normalizeStatus.IsSuccess() {
+			return nil, fmt.Errorf("normalize %s score failed %v", pluginName, normalizeStatus.Message())
+		}
+	}
 
 	nodeScores := make(map[string]float64, len(nodeInfos))
 	for i, nodeScore := range nodeScoreList {

--- a/pkg/scheduler/plugins/util/nodescore/score_helper.go
+++ b/pkg/scheduler/plugins/util/nodescore/score_helper.go
@@ -45,6 +45,17 @@ func NodeInfosForCandidateNodes(nodes []*api.NodeInfo, nodeMap map[string]fwk.No
 	return nodeInfos
 }
 
+func RunPreScorePlugin(plugin fwk.PreScorePlugin, cycleState fwk.CycleState, pod *v1.Pod, nodeInfos []fwk.NodeInfo) (bool, error) {
+	status := plugin.PreScore(context.TODO(), cycleState, pod, nodeInfos)
+	if status.IsSkip() {
+		return true, nil
+	}
+	if !status.IsSuccess() {
+		return false, status.AsError()
+	}
+	return false, nil
+}
+
 func CalculatePluginScore(
 	pluginName string,
 	plugin BaseScorePlugin,
@@ -53,17 +64,6 @@ func CalculatePluginScore(
 	nodeInfos []fwk.NodeInfo,
 	weight int,
 ) (map[string]float64, error) {
-	if preScorePlugin, ok := plugin.(fwk.PreScorePlugin); ok {
-		preScoreStatus := preScorePlugin.PreScore(context.TODO(), cycleState, pod, nodeInfos)
-		if preScoreStatus.IsSkip() {
-			// Skip Score
-			return map[string]float64{}, nil
-		}
-		if !preScoreStatus.IsSuccess() {
-			return nil, preScoreStatus.AsError()
-		}
-	}
-
 	nodeScoreList := make(fwk.NodeScoreList, len(nodeInfos))
 	// the default parallelization worker number is 16.
 	// the whole scoring will fail if one of the processes failed.

--- a/pkg/scheduler/plugins/util/nodescore/score_helper.go
+++ b/pkg/scheduler/plugins/util/nodescore/score_helper.go
@@ -45,7 +45,9 @@ func NodeInfosForCandidateNodes(nodes []*api.NodeInfo, nodeMap map[string]fwk.No
 	return nodeInfos
 }
 
-func RunPreScorePlugin(plugin fwk.PreScorePlugin, cycleState fwk.CycleState, pod *v1.Pod, nodeInfos []fwk.NodeInfo) (bool, error) {
+// RunPreScorePlugin runs a pre-score plugin.
+// It returns whether the plugin requested its Score phase to be skipped and any error from PreScore.
+func RunPreScorePlugin(plugin fwk.PreScorePlugin, cycleState fwk.CycleState, pod *v1.Pod, nodeInfos []fwk.NodeInfo) (skipScore bool, err error) {
 	status := plugin.PreScore(context.TODO(), cycleState, pod, nodeInfos)
 	if status.IsSkip() {
 		return true, nil

--- a/pkg/scheduler/plugins/util/nodescore/score_helper_test.go
+++ b/pkg/scheduler/plugins/util/nodescore/score_helper_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package nodescore
 
 import (
+	"context"
+	"strings"
 	"testing"
 
 	v1 "k8s.io/api/core/v1"
@@ -26,6 +28,41 @@ import (
 
 	"volcano.sh/volcano/pkg/scheduler/api"
 )
+
+type fakeScorePlugin struct {
+	name       string
+	scores     map[string]int64
+	extensions *fakeScoreExtensions
+}
+
+func (p *fakeScorePlugin) Name() string {
+	return p.name
+}
+
+func (p *fakeScorePlugin) Score(_ context.Context, _ fwk.CycleState, _ *v1.Pod, nodeInfo fwk.NodeInfo) (int64, *fwk.Status) {
+	return p.scores[nodeInfo.Node().Name], nil
+}
+
+func (p *fakeScorePlugin) ScoreExtensions() fwk.ScoreExtensions {
+	if p.extensions == nil {
+		return nil
+	}
+	return p.extensions
+}
+
+type fakeScoreExtensions struct {
+	calls     int
+	normalize func(fwk.NodeScoreList)
+	status    *fwk.Status
+}
+
+func (e *fakeScoreExtensions) NormalizeScore(_ context.Context, _ fwk.CycleState, _ *v1.Pod, scores fwk.NodeScoreList) *fwk.Status {
+	e.calls++
+	if e.normalize != nil {
+		e.normalize(scores)
+	}
+	return e.status
+}
 
 func TestNodeInfosForCandidateNodes(t *testing.T) {
 	nodeA := &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-a"}}
@@ -58,4 +95,101 @@ func TestNodeInfosForCandidateNodes(t *testing.T) {
 	if got[1].Node().Name != "node-c" {
 		t.Fatalf("expected second node to be node-c, got %s", got[1].Node().Name)
 	}
+}
+
+func TestCalculatePluginScore(t *testing.T) {
+	tests := []struct {
+		name           string
+		extensions     *fakeScoreExtensions
+		expectedScores map[string]float64
+		expectedCalls  int
+	}{
+		{
+			name: "skips normalization when score extensions are absent",
+			expectedScores: map[string]float64{
+				"node-a": 20,
+				"node-b": 40,
+			},
+		},
+		{
+			name: "normalizes scores before applying weight",
+			extensions: &fakeScoreExtensions{
+				normalize: func(scores fwk.NodeScoreList) {
+					scores[0].Score = 50
+					scores[1].Score = 75
+				},
+			},
+			expectedScores: map[string]float64{
+				"node-a": 100,
+				"node-b": 150,
+			},
+			expectedCalls: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			plugin := &fakeScorePlugin{
+				name:       "test-score-plugin",
+				scores:     map[string]int64{"node-a": 10, "node-b": 20},
+				extensions: tt.extensions,
+			}
+
+			scores, err := CalculatePluginScore(
+				plugin.Name(),
+				plugin,
+				k8sframework.NewCycleState(),
+				&v1.Pod{},
+				testNodeInfos("node-a", "node-b"),
+				2,
+			)
+			if err != nil {
+				t.Fatalf("CalculatePluginScore returned an error: %v", err)
+			}
+			for nodeName, expectedScore := range tt.expectedScores {
+				if score := scores[nodeName]; score != expectedScore {
+					t.Errorf("expected score %v for %s, got %v", expectedScore, nodeName, score)
+				}
+			}
+			if tt.extensions != nil && tt.extensions.calls != tt.expectedCalls {
+				t.Errorf("expected NormalizeScore to be called %d times, got %d", tt.expectedCalls, tt.extensions.calls)
+			}
+		})
+	}
+}
+
+func TestCalculatePluginScoreReturnsNormalizeError(t *testing.T) {
+	extensions := &fakeScoreExtensions{
+		status: fwk.NewStatus(fwk.Error, "normalization failed"),
+	}
+	plugin := &fakeScorePlugin{
+		name:       "test-score-plugin",
+		scores:     map[string]int64{"node-a": 10},
+		extensions: extensions,
+	}
+
+	_, err := CalculatePluginScore(
+		plugin.Name(),
+		plugin,
+		k8sframework.NewCycleState(),
+		&v1.Pod{},
+		testNodeInfos("node-a"),
+		1,
+	)
+	if err == nil || !strings.Contains(err.Error(), "normalization failed") {
+		t.Fatalf("expected normalization error, got %v", err)
+	}
+	if extensions.calls != 1 {
+		t.Errorf("expected NormalizeScore to be called once, got %d", extensions.calls)
+	}
+}
+
+func testNodeInfos(names ...string) []fwk.NodeInfo {
+	nodeInfos := make([]fwk.NodeInfo, 0, len(names))
+	for _, name := range names {
+		nodeInfo := k8sframework.NewNodeInfo()
+		nodeInfo.SetNode(&v1.Node{ObjectMeta: metav1.ObjectMeta{Name: name}})
+		nodeInfos = append(nodeInfos, nodeInfo)
+	}
+	return nodeInfos
 }

--- a/test/e2e/dra/test.go
+++ b/test/e2e/dra/test.go
@@ -429,11 +429,66 @@ var _ = ginkgo.Describe("DRA E2E Test", func() {
 		})
 	}
 
+	prioritizedListScoreTests := func() {
+		nodes := drautils.NewNodes(f, 2, 8)
+		driver := drautils.NewDriver(f, nodes, drautils.DriverResources(
+			-1,
+			map[string]map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
+				"device-1": {},
+				"device-2": {},
+			},
+			map[string]map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
+				"device-1": {},
+			},
+		))
+		b := newBuilder(f, driver)
+
+		ginkgo.It("prefers nodes that satisfy higher-priority device subrequests", func(ctx context.Context) {
+			claim := b.externalClaim()
+			claim.Spec.Devices.Requests = []resourceapi.DeviceRequest{{
+				Name: "my-request",
+				FirstAvailable: []resourceapi.DeviceSubRequest{
+					{
+						Name:            "preferred",
+						DeviceClassName: b.className(),
+						AllocationMode:  resourceapi.DeviceAllocationModeExactCount,
+						Count:           2,
+					},
+					{
+						Name:            "fallback",
+						DeviceClassName: b.className(),
+						AllocationMode:  resourceapi.DeviceAllocationModeExactCount,
+						Count:           1,
+					},
+				},
+			}}
+			pod := b.podExternal()
+			b.create(ctx, claim, pod)
+			b.testPod(ctx, f, pod)
+
+			scheduledPod, err := f.ClientSet.CoreV1().Pods(pod.Namespace).Get(ctx, pod.Name, metav1.GetOptions{})
+			framework.ExpectNoError(err)
+			gomega.Expect(scheduledPod.Spec.NodeName).To(gomega.Equal(nodes.NodeNames[0]))
+
+			allocatedClaim, err := f.ClientSet.ResourceV1().ResourceClaims(pod.Namespace).Get(ctx, claim.Name, metav1.GetOptions{})
+			framework.ExpectNoError(err)
+			gomega.Expect(allocatedClaim.Status.Allocation).ToNot(gomega.BeNil())
+			gomega.Expect(allocatedClaim.Status.Allocation.Devices.Results).To(gomega.HaveLen(2))
+			for _, result := range allocatedClaim.Status.Allocation.Devices.Results {
+				gomega.Expect(result.Request).To(gomega.Equal("my-request/preferred"))
+			}
+		})
+	}
+
 	ginkgo.Context("on single node", func() {
 		singleNodeTests()
 	})
 
 	ginkgo.Context("on multiple nodes", func() {
 		multiNodeTests()
+	})
+
+	ginkgo.Context("with prioritized device requests", func() {
+		prioritizedListScoreTests()
 	})
 })


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:

Adds Kubernetes DRA `Score` and `NormalizeScore` support to Volcano’s predicates plugin.

- Registers the upstream `DynamicResources` plugin as a predicates score plugin with weight `1`.
- Updates the shared score helper to:
  - support Score-only plugins such as DRA.
  - call `ScoreExtensions()` and run `NormalizeScore()` when provided.
  - skip normalization safely when no score extensions exist.
- Updates nodeorder to use the shared plugin-owned normalization path.
- Adds unit coverage for absent score extensions, successful normalization, and normalization failures.
- Adds a focused DRA E2E test with two nodes, where only one node can satisfy the preferred `FirstAvailable` device request.
- Enables `DRAPrioritizedList` in the DRA E2E target.


#### Which issue(s) this PR fixes:
Related to #5329

#### Special notes for your reviewer:

- `DynamicResources` implements `Score` but not `PreScore`. the shared helper now calls `PreScore` only when a score plugin implements that optional extension point.
- The `nodeorder` changes only remove its caller-provided normalizer. It now uses each upstream score plugin’s own `ScoreExtensions()` through the shared helper.
- The DRA E2E test passed locally.

#### Does this PR introduce a user-facing change?
```release-note
Volcano now applies Dynamic Resource Allocation (DRA) Score and NormalizeScore when scheduling Pods with prioritized device requests.
```