### PR TITLE
fix(sharding): keep allocation-rate default range when arguments omitted

### DIFF
--- a/pkg/controllers/sharding/policy/allocationrate/allocationrate.go
+++ b/pkg/controllers/sharding/policy/allocationrate/allocationrate.go
@@ -49,16 +49,15 @@ type allocationRatePolicy struct {
 
 // New creates a new allocation-rate policy instance.
 func New() policy.ShardPolicy {
-	return &allocationRatePolicy{
-		maxCPURounded:   1.0,
-		cpuRangeRounded: 1.0,
-	}
+	return &allocationRatePolicy{}
 }
 
 func (p *allocationRatePolicy) Name() string { return PolicyName }
 
 func (p *allocationRatePolicy) Initialize(args policy.Arguments) error {
-	var minCPU, maxCPU float64
+	// Default to the full range; GetFloat64 overrides only the bounds present
+	// in args, so an omitted arguments block does not collapse it to [0, 0].
+	minCPU, maxCPU := 0.0, 1.0
 	args.GetFloat64(&minCPU, ArgMinCPUUtil)
 	args.GetFloat64(&maxCPU, ArgMaxCPUUtil)
 

--- a/pkg/controllers/sharding/policy/allocationrate/allocationrate_test.go
+++ b/pkg/controllers/sharding/policy/allocationrate/allocationrate_test.go
@@ -61,6 +61,28 @@ func TestAllocationRatePolicyInitialize(t *testing.T) {
 	}
 }
 
+// With no arguments the range must stay [0.0, 1.0]. Before the fix it collapsed
+// to [0.0, 0.0], so the filter kept only nodes at exactly 0 and starved the shard.
+func TestAllocationRatePolicyDefaultRange(t *testing.T) {
+	// nil is what an omitted arguments block decodes to.
+	f, s := newPolicy(t, nil)
+	ctx := &policy.PolicyContext{
+		NodeMetrics: map[string]*policy.NodeMetrics{
+			"idle": {CPUUtilization: 0.0},
+			"busy": {CPUUtilization: 0.5},
+			"hot":  {CPUUtilization: 0.9},
+		},
+	}
+	for _, name := range []string{"idle", "busy", "hot"} {
+		if !f.Filter(ctx, node(name)) {
+			t.Errorf("Filter(%s) = false with no arguments, want true", name)
+		}
+	}
+	if got := s.Score(ctx, node("busy")); got != 0.5 {
+		t.Errorf("Score(busy) = %v with no arguments, want 0.5", got)
+	}
+}
+
 // newPolicy constructs and Initialize-s a policy with the given args.
 func newPolicy(t *testing.T, args policy.Arguments) (policy.Filterer, policy.Scorer) {
 	t.Helper()


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The `allocation-rate` shard policy discards its own default CPU-utilization range whenever the optional `arguments` block is omitted. `Initialize` read the bounds into fresh zero-valued locals and then wrote them onto the policy, so the defaults set in `New()` never survived. The range collapsed to `[0.0, 0.0]`, the filter then kept only nodes at exactly 0 utilization, and the shard was starved. `allocation-rate` is also `DefaultPolicyName`, so this is the policy most configurations reach for first.

The two sibling policies do not have this problem: `warmup` and `node-limit` read into pre-seeded fields, and `GetFloat64` only writes through the pointer when the key is present, so an absent argument leaves the default in place. This change makes `allocation-rate` default the same way, by establishing the full `[0.0, 1.0]` range in `Initialize` before reading arguments. A configured bound still overrides the default.

Added `TestAllocationRatePolicyDefaultRange`, which builds the policy with no arguments and checks that nodes across the utilization range pass the filter. It fails on the old code (range `[0.0, 0.0]`, only a 0-utilization node passes) and passes with this change.

#### Which issue(s) this PR fixes:

Fixes #5710

#### Special notes for your reviewer:

The issue has the end-to-end evidence: real ConfigMap YAML driven through `ParseShardingConfig` and `ShardingManager.CalculateShardAssignments`, where the shard is assigned 1 of 4 nodes with no arguments versus 4 of 4 once the range is spelled out.

`New()` no longer sets the defaults, since `Initialize` now owns them and is always called right after the builder (`sharding_manager.go`). That keeps a single source of truth for the default range and matches how `node-limit`'s `New()` returns a bare struct.

#### Does this PR introduce a user-facing change?

```release-note
Fixed the allocation-rate shard policy discarding its default CPU utilization range when the arguments block is omitted, which starved the shard of nodes.
```
