### PR TITLE
chore(owners): add 'devzizu' to OWNERS.md as reviewer

### DIFF
--- a/pkg/scheduler/OWNERS
+++ b/pkg/scheduler/OWNERS
@@ -12,6 +12,7 @@ approvers:
   - kingeasternsun
   - JesseStutler
   - hajnalmt
+  - devzizu
 reviewers:
   - k82cn
   - animeshsingh

--- a/pkg/scheduler/plugins/OWNERS
+++ b/pkg/scheduler/plugins/OWNERS
@@ -7,6 +7,7 @@ approvers:
   - qiankunli
   - archlitchi
   - hajnalmt
+  - devzizu
 reviewers:
   - k82cn
   - animeshsingh


### PR DESCRIPTION
Opening this PR as a follow-up of:

https://github.com/volcano-sh/community/issues/156

As suggested, I'm starting with the scheduler's related `OWNERS.md` files.

Thank you for supporting this reviewer role!