### PR TITLE
fix: ignore scoped resource quotas

### DIFF
--- a/pkg/scheduler/api/namespace_info.go
+++ b/pkg/scheduler/api/namespace_info.go
@@ -28,20 +28,23 @@ type NamespaceInfo struct {
 	// Name is the name of this namespace
 	Name NamespaceName
 	// QuotaStatus stores the ResourceQuotaStatus of all ResourceQuotas in this namespace
-	QuotaStatus map[string]v1.ResourceQuotaStatus
+	QuotaStatus  map[string]v1.ResourceQuotaStatus
+	scopedQuotas map[string]bool
 }
 
 // NamespaceCollection will record all details about namespace
 type NamespaceCollection struct {
-	Name        string
-	QuotaStatus map[string]v1.ResourceQuotaStatus
+	Name         string
+	QuotaStatus  map[string]v1.ResourceQuotaStatus
+	scopedQuotas map[string]bool
 }
 
 // NewNamespaceCollection creates new NamespaceCollection object to record all information about a namespace
 func NewNamespaceCollection(name string) *NamespaceCollection {
 	n := &NamespaceCollection{
-		Name:        name,
-		QuotaStatus: make(map[string]v1.ResourceQuotaStatus),
+		Name:         name,
+		QuotaStatus:  make(map[string]v1.ResourceQuotaStatus),
+		scopedQuotas: make(map[string]bool),
 	}
 	return n
 }
