### PR TITLE
fix(scheduler): avoid int64 overflow for large scalar resources

### DIFF
--- a/pkg/scheduler/api/resource_info.go
+++ b/pkg/scheduler/api/resource_info.go
@@ -83,6 +83,20 @@ func InfiniteResource() *Resource {
 	}
 }
 
+// quantityToMilliFloat64 converts a resource.Quantity to milli-units as float64.
+// Quantity.MilliValue() overflows int64 for very large quantities (e.g. "10P"
+// ephemeral-storage), which would otherwise be stored as a broken, non-positive
+// value and make the resource appear unavailable. This conversion falls back to
+// a float64 path for such quantities so the value is preserved.
+func quantityToMilliFloat64(q resource.Quantity) float64 {
+	// Fast path: exact int64 milli value when it cannot overflow.
+	if v, ok := q.AsInt64(); ok && v <= math.MaxInt64/1000 && v >= math.MinInt64/1000 {
+		return float64(q.MilliValue())
+	}
+	// Fall back to a float64 representation for values too large for int64.
+	return q.AsApproximateFloat64() * 1000
+}
+
 // NewResource creates a new resource object from resource list
 func NewResource(rl v1.ResourceList) *Resource {
 	r := EmptyResource()
@@ -96,7 +110,7 @@ func NewResource(rl v1.ResourceList) *Resource {
 			r.MaxTaskNum += int(rQuant.Value())
 			r.AddScalar(rName, float64(rQuant.Value()))
 		case v1.ResourceEphemeralStorage:
-			r.AddScalar(rName, float64(rQuant.MilliValue()))
+			r.AddScalar(rName, quantityToMilliFloat64(rQuant))
 		default:
 			if IsCountQuota(rName) {
 				continue
@@ -112,7 +126,7 @@ func NewResource(rl v1.ResourceList) *Resource {
 					return true
 				})
 				if !ignore {
-					r.AddScalar(rName, float64(rQuant.MilliValue()))
+					r.AddScalar(rName, quantityToMilliFloat64(rQuant))
 				} else {
 					klog.V(4).Infof("Ignoring resource %s", rName.String())
 				}

--- a/pkg/scheduler/api/resource_info_test.go
+++ b/pkg/scheduler/api/resource_info_test.go
@@ -66,6 +66,33 @@ func TestNewResource(t *testing.T) {
 	}
 }
 
+func TestNewResourceLargeScalarQuantity(t *testing.T) {
+	// Very large scalar quantities such as "10P" ephemeral-storage are used to
+	// express an effectively unlimited capability. Quantity.MilliValue() overflows
+	// int64 for these values (it returns 0), which used to make the stored
+	// capability non-positive so that even a 1Gi request did not fit.
+	capability := NewResource(v1.ResourceList{
+		v1.ResourceEphemeralStorage: resource.MustParse("10P"),
+		"example.com/scalar":        resource.MustParse("10P"),
+	})
+	request := NewResource(v1.ResourceList{
+		v1.ResourceEphemeralStorage: resource.MustParse("1Gi"),
+		"example.com/scalar":        resource.MustParse("1"),
+	})
+
+	expected := float64(10000000000000000 * 1000)
+	if got := capability.ScalarResources[v1.ResourceEphemeralStorage]; got != expected {
+		t.Errorf("expected ephemeral-storage capability %v, got %v", expected, got)
+	}
+	if got := capability.ScalarResources["example.com/scalar"]; got != expected {
+		t.Errorf("expected extended-resource capability %v, got %v", expected, got)
+	}
+
+	if !request.LessEqual(capability, Zero) {
+		t.Errorf("expected 1Gi ephemeral-storage and 1 extended resource to fit within a 10P capability")
+	}
+}
+
 func TestInfiniteResource(t *testing.T) {
 	expected := &Resource{
 		MilliCPU:   math.MaxFloat64,


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

`NewResource` converts scalar resources (`ephemeral-storage` and extended resources) using `Quantity.MilliValue()`, which overflows `int64` for very large quantities such as `10P`. The overflowed value is stored as 0, so a Queue whose `spec.capability` sets such a large value on that dimension admits nothing, not even a small 1Gi request. The conversion now falls back to a float64 path for quantities too large for int64, preserving the value.

For quantities small enough to fit in int64 the behavior is unchanged.

#### Which issue(s) this PR fixes:

Fixes #5844

#### Special notes for your reviewer:

The PR description was generated with the help of an AI tool.

#### Does this PR introduce a user-facing change?

NONE
