### PR TITLE
helm: use agent_scheduler_replicas in agent_scheduler deployment

### DIFF
--- a/installer/helm/chart/volcano/templates/agent_scheduler.yaml
+++ b/installer/helm/chart/volcano/templates/agent_scheduler.yaml
@@ -149,7 +149,7 @@ metadata:
     {{- mustMerge (.Values.custom.scheduler_labels | default (dict)) (.Values.custom.common_labels | default (dict)) | toYaml | nindent 4 }}
     {{- end }}
 spec:
-  replicas: {{ .Values.custom.scheduler_replicas }}
+  replicas: {{ .Values.custom.agent_scheduler_replicas }}
   selector:
     matchLabels:
       app: agent-scheduler


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

In `installer/helm/chart/volcano/values.yaml`, `agent_scheduler_replicas` is configured under `custom` as the dedicated replica count setting for the Agent Scheduler component.

However, `installer/helm/chart/volcano/templates/agent_scheduler.yaml` previously referenced `.Values.custom.scheduler_replicas` instead of `.Values.custom.agent_scheduler_replicas` in the Deployment spec. Consequently, when users configured `custom.agent_scheduler_replicas` (e.g. setting it to 3), the rendered Deployment ignored this setting and incorrectly tracked `scheduler_replicas`.

This PR updates `installer/helm/chart/volcano/templates/agent_scheduler.yaml` to use `.Values.custom.agent_scheduler_replicas`, aligning it with the rest of Volcano's Helm templates (`admission.yaml` using `admission_replicas`, `controllers.yaml` using `controller_replicas`, and `scheduler.yaml` using `scheduler_replicas`).

Before:
```yaml
spec:
  replicas: {{ .Values.custom.scheduler_replicas }}
```

After:
```yaml
spec:
  replicas: {{ .Values.custom.agent_scheduler_replicas }}
```

#### Which issue(s) this PR fixes:

Fixes #5798

#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?

```release-note
Fix agent_scheduler deployment template to use agent_scheduler_replicas for replica count.
```
