### PR TITLE
fix: wire event recorder into scheduler framework

### DIFF
--- a/pkg/scheduler/cache/cache.go
+++ b/pkg/scheduler/cache/cache.go
@@ -140,7 +140,7 @@ type SchedulerCache struct {
 	StatusUpdater  StatusUpdater
 	PodGroupBinder BatchBinder
 
-	Recorder record.EventRecorder
+	Recorder record.EventRecorderLogger
 
 	Jobs                 map[schedulingapi.JobID]*schedulingapi.JobInfo
 	Nodes                map[string]*schedulingapi.NodeInfo
@@ -1072,7 +1072,7 @@ func (sc *SchedulerCache) AddUnassignedNumaPods(allocatedSets map[schedulingapi.
 }
 
 // EventRecorder returns the Event Recorder
-func (sc *SchedulerCache) EventRecorder() record.EventRecorder {
+func (sc *SchedulerCache) EventRecorder() record.EventRecorderLogger {
 	return sc.Recorder
 }
 

--- a/pkg/scheduler/cache/cache_mock.go
+++ b/pkg/scheduler/cache/cache_mock.go
@@ -47,7 +47,7 @@ func NewCustomMockSchedulerCache(schedulerName string,
 	evictor Evictor,
 	statusUpdater StatusUpdater,
 	PodGroupBinder BatchBinder,
-	recorder record.EventRecorder,
+	recorder record.EventRecorderLogger,
 ) *SchedulerCache {
 	options.Default() // init options first because cache may reference server opts in options
 	msc := newMockSchedulerCache(schedulerName)

--- a/pkg/scheduler/cache/interface.go
+++ b/pkg/scheduler/cache/interface.go
@@ -89,7 +89,7 @@ type Cache interface {
 	GetMetricsConf() map[string]string
 
 	// EventRecorder returns the event recorder
-	EventRecorder() record.EventRecorder
+	EventRecorder() record.EventRecorderLogger
 
 	// RegisterBinder registers the passed binder to the cache's binderRegistry
 	RegisterBinder(name string, binder interface{})

--- a/pkg/scheduler/framework/session.go
+++ b/pkg/scheduler/framework/session.go
@@ -68,7 +68,7 @@ type Session struct {
 
 	kubeClient      kubernetes.Interface
 	vcClient        vcclient.Interface
-	recorder        record.EventRecorder
+	recorder        record.EventRecorderLogger
 	cache           cache.Cache
 	restConfig      *rest.Config
 	informerFactory informers.SharedInformerFactory
@@ -973,6 +973,11 @@ func (ssn *Session) ClientConfig() *rest.Config {
 // InformerFactory returns the scheduler ShareInformerFactory
 func (ssn *Session) InformerFactory() informers.SharedInformerFactory {
 	return ssn.informerFactory
+}
+
+// EventRecorder returns the event recorder
+func (ssn *Session) EventRecorder() record.EventRecorderLogger {
+	return ssn.recorder
 }
 
 // RecordPodGroupEvent records podGroup events

--- a/pkg/scheduler/plugins/predicates/predicates.go
+++ b/pkg/scheduler/plugins/predicates/predicates.go
@@ -199,6 +199,7 @@ func (pp *PredicatesPlugin) OnSessionOpen(ssn *framework.Session) {
 		k8s.WithSharedCSIManager(nodevolumelimits.NewCSIManager(ssn.InformerFactory().Storage().V1().CSINodes().Lister())),
 		k8s.WithClientSet(ssn.KubeClient()),
 		k8s.WithInformerFactory(ssn.InformerFactory()),
+		k8s.WithEventRecorder(ssn.EventRecorder()),
 	)
 	pp.Handle = handle
 

--- a/pkg/scheduler/plugins/predicates/predicates_test.go
+++ b/pkg/scheduler/plugins/predicates/predicates_test.go
@@ -29,6 +29,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/informers"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/klog/v2"
 	k8sframework "k8s.io/kube-scheduler/framework"
 	schedframework "k8s.io/kubernetes/pkg/scheduler/framework"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/dynamicresources"
@@ -733,6 +735,47 @@ func TestBatchNodeOrderRunsPreScorePlugins(t *testing.T) {
 				t.Errorf("expected node score presence to be %t, got %t", tt.wantScore, scored)
 			}
 		})
+	}
+}
+
+func TestFrameworkEventRecorder(t *testing.T) {
+	var predicatePlugin *PredicatesPlugin
+	test := uthelper.TestCommonStruct{
+		Plugins: map[string]framework.PluginBuilder{
+			PluginName: func(arguments framework.Arguments) framework.Plugin {
+				predicatePlugin = New(arguments).(*PredicatesPlugin)
+				return predicatePlugin
+			},
+		},
+	}
+	enabled := true
+	tiers := []conf.Tier{
+		{
+			Plugins: []conf.PluginOption{
+				{
+					Name:             PluginName,
+					EnabledPredicate: &enabled,
+				},
+			},
+		},
+	}
+
+	ssn := test.RegisterSession(tiers, nil)
+	defer test.Close()
+
+	recorder, ok := ssn.EventRecorder().(*record.FakeRecorder)
+	if !ok {
+		t.Fatalf("unexpected event recorder type %T", ssn.EventRecorder())
+	}
+	predicatePlugin.Handle.EventRecorder().WithLogger(klog.Background()).Eventf(
+		&apiv1.Pod{}, nil, apiv1.EventTypeNormal, "BindingConditionsPending", "Scheduling", "waiting for binding conditions",
+	)
+
+	select {
+	case event := <-recorder.Events:
+		assert.Equal(t, "Normal BindingConditionsPending waiting for binding conditions", event)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for event")
 	}
 }
 

--- a/pkg/scheduler/plugins/predicates/predicates_test.go
+++ b/pkg/scheduler/plugins/predicates/predicates_test.go
@@ -777,6 +777,12 @@ func TestFrameworkEventRecorder(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatal("timed out waiting for event")
 	}
+
+	assert.NotPanics(t, func() {
+		k8s.NewFramework(nil).EventRecorder().WithLogger(klog.Background()).Eventf(
+			&apiv1.Pod{}, nil, apiv1.EventTypeNormal, "BindingConditionsPending", "Scheduling", "waiting for binding conditions",
+		)
+	})
 }
 
 func TestPredicateFailureReasonAggregationOrderStable(t *testing.T) {

--- a/pkg/scheduler/plugins/util/k8s/framework.go
+++ b/pkg/scheduler/plugins/util/k8s/framework.go
@@ -253,7 +253,9 @@ func (f *Framework) GetVolcanoNodeInfo(nodeName string) (*api.NodeInfo, error) {
 
 // NewFramework is the constructor of Framework
 func NewFramework(nodeMap map[string]fwk.NodeInfo, opts ...Option) *Framework {
-	fw := &Framework{}
+	fw := &Framework{
+		eventRecorder: &events.FakeRecorder{},
+	}
 
 	for _, opt := range opts {
 		opt(fw)

--- a/pkg/scheduler/plugins/util/k8s/framework.go
+++ b/pkg/scheduler/plugins/util/k8s/framework.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/events"
+	"k8s.io/client-go/tools/record"
 	"k8s.io/klog/v2"
 	fwk "k8s.io/kube-scheduler/framework"
 	"k8s.io/kubernetes/pkg/scheduler/apis/config"
@@ -40,6 +41,7 @@ type Framework struct {
 	snapshot         *Snapshot
 	kubeClient       kubernetes.Interface
 	informerFactory  informers.SharedInformerFactory
+	eventRecorder    events.EventRecorderLogger
 	sharedDRAManager fwk.SharedDRAManager
 	sharedCSIManager fwk.CSIManager
 }
@@ -80,6 +82,13 @@ func WithClientSet(clientSet kubernetes.Interface) Option {
 func WithInformerFactory(informerFactory informers.SharedInformerFactory) Option {
 	return func(o *Framework) {
 		o.informerFactory = informerFactory
+	}
+}
+
+// WithEventRecorder sets the event recorder for the framework.
+func WithEventRecorder(eventRecorder record.EventRecorderLogger) Option {
+	return func(o *Framework) {
+		o.eventRecorder = record.NewEventRecorderAdapter(eventRecorder)
 	}
 }
 
@@ -132,9 +141,8 @@ func (f *Framework) VolumeBinder() volumebinding.SchedulerVolumeBinder {
 	panic("not implemented")
 }
 
-// EventRecorder was introduced in k8s v1.19.6 and to be implemented
 func (f *Framework) EventRecorder() events.EventRecorderLogger {
-	return nil
+	return f.eventRecorder
 }
 
 func (f *Framework) AddNominatedPod(logger klog.Logger, pod fwk.PodInfo, nominatingInfo *fwk.NominatingInfo) {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Passes the scheduler event recorder into the Kubernetes framework adapter.

The DynamicResources PreBind plugin emits an event while DRA binding conditions are pending. The adapter currently returns a nil recorder, causing the bind worker to panic and terminate the scheduler.

Also adds a regression test covering the recorder path through the predicates plugin.

#### Which issue(s) this PR fixes:

Fixes #5812

#### Special notes for your reviewer:

Tested TestFrameworkEventRecorder on Linux.

AI assistance was used during implementation. I reviewed the final diff and ran the focused regression test on my own.

#### Does this PR introduce a user-facing change?

```release-note
Fix scheduler panic when DRA device binding conditions are pending.