### PR TITLE
scheduler: add committed eviction transaction metric

### DIFF
--- a/docs/design/metrics.md
+++ b/docs/design/metrics.md
@@ -32,7 +32,7 @@ This metrics describe internal state of volcano.
 |----------------------------------------|-----------------|-------------------------------------------------------------------|-----------------------------------------------|
 | `pod_preemption_victims`               | Gauge           | None                                                              | The number of selected preemption victims     |
 | `total_preemption_attempts`            | Counter         | None                                                              | Total preemption attempts in the cluster      |
-| `eviction_transactions_total`          | Counter         | `action`=&lt;action_name&gt;                                      | Total committed scheduler transactions containing at least one eviction for `preempt`, `reclaim`, `gangpreempt`, and `gangreclaim` |
+| `eviction_transactions_total`          | Counter         | `action`=&lt;`preempt`\|`reclaim`\|`gangpreempt`\|`gangreclaim`&gt; | Total committed scheduler transactions containing at least one eviction |
 | `unschedule_task_count`                | Gauge           | `job_id`=&lt;job_id&gt;                                           | The number of tasks failed to schedule        |
 | `unschedule_job_counts`                | Gauge           | None                                                              | The number of jobs could not be scheduled     |
 | `queue_allocated_milli_cpu`            | Gauge           | `queue_name`=&lt;queue_name&gt;                                   | Allocated CPU count for one queue             |

--- a/docs/design/metrics.md
+++ b/docs/design/metrics.md
@@ -32,7 +32,7 @@ This metrics describe internal state of volcano.
 |----------------------------------------|-----------------|-------------------------------------------------------------------|-----------------------------------------------|
 | `pod_preemption_victims`               | Gauge           | None                                                              | The number of selected preemption victims     |
 | `total_preemption_attempts`            | Counter         | None                                                              | Total preemption attempts in the cluster      |
-| `eviction_transactions_total`          | Counter         | `action`=&lt;`preempt`\|`reclaim`\|`gangpreempt`\|`gangreclaim`&gt; | Total scheduler commit batches containing one or more per-Pod eviction decisions |
+| `eviction_transactions_total`          | Counter         | `action`=&lt;`preempt`\|`reclaim`\|`gangpreempt`\|`gangreclaim`&gt; | Scheduler commit batches with one or more per-Pod eviction decisions; counted once per batch regardless of victim count; not a Pod/PodGroup count and does not report Pod deletion outcomes |
 | `unschedule_task_count`                | Gauge           | `job_id`=&lt;job_id&gt;                                           | The number of tasks failed to schedule        |
 | `unschedule_job_counts`                | Gauge           | None                                                              | The number of jobs could not be scheduled     |
 | `queue_allocated_milli_cpu`            | Gauge           | `queue_name`=&lt;queue_name&gt;                                   | Allocated CPU count for one queue             |
@@ -66,8 +66,6 @@ This metrics describe internal state of volcano.
 | `job_retry_counts`                     | Counter         | `job_id`=&lt;job_id&gt;                                           | The number of retry counts for one job        |
 | `job_completed_phase_count`            | Counter         | `job_name`=&lt;job_name&gt; `queue_name`=&lt;queue_name&gt;       | The number of job completed phase             |
 | `job_failed_phase_count`               | Counter         | `job_name`=&lt;job_name&gt; `queue_name`=&lt;queue_name&gt;       | The number of job failed phase                |
-
-`eviction_transactions_total` increments once for each scheduler `Statement` that contains one or more per-Pod eviction operations and reaches the commit phase. A transaction can contain victims from one or multiple Jobs or PodGroups, depending on the action, and its victim count does not change the increment. The transaction boundary is defined by each scheduler action, so this metric is not a Pod, PodGroup, or victim Job count. Cache eviction and asynchronous Kubernetes Pod deletion outcomes are not reported by this metric.
 
 ### volcano agent scheduler related metrics
 

