### PR TITLE
Only trigger hyperNode controller when network topology discovery config changes

### DIFF
--- a/pkg/controllers/hypernode/config/loader.go
+++ b/pkg/controllers/hypernode/config/loader.go
@@ -70,8 +70,13 @@ func (l *loader) LoadConfig() (*api.NetworkTopologyConfig, error) {
 		return nil, fmt.Errorf("config key not found in ConfigMap: %s", l.configKey)
 	}
 
+	return ParseConfig(configYaml)
+}
+
+// ParseConfig parses the network topology config from YAML.
+func ParseConfig(configYaml string) (*api.NetworkTopologyConfig, error) {
 	config := &api.NetworkTopologyConfig{}
-	if err = yaml.Unmarshal([]byte(configYaml), config); err != nil {
+	if err := yaml.Unmarshal([]byte(configYaml), config); err != nil {
 		return nil, fmt.Errorf("failed to parse config: %v", err)
 	}
 	return config, nil

--- a/pkg/controllers/hypernode/configmap_handler.go
+++ b/pkg/controllers/hypernode/configmap_handler.go
@@ -19,6 +19,7 @@ package hypernode
 import (
 	"fmt"
 	"os"
+	"reflect"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
@@ -59,7 +60,6 @@ func (hn *hyperNodeController) setupConfigMapInformer() {
 		return filteredInformer
 	})
 	hn.configMapInformer = hn.informerFactory.Core().V1().ConfigMaps()
-	// TODO: Only trigger handler when networkTopologyDiscovery config changed.
 	hn.configMapInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc:    hn.addConfigMap,
 		UpdateFunc: hn.updateConfigMap,
@@ -78,13 +78,46 @@ func (hn *hyperNodeController) addConfigMap(obj interface{}) {
 }
 
 func (hn *hyperNodeController) updateConfigMap(oldObj, newObj interface{}) {
-	cm, ok := newObj.(*v1.ConfigMap)
+	newCM, ok := newObj.(*v1.ConfigMap)
 	if !ok {
 		klog.ErrorS(nil, "Cannot convert to *v1.ConfigMap", "obj", newObj)
 		return
 	}
-	klog.V(3).InfoS("Update ConfigMap", "namespace", cm.Namespace, "name", cm.Name)
-	hn.enqueueConfigMap(cm)
+	oldCM, ok := oldObj.(*v1.ConfigMap)
+	if !ok {
+		klog.ErrorS(nil, "Cannot convert to *v1.ConfigMap", "obj", oldObj)
+		return
+	}
+	if !configChanged(oldCM, newCM) {
+		klog.V(3).InfoS("ConfigMap update without network topology discovery config change, skip",
+			"namespace", newCM.Namespace, "name", newCM.Name)
+		return
+	}
+	klog.V(3).InfoS("Update ConfigMap", "namespace", newCM.Namespace, "name", newCM.Name)
+	hn.enqueueConfigMap(newCM)
+}
+
+// configChanged returns true if the network topology discovery config in the
+// ConfigMap data changed between the old and new ConfigMaps.
+func configChanged(oldCM, newCM *v1.ConfigMap) bool {
+	oldConfig, oldOK := oldCM.Data[config.DefaultConfigKey]
+	newConfig, newOK := newCM.Data[config.DefaultConfigKey]
+
+	if oldOK != newOK {
+		return true
+	}
+	if !oldOK || oldConfig == newConfig {
+		return false
+	}
+
+	// Compare the parsed configs to ignore changes that do not affect the
+	// network topology discovery, such as whitespace or unrelated fields.
+	oldCfg, oldErr := config.ParseConfig(oldConfig)
+	newCfg, newErr := config.ParseConfig(newConfig)
+	if oldErr != nil || newErr != nil {
+		return true
+	}
+	return !reflect.DeepEqual(oldCfg, newCfg)
 }
 
 func (hn *hyperNodeController) deleteConfigMap(obj interface{}) {

--- a/pkg/controllers/hypernode/configmap_handler_test.go
+++ b/pkg/controllers/hypernode/configmap_handler_test.go
@@ -133,35 +133,164 @@ func TestAddConfigMap(t *testing.T) {
 	assert.Equal(t, 1, controller.configMapQueue.Len())
 }
 
-func TestUpdateConfigMap(t *testing.T) {
-	controller := newFakeConfigMapController()
+const testValidConfig = `
+networkTopologyDiscovery:
+  - source: ufm
+    enabled: true
+    config:
+      url: "http://ufm-host:8080"
+`
 
+func TestUpdateConfigMap(t *testing.T) {
+	testCases := []struct {
+		name              string
+		oldConfigMap      *v1.ConfigMap
+		newConfigMap      *v1.ConfigMap
+		expectedQueueSize int
+	}{
+		{
+			name: "Unrelated key change does not trigger",
+			oldConfigMap: &v1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-configmap",
+					Namespace: "test-namespace",
+				},
+				Data: map[string]string{
+					"key1": "value1",
+				},
+			},
+			newConfigMap: &v1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-configmap",
+					Namespace: "test-namespace",
+				},
+				Data: map[string]string{
+					"key1": "value1",
+					"key2": "value2",
+				},
+			},
+			expectedQueueSize: 0,
+		},
+		{
+			name: "Unrelated change with unchanged network topology config does not trigger",
+			oldConfigMap: &v1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-configmap",
+					Namespace: "test-namespace",
+				},
+				Data: map[string]string{
+					config.DefaultConfigKey: testValidConfig,
+					"key1":                  "value1",
+				},
+			},
+			newConfigMap: &v1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-configmap",
+					Namespace: "test-namespace",
+				},
+				Data: map[string]string{
+					config.DefaultConfigKey: testValidConfig,
+					"key1":                  "value2",
+				},
+			},
+			expectedQueueSize: 0,
+		},
+		{
+			name: "Network topology config change triggers",
+			oldConfigMap: &v1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-configmap",
+					Namespace: "test-namespace",
+				},
+				Data: map[string]string{
+					config.DefaultConfigKey: testValidConfig,
+				},
+			},
+			newConfigMap: &v1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-configmap",
+					Namespace: "test-namespace",
+				},
+				Data: map[string]string{
+					config.DefaultConfigKey: `
+networkTopologyDiscovery:
+  - source: ufm
+    enabled: false
+    config:
+      url: "http://ufm-host:8080"
+`,
+				},
+			},
+			expectedQueueSize: 1,
+		},
+		{
+			name: "Network topology config key added triggers",
+			oldConfigMap: &v1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-configmap",
+					Namespace: "test-namespace",
+				},
+				Data: map[string]string{
+					"key1": "value1",
+				},
+			},
+			newConfigMap: &v1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-configmap",
+					Namespace: "test-namespace",
+				},
+				Data: map[string]string{
+					config.DefaultConfigKey: testValidConfig,
+					"key1":                  "value1",
+				},
+			},
+			expectedQueueSize: 1,
+		},
+		{
+			name: "Network topology config key removed triggers",
+			oldConfigMap: &v1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-configmap",
+					Namespace: "test-namespace",
+				},
+				Data: map[string]string{
+					config.DefaultConfigKey: testValidConfig,
+				},
+			},
+			newConfigMap: &v1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-configmap",
+					Namespace: "test-namespace",
+				},
+				Data: map[string]string{},
+			},
+			expectedQueueSize: 1,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			controller := newFakeConfigMapController()
+			controller.updateConfigMap(tc.oldConfigMap, tc.newConfigMap)
+			assert.Equal(t, tc.expectedQueueSize, controller.configMapQueue.Len())
+		})
+	}
+
+	// Test invalid object (non-ConfigMap)
+	controller := newFakeConfigMapController()
 	oldConfigMap := &v1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-configmap",
 			Namespace: "test-namespace",
 		},
