### PR TITLE
scheduler: expose queue workload state metrics

### DIFF
--- a/docs/design/metrics.md
+++ b/docs/design/metrics.md
@@ -61,7 +61,7 @@ This metrics describe internal state of volcano.
 | `queue_pod_group_running_count`        | Gauge           | `queue_name`=&lt;queue_name&gt;                                   | The number of Running PodGroups in this queue |
 | `queue_pod_group_unknown_count`        | Gauge           | `queue_name`=&lt;queue_name&gt;                                   | The number of Unknown PodGroups in this queue |
 | `queue_pod_group_count`                | Gauge           | `queue_name`=&lt;queue_name&gt;, `phase`=&lt;phase&gt;             | Number of directly assigned PodGroups by phase at the beginning of the latest scheduling session |
-| `queue_task_count`                     | Gauge           | `queue_name`=&lt;queue_name&gt;, `status`=&lt;status&gt;           | Number of tasks in directly assigned PodGroups by status at the beginning of the latest scheduling session |
+| `queue_task_count`                     | Gauge           | `queue_name`=&lt;queue_name&gt;, `status`=&lt;status&gt;           | Number of tasks by status in jobs directly assigned to this queue at the beginning of the latest scheduling session |
 | `namespace_share`                      | Gauge           | `namespace_name`=&lt;namespace_name&gt;                           | Deserved CPU count for one namespace          |
 | `namespace_weight`                     | Gauge           | `namespace_name`=&lt;namespace_name&gt;                           | Weight for one namespace                      |
 | `job_share`                            | Gauge           | `job_id`=&lt;job_id&gt;, `job_ns`=&lt;job_ns&gt;                  | Share for one job                             |

--- a/docs/design/metrics.md
+++ b/docs/design/metrics.md
@@ -60,6 +60,7 @@ This metrics describe internal state of volcano.
 | `queue_pod_group_pending_count`        | Gauge           | `queue_name`=&lt;queue_name&gt;                                   | The number of Pending PodGroups in this queue |
 | `queue_pod_group_running_count`        | Gauge           | `queue_name`=&lt;queue_name&gt;                                   | The number of Running PodGroups in this queue |
 | `queue_pod_group_unknown_count`        | Gauge           | `queue_name`=&lt;queue_name&gt;                                   | The number of Unknown PodGroups in this queue |
+| `queue_session_start_task_count`       | Gauge           | `queue_name`=&lt;queue_name&gt;, `status`=&lt;status&gt;           | Number of tasks by status in jobs directly assigned to this queue at the beginning of the latest scheduling session |
 | `namespace_share`                      | Gauge           | `namespace_name`=&lt;namespace_name&gt;                           | Deserved CPU count for one namespace          |
 | `namespace_weight`                     | Gauge           | `namespace_name`=&lt;namespace_name&gt;                           | Weight for one namespace                      |
 | `job_share`                            | Gauge           | `job_id`=&lt;job_id&gt;, `job_ns`=&lt;job_ns&gt;                  | Share for one job                             |

--- a/docs/design/metrics.md
+++ b/docs/design/metrics.md
@@ -60,6 +60,8 @@ This metrics describe internal state of volcano.
 | `queue_pod_group_pending_count`        | Gauge           | `queue_name`=&lt;queue_name&gt;                                   | The number of Pending PodGroups in this queue |
 | `queue_pod_group_running_count`        | Gauge           | `queue_name`=&lt;queue_name&gt;                                   | The number of Running PodGroups in this queue |
 | `queue_pod_group_unknown_count`        | Gauge           | `queue_name`=&lt;queue_name&gt;                                   | The number of Unknown PodGroups in this queue |
+| `queue_pod_group_count`                | Gauge           | `queue_name`=&lt;queue_name&gt;, `phase`=&lt;phase&gt;             | Number of directly assigned PodGroups by phase at the beginning of the latest scheduling session |
+| `queue_task_count`                     | Gauge           | `queue_name`=&lt;queue_name&gt;, `status`=&lt;status&gt;           | Number of tasks in directly assigned PodGroups by status at the beginning of the latest scheduling session |
 | `namespace_share`                      | Gauge           | `namespace_name`=&lt;namespace_name&gt;                           | Deserved CPU count for one namespace          |
 | `namespace_weight`                     | Gauge           | `namespace_name`=&lt;namespace_name&gt;                           | Weight for one namespace                      |
 | `job_share`                            | Gauge           | `job_id`=&lt;job_id&gt;, `job_ns`=&lt;job_ns&gt;                  | Share for one job                             |

