### PR TITLE
capacity: fix ancestor queue losing track of shared ResourceClaims

### DIFF
--- a/pkg/scheduler/plugins/capacity/capacity.go
+++ b/pkg/scheduler/plugins/capacity/capacity.go
@@ -409,61 +409,6 @@ func removeTaskDRAAllocated(attr *queueAttr, task *api.TaskInfo) {
 	}
 }
 
-// addTaskDRAAllocatedForAncestor is like addTaskDRAAllocated but only charges
-// DeviceClasses that are present in the ancestor's capability map. It must be
-// used instead of updateDRAAllocated in the build path so that ancestor queues
-// receive correct resourceClaimRefs and agree with the refcount-aware helpers
-// called by AllocateFn/DeallocateFn and the event handlers.
-//
-// Without this, ancestor.resourceClaimRefs stays empty: removeTaskDRAAllocated
-// always reads refCount=0 and subtracts (over-admission), and
-// addTaskDRAAllocated always reads refCount=0 and charges again (under-admission).
-// See https://github.com/volcano-sh/volcano/issues/5847.
-func addTaskDRAAllocatedForAncestor(attr *queueAttr, task *api.TaskInfo) {
-	if attr == nil || attr.dra == nil || task == nil {
-		return
-	}
-	capability := attr.dra.capability
-	if len(task.ResourceClaimDRAResreq) == 0 {
-		// Non-shared claims: filter task.DRAResreq by ancestor capability.
-		if task.DRAResreq != nil {
-			filtered := make(map[string]*api.DRAResource)
-			for dc, res := range task.DRAResreq {
-				if _, ok := capability[dc]; ok {
-					filtered[dc] = res
-				}
-			}
-			if len(filtered) > 0 {
-				updateDRAAllocated(attr.dra, filtered)
-			}
-		}
-		return
-	}
-	// Shared claims: same refcount logic as addTaskDRAAllocated, but only charge
-	// DeviceClasses that exist in the ancestor's capability.
-	if attr.resourceClaimRefs == nil {
-		attr.resourceClaimRefs = make(map[string]int)
-	}
-	for _, claimKey := range task.ResourceClaimKeys {
-		claimReq := task.ResourceClaimDRAResreq[claimKey]
-		if len(claimReq) == 0 {
-			continue
-		}
-		filtered := make(map[string]*api.DRAResource)
-		for dc, res := range claimReq {
-			if _, ok := capability[dc]; ok {
-				filtered[dc] = res
-			}
-		}
-		if len(filtered) == 0 {
-			continue
-		}
-		if attr.resourceClaimRefs[claimKey] == 0 {
-			updateDRAAllocated(attr.dra, filtered)
-		}
-		attr.resourceClaimRefs[claimKey]++
-	}
-}
 
 // New return capacityPlugin action
 func New(arguments framework.Arguments) framework.Plugin {
@@ -1168,16 +1113,6 @@ func (cp *capacityPlugin) buildQueueAttrs(ssn *framework.Session) {
 					attr.request.Add(t.Resreq)
 					if cp.dynamicResourceAllocationEnable && attr.dra != nil && t.DRAResreq != nil {
 						addTaskDRAAllocated(attr, t)
-						// Propagate to ancestors using the refcount-aware helper so that
-						// ancestorAttr.resourceClaimRefs is seeded for shared claims.
-						// This fixes issue #5847 where the old delta-based update left
-						// resourceClaimRefs empty, causing accounting drift in both directions.
-						for _, ancestor := range attr.ancestors {
-							ancestorAttr := cp.queueOpts[ancestor]
-							if ancestorAttr.dra != nil {
-								addTaskDRAAllocatedForAncestor(ancestorAttr, t)
-							}
-						}
 					}
 				}
 			} else if status == api.Pending {
@@ -1321,14 +1256,10 @@ func (cp *capacityPlugin) buildHierarchicalQueueAttrs(ssn *framework.Session) bo
 					attr.request.Add(t.Resreq)
 					if cp.dynamicResourceAllocationEnable && attr.dra != nil && t.DRAResreq != nil {
 						addTaskDRAAllocated(attr, t)
-						// Propagate to ancestors using the refcount-aware helper so that
-						// ancestorAttr.resourceClaimRefs is seeded for shared claims.
-						// This fixes issue #5847 where the old delta-based update left
-						// resourceClaimRefs empty, causing accounting drift in both directions.
 						for _, ancestor := range attr.ancestors {
 							ancestorAttr := cp.queueOpts[ancestor]
 							if ancestorAttr.dra != nil {
-								addTaskDRAAllocatedForAncestor(ancestorAttr, t)
+								addTaskDRAAllocated(ancestorAttr, t)
 							}
 						}
 					}

--- a/pkg/scheduler/plugins/capacity/capacity.go
+++ b/pkg/scheduler/plugins/capacity/capacity.go
@@ -409,6 +409,62 @@ func removeTaskDRAAllocated(attr *queueAttr, task *api.TaskInfo) {
 	}
 }
 
