### PR TITLE
agentscheduler: skip uninitialized worker states in shard coordinator

### DIFF
--- a/pkg/agentscheduler/cache/shard_coordinator.go
+++ b/pkg/agentscheduler/cache/shard_coordinator.go
@@ -139,13 +139,13 @@ func (sc *ShardCoordinator) tryUpdateNodeShardStatus() bool {
 
 	update := true
 	for index, state := range sc.workerStates {
-		//skip update if any worker is scheduling with nodes before this revision
-		p := &state.revisionInScheduling
-		if p == nil {
+		if state == nil {
+			klog.Errorf("Worker %d state is not inited, skip it when checking nodeshard update", index)
 			continue
 		}
-		revision := atomic.LoadInt64(p)
-		if state != nil && revision > 0 && revision < latest {
+		//skip update if any worker is scheduling with nodes before this revision
+		revision := atomic.LoadInt64(&state.revisionInScheduling)
+		if revision > 0 && revision < latest {
 			klog.V(3).Infof("Worker %d is scheduling with old nodes, skip nodeshard update", index)
 			update = false
 			break

--- a/pkg/agentscheduler/cache/shard_coordinator_test.go
+++ b/pkg/agentscheduler/cache/shard_coordinator_test.go
@@ -237,6 +237,28 @@ func TestTryUpdateNodeShardStatus(t *testing.T) {
 			},
 			expectUpdateAttempt: true,
 		},
+		{
+			name:               "should skip uninitialized worker states",
+			lastSyncedRevision: 4,
+			latestRevision:     5,
+			workerStates: []*workerNodeShardState{
+				nil,
+				{revisionInScheduling: 5}, // Up to date
+				nil,
+			},
+			expectUpdateAttempt: true,
+		},
+		{
+			name:               "should keep inspecting workers after an uninitialized one",
+			lastSyncedRevision: 0,
+			latestRevision:     5,
+			workerStates: []*workerNodeShardState{
+				nil,
+				{revisionInScheduling: 4}, // Actively scheduling old nodes
+				nil,
+			},
+			expectUpdateAttempt: false,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

`tryUpdateNodeShardStatus` checks its worker state for nil twice, and neither check can fire: the address of a field is never nil, and by the time `state != nil` is evaluated the pointer has already been dereferenced. A nil entry in `workerStates` faults instead of being skipped.

`NewShardCoordinator` fills every slot, so nothing reaches this today. It matters because the coordinator's two other nil checks, in `getNodesForScheduling` and `OnWorkerEndSchedulingCycle`, do work — the invariant reads as defended here when it isn't. This makes the third one behave like its siblings: report the anomaly, then carry on scanning the remaining workers.

#### Which issue(s) this PR fixes:

No issue; evidence inline, as the template asks. Present since #4848, so in every release from v1.14.0 onward. `nilness` against master:

```
pkg/agentscheduler/cache/shard_coordinator.go:144:8: impossible condition: non-nil == nil
```

The added `should skip uninitialized worker states` case panics against the unmodified file:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0]
	pkg/agentscheduler/cache/shard_coordinator.go:147 tryUpdateNodeShardStatus
```

The fault lands on the atomic load rather than on the address-taking line because the field sits at offset 0.

On go 1.26, `gofmt`, `go vet`, `golangci-lint run` and `go test -race ./pkg/agentscheduler/...` are clean, and `nilness` reports nothing after the change.

#### Special notes for your reviewer:

AI disclosure per [AI Guidance](https://github.com/volcano-sh/volcano/blob/master/contributing.md#ai-guidance): prepared with Claude Code (Opus 5). I reviewed every change and ran the checks above before submitting.

#### Does this PR introduce a user-facing change?

NONE