--- a/docs/design/metrics.md
+++ b/docs/design/metrics.md
@@ -32,6 +32,7 @@ This metrics describe internal state of volcano.
 |----------------------------------------|-----------------|-------------------------------------------------------------------|-----------------------------------------------|
 | `pod_preemption_victims`               | Gauge           | None                                                              | The number of selected preemption victims     |
 | `total_preemption_attempts`            | Counter         | None                                                              | Total preemption attempts in the cluster      |
+| `eviction_transactions_total`          | Counter         | `action`=&lt;action_name&gt;                                      | Total committed scheduler transactions containing at least one eviction for `preempt`, `reclaim`, `gangpreempt`, and `gangreclaim` |
 | `unschedule_task_count`                | Gauge           | `job_id`=&lt;job_id&gt;                                           | The number of tasks failed to schedule        |
 | `unschedule_job_counts`                | Gauge           | None                                                              | The number of jobs could not be scheduled     |
 | `queue_allocated_milli_cpu`            | Gauge           | `queue_name`=&lt;queue_name&gt;                                   | Allocated CPU count for one queue             |

--- a/docs/design/metrics.md
+++ b/docs/design/metrics.md
@@ -32,7 +32,7 @@ This metrics describe internal state of volcano.
 |----------------------------------------|-----------------|-------------------------------------------------------------------|-----------------------------------------------|
 | `pod_preemption_victims`               | Gauge           | None                                                              | The number of selected preemption victims     |
 | `total_preemption_attempts`            | Counter         | None                                                              | Total preemption attempts in the cluster      |
-| `eviction_transactions_total`          | Counter         | `action`=&lt;`preempt`\|`reclaim`\|`gangpreempt`\|`gangreclaim`&gt; | Total number of committed eviction transactions |
+| `eviction_transactions_total`          | Counter         | `action`=&lt;`preempt`\|`reclaim`\|`gangpreempt`\|`gangreclaim`&gt; | Total scheduler commit batches containing one or more per-Pod eviction decisions |
 | `unschedule_task_count`                | Gauge           | `job_id`=&lt;job_id&gt;                                           | The number of tasks failed to schedule        |
 | `unschedule_job_counts`                | Gauge           | None                                                              | The number of jobs could not be scheduled     |
 | `queue_allocated_milli_cpu`            | Gauge           | `queue_name`=&lt;queue_name&gt;                                   | Allocated CPU count for one queue             |
@@ -66,6 +66,8 @@ This metrics describe internal state of volcano.
 | `job_retry_counts`                     | Counter         | `job_id`=&lt;job_id&gt;                                           | The number of retry counts for one job        |
 | `job_completed_phase_count`            | Counter         | `job_name`=&lt;job_name&gt; `queue_name`=&lt;queue_name&gt;       | The number of job completed phase             |
 | `job_failed_phase_count`               | Counter         | `job_name`=&lt;job_name&gt; `queue_name`=&lt;queue_name&gt;       | The number of job failed phase                |
+
+`eviction_transactions_total` increments once for each scheduler `Statement` that contains one or more per-Pod eviction operations and reaches the commit phase. A transaction can contain victims from one or multiple Jobs or PodGroups, depending on the action, and its victim count does not change the increment. The transaction boundary is defined by each scheduler action, so this metric is not a Pod, PodGroup, or victim Job count. Cache eviction and asynchronous Kubernetes Pod deletion outcomes are not reported by this metric.
 
 ### volcano agent scheduler related metrics
 

--- a/docs/design/metrics.md
+++ b/docs/design/metrics.md
@@ -32,7 +32,7 @@ This metrics describe internal state of volcano.
 |----------------------------------------|-----------------|-------------------------------------------------------------------|-----------------------------------------------|
 | `pod_preemption_victims`               | Gauge           | None                                                              | The number of selected preemption victims     |
 | `total_preemption_attempts`            | Counter         | None                                                              | Total preemption attempts in the cluster      |
