### PR TITLE
Keep the scheduler running when a plugin argument has a wrong type

### DIFF
--- a/pkg/scheduler/framework/arguments.go
+++ b/pkg/scheduler/framework/arguments.go
@@ -130,7 +130,9 @@ func (a Arguments) GetString(ptr *string, key string) {
 // Get can automatically convert parameters according to the passed generic T type.
 // If the parameter conversion is successful, it returns the converted parameter.
 // If the parameter does not exist, it returns false.
-// If the conversion fails, it will terminate the program with a fatal error.
+// If the conversion fails, it logs a warning and returns false, so that the
+// caller keeps its own default instead of the scheduler exiting on a
+// misconfigured argument.
 func Get[T any](a Arguments, key string) (T, bool) {
 	var result T
 	argv, ok := a[key]
@@ -140,7 +142,10 @@ func Get[T any](a Arguments, key string) (T, bool) {
 
 	err := mapstructure.Decode(argv, &result)
 	if err != nil {
-		klog.Fatalf("Could not parse argument for key %s to type %T: %v", key, result, err)
+		klog.Warningf("Could not parse argument: %v for key %s to type %T: %v, the default value is used instead",
+			argv, key, result, err)
+		var zero T
+		return zero, false
 	}
 
 	return result, true

--- a/pkg/scheduler/framework/arguments_test.go
+++ b/pkg/scheduler/framework/arguments_test.go
@@ -314,3 +314,73 @@ func TestArgumentsGetString(t *testing.T) {
 		}
 	}
 }
+
+type getTestConfig struct {
+	Enable bool           `json:"enable"`
+	Name   string         `json:"name"`
+	Weight map[string]int `json:"weight"`
+}
+
+// TestGet checks that Get reports success only for a value it could decode.
+// A value of an unexpected type must be reported as a miss so that the caller
+// keeps its own default, and it must never end the scheduler process.
+func TestGet(t *testing.T) {
+	const key = "argkey"
+
+	t.Run("scalar", func(t *testing.T) {
+		if value, ok := Get[int](Arguments{key: 10}, key); !ok || value != 10 {
+			t.Errorf("expected 10 and true, but got %v and %v", value, ok)
+		}
+		// A quoted number in the scheduler ConfigMap arrives as a string.
+		if value, ok := Get[int](Arguments{key: "10"}, key); ok || value != 0 {
+			t.Errorf("expected 0 and false, but got %v and %v", value, ok)
+		}
+		if value, ok := Get[int](Arguments{"otherkey": 10}, key); ok || value != 0 {
+			t.Errorf("expected 0 and false, but got %v and %v", value, ok)
+		}
+	})
+
+	t.Run("slice", func(t *testing.T) {
+		expected := []string{"nvidia.com/gpu", "nvidia.com/gpumem"}
+		value, ok := Get[[]string](Arguments{key: expected}, key)
+		if !ok || !equality.Semantic.DeepEqual(value, expected) {
+			t.Errorf("expected %v and true, but got %v and %v", expected, value, ok)
+		}
+		// A comma separated string is not a list, even though other plugin
+		// arguments accept that form.
+		if value, ok := Get[[]string](Arguments{key: "nvidia.com/gpu, nvidia.com/gpumem"}, key); ok || value != nil {
+			t.Errorf("expected nil and false, but got %v and %v", value, ok)
+		}
+	})
+
+	t.Run("map", func(t *testing.T) {
+		// Nested maps come from gopkg.in/yaml.v2 with interface{} keys.
+		arg := Arguments{key: map[interface{}]interface{}{"nvidia.com/gpu": 2}}
+		expected := map[string]int{"nvidia.com/gpu": 2}
+		value, ok := Get[map[string]int](arg, key)
+		if !ok || !equality.Semantic.DeepEqual(value, expected) {
+			t.Errorf("expected %v and true, but got %v and %v", expected, value, ok)
+		}
+		if value, ok := Get[map[string]int](Arguments{key: "nvidia.com/gpu"}, key); ok || value != nil {
+			t.Errorf("expected nil and false, but got %v and %v", value, ok)
+		}
+	})
+
+	t.Run("struct", func(t *testing.T) {
+		arg := Arguments{key: map[interface{}]interface{}{
+			"enable": true,
+			"name":   "sra",
+			"weight": map[interface{}]interface{}{"nvidia.com/gpu": 1},
+		}}
+		expected := getTestConfig{Enable: true, Name: "sra", Weight: map[string]int{"nvidia.com/gpu": 1}}
+		value, ok := Get[getTestConfig](arg, key)
+		if !ok || !equality.Semantic.DeepEqual(value, expected) {
+			t.Errorf("expected %v and true, but got %v and %v", expected, value, ok)
+		}
+		// A partially decoded struct must not leak to the caller.
+		badArg := Arguments{key: map[interface{}]interface{}{"enable": true, "name": 1}}
+		if value, ok := Get[getTestConfig](badArg, key); ok || !equality.Semantic.DeepEqual(value, getTestConfig{}) {
+			t.Errorf("expected an empty config and false, but got %v and %v", value, ok)
+		}
+	})
+}

--- a/pkg/scheduler/plugins/resource-strategy-fit/resource_strategy_fit.go
+++ b/pkg/scheduler/plugins/resource-strategy-fit/resource_strategy_fit.go
@@ -173,8 +173,8 @@ func calculateWeight(args framework.Arguments) ResourceStrategyFit {
 }
 
 func applyProportionalPolicy(rsf *resourceStrategyFitPlugin, args framework.Arguments) {
-	cfg, _ := framework.Get[proportionalConfig](args, "proportional")
-	if !cfg.Enable {
+	cfg, ok := framework.Get[proportionalConfig](args, "proportional")
+	if !ok || !cfg.Enable {
 		return
 	}
 
@@ -185,8 +185,8 @@ func applyProportionalPolicy(rsf *resourceStrategyFitPlugin, args framework.Argu
 }
 
 func applySraPolicy(rsf *resourceStrategyFitPlugin, args framework.Arguments) {
-	cfg, _ := framework.Get[sraConfig](args, "sra")
-	if !cfg.Enable {
+	cfg, ok := framework.Get[sraConfig](args, "sra")
+	if !ok || !cfg.Enable {
 		return
 	}
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

`framework.Get[T]` ended the scheduler process with `klog.Fatalf` when a plugin argument value could not be decoded into the type the plugin expects. Plugins are rebuilt from their arguments on every scheduling cycle, so one mistyped value in `volcano-scheduler-configmap` — a quoted number such as `resourceStrategyFitWeight: "10"`, or a comma separated string where `extender.managedResources` expects a list — killed the scheduler and kept it in `CrashLoopBackOff` until the ConfigMap was corrected. Nothing was scheduled in the cluster meanwhile.

The graceful path in `loadSchedulerConf`, which keeps the previous configuration when the ConfigMap is unusable, does not help here: `Arguments` is `map[string]interface{}`, so the YAML unmarshals fine and the type error only surfaces later, when the plugins are built.

This changes `Get[T]` to log a warning and report the argument as missing, so the caller keeps its own default. That is how `GetInt`, `GetFloat64`, `GetBool` and `GetString` in the same file already behave, and the callers of `Get[T]` in `resource-strategy-fit`, `predicates` and `extender` are already written to fall back to their defaults when the argument is absent.

Two details worth pointing out:

- The zero value is returned rather than the partially decoded one. `mapstructure` collects per-field errors, so a struct argument with one bad field would otherwise reach the caller half populated.
- `applyProportionalPolicy` and `applySraPolicy` discarded the boolean result. They now check it, so an undecodable `proportional`/`sra` block leaves the policy disabled, which is the documented default, instead of relying on the zero value.

Behaviour for a valid configuration is unchanged.

#### Which issue(s) this PR fixes:

Fixes #5749

#### Special notes for your reviewer:

The new `TestGet` in `pkg/scheduler/framework/arguments_test.go` covers the scalar, slice, map and struct shapes that `Get[T]` is used with, including nested maps as `gopkg.in/yaml.v2` produces them (`map[interface{}]interface{}`). It is a real regression test: with `klog.Fatalf` restored, the test binary dies instead of failing:

```
F0727 08:21:54.731122 arguments.go:145] Could not parse argument for key argkey to type int: '' expected type 'int', got unconvertible type 'string', value: '10'
FAIL	volcano.sh/volcano/pkg/scheduler/framework	0.038s
```

Tested with:

```
go test -race ./pkg/scheduler/framework/... ./pkg/scheduler/plugins/resource-strategy-fit/...
go test -p 4 -race ./pkg/scheduler/...
gofmt -l -s, go vet and golangci-lint v2.12.2 on the changed packages
```

Left out on purpose, happy to follow up if you would like it in scope: `mapstructure` silently truncates a float into an int, so `volumebinding.weight: 1.5` becomes `1` without any warning. That is a separate behaviour from the fatal exit fixed here.

AI assistance (Claude Code) was used to investigate the issue and prepare this change, as described in contributing.md. I reviewed every line and ran the tests above myself.

#### Does this PR introduce a user-facing change?

```release-note
Fixed the scheduler exiting and crash looping when a plugin argument in the scheduler ConfigMap has an unexpected type. The argument is now ignored with a warning and the plugin keeps its default value.
```
