### PR TITLE
fix(scheduler): clear job metrics on podgroup delete

### DIFF
--- a/pkg/scheduler/cache/event_handlers.go
+++ b/pkg/scheduler/cache/event_handlers.go
@@ -893,6 +893,13 @@ func (sc *SchedulerCache) deletePodGroup(id schedulingapi.JobID) error {
 
 	sc.deleteJob(job)
 
+	// The PodGroup is gone for good at this point, so its metrics are stale
+	// regardless of whether the job still has tasks lingering in the cache.
+	// Clean them up here instead of relying solely on processCleanupJob,
+	// which only fires once the job has no tasks left and can otherwise
+	// leave metrics behind indefinitely for jobs that never reach that state.
+	metrics.DeleteJobMetrics(job.Name, string(job.Queue), job.Namespace)
+
 	return nil
 }
 

--- a/pkg/scheduler/cache/event_handlers_test.go
+++ b/pkg/scheduler/cache/event_handlers_test.go
@@ -21,7 +21,9 @@ import (
 	"log"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -35,8 +37,52 @@ import (
 	topologyv1alpha1 "volcano.sh/apis/pkg/apis/topology/v1alpha1"
 	"volcano.sh/volcano/pkg/scheduler/api"
 	schedulingapi "volcano.sh/volcano/pkg/scheduler/api"
+	"volcano.sh/volcano/pkg/scheduler/metrics"
 	"volcano.sh/volcano/pkg/scheduler/util"
 )
+
+// gaugeValue looks up a gauge series by metric family name and exact label
+// match in the process-wide default registry. It returns ok=false if no
+// series with that label set is currently registered, which is how
+// prometheus.DeleteLabelValues manifests: the series is removed outright
+// rather than reset to zero.
+func gaugeValue(t *testing.T, familyName string, labels map[string]string) (float64, bool) {
+	t.Helper()
+
+	families, err := prometheus.DefaultGatherer.Gather()
+	if err != nil {
+		t.Fatalf("failed to gather metrics: %v", err)
+	}
+
+	for _, f := range families {
+		if f.GetName() != familyName {
+			continue
+		}
+		for _, m := range f.GetMetric() {
+			if len(m.GetLabel()) != len(labels) {
+				continue
+			}
+			match := true
+			for name, value := range labels {
+				found := false
+				for _, l := range m.GetLabel() {
+					if l.GetName() == name && l.GetValue() == value {
+						found = true
+						break
+					}
+				}
+				if !found {
+					match = false
+					break
+				}
+			}
+			if match {
+				return m.GetGauge().GetValue(), true
+			}
+		}
+	}
+	return 0, false
+}
 
 func TestSchedulerCache_updateTask(t *testing.T) {
 	namespace := "test"
@@ -456,6 +502,48 @@ func TestSchedulerCache_DeletePodGroupV1beta1(t *testing.T) {
 		if test.Expected == nil && job.PodGroup != nil {
 			t.Errorf("Expected job  to be: %v but got :%v in case %d", test.Expected, job, i)
 		}
+	}
+}
+
+func TestSchedulerCache_DeletePodGroupV1beta1_ClearsJobMetrics(t *testing.T) {
+	namespace := "test-metrics-cleanup"
+	jobName := "metrics-cleanup-job"
+
+	pg := &schedulingv1.PodGroup{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      jobName,
+			Namespace: namespace,
+		},
+	}
+
+	cache := &SchedulerCache{
+		Jobs:  make(map[api.JobID]*api.JobInfo),
+		Nodes: make(map[string]*api.NodeInfo),
+	}
+	cache.DeletedJobs = workqueue.NewTypedRateLimitingQueue[string](workqueue.DefaultTypedControllerRateLimiter[string]())
+
+	cache.AddPodGroupV1beta1(pg)
+
+	metrics.UpdateE2eSchedulingDurationByJob(jobName, "", namespace, 100*time.Millisecond)
+	metrics.UpdateUnscheduleTaskCount(jobName, 5)
+
+	durationLabels := map[string]string{"job_name": jobName, "queue": "", "job_namespace": namespace}
+	unscheduleLabels := map[string]string{"job_id": jobName}
+
+	if v, ok := gaugeValue(t, "volcano_e2e_job_scheduling_duration", durationLabels); !ok || v != 100 {
+		t.Fatalf("expected e2e scheduling duration to be 100 before delete, got %v (found=%v)", v, ok)
+	}
+	if v, ok := gaugeValue(t, "volcano_unschedule_task_count", unscheduleLabels); !ok || v != 5 {
+		t.Fatalf("expected unschedule task count to be 5 before delete, got %v (found=%v)", v, ok)
+	}
+
+	cache.DeletePodGroupV1beta1(pg)
+
+	if v, ok := gaugeValue(t, "volcano_e2e_job_scheduling_duration", durationLabels); ok {
+		t.Errorf("expected e2e scheduling duration series to be removed after PodGroup delete, still got %v", v)
+	}
+	if v, ok := gaugeValue(t, "volcano_unschedule_task_count", unscheduleLabels); ok {
+		t.Errorf("expected unschedule task count series to be removed after PodGroup delete, still got %v", v)
 	}
 }
 

