### PR TITLE
fix: handle node tombstones in label discovery

### DIFF
--- a/pkg/controllers/hypernode/discovery/label/label.go
+++ b/pkg/controllers/hypernode/discovery/label/label.go
@@ -309,7 +309,21 @@ func (l *labelDiscoverer) UpdateNode(oldObj, newObj interface{}) {
 
 // DeleteNode Reconstruct the hyperNode when the node changes.
 func (l *labelDiscoverer) DeleteNode(obj interface{}) {
-	labelMap := l.getNodeNetworkTopologyLabels(obj)
+	node, ok := obj.(*v1.Node)
+	if !ok {
+		// If we reached here it means the Node was deleted but its final state is unrecorded.
+		tombstones, ok := obj.(cache.DeletedFinalStateUnknown)
+		if !ok {
+			klog.Errorf("Couldn't get object from tombstone %#v", obj)
+			return
+		}
+		node, ok = tombstones.Obj.(*v1.Node)
+		if !ok {
+			klog.Errorf("Tombstone contained object that is not a Node: %#v", obj)
+			return
+		}
+	}
+	labelMap := l.getNodeNetworkTopologyLabels(node)
 	if len(labelMap) > 0 {
 		l.enqueue()
 	}

--- a/pkg/controllers/hypernode/discovery/label/label_test.go
+++ b/pkg/controllers/hypernode/discovery/label/label_test.go
@@ -26,6 +26,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2"
 
 	topologyv1alpha1 "volcano.sh/apis/pkg/apis/topology/v1alpha1"
@@ -102,6 +104,23 @@ func TestNewLabelDiscoverer_start(t *testing.T) {
 			d.Stop()
 		})
 	}
+}
+
+func TestDeleteNodeWithTombstone(t *testing.T) {
+	d := &labelDiscoverer{
+		networkTopologyRecord: parseCfg(getCfg()),
+		queue: workqueue.NewTypedRateLimitingQueue(
+			workqueue.DefaultTypedControllerRateLimiter[string](),
+		),
+	}
+	defer d.queue.ShutDown()
+
+	node := expectedNodeForTest1()["node0"]
+	d.DeleteNode(cache.DeletedFinalStateUnknown{Key: node.Name, Obj: node})
+
+	assert.Eventually(t, func() bool {
+		return d.queue.Len() == 1
+	}, time.Second, 10*time.Millisecond, "expected Node deletion to trigger discovery")
 }
 
 func getCfg() api.DiscoveryConfig {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Handles Node delete events delivered as `DeletedFinalStateUnknown` in label-based HyperNode discovery.

Previously, the tombstone wrapper was passed to a helper that only accepts `*v1.Node`. This returned an empty label map and skipped topology reconciliation, potentially leaving stale Node membership in generated HyperNodes.

The change follows the existing `DeleteHyperNode` tombstone handling and adds a focused regression test.

#### Which issue(s) this PR fixes:

Fixes #5745

#### Special notes for your reviewer:

Tests run:

```text
go test ./pkg/controllers/hypernode/discovery/label -run TestDeleteNodeWithTombstone -count=1
go test ./pkg/controllers/hypernode/...
git diff --check
```

AI assistance disclosure: Codex was used for source review, drafting the initial fix and test, and pre-submit review. I reviewed every change and ran the tests listed above on my own.

#### Does this PR introduce a user-facing change?

```release-note
Fix label-based HyperNode discovery so Node deletions delivered as informer tombstones trigger topology reconciliation.
```
