### PR TITLE
fix(predicates): enforce ReadWriteOncePod volume restrictions

### DIFF
--- a/pkg/scheduler/plugins/predicates/predicates.go
+++ b/pkg/scheduler/plugins/predicates/predicates.go
@@ -44,6 +44,7 @@ import (
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/podtopologyspread"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/tainttoleration"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/volumebinding"
+	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/volumerestrictions"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/volumezone"
 
 	"volcano.sh/volcano/pkg/scheduler/api"
@@ -362,6 +363,17 @@ func (pp *PredicatesPlugin) OnSessionOpen(ssn *framework.Session) {
 			}
 		}
 
+		if volumeRestrictionsFilter, exist := pp.FilterPlugins[volumerestrictions.Name].(*volumerestrictions.VolumeRestrictions); exist {
+			if !handleSkipPredicatePlugin(cycleState, volumeRestrictionsFilter.Name()) {
+				status := volumeRestrictionsFilter.AddPod(ctx, cycleState, taskToSchedule.Pod, podInfoToAdd, k8sNodeInfo)
+				if !status.IsSuccess() {
+					return fmt.Errorf("failed to add pod to node %s: %w", nodeInfo.Name, status.AsError())
+				}
+			}
+		} else {
+			return fmt.Errorf("failed to call %s plugin for task %s/%s on node %s, plugin does not exist", volumerestrictions.Name, taskToAdd.Namespace, taskToAdd.Name, nodeInfo.Name)
+		}
+
 		return nil
 	})
 
@@ -388,6 +400,17 @@ func (pp *PredicatesPlugin) OnSessionOpen(ssn *framework.Session) {
 				return fmt.Errorf("failed to call %s plugin for task %s/%s on node %s, plugin does not exist", interpodaffinity.Name, taskToRemove.Namespace, taskToRemove.Name, nodeInfo.Name)
 			}
 		}
+
+		if volumeRestrictionsFilter, exist := pp.FilterPlugins[volumerestrictions.Name].(*volumerestrictions.VolumeRestrictions); exist {
+			if !handleSkipPredicatePlugin(cycleState, volumeRestrictionsFilter.Name()) {
+				status := volumeRestrictionsFilter.RemovePod(ctx, cycleState, taskToSchedule.Pod, podInfoToRemove, k8sNodeInfo)
+				if !status.IsSuccess() {
+					return fmt.Errorf("failed to remove pod from node %s: %w", nodeInfo.Name, status.AsError())
+				}
+			}
+		} else {
+			return fmt.Errorf("failed to call %s plugin for task %s/%s on node %s, plugin does not exist", volumerestrictions.Name, taskToRemove.Namespace, taskToRemove.Name, nodeInfo.Name)
+		}
 		return nil
 	})
 
@@ -409,6 +432,17 @@ func (pp *PredicatesPlugin) OnSessionOpen(ssn *framework.Session) {
 				} else {
 					return fmt.Errorf("failed to call %s plugin for task %s/%s on node %s, plugin does not exist", interpodaffinity.Name, task.Namespace, task.Name, node.Name)
 				}
+			}
+		}
+
+		if !handleSkipPredicatePlugin(cycleState, volumerestrictions.Name) {
+			if volumeRestrictionsFilter, exist := pp.FilterPlugins[volumerestrictions.Name]; exist {
+				status := volumeRestrictionsFilter.Filter(ctx, cycleState, task.Pod, k8sNodeInfo)
+				if !status.IsSuccess() {
+					return fmt.Errorf("failed to filter pod on node %s: %w", node.Name, status.AsError())
+				}
+			} else {
+				return fmt.Errorf("failed to call %s plugin for task %s/%s on node %s, plugin does not exist", volumerestrictions.Name, task.Namespace, task.Name, node.Name)
 			}
 		}
 
@@ -576,7 +610,15 @@ func (pp *PredicatesPlugin) InitPlugin() {
 			klog.Errorf("Failed to init %s plugin %v", nodevolumelimits.CSIName, err)
 		}
 	}
