### PR TITLE
fix(job): don't count manual resume against MaxRetry

### DIFF
--- a/pkg/controllers/job/job_state_test.go
+++ b/pkg/controllers/job/job_state_test.go
@@ -228,8 +228,8 @@ func TestAbortingState_Execute(t *testing.T) {
 					t.Error("Error while retrieving value from Cache")
 				}
 
-				if jobInfo.Job.Status.RetryCount == 0 {
-					t.Error("Retry Count should not be zero")
+				if jobInfo.Job.Status.RetryCount != 0 {
+					t.Errorf("RetryCount should not be incremented on manual resume, got %d", jobInfo.Job.Status.RetryCount)
 				}
 			}
 

--- a/pkg/controllers/job/state/aborted.go
+++ b/pkg/controllers/job/state/aborted.go
@@ -31,7 +31,6 @@ func (as *abortedState) Execute(action Action) error {
 	case v1alpha1.ResumeJobAction:
 		return KillJob(as.job, PodRetainPhaseSoft, func(status *vcbatch.JobStatus) bool {
 			status.State.Phase = vcbatch.Restarting
-			status.RetryCount++
 			return true
 		})
 	default:

--- a/pkg/controllers/job/state/aborting.go
+++ b/pkg/controllers/job/state/aborting.go
@@ -31,7 +31,6 @@ func (ps *abortingState) Execute(action Action) error {
 	case v1alpha1.ResumeJobAction:
 		return KillJob(ps.job, PodRetainPhaseSoft, func(status *vcbatch.JobStatus) bool {
 			status.State.Phase = vcbatch.Restarting
-			status.RetryCount++
 			return true
 		})
 	default:


### PR DESCRIPTION
## Summary
- Manual suspend/resume operations no longer count against `MaxRetry`.
- `RetryCount` now only tracks automatic restarts triggered by job failures, not manual resume actions.

Before this fix, resuming a job from the `Aborted`/`Aborting` state via `ResumeJobAction` incremented `RetryCount`, causing jobs to eventually fail after `MaxRetry` manual suspend/resume cycles even though the job itself never failed. `RestartJobAction` (triggered by actual failures) still increments `RetryCount` as before.

Fixes #3067

## Test plan
- [x] Updated `pkg/controllers/job/job_state_test.go` to reflect that `ResumeJobAction` no longer increments `RetryCount`
- [x] `go test ./pkg/controllers/job/...` passes