--- a/pkg/scheduler/metrics/job_test.go
+++ b/pkg/scheduler/metrics/job_test.go
@@ -1,0 +1,49 @@
+package metrics
+
+import (
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+)
+
+func TestDeleteJobMetrics(t *testing.T) {
+	jobName := "test-job"
+	queue := "test-queue"
+	namespace := "test-ns"
+
+	UpdateE2eSchedulingDurationByJob(jobName, queue, namespace, 100*time.Millisecond)
+	UpdateE2eSchedulingStartTimeByJob(jobName, queue, namespace, time.Now())
+	UpdateE2eSchedulingLastTimeByJob(jobName, queue, namespace, time.Now())
+	UpdateJobShare(namespace, jobName, 1)
+	RegisterJobRetries(jobName)
+	unscheduleTaskCount.WithLabelValues(jobName).Set(3)
+
+	if got := testutil.ToFloat64(jobShare.WithLabelValues(namespace, jobName)); got != 1 {
+		t.Fatalf("expected jobShare to be 1 before delete, got %v", got)
+	}
+	if got := testutil.ToFloat64(unscheduleTaskCount.WithLabelValues(jobName)); got != 3 {
+		t.Fatalf("expected unscheduleTaskCount to be 3 before delete, got %v", got)
+	}
+
+	DeleteJobMetrics(jobName, queue, namespace)
+
+	if got := testutil.ToFloat64(e2eJobSchedulingDuration.WithLabelValues(jobName, queue, namespace)); got != 0 {
+		t.Errorf("expected e2eJobSchedulingDuration to be reset after delete, got %v", got)
+	}
+	if got := testutil.ToFloat64(e2eJobSchedulingStartTime.WithLabelValues(jobName, queue, namespace)); got != 0 {
+		t.Errorf("expected e2eJobSchedulingStartTime to be reset after delete, got %v", got)
+	}
+	if got := testutil.ToFloat64(e2eJobSchedulingLastTime.WithLabelValues(jobName, queue, namespace)); got != 0 {
+		t.Errorf("expected e2eJobSchedulingLastTime to be reset after delete, got %v", got)
+	}
+	if got := testutil.ToFloat64(unscheduleTaskCount.WithLabelValues(jobName)); got != 0 {
+		t.Errorf("expected unscheduleTaskCount to be reset after delete, got %v", got)
+	}
+	if got := testutil.ToFloat64(jobShare.WithLabelValues(namespace, jobName)); got != 0 {
+		t.Errorf("expected jobShare to be reset after delete, got %v", got)
+	}
+	if got := testutil.ToFloat64(jobRetryCount.WithLabelValues(jobName)); got != 0 {
+		t.Errorf("expected jobRetryCount to be reset after delete, got %v", got)
+	}
+}

