### PR TITLE
agent: fix divide-by-zero and lock contention in oversubscription reporting

### DIFF
--- a/pkg/agent/events/probes/noderesources/resource_calculator.go
+++ b/pkg/agent/events/probes/noderesources/resource_calculator.go
@@ -46,7 +46,7 @@ func init() {
 // historicalUsageCalculator is used to calculate the overSubscription
 type historicalUsageCalculator struct {
 	sync.Mutex
-	cfgLock sync.Mutex
+	cfgLock sync.RWMutex
 	policy.Interface
 	eventQueueFactory *framework.EventQueueFactory
 	queue             *queue.SqQueue
@@ -131,6 +131,11 @@ func (r *historicalUsageCalculator) computeOverSubRes() apis.Resource {
 	overSubRes := make(apis.Resource)
 	totalWeight := int64(0)
 	initWeight := int64(1)
+	// historicalUsages is oldest-first (queue.GetAll returns FIFO order), so
+	// iterating forward while doubling the weight each step already gives the
+	// newest sample the highest weight (512 for a full 10-entry window) and
+	// the oldest sample the lowest weight (1) -- the correct EMA-like recency
+	// weighting.
 	for _, usage := range historicalUsages {
 		totalWeight += initWeight
 		for _, res := range apis.OverSubscriptionResourceTypes {
@@ -145,8 +150,8 @@ func (r *historicalUsageCalculator) computeOverSubRes() apis.Resource {
 }
 
 func (r *historicalUsageCalculator) getOverSubscriptionTypes(node *v1.Node) map[v1.ResourceName]bool {
-	r.cfgLock.Lock()
-	defer r.cfgLock.Unlock()
+	r.cfgLock.RLock()
+	defer r.cfgLock.RUnlock()
 	ret := make(map[v1.ResourceName]bool)
 	for _, item := range r.resourceTypes.List() {
 		ret[v1.ResourceName(item)] = true

--- a/pkg/agent/events/probes/noderesources/resource_calculator_test.go
+++ b/pkg/agent/events/probes/noderesources/resource_calculator_test.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"sync"
 	"testing"
 
 	. "github.com/agiledragon/gomonkey/v2"
@@ -282,4 +283,53 @@ func Test_historicalUsageCalculator_RefreshCfg(t *testing.T) {
 			assert.Equal(t, tt.expectedResourceType, r.resourceTypes)
 		})
 	}
+}
+
+// Test_computeOverSubRes_weightOrder verifies that the most-recent sample in
+// the queue (the tail, since Enqueue appends and GetAll returns oldest-first)
+// receives the highest weight, so the calculator reacts quickly to current
+// utilisation instead of being dominated by stale samples.
+func Test_computeOverSubRes_weightOrder(t *testing.T) {
+	sqQueue := queue.NewSqQueue()
+	// Oldest sample first: a stale usage spike that must NOT dominate the result.
+	sqQueue.Enqueue(apis.Resource{v1.ResourceCPU: 10000, v1.ResourceMemory: 10000})
+	for i := 0; i < 8; i++ {
+		sqQueue.Enqueue(apis.Resource{v1.ResourceCPU: 0, v1.ResourceMemory: 0})
+	}
+	// Newest sample last: current low usage after the spike cleared.
+	sqQueue.Enqueue(apis.Resource{v1.ResourceCPU: 100, v1.ResourceMemory: 100})
+
+	r := &historicalUsageCalculator{queue: sqQueue}
+	res := r.computeOverSubRes()
+
+	// The newest sample carries weight 512 out of totalWeight 1023, while the
+	// stale spike (oldest) carries weight 1, so the weighted result must stay
+	// close to the newest sample and far away from the stale spike.
+	assert.Less(t, res[v1.ResourceCPU], int64(200), "stale spike must not dominate the weighted result")
+	assert.Less(t, res[v1.ResourceMemory], int64(200), "stale spike must not dominate the weighted result")
+}
+
+// Test_historicalUsageCalculator_cfgLock_concurrentReads exercises RefreshCfg
+// (writer) concurrently with getOverSubscriptionTypes (reader) to guard
+// against reintroducing an exclusive sync.Mutex on the read path. Run with
+// -race to catch data races.
+func Test_historicalUsageCalculator_cfgLock_concurrentReads(t *testing.T) {
+	r := &historicalUsageCalculator{resourceTypes: sets.NewString("cpu")}
+	node := &v1.Node{}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			_ = r.RefreshCfg(&api.ColocationConfig{
+				OverSubscriptionConfig: &api.OverSubscription{OverSubscriptionTypes: utilpointer.String("cpu,memory")},
+			})
+		}()
+		go func() {
+			defer wg.Done()
+			_ = r.getOverSubscriptionTypes(node)
+		}()
+	}
+	wg.Wait()
 }

--- a/pkg/agent/oversubscription/policy/policy.go
+++ b/pkg/agent/oversubscription/policy/policy.go
@@ -150,6 +150,14 @@ func ShouldUpdateNodeOverSubscription(current, new apis.Resource) bool {
 			delta = -delta
 		}
 
+		if current[res] == 0 {
+			if delta != 0 {
+				update = true
+				break
+			}
+			continue
+		}
+
 		if float64(delta)/float64(current[res]) > overSubscriptionChangeStep {
 			update = true
 			break

--- a/pkg/agent/oversubscription/policy/policy_test.go
+++ b/pkg/agent/oversubscription/policy/policy_test.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2024 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package policy
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+
+	"volcano.sh/volcano/pkg/agent/apis"
+)
+
+func TestShouldUpdateNodeOverSubscription(t *testing.T) {
+	tests := []struct {
+		name    string
+		current apis.Resource
+		new     apis.Resource
+		want    bool
+	}{
+		{
+			name:    "current is zero and new is zero: no update, first publish handled without NaN",
+			current: apis.Resource{corev1.ResourceCPU: 0, corev1.ResourceMemory: 0},
+			new:     apis.Resource{corev1.ResourceCPU: 0, corev1.ResourceMemory: 0},
+			want:    false,
+		},
+		{
+			name:    "current is zero and new is non-zero: update once, without dividing by zero",
+			current: apis.Resource{corev1.ResourceCPU: 0, corev1.ResourceMemory: 0},
+			new:     apis.Resource{corev1.ResourceCPU: 1000, corev1.ResourceMemory: 0},
+			want:    true,
+		},
+		{
+			name:    "current non-zero, delta below the change step: no update",
+			current: apis.Resource{corev1.ResourceCPU: 1000, corev1.ResourceMemory: 1000},
+			new:     apis.Resource{corev1.ResourceCPU: 1050, corev1.ResourceMemory: 1000},
+			want:    false,
+		},
+		{
+			name:    "current non-zero, delta above the change step: update",
+			current: apis.Resource{corev1.ResourceCPU: 1000, corev1.ResourceMemory: 1000},
+			new:     apis.Resource{corev1.ResourceCPU: 1200, corev1.ResourceMemory: 1000},
+			want:    true,
+		},
+		{
+			name:    "one resource zero and unchanged, other resource changed above step: update",
+			current: apis.Resource{corev1.ResourceCPU: 0, corev1.ResourceMemory: 1000},
+			new:     apis.Resource{corev1.ResourceCPU: 0, corev1.ResourceMemory: 1200},
+			want:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, ShouldUpdateNodeOverSubscription(tt.current, tt.new))
+		})
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Fixes two defects in the volcano-agent oversubscription reporting pipeline:

- **`ShouldUpdateNodeOverSubscription` divide-by-zero** (`pkg/agent/oversubscription/policy/policy.go`): the change-step comparison divided `delta` by `current[res]` without checking for a zero denominator. `current[res]` is `0` on the very first oversubscription enable cycle, or right after `DeleteNodeOverSoldStatus` clears the node annotations. `float64(delta)/float64(0)` yields `+Inf` when `delta > 0` (bypassing the 10% change guard and triggering an update — and a kube-apiserver PATCH — on every 10s tick) or `NaN` when `delta == 0` (silently dropping the very first publish). Fixed by special-casing a zero `current[res]`: update once if the new value differs, otherwise skip, without ever dividing by zero.

- **`cfgLock` was an exclusive `sync.Mutex`** (`pkg/agent/events/probes/noderesources/resource_calculator.go`): `getOverSubscriptionTypes` is a read-only lookup invoked every 10s by `preProcess`, but it took an exclusive lock, serializing it against `RefreshCfg` writes (and against itself) for no reason. Changed `cfgLock` to `sync.RWMutex`, with `getOverSubscriptionTypes` using `RLock`/`RUnlock` so concurrent reads no longer block each other.

A third item from the linked issue (weight ordering in `computeOverSubRes`) was investigated but turned out to already be correct: `historicalUsages` is oldest-first (`queue.SqQueue.Enqueue` appends to the tail, `GetAll` returns oldest-first), so the existing forward iteration with a doubling weight already gives the newest sample the highest weight (512 for a full 10-entry window) and the oldest sample the lowest (1) — i.e. it already behaves like a recency-weighted average. No code change was needed there; a regression test was added instead to lock in that behavior and guard against reintroducing the problem the issue describes.

#### Which issue(s) this PR fixes:

Fixes #5820

Test plan:
- `go test ./pkg/agent/oversubscription/... ./pkg/agent/events/probes/noderesources/... -race -v` — all tests pass (run under WSL, since this dependency tree doesn't build natively on Windows).
- New tests added:
  - `TestShouldUpdateNodeOverSubscription` — covers the zero-denominator guard (first-enable with zero delta, first-enable with non-zero delta, normal below/above-threshold cases, and a mixed zero/non-zero-resource case).
  - `Test_computeOverSubRes_weightOrder` — asserts a stale spike does not dominate the weighted result.
  - `Test_historicalUsageCalculator_cfgLock_concurrentReads` — exercises `RefreshCfg` and `getOverSubscriptionTypes` concurrently under `-race` to guard against reintroducing exclusive locking on the read path.
- `go vet ./pkg/agent/oversubscription/... ./pkg/agent/events/probes/noderesources/...` and `gofmt -l` on the changed files — clean.

#### Does this PR introduce a user-facing change?

```release-note
Fix a divide-by-zero in the agent's oversubscription change-step check that could flood the API server with PATCH requests or silently drop the first oversubscription publish, and fix unnecessary lock contention between concurrent reads of oversubscription resource types.
```
