### PR TITLE
fix(agent): account for native sidecars and pod overhead

### DIFF
--- a/pkg/agent/utils/pod/pod.go
+++ b/pkg/agent/utils/pod/pod.go
@@ -60,24 +60,7 @@ type SortedPodsByRequestCPU []*v1.Pod
 func (s SortedPodsByRequestCPU) Len() int      { return len(s) }
 func (s SortedPodsByRequestCPU) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
 func (s SortedPodsByRequestCPU) Less(i, j int) bool {
-	r1, r2 := int64(0), int64(0)
-	for _, c := range s[i].Spec.Containers {
-		r1 += c.Resources.Requests.Cpu().Value()
-	}
-	for _, c := range s[j].Spec.Containers {
-		r2 += c.Resources.Requests.Cpu().Value()
-	}
-
-	if utilfeature.DefaultFeatureGate.Enabled(k8sfeature.PodLevelResources) {
-		if podLevelResource, found := getPodLevelResourceRequest(s[i], v1.ResourceCPU); found {
-			r1 = podLevelResource.Value()
-		}
-		if podLevelResource, found := getPodLevelResourceRequest(s[j], v1.ResourceCPU); found {
-			r2 = podLevelResource.Value()
-		}
-	}
-
-	return r1 > r2
+	return getEffectivePodRequest(s[i], v1.ResourceCPU).Cmp(getEffectivePodRequest(s[j], v1.ResourceCPU)) > 0
 }
 
 // SortedPodsByRequestMemory sort pods by memory request value.
@@ -86,24 +69,7 @@ type SortedPodsByRequestMemory []*v1.Pod
 func (s SortedPodsByRequestMemory) Len() int      { return len(s) }
 func (s SortedPodsByRequestMemory) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
 func (s SortedPodsByRequestMemory) Less(i, j int) bool {
-	r1, r2 := int64(0), int64(0)
-	for _, c := range s[i].Spec.Containers {
-		r1 += c.Resources.Requests.Memory().Value()
-	}
-	for _, c := range s[j].Spec.Containers {
-		r2 += c.Resources.Requests.Memory().Value()
-	}
-
-	if utilfeature.DefaultFeatureGate.Enabled(k8sfeature.PodLevelResources) {
-		if podLevelResource, found := getPodLevelResourceRequest(s[i], v1.ResourceMemory); found {
-			r1 = podLevelResource.Value()
-		}
-		if podLevelResource, found := getPodLevelResourceRequest(s[j], v1.ResourceMemory); found {
-			r2 = podLevelResource.Value()
-		}
-	}
-
-	return r1 > r2
+	return getEffectivePodRequest(s[i], v1.ResourceMemory).Cmp(getEffectivePodRequest(s[j], v1.ResourceMemory)) > 0
 }
 
 // GetTotalRequest return the total resource of pods
@@ -175,56 +141,21 @@ func getTotalRequestByType(pods []*v1.Pod, fns []FilterPodsFunc, resType v1.Reso
 			continue
 		}
 
-		podRes := resource.Quantity{}
-		for _, container := range pod.Spec.Containers {
-			resValue, found := container.Resources.Requests[resType]
-			if !found {
-				continue
-			}
-			podRes.Add(resValue)
-		}
-
-		// init containers define the minimum of any resource
-		for _, container := range pod.Spec.InitContainers {
-			resValue, found := container.Resources.Requests[resType]
-			if !found {
-				continue
-			}
-			podRes = maxResourceReq(podRes, resValue)
-		}
-
-		if utilfeature.DefaultFeatureGate.Enabled(k8sfeature.PodLevelResources) && helpers.IsSupportedPodLevelResource(resType) {
-			if podLevelResource, found := getPodLevelResourceRequest(pod, resType); found {
-				podRes = podLevelResource
-			}
-		}
-
-		totalRes.Add(podRes)
+		totalRes.Add(getEffectivePodRequest(pod, resType))
 	}
 
 	return totalRes
 }
 
