### PR TITLE
fix(resourcequota): avoid double counting already-running pods against quota

### DIFF
--- a/pkg/scheduler/plugins/resourcequota/resourcequota.go
+++ b/pkg/scheduler/plugins/resourcequota/resourcequota.go
@@ -65,6 +65,12 @@ func (rq *resourceQuotaPlugin) OnSessionOpen(ssn *framework.Session) {
 			return util.Permit
 		}
 
+		// If the job already has Pods in the cluster, their resource requests are
+		// already reflected in resourceQuota.Used by the native ResourceQuota
+		// controller. Adding MinResources on top of Used in that case would count
+		// the same usage twice and could reject a job that actually fits the quota.
+		jobPodsCreated := len(job.Tasks) != 0
+
 		quotas := ssn.NamespaceInfo[api.NamespaceName(job.Namespace)].QuotaStatus
 		for _, resourceQuota := range quotas {
 			hardResources := quotav1.ResourceNames(resourceQuota.Hard)
@@ -74,7 +80,10 @@ func (rq *resourceQuotaPlugin) OnSessionOpen(ssn *framework.Session) {
 			if pendingUse, found := pendingResources[job.Namespace]; found {
 				resourcesUsed = quotav1.Add(pendingUse, resourcesUsed)
 			}
-			newUsage := quotav1.Add(resourcesUsed, requestedUsage)
+			newUsage := resourcesUsed
+			if !jobPodsCreated {
+				newUsage = quotav1.Add(resourcesUsed, requestedUsage)
+			}
 			maskedNewUsage := quotav1.Mask(newUsage, quotav1.ResourceNames(requestedUsage))
 
 			if allowed, exceeded := quotav1.LessThanOrEqual(maskedNewUsage, resourceQuota.Hard); !allowed {
@@ -100,6 +109,11 @@ func (rq *resourceQuotaPlugin) OnSessionOpen(ssn *framework.Session) {
 			return
 		}
 		if ssn.NamespaceInfo[api.NamespaceName(job.Namespace)] == nil {
+			return
+		}
+		// If the job's Pods already exist, resourceQuota.Used already accounts
+		// for them, so there is no pending usage left to track for this job.
+		if len(job.Tasks) != 0 {
 			return
 		}
 		if _, found := pendingResources[job.Namespace]; !found {

--- a/pkg/scheduler/plugins/resourcequota/resourcequota_test.go
+++ b/pkg/scheduler/plugins/resourcequota/resourcequota_test.go
@@ -21,6 +21,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"volcano.sh/apis/pkg/apis/scheduling"
 	schedulingv1 "volcano.sh/apis/pkg/apis/scheduling/v1beta1"
@@ -172,5 +173,61 @@ func TestJobEnqueuedOnOtherPluginsReject(t *testing.T) {
 	test.Run([]framework.Action{enqueue.New()})
 	if err := test.CheckAll(0); err != nil {
 		t.Fatal(err)
+	}
+}
+
+// TestResourceQuotaAlreadyReflectsOwnPod reproduces volcano-sh/volcano#4220.
+// When a PodGroup's own Pod already exists, its resource request is already
+// reflected in ResourceQuota.Status.Used by the native ResourceQuota
+// controller, since that controller counts a Pod's usage as soon as it is
+// created, independent of scheduling. The plugin must not add
+// PodGroup.Spec.MinResources on top of Used again in that case, or a job
+// that actually fits the quota is wrongly rejected.
+func TestResourceQuotaAlreadyReflectsOwnPod(t *testing.T) {
+	podReq := api.BuildResourceList("40m", "400")
+	pod := util.BuildPod("cpu-test", "test-resourcequota-pod-2", "", v1.PodPending, podReq, "pg2", nil, nil)
+
+	pg2 := util.BuildPodGroup("pg2", "cpu-test", "c1", 1, nil, schedulingv1.PodGroupPending)
+	pg2.Spec.MinResources = &podReq
+
+	queue1 := util.BuildQueue("c1", 1, nil)
+
+	rq := &v1.ResourceQuota{
+		ObjectMeta: metav1.ObjectMeta{Name: "cpu-test-resource-quota", Namespace: "cpu-test"},
+		Spec: v1.ResourceQuotaSpec{
+			Hard: api.BuildResourceList("100m", "1000"),
+		},
+		Status: v1.ResourceQuotaStatus{
+			Hard: api.BuildResourceList("100m", "1000"),
+			// Used already includes this Pod's own 40m/400, exactly as the
+			// native ResourceQuota controller reports once the Pod exists.
+			Used: api.BuildResourceList("90m", "700"),
+		},
+	}
+
+	test := uthelper.TestCommonStruct{
+		Name:           "job's own already-created pod must not be double counted against quota",
+		Plugins:        map[string]framework.PluginBuilder{PluginName: New},
+		Pods:           []*v1.Pod{pod},
+		PodGroups:      []*schedulingv1.PodGroup{pg2},
+		Queues:         []*schedulingv1.Queue{queue1},
+		ResourceQuotas: []*v1.ResourceQuota{rq},
+	}
+
+	trueValue := true
+	tiers := []conf.Tier{
+		{
+			Plugins: []conf.PluginOption{
+				{Name: PluginName, EnabledJobEnqueued: &trueValue},
+			},
+		},
+	}
+
+	ssn := test.RegisterSession(tiers, nil)
+	defer test.Close()
+	for _, job := range ssn.Jobs {
+		if !ssn.JobEnqueueable(job) {
+			t.Errorf("expected job to be enqueueable since quota is not actually exceeded, got rejected")
+		}
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The resourceQuota plugin double-counts resource usage for jobs whose pods have already been created.

When `OnSessionOpen`'s job-enqueued checks run, the native Kubernetes ResourceQuota controller has already added a pod's resource requests into `resourceQuota.Status.Used` as soon as that pod exists, regardless of whether it has been scheduled. The plugin was then adding the job's `PodGroup.Spec.MinResources` on top of that same `Used` value, effectively counting the same pod's usage twice.

In practice this means: create one pod that partially uses a quota, then create a second pod under a quota that has plenty of room left, and the second pod's podgroup gets stuck `Pending` with `NotEnoughResources`, even though the quota is nowhere near exceeded.

This PR skips adding `MinResources` on top of `Used` (and skips tracking pending usage) for jobs whose pods already exist in the cluster, since their usage is already reflected in `Used`.

#### Which issue(s) this PR fixes:

Fixes #4220

#### Special notes for your reviewer:

Added a regression test, `TestResourceQuotaAlreadyReflectsOwnPod`, that reproduces the scenario from the issue: a pod already counted in `resourceQuota.Status.Used`, with a podgroup that should be enqueueable because the quota still has room.

#### Does this PR introduce a user-facing change?

```release-note
Fix resourceQuota plugin double counting resource usage for pods that already exist, which could incorrectly reject jobs that fit within their namespace's resource quota.
```