@@ -49,11 +52,14 @@ func NewNamespaceCollection(name string) *NamespaceCollection {
 // Update modify the registered information according quota object
 func (n *NamespaceCollection) Update(quota *v1.ResourceQuota) {
 	n.QuotaStatus[quota.Name] = quota.Status
+	n.scopedQuotas[quota.Name] = len(quota.Spec.Scopes) > 0 ||
+		(quota.Spec.ScopeSelector != nil && len(quota.Spec.ScopeSelector.MatchExpressions) > 0)
 }
 
 // Delete remove the registered information according quota object
 func (n *NamespaceCollection) Delete(quota *v1.ResourceQuota) {
 	delete(n.QuotaStatus, quota.Name)
+	delete(n.scopedQuotas, quota.Name)
 }
 
 // Snapshot will clone a NamespaceInfo without Heap according NamespaceCollection
@@ -62,8 +68,18 @@ func (n *NamespaceCollection) Snapshot() *NamespaceInfo {
 	for k, v := range n.QuotaStatus {
 		copiedQuotaStatus[k] = *v.DeepCopy()
 	}
-	return &NamespaceInfo{
-		Name:        NamespaceName(n.Name),
-		QuotaStatus: copiedQuotaStatus,
+	copiedScopedQuotas := make(map[string]bool, len(n.scopedQuotas))
+	for k, v := range n.scopedQuotas {
+		copiedScopedQuotas[k] = v
 	}
+	return &NamespaceInfo{
+		Name:         NamespaceName(n.Name),
+		QuotaStatus:  copiedQuotaStatus,
+		scopedQuotas: copiedScopedQuotas,
+	}
+}
+
+// IsQuotaScoped returns whether a ResourceQuota has scopes or a scope selector.
+func (n *NamespaceInfo) IsQuotaScoped(name string) bool {
+	return n.scopedQuotas[name]
 }

--- a/pkg/scheduler/api/namespace_info_test.go
+++ b/pkg/scheduler/api/namespace_info_test.go
@@ -74,3 +74,43 @@ func TestNamespaceCollection(t *testing.T) {
 	c.Delete(newQuota("def", 0))
 	c.Delete(newQuota("ghi", 0))
 }
+
+func TestNamespaceCollectionScopedQuota(t *testing.T) {
+	c := NewNamespaceCollection("testCollection")
+
+	scopedQuota := newQuota("scoped", 1)
+	scopedQuota.Spec.Scopes = []v1.ResourceQuotaScope{v1.ResourceQuotaScopeTerminating}
+	c.Update(scopedQuota)
+
+	selectorQuota := newQuota("selector", 1)
+	selectorQuota.Spec.ScopeSelector = &v1.ScopeSelector{
+		MatchExpressions: []v1.ScopedResourceSelectorRequirement{
+			{
+				ScopeName: v1.ResourceQuotaScopePriorityClass,
+				Operator:  v1.ScopeSelectorOpIn,
+				Values:    []string{"high"},
+			},
+		},
+	}
+	c.Update(selectorQuota)
+
+	info := c.Snapshot()
+	for _, name := range []string{scopedQuota.Name, selectorQuota.Name} {
+		if _, found := info.QuotaStatus[name]; !found {
+			t.Errorf("QuotaStatus %s of namespace should exist", name)
+		}
+		if !info.IsQuotaScoped(name) {
+			t.Errorf("ResourceQuota %s should be scoped", name)
+		}
+	}
+
+	c.Update(newQuota(scopedQuota.Name, 2))
+	if c.Snapshot().IsQuotaScoped(scopedQuota.Name) {
+		t.Errorf("ResourceQuota %s should not be scoped", scopedQuota.Name)
+	}
+
+	c.Delete(selectorQuota)
+	if c.Snapshot().IsQuotaScoped(selectorQuota.Name) {
+		t.Errorf("ResourceQuota %s should not exist", selectorQuota.Name)
+	}
+}

--- a/pkg/scheduler/plugins/resourcequota/resourcequota.go
+++ b/pkg/scheduler/plugins/resourcequota/resourcequota.go
@@ -61,12 +61,15 @@ func (rq *resourceQuotaPlugin) OnSessionOpen(ssn *framework.Session) {
 			return util.Permit
 		}
 
-		if ssn.NamespaceInfo[api.NamespaceName(job.Namespace)] == nil {
+		namespaceInfo := ssn.NamespaceInfo[api.NamespaceName(job.Namespace)]
+		if namespaceInfo == nil {
 			return util.Permit
 		}
 
-		quotas := ssn.NamespaceInfo[api.NamespaceName(job.Namespace)].QuotaStatus
-		for _, resourceQuota := range quotas {
+		for name, resourceQuota := range namespaceInfo.QuotaStatus {
+			if namespaceInfo.IsQuotaScoped(name) {
+				continue
+			}
 			hardResources := quotav1.ResourceNames(resourceQuota.Hard)
 			requestedUsage := quotav1.Mask(*resourcesRequests, hardResources)
 

--- a/pkg/scheduler/plugins/resourcequota/resourcequota_test.go
+++ b/pkg/scheduler/plugins/resourcequota/resourcequota_test.go
@@ -48,6 +48,8 @@ func TestResourceQuotaPlugin(t *testing.T) {
 
 	queue1 := util.BuildQueue("c1", 1, nil)
 	rq1 := util.BuildResourceQuota("test", "default", normalResource)
+	scopedRQ := util.BuildResourceQuota("scoped", "default", normalResource)
+	scopedRQ.Spec.Scopes = []v1.ResourceQuotaScope{v1.ResourceQuotaScopeTerminating}
 
 	tests := []struct {
 		uthelper.TestCommonStruct
@@ -72,6 +74,16 @@ func TestResourceQuotaPlugin(t *testing.T) {
 				ResourceQuotas: []*v1.ResourceQuota{rq1},
 			},
 			expectedEnqueueAble: false,
+		},
+		{
+			TestCommonStruct: uthelper.TestCommonStruct{
+				Name:           "Scoped ResourceQuota does not apply to this pg",
+				Plugins:        map[string]framework.PluginBuilder{PluginName: New},
+				PodGroups:      []*schedulingv1.PodGroup{pg2},
+				Queues:         []*schedulingv1.Queue{queue1},
+				ResourceQuotas: []*v1.ResourceQuota{scopedRQ},
+			},
+			expectedEnqueueAble: true,
 		},
 		{
 			TestCommonStruct: uthelper.TestCommonStruct{


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Stops the resourcequota plugin from treating scoped ResourceQuotas as namespace-wide quotas. Scoped quotas are kept in the namespace snapshot but ignored by the plugin until scope matching is supported.

#### Which issue(s) this PR fixes:

Fixes #5793

#### Special notes for your reviewer:

Tests:
- `go test ./pkg/scheduler/api -count=1`
- `TestResourceQuotaPlugin` using a Linux test binary under WSL

#### Does this PR introduce a user-facing change?

```release-note
The resourcequota scheduler plugin no longer applies scoped ResourceQuotas as namespace-wide quotas.