-// maxResourceReq return the greater one of res/newRes.
-func maxResourceReq(res, newRes resource.Quantity) resource.Quantity {
-	if res.Cmp(newRes) > 0 {
-		return res
-	}
-	return newRes
+// getEffectivePodRequest returns the Kubernetes effective request for a Pod resource.
+func getEffectivePodRequest(pod *v1.Pod, resType v1.ResourceName) resource.Quantity {
+	requests := helpers.PodRequests(pod, helpers.PodResourcesOptions{
+		SkipPodLevelResources: !utilfeature.DefaultFeatureGate.Enabled(k8sfeature.PodLevelResources),
+	})
+	return requests[resType]
 }
 
 // IsPodTerminated return true if pod is terminated.
 func IsPodTerminated(pod *v1.Pod) bool {
 	return pod.DeletionTimestamp != nil || pod.Status.Phase == v1.PodSucceeded || pod.Status.Phase == v1.PodFailed
-}
-
-func getPodLevelResourceRequest(pod *v1.Pod, rName v1.ResourceName) (resource.Quantity, bool) {
-	if pod == nil {
-		return resource.Quantity{}, false
-	}
-	if pod.Spec.Resources != nil && len(pod.Spec.Resources.Requests) != 0 {
-		resValue, found := pod.Spec.Resources.Requests[rName]
-		return resValue, found
-	}
-	return resource.Quantity{}, false
 }

--- a/pkg/agent/utils/pod/pod.go
+++ b/pkg/agent/utils/pod/pod.go
@@ -60,8 +60,8 @@ type SortedPodsByRequestCPU []*v1.Pod
 func (s SortedPodsByRequestCPU) Len() int      { return len(s) }
 func (s SortedPodsByRequestCPU) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
 func (s SortedPodsByRequestCPU) Less(i, j int) bool {
-	left := getEffectivePodRequest(s[i], v1.ResourceCPU)
-	right := getEffectivePodRequest(s[j], v1.ResourceCPU)
+	left := getEffectivePodRequestByResource(s[i], v1.ResourceCPU)
+	right := getEffectivePodRequestByResource(s[j], v1.ResourceCPU)
 	return left.Cmp(right) > 0
 }
 
@@ -71,8 +71,8 @@ type SortedPodsByRequestMemory []*v1.Pod
 func (s SortedPodsByRequestMemory) Len() int      { return len(s) }
 func (s SortedPodsByRequestMemory) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
 func (s SortedPodsByRequestMemory) Less(i, j int) bool {
-	left := getEffectivePodRequest(s[i], v1.ResourceMemory)
-	right := getEffectivePodRequest(s[j], v1.ResourceMemory)
+	left := getEffectivePodRequestByResource(s[i], v1.ResourceMemory)
+	right := getEffectivePodRequestByResource(s[j], v1.ResourceMemory)
 	return left.Cmp(right) > 0
 }
 
@@ -145,14 +145,14 @@ func getTotalRequestByType(pods []*v1.Pod, fns []FilterPodsFunc, resType v1.Reso
 			continue
 		}
 
-		totalRes.Add(getEffectivePodRequest(pod, resType))
+		totalRes.Add(getEffectivePodRequestByResource(pod, resType))
 	}
 
 	return totalRes
 }
 
