### PR TITLE
fix(owners): set 'devzizu' as reviewer in OWNERS.md

### DIFF
--- a/pkg/scheduler/OWNERS
+++ b/pkg/scheduler/OWNERS
@@ -12,7 +12,6 @@ approvers:
   - kingeasternsun
   - JesseStutler
   - hajnalmt
-  - devzizu
 reviewers:
   - k82cn
   - animeshsingh
@@ -29,3 +28,4 @@ reviewers:
   - wangyang0616
   - hajnalmt
   - dafu-wu
+  - devzizu

--- a/pkg/scheduler/plugins/OWNERS
+++ b/pkg/scheduler/plugins/OWNERS
@@ -7,7 +7,6 @@ approvers:
   - qiankunli
   - archlitchi
   - hajnalmt
-  - devzizu
 reviewers:
   - k82cn
   - animeshsingh
@@ -21,3 +20,4 @@ reviewers:
   - archlitchi
   - hajnalmt
   - dafu-wu
+  - devzizu


### PR DESCRIPTION
Original PR (https://github.com/volcano-sh/volcano/pull/5736) intent was to set @devzizu as reviewer, but it was accidentally set in the `approvers` list. This PR fixes the intent by setting it as `reviewer`.