-		Data: map[string]string{
-			"key1": "value1",
-		},
 	}
-
-	newConfigMap := oldConfigMap.DeepCopy()
-	newConfigMap.Data["key2"] = "value2"
-
-	controller.updateConfigMap(oldConfigMap, newConfigMap)
-
-	// Verify the ConfigMap was added to the queue
-	assert.Equal(t, 1, controller.configMapQueue.Len())
-
-	// Test invalid object (non-ConfigMap)
 	pod := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "test-pod",
 		},
 	}
 	controller.updateConfigMap(oldConfigMap, pod)
-	assert.Equal(t, 1, controller.configMapQueue.Len())
+	assert.Equal(t, 0, controller.configMapQueue.Len())
 }
 
 func TestDeleteConfigMap(t *testing.T) {
@@ -240,7 +369,7 @@ func TestIntegrationConfigMapHandling(t *testing.T) {
 			Namespace: "test-namespace",
 		},
 		Data: map[string]string{
-			"config": "initial",
+			config.DefaultConfigKey: testValidConfig,
 		},
 	}
 
@@ -263,14 +392,34 @@ func TestIntegrationConfigMapHandling(t *testing.T) {
 	// Process the queue
 	key, _ := controller.configMapQueue.Get()
 	controller.configMapQueue.Done(key)
+	assert.Equal(t, 0, controller.configMapQueue.Len())
 
-	updatedConfigMap := configMap.DeepCopy()
-	updatedConfigMap.Data["config"] = "updated"
+	// Unrelated change should not enqueue
+	unrelatedUpdate := configMap.DeepCopy()
+	unrelatedUpdate.Data["unrelated"] = "value"
 
 	_, err = controller.kubeClient.CoreV1().ConfigMaps("test-namespace").Update(
-		context.Background(), updatedConfigMap, metav1.UpdateOptions{})
+		context.Background(), unrelatedUpdate, metav1.UpdateOptions{})
 	assert.NoError(t, err)
 
 	time.Sleep(1 * time.Second)
