### PR TITLE
fix(deviceshare): support HAMi Ascend normal preemption

### DIFF
--- a/pkg/scheduler/actions/preempt/preempt.go
+++ b/pkg/scheduler/actions/preempt/preempt.go
@@ -377,6 +377,7 @@ func (pmpt *Action) normalPreempt(
 		victimsQueue := ssn.BuildVictimsPriorityQueue(victims, preemptor)
 		// Preempt victims for tasks, pick lowest priority task first.
 		preempted := api.EmptyResource()
+		preemptorFits := preemptorFitsOnNode(ssn, currentQueue, preemptor, node)
 
 		for !victimsQueue.Empty() {
 			// If reclaimed enough resources, break loop to avoid Sub panic.
@@ -389,7 +390,7 @@ func (pmpt *Action) normalPreempt(
 			// so if current queue is not allocatable(the queue will be overused when consider current preemptor's requests)
 			// or current idle resource is not enough for preemptor, it need to continue preempting
 			// otherwise, break out
-			if ssn.Allocatable(currentQueue, preemptor) && preemptor.InitResreq.LessEqual(node.FutureIdle(), api.Zero) {
+			if preemptorFits {
 				break
 			}
 			preemptee := victimsQueue.Pop().(*api.TaskInfo)
@@ -397,6 +398,7 @@ func (pmpt *Action) normalPreempt(
 				preemptee.Namespace, preemptee.Name, preemptor.Namespace, preemptor.Name)
 			nodeStmt.Evict(preemptee, "preempt")
 			preempted.Add(preemptee.Resreq)
+			preemptorFits = preemptorFitsOnNode(ssn, currentQueue, preemptor, node)
 		}
 
 		evictionOccurred := false
@@ -409,7 +411,7 @@ func (pmpt *Action) normalPreempt(
 			preempted, preemptor.Namespace, preemptor.Name, preemptor.InitResreq)
 
 		// If preemptor's queue is not allocatable, it means preemptor cannot be allocated. So no need care about the node idle resource
-		if ssn.Allocatable(currentQueue, preemptor) && preemptor.InitResreq.LessEqual(node.FutureIdle(), api.Zero) {
+		if preemptorFits {
 			if err := nodeStmt.Pipeline(preemptor, node.Name, evictionOccurred); err != nil {
 				klog.Errorf("Failed to pipeline Task <%s/%s> on Node <%s>",
 					preemptor.Namespace, preemptor.Name, node.Name)
@@ -429,6 +431,13 @@ func (pmpt *Action) normalPreempt(
 	}
 
 	return assigned, nil
+}
+
+// preemptorFitsOnNode verifies aggregate resources and plugin predicates after tentative evictions.
+func preemptorFitsOnNode(ssn *framework.Session, queue *api.QueueInfo, preemptor *api.TaskInfo, node *api.NodeInfo) bool {
+	return ssn.Allocatable(queue, preemptor) &&
+		preemptor.InitResreq.LessEqual(node.FutureIdle(), api.Zero) &&
+		ssn.PredicateFn(preemptor, node) == nil
 }
 
 func (pmpt *Action) taskEligibleToPreempt(preemptor *api.TaskInfo) error {

--- a/pkg/scheduler/actions/preempt/preempt.go
+++ b/pkg/scheduler/actions/preempt/preempt.go
@@ -423,11 +423,14 @@ func (pmpt *Action) normalPreempt(
 	return assigned, nil
 }
 
-// preemptorFitsOnNode checks whether it is safe to stop evicting same-queue victims for the preemptor.
-// Same-queue preemption makes the queue allocatable and restores aggregate node resources. If the queue is already
-// allocatable but the cluster lacks resources, the reclaim action handles cross-queue eviction instead. PredicateFn
-// also checks device feasibility, including vNPU or vGPU fragmentation where aggregate resources are sufficient but
-// no valid device allocation exists.
+// preemptorFitsOnNode checks whether the preemptor fits the node after tentative evictions.
+// A job may not be allocatable because:
+// 1. The cluster has free resources, but the queue is not allocatable.
+// 2. The cluster has no free resources, and the queue is not allocatable.
+// 3. The cluster has no free resources, but the queue is allocatable.
+// 4. The node has sufficient aggregate resources, but PredicateFn fails because vNPU or vGPU resources are fragmented.
+// Same-queue preemption handles cases 1 and 2. Reclaim handles case 3. For case 4, normal preemption continues until
+// the predicate passes after enough victims are evicted.
 func preemptorFitsOnNode(ssn *framework.Session, queue *api.QueueInfo, preemptor *api.TaskInfo, node *api.NodeInfo) bool {
 	return ssn.Allocatable(queue, preemptor) &&
 		preemptor.InitResreq.LessEqual(node.FutureIdle(), api.Zero) &&

--- a/pkg/scheduler/actions/preempt/preempt.go
+++ b/pkg/scheduler/actions/preempt/preempt.go
@@ -380,16 +380,6 @@ func (pmpt *Action) normalPreempt(
 		preemptorFits := preemptorFitsOnNode(ssn, currentQueue, preemptor, node)
 
 		for !victimsQueue.Empty() {
-			// If reclaimed enough resources, break loop to avoid Sub panic.
-			// Preempt action is about preempt in same queue, which job is not allocatable in allocate action, due to:
-			// 1. cluster has free resource, but queue not allocatable
-			// 2. cluster has no free resource, but queue not allocatable
-			// 3. cluster has no free resource, but queue allocatable
-			// for case 1 and 2, high priority job/task can preempt low priority job/task in same queue;
-			// for case 3, it need to do reclaim resource from other queue, in reclaim action;
-			// so if current queue is not allocatable(the queue will be overused when consider current preemptor's requests)
-			// or current idle resource is not enough for preemptor, it need to continue preempting
-			// otherwise, break out
 			if preemptorFits {
 				break
 			}
@@ -433,7 +423,11 @@ func (pmpt *Action) normalPreempt(
 	return assigned, nil
 }
 
-// preemptorFitsOnNode verifies aggregate resources and plugin predicates after tentative evictions.
+// preemptorFitsOnNode checks whether it is safe to stop evicting same-queue victims for the preemptor.
+// Same-queue preemption makes the queue allocatable and restores aggregate node resources. If the queue is already
+// allocatable but the cluster lacks resources, the reclaim action handles cross-queue eviction instead. PredicateFn
+// also checks device feasibility, including vNPU or vGPU fragmentation where aggregate resources are sufficient but
+// no valid device allocation exists.
 func preemptorFitsOnNode(ssn *framework.Session, queue *api.QueueInfo, preemptor *api.TaskInfo, node *api.NodeInfo) bool {
 	return ssn.Allocatable(queue, preemptor) &&
 		preemptor.InitResreq.LessEqual(node.FutureIdle(), api.Zero) &&

--- a/pkg/scheduler/actions/preempt/preempt_test.go
+++ b/pkg/scheduler/actions/preempt/preempt_test.go
@@ -51,6 +51,35 @@ func init() {
 	flag.Set("v", "4")
 }
 
+const deviceFitAfterEvictionPluginName = "device-fit-after-eviction"
+
+type deviceFitAfterEvictionPlugin struct{}
+
+func (p *deviceFitAfterEvictionPlugin) Name() string {
+	return deviceFitAfterEvictionPluginName
+}
+
+func (p *deviceFitAfterEvictionPlugin) OnSessionOpen(ssn *framework.Session) {
+	ssn.AddPredicateFn(p.Name(), func(task *api.TaskInfo, node *api.NodeInfo) error {
+		if task.Name != "preemptor" {
+			return nil
+		}
+
+		for _, nodeTask := range node.Tasks {
+			if nodeTask.Name == "preemptee" && nodeTask.Status != api.Releasing {
+				return api.NewFitErrWithStatus(task, node, &api.Status{
+					Code:   api.Unschedulable,
+					Reason: "hidden device capacity is occupied",
+				})
+			}
+		}
+
+		return nil
+	})
+}
+
+func (p *deviceFitAfterEvictionPlugin) OnSessionClose(ssn *framework.Session) {}
+
 func TestPreempt(t *testing.T) {
 	plugins := map[string]framework.PluginBuilder{
 		conformance.PluginName: conformance.New,
@@ -421,6 +450,62 @@ func TestPreempt(t *testing.T) {
 				t.Fatal(err)
 			}
 		})
+	}
+}
+
+func TestNormalPreemptRechecksPredicateAfterEviction(t *testing.T) {
+	plugins := map[string]framework.PluginBuilder{
+		conformance.PluginName: conformance.New,
+		gang.PluginName:        gang.New,
+		priority.PluginName:    priority.New,
+		proportion.PluginName:  proportion.New,
+		deviceFitAfterEvictionPluginName: func(framework.Arguments) framework.Plugin {
+			return &deviceFitAfterEvictionPlugin{}
+		},
+	}
+	highPrio := util.BuildPriorityClass("high-priority", 100000)
+	lowPrio := util.BuildPriorityClass("low-priority", 10)
+	trueValue := true
+	falseValue := false
+	test := uthelper.TestCommonStruct{
+		Name:    "normal preemption evicts a victim when hidden device capacity remains unavailable",
+		Plugins: plugins,
+		PodGroups: []*schedulingv1beta1.PodGroup{
+			util.BuildPodGroupWithPrio("pg-low", "c1", "q1", 1, map[string]int32{"": 1}, schedulingv1beta1.PodGroupInqueue, "low-priority"),
+			util.BuildPodGroupWithPrio("pg-high", "c1", "q1", 1, map[string]int32{"": 1}, schedulingv1beta1.PodGroupInqueue, "high-priority"),
+		},
+		Pods: []*v1.Pod{
+			util.BuildPod("c1", "preemptee", "n1", v1.PodRunning, api.BuildResourceList("1", "1G"), "pg-low", map[string]string{schedulingv1beta1.PodPreemptable: "true"}, make(map[string]string)),
+			util.BuildPod("c1", "preemptor", "", v1.PodPending, api.BuildResourceList("1", "1G"), "pg-high", make(map[string]string), make(map[string]string)),
+		},
+		Nodes: []*v1.Node{
+			util.BuildNode("n1", api.BuildResourceList("2", "2G", []api.ScalarResource{{Name: "pods", Value: "10"}}...), make(map[string]string)),
+		},
+		Queues: []*schedulingv1beta1.Queue{
+			util.BuildQueue("q1", 1, nil),
+		},
+		PriClass:       []*schedulingv1.PriorityClass{highPrio, lowPrio},
+		ExpectEvicted:  []string{"c1/preemptee"},
+		ExpectEvictNum: 1,
+	}
+	tiers := []conf.Tier{{
+		Plugins: []conf.PluginOption{
+			{Name: conformance.PluginName, EnabledPreemptable: &trueValue},
+			{Name: gang.PluginName, EnabledPreemptable: &falseValue, EnabledJobPipelined: &trueValue, EnabledJobStarving: &trueValue},
+			{Name: priority.PluginName, EnabledTaskOrder: &trueValue, EnabledJobOrder: &trueValue, EnabledPreemptable: &trueValue, EnabledJobPipelined: &trueValue, EnabledJobStarving: &trueValue},
+			{Name: proportion.PluginName, EnabledOverused: &trueValue, EnabledAllocatable: &trueValue, EnabledQueueOrder: &trueValue},
+			{Name: deviceFitAfterEvictionPluginName, EnabledPredicate: &trueValue},
+		},
+	}}
+
+	test.RegisterSession(tiers, []conf.Configuration{{
+		Name:      New().Name(),
+		Arguments: map[string]interface{}{EnableTopologyAwarePreemptionKey: false},
+	}})
+	defer test.Close()
+	test.Run([]framework.Action{New()})
+	if err := test.CheckAll(0); err != nil {
+		t.Fatal(err)
 	}
 }
 

--- a/pkg/scheduler/actions/preempt/preempt_test.go
+++ b/pkg/scheduler/actions/preempt/preempt_test.go
@@ -53,6 +53,8 @@ func init() {
 
 const deviceFitAfterEvictionPluginName = "device-fit-after-eviction"
 
+const normalPreemptBenchmarkPredicatePluginName = "normal-preempt-benchmark-predicate"
+
 type deviceFitAfterEvictionPlugin struct{}
 
 func (p *deviceFitAfterEvictionPlugin) Name() string {
@@ -79,6 +81,20 @@ func (p *deviceFitAfterEvictionPlugin) OnSessionOpen(ssn *framework.Session) {
 }
 
 func (p *deviceFitAfterEvictionPlugin) OnSessionClose(ssn *framework.Session) {}
+
+type normalPreemptBenchmarkPredicatePlugin struct{}
+
+func (p *normalPreemptBenchmarkPredicatePlugin) Name() string {
+	return normalPreemptBenchmarkPredicatePluginName
+}
+
+func (p *normalPreemptBenchmarkPredicatePlugin) OnSessionOpen(ssn *framework.Session) {
+	ssn.AddPredicateFn(p.Name(), func(task *api.TaskInfo, node *api.NodeInfo) error {
+		return nil
+	})
+}
+
+func (p *normalPreemptBenchmarkPredicatePlugin) OnSessionClose(ssn *framework.Session) {}
 
 func TestPreempt(t *testing.T) {
 	plugins := map[string]framework.PluginBuilder{
@@ -454,6 +470,19 @@ func TestPreempt(t *testing.T) {
 }
 
 func TestNormalPreemptRechecksPredicateAfterEviction(t *testing.T) {
+	test, tiers := newNormalPreemptDeviceFitFixture()
+	test.RegisterSession(tiers, []conf.Configuration{{
+		Name:      New().Name(),
+		Arguments: map[string]interface{}{EnableTopologyAwarePreemptionKey: false},
+	}})
+	defer test.Close()
+	test.Run([]framework.Action{New()})
+	if err := test.CheckAll(0); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func newNormalPreemptDeviceFitFixture() (uthelper.TestCommonStruct, []conf.Tier) {
 	plugins := map[string]framework.PluginBuilder{
 		conformance.PluginName: conformance.New,
 		gang.PluginName:        gang.New,
@@ -498,15 +527,88 @@ func TestNormalPreemptRechecksPredicateAfterEviction(t *testing.T) {
 		},
 	}}
 
-	test.RegisterSession(tiers, []conf.Configuration{{
+	return test, tiers
+}
+
+func newNormalPreemptBenchmarkFixture() (uthelper.TestCommonStruct, []conf.Tier) {
+	test, tiers := newNormalPreemptDeviceFitFixture()
+	test.Name = "normal preemption benchmark with one required victim"
+	test.Nodes = []*v1.Node{
+		util.BuildNode("n1", api.BuildResourceList("1", "1G", []api.ScalarResource{{Name: "pods", Value: "10"}}...), make(map[string]string)),
+	}
+	test.Plugins[normalPreemptBenchmarkPredicatePluginName] = func(framework.Arguments) framework.Plugin {
+		return &normalPreemptBenchmarkPredicatePlugin{}
+	}
+
+	benchmarkPlugins := make([]conf.PluginOption, 0, len(tiers[0].Plugins))
+	for _, plugin := range tiers[0].Plugins {
+		if plugin.Name != deviceFitAfterEvictionPluginName {
+			benchmarkPlugins = append(benchmarkPlugins, plugin)
+		}
+	}
+	trueValue := true
+	benchmarkPlugins = append(benchmarkPlugins, conf.PluginOption{
+		Name:             normalPreemptBenchmarkPredicatePluginName,
+		EnabledPredicate: &trueValue,
+	})
+	tiers[0].Plugins = benchmarkPlugins
+
+	return test, tiers
+}
+
+// BenchmarkNormalPreemptPredicateRecheck measures the direct normalPreempt
+// call when both revisions must evict one victim.
+func BenchmarkNormalPreemptPredicateRecheck(b *testing.B) {
+	previousVerbosity := flag.Lookup("v").Value.String()
+	if err := flag.Set("v", "0"); err != nil {
+		b.Fatal(err)
+	}
+	b.Cleanup(func() {
+		_ = flag.Set("v", previousVerbosity)
+	})
+
+	test, tiers := newNormalPreemptBenchmarkFixture()
+	ssn := test.RegisterSession(tiers, []conf.Configuration{{
 		Name:      New().Name(),
 		Arguments: map[string]interface{}{EnableTopologyAwarePreemptionKey: false},
 	}})
 	defer test.Close()
-	test.Run([]framework.Action{New()})
-	if err := test.CheckAll(0); err != nil {
-		t.Fatal(err)
+
+	preemptor := benchmarkPreemptor(ssn)
+	if preemptor == nil {
+		b.Fatal("benchmark preemptor was not found")
 	}
+	node := ssn.Nodes["n1"]
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for iteration := 0; iteration < b.N; iteration++ {
+		stmt := framework.NewStatement(ssn)
+
+		assigned, err := New().normalPreempt(ssn, stmt, preemptor, func(task *api.TaskInfo) bool {
+			return api.PreemptableStatus(task.Status) && task.Preemptable && task.Job != preemptor.Job
+		}, []*api.NodeInfo{node})
+
+		if err != nil {
+			b.Fatal(err)
+		}
+		if !assigned {
+			b.Fatal("normal preemption did not assign the preemptor")
+		}
+		stmt.Discard()
+	}
+}
+
+func benchmarkPreemptor(ssn *framework.Session) *api.TaskInfo {
+	for _, jobInfo := range ssn.Jobs {
+		for _, task := range jobInfo.TaskStatusIndex[api.Pending] {
+			if task.Name == "preemptor" {
+				return task
+			}
+		}
+	}
+
+	return nil
 }
 
 func TestTopologyAwarePreempt(t *testing.T) {

--- a/pkg/scheduler/api/devices/ascend/hami/device_info.go
+++ b/pkg/scheduler/api/devices/ascend/hami/device_info.go
@@ -81,6 +81,8 @@ type RuntimeInfo struct {
 var (
 	AscendHAMiVNPUEnable bool
 	NodeLockEnable       bool
+
+	errInsufficientAscendDeviceCapacity = errors.New("no enough ascend device available")
 )
 
 func NewAscendDevices(name string, node *v1.Node) map[string]*AscendDevices {
@@ -278,6 +280,9 @@ func (ads *AscendDevices) HasDeviceRequest(pod *v1.Pod) bool {
 func (ads *AscendDevices) FilterNode(pod *v1.Pod, policy string) (int, string, error) {
 	_, err := ads.selectDevices(pod, policy)
 	if err != nil {
+		if errors.Is(err, errInsufficientAscendDeviceCapacity) {
+			return devices.Unschedulable, "no ascend device available", err
+		}
 		return devices.Error, "no ascend device available", err
 	}
 	klog.V(4).Infoln("ascend DeviceSharing successfully filters pods. device_type:", ads.Type)
@@ -497,7 +502,7 @@ func (ads *AscendDevices) selectDevices(pod *v1.Pod, schedulePolicy string) (dev
 		}
 		if req_nums > 0 {
 			klog.V(5).Infof("no enough ascend device available! raw req_nums %d cur req_nums %d", req.Nums, req_nums)
-			return nil, errors.Errorf("no enough ascend device available")
+			return nil, errors.WithStack(errInsufficientAscendDeviceCapacity)
 		}
 		if needTopology {
 			selectedDevs = selectDevicesWithTopology(int(req.Nums), selectedDevs)

--- a/pkg/scheduler/api/devices/ascend/hami/device_info_test.go
+++ b/pkg/scheduler/api/devices/ascend/hami/device_info_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/yaml.v2"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/fake"
@@ -395,6 +396,73 @@ func Test_fit(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			ret := fit(tt.req, tt.dev, tt.isHAMiCore)
 			assert.Equal(t, tt.result, ret)
+		})
+	}
+}
+
+func TestAscendDevicesFilterNodeErrorClassification(t *testing.T) {
+	newPod := func(deviceCount, deviceMemory string) *v1.Pod {
+		return &v1.Pod{
+			Spec: v1.PodSpec{
+				Containers: []v1.Container{{
+					Name: "worker",
+					Resources: v1.ResourceRequirements{
+						Limits: v1.ResourceList{
+							"huawei.com/Ascend910A":        resource.MustParse(deviceCount),
+							"huawei.com/Ascend910A-memory": resource.MustParse(deviceMemory),
+						},
+					},
+				}},
+			},
+		}
+	}
+
+	tests := []struct {
+		name    string
+		devices map[string]*AscendDevice
+		pod     *v1.Pod
+		status  int
+	}{
+		{
+			name: "insufficient device capacity is retryable",
+			devices: map[string]*AscendDevice{
+				"device-1": func() *AscendDevice {
+					device := createTestAscendAllocateDevice("device-1")
+					device.DeviceUsage.Used = 1
+					device.DeviceUsage.Usedmem = 32768
+					return device
+				}(),
+			},
+			pod:    newPod("1", "32768"),
+			status: devices.Unschedulable,
+		},
+		{
+			name:    "missing device inventory is an error",
+			devices: map[string]*AscendDevice{},
+			pod:     newPod("1", "32768"),
+			status:  devices.Error,
+		},
+		{
+			name: "invalid multi-device partial memory request is an error",
+			devices: map[string]*AscendDevice{
+				"device-1": func() *AscendDevice {
+					device := createTestAscendAllocateDevice("device-1")
+					device.config.Templates = []config.Template{{Name: "vir01", Memory: 4096, AICore: 1}}
+					return device
+				}(),
+			},
+			pod:    newPod("2", "4096"),
+			status: devices.Error,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ascendDevices := createTestAscendDevices("node-a", "Ascend910A", test.devices)
+			status, _, err := ascendDevices.FilterNode(test.pod, binpackPolicy)
+
+			assert.Error(t, err)
+			assert.Equal(t, test.status, status)
 		})
 	}
 }


### PR DESCRIPTION
## Summary
- Return `Unschedulable` only for insufficient HAMi Ascend capacity.
- Preserve `Error` for malformed inventory and other device failures.
- Recheck full predicate feasibility after each tentative victim eviction in normal preemption.
- Add HAMi error-classification and normal-preemption regression tests.

## Validation
- `go test ./pkg/scheduler/actions/preempt ./pkg/scheduler/api/devices/ascend/hami`
- `git diff --check`
- Kind validation with two physical Ascend devices split into 14 vNPUs:
  - normal preemption succeeds
  - topology-aware preemption succeeds
  - both evict one `vir04` low-priority workload and schedule the high-priority workload.
  

Fixes #5828 