### PR TITLE
fix(gpushare): account for native sidecar GPU requests

### DIFF
--- a/pkg/scheduler/api/devices/nvidia/gpushare/device_info_test.go
+++ b/pkg/scheduler/api/devices/nvidia/gpushare/device_info_test.go
@@ -88,6 +88,33 @@ func TestGetGPUMemoryOfPod(t *testing.T) {
 			},
 			want: 3,
 		},
+		{
+			name: "GPU memory required by native sidecar and container",
+			pod: &v1.Pod{
+				Spec: v1.PodSpec{
+					InitContainers: []v1.Container{
+						{
+							RestartPolicy: restartPolicyAlways(),
+							Resources: v1.ResourceRequirements{
+								Limits: v1.ResourceList{
+									VolcanoGPUResource: resource.MustParse("4"),
+								},
+							},
+						},
+					},
+					Containers: []v1.Container{
+						{
+							Resources: v1.ResourceRequirements{
+								Limits: v1.ResourceList{
+									VolcanoGPUResource: resource.MustParse("4"),
+								},
+							},
+						},
+					},
+				},
+			},
+			want: 8,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -163,6 +190,33 @@ func TestGetGPUNumberOfPod(t *testing.T) {
 			},
 			want: 3,
 		},
+		{
+			name: "GPU count required by native sidecar and container",
+			pod: &v1.Pod{
+				Spec: v1.PodSpec{
+					InitContainers: []v1.Container{
+						{
+							RestartPolicy: restartPolicyAlways(),
+							Resources: v1.ResourceRequirements{
+								Limits: v1.ResourceList{
+									VolcanoGPUNumber: resource.MustParse("1"),
+								},
+							},
+						},
+					},
+					Containers: []v1.Container{
+						{
+							Resources: v1.ResourceRequirements{
+								Limits: v1.ResourceList{
+									VolcanoGPUNumber: resource.MustParse("1"),
+								},
+							},
+						},
+					},
+				},
+			},
+			want: 2,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -173,6 +227,11 @@ func TestGetGPUNumberOfPod(t *testing.T) {
 			}
 		})
 	}
+}
+
+func restartPolicyAlways() *v1.ContainerRestartPolicy {
+	restartAlways := v1.ContainerRestartPolicyAlways
+	return &restartAlways
 }
 
 func TestReleaseReturnsRemovedAnnotationKeys(t *testing.T) {

--- a/pkg/scheduler/api/devices/nvidia/gpushare/share.go
+++ b/pkg/scheduler/api/devices/nvidia/gpushare/share.go
@@ -231,17 +231,26 @@ func (g *GPUDevice) isIdleGPU() bool {
 
 // getGPUMemoryPod returns the GPU memory required by the pod.
 func getGPUMemoryOfPod(pod *v1.Pod) uint {
-	var initMem uint
-	for _, container := range pod.Spec.InitContainers {
-		res := getGPUMemoryOfContainer(container.Resources)
-		if initMem < res {
-			initMem = res
-		}
-	}
-
 	var mem uint
 	for _, container := range pod.Spec.Containers {
 		mem += getGPUMemoryOfContainer(container.Resources)
+	}
+
+	var restartableInitMem uint
+	var initMem uint
+	for _, container := range pod.Spec.InitContainers {
+		res := getGPUMemoryOfContainer(container.Resources)
+		if container.RestartPolicy != nil && *container.RestartPolicy == v1.ContainerRestartPolicyAlways {
+			mem += res
+			restartableInitMem += res
+			res = restartableInitMem
+		} else {
+			res += restartableInitMem
+		}
+
+		if initMem < res {
+			initMem = res
+		}
 	}
 
 	if mem > initMem {
@@ -266,9 +275,18 @@ func getGPUNumberOfPod(pod *v1.Pod) int {
 		gpus += getGPUNumberOfContainer(container.Resources)
 	}
 
+	var restartableInitGPUs int
 	var initGPUs int
 	for _, container := range pod.Spec.InitContainers {
 		res := getGPUNumberOfContainer(container.Resources)
+		if container.RestartPolicy != nil && *container.RestartPolicy == v1.ContainerRestartPolicyAlways {
+			gpus += res
+			restartableInitGPUs += res
+			res = restartableInitGPUs
+		} else {
+			res += restartableInitGPUs
+		}
+
 		if initGPUs < res {
 			initGPUs = res
 		}


### PR DESCRIPTION
## What this PR does

Fixes NVIDIA GPU-share accounting for native sidecars (`initContainers` with `restartPolicy: Always`).

Native sidecars run concurrently with regular containers, but GPU-share previously treated all init containers as sequential. As a result, it undercounted:

- `volcano.sh/gpu-memory`
- `volcano.sh/gpu-number`

The accounting now follows Kubernetes Pod resource semantics:

- regular containers and restartable init containers are summed
- ordinary init containers remain sequential and use the maximum requirement
- the final Pod requirement is the maximum of concurrent and init-phase usage.

## Testing

Added regression tests for a Pod with one native sidecar and one regular container:

- GPU memory: `4 + 4 = 8`
- GPU count: `1 + 1 = 2`

Verified with:

```bash
go test ./pkg/scheduler/api/devices/nvidia/gpushare
```

Fixes #5829