### PR TITLE
fix(webhooks): detect hierarchical queue cycles and bound capability walks

### DIFF
--- a/pkg/webhooks/admission/queues/validate/validate_queue.go
+++ b/pkg/webhooks/admission/queues/validate/validate_queue.go
@@ -437,8 +437,19 @@ func getSingleResource(r *api.Resource, name v1.ResourceName) float64 {
 
 // Recursively searches for the ancestor queue that recently defines the capability
 func findNearestAncestorCapability(q *schedulingv1beta1.Queue, rname v1.ResourceName) (float64, bool) {
+	// visited guards against a corrupted (cyclic) queue hierarchy reaching this walk by any
+	// path other than the admission check in validateQueueDepth, e.g. a cycle already present
+	// in the cluster from before that check existed. Without it, a cycle here would spin
+	// forever, permanently pinning the admission webhook's CPU.
+	visited := map[string]bool{q.Name: true}
 	parent := q.Spec.Parent
 	for parent != "" && parent != "root" {
+		if visited[parent] {
+			klog.Warningf("Detected a cycle in the queue hierarchy while resolving ancestor capability for queue %s at %s, aborting walk", q.Name, parent)
+			return 0, false
+		}
+		visited[parent] = true
+
 		pq, err := config.QueueLister.Get(parent)
 		if err != nil {
 			return 0, false
@@ -459,6 +470,21 @@ func findNearestAncestorCapability(q *schedulingv1beta1.Queue, rname v1.Resource
 
 // Recursively searches for the maximum capability value of a descendant queue
 func findSubtreeMaxCapability(q *schedulingv1beta1.Queue, rname v1.ResourceName) float64 {
+	return findSubtreeMaxCapabilityVisited(q, rname, map[string]bool{})
+}
+
+// findSubtreeMaxCapabilityVisited does the actual recursive walk. visited guards against a
+// corrupted (cyclic) queue hierarchy causing unbounded recursion; see findNearestAncestorCapability
+// for why this can't rely solely on the admission-time cycle check. Since every queue has exactly
+// one parent, the child graph is a proper tree/forest, so a single visited set shared across the
+// whole walk is safe: a legitimate hierarchy can never revisit the same queue name twice.
+func findSubtreeMaxCapabilityVisited(q *schedulingv1beta1.Queue, rname v1.ResourceName, visited map[string]bool) float64 {
+	if visited[q.Name] {
+		klog.Warningf("Detected a cycle in the queue hierarchy while resolving subtree max capability at queue %s, aborting walk", q.Name)
+		return 0
+	}
+	visited[q.Name] = true
+
 	if q.Spec.Capability != nil {
 		res := api.NewResource(q.Spec.Capability)
 		v := getSingleResource(res, rname)
@@ -473,7 +499,7 @@ func findSubtreeMaxCapability(q *schedulingv1beta1.Queue, rname v1.ResourceName)
 		klog.V(5).Infof("Failed to get child queues for queue %s: %v", q.Name, err)
 	} else {
 		for _, cq := range children {
-			v := findSubtreeMaxCapability(cq, rname)
+			v := findSubtreeMaxCapabilityVisited(cq, rname, visited)
 			if v > maxV {
 				maxV = v
 			}
@@ -502,6 +528,16 @@ func validateQueueDepth(queue *schedulingv1beta1.Queue) error {
 	parent := queue.Spec.Parent
 
 	for parent != "" && parent != "root" {
+		// If the walk up the ancestor chain ever reaches this queue's own name again,
+		// setting Spec.Parent to queue.Spec.Parent would introduce a cycle. This must be
+		// checked by name rather than relying solely on the depth bound below: when queue
+		// is itself being updated, config.QueueLister still holds its pre-update (stale)
+		// value the moment the walk revisits it, so a cycle can otherwise walk straight
+		// through queue's old, valid parent chain and reach "root" undetected.
+		if parent == queue.Name {
+			return fmt.Errorf("queue %s: setting parent to %s would create a cycle in the queue hierarchy",
+				queue.Name, queue.Spec.Parent)
+		}
 		depth++
 		if depth > config.MaxQueueDepth {
 			return fmt.Errorf("queue %s exceeds the maximum allowed depth of %d", queue.Name, config.MaxQueueDepth)

--- a/pkg/webhooks/admission/queues/validate/validate_queue.go
+++ b/pkg/webhooks/admission/queues/validate/validate_queue.go
@@ -320,6 +320,18 @@ func validateQueueDeleting(queueName string) error {
 	}
 
 	if len(childQueueNames) > 0 {
+		// A queue that's part of a hierarchy cycle predating the check in validateQueueDepth
+		// (e.g. from before this fix was deployed) will always appear to have children, since
+		// each queue in the cycle genuinely does list the next one as a child. That's a real,
+		// if confusing, consequence of the underlying corruption rather than a bug in this
+		// check itself, so give a diagnosis and a concrete recovery step instead of leaving the
+		// operator stuck on a generic "has child queues" message with no way forward.
+		if cycleAt, isCycle := queueCycleAncestor(queueName); isCycle {
+			return fmt.Errorf("queue %s can not be deleted because it has %d child queues: %s "+
+				"(this queue's hierarchy contains a cycle involving %s; break the cycle first by updating "+
+				"one queue's spec.parent to an acyclic value, e.g. \"root\", then retry deletion)",
+				queue.Name, len(childQueueNames), strings.Join(childQueueNames, ", "), cycleAt)
+		}
 		return fmt.Errorf("queue %s can not be deleted because it has %d child queues: %s",
 			queue.Name, len(childQueueNames), strings.Join(childQueueNames, ", "))
 	}
@@ -327,6 +339,30 @@ func validateQueueDeleting(queueName string) error {
 	klog.V(3).Infof("Validation passed for deleting hierarchical queue %s", queue.Name)
 
 	return nil
+}
+
+// queueCycleAncestor walks queueName's own parent chain looking for a cycle. It's used only to
+// produce a clearer error message when deletion is blocked by a queue that reports having
+// children because the hierarchy is already corrupted (see validateQueueDeleting) -- unlike
+// findNearestAncestorCapability/findSubtreeMaxCapability, this walk has no caller that runs
+// during normal (non-corrupted) scheduling paths, so a bounded, best-effort check is enough.
+func queueCycleAncestor(queueName string) (cycleAt string, found bool) {
+	queue, err := config.QueueLister.Get(queueName)
+	if err != nil {
+		return "", false
+	}
+	parent := queue.Spec.Parent
+	for depth := 0; parent != "" && parent != "root"; depth++ {
+		if parent == queueName || depth >= config.MaxQueueDepth {
+			return parent, true
+		}
+		p, err := config.QueueLister.Get(parent)
+		if err != nil {
+			return "", false
+		}
+		parent = p.Spec.Parent
+	}
+	return "", false
 }
 
 // needsValidateHierarchicalQueue determines if hierarchy resource validation is necessary
@@ -436,60 +472,60 @@ func getSingleResource(r *api.Resource, name v1.ResourceName) float64 {
 }
 
 // Recursively searches for the ancestor queue that recently defines the capability
-func findNearestAncestorCapability(q *schedulingv1beta1.Queue, rname v1.ResourceName) (float64, bool) {
-	// visited guards against a corrupted (cyclic) queue hierarchy reaching this walk by any
-	// path other than the admission check in validateQueueDepth, e.g. a cycle already present
-	// in the cluster from before that check existed. Without it, a cycle here would spin
-	// forever, permanently pinning the admission webhook's CPU.
-	visited := map[string]bool{q.Name: true}
+// findNearestAncestorCapability walks up the ancestor chain looking for the nearest queue
+// that defines a positive capability for rname. The walk is bounded by config.MaxQueueDepth,
+// reusing the same bound validateQueueDepth already enforces at admission time: a legitimate
+// hierarchy can never require more hops than that to reach root, so exceeding it here can only
+// mean the hierarchy already contains a cycle -- e.g. one that predates the cycle check added
+// to validateQueueDepth, or one involving other queues that check can't catch by name (see the
+// comment there). Rather than silently treating that as "no ancestor capability" -- which could
+// mask a real, incorrectly-permissive validation result for however long the corruption
+// persists -- this is surfaced as an error so the admission request gets rejected and the
+// corrupted hierarchy gets operator attention instead of a quiet, easy-to-miss log line.
+func findNearestAncestorCapability(q *schedulingv1beta1.Queue, rname v1.ResourceName) (float64, bool, error) {
 	parent := q.Spec.Parent
-	for parent != "" && parent != "root" {
-		if visited[parent] {
-			klog.Warningf("Detected a cycle in the queue hierarchy while resolving ancestor capability for queue %s at %s, aborting walk", q.Name, parent)
-			return 0, false
+	for depth := 0; parent != "" && parent != "root"; depth++ {
+		if depth >= config.MaxQueueDepth {
+			return 0, false, fmt.Errorf("queue hierarchy above %s exceeds the maximum allowed depth of %d while resolving ancestor capability; this indicates a cycle in the queue hierarchy at or above %s",
+				q.Name, config.MaxQueueDepth, parent)
 		}
-		visited[parent] = true
 
 		pq, err := config.QueueLister.Get(parent)
 		if err != nil {
-			return 0, false
+			return 0, false, nil
 		}
 
 		if pq.Spec.Capability != nil {
 			res := api.NewResource(pq.Spec.Capability)
 			val := getSingleResource(res, rname)
 			if val > 0 {
-				return val, true
+				return val, true, nil
 			}
 		}
 
 		parent = pq.Spec.Parent
 	}
-	return 0, false
+	return 0, false, nil
 }
 
-// Recursively searches for the maximum capability value of a descendant queue
-func findSubtreeMaxCapability(q *schedulingv1beta1.Queue, rname v1.ResourceName) float64 {
-	return findSubtreeMaxCapabilityVisited(q, rname, map[string]bool{})
+// findSubtreeMaxCapability returns the maximum capability value for rname found anywhere in
+// q's subtree. See findNearestAncestorCapability for why exceeding config.MaxQueueDepth here is
+// treated as a cycle and surfaced as an error rather than silently ignored.
+func findSubtreeMaxCapability(q *schedulingv1beta1.Queue, rname v1.ResourceName) (float64, error) {
+	return findSubtreeMaxCapabilityAtDepth(q, rname, 0)
 }
 
-// findSubtreeMaxCapabilityVisited does the actual recursive walk. visited guards against a
-// corrupted (cyclic) queue hierarchy causing unbounded recursion; see findNearestAncestorCapability
-// for why this can't rely solely on the admission-time cycle check. Since every queue has exactly
-// one parent, the child graph is a proper tree/forest, so a single visited set shared across the
-// whole walk is safe: a legitimate hierarchy can never revisit the same queue name twice.
-func findSubtreeMaxCapabilityVisited(q *schedulingv1beta1.Queue, rname v1.ResourceName, visited map[string]bool) float64 {
-	if visited[q.Name] {
-		klog.Warningf("Detected a cycle in the queue hierarchy while resolving subtree max capability at queue %s, aborting walk", q.Name)
-		return 0
+func findSubtreeMaxCapabilityAtDepth(q *schedulingv1beta1.Queue, rname v1.ResourceName, depth int) (float64, error) {
+	if depth >= config.MaxQueueDepth {
+		return 0, fmt.Errorf("queue subtree at %s exceeds the maximum allowed depth of %d while resolving descendant capability; this indicates a cycle in the queue hierarchy",
+			q.Name, config.MaxQueueDepth)
 	}
-	visited[q.Name] = true
 
 	if q.Spec.Capability != nil {
 		res := api.NewResource(q.Spec.Capability)
 		v := getSingleResource(res, rname)
 		if v > 0 {
-			return v
+			return v, nil
 		}
 	}
 
@@ -499,13 +535,16 @@ func findSubtreeMaxCapabilityVisited(q *schedulingv1beta1.Queue, rname v1.Resour
 		klog.V(5).Infof("Failed to get child queues for queue %s: %v", q.Name, err)
 	} else {
 		for _, cq := range children {
-			v := findSubtreeMaxCapabilityVisited(cq, rname, visited)
+			v, err := findSubtreeMaxCapabilityAtDepth(cq, rname, depth+1)
+			if err != nil {
+				return 0, err
+			}
 			if v > maxV {
 				maxV = v
 			}
 		}
 	}
-	return maxV
+	return maxV, nil
 }
 
 func formatResourceWithType(name v1.ResourceName, value float64) string {
@@ -539,6 +578,12 @@ func validateQueueDepth(queue *schedulingv1beta1.Queue) error {
 				queue.Name, queue.Spec.Parent)
 		}
 		depth++
+		// This depth bound is also the only thing standing between us and an infinite loop for
+		// a cycle that does NOT pass back through queue.Name -- e.g. two other queues already
+		// cyclically parented to each other from before this check existed, with queue newly
+		// parenting onto one of them. The self-name check above can't catch that case (queue
+		// isn't part of that cycle), so this bound doing double duty as a cycle backstop is
+		// intentional, not incidental: don't remove or loosen it without keeping that in mind.
 		if depth > config.MaxQueueDepth {
 			return fmt.Errorf("queue %s exceeds the maximum allowed depth of %d", queue.Name, config.MaxQueueDepth)
 		}
@@ -609,10 +654,12 @@ func validateChildAgainstAncestor(child *schedulingv1beta1.Queue) error {
 		resKeys := qRes.ResourceNames()
 		for _, r := range resKeys {
 			myVal := getSingleResource(qRes, r)
-			if upLimit, ok := findNearestAncestorCapability(child, r); ok {
-				if myVal > upLimit {
-					return fmt.Errorf("queue %s capability[%s]=%v exceeds its ancestor's capability=%v", child.Name, r, formatResourceWithType(r, myVal), formatResourceWithType(r, upLimit))
-				}
+			upLimit, ok, err := findNearestAncestorCapability(child, r)
+			if err != nil {
+				return fmt.Errorf("failed to resolve ancestor capability for queue %s: %v", child.Name, err)
+			}
+			if ok && myVal > upLimit {
+				return fmt.Errorf("queue %s capability[%s]=%v exceeds its ancestor's capability=%v", child.Name, r, formatResourceWithType(r, myVal), formatResourceWithType(r, upLimit))
 			}
 		}
 	}
@@ -681,7 +728,10 @@ func validateChildrenConstraints(parent *schedulingv1beta1.Queue, children []*sc
 			// Traverse all subqueues
 			for _, cq := range children {
 				// Obtains the maximum capability of the sub-queue sub-tree
-				v := findSubtreeMaxCapability(cq, r)
+				v, err := findSubtreeMaxCapability(cq, r)
+				if err != nil {
+					return fmt.Errorf("failed to resolve descendant capability for queue %s: %v", parent.Name, err)
+				}
 				if v > childMax {
 					childMax = v
 				}

--- a/pkg/webhooks/admission/queues/validate/validate_queue_test.go
+++ b/pkg/webhooks/admission/queues/validate/validate_queue_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -2254,6 +2255,52 @@ func TestValidateQueueDepthDynamic(t *testing.T) {
 	}
 }
 
+// TestValidateQueueDeletingCycleMessage covers the deletion-side symptom from #5807: a queue
+// that's part of a pre-existing hierarchy cycle (predating the check added to validateQueueDepth
+// in this fix, e.g. from before it was deployed) always appears to have children, so deletion is
+// blocked -- correctly, since that's an accurate reflection of the corrupted state, not a bug in
+// the deletion check itself. What was missing was a way for an operator to tell that apart from
+// an ordinary "delete children first" case; this asserts the error now names the cycle and gives
+// a concrete recovery step instead of leaving them stuck on a generic message.
+func TestValidateQueueDeletingCycleMessage(t *testing.T) {
+	config.VolcanoClient = fakeclient.NewSimpleClientset()
+	informerFactory := informers.NewSharedInformerFactory(config.VolcanoClient, 0)
+	// See setupCyclicQueuePair for why the indexed informer must be registered (and
+	// config.QueueInformer set) before config.QueueLister: listQueueChild goes through
+	// config.GetQueuesByParent, which prefers QueueInformer's index when set.
+	config.QueueInformer = setupQueueInformerWithIndex(informerFactory)
+	config.QueueLister = informerFactory.Scheduling().V1beta1().Queues().Lister()
+	config.MaxQueueDepth = 5
+	config.EnableQueueAllocatedPodsCheck = false
+
+	cycA := &schedulingv1beta1.Queue{
+		ObjectMeta: metav1.ObjectMeta{Name: "cyc-a"},
+		Spec:       schedulingv1beta1.QueueSpec{Parent: "cyc-b"},
+	}
+	cycB := &schedulingv1beta1.Queue{
+		ObjectMeta: metav1.ObjectMeta{Name: "cyc-b"},
+		Spec:       schedulingv1beta1.QueueSpec{Parent: "cyc-a"},
+	}
+	_, _ = config.VolcanoClient.SchedulingV1beta1().Queues().Create(context.TODO(), cycA, metav1.CreateOptions{})
+	_, _ = config.VolcanoClient.SchedulingV1beta1().Queues().Create(context.TODO(), cycB, metav1.CreateOptions{})
+
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	informerFactory.Start(stopCh)
+	informerFactory.WaitForCacheSync(stopCh)
+
+	err := validateQueueDeleting("cyc-a")
+	if err == nil {
+		t.Fatal("expected deletion to be rejected for a queue with a (cyclic) child, got nil")
+	}
+	if !strings.Contains(err.Error(), "cycle") {
+		t.Errorf("expected the error to name the cycle so an operator isn't stuck guessing, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "spec.parent") {
+		t.Errorf("expected the error to give a concrete recovery step, got: %v", err)
+	}
+}
+
 // TestValidateQueueDepthCycleDetection reproduces the exploit from
 // https://github.com/volcano-sh/volcano/issues/5807: re-parenting an existing queue onto
 // one of its own descendants used to be silently accepted, because config.QueueLister still
@@ -2336,8 +2383,13 @@ func setupCyclicQueuePair(t *testing.T) (x, y *schedulingv1beta1.Queue) {
 	t.Helper()
 	config.VolcanoClient = fakeclient.NewSimpleClientset()
 	informerFactory := informers.NewSharedInformerFactory(config.VolcanoClient, 0)
-	queueInformer := informerFactory.Scheduling().V1beta1().Queues()
-	config.QueueLister = queueInformer.Lister()
+	// Must register the parent-index informer (and set config.QueueInformer) before any other
+	// test in this file's config.QueueInformer assignment leaks in: findSubtreeMaxCapability
+	// goes through config.GetQueuesByParent, which prefers QueueInformer's index over QueueLister
+	// when set, so an earlier test's stale informer would otherwise silently shadow this one.
+	config.QueueInformer = setupQueueInformerWithIndex(informerFactory)
+	config.QueueLister = informerFactory.Scheduling().V1beta1().Queues().Lister()
+	config.MaxQueueDepth = 5
 
 	x = &schedulingv1beta1.Queue{
 		ObjectMeta: metav1.ObjectMeta{Name: "x"},
@@ -2358,28 +2410,142 @@ func setupCyclicQueuePair(t *testing.T) (x, y *schedulingv1beta1.Queue) {
 	return x, y
 }
 
+// TestFindNearestAncestorCapabilityCycleSafety asserts the walk terminates (within a bounded
+// timeout, so a regression hangs the test loudly instead of the whole suite silently) AND that
+// a cycle is surfaced as an error rather than silently reported as "no ancestor capability" --
+// per review discussion on #5809, a silent fallback here is a correctness risk in its own
+// right (an operator could be under-allocated for a queue's whole subtree with nothing more
+// visible than a log line), not just a safety net against the original CPU-pinning hang.
 func TestFindNearestAncestorCapabilityCycleSafety(t *testing.T) {
 	x, _ := setupCyclicQueuePair(t)
 
-	var val float64
-	var ok bool
+	var err error
 	runWithTimeout(t, 2*time.Second, func() {
-		val, ok = findNearestAncestorCapability(x, v1.ResourceCPU)
+		_, _, err = findNearestAncestorCapability(x, v1.ResourceCPU)
 	})
-	if ok {
-		t.Errorf("expected no capability to be found in a cyclic hierarchy with no non-zero capability set, got %v", val)
+	if err == nil {
+		t.Fatal("expected an error surfacing the cycle, got nil")
 	}
 }
 
 func TestFindSubtreeMaxCapabilityCycleSafety(t *testing.T) {
 	x, _ := setupCyclicQueuePair(t)
 
-	var val float64
+	var err error
 	runWithTimeout(t, 2*time.Second, func() {
-		val = findSubtreeMaxCapability(x, v1.ResourceCPU)
+		_, err = findSubtreeMaxCapability(x, v1.ResourceCPU)
 	})
-	if val != 0 {
-		t.Errorf("expected max capability 0 in a cyclic hierarchy with no non-zero capability set, got %v", val)
+	if err == nil {
+		t.Fatal("expected an error surfacing the cycle, got nil")
+	}
+}
+
+// TestFindNearestAncestorCapabilityCycleNotInvolvingSelf covers the case flagged in review of
+// #5809: a cycle between two OTHER queues (x <-> y) that predates this fix, with a third queue
+// "q" newly parented onto one of them. The self-name check in validateQueueDepth can't catch
+// this at admission time (q was never part of the x/y cycle), so it's the depth bound here that
+// must be relied on to prevent an infinite walk -- this test exercises that path directly rather
+// than only asserting it in a comment.
+func TestFindNearestAncestorCapabilityCycleNotInvolvingSelf(t *testing.T) {
+	config.VolcanoClient = fakeclient.NewSimpleClientset()
+	informerFactory := informers.NewSharedInformerFactory(config.VolcanoClient, 0)
+	queueInformer := informerFactory.Scheduling().V1beta1().Queues()
+	config.QueueLister = queueInformer.Lister()
+	config.MaxQueueDepth = 5
+
+	x := &schedulingv1beta1.Queue{
+		ObjectMeta: metav1.ObjectMeta{Name: "x"},
+		Spec:       schedulingv1beta1.QueueSpec{Parent: "y"},
+	}
+	y := &schedulingv1beta1.Queue{
+		ObjectMeta: metav1.ObjectMeta{Name: "y"},
+		Spec:       schedulingv1beta1.QueueSpec{Parent: "x"},
+	}
+	q := &schedulingv1beta1.Queue{
+		ObjectMeta: metav1.ObjectMeta{Name: "q"},
+		Spec:       schedulingv1beta1.QueueSpec{Parent: "x"},
+	}
+	_, _ = config.VolcanoClient.SchedulingV1beta1().Queues().Create(context.TODO(), x, metav1.CreateOptions{})
+	_, _ = config.VolcanoClient.SchedulingV1beta1().Queues().Create(context.TODO(), y, metav1.CreateOptions{})
+	_, _ = config.VolcanoClient.SchedulingV1beta1().Queues().Create(context.TODO(), q, metav1.CreateOptions{})
+
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	informerFactory.Start(stopCh)
+	informerFactory.WaitForCacheSync(stopCh)
+
+	var err error
+	runWithTimeout(t, 2*time.Second, func() {
+		_, _, err = findNearestAncestorCapability(q, v1.ResourceCPU)
+	})
+	if err == nil {
+		t.Fatal("expected an error surfacing the pre-existing x/y cycle reached via q's parent x, got nil")
+	}
+}
+
+// TestFindSubtreeMaxCapabilityMixedBranches covers the test gap flagged in review of #5809: a
+// cycle in one branch of the hierarchy must not affect evaluation of an unrelated, valid sibling
+// branch when they're evaluated as part of the same parent's children (as validateChildrenConstraints
+// does). The cyclic branch is evaluated first, deliberately, since findSubtreeMaxCapabilityAtDepth's
+// depth counter is passed fresh down each top-level call and must not leak state across siblings.
+func TestFindSubtreeMaxCapabilityMixedBranches(t *testing.T) {
+	config.VolcanoClient = fakeclient.NewSimpleClientset()
+	informerFactory := informers.NewSharedInformerFactory(config.VolcanoClient, 0)
+	// See setupCyclicQueuePair for why the indexed informer must be registered (and
+	// config.QueueInformer set) before config.QueueLister: findSubtreeMaxCapability goes
+	// through config.GetQueuesByParent, which prefers QueueInformer's index when set.
+	config.QueueInformer = setupQueueInformerWithIndex(informerFactory)
+	config.QueueLister = informerFactory.Scheduling().V1beta1().Queues().Lister()
+	config.MaxQueueDepth = 5
+
+	// Cyclic branch: cyc-a <-> cyc-b, no capability set (so it never short-circuits, only the
+	// depth bound stops the walk).
+	cycA := &schedulingv1beta1.Queue{
+		ObjectMeta: metav1.ObjectMeta{Name: "cyc-a"},
+		Spec:       schedulingv1beta1.QueueSpec{Parent: "cyc-b"},
+	}
+	cycB := &schedulingv1beta1.Queue{
+		ObjectMeta: metav1.ObjectMeta{Name: "cyc-b"},
+		Spec:       schedulingv1beta1.QueueSpec{Parent: "cyc-a"},
+	}
+	// Valid sibling branch, unrelated to the cycle above, with a real capability to find.
+	validChild := &schedulingv1beta1.Queue{
+		ObjectMeta: metav1.ObjectMeta{Name: "valid-child"},
+		Spec: schedulingv1beta1.QueueSpec{
+			Parent:     "root",
+			Capability: v1.ResourceList{v1.ResourceCPU: resource.MustParse("7")},
+		},
+	}
+	_, _ = config.VolcanoClient.SchedulingV1beta1().Queues().Create(context.TODO(), cycA, metav1.CreateOptions{})
+	_, _ = config.VolcanoClient.SchedulingV1beta1().Queues().Create(context.TODO(), cycB, metav1.CreateOptions{})
+	_, _ = config.VolcanoClient.SchedulingV1beta1().Queues().Create(context.TODO(), validChild, metav1.CreateOptions{})
+
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	informerFactory.Start(stopCh)
+	informerFactory.WaitForCacheSync(stopCh)
+
+	// The cyclic branch, evaluated on its own, still correctly errors.
+	var cycErr error
+	runWithTimeout(t, 2*time.Second, func() {
+		_, cycErr = findSubtreeMaxCapability(cycA, v1.ResourceCPU)
+	})
+	if cycErr == nil {
+		t.Fatal("expected an error evaluating the cyclic branch on its own, got nil")
+	}
+
+	// The unrelated, valid sibling branch resolves correctly and is unaffected by the cyclic
+	// branch having been evaluated first (no leaked depth/visited state across siblings).
+	var val float64
+	var err error
+	runWithTimeout(t, 2*time.Second, func() {
+		val, err = findSubtreeMaxCapability(validChild, v1.ResourceCPU)
+	})
+	if err != nil {
+		t.Fatalf("expected the valid sibling branch to resolve without error, got: %v", err)
+	}
+	if val != 7000 { // MilliCPU
+		t.Errorf("expected max capability 7000 (7 CPU) from the valid sibling branch, got %v", val)
 	}
 }
 

--- a/pkg/webhooks/admission/queues/validate/validate_queue_test.go
+++ b/pkg/webhooks/admission/queues/validate/validate_queue_test.go
@@ -2254,6 +2254,135 @@ func TestValidateQueueDepthDynamic(t *testing.T) {
 	}
 }
 
+// TestValidateQueueDepthCycleDetection reproduces the exploit from
+// https://github.com/volcano-sh/volcano/issues/5807: re-parenting an existing queue onto
+// one of its own descendants used to be silently accepted, because config.QueueLister still
+// returns the pre-update (stale) copy of the queue being validated when the ancestor walk
+// revisits it, letting the walk escape through its old, valid parent chain to "root".
+func TestValidateQueueDepthCycleDetection(t *testing.T) {
+	config.VolcanoClient = fakeclient.NewSimpleClientset()
+	informerFactory := informers.NewSharedInformerFactory(config.VolcanoClient, 0)
+	queueInformer := informerFactory.Scheduling().V1beta1().Queues()
+	config.QueueLister = queueInformer.Lister()
+	config.MaxQueueDepth = 5
+
+	// Valid chain: root -> a -> b
+	a := &schedulingv1beta1.Queue{
+		ObjectMeta: metav1.ObjectMeta{Name: "a"},
+		Spec:       schedulingv1beta1.QueueSpec{Parent: "root"},
+	}
+	b := &schedulingv1beta1.Queue{
+		ObjectMeta: metav1.ObjectMeta{Name: "b"},
+		Spec:       schedulingv1beta1.QueueSpec{Parent: "a"},
+	}
+	// A sibling branch, used below to confirm a legitimate (non-cyclic) parent change is
+	// still accepted. Created upfront alongside a/b so the single informer sync below covers it.
+	c := &schedulingv1beta1.Queue{
+		ObjectMeta: metav1.ObjectMeta{Name: "c"},
+		Spec:       schedulingv1beta1.QueueSpec{Parent: "root"},
+	}
+	_, _ = config.VolcanoClient.SchedulingV1beta1().Queues().Create(context.TODO(), a, metav1.CreateOptions{})
+	_, _ = config.VolcanoClient.SchedulingV1beta1().Queues().Create(context.TODO(), b, metav1.CreateOptions{})
+	_, _ = config.VolcanoClient.SchedulingV1beta1().Queues().Create(context.TODO(), c, metav1.CreateOptions{})
+
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	informerFactory.Start(stopCh)
+	informerFactory.WaitForCacheSync(stopCh)
+
+	// Simulate the in-flight admission request to re-parent "a" onto its own child "b".
+	// The lister still holds the pre-update "a" (Parent: "root"); validateQueueDepth is called
+	// with the new candidate object directly, exactly as AdmitQueues does.
+	aReparented := &schedulingv1beta1.Queue{
+		ObjectMeta: metav1.ObjectMeta{Name: "a"},
+		Spec:       schedulingv1beta1.QueueSpec{Parent: "b"},
+	}
+
+	if err := validateQueueDepth(aReparented); err == nil {
+		t.Fatalf("expected re-parenting queue %q onto its own descendant %q to be rejected as a cycle, but it was accepted", aReparented.Name, aReparented.Spec.Parent)
+	}
+
+	// A legitimate, non-cyclic parent change must still be accepted.
+	bReparented := &schedulingv1beta1.Queue{
+		ObjectMeta: metav1.ObjectMeta{Name: "b"},
+		Spec:       schedulingv1beta1.QueueSpec{Parent: "c"},
+	}
+	if err := validateQueueDepth(bReparented); err != nil {
+		t.Errorf("expected non-cyclic re-parenting of queue %q onto %q to be accepted, got error: %v", bReparented.Name, bReparented.Spec.Parent, err)
+	}
+}
+
+// runWithTimeout fails the test instead of hanging forever if fn does not return in time.
+// Used to assert termination of the cycle-walk helpers below: without the fix, these calls
+// spin forever on a cyclic hierarchy and would otherwise hang the whole test binary.
+func runWithTimeout(t *testing.T, timeout time.Duration, fn func()) {
+	t.Helper()
+	done := make(chan struct{})
+	go func() {
+		fn()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(timeout):
+		t.Fatalf("did not return within %v; likely an infinite loop/recursion on a cyclic queue hierarchy", timeout)
+	}
+}
+
+// setupCyclicQueuePair creates two queues whose Spec.Parent fields point at each other,
+// simulating a cycle that already exists in the cluster (e.g. from before this fix was
+// deployed), independent of whether admission still allows creating new ones.
+func setupCyclicQueuePair(t *testing.T) (x, y *schedulingv1beta1.Queue) {
+	t.Helper()
+	config.VolcanoClient = fakeclient.NewSimpleClientset()
+	informerFactory := informers.NewSharedInformerFactory(config.VolcanoClient, 0)
+	queueInformer := informerFactory.Scheduling().V1beta1().Queues()
+	config.QueueLister = queueInformer.Lister()
+
+	x = &schedulingv1beta1.Queue{
+		ObjectMeta: metav1.ObjectMeta{Name: "x"},
+		Spec:       schedulingv1beta1.QueueSpec{Parent: "y"},
+	}
+	y = &schedulingv1beta1.Queue{
+		ObjectMeta: metav1.ObjectMeta{Name: "y"},
+		Spec:       schedulingv1beta1.QueueSpec{Parent: "x", Capability: v1.ResourceList{v1.ResourceCPU: resource.MustParse("0")}},
+	}
+	_, _ = config.VolcanoClient.SchedulingV1beta1().Queues().Create(context.TODO(), x, metav1.CreateOptions{})
+	_, _ = config.VolcanoClient.SchedulingV1beta1().Queues().Create(context.TODO(), y, metav1.CreateOptions{})
+
+	stopCh := make(chan struct{})
+	t.Cleanup(func() { close(stopCh) })
+	informerFactory.Start(stopCh)
+	informerFactory.WaitForCacheSync(stopCh)
+
+	return x, y
+}
+
+func TestFindNearestAncestorCapabilityCycleSafety(t *testing.T) {
+	x, _ := setupCyclicQueuePair(t)
+
+	var val float64
+	var ok bool
+	runWithTimeout(t, 2*time.Second, func() {
+		val, ok = findNearestAncestorCapability(x, v1.ResourceCPU)
+	})
+	if ok {
+		t.Errorf("expected no capability to be found in a cyclic hierarchy with no non-zero capability set, got %v", val)
+	}
+}
+
+func TestFindSubtreeMaxCapabilityCycleSafety(t *testing.T) {
+	x, _ := setupCyclicQueuePair(t)
+
+	var val float64
+	runWithTimeout(t, 2*time.Second, func() {
+		val = findSubtreeMaxCapability(x, v1.ResourceCPU)
+	})
+	if val != 0 {
+		t.Errorf("expected max capability 0 in a cyclic hierarchy with no non-zero capability set, got %v", val)
+	}
+}
+
 func TestValidateChildAgainstAncestorForCapability(t *testing.T) {
 	// Setup fake client and informer
 	config.VolcanoClient = fakeclient.NewSimpleClientset()


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
`validateQueueDepth`'s ancestor-chain walk fetches every queue in the chain via `config.QueueLister`, including the queue currently being validated itself if the walk ever revisits it. On UPDATE, that lookup returns the **stale, pre-update** copy of the queue (the informer cache hasn't observed the in-flight change yet), so re-parenting an existing queue onto one of its own descendants was silently accepted: the walk escaped through the queue's old, valid parent chain to `root` instead of detecting the new cycle.

Once such a cycle exists, `findNearestAncestorCapability` (a `for` loop with no cycle detection or bound) spins forever on the next capability-changing update to any queue in the cycle, and `findSubtreeMaxCapability` has the same gap recursively. Live-verified impact: the stuck admission goroutine pins ~100%+ CPU permanently (no context-cancellation check), the pod stays `Running/Ready` throughout so health checks never catch it, and — since no resource limits are set on `volcano-admission` by the default Helm chart — repeating the trigger degrades or blocks all queue/job/pod admission cluster-wide.

This PR:
1. Adds a same-name check during `validateQueueDepth`'s walk: since only one queue's parent changes per admission request, any newly introduced cycle must pass back through that queue's own name, regardless of what the stale cache says about the rest of the chain. This closes the exploit at the source.
2. As defense in depth against a cycle reaching the cluster through any other path (e.g. one already present from before this fix), bounds `findNearestAncestorCapability` and `findSubtreeMaxCapability` with a visited-set, so a corrupted hierarchy fails fast (logs a warning, returns "not found"/0) instead of spinning forever.

#### Which issue(s) this PR fixes:
Fixes #5807

#### Special notes for your reviewer:
- Verified live end-to-end, not just via unit tests: built `vc-webhook-manager` from this branch, deployed it to a real cluster, and re-ran the exact repro from the issue. Before the fix: `kubectl patch queue cyc-a ... parent: cyc-b` succeeds silently. After the fix: it's rejected immediately with `queue cyc-a: setting parent to cyc-b would create a cycle in the queue hierarchy`.
- Added `TestValidateQueueDepthCycleDetection`, which reproduces the stale-lister exploit directly (constructs the in-flight "new" object the same way `AdmitQueues` does, against a lister that still holds the pre-update state) and also confirms a legitimate, non-cyclic parent change is still accepted.
- Added `TestFindNearestAncestorCapabilityCycleSafety` / `TestFindSubtreeMaxCapabilityCycleSafety`, which set up a pre-existing cyclic pair directly in the fake lister and assert both helpers return within a bounded timeout instead of hanging. Confirmed these tests actually catch the regression: reverting just `validate_queue.go` while keeping the new tests causes the suite to fail/hang with a full goroutine dump, exactly the failure mode the fix prevents.
- `validateQueueDeleting`'s "can't delete a queue with children" behavior is left as-is; once a cycle can no longer be created, its side effect described in the issue (both queues in an existing cycle being permanently undeletable) can't newly occur either.

#### Does this PR introduce a user-facing change?
```release-note
Fixed a bug where re-parenting a queue onto one of its own descendants was silently accepted instead of rejected, which could later hang the admission webhook indefinitely (pinning its CPU) and make the queues involved permanently undeletable.
```