### PR TITLE
Fix PodGroup tombstone deletion

### DIFF
--- a/pkg/controllers/queue/queue_controller_handler.go
+++ b/pkg/controllers/queue/queue_controller_handler.go
@@ -121,7 +121,7 @@ func (c *queuecontroller) deletePodGroup(obj interface{}) {
 		}
 	}
 
-	key, _ := cache.MetaNamespaceKeyFunc(obj)
+	key, _ := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
 
 	c.pgMutex.Lock()
 	defer c.pgMutex.Unlock()

--- a/pkg/controllers/queue/queue_controller_test.go
+++ b/pkg/controllers/queue/queue_controller_test.go
@@ -188,6 +188,12 @@ func TestDeletePodGroup(t *testing.T) {
 		if _, ok := c.podGroups[testcase.podGroup.Spec.Queue][key]; ok != testcase.ExpectValue {
 			t.Errorf("case %d (%s): expected: %v, got %v ", i, testcase.Name, testcase.ExpectValue, ok)
 		}
+
+		c.podGroups[testcase.podGroup.Spec.Queue][key] = struct{}{}
+		c.deletePodGroup(cache.DeletedFinalStateUnknown{Key: key, Obj: testcase.podGroup})
+		if _, ok := c.podGroups[testcase.podGroup.Spec.Queue][key]; ok != testcase.ExpectValue {
+			t.Errorf("case %d (%s) tombstone: expected: %v, got %v ", i, testcase.Name, testcase.ExpectValue, ok)
+		}
 	}
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Handles PodGroup tombstone deletes with `DeletionHandlingMetaNamespaceKeyFunc` so the queue cache removes the correct key.

#### Which issue(s) this PR fixes:

Fixes #5734

#### Special notes for your reviewer:

Codex was used to help prepare this change.

Prompt: Fix #5734 with the smallest code change, reuse the existing helper, add regression coverage, and run the queue-controller tests.

Volcano burns bright; stale queues close right.

Tested with:

`
go test ./pkg/controllers/queue -count=1`

#### Does this PR introduce a user-facing change?
`
Fix Queue reconciliation after a PodGroup tombstone deletion.`