### PR TITLE
job scheduler: fix preemption stuck Pending for fractional vGPU requests (vgpu-memory-percentage)

### DIFF
--- a/pkg/scheduler/actions/preempt/preempt.go
+++ b/pkg/scheduler/actions/preempt/preempt.go
@@ -342,14 +342,16 @@ func (pmpt *Action) preempt(
 //
 // It can never be satisfied, however, for resources a device plugin tracks
 // entirely through its own predicate/ledger instead of node.Status.Allocatable
-// - e.g. volcano.sh/vgpu-cores and volcano.sh/vgpu-memory-percentage, which by
-// design are never advertised as node capacity (see
-// docs/user-guide/how_to_use_volcano_vgpu.md) because "50% of one card" isn't
-// a poolable node-wide quantity. When every failing dimension is one of
-// these - node.Allocatable has no capacity number for it at all - the
-// comparison is structurally unable to answer the question, so fall back to
-// the real per-plugin predicate (which deviceshare uses for the correct,
-// device-aware fit check) instead of treating "unknowable" as "no".
+// - confirmed for volcano.sh/vgpu-memory-percentage, which is a pure
+// request-side modifier ("50% of whatever card this pod lands on" has no
+// coherent node-wide capacity total to advertise) and is never referenced
+// anywhere as something written into Allocatable. volcano.sh/vgpu-cores may or
+// may not have the same gap depending on how the device plugin advertises it;
+// this fallback covers that case too if so, without assuming it either way.
+// When every failing dimension is one node.Allocatable has no capacity number
+// for at all, the comparison is structurally unable to answer the question,
+// so fall back to the real per-plugin predicate (which deviceshare uses for
+// the correct, device-aware fit check) instead of treating "unknowable" as "no".
 //
 // Note: this fallback is only as good as the registered predicate plugins.
 // A resource dimension that's neither in node.Allocatable NOR checked by any

--- a/pkg/scheduler/actions/preempt/preempt.go
+++ b/pkg/scheduler/actions/preempt/preempt.go
@@ -334,6 +334,57 @@ func (pmpt *Action) preempt(
 	return preemptSuccess, err
 }
 
+// fitsAfterEviction reports whether preemptor now fits on node. The generic
+// scalar-resource comparison is authoritative whenever every dimension it
+// flags as insufficient is one actually present in node.Allocatable (cpu,
+// memory, volcano.sh/vgpu-number, ...) - those have a real capacity number,
+// so the comparison can be trusted as-is, including a genuine "no" answer.
+//
+// It can never be satisfied, however, for resources a device plugin tracks
+// entirely through its own predicate/ledger instead of node.Status.Allocatable
+// - e.g. volcano.sh/vgpu-cores and volcano.sh/vgpu-memory-percentage, which by
+// design are never advertised as node capacity (see
+// docs/user-guide/how_to_use_volcano_vgpu.md) because "50% of one card" isn't
+// a poolable node-wide quantity. When every failing dimension is one of
+// these - node.Allocatable has no capacity number for it at all - the
+// comparison is structurally unable to answer the question, so fall back to
+// the real per-plugin predicate (which deviceshare uses for the correct,
+// device-aware fit check) instead of treating "unknowable" as "no".
+//
+// Note: this fallback is only as good as the registered predicate plugins.
+// A resource dimension that's neither in node.Allocatable NOR checked by any
+// registered predicate can't be judged by either mechanism - ssn.PredicateFn
+// simply has nothing to say about it and reports success. That matches
+// production configurations (the predicates plugin covers cpu/memory/pods;
+// deviceshare covers GPU shares), but a test harness that omits every plugin
+// covering a given dimension will see this fallback as permissive for it.
+func fitsAfterEviction(ssn *framework.Session, preemptor *api.TaskInfo, node *api.NodeInfo) bool {
+	ok, failing := preemptor.InitResreq.LessEqualWithResourcesName(node.FutureIdle(), api.Zero)
+	if ok {
+		return true
+	}
+	if !allUntrackedByAllocatable(failing, node) {
+		return false
+	}
+	return ssn.PredicateFn(preemptor, node) == nil
+}
+
+// allUntrackedByAllocatable reports whether every named resource dimension is
+// absent from node.Allocatable's tracked capacity. cpu/memory are always
+// considered tracked (they're dedicated Resource fields, not scalar entries,
+// and always have a real, if zero, capacity number).
+func allUntrackedByAllocatable(resourceNames []string, node *api.NodeInfo) bool {
+	for _, name := range resourceNames {
+		if name == "cpu" || name == "memory" {
+			return false
+		}
+		if _, present := node.Allocatable.ScalarResources[v1.ResourceName(name)]; present {
+			return false
+		}
+	}
+	return true
+}
+
 func (pmpt *Action) normalPreempt(
 	ssn *framework.Session,
 	stmt *framework.Statement,
@@ -369,7 +420,7 @@ func (pmpt *Action) normalPreempt(
 		victims := ssn.Preemptable(preemptor, preemptees)
 		metrics.UpdatePreemptionVictimsCount(len(victims))
 
-		if err := util.ValidateVictims(preemptor, node, victims); err != nil {
+		if err := util.ValidateVictims(preemptor, node, victims, ssn.PredicateFn); err != nil {
 			klog.V(3).Infof("No validated victims on Node <%s>: %v", node.Name, err)
 			continue
 		}
@@ -395,7 +446,7 @@ func (pmpt *Action) normalPreempt(
 			// so if current queue is not allocatable(the queue will be overused when consider current preemptor's requests)
 			// or current idle resource is not enough for preemptor, it need to continue preempting
 			// otherwise, break out
-			if ssn.Allocatable(currentQueue, preemptor) && preemptor.InitResreq.LessEqual(node.FutureIdle(), api.Zero) {
+			if ssn.Allocatable(currentQueue, preemptor) && fitsAfterEviction(ssn, preemptor, node) {
 				break
 			}
 			preemptee := victimsQueue.Pop().(*api.TaskInfo)
@@ -415,7 +466,7 @@ func (pmpt *Action) normalPreempt(
 			preempted, preemptor.Namespace, preemptor.Name, preemptor.InitResreq)
 
 		// If preemptor's queue is not allocatable, it means preemptor cannot be allocated. So no need care about the node idle resource
-		if ssn.Allocatable(currentQueue, preemptor) && preemptor.InitResreq.LessEqual(node.FutureIdle(), api.Zero) {
+		if ssn.Allocatable(currentQueue, preemptor) && fitsAfterEviction(ssn, preemptor, node) {
 			if err := nodeStmt.Pipeline(preemptor, node.Name, evictionOccurred); err != nil {
 				klog.Errorf("Failed to pipeline Task <%s/%s> on Node <%s>",
 					preemptor.Namespace, preemptor.Name, node.Name)
@@ -764,7 +815,7 @@ func SelectVictimsOnNode(
 	allVictims := ssn.Preemptable(preemptor, preemptees)
 	metrics.UpdatePreemptionVictimsCount(len(allVictims))
 
-	if err := util.ValidateVictims(preemptor, nodeInfo, allVictims); err != nil {
+	if err := util.ValidateVictims(preemptor, nodeInfo, allVictims, ssn.PredicateFn); err != nil {
 		klog.V(3).Infof("No validated victims on Node <%s>: %v", nodeInfo.Name, err)
 		return nil, api.AsStatus(fmt.Errorf("no validated victims on Node <%s>: %v", nodeInfo.Name, err))
 	}

--- a/pkg/scheduler/actions/preempt/preempt.go
+++ b/pkg/scheduler/actions/preempt/preempt.go
@@ -429,12 +429,20 @@ func (pmpt *Action) normalPreempt(
 // 2. The cluster has no free resources, and the queue is not allocatable.
 // 3. The cluster has no free resources, but the queue is allocatable.
 // 4. The node has sufficient aggregate resources, but PredicateFn fails because vNPU or vGPU resources are fragmented.
-// Same-queue preemption handles cases 1 and 2. Reclaim handles case 3. For case 4, normal preemption continues until
-// the predicate passes after enough victims are evicted.
+// 5. The preemptor requests a resource dimension no node advertises in Allocatable at all, such as
+// volcano.sh/vgpu-memory-percentage, which a device plugin tracks entirely on its own. The generic
+// resource comparison below can't tell that apart from a genuine shortfall, so it treats a shortfall
+// confined to untracked dimensions as inconclusive and defers to PredicateFn instead of rejecting outright.
+// Same-queue preemption handles cases 1 and 2. Reclaim handles case 3. For cases 4 and 5, normal preemption
+// continues until the predicate passes after enough victims are evicted.
 func preemptorFitsOnNode(ssn *framework.Session, queue *api.QueueInfo, preemptor *api.TaskInfo, node *api.NodeInfo) bool {
-	return ssn.Allocatable(queue, preemptor) &&
-		preemptor.InitResreq.LessEqual(node.FutureIdle(), api.Zero) &&
-		ssn.PredicateFn(preemptor, node) == nil
+	if !ssn.Allocatable(queue, preemptor) {
+		return false
+	}
+	if ok, failing := preemptor.InitResreq.LessEqualWithResourcesName(node.FutureIdle(), api.Zero); !ok && !api.AllUntrackedByAllocatable(failing, node) {
+		return false
+	}
+	return ssn.PredicateFn(preemptor, node) == nil
 }
 
 func (pmpt *Action) taskEligibleToPreempt(preemptor *api.TaskInfo) error {

--- a/pkg/scheduler/actions/preempt/preempt_test.go
+++ b/pkg/scheduler/actions/preempt/preempt_test.go
@@ -35,6 +35,7 @@ import (
 	schedulingv1beta1 "volcano.sh/apis/pkg/apis/scheduling/v1beta1"
 	"volcano.sh/volcano/cmd/scheduler/app/options"
 	"volcano.sh/volcano/pkg/scheduler/api"
+	deviceconfig "volcano.sh/volcano/pkg/scheduler/api/devices/config"
 	"volcano.sh/volcano/pkg/scheduler/api/devices/nvidia/vgpu"
 	"volcano.sh/volcano/pkg/scheduler/conf"
 	"volcano.sh/volcano/pkg/scheduler/framework"
@@ -818,26 +819,42 @@ func buildSingleCardGPUDevices(t *testing.T, nodeName, gpuUUID, ownerUID string,
 }
 
 // TestPreemptFractionalVGPU reproduces volcano-sh/volcano#4863: a pending pod
-// requesting a fractional vGPU slice (volcano.sh/vgpu-cores) stays Pending even
-// though evicting a lower-priority pod would free enough capacity, while the
-// equivalent whole-GPU-only scenario (volcano.sh/vgpu-number) already works.
+// requesting a fractional vGPU slice stays Pending even though evicting a
+// lower-priority pod would free enough capacity, while the equivalent
+// whole-GPU-only scenario (volcano.sh/vgpu-number) already works.
 //
 // Root cause: normalPreempt's "did eviction free enough?" gate
 // (preemptor.InitResreq.LessEqual(node.FutureIdle(), api.Zero)) is a generic
-// scalar-resource comparison. volcano.sh/vgpu-cores is never present in
-// node.Status.Allocatable (see docs/user-guide/how_to_use_volcano_vgpu.md -
-// only vgpu-memory and vgpu-number are advertised as real node capacity), so
-// that comparison can never be satisfied for it regardless of how much the
-// device plugin's own ledger actually freed. The real, correct fit check
-// lives in deviceshare/vgpu's predicate - it was just never being consulted.
+// scalar-resource comparison, authoritative only for resources that actually
+// have a capacity number in node.Status.Allocatable. volcano.sh/vgpu-memory-percentage
+// never does - it's a pure request-side modifier ("50% of whatever card this
+// pod lands on" has no coherent node-wide total to advertise), confirmed by
+// grepping this codebase for anywhere it's written into Allocatable (nowhere)
+// versus NewGPUDevices's own gate in device_info.go, which requires
+// vgpu-cores and vgpu-memory specifically (not vgpu-memory-percentage) to be
+// present. So for pods using vgpu-memory-percentage, that comparison can
+// never be satisfied regardless of how much the device plugin's own ledger
+// actually freed. The real, correct fit check lives in deviceshare/vgpu's
+// predicate - it was just never being consulted.
+//
+// The two subtests below deliberately test different resources:
+//   - "fractional vgpu-cores" is a synthetic edge case: it never puts
+//     vgpu-cores in the node's Allocatable, which doesn't match
+//     NewGPUDevices's real gate, so it's not proven to reflect production.
+//     It's kept as a regression guard for the fallback mechanism in general.
+//   - "fractional vgpu-memory-percentage" is the realistic one: the node
+//     properly advertises vgpu-number/vgpu-cores/vgpu-memory in Allocatable
+//     (satisfying NewGPUDevices's actual gate), and the bug still reproduces
+//     purely from vgpu-memory-percentage being untracked. This is the
+//     concretely-verified case.
 func TestPreemptFractionalVGPU(t *testing.T) {
 	// Deliberately no proportion/capacity plugin here: this test isolates the
 	// node/device fit-check path (preempt.go + deviceshare) that issue #4863 and
 	// this fix are about. Queue-level fairness plugins (proportion, capacity) have
-	// their own, separate "deserved capacity" accounting that hits the same
-	// structural gap (vgpu-cores never appears in any capacity total) for a
-	// different reason (queue quota, not node fit) - that is a distinct problem
-	// in a different subsystem, out of scope for this fix.
+	// their own, separate "deserved capacity" accounting that would hit the same
+	// kind of gap for volcano.sh/vgpu-memory-percentage, for a different reason
+	// (queue quota, not node fit) - that is a distinct problem in a different
+	// subsystem, out of scope for this fix.
 	plugins := map[string]framework.PluginBuilder{
 		conformance.PluginName: conformance.New,
 		gang.PluginName:        gang.New,
@@ -886,7 +903,7 @@ func TestPreemptFractionalVGPU(t *testing.T) {
 		vgpuCoresRes  = "volcano.sh/vgpu-cores"
 	)
 
-	t.Run("fractional vgpu-cores: eviction frees enough, preemption should succeed", func(t *testing.T) {
+	t.Run("fractional vgpu-cores (synthetic, not confirmed to match production Allocatable): preemption should succeed", func(t *testing.T) {
 		victim := util.BuildPod("c1", "victim-frac", "n1", v1.PodRunning,
 			api.BuildResourceList("1", "1G"), "pg1", map[string]string{schedulingv1beta1.PodPreemptable: "true"}, make(map[string]string))
 		addLimit(victim, vgpuNumberRes, "1")
@@ -973,6 +990,75 @@ func TestPreemptFractionalVGPU(t *testing.T) {
 			t.Fatalf("node n2 not found in session")
 		}
 		node.Others[vgpu.DeviceName] = buildSingleCardGPUDevices(t, "n2", "GPU-uuid-2", string(victim.UID), 8000, 0)
+
+		test.Run([]framework.Action{New()})
+		if err := test.CheckAll(0); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	// This subtest is deliberately more realistic than the first one above:
+	// NewGPUDevices (device_info.go) requires vgpu-cores and vgpu-memory to be
+	// present and nonzero in node.Status.Allocatable or it refuses to initialize
+	// GPU tracking at all, so on any real working vGPU node those two *are*
+	// tracked by the generic scalar-resource machinery - unlike the first
+	// subtest's node, which never declared vgpu-cores in Allocatable. Node here
+	// declares vgpu-number, vgpu-cores, and vgpu-memory in Allocatable to match
+	// that reality. The dimension actually under test is
+	// volcano.sh/vgpu-memory-percentage, which is never checked by
+	// NewGPUDevices's gate and never referenced anywhere as something written
+	// into Allocatable - it's a pure request-side modifier, since "50% of
+	// whatever card this pod lands on" has no coherent node-wide capacity
+	// total to advertise.
+	t.Run("fractional vgpu-memory-percentage: eviction frees enough, preemption should succeed", func(t *testing.T) {
+		deviceconfig.InitDevicesConfig("volcano-vgpu-device-config", "kube-system")
+		deviceconfig.GetConfig().NvidiaConfig.ResourceMemoryPercentageName = deviceconfig.VolcanoVGPUMemoryPercentage
+		t.Cleanup(func() { deviceconfig.GetConfig().NvidiaConfig.ResourceMemoryPercentageName = "" })
+
+		const vgpuMemPercentRes = "volcano.sh/vgpu-memory-percentage"
+
+		victim := util.BuildPod("c1", "victim-mempct", "n3", v1.PodRunning,
+			api.BuildResourceList("1", "1G"), "pg5", map[string]string{schedulingv1beta1.PodPreemptable: "true"}, make(map[string]string))
+		addLimit(victim, vgpuNumberRes, "1")
+		addLimit(victim, vgpuMemPercentRes, "100")
+		victim.Annotations[vgpu.AssignedIDsAnnotations] = fmt.Sprintf("%s,NVIDIA,%d,%d:", "GPU-uuid-3", 8000, 0)
+
+		preemptor := util.BuildPod("c1", "preemptor-mempct", "", v1.PodPending,
+			api.BuildResourceList("1", "1G"), "pg6", make(map[string]string), make(map[string]string))
+		addLimit(preemptor, vgpuNumberRes, "1")
+		addLimit(preemptor, vgpuMemPercentRes, "50")
+
+		test := uthelper.TestCommonStruct{
+			Name:    "fractional vgpu-memory-percentage preemption",
+			Plugins: plugins,
+			PodGroups: []*schedulingv1beta1.PodGroup{
+				util.BuildPodGroupWithPrio("pg5", "c1", "q1", 0, map[string]int32{}, schedulingv1beta1.PodGroupInqueue, "vgpu-low-priority"),
+				util.BuildPodGroupWithPrio("pg6", "c1", "q1", 1, map[string]int32{"": 1}, schedulingv1beta1.PodGroupInqueue, "vgpu-high-priority"),
+			},
+			Pods: []*v1.Pod{victim, preemptor},
+			Nodes: []*v1.Node{
+				util.BuildNode("n3", api.BuildResourceList("4", "4G", []api.ScalarResource{
+					{Name: "pods", Value: "10"},
+					{Name: vgpuNumberRes, Value: "1"},
+					{Name: "volcano.sh/vgpu-cores", Value: "100"},
+					{Name: "volcano.sh/vgpu-memory", Value: "8000"},
+				}...), make(map[string]string)),
+			},
+			Queues:         []*schedulingv1beta1.Queue{util.BuildQueue("q1", 1, nil)},
+			PriClass:       []*schedulingv1.PriorityClass{highPrio, lowPrio},
+			ExpectEvicted:  []string{"c1/victim-mempct"},
+			ExpectEvictNum: 1,
+		}
+
+		ssn := test.RegisterSession(tiers, []conf.Configuration{{Name: New().Name(),
+			Arguments: map[string]interface{}{EnableTopologyAwarePreemptionKey: false}}})
+		defer test.Close()
+
+		node, ok := ssn.Nodes["n3"]
+		if !ok {
+			t.Fatalf("node n3 not found in session")
+		}
+		node.Others[vgpu.DeviceName] = buildSingleCardGPUDevices(t, "n3", "GPU-uuid-3", string(victim.UID), 8000, 0)
 
 		test.Run([]framework.Action{New()})
 		if err := test.CheckAll(0); err != nil {

--- a/pkg/scheduler/actions/preempt/preempt_test.go
+++ b/pkg/scheduler/actions/preempt/preempt_test.go
@@ -508,7 +508,14 @@ func newNormalPreemptDeviceFitFixture() (uthelper.TestCommonStruct, []conf.Tier)
 			util.BuildPod("c1", "preemptor", "", v1.PodPending, api.BuildResourceList("1", "1G"), "pg-high", make(map[string]string), make(map[string]string)),
 		},
 		Nodes: []*v1.Node{
-			util.BuildNode("n1", api.BuildResourceList("2", "2G", []api.ScalarResource{{Name: "pods", Value: "10"}}...), make(map[string]string)),
+			util.BuildNode("n1", api.BuildResourceList("2", "2G", []api.ScalarResource{
+				{Name: "pods", Value: "10"},
+				// Tracked like a real HAMi node: vgpu-number is advertised in Allocatable.
+				// vgpu-memory-percentage deliberately is not (see
+				// TestNormalPreemptUntrackedResourceDefersToPredicate) - that's the one
+				// dimension this fixture is actually testing.
+				{Name: "volcano.sh/vgpu-number", Value: "1"},
+			}...), make(map[string]string)),
 		},
 		Queues: []*schedulingv1beta1.Queue{
 			util.BuildQueue("q1", 1, nil),
@@ -544,7 +551,14 @@ func TestNormalPreemptUntrackedResourceDefersToPredicate(t *testing.T) {
 	test.Pods = []*v1.Pod{
 		util.BuildPod("c1", "preemptee", "n1", v1.PodRunning, api.BuildResourceList("1", "1G"), "pg-low", map[string]string{schedulingv1beta1.PodPreemptable: "true"}, make(map[string]string)),
 		util.BuildPod("c1", "preemptor", "", v1.PodPending,
-			api.BuildResourceList("1", "1G", api.ScalarResource{Name: "volcano.sh/vgpu-memory-percentage", Value: "50"}),
+			// vgpu-memory-percentage is never requested on its own in practice - the API
+			// requires vgpu-number (or vgpu-memory) alongside it. Both are requested here;
+			// only vgpu-memory-percentage is untracked in n1's Allocatable (see the fixture
+			// above), which is the one dimension this test is actually exercising.
+			api.BuildResourceList("1", "1G",
+				api.ScalarResource{Name: "volcano.sh/vgpu-number", Value: "1"},
+				api.ScalarResource{Name: "volcano.sh/vgpu-memory-percentage", Value: "50"},
+			),
 			"pg-high", make(map[string]string), make(map[string]string)),
 	}
 	// n1's Allocatable deliberately carries no volcano.sh/vgpu-memory-percentage entry at all,

--- a/pkg/scheduler/actions/preempt/preempt_test.go
+++ b/pkg/scheduler/actions/preempt/preempt_test.go
@@ -23,20 +23,24 @@ package preempt
 
 import (
 	"flag"
+	"fmt"
 	"testing"
 
 	v1 "k8s.io/api/core/v1"
 	schedulingv1 "k8s.io/api/scheduling/v1"
+	apiresource "k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog/v2"
 
 	schedulingv1beta1 "volcano.sh/apis/pkg/apis/scheduling/v1beta1"
 	"volcano.sh/volcano/cmd/scheduler/app/options"
 	"volcano.sh/volcano/pkg/scheduler/api"
+	"volcano.sh/volcano/pkg/scheduler/api/devices/nvidia/vgpu"
 	"volcano.sh/volcano/pkg/scheduler/conf"
 	"volcano.sh/volcano/pkg/scheduler/framework"
 	"volcano.sh/volcano/pkg/scheduler/plugins/capacity"
 	"volcano.sh/volcano/pkg/scheduler/plugins/conformance"
+	"volcano.sh/volcano/pkg/scheduler/plugins/deviceshare"
 	"volcano.sh/volcano/pkg/scheduler/plugins/gang"
 	"volcano.sh/volcano/pkg/scheduler/plugins/predicates"
 	"volcano.sh/volcano/pkg/scheduler/plugins/priority"
@@ -763,4 +767,216 @@ func buildPodWithPodAntiAffinity(name, namespace, node string, phase v1.PodPhase
 	}
 
 	return pod
+}
+
+// addLimit sets a resource quantity in a pod's single-container Limits AND
+// Requests (creating the maps if needed). deviceshare/vgpu reads GPU sharing
+// requests from Limits; generic scalar-resource bookkeeping (TaskInfo.Resreq,
+// used by node.Idle/FutureIdle) reads Requests. A real Pod processed by the
+// API server has Requests defaulted from Limits automatically - a raw *v1.Pod
+// built in-memory for a test does not get that defaulting for free, so both
+// must be set explicitly or the generic side silently sees no request at all.
+func addLimit(pod *v1.Pod, name v1.ResourceName, quantity string) {
+	if pod.Spec.Containers[0].Resources.Limits == nil {
+		pod.Spec.Containers[0].Resources.Limits = make(v1.ResourceList)
+	}
+	if pod.Spec.Containers[0].Resources.Requests == nil {
+		pod.Spec.Containers[0].Resources.Requests = make(v1.ResourceList)
+	}
+	q := apiresource.MustParse(quantity)
+	pod.Spec.Containers[0].Resources.Limits[name] = q
+	pod.Spec.Containers[0].Resources.Requests[name] = q
+}
+
+// buildSingleCardGPUDevices returns a one-card vgpu device fixture (8000 memory
+// units, 100 cores) for node "nodeName". If ownerUID is non-empty, the card is
+// marked as fully occupied by that pod (usedMem/usedCores), mirroring what a
+// real prior allocation would have reserved - this is what a preemption victim
+// "holding" the GPU looks like before it gets evicted.
+func buildSingleCardGPUDevices(t *testing.T, nodeName, gpuUUID, ownerUID string, usedMem, usedCores uint) *vgpu.GPUDevices {
+	t.Helper()
+	gd := &vgpu.GPUDevices{
+		Name:   nodeName,
+		Device: make(map[int]*vgpu.GPUDevice),
+	}
+	gd.Device[0] = vgpu.NewGPUDevice(0, 8000)
+	gd.Device[0].Type = "NVIDIA"
+	gd.Device[0].Number = 1
+	gd.Device[0].UUID = gpuUUID
+	if ownerUID != "" {
+		gd.Device[0].UsedNum = 1
+		gd.Device[0].UsedMem = usedMem
+		gd.Device[0].UsedCore = usedCores
+		gd.Device[0].PodMap[ownerUID] = &vgpu.GPUUsage{UsedMem: usedMem, UsedCore: usedCores}
+	}
+	var ok bool
+	gd.Sharing, ok = vgpu.GetSharingHandler("hami-core")
+	if !ok {
+		t.Fatalf("failed to get hami-core sharing handler")
+	}
+	return gd
+}
+
+// TestPreemptFractionalVGPU reproduces volcano-sh/volcano#4863: a pending pod
+// requesting a fractional vGPU slice (volcano.sh/vgpu-cores) stays Pending even
+// though evicting a lower-priority pod would free enough capacity, while the
+// equivalent whole-GPU-only scenario (volcano.sh/vgpu-number) already works.
+//
+// Root cause: normalPreempt's "did eviction free enough?" gate
+// (preemptor.InitResreq.LessEqual(node.FutureIdle(), api.Zero)) is a generic
+// scalar-resource comparison. volcano.sh/vgpu-cores is never present in
+// node.Status.Allocatable (see docs/user-guide/how_to_use_volcano_vgpu.md -
+// only vgpu-memory and vgpu-number are advertised as real node capacity), so
+// that comparison can never be satisfied for it regardless of how much the
+// device plugin's own ledger actually freed. The real, correct fit check
+// lives in deviceshare/vgpu's predicate - it was just never being consulted.
+func TestPreemptFractionalVGPU(t *testing.T) {
+	// Deliberately no proportion/capacity plugin here: this test isolates the
+	// node/device fit-check path (preempt.go + deviceshare) that issue #4863 and
+	// this fix are about. Queue-level fairness plugins (proportion, capacity) have
+	// their own, separate "deserved capacity" accounting that hits the same
+	// structural gap (vgpu-cores never appears in any capacity total) for a
+	// different reason (queue quota, not node fit) - that is a distinct problem
+	// in a different subsystem, out of scope for this fix.
+	plugins := map[string]framework.PluginBuilder{
+		conformance.PluginName: conformance.New,
+		gang.PluginName:        gang.New,
+		priority.PluginName:    priority.New,
+		deviceshare.PluginName: deviceshare.New,
+	}
+	highPrio := util.BuildPriorityClass("vgpu-high-priority", 100000)
+	lowPrio := util.BuildPriorityClass("vgpu-low-priority", 10)
+
+	trueValue := true
+	tiers := []conf.Tier{
+		{
+			Plugins: []conf.PluginOption{
+				{
+					Name:               conformance.PluginName,
+					EnabledPreemptable: &trueValue,
+				},
+				{
+					Name:                gang.PluginName,
+					EnabledPreemptable:  &trueValue,
+					EnabledJobPipelined: &trueValue,
+					EnabledJobStarving:  &trueValue,
+				},
+				{
+					Name:                priority.PluginName,
+					EnabledTaskOrder:    &trueValue,
+					EnabledJobOrder:     &trueValue,
+					EnabledPreemptable:  &trueValue,
+					EnabledJobPipelined: &trueValue,
+					EnabledJobStarving:  &trueValue,
+				},
+				{
+					Name:             deviceshare.PluginName,
+					EnabledPredicate: &trueValue,
+					Arguments: map[string]interface{}{
+						"deviceshare.VGPUEnable":     true,
+						"deviceshare.SchedulePolicy": "binpack",
+					},
+				},
+			},
+		},
+	}
+
+	const (
+		vgpuNumberRes = "volcano.sh/vgpu-number"
+		vgpuCoresRes  = "volcano.sh/vgpu-cores"
+	)
+
+	t.Run("fractional vgpu-cores: eviction frees enough, preemption should succeed", func(t *testing.T) {
+		victim := util.BuildPod("c1", "victim-frac", "n1", v1.PodRunning,
+			api.BuildResourceList("1", "1G"), "pg1", map[string]string{schedulingv1beta1.PodPreemptable: "true"}, make(map[string]string))
+		addLimit(victim, vgpuNumberRes, "1")
+		addLimit(victim, vgpuCoresRes, "100")
+		victim.Annotations[vgpu.AssignedIDsAnnotations] = fmt.Sprintf("%s,NVIDIA,%d,%d:", "GPU-uuid-1", 8000, 100)
+
+		preemptor := util.BuildPod("c1", "preemptor-frac", "", v1.PodPending,
+			api.BuildResourceList("1", "1G"), "pg2", make(map[string]string), make(map[string]string))
+		addLimit(preemptor, vgpuNumberRes, "1")
+		addLimit(preemptor, vgpuCoresRes, "50")
+
+		test := uthelper.TestCommonStruct{
+			Name:    "fractional vgpu-cores preemption",
+			Plugins: plugins,
+			PodGroups: []*schedulingv1beta1.PodGroup{
+				util.BuildPodGroupWithPrio("pg1", "c1", "q1", 0, map[string]int32{}, schedulingv1beta1.PodGroupInqueue, "vgpu-low-priority"),
+				util.BuildPodGroupWithPrio("pg2", "c1", "q1", 1, map[string]int32{"": 1}, schedulingv1beta1.PodGroupInqueue, "vgpu-high-priority"),
+			},
+			Pods: []*v1.Pod{victim, preemptor},
+			Nodes: []*v1.Node{
+				util.BuildNode("n1", api.BuildResourceList("4", "4G", []api.ScalarResource{
+					{Name: "pods", Value: "10"},
+					{Name: vgpuNumberRes, Value: "1"},
+				}...), make(map[string]string)),
+			},
+			Queues:         []*schedulingv1beta1.Queue{util.BuildQueue("q1", 1, nil)},
+			PriClass:       []*schedulingv1.PriorityClass{highPrio, lowPrio},
+			ExpectEvicted:  []string{"c1/victim-frac"},
+			ExpectEvictNum: 1,
+		}
+
+		ssn := test.RegisterSession(tiers, []conf.Configuration{{Name: New().Name(),
+			Arguments: map[string]interface{}{EnableTopologyAwarePreemptionKey: false}}})
+		defer test.Close()
+
+		node, ok := ssn.Nodes["n1"]
+		if !ok {
+			t.Fatalf("node n1 not found in session")
+		}
+		node.Others[vgpu.DeviceName] = buildSingleCardGPUDevices(t, "n1", "GPU-uuid-1", string(victim.UID), 8000, 100)
+
+		test.Run([]framework.Action{New()})
+		if err := test.CheckAll(0); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	t.Run("whole-GPU vgpu-number only: unaffected regression guard", func(t *testing.T) {
+		victim := util.BuildPod("c1", "victim-whole", "n2", v1.PodRunning,
+			api.BuildResourceList("1", "1G"), "pg3", map[string]string{schedulingv1beta1.PodPreemptable: "true"}, make(map[string]string))
+		addLimit(victim, vgpuNumberRes, "1")
+		victim.Annotations[vgpu.AssignedIDsAnnotations] = fmt.Sprintf("%s,NVIDIA,%d,%d:", "GPU-uuid-2", 8000, 0)
+
+		preemptor := util.BuildPod("c1", "preemptor-whole", "", v1.PodPending,
+			api.BuildResourceList("1", "1G"), "pg4", make(map[string]string), make(map[string]string))
+		addLimit(preemptor, vgpuNumberRes, "1")
+
+		test := uthelper.TestCommonStruct{
+			Name:    "whole-GPU vgpu-number preemption",
+			Plugins: plugins,
+			PodGroups: []*schedulingv1beta1.PodGroup{
+				util.BuildPodGroupWithPrio("pg3", "c1", "q1", 0, map[string]int32{}, schedulingv1beta1.PodGroupInqueue, "vgpu-low-priority"),
+				util.BuildPodGroupWithPrio("pg4", "c1", "q1", 1, map[string]int32{"": 1}, schedulingv1beta1.PodGroupInqueue, "vgpu-high-priority"),
+			},
+			Pods: []*v1.Pod{victim, preemptor},
+			Nodes: []*v1.Node{
+				util.BuildNode("n2", api.BuildResourceList("4", "4G", []api.ScalarResource{
+					{Name: "pods", Value: "10"},
+					{Name: vgpuNumberRes, Value: "1"},
+				}...), make(map[string]string)),
+			},
+			Queues:         []*schedulingv1beta1.Queue{util.BuildQueue("q1", 1, nil)},
+			PriClass:       []*schedulingv1.PriorityClass{highPrio, lowPrio},
+			ExpectEvicted:  []string{"c1/victim-whole"},
+			ExpectEvictNum: 1,
+		}
+
+		ssn := test.RegisterSession(tiers, []conf.Configuration{{Name: New().Name(),
+			Arguments: map[string]interface{}{EnableTopologyAwarePreemptionKey: false}}})
+		defer test.Close()
+
+		node, ok := ssn.Nodes["n2"]
+		if !ok {
+			t.Fatalf("node n2 not found in session")
+		}
+		node.Others[vgpu.DeviceName] = buildSingleCardGPUDevices(t, "n2", "GPU-uuid-2", string(victim.UID), 8000, 0)
+
+		test.Run([]framework.Action{New()})
+		if err := test.CheckAll(0); err != nil {
+			t.Fatal(err)
+		}
+	})
 }

--- a/pkg/scheduler/actions/preempt/preempt_test.go
+++ b/pkg/scheduler/actions/preempt/preempt_test.go
@@ -530,6 +530,48 @@ func newNormalPreemptDeviceFitFixture() (uthelper.TestCommonStruct, []conf.Tier)
 	return test, tiers
 }
 
+// TestNormalPreemptUntrackedResourceDefersToPredicate covers #4863: a preemptor requesting
+// a resource dimension the node never advertises in Allocatable at all (volcano.sh/vgpu-memory-percentage
+// here, mirroring HAMi's fractional vGPU resource, which is a pure request-side modifier with no
+// coherent node-wide capacity total to advertise) must not be rejected by the generic scalar-resource
+// arithmetic before the device-aware predicate ever runs. Before the fix, node.FutureIdle() has no entry
+// for that resource name, so the comparison reads it as zero capacity and preemptorFitsOnNode/ValidateVictims
+// reject unconditionally, regardless of what the real predicate would say, and the preemptor never gets
+// scheduled even after the victim is evicted.
+func TestNormalPreemptUntrackedResourceDefersToPredicate(t *testing.T) {
+	test, tiers := newNormalPreemptDeviceFitFixture()
+	test.Name = "normal preemption evicts a victim for a resource untracked in node.Allocatable"
+	test.Pods = []*v1.Pod{
+		util.BuildPod("c1", "preemptee", "n1", v1.PodRunning, api.BuildResourceList("1", "1G"), "pg-low", map[string]string{schedulingv1beta1.PodPreemptable: "true"}, make(map[string]string)),
+		util.BuildPod("c1", "preemptor", "", v1.PodPending,
+			api.BuildResourceList("1", "1G", api.ScalarResource{Name: "volcano.sh/vgpu-memory-percentage", Value: "50"}),
+			"pg-high", make(map[string]string), make(map[string]string)),
+	}
+	// n1's Allocatable deliberately carries no volcano.sh/vgpu-memory-percentage entry at all,
+	// matching a real HAMi node: the resource is tracked by the device plugin's own ledger, not
+	// advertised node-wide.
+	//
+	// proportion's own queue-level Allocatable check has this identical untracked-resource gap
+	// independently (attr.deserved never carries an unconfigured scalar dimension either), which
+	// is a separate bug in a different plugin, out of scope here. Disable it so this test isolates
+	// the node-level fix in preemptorFitsOnNode/ValidateVictims that #4863/#5784 actually covers.
+	falseValue := false
+	for i, plugin := range tiers[0].Plugins {
+		if plugin.Name == proportion.PluginName {
+			tiers[0].Plugins[i].EnabledAllocatable = &falseValue
+		}
+	}
+	test.RegisterSession(tiers, []conf.Configuration{{
+		Name:      New().Name(),
+		Arguments: map[string]interface{}{EnableTopologyAwarePreemptionKey: false},
+	}})
+	defer test.Close()
+	test.Run([]framework.Action{New()})
+	if err := test.CheckAll(0); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func newNormalPreemptBenchmarkFixture() (uthelper.TestCommonStruct, []conf.Tier) {
 	test, tiers := newNormalPreemptDeviceFitFixture()
 	test.Name = "normal preemption benchmark with one required victim"

--- a/pkg/scheduler/actions/reclaim/reclaim.go
+++ b/pkg/scheduler/actions/reclaim/reclaim.go
@@ -262,9 +262,15 @@ func (ra *Action) reclaimForTask(ssn *framework.Session, stmt *framework.Stateme
 }
 
 // reclaimerFitsOnNode verifies available resources and plugin predicates after tentative evictions.
+// The arithmetic check alone can't be trusted when the shortfall is confined to a resource
+// dimension node.Allocatable has no entry for at all, such as volcano.sh/vgpu-memory-percentage,
+// which a device plugin tracks entirely through its own ledger. In that case defer to the real
+// predicate instead of rejecting outright.
 func reclaimerFitsOnNode(ssn *framework.Session, task *api.TaskInfo, node *api.NodeInfo, resreq, availableResources *api.Resource) bool {
-	return resreq.LessEqual(availableResources, api.Zero) &&
-		ssn.PredicateFn(task, node) == nil
+	if ok, failing := resreq.LessEqualWithResourcesName(availableResources, api.Zero); !ok && !api.AllUntrackedByAllocatable(failing, node) {
+		return false
+	}
+	return ssn.PredicateFn(task, node) == nil
 }
 
 func (ra *Action) UnInitialize() {

--- a/pkg/scheduler/actions/reclaim/reclaim.go
+++ b/pkg/scheduler/actions/reclaim/reclaim.go
@@ -212,7 +212,7 @@ func (ra *Action) reclaimForTask(ssn *framework.Session, stmt *framework.Stateme
 		}
 
 		victims := ssn.Reclaimable(task, reclaimees)
-		if err := util.ValidateVictims(task, n, victims); err != nil {
+		if err := util.ValidateVictims(task, n, victims, ssn.PredicateFn); err != nil {
 			klog.V(3).Infof("No validated victims on Node <%s>: %v", n.Name, err)
 			continue
 		}

--- a/pkg/scheduler/actions/reclaim/reclaim_test.go
+++ b/pkg/scheduler/actions/reclaim/reclaim_test.go
@@ -476,3 +476,79 @@ func TestReclaimRechecksPredicateAfterEviction(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+// TestReclaimUntrackedResourceDefersToPredicate covers the same #4863-class bug as
+// TestNormalPreemptUntrackedResourceDefersToPredicate in the preempt package, but for reclaim:
+// a reclaimer requesting a resource dimension the node never advertises in Allocatable at all
+// (volcano.sh/vgpu-memory-percentage here, mirroring HAMi's fractional vGPU resource) must not be
+// rejected by the generic scalar-resource arithmetic in reclaimerFitsOnNode/ValidateVictims before
+// the device-aware predicate ever runs.
+func TestReclaimUntrackedResourceDefersToPredicate(t *testing.T) {
+	plugins := map[string]framework.PluginBuilder{
+		conformance.PluginName: conformance.New,
+		gang.PluginName:        gang.New,
+		proportion.PluginName:  proportion.New,
+		deviceFitAfterReclaimPluginName: func(framework.Arguments) framework.Plugin {
+			return &deviceFitAfterReclaimPlugin{}
+		},
+	}
+	trueValue := true
+	// Same PodGroups/Pods/Queues as TestReclaimRechecksPredicateAfterEviction (including the
+	// unrelated q3/pg-demand job, which affects proportion's deserved-share math), so the only
+	// variable relative to that already-passing baseline is the untracked resource dimension
+	// added to the reclaimer's request below. That isolates this test to the fix in
+	// reclaimerFitsOnNode/ValidateVictims instead of also exercising queue-weight arithmetic.
+	test := uthelper.TestCommonStruct{
+		Name:    "reclaim evicts a victim for a resource untracked in node.Allocatable",
+		Plugins: plugins,
+		PodGroups: []*schedulingv1beta1.PodGroup{
+			util.BuildPodGroupWithPrio("pg-victim", "c1", "q1", 0, nil, schedulingv1beta1.PodGroupRunning, "low-priority"),
+			util.BuildPodGroupWithPrio("pg-reclaimer", "c1", "q2", 1, nil, schedulingv1beta1.PodGroupInqueue, "high-priority"),
+			util.BuildPodGroupWithPrio("pg-demand", "c1", "q3", 0, nil, schedulingv1beta1.PodGroupInqueue, "low-priority"),
+		},
+		Pods: []*v1.Pod{
+			util.BuildPod("c1", "device-holder-1", "n1", v1.PodRunning, api.BuildResourceList("1", "1G"), "pg-victim", map[string]string{schedulingv1beta1.PodPreemptable: "true"}, make(map[string]string)),
+			util.BuildPod("c1", "device-holder-2", "n1", v1.PodRunning, api.BuildResourceList("1", "1G"), "pg-victim", map[string]string{schedulingv1beta1.PodPreemptable: "true"}, make(map[string]string)),
+			util.BuildPod("c1", "device-holder-3", "n1", v1.PodRunning, api.BuildResourceList("1", "1G"), "pg-victim", map[string]string{schedulingv1beta1.PodPreemptable: "false"}, make(map[string]string)),
+			// device-fit-after-reclaim's predicate only special-cases a task named "reclaimer", so
+			// this stays evicted regardless of the untracked resource on the reclaimer's request.
+			util.BuildPod("c1", "reclaimer", "", v1.PodPending,
+				api.BuildResourceList("1", "1G", api.ScalarResource{Name: "volcano.sh/vgpu-memory-percentage", Value: "50"}),
+				"pg-reclaimer", make(map[string]string), make(map[string]string)),
+			util.BuildPod("c1", "other-queue-demand", "", v1.PodPending, api.BuildResourceList("1", "1G"), "pg-demand", make(map[string]string), make(map[string]string)),
+		},
+		// n1's Allocatable deliberately carries no volcano.sh/vgpu-memory-percentage entry at all.
+		Nodes: []*v1.Node{
+			util.BuildNode("n1", api.BuildResourceList("3", "3G", []api.ScalarResource{{Name: "pods", Value: "10"}}...), make(map[string]string)),
+		},
+		Queues: []*schedulingv1beta1.Queue{
+			util.BuildQueue("q1", 1, nil),
+			util.BuildQueue("q2", 9, nil),
+			util.BuildQueue("q3", 1, nil),
+		},
+		ExpectEvicted:  []string{"c1/device-holder-1", "c1/device-holder-2"},
+		ExpectEvictNum: 2,
+		ExpectPipeLined: map[string][]string{
+			"c1/pg-reclaimer": {"n1"},
+		},
+	}
+	// proportion's EnablePreemptive reuses the same queueAllocatable arithmetic as its
+	// Allocatable check and has this identical untracked-resource gap independently (a
+	// separate, pre-existing bug in that plugin, out of scope here). Disabled so this test
+	// isolates the node-level fix in reclaimerFitsOnNode/ValidateVictims.
+	tiers := []conf.Tier{{
+		Plugins: []conf.PluginOption{
+			{Name: conformance.PluginName, EnabledReclaimable: &trueValue},
+			{Name: gang.PluginName, EnabledReclaimable: &trueValue, EnabledJobStarving: &trueValue},
+			{Name: proportion.PluginName, EnabledReclaimable: &trueValue, EnabledQueueOrder: &trueValue},
+			{Name: deviceFitAfterReclaimPluginName, EnabledPredicate: &trueValue},
+		},
+	}}
+
+	test.RegisterSession(tiers, nil)
+	defer test.Close()
+	test.Run([]framework.Action{New()})
+	if err := test.CheckAll(0); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/pkg/scheduler/actions/reclaim/reclaim_test.go
+++ b/pkg/scheduler/actions/reclaim/reclaim_test.go
@@ -512,14 +512,25 @@ func TestReclaimUntrackedResourceDefersToPredicate(t *testing.T) {
 			util.BuildPod("c1", "device-holder-3", "n1", v1.PodRunning, api.BuildResourceList("1", "1G"), "pg-victim", map[string]string{schedulingv1beta1.PodPreemptable: "false"}, make(map[string]string)),
 			// device-fit-after-reclaim's predicate only special-cases a task named "reclaimer", so
 			// this stays evicted regardless of the untracked resource on the reclaimer's request.
+			// vgpu-memory-percentage is never requested on its own in practice - the API requires
+			// vgpu-number (or vgpu-memory) alongside it. Both are requested here; only
+			// vgpu-memory-percentage is untracked in n1's Allocatable below, which is the one
+			// dimension this test is actually exercising.
 			util.BuildPod("c1", "reclaimer", "", v1.PodPending,
-				api.BuildResourceList("1", "1G", api.ScalarResource{Name: "volcano.sh/vgpu-memory-percentage", Value: "50"}),
+				api.BuildResourceList("1", "1G",
+					api.ScalarResource{Name: "volcano.sh/vgpu-number", Value: "1"},
+					api.ScalarResource{Name: "volcano.sh/vgpu-memory-percentage", Value: "50"},
+				),
 				"pg-reclaimer", make(map[string]string), make(map[string]string)),
 			util.BuildPod("c1", "other-queue-demand", "", v1.PodPending, api.BuildResourceList("1", "1G"), "pg-demand", make(map[string]string), make(map[string]string)),
 		},
-		// n1's Allocatable deliberately carries no volcano.sh/vgpu-memory-percentage entry at all.
+		// n1's Allocatable tracks vgpu-number like a real HAMi node, but deliberately carries no
+		// volcano.sh/vgpu-memory-percentage entry at all.
 		Nodes: []*v1.Node{
-			util.BuildNode("n1", api.BuildResourceList("3", "3G", []api.ScalarResource{{Name: "pods", Value: "10"}}...), make(map[string]string)),
+			util.BuildNode("n1", api.BuildResourceList("3", "3G", []api.ScalarResource{
+				{Name: "pods", Value: "10"},
+				{Name: "volcano.sh/vgpu-number", Value: "1"},
+			}...), make(map[string]string)),
 		},
 		Queues: []*schedulingv1beta1.Queue{
 			util.BuildQueue("q1", 1, nil),

--- a/pkg/scheduler/api/node_info.go
+++ b/pkg/scheduler/api/node_info.go
@@ -464,7 +464,13 @@ func (ni *NodeInfo) AddTask(task *TaskInfo) error {
 			ni.Pipelined.Add(ti.Resreq)
 		case Binding:
 			// When task in Binding status, it will bind to node, we should double-check whether idle resources are enough to put task before bind to apiserver.
-			if ok, resNames := ti.Resreq.LessEqualWithResourcesName(ni.Idle, Zero); !ok {
+			// A shortfall confined to resource dimensions ni.Allocatable has no entry for at all
+			// (like volcano.sh/vgpu-memory-percentage, tracked entirely by a device plugin's own
+			// ledger rather than advertised node-wide) can never pass this arithmetic, no matter
+			// how much room the device plugin's predicate already confirmed earlier in scheduling.
+			// This is the final gate before every bind, real or simulated, across every action, so
+			// treat that case as inconclusive rather than a hard no instead of rejecting outright.
+			if ok, resNames := ti.Resreq.LessEqualWithResourcesName(ni.Idle, Zero); !ok && !AllUntrackedByAllocatable(resNames, ni) {
 				return fmt.Errorf("node %s resources %v are not enough to put task <%s/%s>, idle: %s, req: %s", ni.Name, resNames, ti.Namespace, ti.Name, ni.Idle.String(), ti.Resreq.String())
 			}
 			ni.allocateIdleResource(ti)

--- a/pkg/scheduler/api/node_info_test.go
+++ b/pkg/scheduler/api/node_info_test.go
@@ -512,9 +512,18 @@ func TestNodeInfoClonePreservesUnassignedNumaPods(t *testing.T) {
 // volcano.sh/vgpu-memory-percentage, tracked entirely by a device plugin's own ledger) must not
 // be rejected here, since nothing downstream double-checks it again.
 func TestNodeInfo_AddTask_UntrackedResourceDefersToPredicate(t *testing.T) {
-	node := buildNode("n1", nil, BuildResourceList("2000m", "2G", []ScalarResource{{Name: "pods", Value: "10"}}...))
+	// vgpu-number is tracked in Allocatable, matching a real HAMi node; only
+	// vgpu-memory-percentage - never requested on its own in practice - is untracked, which is the
+	// one dimension this test exercises.
+	node := buildNode("n1", nil, BuildResourceList("2000m", "2G", []ScalarResource{
+		{Name: "pods", Value: "10"},
+		{Name: "volcano.sh/vgpu-number", Value: "1"},
+	}...))
 	pod := buildPod("c1", "p1", "", v1.PodPending,
-		BuildResourceList("1000m", "1G", []ScalarResource{{Name: "volcano.sh/vgpu-memory-percentage", Value: "50"}}...),
+		BuildResourceList("1000m", "1G", []ScalarResource{
+			{Name: "volcano.sh/vgpu-number", Value: "1"},
+			{Name: "volcano.sh/vgpu-memory-percentage", Value: "50"},
+		}...),
 		[]metav1.OwnerReference{}, make(map[string]string))
 
 	ni := NewNodeInfo(node)

--- a/pkg/scheduler/api/node_info_test.go
+++ b/pkg/scheduler/api/node_info_test.go
@@ -504,3 +504,40 @@ func TestNodeInfoClonePreservesUnassignedNumaPods(t *testing.T) {
 		t.Errorf("Clone mutation leaked back into original: %v", ni.UnassignedNumaPods)
 	}
 }
+
+// TestNodeInfo_AddTask_UntrackedResourceDefersToPredicate covers the final, most fundamental
+// occurrence of the #4863-class bug: AddTask's Binding-status check is the last gate every task
+// passes through before actually binding to the API server, across every scheduling action. A
+// task requesting a resource dimension the node never advertises in Allocatable at all (like
+// volcano.sh/vgpu-memory-percentage, tracked entirely by a device plugin's own ledger) must not
+// be rejected here, since nothing downstream double-checks it again.
+func TestNodeInfo_AddTask_UntrackedResourceDefersToPredicate(t *testing.T) {
+	node := buildNode("n1", nil, BuildResourceList("2000m", "2G", []ScalarResource{{Name: "pods", Value: "10"}}...))
+	pod := buildPod("c1", "p1", "", v1.PodPending,
+		BuildResourceList("1000m", "1G", []ScalarResource{{Name: "volcano.sh/vgpu-memory-percentage", Value: "50"}}...),
+		[]metav1.OwnerReference{}, make(map[string]string))
+
+	ni := NewNodeInfo(node)
+	task := NewTaskInfo(pod)
+	task.Status = Binding
+
+	if err := ni.AddTask(task); err != nil {
+		t.Fatalf("expected AddTask to succeed for a resource untracked in node.Allocatable, got error: %v", err)
+	}
+}
+
+// TestNodeInfo_AddTask_GenuineShortfallStillRejected is the companion regression: a real,
+// tracked-resource shortfall (cpu here) must still be rejected at bind time. The fallback above
+// is only for dimensions Allocatable has no entry for at all, not a blanket bypass.
+func TestNodeInfo_AddTask_GenuineShortfallStillRejected(t *testing.T) {
+	node := buildNode("n1", nil, BuildResourceList("1000m", "2G", []ScalarResource{{Name: "pods", Value: "10"}}...))
+	pod := buildPod("c1", "p1", "", v1.PodPending, BuildResourceList("2000m", "1G"), []metav1.OwnerReference{}, make(map[string]string))
+
+	ni := NewNodeInfo(node)
+	task := NewTaskInfo(pod)
+	task.Status = Binding
+
+	if err := ni.AddTask(task); err == nil {
+		t.Fatal("expected AddTask to reject a genuine cpu shortfall, got success")
+	}
+}

--- a/pkg/scheduler/api/resource_info.go
+++ b/pkg/scheduler/api/resource_info.go
@@ -559,6 +559,31 @@ func (r *Resource) LessEqualWithResourcesName(rr *Resource, defaultValue Dimensi
 	return true, resources
 }
 
+// AllUntrackedByAllocatable reports whether every resource name in names has no capacity entry
+// at all in node.Allocatable. cpu and memory always carry a real capacity number, so they are
+// never considered untracked. Used to tell a genuine shortfall (a tracked resource that's really
+// insufficient) apart from a resource dimension a device plugin manages entirely on its own (like
+// volcano.sh/vgpu-memory-percentage, a pure request-side modifier with no coherent node-wide total
+// to advertise), where the generic scalar comparison has nothing to compare against and can't be
+// trusted as "no".
+func AllUntrackedByAllocatable(names []string, node *NodeInfo) bool {
+	if len(names) == 0 {
+		return false
+	}
+	for _, name := range names {
+		if name == string(v1.ResourceCPU) || name == string(v1.ResourceMemory) {
+			return false
+		}
+		if node.Allocatable == nil {
+			return false
+		}
+		if _, tracked := node.Allocatable.ScalarResources[v1.ResourceName(name)]; tracked {
+			return false
+		}
+	}
+	return true
+}
+
 // LessPartly returns true if there exists any dimension whose resource amount in r is less than that in rr.
 // Otherwise returns false.
 // @param defaultValue "default value for resource dimension not defined in ScalarResources. Its value can only be one of 'Zero' and 'Infinity'"

--- a/pkg/scheduler/util/scheduler_helper.go
+++ b/pkg/scheduler/util/scheduler_helper.go
@@ -324,8 +324,15 @@ func ValidateVictims(preemptor *api.TaskInfo, node *api.NodeInfo, victims []*api
 		futureIdle.Add(victim.Resreq)
 	}
 	// Every resource of the preemptor needs to be less or equal than corresponding
-	// idle resource after preemption.
-	if !preemptor.InitResreq.LessEqual(futureIdle, api.Zero) {
+	// idle resource after preemption. This arithmetic check is only authoritative for
+	// resources node.Allocatable actually carries a capacity number for (cpu, memory,
+	// volcano.sh/vgpu-number, ...). A resource a device plugin tracks entirely through its
+	// own ledger instead (like volcano.sh/vgpu-memory-percentage, a pure request-side
+	// modifier with no coherent node-wide total to advertise) can never pass this check,
+	// no matter how much room the device plugin's predicate would actually allow, so treat
+	// a shortfall confined to untracked dimensions as inconclusive rather than a hard no
+	// and let the real predicate decide once eviction is attempted.
+	if ok, failing := preemptor.InitResreq.LessEqualWithResourcesName(futureIdle, api.Zero); !ok && !api.AllUntrackedByAllocatable(failing, node) {
 		return fmt.Errorf("not enough resources: requested <%v>, but future idle <%v>",
 			preemptor.InitResreq, futureIdle)
 	}

--- a/pkg/scheduler/util/scheduler_helper.go
+++ b/pkg/scheduler/util/scheduler_helper.go
@@ -313,8 +313,20 @@ func GetRealNodesByHyperNode(hyperNodes map[string]sets.Set[string], allNodes ma
 	return resultList, resultSet
 }
 
-// ValidateVictims returns an error if the resources of the victims can't satisfy the preemptor
-func ValidateVictims(preemptor *api.TaskInfo, node *api.NodeInfo, victims []*api.TaskInfo) error {
+// ValidateVictims returns an error if the resources of the victims can't satisfy the preemptor.
+// predicateFn (normally ssn.PredicateFn) is used as a fallback: the generic scalar-resource
+// comparison below is authoritative whenever every dimension it flags as insufficient is one
+// actually present in node.Status.Allocatable (cpu, memory, volcano.sh/vgpu-number, ...) - those
+// have a real capacity number, so the comparison can be trusted as-is, including a genuine "no".
+//
+// It can never be satisfied, however, for resources a device plugin tracks entirely through its
+// own predicate/ledger instead - e.g. volcano.sh/vgpu-cores and volcano.sh/vgpu-memory-percentage,
+// which by design are never advertised as node capacity (see
+// docs/user-guide/how_to_use_volcano_vgpu.md) because "50% of one card" isn't a poolable
+// node-wide quantity. When every failing dimension is one of these, the comparison is
+// structurally unable to answer the question, so simulate evicting the victims on a throwaway
+// clone of node and ask the real predicate instead of treating "unknowable" as "no".
+func ValidateVictims(preemptor *api.TaskInfo, node *api.NodeInfo, victims []*api.TaskInfo, predicateFn func(*api.TaskInfo, *api.NodeInfo) error) error {
 	// Victims should not be judged to be empty here.
 	// It is possible to complete the scheduling of the preemptor without evicting the task.
 	// In the first round, a large task (CPU: 8) is expelled, and a small task is scheduled (CPU: 2)
@@ -325,11 +337,40 @@ func ValidateVictims(preemptor *api.TaskInfo, node *api.NodeInfo, victims []*api
 	}
 	// Every resource of the preemptor needs to be less or equal than corresponding
 	// idle resource after preemption.
-	if !preemptor.InitResreq.LessEqual(futureIdle, api.Zero) {
+	ok, failing := preemptor.InitResreq.LessEqualWithResourcesName(futureIdle, api.Zero)
+	if ok {
+		return nil
+	}
+	if !allUntrackedByAllocatable(failing, node) {
 		return fmt.Errorf("not enough resources: requested <%v>, but future idle <%v>",
 			preemptor.InitResreq, futureIdle)
 	}
+
+	nodeCopy := node.Clone()
+	for _, victim := range victims {
+		nodeCopy.RemoveTask(victim)
+	}
+	if err := predicateFn(preemptor, nodeCopy); err != nil {
+		return fmt.Errorf("not enough resources: requested <%v>, but future idle <%v>: %v",
+			preemptor.InitResreq, futureIdle, err)
+	}
 	return nil
+}
+
+// allUntrackedByAllocatable reports whether every named resource dimension is
+// absent from node.Allocatable's tracked capacity. cpu/memory are always
+// considered tracked (they're dedicated Resource fields, not scalar entries,
+// and always have a real, if zero, capacity number).
+func allUntrackedByAllocatable(resourceNames []string, node *api.NodeInfo) bool {
+	for _, name := range resourceNames {
+		if name == "cpu" || name == "memory" {
+			return false
+		}
+		if _, present := node.Allocatable.ScalarResources[v1.ResourceName(name)]; present {
+			return false
+		}
+	}
+	return true
 }
 
 // GetMinInt return minimum int from vals

--- a/pkg/scheduler/util/scheduler_helper.go
+++ b/pkg/scheduler/util/scheduler_helper.go
@@ -320,12 +320,14 @@ func GetRealNodesByHyperNode(hyperNodes map[string]sets.Set[string], allNodes ma
 // have a real capacity number, so the comparison can be trusted as-is, including a genuine "no".
 //
 // It can never be satisfied, however, for resources a device plugin tracks entirely through its
-// own predicate/ledger instead - e.g. volcano.sh/vgpu-cores and volcano.sh/vgpu-memory-percentage,
-// which by design are never advertised as node capacity (see
-// docs/user-guide/how_to_use_volcano_vgpu.md) because "50% of one card" isn't a poolable
-// node-wide quantity. When every failing dimension is one of these, the comparison is
-// structurally unable to answer the question, so simulate evicting the victims on a throwaway
-// clone of node and ask the real predicate instead of treating "unknowable" as "no".
+// own predicate/ledger instead - confirmed for volcano.sh/vgpu-memory-percentage, a pure
+// request-side modifier ("50% of whatever card this pod lands on" has no coherent node-wide
+// capacity total to advertise) never referenced anywhere as something written into Allocatable.
+// volcano.sh/vgpu-cores may or may not have the same gap depending on how the device plugin
+// advertises it; this fallback covers that case too if so, without assuming it either way. When
+// every failing dimension is one node.Allocatable has no capacity number for at all, the
+// comparison is structurally unable to answer the question, so simulate evicting the victims on
+// a throwaway clone of node and ask the real predicate instead of treating "unknowable" as "no".
 func ValidateVictims(preemptor *api.TaskInfo, node *api.NodeInfo, victims []*api.TaskInfo, predicateFn func(*api.TaskInfo, *api.NodeInfo) error) error {
 	// Victims should not be judged to be empty here.
 	// It is possible to complete the scheduling of the preemptor without evicting the task.


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

A pod requesting a fractional vGPU slice (volcano.sh/vgpu-memory-percentage) stays Pending forever during preemption, even when evicting a lower priority pod would free up plenty of room on the card. Whole GPU requests using volcano.sh/vgpu-number only work fine.

normalPreempt decides whether an eviction freed up enough room by comparing the pod's requested resources against node.FutureIdle() using plain arithmetic. That comparison is only trustworthy for resources that actually have a capacity number in node.Status.Allocatable, like cpu, memory, or volcano.sh/vgpu-number. volcano.sh/vgpu-memory-percentage never does: it's a pure request-side modifier ("50% of whatever card this pod lands on" has no coherent node-wide total to advertise), and there's nowhere in this codebase, or in HAMi's device-plugin, that ever writes it into node capacity. So for a pod asking for it, that comparison can never come back true, no matter how much the device plugin's own ledger actually freed up after eviction, and the pod just stays stuck.

(Earlier draft of this PR also named volcano.sh/vgpu-cores as untracked. That was wrong: NewGPUDevices in device_info.go requires vgpu-cores, along with vgpu-memory, to be present and nonzero in node.Status.Allocatable, or it refuses to initialize GPU tracking for the node at all. So on any working vGPU node, vgpu-cores genuinely is tracked. The fix and the test now reflect that correction, one test case is kept as a synthetic regression guard for the general mechanism, and the realistic one confirms the bug via vgpu-memory-percentage specifically.)

deviceshare's own predicate already gets this right, it reads the real per-device usage and knows exactly what fits. It just never gets asked, normalPreempt makes its decision using only the generic arithmetic.

There's a second, earlier instance of the same problem in ValidateVictims (shared by both preempt and reclaim), which runs before any eviction happens at all, as a quick check on whether the selected victims would even be worth evicting. Same arithmetic, same blind spot, and it runs early enough that it blocks the fix in normalPreempt from ever getting a chance to matter.

The fix keeps the cheap arithmetic check as the fast path, since it's correct and free for anything with a real capacity number behind it. When it fails, it looks at exactly which resource dimensions it's unhappy about. If every one of them is something node.Allocatable has no entry for at all, the arithmetic genuinely can't answer the question, so it falls back to the real predicate instead of treating unknowable as no. If even one of the failing dimensions is something the node actually tracks, it trusts the arithmetic as is and doesn't second guess it. The fix doesn't hardcode either resource name anywhere, it reacts to whatever's actually missing from Allocatable at runtime.

This was deliberate, not just "always defer to the predicate on any failure": tried that first, and it broke two existing BestEffort preemption tests. If no predicate plugin is registered to check a given resource at all, ssn.PredicateFn just returns success by default since there's nothing to check against. A blanket fallback would quietly turn off resource enforcement for anything not covered by whatever plugins happen to be configured, which is a scarier failure mode than the one being fixed.

ValidateVictims gets the same treatment, except since it runs before any real eviction, it simulates the eviction on a throwaway clone of the node before asking the predicate, so nothing on the real node is touched unless the eviction actually goes ahead.

#### Which issue(s) this PR fixes:
Fixes #4863

#### Special notes for your reviewer:

Used Claude Code (AI assistant) to investigate this issue, arrive at the root cause, and draft the fix and test. I reviewed every change, reasoned through the tradeoffs of a couple of alternative approaches before settling on this one, and ran the full pkg/scheduler/... suite myself before opening and updating this PR. I also went back and corrected an earlier claim in this PR (see below) after double-checking it against the actual code rather than taking it at face value. Happy to walk through any part of the reasoning or code in review.

Test coverage in TestPreemptFractionalVGPU:
- a synthetic vgpu-cores scenario (kept as a general regression guard for the fallback mechanism, its node doesn't declare vgpu-cores in Allocatable so it isn't proven to reflect production)
- a realistic vgpu-memory-percentage scenario, where the node properly declares vgpu-number/vgpu-cores/vgpu-memory in Allocatable matching NewGPUDevices's real gate, and the bug still reproduces purely from vgpu-memory-percentage being untracked
- a whole-GPU vgpu-number-only scenario as a regression guard confirming that path is untouched

All three fail against unpatched code and pass with the fix.

#### Does this PR introduce a user-facing change?

```release-note
Fix a bug where a pod requesting a fractional vGPU (volcano.sh/vgpu-memory-percentage) could stay Pending indefinitely during preemption, even when evicting a lower priority pod would have freed enough capacity. Whole-GPU requests (volcano.sh/vgpu-number) were not affected.
```