+// addTaskDRAAllocatedForAncestor is like addTaskDRAAllocated but only charges
+// DeviceClasses that are present in the ancestor's capability map. It must be
+// used instead of updateDRAAllocated in the build path so that ancestor queues
+// receive correct resourceClaimRefs and agree with the refcount-aware helpers
+// called by AllocateFn/DeallocateFn and the event handlers.
+//
+// Without this, ancestor.resourceClaimRefs stays empty: removeTaskDRAAllocated
+// always reads refCount=0 and subtracts (over-admission), and
+// addTaskDRAAllocated always reads refCount=0 and charges again (under-admission).
+// See https://github.com/volcano-sh/volcano/issues/5847.
+func addTaskDRAAllocatedForAncestor(attr *queueAttr, task *api.TaskInfo) {
+	if attr == nil || attr.dra == nil || task == nil {
+		return
+	}
+	capability := attr.dra.capability
+	if len(task.ResourceClaimDRAResreq) == 0 {
+		// Non-shared claims: filter task.DRAResreq by ancestor capability.
+		if task.DRAResreq != nil {
+			filtered := make(map[string]*api.DRAResource)
+			for dc, res := range task.DRAResreq {
+				if _, ok := capability[dc]; ok {
+					filtered[dc] = res
+				}
+			}
+			if len(filtered) > 0 {
+				updateDRAAllocated(attr.dra, filtered)
+			}
+		}
+		return
+	}
+	// Shared claims: same refcount logic as addTaskDRAAllocated, but only charge
+	// DeviceClasses that exist in the ancestor's capability.
+	if attr.resourceClaimRefs == nil {
+		attr.resourceClaimRefs = make(map[string]int)
+	}
+	for _, claimKey := range task.ResourceClaimKeys {
+		claimReq := task.ResourceClaimDRAResreq[claimKey]
+		if len(claimReq) == 0 {
+			continue
+		}
+		filtered := make(map[string]*api.DRAResource)
+		for dc, res := range claimReq {
+			if _, ok := capability[dc]; ok {
+				filtered[dc] = res
+			}
+		}
+		if len(filtered) == 0 {
+			continue
+		}
+		if attr.resourceClaimRefs[claimKey] == 0 {
+			updateDRAAllocated(attr.dra, filtered)
+		}
+		attr.resourceClaimRefs[claimKey]++
+	}
+}
+
 // New return capacityPlugin action
 func New(arguments framework.Arguments) framework.Plugin {
 	// Default to k8s feature gate values, allow override via plugin arguments
@@ -1112,6 +1168,16 @@ func (cp *capacityPlugin) buildQueueAttrs(ssn *framework.Session) {
 					attr.request.Add(t.Resreq)
 					if cp.dynamicResourceAllocationEnable && attr.dra != nil && t.DRAResreq != nil {
 						addTaskDRAAllocated(attr, t)
+						// Propagate to ancestors using the refcount-aware helper so that
+						// ancestorAttr.resourceClaimRefs is seeded for shared claims.
+						// This fixes issue #5847 where the old delta-based update left
+						// resourceClaimRefs empty, causing accounting drift in both directions.
+						for _, ancestor := range attr.ancestors {
+							ancestorAttr := cp.queueOpts[ancestor]
+							if ancestorAttr.dra != nil {
+								addTaskDRAAllocatedForAncestor(ancestorAttr, t)
+							}
+						}
 					}
 				}
 			} else if status == api.Pending {
@@ -1247,10 +1313,6 @@ func (cp *capacityPlugin) buildHierarchicalQueueAttrs(ssn *framework.Session) bo
 		oldRequest := attr.request.Clone()
 		oldInqueue := attr.inqueue.Clone()
 		oldElastic := attr.elastic.Clone()
-		var oldDRA *draQuotaAttr
-		if attr.dra != nil {
-			oldDRA = attr.dra.Clone()
-		}
 
 		for status, tasks := range job.TaskStatusIndex {
 			if api.AllocatedStatus(status) {
@@ -1259,6 +1321,16 @@ func (cp *capacityPlugin) buildHierarchicalQueueAttrs(ssn *framework.Session) bo
 					attr.request.Add(t.Resreq)
 					if cp.dynamicResourceAllocationEnable && attr.dra != nil && t.DRAResreq != nil {
 						addTaskDRAAllocated(attr, t)
+						// Propagate to ancestors using the refcount-aware helper so that
+						// ancestorAttr.resourceClaimRefs is seeded for shared claims.
+						// This fixes issue #5847 where the old delta-based update left
+						// resourceClaimRefs empty, causing accounting drift in both directions.
+						for _, ancestor := range attr.ancestors {
+							ancestorAttr := cp.queueOpts[ancestor]
+							if ancestorAttr.dra != nil {
+								addTaskDRAAllocatedForAncestor(ancestorAttr, t)
+							}
+						}
 					}
 				}
 			} else if status == api.Pending {
@@ -1293,29 +1365,13 @@ func (cp *capacityPlugin) buildHierarchicalQueueAttrs(ssn *framework.Session) bo
 		inqueueDelta := attr.inqueue.Clone().Sub(oldInqueue)
 		elasticDelta := attr.elastic.Clone().Sub(oldElastic)
 
-		var draDelta map[string]*api.DRAResource
-		if attr.dra != nil {
-			draDelta = getDRADelta(attr.dra, oldDRA)
-		}
-
 		for _, ancestor := range attr.ancestors {
 			ancestorAttr := cp.queueOpts[ancestor]
 			ancestorAttr.allocated.Add(allocatedDelta)
 			ancestorAttr.request.Add(requestDelta)
 			ancestorAttr.inqueue.Add(inqueueDelta)
 			ancestorAttr.elastic.Add(elasticDelta)
-			if cp.dynamicResourceAllocationEnable && ancestorAttr.dra != nil && draDelta != nil {
-				// Only propagate Delta for DeviceClasses that are configured in ancestor's capability
-				filteredDelta := make(map[string]*api.DRAResource)
-				for dc, res := range draDelta {
-					if _, ok := ancestorAttr.dra.capability[dc]; ok {
-						filteredDelta[dc] = res
-					}
-				}
-				if len(filteredDelta) > 0 {
-					updateDRAAllocated(ancestorAttr.dra, filteredDelta)
-				}
-			}
+			// DRA is now propagated per-task inside the task loop above.
 		}
 
 		klog.V(5).Infof("Queue %s allocated <%s> request <%s> inqueue <%s> elastic <%s>",

--- a/pkg/scheduler/plugins/capacity/capacity_test.go
+++ b/pkg/scheduler/plugins/capacity/capacity_test.go
@@ -2108,3 +2108,74 @@ func TestCheckDRAAllocatable_overflowRejected(t *testing.T) {
 		t.Fatalf("checkDRAAllocatable rejected a valid request (4 <= 8); want admitted")
 	}
 }
+
+// TestAncestorSharedClaim reproduces issue #5847: ancestor queues must track
+// shared ResourceClaim refcounts just like leaf queues do.
+//
+// Two failure modes are tested:
+//  1. Release direction: when one of two tasks sharing a claim is released, the
+//     ancestor must still charge the claim (the other task still holds it).
+//  2. Admit direction: when a task is admitted during a session against a claim
+//     the ancestor was already charged for at build time, the ancestor must not
+//     charge it a second time.
+func TestAncestorSharedClaim(t *testing.T) {
+	sharedTask := func(name string) *api.TaskInfo {
+		return &api.TaskInfo{
+			Name:              name,
+			Resreq:            api.EmptyResource(),
+			ResourceClaimKeys: []string{"ns1/shared"},
+			ResourceClaimDRAResreq: map[string]map[string]*api.DRAResource{
+				"ns1/shared": {"gpu.com": {Count: 1}},
+			},
+			DRAResreq: map[string]*api.DRAResource{"gpu.com": {Count: 1}},
+		}
+	}
+	newAttr := func(charged int64) *queueAttr {
+		return &queueAttr{
+			allocated:      api.EmptyResource(),
+			realCapability: api.InfiniteResource(),
+			dra: &draQuotaAttr{
+				allocated:  map[string]*api.DRAResource{"gpu.com": {Count: charged}},
+				capability: map[string]*api.DRAResource{"gpu.com": {Count: 4}},
+			},
+			resourceClaimRefs: make(map[string]int),
+		}
+	}
+
+	taskA, taskB := sharedTask("a"), sharedTask("b")
+
+	// --- Release direction ---
+	// Simulate what buildHierarchicalQueueAttrs produces:
+	//   leaf: addTaskDRAAllocated called for both tasks → refcount=2, charged once.
+	//   ancestor (fixed path): addTaskDRAAllocated called for both tasks → refcount=2, charged once.
+	leaf := newAttr(0)
+	addTaskDRAAllocated(leaf, taskA)
+	addTaskDRAAllocated(leaf, taskB)
+
+	ancestor := newAttr(0)
+	addTaskDRAAllocated(ancestor, taskA)
+	addTaskDRAAllocated(ancestor, taskB)
+
+	// Release one task. The claim is still held by the other.
+	removeTaskDRAAllocated(leaf, taskA)
+	removeTaskDRAAllocated(ancestor, taskA)
+
+	leafCount := leaf.dra.allocated["gpu.com"].Count
+	ancestorCount := ancestor.dra.allocated["gpu.com"].Count
+	t.Logf("after releasing one of two tasks: leaf=%d, ancestor=%d", leafCount, ancestorCount)
+	if ancestorCount < leafCount {
+		t.Errorf("release direction: ancestor charges %d for a claim its child still charges %d for (want ancestor >= leaf)",
+			ancestorCount, leafCount)
+	}
+
+	// --- Admit direction ---
+	// Ancestor was charged once at build time (refcount=1 via addTaskDRAAllocated).
+	// A second task for the same claim is admitted during the session.
+	// addTaskDRAAllocated should see refcount>0 and NOT charge again.
+	admitted := newAttr(0)
+	addTaskDRAAllocated(admitted, taskA) // simulates the build-time charge (refcount → 1)
+	addTaskDRAAllocated(admitted, taskB) // simulates AllocateFn during the session (refcount → 2, no new charge)
+	if got := admitted.dra.allocated["gpu.com"].Count; got != 1 {
+		t.Errorf("admit direction: ancestor charges %d for one shared claim (want 1)", got)
+	}
+}

--- a/pkg/scheduler/plugins/capacity/capacity_test.go
+++ b/pkg/scheduler/plugins/capacity/capacity_test.go
@@ -2112,70 +2112,155 @@ func TestCheckDRAAllocatable_overflowRejected(t *testing.T) {
 // TestAncestorSharedClaim reproduces issue #5847: ancestor queues must track
 // shared ResourceClaim refcounts just like leaf queues do.
 //
-// Two failure modes are tested:
-//  1. Release direction: when one of two tasks sharing a claim is released, the
-//     ancestor must still charge the claim (the other task still holds it).
-//  2. Admit direction: when a task is admitted during a session against a claim
-//     the ancestor was already charged for at build time, the ancestor must not
-//     charge it a second time.
+// By constructing an actual session hierarchy, we exercise the real
+// buildHierarchicalQueueAttrs path. A job has two tasks sharing a claim.
+// Without the fix, the build path leaves resourceClaimRefs empty on the
+// ancestor, causing Allocate to double-charge the ancestor and Reject the task.
 func TestAncestorSharedClaim(t *testing.T) {
-	sharedTask := func(name string) *api.TaskInfo {
-		return &api.TaskInfo{
-			Name:              name,
-			Resreq:            api.EmptyResource(),
-			ResourceClaimKeys: []string{"ns1/shared"},
-			ResourceClaimDRAResreq: map[string]map[string]*api.DRAResource{
-				"ns1/shared": {"gpu.com": {Count: 1}},
+	if err := utilfeature.DefaultMutableFeatureGate.Set(fmt.Sprintf("%s=true", kubefeatures.DynamicResourceAllocation)); err != nil {
+		t.Fatal(err)
+	}
+
+	claimName := "shared-claim"
+	claim := &resourcev1.ResourceClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: claimName, Namespace: "ns1"},
+		Spec: resourcev1.ResourceClaimSpec{
+			Devices: resourcev1.DeviceClaim{
+				Requests: []resourcev1.DeviceRequest{
+					{
+						Name: "req-1",
+						Exactly: &resourcev1.ExactDeviceRequest{
+							DeviceClassName: "gpu.com",
+							Count:           1,
+						},
+					},
+				},
 			},
-			DRAResreq: map[string]*api.DRAResource{"gpu.com": {Count: 1}},
+		},
+	}
+
+	buildPod := func(name string, phase corev1.PodPhase, node, pgName string) *corev1.Pod {
+		pod := util.BuildPod("ns1", name, node, phase, api.BuildResourceList("1", "1Gi"), pgName, nil, nil)
+		pod.Spec.ResourceClaims = []corev1.PodResourceClaim{
+			{Name: "claim-1", ResourceClaimName: &claimName},
+		}
+		if pod.Annotations == nil {
+			pod.Annotations = make(map[string]string)
+		}
+		pod.Annotations[batchv1alpha1.TaskSpecKey] = "worker"
+		return pod
+	}
+
+	pA := buildPod("pA", corev1.PodRunning, "n1", "pg1")
+	pB := buildPod("pB", corev1.PodRunning, "n1", "pg2")
+
+	pg1 := util.BuildPodGroup("pg1", "ns1", "leaf1", 1, nil, schedulingv1beta1.PodGroupRunning)
+	pg2 := util.BuildPodGroup("pg2", "ns1", "leaf2", 1, nil, schedulingv1beta1.PodGroupRunning)
+
+	n1 := util.BuildNode("n1", api.BuildResourceList("10", "10Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), nil)
+
+	rootQ := buildQueueWithParents("root", "", nil, nil)
+	rootQ.Spec.Capability = map[corev1.ResourceName]resource.Quantity{
+		corev1.ResourceName(DeviceClassCountPrefix + "gpu.com"): resource.MustParse("4"),
+	}
+	leaf1Q := buildQueueWithParents("leaf1", "root", nil, nil)
+	leaf1Q.Spec.Capability = map[corev1.ResourceName]resource.Quantity{
+		corev1.ResourceName(DeviceClassCountPrefix + "gpu.com"): resource.MustParse("4"),
+	}
+	leaf2Q := buildQueueWithParents("leaf2", "root", nil, nil)
+	leaf2Q.Spec.Capability = map[corev1.ResourceName]resource.Quantity{
+		corev1.ResourceName(DeviceClassCountPrefix + "gpu.com"): resource.MustParse("4"),
+	}
+
+	test := uthelper.TestCommonStruct{
+		Name:           "Ancestor double-charge bug",
+		Plugins:        map[string]framework.PluginBuilder{PluginName: New},
+		Pods:           []*corev1.Pod{pA, pB},
+		PodGroups:      []*schedulingv1beta1.PodGroup{pg1, pg2},
+		Queues:         []*schedulingv1beta1.Queue{rootQ, leaf1Q, leaf2Q},
+		Nodes:          []*corev1.Node{n1},
+		ResourceClaims: []*resourcev1.ResourceClaim{claim},
+	}
+
+	trueValue := true
+	tiers := []conf.Tier{
+		{
+			Plugins: []conf.PluginOption{
+				{
+					Name:             PluginName,
+					EnabledHierarchy: &trueValue,
+				},
+			},
+		},
+	}
+	sc := test.RegisterSession(tiers, nil)
+	defer test.Close()
+
+	cp := New(nil).(*capacityPlugin)
+	cp.OnSessionOpen(sc)
+
+	rootAttr := cp.queueOpts["root"]
+	leaf1Attr := cp.queueOpts["leaf1"]
+	leaf2Attr := cp.queueOpts["leaf2"]
+
+	if rootAttr == nil || leaf1Attr == nil || leaf2Attr == nil {
+		t.Fatalf("expected queue attributes to be created")
+	}
+
+	assertState := func(step string, q *queueAttr, expectedCount int64, expectedRefs int) {
+		t.Helper()
+		count := int64(0)
+		if q.dra.allocated["gpu.com"] != nil {
+			count = q.dra.allocated["gpu.com"].Count
+		}
+		if count != expectedCount {
+			t.Errorf("[%s] %s: expected allocated count %d, got %d", step, q.name, expectedCount, count)
+		}
+		refs := q.resourceClaimRefs["ns1/shared-claim"]
+		if refs != expectedRefs {
+			t.Errorf("[%s] %s: expected refcount %d, got %d", step, q.name, expectedRefs, refs)
 		}
 	}
-	newAttr := func(charged int64) *queueAttr {
-		return &queueAttr{
-			allocated:      api.EmptyResource(),
-			realCapability: api.InfiniteResource(),
-			dra: &draQuotaAttr{
-				allocated:  map[string]*api.DRAResource{"gpu.com": {Count: charged}},
-				capability: map[string]*api.DRAResource{"gpu.com": {Count: 4}},
-			},
-			resourceClaimRefs: make(map[string]int),
+
+	// 1. Verify build phase
+	assertState("build", leaf1Attr, 1, 1)
+	assertState("build", leaf2Attr, 1, 1)
+	assertState("build", rootAttr, 1, 2)
+
+	var taskA, taskB *api.TaskInfo
+	for _, job := range sc.Jobs {
+		for _, tasks := range job.TaskStatusIndex {
+			for _, task := range tasks {
+				if task.Name == "pA" {
+					taskA = task
+				}
+				if task.Name == "pB" {
+					taskB = task
+				}
+			}
 		}
 	}
 
-	taskA, taskB := sharedTask("a"), sharedTask("b")
-
-	// --- Release direction ---
-	// Simulate what buildHierarchicalQueueAttrs produces:
-	//   leaf: addTaskDRAAllocated called for both tasks → refcount=2, charged once.
-	//   ancestor (fixed path): addTaskDRAAllocated called for both tasks → refcount=2, charged once.
-	leaf := newAttr(0)
-	addTaskDRAAllocated(leaf, taskA)
-	addTaskDRAAllocated(leaf, taskB)
-
-	ancestor := newAttr(0)
-	addTaskDRAAllocated(ancestor, taskA)
-	addTaskDRAAllocated(ancestor, taskB)
-
-	// Release one task. The claim is still held by the other.
-	removeTaskDRAAllocated(leaf, taskA)
-	removeTaskDRAAllocated(ancestor, taskA)
-
-	leafCount := leaf.dra.allocated["gpu.com"].Count
-	ancestorCount := ancestor.dra.allocated["gpu.com"].Count
-	t.Logf("after releasing one of two tasks: leaf=%d, ancestor=%d", leafCount, ancestorCount)
-	if ancestorCount < leafCount {
-		t.Errorf("release direction: ancestor charges %d for a claim its child still charges %d for (want ancestor >= leaf)",
-			ancestorCount, leafCount)
+	if taskA == nil || taskB == nil {
+		t.Fatalf("tasks not found")
 	}
 
-	// --- Admit direction ---
-	// Ancestor was charged once at build time (refcount=1 via addTaskDRAAllocated).
-	// A second task for the same claim is admitted during the session.
-	// addTaskDRAAllocated should see refcount>0 and NOT charge again.
-	admitted := newAttr(0)
-	addTaskDRAAllocated(admitted, taskA) // simulates the build-time charge (refcount → 1)
-	addTaskDRAAllocated(admitted, taskB) // simulates AllocateFn during the session (refcount → 2, no new charge)
-	if got := admitted.dra.allocated["gpu.com"].Count; got != 1 {
-		t.Errorf("admit direction: ancestor charges %d for one shared claim (want 1)", got)
-	}
+	// 2. Remove one task
+	removeTaskDRAAllocated(leaf1Attr, taskA)
+	removeTaskDRAAllocated(rootAttr, taskA)
+	assertState("remove 1st", rootAttr, 1, 1)
+
+	// 3. Remove final task
+	removeTaskDRAAllocated(leaf2Attr, taskB)
+	removeTaskDRAAllocated(rootAttr, taskB)
+	assertState("remove 2nd", rootAttr, 0, 0)
+
+	// 4. Admit another task for already-counted claim does not charge it again
+	addTaskDRAAllocated(leaf1Attr, taskA)
+	addTaskDRAAllocated(rootAttr, taskA)
+	assertState("admit 1st", rootAttr, 1, 1)
+
+	addTaskDRAAllocated(leaf2Attr, taskB)
+	addTaskDRAAllocated(rootAttr, taskB)
+	assertState("admit 2nd", rootAttr, 1, 2)
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
Previously, ancestor queues were charged using `updateDRAAllocated` during the build phase. This skipped updating `resourceClaimRefs` and left it empty. Because of this, the ancestor queue would incorrectly drop its charge on the first release and then double-charge when admitting the same shared claim.

This PR fixes that by using `addTaskDRAAllocated` directly for ancestor queues in the build path. This correctly seeds the per-task refcounts and keeps the build logic perfectly consistent with the live-update path.

**Test Command:**
`go test ./pkg/scheduler/plugins/capacity/ -v -run TestAncestorSharedClaim -count=1`

**Results:**
=== RUN   TestAncestorSharedClaim
I0812 02:34:16.065976  121163 feature_gate.go:362] "Warning: setting GA feature gate. It will be removed in a future release." featureGate="DynamicResourceAllocation" value=true
PASS: TestAncestorSharedClaim (0.00s)
PASS
ok      volcano.sh/volcano/pkg/scheduler/plugins/capacity       0.019s

#### Which issue(s) this PR fixes:
Fixes #5847

#### Special notes for your reviewer:
Following up on the review feedback:
* Removed the unreachable `ancestors` propagation block from the non-hierarchical `buildQueueAttrs`.
* Dropped the custom filtered helper to keep the build and live-update paths fully consistent.
* Rewrote the regression test to construct a real hierarchical session with two leaf queues under one root. It now explicitly verifies all 5 requested invariants on the caller-visible state.

#### Does this PR introduce a user-facing change?
```release-note
Fix shared ResourceClaim refcount drift on ancestor queues during capacity allocation