-// getEffectivePodRequest returns the Kubernetes effective request for a Pod resource.
-func getEffectivePodRequest(pod *v1.Pod, resType v1.ResourceName) resource.Quantity {
+// getEffectivePodRequestByResource returns the Kubernetes effective request for a Pod resource.
+func getEffectivePodRequestByResource(pod *v1.Pod, resType v1.ResourceName) resource.Quantity {
 	requests := helpers.PodRequests(pod, helpers.PodResourcesOptions{
 		SkipPodLevelResources: !utilfeature.DefaultFeatureGate.Enabled(k8sfeature.PodLevelResources),
 	})

--- a/pkg/agent/utils/pod/pod.go
+++ b/pkg/agent/utils/pod/pod.go
@@ -60,7 +60,9 @@ type SortedPodsByRequestCPU []*v1.Pod
 func (s SortedPodsByRequestCPU) Len() int      { return len(s) }
 func (s SortedPodsByRequestCPU) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
 func (s SortedPodsByRequestCPU) Less(i, j int) bool {
-	return getEffectivePodRequest(s[i], v1.ResourceCPU).Cmp(getEffectivePodRequest(s[j], v1.ResourceCPU)) > 0
+	left := getEffectivePodRequest(s[i], v1.ResourceCPU)
+	right := getEffectivePodRequest(s[j], v1.ResourceCPU)
+	return left.Cmp(right) > 0
 }
 
 // SortedPodsByRequestMemory sort pods by memory request value.
@@ -69,7 +71,9 @@ type SortedPodsByRequestMemory []*v1.Pod
 func (s SortedPodsByRequestMemory) Len() int      { return len(s) }
 func (s SortedPodsByRequestMemory) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
 func (s SortedPodsByRequestMemory) Less(i, j int) bool {
-	return getEffectivePodRequest(s[i], v1.ResourceMemory).Cmp(getEffectivePodRequest(s[j], v1.ResourceMemory)) > 0
+	left := getEffectivePodRequest(s[i], v1.ResourceMemory)
+	right := getEffectivePodRequest(s[j], v1.ResourceMemory)
+	return left.Cmp(right) > 0
 }
 
 // GetTotalRequest return the total resource of pods

--- a/pkg/agent/utils/pod/pod_test.go
+++ b/pkg/agent/utils/pod/pod_test.go
@@ -34,10 +34,30 @@ func makePodWithCPURequest(containerCPU, podLevelCPU string) *v1.Pod {
 	return pod
 }
 
+func makePodWithNativeSidecarCPU(containerCPU, sidecarCPU string) *v1.Pod {
+	always := v1.ContainerRestartPolicyAlways
+	return &v1.Pod{
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{{
+				Resources: v1.ResourceRequirements{Requests: v1.ResourceList{
+					v1.ResourceCPU: resource.MustParse(containerCPU),
+				}},
+			}},
+			InitContainers: []v1.Container{{
+				RestartPolicy: &always,
+				Resources: v1.ResourceRequirements{Requests: v1.ResourceList{
+					v1.ResourceCPU: resource.MustParse(sidecarCPU),
+				}},
+			}},
+		},
+	}
+}
+
 func TestSortedPodsByRequestCPU_Less(t *testing.T) {
 	pod1 := makePodWithCPURequest("1", "") // container-only, cpu=1
 	pod2 := makePodWithCPURequest("2", "") // container-only, cpu=2
 	pod3 := makePodWithCPURequest("3", "") // container-only, cpu=3
+	podWithSidecar := makePodWithNativeSidecarCPU("1", "2")
 	// Pod-level resources value should override container-level sum when the
 	// PodLevelResources feature gate is enabled.
 	podLevel := makePodWithCPURequest("1", "5") // pod-level cpu=5
@@ -101,6 +121,13 @@ func TestSortedPodsByRequestCPU_Less(t *testing.T) {
 			j:                 1,
 			podLevelResources: true,
 			expected:          true, // 3 > 1
+		},
+		{
+			name:     "native sidecar is included when sorting cpu requests",
+			s:        SortedPodsByRequestCPU{podWithSidecar, pod2},
+			i:        0,
+			j:        1,
+			expected: true, // 1 app + 2 sidecar > 2
 		},
 	}
 
@@ -293,6 +320,45 @@ func TestGetTotalRequestByType(t *testing.T) {
 		}
 		return p
 	}
