### PR TITLE
fix: populate job.Status.Succeeded for retained pods on job completion

### DIFF
--- a/pkg/controllers/job/job_controller_actions.go
+++ b/pkg/controllers/job/job_controller_actions.go
@@ -103,6 +103,9 @@ func (cc *jobcontroller) killPods(jobInfo *apis.JobInfo, podRetainPhase state.Ph
 	var total int
 
 	podsToKill := make(map[string]*v1.Pod)
+	// retainedPods holds pods that are kept alive (not sent to kill) and need
+	// their phase counted into the job status.
+	retainedPods := make(map[string]*v1.Pod)
 
 	if target != nil {
 		switch target.Type {
@@ -172,6 +175,9 @@ func (cc *jobcontroller) killPods(jobInfo *apis.JobInfo, podRetainPhase state.Ph
 
 				if !retain {
 					podsToKill[pod.Name] = pod
+				} else {
+					// Pod is retained; record it so we can update job status below.
+					retainedPods[pod.Name] = pod
 				}
 			}
 		}
@@ -208,6 +214,14 @@ func (cc *jobcontroller) killPods(jobInfo *apis.JobInfo, podRetainPhase state.Ph
 		errs = append(errs, err)
 		cc.resyncTask(pod)
 
+		classifyAndAddUpPodBaseOnPhase(pod, &pending, &running, &succeeded, &failed, &unknown)
+		calcPodStatus(pod, taskStatusCount)
+	}
+
+	// Update job status for retained pods (pods kept alive due to podRetainPhase).
+	// retainedPods was populated during the target==nil scan above, so terminating
+	// pods that were already counted there are not included here, avoiding double-counting.
+	for _, pod := range retainedPods {
 		classifyAndAddUpPodBaseOnPhase(pod, &pending, &running, &succeeded, &failed, &unknown)
 		calcPodStatus(pod, taskStatusCount)
 	}

--- a/pkg/controllers/job/job_controller_actions_test.go
+++ b/pkg/controllers/job/job_controller_actions_test.go
@@ -1364,6 +1364,75 @@ func TestPodsToKill(t *testing.T) {
 	}
 }
 
+func TestKillPodsRetainedStatus(t *testing.T) {
+	namespace := "test"
+
+	job := &v1alpha1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "job1",
+			Namespace:       namespace,
+			ResourceVersion: "100",
+		},
+		Spec: v1alpha1.JobSpec{
+			Tasks: []v1alpha1.TaskSpec{
+				{
+					Name:     "task1",
+					Replicas: 1,
+				},
+			},
+		},
+	}
+
+	succeededPod := buildPod(namespace, "pod1", v1.PodSucceeded, nil)
+	addPodAnnotation(succeededPod, map[string]string{
+		v1alpha1.TaskSpecKey: "task1",
+	})
+
+	jobInfo := &apis.JobInfo{
+		Job: job,
+		Pods: map[string]map[string]*v1.Pod{
+			"task1": {
+				"pod1": succeededPod,
+			},
+		},
+	}
+
+	fakeController := newFakeController()
+
+	_, err := fakeController.kubeClient.CoreV1().Pods(namespace).Create(context.TODO(), succeededPod, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("Error creating pod: %v", err)
+	}
+
+	_, err = fakeController.vcClient.BatchV1alpha1().Jobs(namespace).Create(context.TODO(), job, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("Error creating job: %v", err)
+	}
+	if err = fakeController.cache.Add(job); err != nil {
+		t.Fatalf("Error adding job to cache: %v", err)
+	}
+
+	err = fakeController.killPods(jobInfo, state.PodRetainPhaseSoft, nil, nil)
+	if err != nil {
+		t.Fatalf("killPods returned unexpected error: %v", err)
+	}
+
+	updatedJob, err := fakeController.vcClient.BatchV1alpha1().Jobs(namespace).Get(context.TODO(), job.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Error getting updated job: %v", err)
+	}
+
+	if updatedJob.Status.Succeeded != 1 {
+		t.Errorf("Expected job.Status.Succeeded to be 1, got %d", updatedJob.Status.Succeeded)
+	}
+	if updatedJob.Status.Failed != 0 {
+		t.Errorf("Expected job.Status.Failed to be 0, got %d", updatedJob.Status.Failed)
+	}
+	if taskStatus, found := updatedJob.Status.TaskStatusCount["task1"]; !found || taskStatus.Phase[v1.PodSucceeded] != 1 {
+		t.Errorf("Expected TaskStatusCount for task1 succeeded to be 1, got %#v", taskStatus)
+	}
+}
+
 func TestKillPodsPodGroupDeletion(t *testing.T) {
 	namespace := "test"
 	jobUID := "e7f18111-1cec-11ea-b688-fa163ec79500"


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

When `killPods` is invoked (such as during job completion), pods retained based on `podRetainPhase` are excluded from `podsToKill`. Previously, these retained pods were skipped during status calculation in `killPods`, leaving `job.Status.Succeeded` and `job.Status.Failed` unpopulated (remaining 0).

This PR updates `killPods` to classify and count retained pods that are not targeted for deletion, ensuring that `job.Status.Succeeded`, `job.Status.Failed`, and task status counts are accurately updated upon job completion. Added unit tests in `job_controller_actions_test.go` to verify this behavior.

#### Which issue(s) this PR fixes:

Fixes #4616

#### Special notes for your reviewer:

NONE

#### Does this PR introduce a user-facing change?

```release-note
Fix an issue where job.Status.Succeeded and job.Status.Failed were not populated upon job completion.
```