-| `eviction_transactions_total`          | Counter         | `action`=&lt;`preempt`\|`reclaim`\|`gangpreempt`\|`gangreclaim`&gt; | Total committed scheduler transactions containing at least one eviction |
+| `eviction_transactions_total`          | Counter         | `action`=&lt;`preempt`\|`reclaim`\|`gangpreempt`\|`gangreclaim`&gt; | Total number of committed eviction transactions |
 | `unschedule_task_count`                | Gauge           | `job_id`=&lt;job_id&gt;                                           | The number of tasks failed to schedule        |
 | `unschedule_job_counts`                | Gauge           | None                                                              | The number of jobs could not be scheduled     |
 | `queue_allocated_milli_cpu`            | Gauge           | `queue_name`=&lt;queue_name&gt;                                   | Allocated CPU count for one queue             |

--- a/pkg/scheduler/actions/gangpreempt/gangpreempt.go
+++ b/pkg/scheduler/actions/gangpreempt/gangpreempt.go
@@ -23,6 +23,7 @@ import (
 	"volcano.sh/volcano/pkg/scheduler/api"
 	"volcano.sh/volcano/pkg/scheduler/conf"
 	"volcano.sh/volcano/pkg/scheduler/framework"
+	"volcano.sh/volcano/pkg/scheduler/metrics"
 	"volcano.sh/volcano/pkg/scheduler/util"
 )
 
