### PR TITLE
scheduler/capacity: guard AddUnifiedEvictableFn against nil job/queue attrs

### DIFF
--- a/pkg/scheduler/plugins/capacity/capacity.go
+++ b/pkg/scheduler/plugins/capacity/capacity.go
@@ -622,7 +622,17 @@ func (cp *capacityPlugin) OnSessionOpen(ssn *framework.Session) {
 		allocations := map[api.QueueID]*api.Resource{}
 		for _, reclaimee := range candidates {
 			job := ssn.Jobs[reclaimee.Job]
+			if job == nil {
+				klog.Warningf("[capacity] Skip reclaimee <%s/%s>: job <%s> not found in session (orphaned task from deleted PodGroup)",
+					reclaimee.Namespace, reclaimee.Name, reclaimee.Job)
+				continue
+			}
 			attr := cp.queueOpts[job.Queue]
+			if attr == nil {
+				klog.Warningf("[capacity] Skip reclaimee <%s/%s>: queue <%s> not found in queueOpts",
+					reclaimee.Namespace, reclaimee.Name, job.Queue)
+				continue
+			}
 			if _, found := allocations[job.Queue]; !found {
 				allocations[job.Queue] = attr.allocated.Clone()
 			}

--- a/pkg/scheduler/plugins/capacity/capacity_test.go
+++ b/pkg/scheduler/plugins/capacity/capacity_test.go
@@ -1435,6 +1435,105 @@ func Test_buildHierarchicalQueueAttrs_nilSafety(t *testing.T) {
 	}
 }
 
+// Test_capacityPlugin_UnifiedEvictableFn_NilSafety is a regression test for
+// https://github.com/volcano-sh/volcano/issues/5782: the GangReclaim branch of
+// AddUnifiedEvictableFn dereferenced the reclaimee's job/queue attributes without
+// the nil checks that the sibling AddReclaimableFn already applies, so a
+// gang-reclaim candidate belonging to a job that's no longer in the session (or
+// whose queue isn't tracked in queueOpts) panicked the scheduler instead of being
+// skipped.
+func Test_capacityPlugin_UnifiedEvictableFn_NilSafety(t *testing.T) {
+	plugins := map[string]framework.PluginBuilder{PluginName: New, predicates.PluginName: predicates.New, gang.PluginName: gang.New}
+	trueValue := true
+
+	n1 := util.BuildNode("n1", api.BuildResourceList("4", "4Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), map[string]string{})
+	p1 := util.BuildPod("ns1", "p1", "n1", corev1.PodRunning, api.BuildResourceList("1", "1Gi"), "pg1", make(map[string]string), make(map[string]string))
+	pg1 := util.BuildPodGroup("pg1", "ns1", "q1", 1, nil, schedulingv1beta1.PodGroupRunning)
+	queue1 := util.BuildQueueWithResourcesQuantity("q1", nil, api.BuildResourceList("2", "2Gi"))
+
+	tiers := []conf.Tier{
+		{
+			Plugins: []conf.PluginOption{
+				{
+					Name:               PluginName,
+					EnabledAllocatable: &trueValue,
+					EnabledReclaimable: &trueValue,
+					EnabledQueueOrder:  &trueValue,
+				},
+				{
+					Name:             predicates.PluginName,
+					EnabledPredicate: &trueValue,
+				},
+				{
+					Name:               gang.PluginName,
+					EnabledJobStarving: &trueValue,
+				},
+			},
+		},
+	}
+
+	test := &uthelper.TestCommonStruct{
+		Plugins:   plugins,
+		Pods:      []*corev1.Pod{p1},
+		Nodes:     []*corev1.Node{n1},
+		PodGroups: []*schedulingv1beta1.PodGroup{pg1},
+		Queues:    []*schedulingv1beta1.Queue{queue1},
+	}
+	ssn := test.RegisterSession(tiers, nil)
+	defer test.Close()
+
+	ctx := &api.EvictionContext{Kind: api.EvictionKindGangReclaim}
+
+	// orphanTask simulates a gang-reclaim candidate whose job was deleted from the
+	// session (e.g. the PodGroup was removed) between when the candidate list was
+	// built and when this callback runs: reclaimee.Job doesn't resolve in ssn.Jobs.
+	orphanTask := &api.TaskInfo{
+		UID:       "orphan-task",
+		Job:       "ns1/deleted-job",
+		Name:      "orphan",
+		Namespace: "ns1",
+		Resreq:    api.EmptyResource(),
+	}
+
+	// Must not panic: previously `job := ssn.Jobs[reclaimee.Job]` followed by
+	// `job.Queue` would dereference a nil job here.
+	victims := ssn.UnifiedEvictable(ctx, []*api.TaskInfo{orphanTask})
+	for _, v := range victims {
+		if v.UID == orphanTask.UID {
+			t.Fatalf("expected orphaned task with no matching job to be skipped, not returned as a victim")
+		}
+	}
+
+	// ghostQueueJob simulates a job whose queue was removed from queueOpts after
+	// buildQueueAttrs ran for this session (queue deleted mid-cycle): the job
+	// itself resolves, but cp.queueOpts[job.Queue] does not.
+	ghostQueueJob := api.NewJobInfo("ghost-queue-job")
+	ghostQueueJob.SetPodGroup(&api.PodGroup{
+		PodGroup: scheduling.PodGroup{
+			ObjectMeta: metav1.ObjectMeta{Name: "ghost-queue-job", Namespace: "ns1"},
+			Spec:       scheduling.PodGroupSpec{Queue: "ghost-queue"},
+			Status:     scheduling.PodGroupStatus{Phase: scheduling.PodGroupRunning},
+		},
+	})
+	ssn.Jobs[ghostQueueJob.UID] = ghostQueueJob
+	ghostQueueTask := &api.TaskInfo{
+		UID:       "ghost-queue-task",
+		Job:       ghostQueueJob.UID,
+		Name:      "ghost-queue-task",
+		Namespace: "ns1",
+		Resreq:    api.EmptyResource(),
+	}
+
+	// Must not panic: previously `attr := cp.queueOpts[job.Queue]` followed by
+	// `attr.allocated.Clone()` would dereference a nil attr here.
+	victims = ssn.UnifiedEvictable(ctx, []*api.TaskInfo{ghostQueueTask})
+	for _, v := range victims {
+		if v.UID == ghostQueueTask.UID {
+			t.Fatalf("expected task from a queue missing in queueOpts to be skipped, not returned as a victim")
+		}
+	}
+}
+
 // TestNoDoubleCountingForInqueueJobWithBindingTasks is a regression test for a
 // double-counting bug in the capacity plugin.
 //


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The GangReclaim branch of `AddUnifiedEvictableFn` in the capacity plugin looks up the reclaimee's job and queue attribute and dereferences them immediately, with no nil check:

```go
job := ssn.Jobs[reclaimee.Job]
attr := cp.queueOpts[job.Queue]
```

If a candidate's job was already removed from the session (job/PodGroup deleted mid-cycle) or its queue isn't tracked in `queueOpts`, this panics the scheduler instead of just skipping the candidate.

The sibling function `AddReclaimableFn`, a few dozen lines above in the same file, already guards against exactly this with a nil check and a `continue`. This PR applies the same pattern to `AddUnifiedEvictableFn` so a stale/orphaned candidate is skipped with a warning log instead of crashing the scheduling cycle.

Added a regression test that exercises both nil-guard paths directly against the plugin's registered `UnifiedEvictableFn` (a task whose job is missing from the session, and a task whose job exists but whose queue is missing from `queueOpts`), confirming neither panics and both are excluded from the returned victims.

#### Which issue(s) this PR fixes:
Fixes #5782

#### Special notes for your reviewer:

None.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