-	assert.Equal(t, 1, controller.configMapQueue.Len())
+	assert.Equal(t, 0, controller.configMapQueue.Len(), "unrelated ConfigMap change should not enqueue")
+
+	// Network topology config change should enqueue
+	relevantUpdate := configMap.DeepCopy()
+	relevantUpdate.Data[config.DefaultConfigKey] = `
+networkTopologyDiscovery:
+  - source: ufm
+    enabled: false
+    config:
+      url: "http://ufm-host:8080"
+`
+
+	_, err = controller.kubeClient.CoreV1().ConfigMaps("test-namespace").Update(
+		context.Background(), relevantUpdate, metav1.UpdateOptions{})
+	assert.NoError(t, err)
+
+	assert.Eventually(t, func() bool {
+		return controller.configMapQueue.Len() == 1
+	}, 5*time.Second, 10*time.Millisecond, "expected network topology config change to enqueue one key")
 }


### PR DESCRIPTION
## Description:
The hyperNode controller's ConfigMap informer enqueued the ConfigMap on every update, even when the networkTopologyDiscovery content was unchanged or only unrelated keys in the ConfigMap Data changed. This caused the discovery manager to be triggered unnecessarily on every ConfigMap resync/update.
## This PR makes the handler change-aware:
- Extract ParseConfig in pkg/controllers/hypernode/config/loader.go so the YAML parsing logic is shared between the loader and change detection.
- Rewrite updateConfigMap in pkg/controllers/hypernode/configmap_handler.go to only enqueue when the config actually changed. A new configChanged helper:
  - Triggers when the volcano-controller.conf key is added or removed
  - Skips when the key is absent or byte-identical
  - Compares the parsed NetworkTopologyConfig so whitespace-only or unrelated-data changes are ignored
  - Falls back to triggering on any difference if parsing fails (conservative)
- Update unit and integration tests to cover: unrelated change (no trigger), unrelated change with unchanged config (no trigger), relevant config change (trigger), config key added/removed (trigger), and invalid objects (no trigger).
No behavior change when the config is actually modified — this only avoids spurious wake-ups of the discovery manager.

#5803 