--- a/pkg/scheduler/framework/framework.go
+++ b/pkg/scheduler/framework/framework.go
@@ -34,6 +34,7 @@ import (
 func OpenSession(cache cache.Cache, tiers []conf.Tier, configurations []conf.Configuration) *Session {
 	openStart := time.Now()
 	ssn := openSession(cache)
+	updateQueueStateMetrics(ssn)
 	ssn.Tiers = tiers
 	ssn.Configurations = configurations
 	ssn.NodeMap = GenerateNodeMapAndSlice(ssn.Nodes)

--- a/pkg/scheduler/framework/queue_metrics_test.go
+++ b/pkg/scheduler/framework/queue_metrics_test.go
@@ -1,0 +1,169 @@
+/*
+Copyright 2026 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package framework
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
+
+	"volcano.sh/apis/pkg/apis/scheduling"
+	"volcano.sh/volcano/pkg/scheduler/api"
+	schedmetrics "volcano.sh/volcano/pkg/scheduler/metrics"
+)
+
+func TestUpdateQueueStateMetrics(t *testing.T) {
+	const (
+		parentQueueName = "queue-state-metrics-parent"
+		childQueueName  = "queue-state-metrics-child"
+	)
+	parentQueueID := api.QueueID(parentQueueName)
+	childQueueID := api.QueueID(childQueueName)
+
+	for _, queueName := range []string{parentQueueName, childQueueName} {
+		schedmetrics.DeleteQueueMetrics(queueName)
+		defer schedmetrics.DeleteQueueMetrics(queueName)
+	}
+
+	ssn := &Session{
+		Queues: map[api.QueueID]*api.QueueInfo{
+			parentQueueID: {UID: parentQueueID, Name: parentQueueName},
+			childQueueID:  {UID: childQueueID, Name: childQueueName},
+		},
+		Jobs: map[api.JobID]*api.JobInfo{
+			"pending-job": {
+				Queue: childQueueID,
+				PodGroup: &api.PodGroup{PodGroup: scheduling.PodGroup{
+					Status: scheduling.PodGroupStatus{Phase: scheduling.PodGroupPending},
+				}},
+				TaskStatusIndex: map[api.TaskStatus]api.TasksMap{
+					api.Pending: {
+						"pending-task-1": nil,
+						"pending-task-2": nil,
+					},
+					api.Allocated: {"allocated-task": nil},
+				},
+			},
+			"running-job": {
+				Queue: childQueueID,
+				PodGroup: &api.PodGroup{PodGroup: scheduling.PodGroup{
+					Status: scheduling.PodGroupStatus{Phase: scheduling.PodGroupRunning},
+				}},
+				TaskStatusIndex: map[api.TaskStatus]api.TasksMap{
+					api.Running: {"running-task": nil},
+					api.Failed:  {"failed-task": nil},
+				},
+			},
+		},
+	}
+
+	updateQueueStateMetrics(ssn)
+
+	podGroupCounts := map[string]float64{
+		"pending": 1, "inqueue": 0, "running": 1, "completed": 0, "unknown": 0,
+	}
+	for phase, expected := range podGroupCounts {
+		requireQueueGaugeValue(t, "volcano_queue_pod_group_count", map[string]string{
+			"queue_name": childQueueName,
+			"phase":      phase,
+		}, expected)
+	}
+	taskCounts := map[string]float64{
+		"pending": 2, "allocated": 1, "pipelined": 0, "binding": 0, "bound": 0,
+		"running": 1, "releasing": 0, "succeeded": 0, "failed": 1, "unknown": 0,
+	}
+	for status, expected := range taskCounts {
+		requireQueueGaugeValue(t, "volcano_queue_task_count", map[string]string{
+			"queue_name": childQueueName,
+			"status":     status,
+		}, expected)
+	}
+
+	// Jobs in a child queue must not be rolled up into its parent queue.
+	requireQueueGaugeValue(t, "volcano_queue_pod_group_count", map[string]string{
+		"queue_name": parentQueueName,
+		"phase":      "pending",
+	}, 0)
+	requireQueueGaugeValue(t, "volcano_queue_task_count", map[string]string{
+		"queue_name": parentQueueName,
+		"status":     "pending",
+	}, 0)
+
+	// A later session with no jobs must reset previously non-zero series.
+	ssn.Jobs = map[api.JobID]*api.JobInfo{}
+	updateQueueStateMetrics(ssn)
+	requireQueueGaugeValue(t, "volcano_queue_pod_group_count", map[string]string{
+		"queue_name": childQueueName,
+		"phase":      "pending",
+	}, 0)
+	requireQueueGaugeValue(t, "volcano_queue_task_count", map[string]string{
+		"queue_name": childQueueName,
+		"status":     "pending",
+	}, 0)
+
+	// Queue deletion must remove every phase/status series for that queue.
+	schedmetrics.DeleteQueueMetrics(childQueueName)
+	_, found := queueGaugeValue(t, "volcano_queue_pod_group_count", map[string]string{
+		"queue_name": childQueueName,
+		"phase":      "pending",
+	})
+	require.False(t, found)
+	_, found = queueGaugeValue(t, "volcano_queue_task_count", map[string]string{
+		"queue_name": childQueueName,
+		"status":     "pending",
+	})
+	require.False(t, found)
+}
+
+func requireQueueGaugeValue(t *testing.T, metricName string, labels map[string]string, expected float64) {
+	t.Helper()
+	actual, found := queueGaugeValue(t, metricName, labels)
+	require.True(t, found, "metric %s with labels %v was not found", metricName, labels)
+	require.Equal(t, expected, actual)
+}
+
+func queueGaugeValue(t *testing.T, metricName string, labels map[string]string) (float64, bool) {
+	t.Helper()
+	metricFamilies, err := prometheus.DefaultGatherer.Gather()
+	require.NoError(t, err)
+
+	for _, metricFamily := range metricFamilies {
+		if metricFamily.GetName() != metricName {
+			continue
+		}
+		for _, metric := range metricFamily.GetMetric() {
+			if len(metric.GetLabel()) != len(labels) {
+				continue
+			}
+			matches := true
+			for _, label := range metric.GetLabel() {
+				expected, found := labels[label.GetName()]
+				if !found || expected != label.GetValue() {
+					matches = false
+					break
+				}
+			}
+			if matches {
+				require.NotNil(t, metric.GetGauge())
+				return metric.GetGauge().GetValue(), true
+			}
+		}
+	}
+
+	return 0, false
+}

--- a/pkg/scheduler/framework/queue_metrics_test.go
+++ b/pkg/scheduler/framework/queue_metrics_test.go
@@ -1,0 +1,152 @@
+/*
+Copyright 2026 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package framework
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"volcano.sh/apis/pkg/apis/scheduling"
+	"volcano.sh/volcano/pkg/scheduler/api"
+	"volcano.sh/volcano/pkg/scheduler/cache"
+	schedmetrics "volcano.sh/volcano/pkg/scheduler/metrics"
+	"volcano.sh/volcano/pkg/scheduler/util"
+)
+
+func TestOpenSessionUpdatesQueueTaskMetrics(t *testing.T) {
+	const (
+		parentQueueName = "queue-state-metrics-parent"
+		childQueueName  = "queue-state-metrics-child"
+	)
+	for _, queueName := range []string{parentQueueName, childQueueName} {
+		schedmetrics.DeleteQueueMetrics(queueName)
+		defer schedmetrics.DeleteQueueMetrics(queueName)
+	}
+
+	schedulerCache := cache.NewDefaultMockSchedulerCache("test-scheduler")
+	defer schedulerCache.OnSessionClose()
+	for _, queueName := range []string{parentQueueName, childQueueName} {
+		queue := api.NewQueueInfo(&scheduling.Queue{ObjectMeta: metav1.ObjectMeta{Name: queueName}})
+		schedulerCache.Queues[queue.UID] = queue
+	}
+
+	newTask := func(name string, status api.TaskStatus) *api.TaskInfo {
+		pod := util.BuildPod("test", name, "", v1.PodPending, nil, "test-job", nil, nil)
+		task := api.NewTaskInfo(pod)
+		task.Status = status
+		return task
+	}
+	job := api.NewJobInfo(
+		"test/test-job",
+		newTask("pending-task-1", api.Pending),
+		newTask("pending-task-2", api.Pending),
+		newTask("allocated-task", api.Allocated),
+		newTask("running-task", api.Running),
+		newTask("failed-task", api.Failed),
+		newTask("unexpected-status-task", api.Pending|api.Running),
+	)
+	job.Queue = api.QueueID(childQueueName)
+	job.PodGroup = &api.PodGroup{PodGroup: scheduling.PodGroup{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-job", Namespace: "test"},
+		Spec:       scheduling.PodGroupSpec{Queue: childQueueName},
+	}}
+	schedulerCache.Jobs[job.UID] = job
+
+	OpenSession(schedulerCache, nil, nil)
+
+	_, found := queueGaugeValue(t, "volcano_queue_pod_group_count", map[string]string{
+		"queue_name": childQueueName,
+		"phase":      "pending",
+	})
+	require.False(t, found, "the controller-manager metrics already cover PodGroup counts")
+
+	taskCounts := map[string]float64{
+		"pending": 2, "allocated": 1, "pipelined": 0, "binding": 0, "bound": 0,
+		"running": 1, "releasing": 0, "succeeded": 0, "failed": 1, "unknown": 1,
+	}
+	for status, expected := range taskCounts {
+		requireQueueGaugeValue(t, "volcano_queue_session_start_task_count", map[string]string{
+			"queue_name": childQueueName,
+			"status":     status,
+		}, expected)
+	}
+
+	// Jobs in a child queue must not be rolled up into its parent queue.
+	requireQueueGaugeValue(t, "volcano_queue_session_start_task_count", map[string]string{
+		"queue_name": parentQueueName,
+		"status":     "pending",
+	}, 0)
+
+	// A later session with no jobs must reset previously non-zero series.
+	schedulerCache.OnSessionClose()
+	delete(schedulerCache.Jobs, job.UID)
+	OpenSession(schedulerCache, nil, nil)
+	requireQueueGaugeValue(t, "volcano_queue_session_start_task_count", map[string]string{
+		"queue_name": childQueueName,
+		"status":     "pending",
+	}, 0)
+
+	// Queue deletion must remove every status series for that queue.
+	schedmetrics.DeleteQueueMetrics(childQueueName)
+	_, found = queueGaugeValue(t, "volcano_queue_session_start_task_count", map[string]string{
+		"queue_name": childQueueName,
+		"status":     "pending",
+	})
+	require.False(t, found)
+}
+
+func requireQueueGaugeValue(t *testing.T, metricName string, labels map[string]string, expected float64) {
+	t.Helper()
+	actual, found := queueGaugeValue(t, metricName, labels)
+	require.True(t, found, "metric %s with labels %v was not found", metricName, labels)
+	require.Equal(t, expected, actual)
+}
+
+func queueGaugeValue(t *testing.T, metricName string, labels map[string]string) (float64, bool) {
+	t.Helper()
+	metricFamilies, err := prometheus.DefaultGatherer.Gather()
+	require.NoError(t, err)
+
+	for _, metricFamily := range metricFamilies {
+		if metricFamily.GetName() != metricName {
+			continue
+		}
+		for _, metric := range metricFamily.GetMetric() {
+			if len(metric.GetLabel()) != len(labels) {
+				continue
+			}
+			matches := true
+			for _, label := range metric.GetLabel() {
+				expected, found := labels[label.GetName()]
+				if !found || expected != label.GetValue() {
+					matches = false
+					break
+				}
+			}
+			if matches {
+				require.NotNil(t, metric.GetGauge())
+				return metric.GetGauge().GetValue(), true
+			}
+		}
+	}
+
+	return 0, false
+}

--- a/pkg/scheduler/framework/queue_metrics_test.go
+++ b/pkg/scheduler/framework/queue_metrics_test.go
@@ -46,6 +46,10 @@ func TestUpdateQueueStateMetrics(t *testing.T) {
 			childQueueID:  {UID: childQueueID, Name: childQueueName},
 		},
 		Jobs: map[api.JobID]*api.JobInfo{
+			"empty-phase-job": {
+				Queue:    childQueueID,
+				PodGroup: &api.PodGroup{PodGroup: scheduling.PodGroup{}},
+			},
 			"pending-job": {
 				Queue: childQueueID,
 				PodGroup: &api.PodGroup{PodGroup: scheduling.PodGroup{
@@ -75,7 +79,7 @@ func TestUpdateQueueStateMetrics(t *testing.T) {
 	updateQueueStateMetrics(ssn)
 
 	podGroupCounts := map[string]float64{
-		"pending": 1, "inqueue": 0, "running": 1, "completed": 0, "unknown": 0,
+		"pending": 1, "inqueue": 0, "running": 1, "completed": 0, "unknown": 1,
 	}
 	for phase, expected := range podGroupCounts {
 		requireQueueGaugeValue(t, "volcano_queue_pod_group_count", map[string]string{

--- a/pkg/scheduler/framework/session.go
+++ b/pkg/scheduler/framework/session.go
@@ -51,6 +51,7 @@ import (
 	"volcano.sh/volcano/pkg/scheduler/cache"
 	"volcano.sh/volcano/pkg/scheduler/conf"
 	"volcano.sh/volcano/pkg/scheduler/gate"
+	"volcano.sh/volcano/pkg/scheduler/metrics"
 	"volcano.sh/volcano/pkg/scheduler/util"
 )
 
@@ -60,6 +61,34 @@ const (
 	// Its Tier value is set to the maximum existing Tier + 1 among real HyperNodes. This is recalculated every time a session opens.
 	// If no real HyperNodes exist in the cluster, this virtual top-tier HyperNode will still exist with Tier = 1 and will encompass all Nodes in the cluster.
 	ClusterTopHyperNode = "<cluster-top-hypernode>"
+)
+
+var (
+	podGroupStatesForQueueMetrics = [...]struct {
+		phase scheduling.PodGroupPhase
+		label string
+	}{
+		{phase: scheduling.PodGroupPending, label: "pending"},
+		{phase: scheduling.PodGroupInqueue, label: "inqueue"},
+		{phase: scheduling.PodGroupRunning, label: "running"},
+		{phase: scheduling.PodGroupCompleted, label: "completed"},
+		{phase: scheduling.PodGroupUnknown, label: "unknown"},
+	}
+	taskStatesForQueueMetrics = [...]struct {
+		status api.TaskStatus
+		label  string
+	}{
+		{status: api.Pending, label: "pending"},
+		{status: api.Allocated, label: "allocated"},
+		{status: api.Pipelined, label: "pipelined"},
+		{status: api.Binding, label: "binding"},
+		{status: api.Bound, label: "bound"},
+		{status: api.Running, label: "running"},
+		{status: api.Releasing, label: "releasing"},
+		{status: api.Succeeded, label: "succeeded"},
+		{status: api.Failed, label: "failed"},
+		{status: api.Unknown, label: "unknown"},
+	}
 )
 
 // Session information for the current session
@@ -281,6 +310,36 @@ func openSession(cache cache.Cache) *Session {
 		ssn.UID, len(ssn.Jobs), len(ssn.Queues), ssn.HyperNodesReadyToSchedule)
 
 	return ssn
+}
+
+func updateQueueStateMetrics(ssn *Session) {
+	podGroupCounts := make(map[api.QueueID]map[scheduling.PodGroupPhase]int, len(ssn.Queues))
+	taskCounts := make(map[api.QueueID]map[api.TaskStatus]int, len(ssn.Queues))
+
+	for _, job := range ssn.Jobs {
+		if podGroupCounts[job.Queue] == nil {
+			podGroupCounts[job.Queue] = make(map[scheduling.PodGroupPhase]int)
+		}
+		if taskCounts[job.Queue] == nil {
+			taskCounts[job.Queue] = make(map[api.TaskStatus]int)
+		}
+
+		if job.PodGroup != nil {
+			podGroupCounts[job.Queue][job.PodGroup.Status.Phase]++
+		}
+		for status, tasks := range job.TaskStatusIndex {
+			taskCounts[job.Queue][status] += len(tasks)
+		}
+	}
+
+	for queueID, queue := range ssn.Queues {
+		for _, state := range podGroupStatesForQueueMetrics {
+			metrics.UpdateQueuePodGroupCount(queue.Name, state.label, podGroupCounts[queueID][state.phase])
+		}
+		for _, state := range taskStatesForQueueMetrics {
+			metrics.UpdateQueueTaskCount(queue.Name, state.label, taskCounts[queueID][state.status])
+		}
+	}
 }
 
 // addClusterTopHyperNode adds a virtual top hyperNode of all hyperNodes in the cluster into the session

--- a/pkg/scheduler/framework/session.go
+++ b/pkg/scheduler/framework/session.go
@@ -325,7 +325,14 @@ func updateQueueStateMetrics(ssn *Session) {
 		}
 
 		if job.PodGroup != nil {
-			podGroupCounts[job.Queue][job.PodGroup.Status.Phase]++
+			phase := job.PodGroup.Status.Phase
+			switch phase {
+			case scheduling.PodGroupPending, scheduling.PodGroupInqueue, scheduling.PodGroupRunning,
+				scheduling.PodGroupCompleted, scheduling.PodGroupUnknown:
+			default:
+				phase = scheduling.PodGroupUnknown
+			}
+			podGroupCounts[job.Queue][phase]++
 		}
 		for status, tasks := range job.TaskStatusIndex {
 			taskCounts[job.Queue][status] += len(tasks)

--- a/pkg/scheduler/framework/session.go
+++ b/pkg/scheduler/framework/session.go
@@ -51,6 +51,7 @@ import (
 	"volcano.sh/volcano/pkg/scheduler/cache"
 	"volcano.sh/volcano/pkg/scheduler/conf"
 	"volcano.sh/volcano/pkg/scheduler/gate"
+	"volcano.sh/volcano/pkg/scheduler/metrics"
 	"volcano.sh/volcano/pkg/scheduler/util"
 )
 
@@ -228,6 +229,7 @@ func openSession(cache cache.Cache) *Session {
 	}
 
 	snapshot := cache.Snapshot()
+	taskCountsByQueue := make(map[api.QueueID]map[string]int, len(snapshot.Queues))
 
 	ssn.Jobs = snapshot.Jobs
 	for _, job := range ssn.Jobs {
@@ -235,6 +237,15 @@ func openSession(cache cache.Cache) *Session {
 			ssn.PodGroupOldState.Status[job.UID] = *job.PodGroup.Status.DeepCopy()
 			ssn.PodGroupOldState.Annotations[job.UID] = maps.Clone(job.PodGroup.GetAnnotations())
 		}
+		if taskCountsByQueue[job.Queue] == nil {
+			taskCountsByQueue[job.Queue] = make(map[string]int)
+		}
+		for status, tasks := range job.TaskStatusIndex {
+			taskCountsByQueue[job.Queue][strings.ToLower(status.String())] += len(tasks)
+		}
+	}
+	for queueID, queue := range snapshot.Queues {
+		metrics.UpdateQueueTaskCounts(queue.Name, taskCountsByQueue[queueID])
 	}
 	ssn.NodeList = util.GetNodeList(snapshot.Nodes, snapshot.NodeList)
 

--- a/pkg/scheduler/metrics/queue.go
+++ b/pkg/scheduler/metrics/queue.go
@@ -193,6 +193,26 @@ var (
 		}, []string{"queue_name", "resource"},
 	)
 
+	queueTaskCount = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Subsystem: VolcanoSubSystemName,
+			Name:      "queue_session_start_task_count",
+			Help:      "Number of tasks by status in jobs directly assigned to this queue at the beginning of the latest scheduling session",
+		}, []string{"queue_name", "status"},
+	)
+	queueTaskStatuses = [...]string{
+		"pending",
+		"allocated",
+		"pipelined",
+		"binding",
+		"bound",
+		"running",
+		"releasing",
+		"succeeded",
+		"failed",
+		"unknown",
+	}
+
 	// Track all known scalar resources for each queue
 	knownScalarResources     = make(map[string]map[string]struct{})
 	knownScalarResourcesLock sync.RWMutex
@@ -283,6 +303,13 @@ func UpdateQueueInqueue(queueName string, milliCPU, memory float64, scalarResour
 	updateScalarResourceMetrics(queueInqueueScalarResource, queueName, scalarResources)
 }
 
+// UpdateQueueTaskCounts records the number of tasks in each status for a queue
+func UpdateQueueTaskCounts(queueName string, taskCounts map[string]int) {
+	for _, status := range queueTaskStatuses {
+		queueTaskCount.WithLabelValues(queueName, status).Set(float64(taskCounts[status]))
+	}
+}
+
 // DeleteQueueMetrics delete all metrics related to the queue
 func DeleteQueueMetrics(queueName string) {
 	queueAllocatedMilliCPU.DeleteLabelValues(queueName)
@@ -307,6 +334,7 @@ func DeleteQueueMetrics(queueName string) {
 	queueCapacityScalarResource.DeletePartialMatch(partialLabelMap)
 	queueRealCapacityScalarResource.DeletePartialMatch(partialLabelMap)
 	queueInqueueScalarResource.DeletePartialMatch(partialLabelMap)
+	queueTaskCount.DeletePartialMatch(partialLabelMap)
 	knownScalarResourcesLock.Lock()
 	delete(knownScalarResources, queueName)
 	knownScalarResourcesLock.Unlock()

--- a/pkg/scheduler/metrics/queue.go
+++ b/pkg/scheduler/metrics/queue.go
@@ -205,7 +205,7 @@ var (
 		prometheus.GaugeOpts{
 			Subsystem: VolcanoSubSystemName,
 			Name:      "queue_task_count",
-			Help:      "Number of tasks in this queue by status at the beginning of the latest scheduling session",
+			Help:      "Number of tasks by status in jobs directly assigned to this queue at the beginning of the latest scheduling session",
 		}, []string{"queue_name", "status"},
 	)
 

--- a/pkg/scheduler/metrics/queue.go
+++ b/pkg/scheduler/metrics/queue.go
@@ -193,6 +193,22 @@ var (
 		}, []string{"queue_name", "resource"},
 	)
 
+	queuePodGroupCount = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Subsystem: VolcanoSubSystemName,
+			Name:      "queue_pod_group_count",
+			Help:      "Number of PodGroups in this queue by phase at the beginning of the latest scheduling session",
+		}, []string{"queue_name", "phase"},
+	)
+
+	queueTaskCount = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Subsystem: VolcanoSubSystemName,
+			Name:      "queue_task_count",
+			Help:      "Number of tasks in this queue by status at the beginning of the latest scheduling session",
+		}, []string{"queue_name", "status"},
+	)
+
 	// Track all known scalar resources for each queue
 	knownScalarResources     = make(map[string]map[string]struct{})
 	knownScalarResourcesLock sync.RWMutex
@@ -283,6 +299,16 @@ func UpdateQueueInqueue(queueName string, milliCPU, memory float64, scalarResour
 	updateScalarResourceMetrics(queueInqueueScalarResource, queueName, scalarResources)
 }
 
+// UpdateQueuePodGroupCount records the number of PodGroups in one phase for a queue
+func UpdateQueuePodGroupCount(queueName, phase string, count int) {
+	queuePodGroupCount.WithLabelValues(queueName, phase).Set(float64(count))
+}
+
+// UpdateQueueTaskCount records the number of tasks in one status for a queue
+func UpdateQueueTaskCount(queueName, status string, count int) {
+	queueTaskCount.WithLabelValues(queueName, status).Set(float64(count))
+}
+
 // DeleteQueueMetrics delete all metrics related to the queue
 func DeleteQueueMetrics(queueName string) {
 	queueAllocatedMilliCPU.DeleteLabelValues(queueName)
@@ -307,6 +333,8 @@ func DeleteQueueMetrics(queueName string) {
 	queueCapacityScalarResource.DeletePartialMatch(partialLabelMap)
 	queueRealCapacityScalarResource.DeletePartialMatch(partialLabelMap)
 	queueInqueueScalarResource.DeletePartialMatch(partialLabelMap)
+	queuePodGroupCount.DeletePartialMatch(partialLabelMap)
+	queueTaskCount.DeletePartialMatch(partialLabelMap)
 	knownScalarResourcesLock.Lock()
 	delete(knownScalarResources, queueName)
 	knownScalarResourcesLock.Unlock()


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This PR adds a scheduler gauge that describes the task state in each queue at the beginning of the latest scheduling session:

- `volcano_queue_task_count{queue_name,status}`

The metric is collected while the session snapshot is opened and before plugins or scheduling actions mutate it. Counts use direct `job.Queue` membership without hierarchical rollup, and every known task status is explicitly updated on each session, including zero values. Unexpected task statuses are normalized to `unknown`, and queue deletion removes the metric through the existing scheduler metrics cleanup path.

Task aggregation is folded into the existing `openSession` job traversal, so it does not add another full job iteration. Existing controller-manager gauges remain the source for per-queue PodGroup phase counts, avoiding duplicate scheduler metrics.

This allows operators to correlate pending task backlog with action and end-to-end scheduling latency.

Validation:

- `go test ./pkg/scheduler/... -count=1`
- `go vet ./pkg/scheduler/framework ./pkg/scheduler/metrics`
- `make verify`
- `golangci-lint run ./pkg/scheduler/framework ./pkg/scheduler/metrics`

#### Which issue(s) this PR fixes:

Fixes #5825

#### Special notes for your reviewer:

This PR was prepared with AI assistance.

#### Does this PR introduce a user-facing change?

```release-note
Add volcano_queue_task_count scheduler metrics for per-queue task state at the beginning of each scheduling session.
```