### PR TITLE
webhooks: fix admission dropping pod rejection events

### DIFF
--- a/cmd/webhook-manager/app/server.go
+++ b/cmd/webhook-manager/app/server.go
@@ -24,13 +24,13 @@ import (
 	"strconv"
 
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes/scheme"
 	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/klog/v2"
 
 	"volcano.sh/apis/pkg/apis/helpers"
-	"volcano.sh/apis/pkg/apis/scheduling/scheme"
 	informers "volcano.sh/apis/pkg/client/informers/externalversions"
 	"volcano.sh/volcano/cmd/webhook-manager/app/options"
 	"volcano.sh/volcano/pkg/kube"

--- a/installer/helm/chart/volcano/templates/admission.yaml
+++ b/installer/helm/chart/volcano/templates/admission.yaml
@@ -63,6 +63,10 @@ rules:
   - apiGroups: ["scheduling.incubator.k8s.io", "scheduling.volcano.sh"]
     resources: ["podgroups"]
     verbs: ["get", "list", "watch"]
+  # Rule below is used to record events for objects rejected by admission
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create", "patch"]
   {{- if .Values.custom.enabled_admissions | regexMatch "/podgroups/mutate" }}
   - apiGroups: [""]
     resources: ["namespaces"]

--- a/installer/volcano-development-vap-map.yaml
+++ b/installer/volcano-development-vap-map.yaml
@@ -81,6 +81,10 @@ rules:
   - apiGroups: ["scheduling.incubator.k8s.io", "scheduling.volcano.sh"]
     resources: ["podgroups"]
     verbs: ["get", "list", "watch"]
+  # Rule below is used to record events for objects rejected by admission
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create", "patch"]
 ---
 # Source: volcano/templates/admission.yaml
 kind: ClusterRoleBinding

--- a/installer/volcano-development-vap.yaml
+++ b/installer/volcano-development-vap.yaml
@@ -81,6 +81,10 @@ rules:
   - apiGroups: ["scheduling.incubator.k8s.io", "scheduling.volcano.sh"]
     resources: ["podgroups"]
     verbs: ["get", "list", "watch"]
+  # Rule below is used to record events for objects rejected by admission
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create", "patch"]
 ---
 # Source: volcano/templates/admission.yaml
 kind: ClusterRoleBinding

--- a/installer/volcano-development.yaml
+++ b/installer/volcano-development.yaml
@@ -81,6 +81,10 @@ rules:
   - apiGroups: ["scheduling.incubator.k8s.io", "scheduling.volcano.sh"]
     resources: ["podgroups"]
     verbs: ["get", "list", "watch"]
+  # Rule below is used to record events for objects rejected by admission
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create", "patch"]
 ---
 # Source: volcano/templates/admission.yaml
 kind: ClusterRoleBinding

--- a/pkg/webhooks/admission/pods/validate/admit_pod.go
+++ b/pkg/webhooks/admission/pods/validate/admit_pod.go
@@ -122,7 +122,7 @@ func validateAnnotation(pod *v1.Pod) error {
 			if value, found := pod.Annotations[key]; found {
 				num++
 				if err := validateIntPercentageStr(key, value); err != nil {
-					recordEvent(err)
+					recordEvent(pod, err)
 					return err
 				}
 			}
@@ -134,8 +134,10 @@ func validateAnnotation(pod *v1.Pod) error {
 	return nil
 }
 
-func recordEvent(err error) {
-	config.Recorder.Eventf(nil, v1.EventTypeWarning, "Admit", "Create pod failed due to %v", err)
+func recordEvent(pod *v1.Pod, err error) {
+	// The pod is never persisted once admission rejects it, so the event is only
+	// reachable through its namespace's event list, not through the pod itself.
+	config.Recorder.Eventf(pod, v1.EventTypeWarning, "Admit", "Create pod failed due to %v", err)
 }
 
 func validateIntPercentageStr(key, value string) error {

--- a/pkg/webhooks/admission/pods/validate/admit_pod_test.go
+++ b/pkg/webhooks/admission/pods/validate/admit_pod_test.go
@@ -20,10 +20,13 @@ import (
 	"context"
 	"strings"
 	"testing"
+	"time"
 
 	admissionv1 "k8s.io/api/admission/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/record"
 
 	vcschedulingv1 "volcano.sh/apis/pkg/apis/scheduling/v1beta1"
 	vcclient "volcano.sh/apis/pkg/client/clientset/versioned/fake"
@@ -130,5 +133,56 @@ func TestValidatePod(t *testing.T) {
 		if testCase.ExpectErr == false && testCase.reviewResponse.Allowed != true {
 			t.Errorf("%s: test case Expect Allowed as true but got false. %v", testCase.Name, testCase.reviewResponse)
 		}
+	}
+}
+
+func TestValidatePodRecordsRejectionEvent(t *testing.T) {
+	broadcaster := record.NewBroadcaster()
+	defer broadcaster.Shutdown()
+
+	events := make(chan *v1.Event, 1)
+	watcher := broadcaster.StartEventWatcher(func(event *v1.Event) {
+		events <- event
+	})
+	defer watcher.Stop()
+
+	oldRecorder, oldSchedulerNames := config.Recorder, config.SchedulerNames
+	t.Cleanup(func() {
+		config.Recorder, config.SchedulerNames = oldRecorder, oldSchedulerNames
+	})
+	config.Recorder = broadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: "volcano-admission"})
+	config.SchedulerNames = []string{"volcano"}
+
+	// TypeMeta is left empty so that the recorder has to resolve the pod's kind
+	// through the scheme it was built with.
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:   "test",
+			Name:        "invalid-jdb-pod",
+			UID:         "invalid-jdb-pod-uid",
+			Annotations: map[string]string{vcschedulingv1.JDBMinAvailable: "not-a-number"},
+		},
+		Spec: v1.PodSpec{SchedulerName: "volcano"},
+	}
+
+	reviewResponse := admissionv1.AdmissionResponse{Allowed: true}
+	if msg := validatePod(pod, &reviewResponse); msg == "" {
+		t.Fatal("Expect the pod to be rejected, but got an empty message")
+	}
+
+	select {
+	case event := <-events:
+		if event.InvolvedObject.Name != pod.Name || event.InvolvedObject.UID != pod.UID {
+			t.Errorf("Expect the event to reference pod %s (uid %s), but got %+v",
+				pod.Name, pod.UID, event.InvolvedObject)
+		}
+		if event.Namespace != pod.Namespace {
+			t.Errorf("Expect the event in namespace %s, but got %s", pod.Namespace, event.Namespace)
+		}
+		if event.Type != v1.EventTypeWarning {
+			t.Errorf("Expect a %s event, but got %s", v1.EventTypeWarning, event.Type)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Timed out waiting for the rejection event to be recorded")
 	}
 }


### PR DESCRIPTION
### What type of PR is this?

/kind bug

### What this PR does / why we need it:

The pod validating admission webhook records a Warning event when it rejects a pod, but the event was never reaching the API server. Three issues prevent the event from being recorded:

- The recorder receives a `nil` object and cannot build an event reference.
- The recorder's scheme only registers the scheduling API group, so it cannot resolve `v1.Pod` when `TypeMeta` is empty.
- The `volcano-admission` ClusterRole does not grant access to `events`, so a correctly constructed event would still be rejected by RBAC.

As a result, admission failures are invisible when pods are created by controllers. The admission error is not propagated to the owner, and the Warning event that should surface the failure is lost.

This PR fixes all three issues by providing the recorder with the rejected pod, registering the required API types, and granting the admission webhook `create` and `patch` permissions on events.

### Which issue(s) this PR fixes:

No issue.

The problem reproduces with the pod validating webhook enabled and a pod using `schedulerName: volcano` with an invalid annotation such as `volcano.sh/jdb-min-available: not-a-number`. The pod is rejected as expected, but no `Admit` Warning event is recorded.

`TestValidatePodRecordsRejectionEvent` reproduces the failure against `master` and verifies that the rejection event is recorded after the fix.

### Special notes for your reviewer:

The events RBAC rule is intentionally limited to `create` and `patch`. These are the only event operations used by client-go's event sink; unlike the scheduler, controller, and agent roles, the admission webhook does not need `list`, `watch`, or `update`.

The scheme registration brings `webhook-manager` in line with the other entrypoints. The test leaves `TypeMeta` empty intentionally, ensuring the recorder does not rely on metadata that may not be present after decoding.

The `installer/volcano-development*.yaml` files were regenerated with `hack/generate-yaml.sh`. The two `-vap` variants are not covered by `check-generated-yaml.sh` and were verified separately.

AI tools were used to prepare this PR, per the project's [AI Guidance](https://github.com/volcano-sh/volcano/blob/master/contributing.md#ai-guidance). The changes and tests were verified against the current codebase.

### Does this PR introduce a user-facing change?

```release-note
Fixed the admission webhook silently dropping Warning events when pods are rejected for invalid `volcano.sh/jdb-min-available` or `volcano.sh/jdb-max-unavailable` annotations. The `volcano-admission` ClusterRole now grants `create` and `patch` permissions on events.