### PR TITLE
Flush logs before exiting on startup failure

### DIFF
--- a/cmd/agent-scheduler/main.go
+++ b/cmd/agent-scheduler/main.go
@@ -74,6 +74,7 @@ func main() {
 
 	if err := s.CheckOptionOrDie(); err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)
+		klog.Flush()
 		os.Exit(1)
 	}
 	if s.CaCertFile != "" && s.CertFile != "" && s.KeyFile != "" {
@@ -87,6 +88,7 @@ func main() {
 
 	if err := app.Run(s); err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)
+		klog.Flush()
 		os.Exit(1)
 	}
 }

--- a/cmd/agent/app/agent.go
+++ b/cmd/agent/app/agent.go
@@ -49,6 +49,7 @@ func NewVolcanoAgentCommand(ctx context.Context) *cobra.Command {
 			cliflag.PrintFlags(cmd.Flags())
 			if err := Run(ctx, opts); err != nil {
 				_, _ = fmt.Fprintf(os.Stderr, "%v\n", err)
+				klog.Flush()
 				os.Exit(1)
 			}
 		},

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -35,6 +35,7 @@ func main() {
 
 	if err := command.Execute(); err != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "%v\n", err)
+		logs.FlushLogs()
 		os.Exit(1)
 	}
 }

--- a/cmd/controller-manager/main.go
+++ b/cmd/controller-manager/main.go
@@ -97,11 +97,13 @@ func main() {
 	}
 	if err := s.CheckOptionOrDie(); err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)
+		klog.Flush()
 		os.Exit(1)
 	}
 	if s.CaCertFile != "" && s.CertFile != "" && s.KeyFile != "" {
 		if err := s.ParseCAFiles(nil); err != nil {
 			fmt.Fprintf(os.Stderr, "Failed to parse CA file: %v\n", err)
+			klog.Flush()
 			os.Exit(1)
 		}
 	}
@@ -111,6 +113,7 @@ func main() {
 
 	if err := app.Run(s); err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)
+		klog.Flush()
 		os.Exit(1)
 	}
 }

--- a/cmd/scheduler/main.go
+++ b/cmd/scheduler/main.go
@@ -76,6 +76,7 @@ func main() {
 
 	if err := s.CheckOptionOrDie(); err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)
+		klog.Flush()
 		os.Exit(1)
 	}
 	if s.CaCertFile != "" && s.CertFile != "" && s.KeyFile != "" {
@@ -89,6 +90,7 @@ func main() {
 
 	if err := app.Run(s); err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)
+		klog.Flush()
 		os.Exit(1)
 	}
 }

--- a/cmd/webhook-manager/main.go
+++ b/cmd/webhook-manager/main.go
@@ -84,6 +84,7 @@ func main() {
 
 	if err := app.Run(config); err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)
+		klog.Flush()
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Each component registers a deferred log flush, then calls `os.Exit(1)` when startup fails — and `os.Exit` skips defers, so a component logging to a file loses the records saying why it could not come up. The defers already express the intent; this restores it on the paths that bypass them. #5836 has the full path and the klog buffering behind it.

The agent accounts for the sixth file: its cobra command uses `Run:` rather than `RunE:`, so a failing `Run(ctx, opts)` exits inside `cmd/agent/app/agent.go` without `command.Execute()` ever returning an error. `klog.Fatalf` sites need nothing — it flushes internally.

#### Which issue(s) this PR fixes:

Fixes #5836

#### Special notes for your reviewer:

Two judgement calls, happy to revisit either: I kept the repetition rather than extracting an `exitOnError` helper into `pkg/util`, since five binaries for a three-line function seemed the worse trade; and I left `version.PrintVersionAndExit()` alone, which has the same gap on the `--version` path where only a GOMAXPROCS warning is at stake.

Prepared with AI assistance (Claude Code, Opus 5); the klog buffering and the agent's control flow were each verified against the source, and `go build`, `go vet` and `gofmt` are clean over `./cmd/...`.

#### Does this PR introduce a user-facing change?

```release-note
Fixed Volcano components discarding buffered log records when they exit on a startup failure, so file-backed logs retain the error that caused the exit.
```