@@ -124,7 +125,11 @@ func (gp *Action) Execute(ssn *framework.Session) {
 
 			// Mirror legacy commit behavior: commit only when the job becomes pipelined.
 			if ssn.JobPipelined(preemptorJob) {
+				hasEvictions := stmt.HasEvictions()
 				stmt.Commit()
+				if hasEvictions {
+					metrics.RegisterEvictionTransaction(gp.Name())
+				}
 				utils.ApplySubJobNominations(preemptorJob, subJobHyperNodes)
 			} else {
 				stmt.Discard()

--- a/pkg/scheduler/actions/gangreclaim/gangreclaim.go
+++ b/pkg/scheduler/actions/gangreclaim/gangreclaim.go
@@ -23,6 +23,7 @@ import (
 	"volcano.sh/volcano/pkg/scheduler/api"
 	"volcano.sh/volcano/pkg/scheduler/conf"
 	"volcano.sh/volcano/pkg/scheduler/framework"
+	"volcano.sh/volcano/pkg/scheduler/metrics"
 	"volcano.sh/volcano/pkg/scheduler/util"
 )
 
@@ -126,7 +127,11 @@ func (gr *Action) Execute(ssn *framework.Session) {
 
 			// Mirror legacy commit behavior: commit only when the job becomes pipelined.
 			if ssn.JobPipelined(job) {
+				hasEvictions := stmt.HasEvictions()
 				stmt.Commit()
+				if hasEvictions {
+					metrics.RegisterEvictionTransaction(gr.Name())
+				}
 				utils.ApplySubJobNominations(job, subJobHyperNodes)
 			} else {
 				stmt.Discard()

--- a/pkg/scheduler/actions/preempt/preempt.go
+++ b/pkg/scheduler/actions/preempt/preempt.go
@@ -221,7 +221,11 @@ func (pmpt *Action) Execute(ssn *framework.Session) {
 
 			// Commit changes only if job is pipelined, otherwise try next job.
 			if ssn.JobPipelined(preemptorJob) {
+				hasEvictions := stmt.HasEvictions()
 				stmt.Commit()
+				if hasEvictions {
+					metrics.RegisterEvictionTransaction(pmpt.Name())
+				}
 			} else {
 				stmt.Discard()
 				continue
@@ -282,7 +286,11 @@ func (pmpt *Action) Execute(ssn *framework.Session) {
 					stmt.Discard()
 					break
 				}
+				hasEvictions := stmt.HasEvictions()
 				stmt.Commit()
+				if hasEvictions {
+					metrics.RegisterEvictionTransaction(pmpt.Name())
+				}
 			}
 		}
 	}

--- a/pkg/scheduler/actions/reclaim/reclaim.go
+++ b/pkg/scheduler/actions/reclaim/reclaim.go
@@ -29,6 +29,7 @@ import (
 	"volcano.sh/volcano/pkg/scheduler/api"
 	"volcano.sh/volcano/pkg/scheduler/conf"
 	"volcano.sh/volcano/pkg/scheduler/framework"
+	"volcano.sh/volcano/pkg/scheduler/metrics"
 	"volcano.sh/volcano/pkg/scheduler/util"
 )
 
@@ -160,7 +161,11 @@ func (ra *Action) Execute(ssn *framework.Session) {
 			}
 
 			if ssn.JobPipelined(job) {
+				hasEvictions := stmt.HasEvictions()
 				stmt.Commit()
+				if hasEvictions {
+					metrics.RegisterEvictionTransaction(ra.Name())
+				}
 			} else {
 				stmt.Discard()
 			}

--- a/pkg/scheduler/framework/statement.go
+++ b/pkg/scheduler/framework/statement.go
@@ -68,6 +68,16 @@ func (s *Statement) Operations() []operation {
 	return s.operations
 }
 
+// HasEvictions returns whether the statement contains at least one eviction operation.
+func (s *Statement) HasEvictions() bool {
+	for _, op := range s.operations {
+		if op.name == Evict {
+			return true
+		}
+	}
+	return false
+}
+
 // Evict the pod
 func (s *Statement) Evict(reclaimee *api.TaskInfo, reason string) {
 	// Update status in session

--- a/pkg/scheduler/framework/statement_test.go
+++ b/pkg/scheduler/framework/statement_test.go
@@ -27,6 +27,44 @@ import (
 	"volcano.sh/volcano/pkg/scheduler/util"
 )
 
+func TestStatementHasEvictions(t *testing.T) {
+	task := &api.TaskInfo{Name: "task"}
+
+	tests := []struct {
+		name       string
+		operations []operation
+		want       bool
+	}{
+		{
+			name: "empty statement",
+		},
+		{
+			name: "statement without eviction",
+			operations: []operation{
+				{name: Pipeline, task: task},
+				{name: Allocate, task: task},
+			},
+		},
+		{
+			name: "statement with eviction",
+			operations: []operation{
+				{name: Pipeline, task: task},
+				{name: Evict, task: task, reason: "preempt"},
+			},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stmt := &Statement{operations: tt.operations}
+			if got := stmt.HasEvictions(); got != tt.want {
+				t.Fatalf("HasEvictions() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestStatementMerge(t *testing.T) {
 	makeTask := func(name string) *api.TaskInfo {
 		return &api.TaskInfo{

--- a/pkg/scheduler/metrics/metrics.go
+++ b/pkg/scheduler/metrics/metrics.go
@@ -172,7 +172,7 @@ var (
 		prometheus.CounterOpts{
 			Subsystem: VolcanoSubSystemName,
 			Name:      "eviction_transactions_total",
-			Help:      "Total number of committed scheduler transactions containing at least one eviction, by action",
+			Help:      "Total number of committed eviction transactions, by action",
 		},
 		[]string{"action"},
 	)

--- a/pkg/scheduler/metrics/metrics.go
+++ b/pkg/scheduler/metrics/metrics.go
@@ -35,6 +35,11 @@ const (
 	// OnSessionClose label
 	OnSessionClose = "OnSessionClose"
 
+	evictionActionPreempt     = "preempt"
+	evictionActionReclaim     = "reclaim"
+	evictionActionGangPreempt = "gangpreempt"
+	evictionActionGangReclaim = "gangreclaim"
+
 	// Task Scheduling Stages (used for taskSchedulingLatency)
 	TaskStageWatched  = "Watched"
 	TaskStageAssumed  = "Assumed"  // The time when a task is logically allocated to a node(in the memory but hasn't been bound yet)
@@ -264,7 +269,16 @@ func RegisterPreemptionAttempts() {
 }
 
 // RegisterEvictionTransaction records a committed scheduler transaction containing at least one eviction.
+// Unsupported actions are ignored to keep the action label cardinality bounded.
 func RegisterEvictionTransaction(action string) {
+	switch action {
+	case evictionActionPreempt,
+		evictionActionReclaim,
+		evictionActionGangPreempt,
+		evictionActionGangReclaim:
+	default:
+		return
+	}
 	evictionTransactions.WithLabelValues(action).Inc()
 }
 

--- a/pkg/scheduler/metrics/metrics.go
+++ b/pkg/scheduler/metrics/metrics.go
@@ -163,6 +163,15 @@ var (
 		},
 	)
 
+	evictionTransactions = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Subsystem: VolcanoSubSystemName,
+			Name:      "eviction_transactions_total",
+			Help:      "Total number of committed scheduler transactions containing at least one eviction, by action",
+		},
+		[]string{"action"},
+	)
+
 	unscheduleTaskCount = promauto.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Subsystem: VolcanoSubSystemName,
@@ -252,6 +261,11 @@ func UpdatePreemptionVictimsCount(victimsCount int) {
 // RegisterPreemptionAttempts records number of attempts for preemtion
 func RegisterPreemptionAttempts() {
 	preemptionAttempts.Inc()
+}
+
+// RegisterEvictionTransaction records a committed scheduler transaction containing at least one eviction.
+func RegisterEvictionTransaction(action string) {
+	evictionTransactions.WithLabelValues(action).Inc()
 }
 
 // UpdateUnscheduleTaskCount records total number of unscheduleable tasks

--- a/pkg/scheduler/metrics/metrics_test.go
+++ b/pkg/scheduler/metrics/metrics_test.go
@@ -23,14 +23,29 @@ import (
 )
 
 func TestRegisterEvictionTransaction(t *testing.T) {
-	const action = "test-action"
+	actions := []string{
+		evictionActionPreempt,
+		evictionActionReclaim,
+		evictionActionGangPreempt,
+		evictionActionGangReclaim,
+	}
 
-	counter := evictionTransactions.WithLabelValues(action)
-	before := testutil.ToFloat64(counter)
+	for _, action := range actions {
+		t.Run(action, func(t *testing.T) {
+			counter := evictionTransactions.WithLabelValues(action)
+			before := testutil.ToFloat64(counter)
 
-	RegisterEvictionTransaction(action)
+			RegisterEvictionTransaction(action)
 
-	if got := testutil.ToFloat64(counter); got != before+1 {
-		t.Fatalf("eviction transaction counter = %v, want %v", got, before+1)
+			if got := testutil.ToFloat64(counter); got != before+1 {
+				t.Fatalf("eviction transaction counter = %v, want %v", got, before+1)
+			}
+		})
+	}
+
+	before := testutil.CollectAndCount(evictionTransactions)
+	RegisterEvictionTransaction("unsupported-action")
+	if got := testutil.CollectAndCount(evictionTransactions); got != before {
+		t.Fatalf("metric count after unsupported action = %d, want %d", got, before)
 	}
 }

--- a/pkg/scheduler/metrics/metrics_test.go
+++ b/pkg/scheduler/metrics/metrics_test.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2026 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+)
+
+func TestRegisterEvictionTransaction(t *testing.T) {
+	const action = "test-action"
+
+	counter := evictionTransactions.WithLabelValues(action)
+	before := testutil.ToFloat64(counter)
+
+	RegisterEvictionTransaction(action)
+
+	if got := testutil.ToFloat64(counter); got != before+1 {
+		t.Fatalf("eviction transaction counter = %v, want %v", got, before+1)
+	}
+}

--- a/pkg/scheduler/metrics/metrics_test.go
+++ b/pkg/scheduler/metrics/metrics_test.go
@@ -31,6 +31,7 @@ func TestRegisterEvictionTransaction(t *testing.T) {
 	}
 
 	for _, action := range actions {
+		action := action
 		t.Run(action, func(t *testing.T) {
 			counter := evictionTransactions.WithLabelValues(action)
 			before := testutil.ToFloat64(counter)


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/area scheduling
/area metrics

#### What this PR does / why we need it:

This PR adds a low-cardinality Counter:

```text
volcano_eviction_transactions_total{action}
```

It records one scheduler `Statement` containing at least one eviction operation after that Statement reaches `Commit()`.

The bounded `action` label supports:

| Action | Queue scope | Gang-level |
|---|---|---|
| `preempt` | Same queue | No |
| `reclaim` | Cross queue | No |
| `gangpreempt` | Same queue | Yes |
| `gangreclaim` | Cross queue | Yes |

A discarded Statement does not increment the Counter. A committed Statement containing multiple victim Pods increments it once. The metric represents a committed scheduler decision, not a victim Pod count or confirmation that every asynchronous Kubernetes Pod deletion completed successfully.

Implementation details:

- Adds `Statement.HasEvictions()` to detect whether a transaction contains an eviction operation.
- Updates the Counter only after the commit decision in all four actions.
- Covers both commit paths in the legacy `preempt` action.
- Adds unit tests for Statement eviction detection and Counter increments.
- Documents the metric in `docs/design/metrics.md`.

This metric complements rather than replaces the related observability work:

| Related work | Signal |
|---|---|
| #4040 / #4412 | Per-victim Pod, Node, and Queue attribution |
| #5223 / #5226 | Non-gang reclaim attempts and victim-count distribution |
| #5661 / #5662 | Gang preemption/reclaim attempts and latest victim counts |
| This PR | Committed eviction transaction count across all four actions |

Attempt, victim, attribution, and committed-transaction metrics have different counting units and should not be treated as interchangeable.

#### Which issue(s) this PR fixes:

Fixes #5753

#### Special notes for your reviewer:

Local validation:

```text
hack/verify-gofmt.sh
git diff --check
go test -count=1 \
  ./pkg/scheduler/metrics \
  ./pkg/scheduler/framework \
  ./pkg/scheduler/actions/preempt \
  ./pkg/scheduler/actions/reclaim \
  ./pkg/scheduler/actions/gangpreempt \
  ./pkg/scheduler/actions/gangreclaim
```

A locally built scheduler was also deployed into a one-node kind Kubernetes v1.36.1 cluster. Independent workloads triggered all four paths:

| Action | Requester result | Victim count changed | Counter increment |
|---|---|---|---|
| `preempt` | Running | Yes | `1` |
| `reclaim` | Running | Yes | `1` |
| `gangpreempt` | Running | Yes | `1` |
| `gangreclaim` | Running | Yes | `1` |

The counters remained unchanged during subsequent idle scheduling cycles. The cluster validation used the same implementation under the provisional series name `volcano_eviction_events_total`; the final change renamed the series and helper to `eviction_transactions` without changing the counting logic, and the complete local test set above was rerun after the rename.

For comparison, `volcano_total_preemption_attempts` had already reached 100 before the first real eviction in the preempt scenario, demonstrating why attempt count and committed eviction transaction count are distinct.

AI assistance disclosure: OpenAI Codex was used for source inspection, implementation assistance, tests, kind-based validation, and drafting this PR. I reviewed the resulting changes and validation evidence.

Volcano rhyme:

> When queues run hot beneath the load,  
> Volcano clears a measured road;  
> Each committed choice is now in sight,  
> So operators can read it right.

Consolidated user prompt supplied to Codex:

> Analyze the current Volcano eviction metrics, implement a low-cardinality counter that counts committed eviction occurrences across preempt, reclaim, gangpreempt, and gangreclaim, validate it using unit tests and a minimal kind Kubernetes cluster, and prepare the related Issue and PR while explaining how the metric complements existing attempts, victim-count, and attribution work.

#### Does this PR introduce a user-facing change?

```release-note
Add `volcano_eviction_transactions_total`, labeled by scheduler action, to count committed preempt, reclaim, gangpreempt, and gangreclaim transactions containing evictions.
```