+	podWithSidecarsAndOverhead := func() *v1.Pod {
+		always := v1.ContainerRestartPolicyAlways
+		return &v1.Pod{
+			Spec: v1.PodSpec{
+				Containers: []v1.Container{{
+					Resources: v1.ResourceRequirements{Requests: v1.ResourceList{
+						v1.ResourceCPU:    resource.MustParse("1"),
+						v1.ResourceMemory: resource.MustParse("128Mi"),
+					}},
+				}},
+				InitContainers: []v1.Container{
+					{
+						RestartPolicy: &always,
+						Resources: v1.ResourceRequirements{Requests: v1.ResourceList{
+							v1.ResourceCPU:    resource.MustParse("1"),
+							v1.ResourceMemory: resource.MustParse("64Mi"),
+						}},
+					},
+					{
+						RestartPolicy: &always,
+						Resources: v1.ResourceRequirements{Requests: v1.ResourceList{
+							v1.ResourceCPU:    resource.MustParse("500m"),
+							v1.ResourceMemory: resource.MustParse("32Mi"),
+						}},
+					},
+					{
+						Resources: v1.ResourceRequirements{Requests: v1.ResourceList{
+							v1.ResourceCPU:    resource.MustParse("3"),
+							v1.ResourceMemory: resource.MustParse("256Mi"),
+						}},
+					},
+				},
+				Overhead: v1.ResourceList{
+					v1.ResourceCPU:    resource.MustParse("500m"),
+					v1.ResourceMemory: resource.MustParse("64Mi"),
+				},
+			},
+		}
+	}
 
 	tests := []struct {
 		name              string
@@ -375,6 +441,18 @@ func TestGetTotalRequestByType(t *testing.T) {
 			podLevelResources: true,
 			expected:          resource.MustParse("14"),
 		},
+		{
+			name:     "includes native sidecars ordinary init containers and pod overhead for cpu",
+			pods:     []*v1.Pod{podWithSidecarsAndOverhead()},
+			resType:  v1.ResourceCPU,
+			expected: resource.MustParse("5"),
+		},
+		{
+			name:     "includes native sidecars ordinary init containers and pod overhead for memory",
+			pods:     []*v1.Pod{podWithSidecarsAndOverhead()},
+			resType:  v1.ResourceMemory,
+			expected: resource.MustParse("416Mi"),
+		},
 	}
 
 	for _, tt := range tests {
@@ -384,99 +462,6 @@ func TestGetTotalRequestByType(t *testing.T) {
 			got := getTotalRequestByType(tt.pods, tt.fns, tt.resType)
 			if got.Cmp(tt.expected) != 0 {
 				t.Fatalf("expected %s, got %s", tt.expected.String(), got.String())
-			}
-		})
-	}
-}
-
-func TestGetPodLevelResourceRequest(t *testing.T) {
-	cpuQuantity := resource.MustParse("4")
-	memoryQuantity := resource.MustParse("8Gi")
-
-	tests := []struct {
-		name     string
-		pod      *v1.Pod
-		rName    v1.ResourceName
-		expected resource.Quantity
-		found    bool
-	}{
-		{
-			name: "nil resources returns not found",
-			pod: &v1.Pod{
-				Spec: v1.PodSpec{},
-			},
-			rName:    v1.ResourceCPU,
-			expected: resource.Quantity{},
-			found:    false,
-		},
-		{
-			name: "empty requests returns not found",
-			pod: &v1.Pod{
-				Spec: v1.PodSpec{
-					Resources: &v1.ResourceRequirements{},
-				},
-			},
-			rName:    v1.ResourceCPU,
-			expected: resource.Quantity{},
-			found:    false,
-		},
-		{
-			name: "cpu request found",
-			pod: &v1.Pod{
-				Spec: v1.PodSpec{
-					Resources: &v1.ResourceRequirements{
-						Requests: v1.ResourceList{
-							v1.ResourceCPU:    cpuQuantity,
-							v1.ResourceMemory: memoryQuantity,
-						},
-					},
-				},
-			},
-			rName:    v1.ResourceCPU,
-			expected: cpuQuantity,
-			found:    true,
-		},
-		{
-			name: "memory request found",
-			pod: &v1.Pod{
-				Spec: v1.PodSpec{
-					Resources: &v1.ResourceRequirements{
-						Requests: v1.ResourceList{
-							v1.ResourceCPU:    cpuQuantity,
-							v1.ResourceMemory: memoryQuantity,
-						},
-					},
-				},
-			},
-			rName:    v1.ResourceMemory,
-			expected: memoryQuantity,
-			found:    true,
-		},
-		{
-			name: "requested resource not present returns not found",
-			pod: &v1.Pod{
-				Spec: v1.PodSpec{
-					Resources: &v1.ResourceRequirements{
-						Requests: v1.ResourceList{
-							v1.ResourceCPU: cpuQuantity,
-						},
-					},
-				},
-			},
-			rName:    v1.ResourceMemory,
-			expected: resource.Quantity{},
-			found:    false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, found := getPodLevelResourceRequest(tt.pod, tt.rName)
-			if found != tt.found {
-				t.Fatalf("expected found=%v, got found=%v", tt.found, found)
-			}
-			if got.Cmp(tt.expected) != 0 {
-				t.Fatalf("expected quantity=%s, got quantity=%s", tt.expected.String(), got.String())
 			}
 		})
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Updates Volcano Agent Pod request accounting to use Kubernetes' canonical `PodRequests` helper.

This correctly includes:
- restartable init containers (native sidecars)
- ordinary init-container lifecycle semantics
- `Pod.spec.overhead` and
- enabled Pod-level resource requests.

It prevents Agent oversubscription reporting from advertising CPU or memory already reserved by native sidecars and Pod runtime overhead. Pod request sorting now uses the same effective request calculation.

#### Which issue(s) this PR fixes:

Fixes #5788

#### Special notes for your reviewer:

- Adds regression coverage for multiple native sidecars, ordinary init containers, Pod overhead, and sidecar-aware CPU request sorting.
- `gofmt`, `git diff --check`, and Linux-targeted test compilation pass:
  `GOOS=linux GOARCH=amd64 go test -c ./pkg/agent/utils/pod`.

#### Does this PR introduce a user-facing change?

```release-note
Volcano Agent now correctly accounts for native sidecar requests and Pod overhead when calculating effective CPU and memory requests for oversubscription.
```