### PR TITLE
fix(scheduler): discard partially recovered operations when RecoverOperations fails

### DIFF
--- a/pkg/scheduler/actions/allocate/allocate.go
+++ b/pkg/scheduler/actions/allocate/allocate.go
@@ -446,6 +446,11 @@ func (alloc *Action) allocateForJob(job *api.JobInfo, jobWorksheet *JobWorksheet
 		finalStmt := framework.NewStatement(ssn)
 		if err = finalStmt.RecoverOperations(bestStmt); err != nil {
 			klog.ErrorS(err, "Failed to recover operations", "job", job.UID, "hyperNode", bestHyperNode)
+			// RecoverOperations replays operations one by one, so a failure part way
+			// through leaves the earlier ones applied to the session and recorded on
+			// finalStmt. Roll them back, otherwise they stay orphaned and corrupt node
+			// accounting and task statuses for the rest of the scheduling cycle.
+			finalStmt.Discard()
 			return nil
 		}
 
@@ -519,6 +524,9 @@ func (alloc *Action) allocateForSubJob(subJob *api.SubJobInfo, subJobWorksheet *
 		finalStmt := framework.NewStatement(ssn)
 		if err = finalStmt.RecoverOperations(bestStmt); err != nil {
 			klog.ErrorS(err, "Failed to recover operations", "subJob", subJob.UID, "hyperNode", bestHyperNode)
+			// See allocateForJob: partially applied operations must be rolled back or
+			// they remain orphaned in the session.
+			finalStmt.Discard()
 			return nil, 0
 		}
 		newAllocatedHyperNode := ssn.HyperNodes.GetLCAHyperNode(subJob.AllocatedHyperNode, bestHyperNode)

--- a/pkg/scheduler/actions/allocate/allocate.go
+++ b/pkg/scheduler/actions/allocate/allocate.go
@@ -502,6 +502,11 @@ func (alloc *Action) allocateForJob(job *api.JobInfo, jobWorksheet *JobWorksheet
 		finalStmt := framework.NewStatement(ssn)
 		if err = finalStmt.RecoverOperations(bestStmt); err != nil {
 			klog.ErrorS(err, "Failed to recover operations", "job", job.UID, "hyperNode", bestHyperNode)
+			// RecoverOperations replays operations one by one, so a failure part way
+			// through leaves the earlier ones applied to the session and recorded on
+			// finalStmt. Roll them back, otherwise they stay orphaned and corrupt node
+			// accounting and task statuses for the rest of the scheduling cycle.
+			finalStmt.Discard()
 			return nil
 		}
 
@@ -575,6 +580,9 @@ func (alloc *Action) allocateForSubJob(subJob *api.SubJobInfo, subJobWorksheet *
 		finalStmt := framework.NewStatement(ssn)
 		if err = finalStmt.RecoverOperations(bestStmt); err != nil {
 			klog.ErrorS(err, "Failed to recover operations", "subJob", subJob.UID, "hyperNode", bestHyperNode)
+			// See allocateForJob: partially applied operations must be rolled back or
+			// they remain orphaned in the session.
+			finalStmt.Discard()
 			return nil, 0
 		}
 		newAllocatedHyperNode := ssn.HyperNodes.GetLCAHyperNode(subJob.AllocatedHyperNode, bestHyperNode)

--- a/pkg/scheduler/framework/statement_recover_test.go
+++ b/pkg/scheduler/framework/statement_recover_test.go
@@ -77,3 +77,71 @@ func TestRecoverOperations_PipelinePreservesEvictionFlag(t *testing.T) {
 		assert.True(t, recoveredTask.EvictionOccurred)
 	}
 }
+
+// TestRecoverOperations_PartialFailureLeavesOperationsApplied documents the
+// invariant that callers of RecoverOperations depend on: the operations are
+// replayed one at a time, so a failure part way through leaves the earlier ones
+// applied to the session and recorded on the recovering statement. The caller
+// must Discard() them, otherwise they stay orphaned and corrupt node accounting
+// for the rest of the scheduling cycle.
+func TestRecoverOperations_PartialFailureLeavesOperationsApplied(t *testing.T) {
+	ssn, _, task, node := newTestSession(t)
+
+	// Build a plan that allocates the task, then record the node's idle capacity
+	// so the rollback can be checked against it.
+	idleBefore := node.Idle.Clone()
+
+	sourceStmt := NewStatement(ssn)
+	if err := sourceStmt.Allocate(task, node); err != nil {
+		t.Fatalf("expected Allocate to succeed, got: %v", err)
+	}
+	plan := SaveOperations(sourceStmt)
+	sourceStmt.Discard()
+
+	// Append a second operation targeting a node that is not in the session, so
+	// replay fails only after the first operation has already been applied. A
+	// Pipeline op is used because it resolves the node by name and reports a clean
+	// error, and its rollback touches only its own task.
+	orphanPod := task.Pod.DeepCopy()
+	orphanPod.Name = "orphan-pod"
+	orphanPod.UID = types.UID("orphan-pod")
+	plan.operations = append(plan.operations, operation{
+		name: Pipeline,
+		task: &api.TaskInfo{
+			UID:       "orphan-task",
+			Job:       task.Job,
+			Name:      "orphan-task",
+			Namespace: task.Namespace,
+			Resreq:    (&api.Resource{MilliCPU: 1000}).Clone(),
+			Pod:       orphanPod,
+			TransactionContext: api.TransactionContext{
+				NodeName: "nonexistent-node",
+				Status:   api.Pending,
+			},
+		},
+	})
+
+	recoverStmt := NewStatement(ssn)
+	err := recoverStmt.RecoverOperations(plan)
+	if err == nil {
+		t.Fatal("expected RecoverOperations to fail on the unresolvable node")
+	}
+
+	// The first operation is applied and recorded even though the call failed.
+	if len(recoverStmt.operations) == 0 {
+		t.Fatal("expected the successfully replayed operation to remain recorded on the statement")
+	}
+	if node.Idle.Equal(idleBefore, api.Zero) {
+		t.Fatal("expected node idle resources to be reduced by the applied operation")
+	}
+
+	// Only Discard puts the session back; without it these mutations are orphaned.
+	recoverStmt.Discard()
+
+	if !node.Idle.Equal(idleBefore, api.Zero) {
+		t.Errorf("expected node idle resources restored after Discard, got %v want %v", node.Idle, idleBefore)
+	}
+	if task.Status != api.Pending {
+		t.Errorf("expected task status Pending after Discard, got %v", task.Status)
+	}
+}


### PR DESCRIPTION
### What type of PR is this?

/kind bug

### What this PR does / why we need it

`allocateForJob` and `allocateForSubJob` in `pkg/scheduler/actions/allocate/allocate.go` return early when `RecoverOperations` fails, without discarding the statement:

```go
finalStmt := framework.NewStatement(ssn)
if err = finalStmt.RecoverOperations(bestStmt); err != nil {
    klog.ErrorS(err, "Failed to recover operations", ...)
    return nil   // no finalStmt.Discard()
}
```

`RecoverOperations` replays saved operations one at a time through `Evict` / `Pipeline` / `Allocate`. Each one mutates session state (`node.AddTask`, `job.UpdateTaskStatus`, plugin event handlers) and is appended to the recovering statement's operations. So when it fails on the Nth operation, operations 1..N-1 are already applied — and returning without `Discard()` leaves them orphaned, with no statement reference left to commit or roll them back. Nodes show reduced `Idle`, tasks sit in `Allocated`/`Pipelined`, and every remaining job in that scheduling cycle schedules against corrupted accounting.

This adds `finalStmt.Discard()` on both paths, which is how every other early return in this file releases a statement (lines 429, 501, 633, 865).

### Which issue(s) this PR fixes

Fixes #5362

### Testing

Added `TestRecoverOperations_PartialFailureLeavesOperationsApplied` to `pkg/scheduler/framework`. It builds a plan whose second operation targets a node absent from the session, so replay fails after the first operation has been applied, and asserts that:

- `RecoverOperations` returns an error,
- the successfully replayed operation is still recorded on the statement,
- the node's `Idle` resources remain consumed,
- and only `Discard()` restores the node's resources and the task's `Pending` status.

That is the invariant the callers depend on, and it is what makes the missing `Discard()` a correctness bug rather than a cosmetic one.

`pkg/scheduler/framework` and `pkg/scheduler/actions/allocate` suites both pass; `gofmt` and `go vet` are clean.

### Note for reviewers

While writing the test I noticed that `RecoverOperations` resolves an `Allocate` op's node with `node := s.ssn.Nodes[op.task.NodeName]` and passes the result straight to `Allocate`, which dereferences `nodeInfo.Name`, so an unguarded map miss would segfault. I raised that separately in #5778/#5779 and have since closed both: it is not reachable through the current call graph, because `SaveOperations` stores `op.task.Clone()` and the replayed op keeps the `NodeName` it recorded. Noting it here only so the earlier cross-reference is not left dangling — it has no bearing on this PR.

Disclosure: this change was prepared with the assistance of an AI coding agent. The analysis, fix, and test were verified against the source and the existing suites before submitting.
