### PR TITLE
Re-organize vNPU document and usage-monitor guide 

### DIFF
--- a/docs/user-guide/how_to_use_vnpu.md
+++ b/docs/user-guide/how_to_use_vnpu.md
@@ -4,124 +4,51 @@
 
 Volcano supports **two vNPU modes** for sharing Ascend devices:
 
----
+| Mode | Maintained by | Supported chips | Use case |
+|------|---------------|------------------|----------|
+| [HAMi Mode](#hami-mode) | Third-party community [HAMi](https://github.com/Project-HAMi) | Ascend 310 and Ascend 910 series | NPU/vNPU cluster for 910 or 310 series; heterogeneous Ascend cluster (mixed chip types, e.g. 910A/910B2/910B3/310P) |
+| [MindCluster Mode](#mindcluster-mode) | [MindCluster](https://gitcode.com/Ascend/mind-cluster) (official Ascend cluster scheduling add-on) | Ascend 310 series | vNPU cluster for Ascend 310 series, with support for more chip types to come |
 
-### 1. MindCluster mode
-
-**Description**:
-
-The initial version of [MindCluster](https://gitcode.com/Ascend/mind-cluster)—the official Ascend cluster scheduling add-on—required custom modifications and recompilation of Volcano. Furthermore, it was limited to Volcano release1.7 and release1.9, which complicated its use and restricted access to newer Volcano features.
-
-To address this, we have integrated its core scheduling logic for Ascend vNPU into Volcano's native device-share plugin, which is designed specifically for scheduling and sharing heterogeneous resources like GPUs and NPUs. This integration provides seamless access to vNPU capabilities through the procedure below, while maintaining full compatibility with the latest Volcano features.
-
-**Use case**:
-
-vNPU cluster for Ascend 310 series  
-with support for more chip types to come
+Pick the section below that matches the mode you want to use; each section is self-contained and covers installation and usage for that mode.
 
 ---
 
-### 2. HAMi mode
+## Common Prerequisites
 
-**Description**:
+- Kubernetes >= 1.16
+- Volcano >= 1.14 (1.16 for `hami-core` mode)
 
-This mode is developed by a third-party community 'HAMi', which is the developer of [volcano-vgpu](./how_to_use_volcano_vgpu.md) feature. It supports vNPU feature for both Ascend 310 and Ascend 910. It also supports managing heterogeneous Ascend cluster(Cluster with multiple Ascend types, i.e. 910A,910B2,910B3,310P). Starting with version 1.16, we support soft device partitioning through [hami-vnpu-core](https://github.com/Project-HAMi/hami-vnpu-core). This feature is known as the `hami-core` mode.
+### Install Volcano
 
-**Use case**:
-
-NPU and vNPU cluster for Ascend 910 series  
-NPU and vNPU cluster for Ascend 310 series  
-Heterogeneous Ascend cluster
+Follow instructions in the [Volcano Installer Guide](https://github.com/volcano-sh/volcano?tab=readme-ov-file#quick-start-guide).
 
 ---
 
-## Installation
+## HAMi Mode
 
-To enable vNPU scheduling, the following components must be set up based on the selected mode:
+### Description
 
+This mode is developed by a third-party community 'HAMi', which is also the developer of the [volcano-vgpu](./how_to_use_volcano_vgpu.md) feature. It supports vNPU for both Ascend 310 and Ascend 910, and can manage a heterogeneous Ascend cluster (a cluster with multiple Ascend chip types, e.g. 910A/910B2/910B3/310P).
+
+1. HAMi provides a distinct `ResourceName` for each supported Ascend chip model.
+2. Supports template-based hard partitioning of vNPU devices.
+3. Starting with version 1.16, supports soft partitioning based on [`hami-core`](https://github.com/Project-HAMi/hami-vnpu-core), known as the `hami-core` mode.
+
+### Installation
 
 **Prerequisites**:
 
-Kubernetes >= 1.16  
-Volcano >= 1.14 (1.16 for `hami-core` mode)  
-[ascend-docker-runtime](https://gitcode.com/Ascend/mind-cluster/tree/master/component/ascend-docker-runtime) (for HAMi Mode)
+[ascend-docker-runtime](https://gitcode.com/Ascend/mind-cluster/tree/master/component/ascend-docker-runtime) is required for HAMi mode.
 
-### Install Volcano:
+Make sure the [Common Prerequisites](#common-prerequisites) above are satisfied first.
 
-Follow instructions in Volcano Installer Guide
-
-  * Follow instructions in [Volcano Installer Guide](https://github.com/volcano-sh/volcano?tab=readme-ov-file#quick-start-guide)
-
-### Install ascend-device-plugin and third-party components
-
-In this step, you need to select different ascend-device-plugin based on the vNPU mode you selected. MindCluster mode requires additional components from Ascend to be installed.
-
----
-
-#### MindCluster Mode
-
-##### Install Third-Party Components
-
-Follow the official [Ascend documentation](https://www.hiascend.com/document/detail/zh/mindcluster/72rc1/clustersched/dlug/mxdlug_start_006.html#ZH-CN_TOPIC_0000002470358262__section1837511531098) to install the following components:
-- NodeD
-- Ascend Device Plugin
-- Ascend Docker Runtime
-- ClusterD
-- Ascend Operator
-
-> **Note:** Skip the installation of `ascend-volcano` mentioned in the document above, as we have already installed the native Volcano from the Volcano community in the **Prerequisites** part.
-
-**Configuration Adjustment for Ascend Device Plugin:**
-
-When installing `ascend-device-plugin`, you must set the `presetVirtualDevice` parameter to `"false"` in the `device-plugin-310P-volcano-v{version}.yaml` file to enable dynamic virtualization of 310P:
-
-```yaml
-...
-args: [
-  "device-plugin",
-  "-useAscendDocker=true",
-  "-volcanoType=true",
-  "-presetVirtualDevice=false",
-  "-logFile=/var/log/mindx-dl/devicePlugin/devicePlugin.log",
-  "-logLevel=0"
-]
-...
-```
-For detailed information, please consult the official [Ascend MindCluster documentation.](https://www.hiascend.com/document/detail/zh/mindcluster/72rc1/clustersched/dlug/cpaug_0020.html)
-
-##### Scheduler Config Update
-```yaml
-kind: ConfigMap
-apiVersion: v1
-metadata:
-  name: volcano-scheduler-configmap
-  namespace: volcano-system
-data:
-  volcano-scheduler.conf: |
-    actions: "enqueue, allocate, backfill"
-    tiers:
-    - plugins:
-      - name: predicates
-      - name: deviceshare
-        arguments:
-          deviceshare.AscendMindClusterVNPUEnable: true   # enable ascend vnpu
-    configurations:
-    ...
-    - name: init-params
-      arguments: {"grace-over-time":"900","presetVirtualDevice":"false"}  # to enable dynamic virtualization, presetVirtualDevice need to be set false
-```
-
----
-
-#### HAMi mode
-
-##### Label the Node with `ascend=on`
+#### Label the Node with `ascend=on`
 
 ```
 kubectl label node {ascend-node} ascend=on
 ```
 
-##### Deploy `hami-scheduler-device` ConfigMap
+#### Deploy `hami-scheduler-device` ConfigMap
 
 1. Download file
 ```
@@ -134,7 +61,7 @@ curl -O https://raw.githubusercontent.com/Project-HAMi/ascend-device-plugin/main
 kubectl apply -f ascend-device-configmap.yaml
 ```
 
-##### Deploy ascend-device-plugin
+#### Deploy ascend-device-plugin
 
 ```
 kubectl apply -f https://raw.githubusercontent.com/Project-HAMi/ascend-device-plugin/main/ascend-device-plugin.yaml
@@ -142,7 +69,7 @@ kubectl apply -f https://raw.githubusercontent.com/Project-HAMi/ascend-device-pl
 
 For more information, refer to the [ascend-device-plugin documentation](https://github.com/Project-HAMi/ascend-device-plugin).
 
-##### Update Scheduler Config
+#### Update Scheduler Config
 ```yaml
 kind: ConfigMap
 apiVersion: v1
@@ -165,13 +92,162 @@ data:
 
   **Note:** You may notice that, 'volcano-vgpu' has its own GeometriesCMName and GeometriesCMNamespace, which means if you want to use both vNPU and vGPU in a same volcano cluster, you need to merge the configMap from both sides and set it here.
 
-## Usage
+### Usage
 
-Usage is different depending on the mode you selected
+The supported Ascend chips and their `ResourceNames` are shown in the following table (`ResourceCoreName` only applies to `hami-core` mode; it can be ignored for template vNPU mode):
+
+| ChipName | ResourceName | ResourceMemoryName | ResourceCoreName |
+|-------|-------|-------|-------|
+| 910A | huawei.com/Ascend910A | huawei.com/Ascend910A-memory | huawei.com/Ascend910A-core |
+| 910B2 | huawei.com/Ascend910B2 | huawei.com/Ascend910B2-memory | huawei.com/Ascend910B2-core |
+| 910B3 | huawei.com/Ascend910B3 | huawei.com/Ascend910B3-memory | huawei.com/Ascend910B3-core |
+| 910B4 | huawei.com/Ascend910B4 | huawei.com/Ascend910B4-memory | huawei.com/Ascend910B4-core |
+| 910B4-1 | huawei.com/Ascend910B4-1 | huawei.com/Ascend910B4-1-memory | huawei.com/Ascend910B4-1-core |
+| 910C | huawei.com/Ascend910C | huawei.com/Ascend910C-memory | huawei.com/Ascend910C-core |
+| 310P3 | huawei.com/Ascend310P | huawei.com/Ascend310P-memory | huawei.com/Ascend310P-core |
+
+#### Template vNPU mode
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: ascend-pod
+spec:
+  schedulerName: volcano
+  containers:
+    - name: ubuntu-container
+      image: swr.cn-south-1.myhuaweicloud.com/ascendhub/ascend-pytorch:24.0.RC1-A2-1.11.0-ubuntu20.04
+      command: ["sleep"]
+      args: ["100000"]
+      resources:
+        limits:
+          huawei.com/Ascend310P: "1"
+          huawei.com/Ascend310P-memory: "4096"
+```
+
+#### Hami vNPU scene memory allocation restrictions
+
+- When a container requests a single vNPU device, the memory can be configured to any value, and the memory request will automatically align with the closest sharding strategy
+  - Example: Single card memory is 65536, virtualization templates are 1/4 (16384), 1/2 (32768)
+    - A container requests 1 vNPU device and requests 1024 memory, so the actual allocated memory is 16384
+    - A container requests 1 vNPU device with a requested memory of 20480, resulting in an actual allocated memory of 32768
+
+- When a container requests multiple vNPU devices, the memory resource request can be left unspecified or filled with the maximum value; the memory allocated to that container is the actual memory of the entire card
+
+#### `hami-core` mode
+
+```
+apiVersion: v1
+kind: Pod
+metadata:
+  name: ascend-pod
+  annotations:
+    huawei.com/vnpu-mode: hami-core
+spec:
+  schedulerName: volcano
+  containers:
+    - name: ubuntu-container
+      image: quay.io/ascend/vllm-ascend:v0.18.0-310p
+      command: ["sleep"]
+      args: ["100000"]
+      resources:
+        limits:
+          huawei.com/Ascend310P: "1"
+          huawei.com/Ascend310P-memory: "4096"
+          huawei.com/Ascend310P-core: "90"
+```
+
+See the `ResourceName` table in the [Usage](#usage) section above for the supported Ascend chips.
+
+**Note**: If the pod's annotations do not specify `hami-core`, the device will be allocated in the template vNPU mode even if the `hami-core` feature is enabled in the configuration file.
+
+### Monitoring
+
+When a node runs in **`hami-core` (soft slicing) mode**, `ascend-device-plugin` starts an **embedded Prometheus exporter** on **`:9395/metrics`** that reports physical-device and per-container vNPU usage. It is **not** started for the template vNPU (or whole-card) path. 
+
+#### Exposed metrics
+
+| Metric | Labels | Description |
+| :--- | :--- | :--- |
+| `hami_host_gpu_memory_used_bytes` | `device_index`, `device_uuid`, `device_type` | Physical NPU memory used (bytes) |
+| `hami_host_gpu_utilization_ratio` | `device_index`, `device_uuid`, `device_type` | Physical NPU AICore utilization (0-100) |
+| `hami_vgpu_memory_used_bytes` | `namespace`, `pod`, `container`, `vdevice_index`, `device_uuid` | Per-container vNPU memory used (bytes) |
+| `hami_vgpu_memory_limit_bytes` | `namespace`, `pod`, `container`, `vdevice_index`, `device_uuid` | Per-container vNPU memory limit (bytes) |
+| `hami_container_device_utilization_ratio` | `namespace`, `pod`, `container`, `vdevice_index`, `device_uuid` | AICore utilization of the device the container runs on (0-100) |
+
 
 ---
 
-### MindCluster mode
+## MindCluster Mode
+
+### Description
+
+The initial version of [MindCluster](https://gitcode.com/Ascend/mind-cluster)—the official Ascend cluster scheduling add-on—required custom modifications and recompilation of Volcano. Furthermore, it was limited to Volcano release1.7 and release1.9, which complicated its use and restricted access to newer Volcano features.
+
+To address this, we have integrated its core scheduling logic for Ascend vNPU into Volcano's native device-share plugin, which is designed specifically for scheduling and sharing heterogeneous resources like GPUs and NPUs. This integration provides seamless access to vNPU capabilities through the procedure below, while maintaining full compatibility with the latest Volcano features.
+
+### Use case
+
+- vNPU cluster for Ascend 310 series
+- with support for more chip types to come
+
+### Installation
+
+Make sure the [Common Prerequisites](#common-prerequisites) above are satisfied first.
+
+#### Install Third-Party Components
+
+Follow the official [Ascend documentation](https://www.hiascend.com/document/detail/zh/mindcluster/72rc1/clustersched/dlug/mxdlug_start_006.html#ZH-CN_TOPIC_0000002470358262__section1837511531098) to install the following components:
+- NodeD
+- Ascend Device Plugin
+- Ascend Docker Runtime
+- ClusterD
+- Ascend Operator
+
+> **Note:** Skip the installation of `ascend-volcano` mentioned in the document above, as we have already installed the native Volcano from the Volcano community in the **Common Prerequisites** part.
+
+**Configuration Adjustment for Ascend Device Plugin:**
+
+When installing `ascend-device-plugin`, you must set the `presetVirtualDevice` parameter to `"false"` in the `device-plugin-310P-volcano-v{version}.yaml` file to enable dynamic virtualization of 310P:
+
+```yaml
+...
+args: [
+  "device-plugin",
+  "-useAscendDocker=true",
+  "-volcanoType=true",
+  "-presetVirtualDevice=false",
+  "-logFile=/var/log/mindx-dl/devicePlugin/devicePlugin.log",
+  "-logLevel=0"
+]
+...
+```
+For detailed information, please consult the official [Ascend MindCluster documentation.](https://www.hiascend.com/document/detail/zh/mindcluster/72rc1/clustersched/dlug/cpaug_0020.html)
+
+#### Scheduler Config Update
+```yaml
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: volcano-scheduler-configmap
+  namespace: volcano-system
+data:
+  volcano-scheduler.conf: |
+    actions: "enqueue, allocate, backfill"
+    tiers:
+    - plugins:
+      - name: predicates
+      - name: deviceshare
+        arguments:
+          deviceshare.AscendMindClusterVNPUEnable: true   # enable ascend vnpu
+    configurations:
+    ...
+    - name: init-params
+      arguments: {"grace-over-time":"900","presetVirtualDevice":"false"}  # to enable dynamic virtualization, presetVirtualDevice need to be set false
+```
+
+### Usage
 
 ```yaml
 apiVersion: batch.volcano.sh/v1alpha1
@@ -256,92 +332,9 @@ The supported Ascend chips and their `ResourceNames` are shown in the following 
 |                                         | **4**                       | `null`        | `high`               | Yes           | `vir04_3c`            |
 |                                         | **8 or multiples of 8**     | Any value     | Any value            | –             | –                     |
 
-
 **Notice**
 
 For **chip virtualization (non-full card usage)**, the value of `vnpu-dvpp` must strictly match the corresponding value listed in the above table.
 Any other values will cause the task to fail to be dispatched.
 
-
 For detailed information, please consult the official [Ascend MindCluster documentation.](https://www.hiascend.com/document/detail/zh/mindcluster/72rc1/clustersched/dlug/cpaug_0020.html)
-
----
-
-### HAMi mode
-
-#### Template vNPU mode
-
-```yaml
-apiVersion: v1
-kind: Pod
-metadata:
-  name: ascend-pod
-spec:
-  schedulerName: volcano
-  containers:
-    - name: ubuntu-container
-      image: swr.cn-south-1.myhuaweicloud.com/ascendhub/ascend-pytorch:24.0.RC1-A2-1.11.0-ubuntu20.04
-      command: ["sleep"]
-      args: ["100000"]
-      resources:
-        limits:
-          huawei.com/Ascend310P: "1"
-          huawei.com/Ascend310P-memory: "4096"
-```
-
-The supported Ascend chips and their `ResourceNames` are shown in the following table:
-
-| ChipName | ResourceName | ResourceMemoryName |
-|-------|-------|-------|
-| 910A | huawei.com/Ascend910A | huawei.com/Ascend910A-memory |
-| 910B2 | huawei.com/Ascend910B2 | huawei.com/Ascend910B2-memory |
-| 910B3 | huawei.com/Ascend910B3 | huawei.com/Ascend910B3-memory |
-| 910B4 | huawei.com/Ascend910B4 | huawei.com/Ascend910B4-memory |
-| 910B4-1 | huawei.com/Ascend910B4-1 | huawei.com/Ascend910B4-1-memory |
-| 910C | huawei.com/Ascend910C | huawei.com/Ascend910C-memory |
-| 310P3 | huawei.com/Ascend310P | huawei.com/Ascend310P-memory |
-
-#### Hami vNPU scene memory allocation restrictions
-
-- When a Pod requests a single vNPU device, the memory can be configured to any value, and the memory request of the job will automatically align with the closest sharding strategy
-  - Example: Single card memory is 65536, virtualization templates are 1/4 (16384), 1/2 (32768)
-    - Pod requests 1 vNPU device and requests 1024 memory, so the actual allocated memory is 16384
-    - Pod requests 1 vNPU device with a requested memory of 20480, resulting in an actual allocated memory of 32768
-
-- When a Pod requests multiple vNPU devices, the memory resource request can be left unspecified or filled with the maximum value, The memory allocated to Pod is the actual memory of the entire card
-
-#### `hami-core` mode
-
-```
-apiVersion: v1
-kind: Pod
-metadata:
-  name: ascend-pod
-  annotations:
-    huawei.com/vnpu-mode: hami-core
-spec:
-  schedulerName: volcano
-  containers:
-    - name: ubuntu-container
-      image: quay.io/ascend/vllm-ascend:v0.18.0-310p
-      command: ["sleep"]
-      args: ["100000"]
-      resources:
-        limits:
-          huawei.com/Ascend310P: "1"
-          huawei.com/Ascend310P-memory: "4096"
-          huawei.com/Ascend310P-core: "90"
-```
-The supported Ascend chips and their `ResourceNames` are shown in the following table:
-
-| ChipName | ResourceName | ResourceMemoryName | ResourceCoreName
-|-------|-------|-------|
-| 910A | huawei.com/Ascend910A | huawei.com/Ascend910A-memory | huawei.com/Ascend910A-core |
-| 910B2 | huawei.com/Ascend910B2 | huawei.com/Ascend910B2-memory | huawei.com/Ascend910B2-core |
-| 910B3 | huawei.com/Ascend910B3 | huawei.com/Ascend910B3-memory | huawei.com/Ascend910B3-core |
-| 910B4 | huawei.com/Ascend910B4 | huawei.com/Ascend910B4-memory | huawei.com/Ascend910B4-core |
-| 910B4-1 | huawei.com/Ascend910B4-1 | huawei.com/Ascend910B4-1-memory | huawei.com/Ascend910B4-1-core |
-| 910C | huawei.com/Ascend910C | huawei.com/Ascend910C-memory | huawei.com/Ascend910C-core |
-| 310P3 | huawei.com/Ascend310P | huawei.com/Ascend310P-memory | huawei.com/Ascend310P-core |
-
-**Note**: If the pod's annotations do not specify `hami-core`, the device will be allocated in the template vNPU mode even if the `hami-core` feature is enabled in the configuration file.


### PR DESCRIPTION
/kind documentations

1. We re-organize document about vNPU: Split mIndCluster mode and HAMi vNPU mode into two sections, so the user's attention won't get distracted

2. Add monitor section in HAMi mode
