### PR TITLE
helm: quote flag values in agent template

### DIFF
--- a/installer/helm/chart/volcano/templates/agent.yaml
+++ b/installer/helm/chart/volcano/templates/agent.yaml
@@ -131,16 +131,16 @@ spec:
           - |
            /vc-agent \
            {{- with .Values.custom.agent_supported_features }}
-           --supported-features={{ . }} \
+           --supported-features={{ . | quote }} \
            {{- end }}
            {{- with .Values.custom.agent_kube_cgroup_root }}
-           --kube-cgroup-root={{ . }} \
+           --kube-cgroup-root={{ . | quote }} \
            {{- end }}
            {{- with .Values.custom.agent_extend_resource_cpu_name }}
-           --extend-resource-cpu-name={{ . }} \
+           --extend-resource-cpu-name={{ . | quote }} \
            {{- end }}
            {{- with .Values.custom.agent_extend_resource_memory_name }}
-           --extend-resource-memory-name={{ . }} \
+           --extend-resource-memory-name={{ . | quote }} \
            {{- end }}
            --v=2 1>> /var/log/volcano/agent/volcano-agent.log 2>&1
           env:


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Quotes `--supported-features`, `--kube-cgroup-root`, and extended resource flag values in `installer/helm/chart/volcano/templates/agent.yaml` to prevent argument splitting issues under `/bin/sh -c` evaluation when helm values are provided.

#### Which issue(s) this PR fixes:

Fixes #4682

#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?

```release-note
Fix argument quoting in agent helm chart template for supported features and extended resource flags.
```
