### PR TITLE
job controller: skip stale cache cleanup for recreated jobs

### DIFF
--- a/pkg/controllers/cache/cache.go
+++ b/pkg/controllers/cache/cache.go
@@ -371,9 +371,20 @@ func (jc *jobCache) processCleanupJob() bool {
 	jc.Mutex.Lock()
 	defer jc.Mutex.Unlock()
 
+	key := keyFn(job.Namespace, job.Name)
+	// A rate-limited cleanup task can outlive the JobInfo it was scheduled
+	// for: if the job is deleted and recreated under the same key while a
+	// previous, already-scheduled retry is still pending, that stale retry
+	// must not be allowed to evict the cache entry of the recreated job.
+	// Only proceed if this task's JobInfo is still the one currently cached
+	// for this key.
+	if current, found := jc.jobs[key]; !found || current != job {
+		jc.deletedJobs.Forget(job)
+		return true
+	}
+
 	if jobTerminated(job) {
 		jc.deletedJobs.Forget(job)
-		key := keyFn(job.Namespace, job.Name)
 		delete(jc.jobs, key)
 		klog.V(3).Infof("Job <%s> was deleted.", key)
 	} else {

--- a/pkg/controllers/cache/cache_test.go
+++ b/pkg/controllers/cache/cache_test.go
@@ -394,6 +394,50 @@ func TestJobCache_Delete(t *testing.T) {
 	}
 }
 
+func TestJobCache_ProcessCleanupJob_SkipsStaleGeneration(t *testing.T) {
+	namespace := "test"
+	name := "job1"
+	key := JobKeyByName(namespace, name)
+
+	jc := New().(*jobCache)
+
+	// staleInfo represents a generation of the job whose cleanup was
+	// already scheduled (Job == nil, no pods left), mirroring what the
+	// cache looks like right after Delete() drains it.
+	staleInfo := &apis.JobInfo{
+		Namespace: namespace,
+		Name:      name,
+		Pods:      make(map[string]map[string]*v1.Pod),
+	}
+
+	// liveInfo represents the job having been recreated under the same
+	// key before the stale generation's queued retry got a chance to run,
+	// e.g. a duplicate rate-limited retry left over from before the
+	// recreation firing late.
+	liveInfo := &apis.JobInfo{}
+	liveInfo.SetJob(&v1alpha1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+	})
+	jc.jobs[key] = liveInfo
+
+	jc.deletedJobs.Add(staleInfo)
+
+	if !jc.processCleanupJob() {
+		t.Fatalf("expected processCleanupJob to process an item")
+	}
+
+	got, found := jc.jobs[key]
+	if !found {
+		t.Fatalf("expected the live job to remain cached, but it was removed")
+	}
+	if got != liveInfo {
+		t.Fatalf("expected the cached job info to be untouched by the stale cleanup task")
+	}
+}
+
 func TestJobCache_AddPod(t *testing.T) {
 	namespace := "test"
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The job cache removes a job by pushing it onto a rate-limited work queue
and retrying with backoff (`retryDeleteJob`) until all of its pods are
gone. If a job is deleted and quickly recreated under the same
namespace/name, an earlier retry scheduled for the old generation can
still fire after the new job has already been re-added to the cache.

`processCleanupJob` only looked the cache entry up by key before
deleting it:

```go
if jobTerminated(job) {
    jc.deletedJobs.Forget(job)
    key := keyFn(job.Namespace, job.Name)
    delete(jc.jobs, key)
    ...
}
```

Because the lookup is by key and not by the specific `JobInfo` the
retry was scheduled for, a late-firing retry belonging to the old,
already-cleaned-up generation ends up deleting whatever is currently
cached under that key, even if it's the live, recreated job. Once that
happens the job's cache entry is gone and it never gets scheduled
again.

This PR checks that the queued `JobInfo` is still the entry currently
cached for that key before removing it. If the cache has moved on to a
newer generation, the stale retry is simply forgotten instead of
evicting the live entry.

Added a unit test that reproduces the race directly: a stale,
already-terminated `JobInfo` is queued for cleanup while a different,
live `JobInfo` occupies the same key (simulating the recreate), and
asserts the live entry survives `processCleanupJob`.

#### Which issue(s) this PR fixes:

Fixes #3968

#### Special notes for your reviewer:

The fix is scoped to `processCleanupJob` in `pkg/controllers/cache/cache.go`
and doesn't change the cache's external behavior for the normal
(non-racing) delete path.

#### Does this PR introduce a user-facing change?

```release-note
Fix a race in the job controller cache where a stale, rate-limited cleanup retry from a deleted job could evict the cache entry of a job recreated with the same name, leaving it stuck and never scheduled.
```
