### PR TITLE
lint: drop duplicate imports and re-enable the ST1019 check

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -29,7 +29,6 @@ linters:
         - "-ST1005" # Error strings should not be capitalized or end with punctuation
         - "-ST1012" # Poorly chosen name for error variable
         - "-ST1016" # Methods on the same type should have the same receiver name
-        - "-ST1019" # Import the same package multiple times
         - "-ST1020" # The documentation of an exported function should start with function's name
         - "-ST1021" # The documentation of an exported type should start with type's name
         - "-QF1001" # Apply De Morgan's law

--- a/pkg/agent/events/handlers/memoryqosv2/memoryqosv2_linux.go
+++ b/pkg/agent/events/handlers/memoryqosv2/memoryqosv2_linux.go
@@ -21,7 +21,6 @@ import (
 	"path"
 
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	corelisters "k8s.io/client-go/listers/core/v1"
@@ -97,7 +96,7 @@ func (h *MemoryQoSV2Handle) Handle(event interface{}) error {
 
 	cfg, err := parseColocationConfig(cfgStr)
 	if err != nil {
-		h.recorder.Event(pod, v1.EventTypeWarning, "ColocationConfigParseFailed", err.Error())
+		h.recorder.Event(pod, corev1.EventTypeWarning, "ColocationConfigParseFailed", err.Error())
 		klog.ErrorS(err, "Failed to parse memory qos config", "pod", klog.KObj(pod))
 		return nil
 	}

--- a/pkg/controllers/queue/queue_controller_action.go
+++ b/pkg/controllers/queue/queue_controller_action.go
@@ -30,7 +30,6 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 
-	"volcano.sh/apis/pkg/apis/bus/v1alpha1"
 	busv1alpha1 "volcano.sh/apis/pkg/apis/bus/v1alpha1"
 	schedulingv1beta1 "volcano.sh/apis/pkg/apis/scheduling/v1beta1"
 	v1beta1apply "volcano.sh/apis/pkg/client/applyconfiguration/scheduling/v1beta1"
@@ -131,7 +130,7 @@ func (c *queuecontroller) openQueue(queue *schedulingv1beta1.Queue, updateStateF
 		queueStatusApply := v1beta1apply.QueueStatus().WithState(newQueue.Status.State)
 		queueApply := v1beta1apply.Queue(queue.Name).WithStatus(queueStatusApply)
 		if _, err := c.vcClient.SchedulingV1beta1().Queues().ApplyStatus(context.TODO(), queueApply, metav1.ApplyOptions{FieldManager: controllerName}); err != nil {
-			c.recorder.Event(newQueue, v1.EventTypeWarning, string(v1alpha1.OpenQueueAction),
+			c.recorder.Event(newQueue, v1.EventTypeWarning, string(busv1alpha1.OpenQueueAction),
 				fmt.Sprintf("Update queue status from %s to %s failed for %v",
 					queue.Status.State, newQueue.Status.State, err))
 			return err
@@ -162,11 +161,11 @@ func (c *queuecontroller) closeQueue(queue *schedulingv1beta1.Queue, updateState
 		queueStatusApply := v1beta1apply.QueueStatus().WithState(newQueue.Status.State)
 		queueApply := v1beta1apply.Queue(queue.Name).WithStatus(queueStatusApply)
 		if _, err := c.vcClient.SchedulingV1beta1().Queues().ApplyStatus(context.TODO(), queueApply, metav1.ApplyOptions{FieldManager: controllerName}); err != nil {
-			c.recorder.Event(newQueue, v1.EventTypeWarning, string(v1alpha1.CloseQueueAction),
+			c.recorder.Event(newQueue, v1.EventTypeWarning, string(busv1alpha1.CloseQueueAction),
 				fmt.Sprintf("Close queue failed for %v", err))
 			return err
 		}
-		c.recorder.Event(newQueue, v1.EventTypeNormal, string(v1alpha1.CloseQueueAction), "Close queue succeed")
+		c.recorder.Event(newQueue, v1.EventTypeNormal, string(busv1alpha1.CloseQueueAction), "Close queue succeed")
 	}
 
 	return nil

--- a/pkg/scheduler/cache/event_handlers_test.go
+++ b/pkg/scheduler/cache/event_handlers_test.go
@@ -34,7 +34,6 @@ import (
 	schedulingv1 "volcano.sh/apis/pkg/apis/scheduling/v1beta1"
 	topologyv1alpha1 "volcano.sh/apis/pkg/apis/topology/v1alpha1"
 	"volcano.sh/volcano/pkg/scheduler/api"
-	schedulingapi "volcano.sh/volcano/pkg/scheduler/api"
 	"volcano.sh/volcano/pkg/scheduler/util"
 )
 
@@ -650,8 +649,8 @@ func TestSchedulerCache_DeleteQueueV1beta1(t *testing.T) {
 
 func TestSchedulerCache_SyncNode(t *testing.T) {
 	n1 := util.BuildNode("n1", nil, map[string]string{"label-key": "label-value"})
-	expectedNodeInfo := schedulingapi.NewNodeInfo(n1)
-	expectedNodeInfo.State.Phase = schedulingapi.Ready
+	expectedNodeInfo := api.NewNodeInfo(n1)
+	expectedNodeInfo.State.Phase = api.Ready
 
 	tests := []struct {
 		name          string
@@ -659,13 +658,13 @@ func TestSchedulerCache_SyncNode(t *testing.T) {
 		nodes         []*v1.Node
 		nodeName      string
 		nodeSelector  map[string]sets.Empty
-		expectedNodes map[string]*schedulingapi.NodeInfo
+		expectedNodes map[string]*api.NodeInfo
 		wantErr       bool
 	}{
 		{
 			name:          "Node not exists",
 			nodeName:      "n1",
-			expectedNodes: map[string]*schedulingapi.NodeInfo{},
+			expectedNodes: map[string]*api.NodeInfo{},
 			wantErr:       true,
 		},
 		{
@@ -677,7 +676,7 @@ func TestSchedulerCache_SyncNode(t *testing.T) {
 			nodeSelector: map[string]sets.Empty{
 				"label-key:label-value": {},
 			},
-			expectedNodes: map[string]*schedulingapi.NodeInfo{"n1": expectedNodeInfo},
+			expectedNodes: map[string]*api.NodeInfo{"n1": expectedNodeInfo},
 			wantErr:       false,
 		},
 		{
@@ -689,7 +688,7 @@ func TestSchedulerCache_SyncNode(t *testing.T) {
 			nodeSelector: map[string]sets.Empty{
 				"label-key:label-value": {},
 			},
-			expectedNodes: map[string]*schedulingapi.NodeInfo{},
+			expectedNodes: map[string]*api.NodeInfo{},
 			wantErr:       false,
 		},
 	}
@@ -706,7 +705,7 @@ func TestSchedulerCache_SyncNode(t *testing.T) {
 				t.Errorf("SyncNode() error = %v, wantErr %v", err, tt.wantErr)
 			}
 
-			actualNodes := make(map[string]*schedulingapi.NodeInfo)
+			actualNodes := make(map[string]*api.NodeInfo)
 			for n, i := range sc.Nodes {
 				actualNodes[n] = i
 			}
@@ -717,45 +716,45 @@ func TestSchedulerCache_SyncNode(t *testing.T) {
 
 func TestSchedulerCache_AddHyperNode(t *testing.T) {
 	exactSelector := "exact"
-	s5 := schedulingapi.BuildHyperNode("s5", 2, []schedulingapi.MemberConfig{
+	s5 := api.BuildHyperNode("s5", 2, []api.MemberConfig{
 		{"s2", topologyv1alpha1.MemberTypeHyperNode, exactSelector, nil},
 		{"s3", topologyv1alpha1.MemberTypeHyperNode, exactSelector, nil},
 	})
-	s4 := schedulingapi.BuildHyperNode("s4", 2, []schedulingapi.MemberConfig{
+	s4 := api.BuildHyperNode("s4", 2, []api.MemberConfig{
 		{"s0", topologyv1alpha1.MemberTypeHyperNode, exactSelector, nil},
 		{"s1", topologyv1alpha1.MemberTypeHyperNode, exactSelector, nil},
 	})
-	s3 := schedulingapi.BuildHyperNode("s3", 1, []schedulingapi.MemberConfig{
+	s3 := api.BuildHyperNode("s3", 1, []api.MemberConfig{
 		{"node-6", topologyv1alpha1.MemberTypeNode, exactSelector, nil},
 		{"node-7", topologyv1alpha1.MemberTypeNode, exactSelector, nil},
 	})
-	s1 := schedulingapi.BuildHyperNode("s1", 1, []schedulingapi.MemberConfig{
+	s1 := api.BuildHyperNode("s1", 1, []api.MemberConfig{
 		{"node-2", topologyv1alpha1.MemberTypeNode, exactSelector, nil},
 		{"node-3", topologyv1alpha1.MemberTypeNode, exactSelector, nil},
 	})
-	s2 := schedulingapi.BuildHyperNode("s2", 1, []schedulingapi.MemberConfig{
+	s2 := api.BuildHyperNode("s2", 1, []api.MemberConfig{
 		{"node-4", topologyv1alpha1.MemberTypeNode, exactSelector, nil},
 		{"node-5", topologyv1alpha1.MemberTypeNode, exactSelector, nil},
 	})
-	s0 := schedulingapi.BuildHyperNode("s0", 1, []schedulingapi.MemberConfig{
+	s0 := api.BuildHyperNode("s0", 1, []api.MemberConfig{
 		{"node-0", topologyv1alpha1.MemberTypeNode, exactSelector, nil},
 		{"node-1", topologyv1alpha1.MemberTypeNode, exactSelector, nil},
 	})
 	initialHyperNodes0 := []*topologyv1alpha1.HyperNode{s5, s0, s4, s3, s1, s2}
 
 	regexSelector := "regex"
-	s00 := schedulingapi.BuildHyperNode("s0", 1, []schedulingapi.MemberConfig{
+	s00 := api.BuildHyperNode("s0", 1, []api.MemberConfig{
 		{"node-0", topologyv1alpha1.MemberTypeNode, exactSelector, nil},
 		{"node-1", topologyv1alpha1.MemberTypeNode, exactSelector, nil},
 	})
-	s10 := schedulingapi.BuildHyperNode("s1", 1, []schedulingapi.MemberConfig{
+	s10 := api.BuildHyperNode("s1", 1, []api.MemberConfig{
 		{"node-[2-3]", topologyv1alpha1.MemberTypeNode, regexSelector, nil},
 	})
-	s20 := schedulingapi.BuildHyperNode("s2", 1, []schedulingapi.MemberConfig{
+	s20 := api.BuildHyperNode("s2", 1, []api.MemberConfig{
 		{"^prefix", topologyv1alpha1.MemberTypeNode, regexSelector, nil},
 	})
 	initialHyperNodes1 := []*topologyv1alpha1.HyperNode{s5, s00, s4, s3, s10, s20}
-	s6 := schedulingapi.BuildHyperNode("s6", 3, []schedulingapi.MemberConfig{
+	s6 := api.BuildHyperNode("s6", 3, []api.MemberConfig{
 		{"s4", topologyv1alpha1.MemberTypeHyperNode, exactSelector, nil},
 		{"s5", topologyv1alpha1.MemberTypeHyperNode, exactSelector, nil},
 	})
@@ -888,31 +887,31 @@ func TestSchedulerCache_AddHyperNode(t *testing.T) {
 func TestSchedulerCache_Delete_Then_AddBack(t *testing.T) {
 	exactSelector := "exact"
 
-	s5 := schedulingapi.BuildHyperNode("s5", 2, []schedulingapi.MemberConfig{
+	s5 := api.BuildHyperNode("s5", 2, []api.MemberConfig{
 		{"s2", topologyv1alpha1.MemberTypeHyperNode, exactSelector, nil},
 		{"s3", topologyv1alpha1.MemberTypeHyperNode, exactSelector, nil},
 	})
-	s4 := schedulingapi.BuildHyperNode("s4", 2, []schedulingapi.MemberConfig{
+	s4 := api.BuildHyperNode("s4", 2, []api.MemberConfig{
 		{"s0", topologyv1alpha1.MemberTypeHyperNode, exactSelector, nil},
 		{"s1", topologyv1alpha1.MemberTypeHyperNode, exactSelector, nil},
 	})
-	s3 := schedulingapi.BuildHyperNode("s3", 1, []schedulingapi.MemberConfig{
+	s3 := api.BuildHyperNode("s3", 1, []api.MemberConfig{
 		{"node-6", topologyv1alpha1.MemberTypeNode, exactSelector, nil},
 		{"node-7", topologyv1alpha1.MemberTypeNode, exactSelector, nil},
 	})
-	s1 := schedulingapi.BuildHyperNode("s1", 1, []schedulingapi.MemberConfig{
+	s1 := api.BuildHyperNode("s1", 1, []api.MemberConfig{
 		{"node-2", topologyv1alpha1.MemberTypeNode, exactSelector, nil},
 		{"node-3", topologyv1alpha1.MemberTypeNode, exactSelector, nil},
 	})
-	s2 := schedulingapi.BuildHyperNode("s2", 1, []schedulingapi.MemberConfig{
+	s2 := api.BuildHyperNode("s2", 1, []api.MemberConfig{
 		{"node-4", topologyv1alpha1.MemberTypeNode, exactSelector, nil},
 		{"node-5", topologyv1alpha1.MemberTypeNode, exactSelector, nil},
 	})
-	s0 := schedulingapi.BuildHyperNode("s0", 1, []schedulingapi.MemberConfig{
+	s0 := api.BuildHyperNode("s0", 1, []api.MemberConfig{
 		{"node-0", topologyv1alpha1.MemberTypeNode, exactSelector, nil},
 		{"node-1", topologyv1alpha1.MemberTypeNode, exactSelector, nil},
 	})
-	s6 := schedulingapi.BuildHyperNode("s6", 3, []schedulingapi.MemberConfig{
+	s6 := api.BuildHyperNode("s6", 3, []api.MemberConfig{
 		{"s4", topologyv1alpha1.MemberTypeHyperNode, exactSelector, nil},
 		{"s5", topologyv1alpha1.MemberTypeHyperNode, exactSelector, nil},
 	})
@@ -999,33 +998,33 @@ func TestSchedulerCache_UpdateHyperNode(t *testing.T) {
 	exactSelector := "exact"
 	regexSelector := "regex"
 
-	s0 := schedulingapi.BuildHyperNode("s0", 1, []schedulingapi.MemberConfig{
+	s0 := api.BuildHyperNode("s0", 1, []api.MemberConfig{
 		{"node-0", topologyv1alpha1.MemberTypeNode, exactSelector, nil},
 		{"node-1", topologyv1alpha1.MemberTypeNode, exactSelector, nil},
 	})
-	s1 := schedulingapi.BuildHyperNode("s1", 1, []schedulingapi.MemberConfig{
+	s1 := api.BuildHyperNode("s1", 1, []api.MemberConfig{
 		{"node-2", topologyv1alpha1.MemberTypeNode, exactSelector, nil},
 		{"node-3", topologyv1alpha1.MemberTypeNode, exactSelector, nil},
 	})
-	s2 := schedulingapi.BuildHyperNode("s2", 1, []schedulingapi.MemberConfig{
+	s2 := api.BuildHyperNode("s2", 1, []api.MemberConfig{
 		{"node-4", topologyv1alpha1.MemberTypeNode, exactSelector, nil},
 		{"node-5", topologyv1alpha1.MemberTypeNode, exactSelector, nil},
 	})
-	s3 := schedulingapi.BuildHyperNode("s3", 1, []schedulingapi.MemberConfig{
+	s3 := api.BuildHyperNode("s3", 1, []api.MemberConfig{
 		{"node-6", topologyv1alpha1.MemberTypeNode, exactSelector, nil},
 		{"node-7", topologyv1alpha1.MemberTypeNode, exactSelector, nil},
 	})
-	s4 := schedulingapi.BuildHyperNode("s4", 2, []schedulingapi.MemberConfig{
+	s4 := api.BuildHyperNode("s4", 2, []api.MemberConfig{
 		{"s0", topologyv1alpha1.MemberTypeHyperNode, exactSelector, nil},
 		{"s1", topologyv1alpha1.MemberTypeHyperNode, exactSelector, nil},
 	})
 
-	s5 := schedulingapi.BuildHyperNode("s5", 2, []schedulingapi.MemberConfig{
+	s5 := api.BuildHyperNode("s5", 2, []api.MemberConfig{
 		{"s2", topologyv1alpha1.MemberTypeHyperNode, exactSelector, nil},
 		{"s3", topologyv1alpha1.MemberTypeHyperNode, exactSelector, nil},
 	})
-	s6 := schedulingapi.BuildHyperNode("s6", 3,
-		[]schedulingapi.MemberConfig{
+	s6 := api.BuildHyperNode("s6", 3,
+		[]api.MemberConfig{
 			{"s4", topologyv1alpha1.MemberTypeHyperNode, exactSelector, nil},
 			{"s5", topologyv1alpha1.MemberTypeHyperNode, exactSelector, nil},
 		})
@@ -1046,11 +1045,11 @@ func TestSchedulerCache_UpdateHyperNode(t *testing.T) {
 			initialHyperNodes: initialHyperNodes,
 			hyperNodesToUpdated: []*topologyv1alpha1.HyperNode{
 				// first remove s2 from s5.
-				schedulingapi.BuildHyperNode("s5", 2, []schedulingapi.MemberConfig{
+				api.BuildHyperNode("s5", 2, []api.MemberConfig{
 					{"s3", topologyv1alpha1.MemberTypeHyperNode, exactSelector, nil},
 				}),
 				// second add s2 to s4.
-				schedulingapi.BuildHyperNode("s4", 2, []schedulingapi.MemberConfig{
+				api.BuildHyperNode("s4", 2, []api.MemberConfig{
 					{"s0", topologyv1alpha1.MemberTypeHyperNode, exactSelector, nil},
 					{"s1", topologyv1alpha1.MemberTypeHyperNode, exactSelector, nil},
 					{"s2", topologyv1alpha1.MemberTypeHyperNode, exactSelector, nil},
@@ -1114,7 +1113,7 @@ func TestSchedulerCache_UpdateHyperNode(t *testing.T) {
 			name:              "Remove hyperNode s3's members node-6 and node-7.",
 			initialHyperNodes: initialHyperNodes,
 			hyperNodesToUpdated: []*topologyv1alpha1.HyperNode{
-				schedulingapi.BuildHyperNode("s3", 1, []schedulingapi.MemberConfig{}),
+				api.BuildHyperNode("s3", 1, []api.MemberConfig{}),
 			},
 			expectedHyperNodesSetByTier: []map[int]sets.Set[string]{
 				{
@@ -1155,7 +1154,7 @@ func TestSchedulerCache_UpdateHyperNode(t *testing.T) {
 			},
 			initialHyperNodes: initialHyperNodes,
 			hyperNodesToUpdated: []*topologyv1alpha1.HyperNode{
-				schedulingapi.BuildHyperNode("s2", 1, []schedulingapi.MemberConfig{
+				api.BuildHyperNode("s2", 1, []api.MemberConfig{
 					{"-suffix", topologyv1alpha1.MemberTypeNode, regexSelector, nil},
 				}),
 			},
@@ -1219,31 +1218,31 @@ func TestSchedulerCache_UpdateHyperNode(t *testing.T) {
 
 func TestSchedulerCache_DeleteHyperNode(t *testing.T) {
 	selector := "exact"
-	s0 := schedulingapi.BuildHyperNode("s0", 1, []schedulingapi.MemberConfig{
+	s0 := api.BuildHyperNode("s0", 1, []api.MemberConfig{
 		{"node-0", topologyv1alpha1.MemberTypeNode, selector, nil},
 		{"node-1", topologyv1alpha1.MemberTypeNode, selector, nil},
 	})
-	s1 := schedulingapi.BuildHyperNode("s1", 1, []schedulingapi.MemberConfig{
+	s1 := api.BuildHyperNode("s1", 1, []api.MemberConfig{
 		{"node-2", topologyv1alpha1.MemberTypeNode, selector, nil},
 		{"node-3", topologyv1alpha1.MemberTypeNode, selector, nil},
 	})
-	s2 := schedulingapi.BuildHyperNode("s2", 1, []schedulingapi.MemberConfig{
+	s2 := api.BuildHyperNode("s2", 1, []api.MemberConfig{
 		{"node-4", topologyv1alpha1.MemberTypeNode, selector, nil},
 		{"node-5", topologyv1alpha1.MemberTypeNode, selector, nil},
 	})
-	s3 := schedulingapi.BuildHyperNode("s3", 1, []schedulingapi.MemberConfig{
+	s3 := api.BuildHyperNode("s3", 1, []api.MemberConfig{
 		{"node-6", topologyv1alpha1.MemberTypeNode, selector, nil},
 		{"node-7", topologyv1alpha1.MemberTypeNode, selector, nil},
 	})
-	s4 := schedulingapi.BuildHyperNode("s4", 2, []schedulingapi.MemberConfig{
+	s4 := api.BuildHyperNode("s4", 2, []api.MemberConfig{
 		{"s0", topologyv1alpha1.MemberTypeHyperNode, selector, nil},
 		{"s1", topologyv1alpha1.MemberTypeHyperNode, selector, nil},
 	})
-	s5 := schedulingapi.BuildHyperNode("s5", 2, []schedulingapi.MemberConfig{
+	s5 := api.BuildHyperNode("s5", 2, []api.MemberConfig{
 		{"s2", topologyv1alpha1.MemberTypeHyperNode, selector, nil},
 		{"s3", topologyv1alpha1.MemberTypeHyperNode, selector, nil},
 	})
-	s6 := schedulingapi.BuildHyperNode("s6", 3, []schedulingapi.MemberConfig{
+	s6 := api.BuildHyperNode("s6", 3, []api.MemberConfig{
 		{"s4", topologyv1alpha1.MemberTypeHyperNode, selector, nil},
 		{"s5", topologyv1alpha1.MemberTypeHyperNode, selector, nil},
 	})
@@ -1361,49 +1360,49 @@ func TestSchedulerCache_DeleteHyperNode(t *testing.T) {
 func TestSchedulerCache_SyncHyperNode(t *testing.T) {
 	exactSelector := "exact"
 	regexSelector := "regex"
-	s6 := schedulingapi.BuildHyperNode("s6", 3, []schedulingapi.MemberConfig{
+	s6 := api.BuildHyperNode("s6", 3, []api.MemberConfig{
 		{"s4", topologyv1alpha1.MemberTypeHyperNode, exactSelector, nil},
 		{"s5", topologyv1alpha1.MemberTypeHyperNode, exactSelector, nil},
 	})
-	s5 := schedulingapi.BuildHyperNode("s5", 2, []schedulingapi.MemberConfig{
+	s5 := api.BuildHyperNode("s5", 2, []api.MemberConfig{
 		{"s2", topologyv1alpha1.MemberTypeHyperNode, exactSelector, nil},
 		{"s3", topologyv1alpha1.MemberTypeHyperNode, exactSelector, nil},
 	})
-	s4 := schedulingapi.BuildHyperNode("s4", 2, []schedulingapi.MemberConfig{
+	s4 := api.BuildHyperNode("s4", 2, []api.MemberConfig{
 		{"s0", topologyv1alpha1.MemberTypeHyperNode, exactSelector, nil},
 		{"s1", topologyv1alpha1.MemberTypeHyperNode, exactSelector, nil},
 	})
-	s3 := schedulingapi.BuildHyperNode("s3", 1, []schedulingapi.MemberConfig{
+	s3 := api.BuildHyperNode("s3", 1, []api.MemberConfig{
 		{"node-6", topologyv1alpha1.MemberTypeNode, exactSelector, nil},
 		{"node-7", topologyv1alpha1.MemberTypeNode, exactSelector, nil},
 	})
-	s2 := schedulingapi.BuildHyperNode("s2", 1, []schedulingapi.MemberConfig{
+	s2 := api.BuildHyperNode("s2", 1, []api.MemberConfig{
 		{"node-4", topologyv1alpha1.MemberTypeNode, exactSelector, nil},
 		{"node-5", topologyv1alpha1.MemberTypeNode, exactSelector, nil},
 	})
-	s20 := schedulingapi.BuildHyperNode("s2", 1, []schedulingapi.MemberConfig{
+	s20 := api.BuildHyperNode("s2", 1, []api.MemberConfig{
 		{"node-4", topologyv1alpha1.MemberTypeNode, exactSelector, nil},
 		{"node-5", topologyv1alpha1.MemberTypeNode, exactSelector, nil},
 		{"node-9", topologyv1alpha1.MemberTypeNode, regexSelector, nil},
 	})
-	s21 := schedulingapi.BuildHyperNode("s2", 1, []schedulingapi.MemberConfig{
+	s21 := api.BuildHyperNode("s2", 1, []api.MemberConfig{
 		{"node-4", topologyv1alpha1.MemberTypeNode, exactSelector, nil},
 		{"node-5", topologyv1alpha1.MemberTypeNode, regexSelector, nil},
 	})
-	s1 := schedulingapi.BuildHyperNode("s1", 1, []schedulingapi.MemberConfig{
+	s1 := api.BuildHyperNode("s1", 1, []api.MemberConfig{
 		{"node-2", topologyv1alpha1.MemberTypeNode, exactSelector, nil},
 		{"node-3", topologyv1alpha1.MemberTypeNode, exactSelector, nil},
 	})
-	s0 := schedulingapi.BuildHyperNode("s0", 1, []schedulingapi.MemberConfig{
+	s0 := api.BuildHyperNode("s0", 1, []api.MemberConfig{
 		{"node-0", topologyv1alpha1.MemberTypeNode, exactSelector, nil},
 		{"node-1", topologyv1alpha1.MemberTypeNode, exactSelector, nil},
 	})
-	s00 := schedulingapi.BuildHyperNode("s0", 1, []schedulingapi.MemberConfig{
+	s00 := api.BuildHyperNode("s0", 1, []api.MemberConfig{
 		{"node-0", topologyv1alpha1.MemberTypeNode, exactSelector, nil},
 		{"node-1", topologyv1alpha1.MemberTypeNode, exactSelector, nil},
 		{"^prefix", topologyv1alpha1.MemberTypeNode, regexSelector, nil},
 	})
-	s01 := schedulingapi.BuildHyperNode("s0", 1, []schedulingapi.MemberConfig{
+	s01 := api.BuildHyperNode("s0", 1, []api.MemberConfig{
 		{"node-[01]", topologyv1alpha1.MemberTypeNode, regexSelector, nil},
 	})
 	initialHyperNodes0 := []*topologyv1alpha1.HyperNode{s5, s0, s4, s3, s1, s2, s6}
@@ -1580,17 +1579,17 @@ func TestSchedulerCache_SyncHyperNode(t *testing.T) {
 
 func newCacheWithNodes(names ...string) *SchedulerCache {
 	sc := &SchedulerCache{
-		Nodes: make(map[string]*schedulingapi.NodeInfo),
-		Jobs:  make(map[schedulingapi.JobID]*schedulingapi.JobInfo),
+		Nodes: make(map[string]*api.NodeInfo),
+		Jobs:  make(map[api.JobID]*api.JobInfo),
 	}
 	for _, n := range names {
-		sc.Nodes[n] = schedulingapi.NewNodeInfo(buildNode(n, nil))
+		sc.Nodes[n] = api.NewNodeInfo(buildNode(n, nil))
 	}
 	return sc
 }
 
-func resSets(cpuSet string) schedulingapi.ResNumaSets {
-	return schedulingapi.ResNumaSets{"cpu": mustParseCPUSet(cpuSet)}
+func resSets(cpuSet string) api.ResNumaSets {
+	return api.ResNumaSets{"cpu": mustParseCPUSet(cpuSet)}
 }
 
 func mustParseCPUSet(s string) cpuset.CPUSet {
@@ -1603,8 +1602,8 @@ func mustParseCPUSet(s string) cpuset.CPUSet {
 
 // podMetaFrom returns the PodMeta matching buildPod's UID convention so we look
 // up the same key that clearUnassignedNumaTask derives from the pod.
-func podMetaFrom(pod *v1.Pod) schedulingapi.PodMeta {
-	return schedulingapi.PodMeta{UID: pod.UID, Name: pod.Name, Namespace: pod.Namespace}
+func podMetaFrom(pod *v1.Pod) api.PodMeta {
+	return api.PodMeta{UID: pod.UID, Name: pod.Name, Namespace: pod.Namespace}
 }
 
 func TestClearUnassignedNumaTask_RemovesEntry(t *testing.T) {
@@ -1612,10 +1611,10 @@ func TestClearUnassignedNumaTask_RemovesEntry(t *testing.T) {
 	node := sc.Nodes["n1"]
 
 	pod := buildPod("ns1", "p1", "n1", v1.PodRunning, nil, nil, nil)
-	node.UnassignedNumaPods = map[schedulingapi.PodMeta]schedulingapi.ResNumaSets{
+	node.UnassignedNumaPods = map[api.PodMeta]api.ResNumaSets{
 		podMetaFrom(pod): resSets("0-1"),
 	}
-	task := schedulingapi.NewTaskInfo(pod)
+	task := api.NewTaskInfo(pod)
 
 	sc.clearUnassignedNumaTask(task)
 
@@ -1629,10 +1628,10 @@ func TestClearUnassignedNumaTask_NoOpWhenTaskHasNoNode(t *testing.T) {
 	node := sc.Nodes["n1"]
 
 	pod := buildPod("ns1", "p1", "", v1.PodRunning, nil, nil, nil)
-	node.UnassignedNumaPods = map[schedulingapi.PodMeta]schedulingapi.ResNumaSets{
+	node.UnassignedNumaPods = map[api.PodMeta]api.ResNumaSets{
 		podMetaFrom(pod): resSets("0-1"),
 	}
-	task := schedulingapi.NewTaskInfo(pod)
+	task := api.NewTaskInfo(pod)
 
 	sc.clearUnassignedNumaTask(task)
 
@@ -1645,12 +1644,12 @@ func TestClearUnassignedNumaTask_NoOpWhenEntryMissing(t *testing.T) {
 	sc := newCacheWithNodes("n1")
 	node := sc.Nodes["n1"]
 	otherPod := buildPod("ns1", "pother", "n1", v1.PodRunning, nil, nil, nil)
-	node.UnassignedNumaPods = map[schedulingapi.PodMeta]schedulingapi.ResNumaSets{
+	node.UnassignedNumaPods = map[api.PodMeta]api.ResNumaSets{
 		podMetaFrom(otherPod): resSets("0-1"),
 	}
 
 	pod := buildPod("ns1", "p1", "n1", v1.PodRunning, nil, nil, nil)
-	task := schedulingapi.NewTaskInfo(pod)
+	task := api.NewTaskInfo(pod)
 
 	sc.clearUnassignedNumaTask(task)
 
@@ -1662,7 +1661,7 @@ func TestClearUnassignedNumaTask_NoOpWhenEntryMissing(t *testing.T) {
 func TestClearUnassignedNumaTask_NoOpWhenNodeMissing(t *testing.T) {
 	sc := newCacheWithNodes()
 	pod := buildPod("ns1", "p1", "ghost", v1.PodRunning, nil, nil, nil)
-	task := schedulingapi.NewTaskInfo(pod)
+	task := api.NewTaskInfo(pod)
 
 	// Must not panic.
 	sc.clearUnassignedNumaTask(task)
@@ -1673,7 +1672,7 @@ func TestClearUnassignedNumaPod_FallsBackToPodInfoWhenTaskNotInJob(t *testing.T)
 	node := sc.Nodes["n1"]
 
 	pod := buildPod("ns1", "p1", "n1", v1.PodRunning, nil, nil, nil)
-	node.UnassignedNumaPods = map[schedulingapi.PodMeta]schedulingapi.ResNumaSets{
+	node.UnassignedNumaPods = map[api.PodMeta]api.ResNumaSets{
 		podMetaFrom(pod): resSets("0-1"),
 	}
 	// No job registered in sc.Jobs, so clearUnassignedNumaPod falls back to the
@@ -1689,22 +1688,22 @@ func TestClearUnassignedNumaPod_UsesTaskFromJobWhenPresent(t *testing.T) {
 	sc := newCacheWithNodes("n1")
 	nodeN1 := sc.Nodes["n1"]
 
-	sc.Nodes["n2"] = schedulingapi.NewNodeInfo(buildNode("n2", nil))
+	sc.Nodes["n2"] = api.NewNodeInfo(buildNode("n2", nil))
 	nodeN2 := sc.Nodes["n2"]
 
 	pod := buildPod("ns1", "p1", "n1", v1.PodRunning, nil, nil, nil)
 	podMeta := podMetaFrom(pod)
-	nodeN1.UnassignedNumaPods = map[schedulingapi.PodMeta]schedulingapi.ResNumaSets{podMeta: resSets("0-1")}
-	nodeN2.UnassignedNumaPods = map[schedulingapi.PodMeta]schedulingapi.ResNumaSets{podMeta: resSets("2-3")}
+	nodeN1.UnassignedNumaPods = map[api.PodMeta]api.ResNumaSets{podMeta: resSets("0-1")}
+	nodeN2.UnassignedNumaPods = map[api.PodMeta]api.ResNumaSets{podMeta: resSets("2-3")}
 
-	fallbackTask := schedulingapi.NewTaskInfo(pod)
+	fallbackTask := api.NewTaskInfo(pod)
 	// Register a job whose task points at n2 (different from the pod's nn=n1 so
 	// the fallback TaskInfo would clear the wrong node). clearUnassignedNumaPod
 	// must prefer the job's task.
-	standalone := schedulingapi.NewTaskInfo(pod)
+	standalone := api.NewTaskInfo(pod)
 	jobTask := *standalone
 	jobTask.NodeName = "n2"
-	job := &schedulingapi.JobInfo{Tasks: map[schedulingapi.TaskID]*schedulingapi.TaskInfo{fallbackTask.UID: &jobTask}}
+	job := &api.JobInfo{Tasks: map[api.TaskID]*api.TaskInfo{fallbackTask.UID: &jobTask}}
 	sc.Jobs[fallbackTask.Job] = job
 
 	sc.clearUnassignedNumaPod(pod)
@@ -1758,12 +1757,12 @@ func TestAddPodWithUnresolvedPVCCachesTaskForResync(t *testing.T) {
 
 	// The task must exist in the cache as a proper TaskInfo carrying the
 	// pod reference, so it can be scheduled once the PVC informer syncs.
-	job, found := sc.Jobs[schedulingapi.JobID("default/pg-with-pvc")]
+	job, found := sc.Jobs[api.JobID("default/pg-with-pvc")]
 	assert.True(t, found, "job must be present in the cache")
 	if !assert.NotNil(t, job) {
 		return
 	}
-	task, found := job.Tasks[schedulingapi.TaskID("pod-with-pvc-uid")]
+	task, found := job.Tasks[api.TaskID("pod-with-pvc-uid")]
 	assert.True(t, found, "task must be added to the cache")
 	if assert.NotNil(t, task) {
 		assert.NotNil(t, task.Pod, "cached task must carry its pod reference")

--- a/pkg/scheduler/cache/shard_coordinator_test.go
+++ b/pkg/scheduler/cache/shard_coordinator_test.go
@@ -28,7 +28,6 @@ import (
 	nodeshardv1alpha1 "volcano.sh/apis/pkg/apis/shard/v1alpha1"
 	"volcano.sh/volcano/cmd/scheduler/app/options"
 	"volcano.sh/volcano/pkg/scheduler/api"
-	schedulingapi "volcano.sh/volcano/pkg/scheduler/api"
 	commonutil "volcano.sh/volcano/pkg/util"
 )
 
@@ -140,8 +139,8 @@ func TestRefreshNodeShards_AvailableNodesCalculation(t *testing.T) {
 	}
 
 	// Setup test data
-	nodeShard := schedulingapi.NewNodeShardInfo(buildShard("test-shard", []string{"node-1", "node-2", "node-3"}, []string{"node-1"}))
-	otherShard := schedulingapi.NewNodeShardInfo(buildShard("other-shard", []string{"node-2", "node-3"}, []string{"node-2"}))
+	nodeShard := api.NewNodeShardInfo(buildShard("test-shard", []string{"node-1", "node-2", "node-3"}, []string{"node-1"}))
+	otherShard := api.NewNodeShardInfo(buildShard("other-shard", []string{"node-2", "node-3"}, []string{"node-2"}))
 
 	tests := []struct {
 		name                string
@@ -257,7 +256,7 @@ func buildShard(name string, desired []string, inuse []string) *nodeshardv1alpha
 }
 
 func TestGenerateNodeShardWithStatusRecordsTransitionNodes(t *testing.T) {
-	shard := schedulingapi.NewNodeShardInfo(buildShard("test-shard", []string{"node-new"}, []string{"node-old"}))
+	shard := api.NewNodeShardInfo(buildShard("test-shard", []string{"node-new"}, []string{"node-old"}))
 	sc := &SchedulerCache{
 		NodeShards: map[string]*api.NodeShardInfo{
 			"test-shard": shard,

--- a/pkg/scheduler/uthelper/helper.go
+++ b/pkg/scheduler/uthelper/helper.go
@@ -36,7 +36,6 @@ import (
 	vcapisv1 "volcano.sh/apis/pkg/apis/scheduling/v1beta1"
 	topologyv1alpha1 "volcano.sh/apis/pkg/apis/topology/v1alpha1"
 	"volcano.sh/volcano/pkg/scheduler/api"
-	schedulingapi "volcano.sh/volcano/pkg/scheduler/api"
 	"volcano.sh/volcano/pkg/scheduler/cache"
 	"volcano.sh/volcano/pkg/scheduler/conf"
 	"volcano.sh/volcano/pkg/scheduler/framework"
@@ -96,7 +95,7 @@ type TestCommonStruct struct {
 	// ExpectStatus the expected final podgroup status.
 	ExpectStatus map[api.JobID]scheduling.PodGroupPhase
 	// ExpectTaskStatusNums represents the expected number map of various TaskStatuses in podgroup
-	ExpectTaskStatusNums map[api.JobID]map[schedulingapi.TaskStatus]int
+	ExpectTaskStatusNums map[api.JobID]map[api.TaskStatus]int
 	// ExpectBindsNum the expected bind events numbers.
 	ExpectBindsNum int
 	// ExpectEvictNum the expected evict events numbers, include preempted and reclaimed evict events
@@ -205,7 +204,7 @@ func (test *TestCommonStruct) createSchedulerCache() *cache.SchedulerCache {
 			}
 		}
 	}
-	schedulerCache.HyperNodesInfo = schedulingapi.NewHyperNodesInfoWithCache(test.HyperNodesMap, test.HyperNodesSetByTier, test.HyperNodes, ready)
+	schedulerCache.HyperNodesInfo = api.NewHyperNodesInfoWithCache(test.HyperNodesMap, test.HyperNodesSetByTier, test.HyperNodes, ready)
 
 	return schedulerCache
 }

--- a/test/e2e/cronjob/cronjob_basic.go
+++ b/test/e2e/cronjob/cronjob_basic.go
@@ -26,7 +26,6 @@ import (
 	. "github.com/onsi/gomega"
 
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"volcano.sh/apis/pkg/apis/batch/v1alpha1"
 	e2eutil "volcano.sh/volcano/test/e2e/util"
@@ -495,7 +494,7 @@ func createTestCronjob(name, nameSpace, schedule string, concurrency v1alpha1.Co
 										{
 											Name:            "test-container",
 											Image:           e2eutil.DefaultBusyBoxImage,
-											ImagePullPolicy: v1.PullIfNotPresent,
+											ImagePullPolicy: corev1.PullIfNotPresent,
 											Command:         command,
 										},
 									},

--- a/test/e2e/jobp/admission.go
+++ b/test/e2e/jobp/admission.go
@@ -25,11 +25,9 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"volcano.sh/apis/pkg/apis/batch/v1alpha1"
 	schedulingv1beta1 "volcano.sh/apis/pkg/apis/scheduling/v1beta1"
-	vcschedulingv1 "volcano.sh/apis/pkg/apis/scheduling/v1beta1"
 
 	e2eutil "volcano.sh/volcano/test/e2e/util"
 )
@@ -56,7 +54,7 @@ var _ = ginkgo.Describe("Job E2E Test: Test Admission service", func() {
 			},
 		})
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		createdJob, err := ctx.Vcclient.BatchV1alpha1().Jobs(ctx.Namespace).Get(context.TODO(), jobName, v1.GetOptions{})
+		createdJob, err := ctx.Vcclient.BatchV1alpha1().Jobs(ctx.Namespace).Get(context.TODO(), jobName, metav1.GetOptions{})
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		gomega.Expect(createdJob.Spec.Queue).Should(gomega.Equal("default"),
 			"Job queue attribute would default to 'default' ")
@@ -104,7 +102,7 @@ var _ = ginkgo.Describe("Job E2E Test: Test Admission service", func() {
 		}`)
 		err := json.Unmarshal(jsonData, &job)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		_, err = ctx.Vcclient.BatchV1alpha1().Jobs(ctx.Namespace).Create(context.TODO(), &job, v1.CreateOptions{})
+		_, err = ctx.Vcclient.BatchV1alpha1().Jobs(ctx.Namespace).Create(context.TODO(), &job, metav1.CreateOptions{})
 		gomega.Expect(err).To(gomega.HaveOccurred())
 
 	})
@@ -152,7 +150,7 @@ var _ = ginkgo.Describe("Job E2E Test: Test Admission service", func() {
 
 		err := json.Unmarshal(jsonData, &job)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		_, err = ctx.Vcclient.BatchV1alpha1().Jobs(ctx.Namespace).Create(context.TODO(), &job, v1.CreateOptions{})
+		_, err = ctx.Vcclient.BatchV1alpha1().Jobs(ctx.Namespace).Create(context.TODO(), &job, metav1.CreateOptions{})
 		gomega.Expect(err).To(gomega.HaveOccurred())
 
 	})
@@ -163,11 +161,11 @@ var _ = ginkgo.Describe("Job E2E Test: Test Admission service", func() {
 		defer e2eutil.CleanupTestContext(ctx)
 
 		pod := &corev1.Pod{
-			TypeMeta: v1.TypeMeta{
+			TypeMeta: metav1.TypeMeta{
 				APIVersion: "v1",
 				Kind:       "Pod",
 			},
-			ObjectMeta: v1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Namespace: ctx.Namespace,
 				Name:      podName,
 			},
@@ -176,7 +174,7 @@ var _ = ginkgo.Describe("Job E2E Test: Test Admission service", func() {
 			},
 		}
 
-		_, err := ctx.Kubeclient.CoreV1().Pods(ctx.Namespace).Create(context.TODO(), pod, v1.CreateOptions{})
+		_, err := ctx.Kubeclient.CoreV1().Pods(ctx.Namespace).Create(context.TODO(), pod, metav1.CreateOptions{})
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		err = e2eutil.WaitPodPhase(ctx, pod, []corev1.PodPhase{corev1.PodRunning})
@@ -189,11 +187,11 @@ var _ = ginkgo.Describe("Job E2E Test: Test Admission service", func() {
 		defer e2eutil.CleanupTestContext(ctx)
 
 		pod := &corev1.Pod{
-			TypeMeta: v1.TypeMeta{
+			TypeMeta: metav1.TypeMeta{
 				APIVersion: "v1",
 				Kind:       "Pod",
 			},
-			ObjectMeta: v1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Namespace: ctx.Namespace,
 				Name:      podName,
 			},
@@ -203,7 +201,7 @@ var _ = ginkgo.Describe("Job E2E Test: Test Admission service", func() {
 			},
 		}
 
-		_, err := ctx.Kubeclient.CoreV1().Pods(ctx.Namespace).Create(context.TODO(), pod, v1.CreateOptions{})
+		_, err := ctx.Kubeclient.CoreV1().Pods(ctx.Namespace).Create(context.TODO(), pod, metav1.CreateOptions{})
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		err = e2eutil.WaitPodPhase(ctx, pod, []corev1.PodPhase{corev1.PodRunning})
@@ -217,7 +215,7 @@ var _ = ginkgo.Describe("Job E2E Test: Test Admission service", func() {
 		defer e2eutil.CleanupTestContext(ctx)
 
 		pg := &schedulingv1beta1.PodGroup{
-			ObjectMeta: v1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Namespace: ctx.Namespace,
 				Name:      pgName,
 			},
@@ -228,14 +226,14 @@ var _ = ginkgo.Describe("Job E2E Test: Test Admission service", func() {
 		}
 
 		pod := &corev1.Pod{
-			TypeMeta: v1.TypeMeta{
+			TypeMeta: metav1.TypeMeta{
 				APIVersion: "v1",
 				Kind:       "Pod",
 			},
-			ObjectMeta: v1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Namespace:   ctx.Namespace,
 				Name:        podName,
-				Annotations: map[string]string{vcschedulingv1.KubeGroupNameAnnotationKey: pgName},
+				Annotations: map[string]string{schedulingv1beta1.KubeGroupNameAnnotationKey: pgName},
 			},
 			Spec: corev1.PodSpec{
 				Containers:    e2eutil.CreateContainers(e2eutil.DefaultNginxImage, "", "", e2eutil.HalfCPU, e2eutil.HalfCPU, 0),
@@ -243,11 +241,11 @@ var _ = ginkgo.Describe("Job E2E Test: Test Admission service", func() {
 			},
 		}
 
-		podGroup, err := ctx.Vcclient.SchedulingV1beta1().PodGroups(ctx.Namespace).Create(context.TODO(), pg, v1.CreateOptions{})
+		podGroup, err := ctx.Vcclient.SchedulingV1beta1().PodGroups(ctx.Namespace).Create(context.TODO(), pg, metav1.CreateOptions{})
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		err = e2eutil.WaitPodGroupPhase(ctx, podGroup, schedulingv1beta1.PodGroupInqueue)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		_, err = ctx.Kubeclient.CoreV1().Pods(ctx.Namespace).Create(context.TODO(), pod, v1.CreateOptions{})
+		_, err = ctx.Kubeclient.CoreV1().Pods(ctx.Namespace).Create(context.TODO(), pod, metav1.CreateOptions{})
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		err = e2eutil.WaitPodPhase(ctx, pod, []corev1.PodPhase{corev1.PodRunning})
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -260,7 +258,7 @@ var _ = ginkgo.Describe("Job E2E Test: Test Admission service", func() {
 		defer e2eutil.CleanupTestContext(ctx)
 
 		pg := &schedulingv1beta1.PodGroup{
-			ObjectMeta: v1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Namespace: ctx.Namespace,
 				Name:      pgName,
 			},
@@ -274,11 +272,11 @@ var _ = ginkgo.Describe("Job E2E Test: Test Admission service", func() {
 		}
 
 		pod := &corev1.Pod{
-			TypeMeta: v1.TypeMeta{
+			TypeMeta: metav1.TypeMeta{
 				APIVersion: "v1",
 				Kind:       "Pod",
 			},
-			ObjectMeta: v1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Namespace:   ctx.Namespace,
 				Name:        podName,
 				Annotations: map[string]string{schedulingv1beta1.KubeGroupNameAnnotationKey: pgName},
@@ -289,10 +287,10 @@ var _ = ginkgo.Describe("Job E2E Test: Test Admission service", func() {
 			},
 		}
 
-		_, err := ctx.Vcclient.SchedulingV1beta1().PodGroups(ctx.Namespace).Create(context.TODO(), pg, v1.CreateOptions{})
+		_, err := ctx.Vcclient.SchedulingV1beta1().PodGroups(ctx.Namespace).Create(context.TODO(), pg, metav1.CreateOptions{})
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-		_, err = ctx.Kubeclient.CoreV1().Pods(ctx.Namespace).Create(context.TODO(), pod, v1.CreateOptions{})
+		_, err = ctx.Kubeclient.CoreV1().Pods(ctx.Namespace).Create(context.TODO(), pod, metav1.CreateOptions{})
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	})
 
@@ -355,7 +353,7 @@ var _ = ginkgo.Describe("Job E2E Test: Test Admission service", func() {
 		}`)
 		err := json.Unmarshal(jsonData, &job)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		testJob, err := ctx.Vcclient.BatchV1alpha1().Jobs(ctx.Namespace).Create(context.TODO(), &job, v1.CreateOptions{})
+		testJob, err := ctx.Vcclient.BatchV1alpha1().Jobs(ctx.Namespace).Create(context.TODO(), &job, metav1.CreateOptions{})
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		gomega.Expect(testJob.Spec.Queue).Should(gomega.Equal("default"), "Job queue attribute would default to 'default' ")
 		gomega.Expect(testJob.Spec.SchedulerName).Should(gomega.Equal("volcano"), "Job scheduler wolud default to 'volcano'")
@@ -424,7 +422,7 @@ var _ = ginkgo.Describe("Job E2E Test: Test Admission service", func() {
 		}`)
 		err := json.Unmarshal(jsonData, &job)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		_, err = ctx.Vcclient.BatchV1alpha1().Jobs(ctx.Namespace).Create(context.TODO(), &job, v1.CreateOptions{})
+		_, err = ctx.Vcclient.BatchV1alpha1().Jobs(ctx.Namespace).Create(context.TODO(), &job, metav1.CreateOptions{})
 		gomega.Expect(err).To(gomega.HaveOccurred())
 	})
 
@@ -477,7 +475,7 @@ var _ = ginkgo.Describe("Job E2E Test: Test Admission service", func() {
 	 }`)
 		err := json.Unmarshal(jsonData, &job)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		_, err = ctx.Vcclient.BatchV1alpha1().Jobs(ctx.Namespace).Create(context.TODO(), &job, v1.CreateOptions{})
+		_, err = ctx.Vcclient.BatchV1alpha1().Jobs(ctx.Namespace).Create(context.TODO(), &job, metav1.CreateOptions{})
 		gomega.Expect(err).To(gomega.HaveOccurred())
 	})
 
@@ -520,7 +518,7 @@ var _ = ginkgo.Describe("Job E2E Test: Test Admission service", func() {
 	 }`)
 		err := json.Unmarshal(jsonData, &job)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		_, err = ctx.Vcclient.BatchV1alpha1().Jobs(ctx.Namespace).Create(context.TODO(), &job, v1.CreateOptions{})
+		_, err = ctx.Vcclient.BatchV1alpha1().Jobs(ctx.Namespace).Create(context.TODO(), &job, metav1.CreateOptions{})
 		gomega.Expect(err).To(gomega.HaveOccurred())
 	})
 
@@ -566,7 +564,7 @@ var _ = ginkgo.Describe("Job E2E Test: Test Admission service", func() {
 	 }`)
 		err := json.Unmarshal(jsonData, &job)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		_, err = ctx.Vcclient.BatchV1alpha1().Jobs(ctx.Namespace).Create(context.TODO(), &job, v1.CreateOptions{})
+		_, err = ctx.Vcclient.BatchV1alpha1().Jobs(ctx.Namespace).Create(context.TODO(), &job, metav1.CreateOptions{})
 		gomega.Expect(err).To(gomega.HaveOccurred())
 	})
 
@@ -610,7 +608,7 @@ var _ = ginkgo.Describe("Job E2E Test: Test Admission service", func() {
 	 }`)
 		err := json.Unmarshal(jsonData, &job)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		_, err = ctx.Vcclient.BatchV1alpha1().Jobs(ctx.Namespace).Create(context.TODO(), &job, v1.CreateOptions{})
+		_, err = ctx.Vcclient.BatchV1alpha1().Jobs(ctx.Namespace).Create(context.TODO(), &job, metav1.CreateOptions{})
 		gomega.Expect(err).To(gomega.HaveOccurred())
 	})
 
@@ -653,7 +651,7 @@ var _ = ginkgo.Describe("Job E2E Test: Test Admission service", func() {
 	 }`)
 		err := json.Unmarshal(jsonData, &job)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		_, err = ctx.Vcclient.BatchV1alpha1().Jobs(ctx.Namespace).Create(context.TODO(), &job, v1.CreateOptions{})
+		_, err = ctx.Vcclient.BatchV1alpha1().Jobs(ctx.Namespace).Create(context.TODO(), &job, metav1.CreateOptions{})
 		gomega.Expect(err).To(gomega.HaveOccurred())
 	})
 
@@ -697,7 +695,7 @@ var _ = ginkgo.Describe("Job E2E Test: Test Admission service", func() {
 	 }`)
 		err := json.Unmarshal(jsonData, &job)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		_, err = ctx.Vcclient.BatchV1alpha1().Jobs(ctx.Namespace).Create(context.TODO(), &job, v1.CreateOptions{})
+		_, err = ctx.Vcclient.BatchV1alpha1().Jobs(ctx.Namespace).Create(context.TODO(), &job, metav1.CreateOptions{})
 		gomega.Expect(err).To(gomega.HaveOccurred())
 	})
 
@@ -719,7 +717,7 @@ var _ = ginkgo.Describe("Job E2E Test: Test Admission service", func() {
 	 }`)
 		err := json.Unmarshal(jsonData, &job)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		_, err = ctx.Vcclient.BatchV1alpha1().Jobs(ctx.Namespace).Create(context.TODO(), &job, v1.CreateOptions{})
+		_, err = ctx.Vcclient.BatchV1alpha1().Jobs(ctx.Namespace).Create(context.TODO(), &job, metav1.CreateOptions{})
 		gomega.Expect(err).To(gomega.HaveOccurred())
 	})
 
@@ -762,7 +760,7 @@ var _ = ginkgo.Describe("Job E2E Test: Test Admission service", func() {
 	 }`)
 		err := json.Unmarshal(jsonData, &job)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		_, err = ctx.Vcclient.BatchV1alpha1().Jobs(ctx.Namespace).Create(context.TODO(), &job, v1.CreateOptions{})
+		_, err = ctx.Vcclient.BatchV1alpha1().Jobs(ctx.Namespace).Create(context.TODO(), &job, metav1.CreateOptions{})
 		gomega.Expect(err).To(gomega.HaveOccurred())
 	})
 
@@ -806,7 +804,7 @@ var _ = ginkgo.Describe("Job E2E Test: Test Admission service", func() {
 	 }`)
 		err := json.Unmarshal(jsonData, &job)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		_, err = ctx.Vcclient.BatchV1alpha1().Jobs(ctx.Namespace).Create(context.TODO(), &job, v1.CreateOptions{})
+		_, err = ctx.Vcclient.BatchV1alpha1().Jobs(ctx.Namespace).Create(context.TODO(), &job, metav1.CreateOptions{})
 		gomega.Expect(err).To(gomega.HaveOccurred())
 	})
 
@@ -856,7 +854,7 @@ var _ = ginkgo.Describe("Job E2E Test: Test Admission service", func() {
 	 }`)
 		err := json.Unmarshal(jsonData, &job)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		_, err = ctx.Vcclient.BatchV1alpha1().Jobs(ctx.Namespace).Create(context.TODO(), &job, v1.CreateOptions{})
+		_, err = ctx.Vcclient.BatchV1alpha1().Jobs(ctx.Namespace).Create(context.TODO(), &job, metav1.CreateOptions{})
 		gomega.Expect(err).To(gomega.HaveOccurred())
 	})
 
@@ -904,7 +902,7 @@ var _ = ginkgo.Describe("Job E2E Test: Test Admission service", func() {
 	 }`)
 		err := json.Unmarshal(jsonData, &job)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		_, err = ctx.Vcclient.BatchV1alpha1().Jobs(ctx.Namespace).Create(context.TODO(), &job, v1.CreateOptions{})
+		_, err = ctx.Vcclient.BatchV1alpha1().Jobs(ctx.Namespace).Create(context.TODO(), &job, metav1.CreateOptions{})
 		gomega.Expect(err).To(gomega.HaveOccurred())
 	})
 
@@ -953,7 +951,7 @@ var _ = ginkgo.Describe("Job E2E Test: Test Admission service", func() {
 	 }`)
 		err := json.Unmarshal(jsonData, &job)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		_, err = ctx.Vcclient.BatchV1alpha1().Jobs(ctx.Namespace).Create(context.TODO(), &job, v1.CreateOptions{})
+		_, err = ctx.Vcclient.BatchV1alpha1().Jobs(ctx.Namespace).Create(context.TODO(), &job, metav1.CreateOptions{})
 		gomega.Expect(err).To(gomega.HaveOccurred())
 	})
 
@@ -1002,7 +1000,7 @@ var _ = ginkgo.Describe("Job E2E Test: Test Admission service", func() {
 	 }`)
 		err := json.Unmarshal(jsonData, &job)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		_, err = ctx.Vcclient.BatchV1alpha1().Jobs(ctx.Namespace).Create(context.TODO(), &job, v1.CreateOptions{})
+		_, err = ctx.Vcclient.BatchV1alpha1().Jobs(ctx.Namespace).Create(context.TODO(), &job, metav1.CreateOptions{})
 		gomega.Expect(err).To(gomega.HaveOccurred())
 	})
 
@@ -1051,7 +1049,7 @@ var _ = ginkgo.Describe("Job E2E Test: Test Admission service", func() {
 	 }`)
 		err := json.Unmarshal(jsonData, &job)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		_, err = ctx.Vcclient.BatchV1alpha1().Jobs(ctx.Namespace).Create(context.TODO(), &job, v1.CreateOptions{})
+		_, err = ctx.Vcclient.BatchV1alpha1().Jobs(ctx.Namespace).Create(context.TODO(), &job, metav1.CreateOptions{})
 		gomega.Expect(err).To(gomega.HaveOccurred())
 	})
 
@@ -1104,7 +1102,7 @@ var _ = ginkgo.Describe("Job E2E Test: Test Admission service", func() {
 	 }`)
 		err := json.Unmarshal(jsonData, &job)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		_, err = ctx.Vcclient.BatchV1alpha1().Jobs(ctx.Namespace).Create(context.TODO(), &job, v1.CreateOptions{})
+		_, err = ctx.Vcclient.BatchV1alpha1().Jobs(ctx.Namespace).Create(context.TODO(), &job, metav1.CreateOptions{})
 		gomega.Expect(err).To(gomega.HaveOccurred())
 	})
 
@@ -1152,7 +1150,7 @@ var _ = ginkgo.Describe("Job E2E Test: Test Admission service", func() {
 	 }`)
 		err := json.Unmarshal(jsonData, &job)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		_, err = ctx.Vcclient.BatchV1alpha1().Jobs(ctx.Namespace).Create(context.TODO(), &job, v1.CreateOptions{})
+		_, err = ctx.Vcclient.BatchV1alpha1().Jobs(ctx.Namespace).Create(context.TODO(), &job, metav1.CreateOptions{})
 		gomega.Expect(err).To(gomega.HaveOccurred())
 	})
 
@@ -1205,7 +1203,7 @@ var _ = ginkgo.Describe("Job E2E Test: Test Admission service", func() {
 	 }`)
 		err := json.Unmarshal(jsonData, &job)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		_, err = ctx.Vcclient.BatchV1alpha1().Jobs(ctx.Namespace).Create(context.TODO(), &job, v1.CreateOptions{})
+		_, err = ctx.Vcclient.BatchV1alpha1().Jobs(ctx.Namespace).Create(context.TODO(), &job, metav1.CreateOptions{})
 		gomega.Expect(err).To(gomega.HaveOccurred())
 	})
 
@@ -1253,7 +1251,7 @@ var _ = ginkgo.Describe("Job E2E Test: Test Admission service", func() {
 	 }`)
 		err := json.Unmarshal(jsonData, &job)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		_, err = ctx.Vcclient.BatchV1alpha1().Jobs(ctx.Namespace).Create(context.TODO(), &job, v1.CreateOptions{})
+		_, err = ctx.Vcclient.BatchV1alpha1().Jobs(ctx.Namespace).Create(context.TODO(), &job, metav1.CreateOptions{})
 		gomega.Expect(err).To(gomega.HaveOccurred())
 	})
 
@@ -1301,7 +1299,7 @@ var _ = ginkgo.Describe("Job E2E Test: Test Admission service", func() {
 	 }`)
 		err := json.Unmarshal(jsonData, &job)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		_, err = ctx.Vcclient.BatchV1alpha1().Jobs(ctx.Namespace).Create(context.TODO(), &job, v1.CreateOptions{})
+		_, err = ctx.Vcclient.BatchV1alpha1().Jobs(ctx.Namespace).Create(context.TODO(), &job, metav1.CreateOptions{})
 		gomega.Expect(err).To(gomega.HaveOccurred())
 	})
 
@@ -1345,7 +1343,7 @@ var _ = ginkgo.Describe("Job E2E Test: Test Admission service", func() {
 	 }`)
 		err := json.Unmarshal(jsonData, &job)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		_, err = ctx.Vcclient.BatchV1alpha1().Jobs(ctx.Namespace).Create(context.TODO(), &job, v1.CreateOptions{})
+		_, err = ctx.Vcclient.BatchV1alpha1().Jobs(ctx.Namespace).Create(context.TODO(), &job, metav1.CreateOptions{})
 		gomega.Expect(err).To(gomega.HaveOccurred())
 	})
 
@@ -1389,7 +1387,7 @@ var _ = ginkgo.Describe("Job E2E Test: Test Admission service", func() {
 	 }`)
 		err := json.Unmarshal(jsonData, &job)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		_, err = ctx.Vcclient.BatchV1alpha1().Jobs(ctx.Namespace).Create(context.TODO(), &job, v1.CreateOptions{})
+		_, err = ctx.Vcclient.BatchV1alpha1().Jobs(ctx.Namespace).Create(context.TODO(), &job, metav1.CreateOptions{})
 		gomega.Expect(err).To(gomega.HaveOccurred())
 	})
 
@@ -1441,7 +1439,7 @@ var _ = ginkgo.Describe("Job E2E Test: Test Admission service", func() {
 	 }`)
 		err := json.Unmarshal(jsonData, &job)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		_, err = ctx.Vcclient.BatchV1alpha1().Jobs(ctx.Namespace).Create(context.TODO(), &job, v1.CreateOptions{})
+		_, err = ctx.Vcclient.BatchV1alpha1().Jobs(ctx.Namespace).Create(context.TODO(), &job, metav1.CreateOptions{})
 		gomega.Expect(err).To(gomega.HaveOccurred())
 	})
 
@@ -1487,7 +1485,7 @@ var _ = ginkgo.Describe("Job E2E Test: Test Admission service", func() {
 	 }`)
 		err := json.Unmarshal(jsonData, &job)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		_, err = ctx.Vcclient.BatchV1alpha1().Jobs(ctx.Namespace).Create(context.TODO(), &job, v1.CreateOptions{})
+		_, err = ctx.Vcclient.BatchV1alpha1().Jobs(ctx.Namespace).Create(context.TODO(), &job, metav1.CreateOptions{})
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	})
 

--- a/test/e2e/schedulingaction/allocate.go
+++ b/test/e2e/schedulingaction/allocate.go
@@ -25,7 +25,6 @@ import (
 	"github.com/onsi/gomega"
 
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -323,7 +322,7 @@ var _ = ginkgo.Describe("Job E2E Test", func() {
 					Req:      slot1,
 					Min:      2,
 					Rep:      2,
-					SchGates: []v1.PodSchedulingGate{{Name: "example.com/g1"}},
+					SchGates: []corev1.PodSchedulingGate{{Name: "example.com/g1"}},
 				},
 			},
 		}
@@ -357,7 +356,7 @@ var _ = ginkgo.Describe("Job E2E Test", func() {
 			corev1.ResourceCPU:    resource.MustParse("2000m"),
 			corev1.ResourceMemory: resource.MustParse("2048Mi")}
 
-		dep := e2eutil.CreateDeploymentGated(ctx, "dep-gated", 4, e2eutil.DefaultNginxImage, slot1, []v1.PodSchedulingGate{{Name: "g1"}})
+		dep := e2eutil.CreateDeploymentGated(ctx, "dep-gated", 4, e2eutil.DefaultNginxImage, slot1, []corev1.PodSchedulingGate{{Name: "g1"}})
 
 		// need to wait for podgroup to be created
 		var pg *schedulingv1beta1.PodGroup

--- a/test/e2e/schedulingaction/preempt.go
+++ b/test/e2e/schedulingaction/preempt.go
@@ -27,7 +27,6 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog/v2"
 
 	schedulingv1beta1 "volcano.sh/apis/pkg/apis/scheduling/v1beta1"
@@ -156,7 +155,7 @@ var _ = Describe("Job E2E Test", func() {
 
 		pgName := "pending-pg"
 		pg := &schedulingv1beta1.PodGroup{
-			ObjectMeta: v1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Namespace: ctx.Namespace,
 				Name:      pgName,
 			},
@@ -165,7 +164,7 @@ var _ = Describe("Job E2E Test", func() {
 				MinResources: &e2eutil.ThirtyCPU,
 			},
 		}
-		_, err := ctx.Vcclient.SchedulingV1beta1().PodGroups(ctx.Namespace).Create(context.TODO(), pg, v1.CreateOptions{})
+		_, err := ctx.Vcclient.SchedulingV1beta1().PodGroups(ctx.Namespace).Create(context.TODO(), pg, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
 
 		slot := e2eutil.OneCPU
@@ -187,11 +186,11 @@ var _ = Describe("Job E2E Test", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		pod := &corev1.Pod{
-			TypeMeta: v1.TypeMeta{
+			TypeMeta: metav1.TypeMeta{
 				APIVersion: "v1",
 				Kind:       "Pod",
 			},
-			ObjectMeta: v1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Namespace:   ctx.Namespace,
 				Name:        "preemptor-pod",
 				Annotations: map[string]string{schedulingv1beta1.KubeGroupNameAnnotationKey: pgName},
@@ -203,7 +202,7 @@ var _ = Describe("Job E2E Test", func() {
 			},
 		}
 		// Pod is allowed to be created, preemption does not happen due to PodGroup is in pending state
-		_, err = ctx.Kubeclient.CoreV1().Pods(ctx.Namespace).Create(context.TODO(), pod, v1.CreateOptions{})
+		_, err = ctx.Kubeclient.CoreV1().Pods(ctx.Namespace).Create(context.TODO(), pod, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
 		// Make sure preempteeJob is not preempted as expected
 		err = e2eutil.WaitTasksReady(ctx, preempteeJob, int(rep))

--- a/test/e2e/schedulingbase/volume_binding.go
+++ b/test/e2e/schedulingbase/volume_binding.go
@@ -48,7 +48,6 @@ import (
 	admissionapi "k8s.io/pod-security-admission/api"
 
 	e2eutil "volcano.sh/volcano/test/e2e/util"
-	volcanotestutil "volcano.sh/volcano/test/e2e/util"
 )
 
 type localTestConfig struct {
@@ -859,12 +858,12 @@ func createStatefulSet(ctx context.Context, config *localTestConfig, ssReplicas 
 	ss, err := config.client.AppsV1().StatefulSets(config.ns).Create(ctx, spec, metav1.CreateOptions{})
 	framework.ExpectNoError(err)
 
-	volcanotestutil.WaitForRunningAndReady(ctx, config.client, ssReplicas, ss)
+	e2eutil.WaitForRunningAndReady(ctx, config.client, ssReplicas, ss)
 	return ss
 }
 
 func validateStatefulSet(ctx context.Context, config *localTestConfig, ss *appsv1.StatefulSet, anti bool) {
-	pods := volcanotestutil.GetPodList(ctx, config.client, ss.Namespace, ss.Spec.Selector)
+	pods := e2eutil.GetPodList(ctx, config.client, ss.Namespace, ss.Spec.Selector)
 
 	nodes := sets.NewString()
 	for _, pod := range pods.Items {

--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -29,7 +29,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
 	schedv1 "k8s.io/api/scheduling/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -38,7 +37,6 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
-	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/yaml"
 
@@ -344,7 +342,7 @@ func setPlaceHolderForSchedulerTesting(ctx *TestContext, req v1.ResourceList, re
 }
 
 func createPlaceHolder(ctx *TestContext, phr v1.ResourceList, nodeName string) error {
-	pod := &corev1.Pod{
+	pod := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      nodeName + "-placeholder",
 			Namespace: ctx.Namespace,
@@ -352,11 +350,11 @@ func createPlaceHolder(ctx *TestContext, phr v1.ResourceList, nodeName string) e
 				"role": "placeholder",
 			},
 		},
-		Spec: corev1.PodSpec{
-			Containers: []corev1.Container{
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
 				{
 					Name: "placeholder",
-					Resources: corev1.ResourceRequirements{
+					Resources: v1.ResourceRequirements{
 						Requests: phr,
 						Limits:   phr,
 					},
@@ -383,7 +381,7 @@ func deletePlaceHolder(ctx *TestContext) {
 	}
 }
 
-func GetPodList(ctx context.Context, c clientset.Interface, namespace string, ls *metav1.LabelSelector) *v1.PodList {
+func GetPodList(ctx context.Context, c kubernetes.Interface, namespace string, ls *metav1.LabelSelector) *v1.PodList {
 	selector, err := metav1.LabelSelectorAsSelector(ls)
 	Expect(err).NotTo(HaveOccurred())
 	podList, err := c.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{LabelSelector: selector.String()})


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Eleven files import the same package twice under different names, allowing the same type to appear as both `api.JobID` and `schedulingapi.JobID` in the same file. This makes the code harder to read and is reported by `staticcheck`'s ST1019 check.

ST1019 was disabled during the golangci-lint v2 migration when `stylecheck` was merged into `staticcheck`. This PR removes the duplicate imports and re-enables the check.

Each file now uses the import name already established elsewhere in the tree, falling back to the local majority where needed. Only package aliases are changed; there are no type or behavior changes.

#### Which issue(s) this PR fixes:

None — lint cleanup only.

#### Special notes for your reviewer:

The re-enabled ST1019 check currently covers only 3 of the 13 duplicate-import sites because `.golangci.yml` excludes `test/`, `example/`, `third_party/`, and `*_test.go` from all linters. Expanding those exclusions is outside the scope of this PR.

The changes were verified with an AST-based comparison to ensure the canonicalized source is identical before and after the renames. `golangci-lint` reports no ST1019 issues, no duplicate imports remain, and `go vet` and unit tests pass for the affected non-e2e packages. The e2e files compile but were not run against a cluster.

Per the project's [AI Guidance](https://github.com/volcano-sh/volcano/blob/master/contributing.md#ai-guidance), this PR was prepared by Claude Code (Opus 5) and opened as a draft on my behalf.

#### Does this PR introduce a user-facing change?

NONE