-	// 7. VolumeZone
+	// 7. VolumeRestrictions
+	if plugin, err := volumerestrictions.New(context.TODO(), nil, pp.Handle, pp.features); err == nil {
+		volumeRestrictionsFilter := plugin.(*volumerestrictions.VolumeRestrictions)
+		addFilterPlugin(volumerestrictions.Name, volumeRestrictionsFilter)
+		addPreFilterPlugin(volumerestrictions.Name, volumeRestrictionsFilter)
+	} else {
+		klog.Errorf("Failed to init %s plugin %v", volumerestrictions.Name, err)
+	}
+	// 8. VolumeZone
 	if pp.enabledPredicates.volumeZoneEnable {
 		if plugin, err := volumezone.New(context.TODO(), nil, pp.Handle, pp.features); err == nil {
 			volumeZoneFilter := plugin.(*volumezone.VolumeZone)
@@ -586,7 +628,7 @@ func (pp *PredicatesPlugin) InitPlugin() {
 			klog.Errorf("Failed to init %s plugin %v", volumezone.Name, err)
 		}
 	}
-	// 8. PodTopologySpread
+	// 9. PodTopologySpread
 	if pp.enabledPredicates.podTopologySpreadEnable {
 		// Setting cluster level default constraints is not support for now.
 		ptsArgs := &config.PodTopologySpreadArgs{DefaultingType: config.SystemDefaulting}
@@ -598,7 +640,7 @@ func (pp *PredicatesPlugin) InitPlugin() {
 			klog.Errorf("Failed to init %s plugin %v", podtopologyspread.Name, err)
 		}
 	}
-	// 9. VolumeBinding
+	// 10. VolumeBinding
 	if pp.enabledPredicates.volumeBindingEnable {
 		vbArgs := defaultVolumeBindingArgs()
 		// Currently, we support initializing the VolumeBinding plugin once, but do not support hot loading the plugin after modifying the VolumeBinding parameters.
@@ -621,7 +663,7 @@ func (pp *PredicatesPlugin) InitPlugin() {
 		addPreBindPlugin(volumebinding.Name, volumeBindingPluginInstance)
 		addScorePlugin(volumebinding.Name, volumeBindingPluginInstance, vbArgs.Weight)
 	}
-	// 10. DRA
+	// 11. DRA
 	if pp.enabledPredicates.dynamicResourceAllocationEnable {
 		draArgs := defaultDynamicResourcesArgs()
 		setUpDynamicResourcesArgs(draArgs, pp.pluginArguments)

--- a/pkg/scheduler/plugins/predicates/predicates_test.go
+++ b/pkg/scheduler/plugins/predicates/predicates_test.go
@@ -40,6 +40,7 @@ import (
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/podtopologyspread"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/tainttoleration"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/volumebinding"
+	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/volumerestrictions"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/volumezone"
 
 	schedulingv1beta1 "volcano.sh/apis/pkg/apis/scheduling/v1beta1"
@@ -378,6 +379,83 @@ func TestPodAntiAffinity(t *testing.T) {
 	}
 }
 
+func TestReadWriteOncePodPreemption(t *testing.T) {
+	const (
+		namespace = "ns1"
+		claimName = "data"
+		nodeName  = "node1"
+	)
+	pvc := &apiv1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: claimName},
+		Spec: apiv1.PersistentVolumeClaimSpec{
+			AccessModes: []apiv1.PersistentVolumeAccessMode{apiv1.ReadWriteOncePod},
+		},
+	}
+	preempteePod := util.BuildPodWithPVC(namespace, "preemptee", nodeName, apiv1.PodRunning,
+		api.BuildResourceList("1", "1G"), pvc, "pg1", nil, nil)
+	preemptorPod := util.BuildPodWithPVC(namespace, "preemptor", "", apiv1.PodPending,
+		api.BuildResourceList("1", "1G"), pvc, "pg2", nil, nil)
+
+	test := uthelper.TestCommonStruct{
+		Name:    "preempt pod using ReadWriteOncePod PVC",
+		Plugins: map[string]framework.PluginBuilder{PluginName: New},
+		Pods:    []*apiv1.Pod{preempteePod, preemptorPod},
+		Nodes:   []*apiv1.Node{util.BuildNode(nodeName, api.BuildResourceList("2", "2G", []api.ScalarResource{{Name: "pods", Value: "10"}}...), nil)},
+		PodGroups: []*schedulingv1beta1.PodGroup{
+			util.BuildPodGroup("pg1", namespace, "q1", 0, nil, schedulingv1beta1.PodGroupRunning),
+			util.BuildPodGroup("pg2", namespace, "q1", 1, nil, schedulingv1beta1.PodGroupInqueue),
+		},
+		Queues: []*schedulingv1beta1.Queue{util.BuildQueue("q1", 1, api.BuildResourceList("2", "2G"))},
+		PVCs:   []*apiv1.PersistentVolumeClaim{pvc},
+	}
+	enabled := true
+	tiers := []conf.Tier{
+		{
+			Plugins: []conf.PluginOption{
+				{
+					Name:               PluginName,
+					EnabledPredicate:   &enabled,
+					EnabledPreemptable: &enabled,
+					Arguments: map[string]interface{}{
+						NodeVolumeLimitsEnable: false,
+						VolumeBindingEnable:    false,
+						VolumeZoneEnable:       false,
+					},
+				},
+			},
+		},
+	}
+
+	ssn := test.RegisterSession(tiers, nil)
+	defer test.Close()
+	preemptee := api.NewTaskInfo(preempteePod)
+	preemptor := api.NewTaskInfo(preemptorPod)
+	state := ssn.GetCycleState(preemptor.UID)
+	if err := ssn.PrePredicateFn(preemptor); err != nil {
+		t.Fatalf("unexpected PrePredicate error: %v", err)
+	}
+	nodeInfo := ssn.Nodes[nodeName]
+	if err := ssn.SimulatePredicateFn(context.Background(), state, preemptor, nodeInfo); err == nil {
+		t.Fatal("expected RWOP conflict before removing preemptee")
+	}
+	if err := ssn.SimulateRemoveTaskFn(context.Background(), state, preemptor, preemptee, nodeInfo); err != nil {
+		t.Fatalf("failed to simulate preemptee removal: %v", err)
+	}
+	nodeInfo.RemoveTask(preemptee)
+	if err := ssn.SimulatePredicateFn(context.Background(), state, preemptor, nodeInfo); err != nil {
+		t.Fatalf("expected preemptor to fit after removing RWOP holder: %v", err)
+	}
+	if err := ssn.SimulateAddTaskFn(context.Background(), state, preemptor, preemptee, nodeInfo); err != nil {
+		t.Fatalf("failed to simulate preemptee addition: %v", err)
+	}
+	if err := nodeInfo.AddTask(preemptee); err != nil {
+		t.Fatalf("failed to add preemptee: %v", err)
+	}
+	if err := ssn.SimulatePredicateFn(context.Background(), state, preemptor, nodeInfo); err == nil {
+		t.Fatal("expected RWOP conflict after adding preemptee back")
+	}
+}
+
 func TestSetUpDynamicResourcesArgs_Default(t *testing.T) {
 	dra := defaultDynamicResourcesArgs()
 	setUpDynamicResourcesArgs(dra, nil)
@@ -451,9 +529,9 @@ func TestInitPlugin(t *testing.T) {
 			enablePodTopologySpread: true,
 			enableVolumeBinding:     false,
 			enableDRA:               false,
-			expectInFilter:          []string{nodeunschedulable.Name, nodeaffinity.Name, nodeports.Name, tainttoleration.Name, interpodaffinity.Name, nodevolumelimits.CSIName, volumezone.Name, podtopologyspread.Name},
+			expectInFilter:          []string{nodeunschedulable.Name, nodeaffinity.Name, nodeports.Name, tainttoleration.Name, interpodaffinity.Name, nodevolumelimits.CSIName, volumerestrictions.Name, volumezone.Name, podtopologyspread.Name},
 			expectInStableFilter:    []string{nodeunschedulable.Name, nodeaffinity.Name, tainttoleration.Name},
-			expectInPrefilter:       []string{nodeaffinity.Name, nodeports.Name, interpodaffinity.Name, nodevolumelimits.CSIName, volumezone.Name, podtopologyspread.Name},
+			expectInPrefilter:       []string{nodeaffinity.Name, nodeports.Name, interpodaffinity.Name, nodevolumelimits.CSIName, volumerestrictions.Name, volumezone.Name, podtopologyspread.Name},
 			expectInReserve:         []string{},
 			expectInPreBind:         []string{},
 			expectInScore:           []string{},
@@ -473,9 +551,9 @@ func TestInitPlugin(t *testing.T) {
 			enablePodTopologySpread: false,
 			enableVolumeBinding:     true,
 			enableDRA:               false,
-			expectInFilter:          []string{nodeunschedulable.Name, nodeaffinity.Name, tainttoleration.Name, volumebinding.Name},
+			expectInFilter:          []string{nodeunschedulable.Name, nodeaffinity.Name, tainttoleration.Name, volumerestrictions.Name, volumebinding.Name},
 			expectInStableFilter:    []string{nodeunschedulable.Name, nodeaffinity.Name, tainttoleration.Name},
-			expectInPrefilter:       []string{volumebinding.Name},
+			expectInPrefilter:       []string{volumerestrictions.Name, volumebinding.Name},
 			expectInReserve:         []string{volumebinding.Name},
 			expectInPreBind:         []string{volumebinding.Name},
 			expectInScore:           []string{volumebinding.Name},
@@ -494,9 +572,9 @@ func TestInitPlugin(t *testing.T) {
 			enablePodTopologySpread: false,
 			enableVolumeBinding:     false,
 			enableDRA:               true,
-			expectInFilter:          []string{nodeunschedulable.Name, nodeaffinity.Name, tainttoleration.Name, dynamicresources.Name},
+			expectInFilter:          []string{nodeunschedulable.Name, nodeaffinity.Name, tainttoleration.Name, volumerestrictions.Name, dynamicresources.Name},
 			expectInStableFilter:    []string{nodeunschedulable.Name, nodeaffinity.Name, tainttoleration.Name},
-			expectInPrefilter:       []string{nodeaffinity.Name, dynamicresources.Name},
+			expectInPrefilter:       []string{nodeaffinity.Name, volumerestrictions.Name, dynamicresources.Name},
 			expectInReserve:         []string{dynamicresources.Name},
 			expectInPreBind:         []string{dynamicresources.Name},
 			expectInScore:           []string{},
@@ -516,9 +594,9 @@ func TestInitPlugin(t *testing.T) {
 			enablePodTopologySpread: true,
 			enableVolumeBinding:     true,
 			enableDRA:               true,
-			expectInFilter:          []string{nodeunschedulable.Name, nodeaffinity.Name, nodeports.Name, tainttoleration.Name, interpodaffinity.Name, nodevolumelimits.CSIName, volumezone.Name, podtopologyspread.Name, volumebinding.Name, dynamicresources.Name},
+			expectInFilter:          []string{nodeunschedulable.Name, nodeaffinity.Name, nodeports.Name, tainttoleration.Name, interpodaffinity.Name, nodevolumelimits.CSIName, volumerestrictions.Name, volumezone.Name, podtopologyspread.Name, volumebinding.Name, dynamicresources.Name},
 			expectInStableFilter:    []string{nodeunschedulable.Name, nodeaffinity.Name, tainttoleration.Name},
-			expectInPrefilter:       []string{nodeports.Name, interpodaffinity.Name, podtopologyspread.Name, volumebinding.Name, dynamicresources.Name},
+			expectInPrefilter:       []string{nodeports.Name, interpodaffinity.Name, volumerestrictions.Name, podtopologyspread.Name, volumebinding.Name, dynamicresources.Name},
 			expectInReserve:         []string{volumebinding.Name, dynamicresources.Name},
 			expectInPreBind:         []string{volumebinding.Name, dynamicresources.Name},
 			expectInScore:           []string{volumebinding.Name},
@@ -623,6 +701,65 @@ func TestInitPlugin(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestVolumeRestrictionsReadWriteOncePod(t *testing.T) {
+	const (
+		namespace = "default"
+		claimName = "data"
+		nodeName  = "node-1"
+	)
+	pvc := &apiv1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: claimName},
+		Spec: apiv1.PersistentVolumeClaimSpec{
+			AccessModes: []apiv1.PersistentVolumeAccessMode{apiv1.ReadWriteOncePod},
+		},
+	}
+	existingPod := &apiv1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: "existing"},
+		Spec: apiv1.PodSpec{
+			NodeName: nodeName,
+			Volumes: []apiv1.Volume{
+				{
+					Name: "data",
+					VolumeSource: apiv1.VolumeSource{
+						PersistentVolumeClaim: &apiv1.PersistentVolumeClaimVolumeSource{ClaimName: claimName},
+					},
+				},
+			},
+		},
+	}
+	nodeInfo := schedframework.NewNodeInfo(existingPod)
+	nodeInfo.SetNode(&apiv1.Node{ObjectMeta: metav1.ObjectMeta{Name: nodeName}})
+	nodeMap := map[string]k8sframework.NodeInfo{nodeName: nodeInfo}
+
+	client := k8sfake.NewSimpleClientset(pvc)
+	informerFactory := informers.NewSharedInformerFactory(client, 0)
+	if err := informerFactory.Core().V1().PersistentVolumeClaims().Informer().GetStore().Add(pvc); err != nil {
+		t.Fatalf("failed to add PVC to informer store: %v", err)
+	}
+
+	pp := New(nil).(*PredicatesPlugin)
+	pp.enabledPredicates = predicateEnable{}
+	pp.Handle = k8s.NewFramework(
+		nodeMap,
+		k8s.WithClientSet(client),
+		k8s.WithInformerFactory(informerFactory),
+	)
+	pp.InitPlugin()
+
+	pod := existingPod.DeepCopy()
+	pod.Name = "pending"
+	pod.Spec.NodeName = ""
+	state := schedframework.NewCycleState()
+	preFilter := pp.PreFilterPlugins[volumerestrictions.Name]
+	if _, status := preFilter.PreFilter(context.Background(), state, pod, []k8sframework.NodeInfo{nodeInfo}); !status.IsSuccess() {
+		t.Fatalf("unexpected PreFilter status: %v", status)
+	}
+
+	status := pp.FilterPlugins[volumerestrictions.Name].Filter(context.Background(), state, pod, nodeInfo)
+	assert.Equal(t, k8sframework.Unschedulable, status.Code())
+	assert.Equal(t, volumerestrictions.ErrReasonReadWriteOncePodConflict, status.Message())
 }
 
 func TestPredicateFailureReasonAggregationOrderStable(t *testing.T) {

--- a/pkg/scheduler/plugins/util/k8s/snapshot.go
+++ b/pkg/scheduler/plugins/util/k8s/snapshot.go
@@ -416,7 +416,12 @@ func (s *Snapshot) Get(nodeName string) (fwk.NodeInfo, error) {
 }
 
 func (s *Snapshot) IsPVCUsedByPods(key string) bool {
-	panic("not implemented")
+	for _, nodeInfo := range s.fwkInfo.nodeInfoList {
+		if nodeInfo.GetPVCRefCounts()[key] > 0 {
+			return true
+		}
+	}
+	return false
 }
 
 func (s *Snapshot) GetGeneration() int64 {

--- a/pkg/scheduler/plugins/util/k8s/snapshot_test.go
+++ b/pkg/scheduler/plugins/util/k8s/snapshot_test.go
@@ -109,6 +109,38 @@ func TestSnapshot(t *testing.T) {
 	}
 }
 
+func TestSnapshotIsPVCUsedByPods(t *testing.T) {
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "pod",
+		},
+		Spec: v1.PodSpec{
+			NodeName: "node-1",
+			Volumes: []v1.Volume{
+				{
+					Name: "data",
+					VolumeSource: v1.VolumeSource{
+						PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
+							ClaimName: "data",
+						},
+					},
+				},
+			},
+		},
+	}
+	nodeInfo := framework.NewNodeInfo(pod)
+	nodeInfo.SetNode(&v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-1"}})
+	snapshot := NewSnapshot(map[string]fwk.NodeInfo{"node-1": nodeInfo})
+
+	if !snapshot.IsPVCUsedByPods("default/data") {
+		t.Error("expected PVC to be in use")
+	}
+	if snapshot.IsPVCUsedByPods("other/data") {
+		t.Error("expected PVC in another namespace to not be in use")
+	}
+}
+
 func TestSnapshot_AddOrUpdateNodes(t *testing.T) {
 	tests := []struct {
 		name        string


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Registers the Kubernetes `VolumeRestrictions` plugin in predicates and keeps its state updated during preemption simulation. This prevents a second pod from being scheduled with an in-use `ReadWriteOncePod` PVC.

#### Which issue(s) this PR fixes:

Fixes #5767

#### Special notes for your reviewer:

Tested the affected predicate and snapshot packages on Linux.

AI tooling was used during implementation. I reviewed the complete diff and verified the tests locally on my own.

#### Does this PR introduce a user-facing change?

```release-note
Enforce ReadWriteOncePod PVC exclusivity during predicate checks.