### PR TITLE
scheduler: remove redundant preemptor requeue

### DIFF
--- a/pkg/scheduler/actions/preempt/preempt.go
+++ b/pkg/scheduler/actions/preempt/preempt.go
@@ -178,8 +178,6 @@ func (pmpt *Action) Execute(ssn *framework.Session) {
 			preemptorJob := preemptors.Pop().(*api.JobInfo)
 
 			stmt := framework.NewStatement(ssn)
-			var assigned bool
-			var err error
 			for {
 				// If job is not request more resource, then stop preempting.
 				if !ssn.JobStarving(preemptorJob) {
@@ -195,7 +193,7 @@ func (pmpt *Action) Execute(ssn *framework.Session) {
 
 				preemptor := preemptorTasks[preemptorJob.UID].Pop().(*api.TaskInfo)
 
-				assigned, err = pmpt.preempt(ssn, stmt, preemptor, func(task *api.TaskInfo) bool {
+				_, err := pmpt.preempt(ssn, stmt, preemptor, func(task *api.TaskInfo) bool {
 					// Ignore non running task.
 					if !api.PreemptableStatus(task.Status) {
 						return false
@@ -229,10 +227,6 @@ func (pmpt *Action) Execute(ssn *framework.Session) {
 			} else {
 				stmt.Discard()
 				continue
-			}
-
-			if assigned {
-				preemptors.Push(preemptorJob)
 			}
 		}
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

The inner between-job preemption loop already processes a preemptor job
until either the job is no longer starving or its preemptor task queue is
empty.

The preemptor task queue is not replenished during the action. Therefore,
pushing the job back into the priority queue after a successful assignment
causes the next iteration to immediately reach one of the same exit
conditions without performing additional preemption work.

This PR removes the redundant requeue and the now-unused `assigned`
variable. It does not change the expected scheduling behavior.

#### Which issue(s) this PR fixes:

Fixes #5776 

#### Special notes for your reviewer:

No new test case is added because this cleanup intentionally does not
change observable scheduling behavior.

The existing normal and topology-aware preemption test cases already
exercise the successful assignment path affected by this change and verify
the resulting victim evictions. All existing tests continue to pass after
the redundant requeue is removed.

Tests performed:

- `make lint`
- `make verify`
- `make unit-test`

AI disclosure: I used OpenAI Codex to help inspect the scheduler control
flow and execute the repository checks. I reviewed the final change and
test results and take responsibility for the contribution.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```