### PR TITLE
fix : remove unnecessary mutation of old job object in webhook validation

### DIFF
--- a/pkg/webhooks/admission/jobs/validate/admit_job.go
+++ b/pkg/webhooks/admission/jobs/validate/admit_job.go
@@ -290,11 +290,6 @@ func validateJobUpdate(old, new *v1alpha1.Job) error {
 			new.Spec.Volumes[i].VolumeClaimName = ""
 		}
 	}
-	for i := range old.Spec.Volumes {
-		if old.Spec.Volumes[i].VolumeClaim != nil {
-			old.Spec.Volumes[i].VolumeClaimName = ""
-		}
-	}
 
 	if !apiequality.Semantic.DeepEqual(new.Spec, old.Spec) {
 		return fmt.Errorf("job updates may not change fields other than `minAvailable`, `tasks[*].replicas under spec` and `PriorityClassName`")


### PR DESCRIPTION
## Description: 
During job update validation in validateJobUpdate, both new and old job objects were being normalized by clearing VolumeClaimName when VolumeClaim is set. Mutating the old object is unnecessary since only the new object needs normalization for the DeepEqual comparison. This violates the principle that validating webhooks should not mutate their inputs and could potentially corrupt the API server's copy if the calling convention changes. This fix removes the unnecessary mutation of the old object, keeping only the new object normalization.
#5740