--- a/pkg/scheduler/metrics/job_test.go
+++ b/pkg/scheduler/metrics/job_test.go
@@ -11,16 +11,30 @@ func TestDeleteJobMetrics(t *testing.T) {
 	jobName := "test-job"
 	queue := "test-queue"
 	namespace := "test-ns"
+	fixedTime := time.Unix(1700000000, 0)
+	wantUnixTime := ConvertToUnix(fixedTime)
 
 	UpdateE2eSchedulingDurationByJob(jobName, queue, namespace, 100*time.Millisecond)
-	UpdateE2eSchedulingStartTimeByJob(jobName, queue, namespace, time.Now())
-	UpdateE2eSchedulingLastTimeByJob(jobName, queue, namespace, time.Now())
+	UpdateE2eSchedulingStartTimeByJob(jobName, queue, namespace, fixedTime)
+	UpdateE2eSchedulingLastTimeByJob(jobName, queue, namespace, fixedTime)
 	UpdateJobShare(namespace, jobName, 1)
 	RegisterJobRetries(jobName)
 	unscheduleTaskCount.WithLabelValues(jobName).Set(3)
 
+	if got := testutil.ToFloat64(e2eJobSchedulingDuration.WithLabelValues(jobName, queue, namespace)); got != 100 {
+		t.Fatalf("expected e2eJobSchedulingDuration to be 100 before delete, got %v", got)
+	}
+	if got := testutil.ToFloat64(e2eJobSchedulingStartTime.WithLabelValues(jobName, queue, namespace)); got != wantUnixTime {
+		t.Fatalf("expected e2eJobSchedulingStartTime to be %v before delete, got %v", wantUnixTime, got)
+	}
+	if got := testutil.ToFloat64(e2eJobSchedulingLastTime.WithLabelValues(jobName, queue, namespace)); got != wantUnixTime {
+		t.Fatalf("expected e2eJobSchedulingLastTime to be %v before delete, got %v", wantUnixTime, got)
+	}
 	if got := testutil.ToFloat64(jobShare.WithLabelValues(namespace, jobName)); got != 1 {
 		t.Fatalf("expected jobShare to be 1 before delete, got %v", got)
+	}
+	if got := testutil.ToFloat64(jobRetryCount.WithLabelValues(jobName)); got != 1 {
+		t.Fatalf("expected jobRetryCount to be 1 before delete, got %v", got)
 	}
 	if got := testutil.ToFloat64(unscheduleTaskCount.WithLabelValues(jobName)); got != 3 {
 		t.Fatalf("expected unscheduleTaskCount to be 3 before delete, got %v", got)

--- a/pkg/scheduler/metrics/job_test.go
+++ b/pkg/scheduler/metrics/job_test.go
@@ -42,22 +42,25 @@ func TestDeleteJobMetrics(t *testing.T) {
 
 	DeleteJobMetrics(jobName, queue, namespace)
 
-	if got := testutil.ToFloat64(e2eJobSchedulingDuration.WithLabelValues(jobName, queue, namespace)); got != 0 {
-		t.Errorf("expected e2eJobSchedulingDuration to be reset after delete, got %v", got)
+	// WithLabelValues would silently recreate a zero-value series here even
+	// if DeleteJobMetrics failed to remove it, masking a regression. Check
+	// the vec is actually empty instead of reading a (possibly fresh) value.
+	if count := testutil.CollectAndCount(e2eJobSchedulingDuration); count != 0 {
+		t.Errorf("expected no e2eJobSchedulingDuration series after delete, got %d", count)
 	}
-	if got := testutil.ToFloat64(e2eJobSchedulingStartTime.WithLabelValues(jobName, queue, namespace)); got != 0 {
-		t.Errorf("expected e2eJobSchedulingStartTime to be reset after delete, got %v", got)
+	if count := testutil.CollectAndCount(e2eJobSchedulingStartTime); count != 0 {
+		t.Errorf("expected no e2eJobSchedulingStartTime series after delete, got %d", count)
 	}
-	if got := testutil.ToFloat64(e2eJobSchedulingLastTime.WithLabelValues(jobName, queue, namespace)); got != 0 {
-		t.Errorf("expected e2eJobSchedulingLastTime to be reset after delete, got %v", got)
+	if count := testutil.CollectAndCount(e2eJobSchedulingLastTime); count != 0 {
+		t.Errorf("expected no e2eJobSchedulingLastTime series after delete, got %d", count)
 	}
-	if got := testutil.ToFloat64(unscheduleTaskCount.WithLabelValues(jobName)); got != 0 {
-		t.Errorf("expected unscheduleTaskCount to be reset after delete, got %v", got)
+	if count := testutil.CollectAndCount(unscheduleTaskCount); count != 0 {
+		t.Errorf("expected no unscheduleTaskCount series after delete, got %d", count)
 	}
-	if got := testutil.ToFloat64(jobShare.WithLabelValues(namespace, jobName)); got != 0 {
-		t.Errorf("expected jobShare to be reset after delete, got %v", got)
+	if count := testutil.CollectAndCount(jobShare); count != 0 {
+		t.Errorf("expected no jobShare series after delete, got %d", count)
 	}
-	if got := testutil.ToFloat64(jobRetryCount.WithLabelValues(jobName)); got != 0 {
-		t.Errorf("expected jobRetryCount to be reset after delete, got %v", got)
+	if count := testutil.CollectAndCount(jobRetryCount); count != 0 {
+		t.Errorf("expected no jobRetryCount series after delete, got %d", count)
 	}
 }


### PR DESCRIPTION
Job related metrics in the scheduler cache are only cleared through processCleanupJob, and that path only fires once JobTerminated is true, meaning the job has no PodGroup and no tasks left. When a PodGroup is deleted while the job still has tasks lingering in the cache (a burst of pod deletions under load, pods removed out of order, etc), the job never reaches that state through the normal path and its metrics just sit there. unschedule_task_count, job_share, job_retry_counts and the e2e scheduling timing gauges stick around indefinitely unless the scheduler restarts, since restart is the only thing that resets the in memory registry.

deletePodGroup already unsets the job's PodGroup and queues it for cleanup, so it already has the definitive signal that this PodGroup is gone for good. This adds a direct call to metrics.DeleteJobMetrics right there, so metrics get cleared immediately on the PodGroup delete event instead of waiting on the async queue to eventually converge. processCleanupJob is untouched, this is purely additive and doesn't change its behavior or the sc.Jobs bookkeeping.

Tested with a new unit test in pkg/scheduler/metrics covering DeleteJobMetrics directly (sets each metric to a nonzero value, deletes, confirms all six are reset). Also cross compiled pkg/scheduler/cache and pkg/scheduler/metrics for linux and ran golangci-lint against both packages, both clean.

Fixes #4705