### PR TITLE
fix(reclaim): recheck device feasibility after tentative evictions

### DIFF
--- a/pkg/scheduler/actions/reclaim/reclaim.go
+++ b/pkg/scheduler/actions/reclaim/reclaim.go
@@ -218,11 +218,8 @@ func (ra *Action) reclaimForTask(ssn *framework.Session, stmt *framework.Stateme
 		}
 
 		victimsQueue := ssn.BuildVictimsPriorityQueue(victims, task)
-		resreq := task.InitResreq.Clone()
 		reclaimed := api.EmptyResource()
-
-		// The reclaimed resources should be added to the remaining available resources of the nodes to avoid over-reclaiming.
-		availableResources := n.FutureIdle()
+		reclaimerFits := reclaimerFitsOnNode(ssn, task, n)
 
 		// Use a per-node statement so that evictions are isolated to this node.
 		// Only merge into the caller's stmt if Pipeline succeeds; otherwise discard
@@ -230,7 +227,7 @@ func (ra *Action) reclaimForTask(ssn *framework.Session, stmt *framework.Stateme
 		nodeStmt := framework.NewStatement(ssn)
 		evictionOccurred := false
 		for !victimsQueue.Empty() {
-			if resreq.LessEqual(availableResources, api.Zero) {
+			if reclaimerFits {
 				break
 			}
 			reclaimee := victimsQueue.Pop().(*api.TaskInfo)
@@ -238,13 +235,13 @@ func (ra *Action) reclaimForTask(ssn *framework.Session, stmt *framework.Stateme
 				reclaimee.Namespace, reclaimee.Name, task.Namespace, task.Name)
 			nodeStmt.Evict(reclaimee, "reclaim")
 			reclaimed.Add(reclaimee.Resreq)
-			availableResources.Add(reclaimee.Resreq)
 			evictionOccurred = true
+			reclaimerFits = reclaimerFitsOnNode(ssn, task, n)
 		}
 
-		klog.V(3).Infof("Reclaimed <%v> for task <%s/%s> requested <%v>, and Node <%s> availableResources <%v>.", reclaimed, task.Namespace, task.Name, task.InitResreq, n.Name, availableResources)
+		klog.V(3).Infof("Reclaimed <%v> for task <%s/%s> requested <%v>.", reclaimed, task.Namespace, task.Name, task.InitResreq)
 
-		if !resreq.LessEqual(availableResources, api.Zero) {
+		if !reclaimerFits {
 			nodeStmt.Discard()
 			continue
 		}
@@ -258,6 +255,12 @@ func (ra *Action) reclaimForTask(ssn *framework.Session, stmt *framework.Stateme
 		stmt.Merge(nodeStmt)
 		break
 	}
+}
+
+// reclaimerFitsOnNode verifies aggregate resources and plugin predicates after tentative evictions.
+func reclaimerFitsOnNode(ssn *framework.Session, task *api.TaskInfo, node *api.NodeInfo) bool {
+	return task.InitResreq.LessEqual(node.FutureIdle(), api.Zero) &&
+		ssn.PredicateFn(task, node) == nil
 }
 
 func (ra *Action) UnInitialize() {

--- a/pkg/scheduler/actions/reclaim/reclaim.go
+++ b/pkg/scheduler/actions/reclaim/reclaim.go
@@ -218,8 +218,11 @@ func (ra *Action) reclaimForTask(ssn *framework.Session, stmt *framework.Stateme
 		}
 
 		victimsQueue := ssn.BuildVictimsPriorityQueue(victims, task)
+		resreq := task.InitResreq.Clone()
 		reclaimed := api.EmptyResource()
-		reclaimerFits := reclaimerFitsOnNode(ssn, task, n)
+
+		availableResources := n.FutureIdle()
+		reclaimerFits := reclaimerFitsOnNode(ssn, task, n, resreq, availableResources)
 
 		// Use a per-node statement so that evictions are isolated to this node.
 		// Only merge into the caller's stmt if Pipeline succeeds; otherwise discard
@@ -235,11 +238,12 @@ func (ra *Action) reclaimForTask(ssn *framework.Session, stmt *framework.Stateme
 				reclaimee.Namespace, reclaimee.Name, task.Namespace, task.Name)
 			nodeStmt.Evict(reclaimee, "reclaim")
 			reclaimed.Add(reclaimee.Resreq)
+			availableResources.Add(reclaimee.Resreq)
 			evictionOccurred = true
-			reclaimerFits = reclaimerFitsOnNode(ssn, task, n)
+			reclaimerFits = reclaimerFitsOnNode(ssn, task, n, resreq, availableResources)
 		}
 
-		klog.V(3).Infof("Reclaimed <%v> for task <%s/%s> requested <%v>.", reclaimed, task.Namespace, task.Name, task.InitResreq)
+		klog.V(3).Infof("Reclaimed <%v> for task <%s/%s> requested <%v>, and Node <%s> availableResources <%v>.", reclaimed, task.Namespace, task.Name, task.InitResreq, n.Name, availableResources)
 
 		if !reclaimerFits {
 			nodeStmt.Discard()
@@ -257,9 +261,9 @@ func (ra *Action) reclaimForTask(ssn *framework.Session, stmt *framework.Stateme
 	}
 }
 
-// reclaimerFitsOnNode verifies aggregate resources and plugin predicates after tentative evictions.
-func reclaimerFitsOnNode(ssn *framework.Session, task *api.TaskInfo, node *api.NodeInfo) bool {
-	return task.InitResreq.LessEqual(node.FutureIdle(), api.Zero) &&
+// reclaimerFitsOnNode verifies available resources and plugin predicates after tentative evictions.
+func reclaimerFitsOnNode(ssn *framework.Session, task *api.TaskInfo, node *api.NodeInfo, resreq, availableResources *api.Resource) bool {
+	return resreq.LessEqual(availableResources, api.Zero) &&
 		ssn.PredicateFn(task, node) == nil
 }
 

--- a/pkg/scheduler/actions/reclaim/reclaim_test.go
+++ b/pkg/scheduler/actions/reclaim/reclaim_test.go
@@ -44,6 +44,40 @@ func init() {
 	options.Default()
 }
 
+const deviceFitAfterReclaimPluginName = "device-fit-after-reclaim"
+
+type deviceFitAfterReclaimPlugin struct{}
+
+func (p *deviceFitAfterReclaimPlugin) Name() string {
+	return deviceFitAfterReclaimPluginName
+}
+
+func (p *deviceFitAfterReclaimPlugin) OnSessionOpen(ssn *framework.Session) {
+	ssn.AddPredicateFn(p.Name(), func(task *api.TaskInfo, node *api.NodeInfo) error {
+		if task.Name != "reclaimer" {
+			return nil
+		}
+
+		remainingDeviceHolders := 0
+		for _, nodeTask := range node.Tasks {
+			if (nodeTask.Name == "device-holder-1" || nodeTask.Name == "device-holder-2" || nodeTask.Name == "device-holder-3") && nodeTask.Status != api.Releasing {
+				remainingDeviceHolders++
+			}
+		}
+
+		if remainingDeviceHolders > 1 {
+			return api.NewFitErrWithStatus(task, node, &api.Status{
+				Code:   api.Unschedulable,
+				Reason: "hidden device capacity is occupied",
+			})
+		}
+
+		return nil
+	})
+}
+
+func (p *deviceFitAfterReclaimPlugin) OnSessionClose(ssn *framework.Session) {}
+
 func TestReclaim(t *testing.T) {
 	tests := []uthelper.TestCommonStruct{
 		{
@@ -384,5 +418,61 @@ func TestReclaim(t *testing.T) {
 				t.Fatal(err)
 			}
 		})
+	}
+}
+
+func TestReclaimRechecksPredicateAfterEviction(t *testing.T) {
+	plugins := map[string]framework.PluginBuilder{
+		conformance.PluginName: conformance.New,
+		gang.PluginName:        gang.New,
+		proportion.PluginName:  proportion.New,
+		deviceFitAfterReclaimPluginName: func(framework.Arguments) framework.Plugin {
+			return &deviceFitAfterReclaimPlugin{}
+		},
+	}
+	trueValue := true
+	test := uthelper.TestCommonStruct{
+		Name:    "reclaim continues until hidden device capacity is available",
+		Plugins: plugins,
+		PodGroups: []*schedulingv1beta1.PodGroup{
+			util.BuildPodGroupWithPrio("pg-victim", "c1", "q1", 0, nil, schedulingv1beta1.PodGroupRunning, "low-priority"),
+			util.BuildPodGroupWithPrio("pg-reclaimer", "c1", "q2", 1, nil, schedulingv1beta1.PodGroupInqueue, "high-priority"),
+			util.BuildPodGroupWithPrio("pg-demand", "c1", "q3", 0, nil, schedulingv1beta1.PodGroupInqueue, "low-priority"),
+		},
+		Pods: []*v1.Pod{
+			util.BuildPod("c1", "device-holder-1", "n1", v1.PodRunning, api.BuildResourceList("1", "1G"), "pg-victim", map[string]string{schedulingv1beta1.PodPreemptable: "true"}, make(map[string]string)),
+			util.BuildPod("c1", "device-holder-2", "n1", v1.PodRunning, api.BuildResourceList("1", "1G"), "pg-victim", map[string]string{schedulingv1beta1.PodPreemptable: "true"}, make(map[string]string)),
+			util.BuildPod("c1", "device-holder-3", "n1", v1.PodRunning, api.BuildResourceList("1", "1G"), "pg-victim", map[string]string{schedulingv1beta1.PodPreemptable: "false"}, make(map[string]string)),
+			util.BuildPod("c1", "reclaimer", "", v1.PodPending, api.BuildResourceList("1", "1G"), "pg-reclaimer", make(map[string]string), make(map[string]string)),
+			util.BuildPod("c1", "other-queue-demand", "", v1.PodPending, api.BuildResourceList("1", "1G"), "pg-demand", make(map[string]string), make(map[string]string)),
+		},
+		Nodes: []*v1.Node{
+			util.BuildNode("n1", api.BuildResourceList("3", "3G", []api.ScalarResource{{Name: "pods", Value: "10"}}...), make(map[string]string)),
+		},
+		Queues: []*schedulingv1beta1.Queue{
+			util.BuildQueue("q1", 1, nil),
+			util.BuildQueue("q2", 9, nil),
+			util.BuildQueue("q3", 1, nil),
+		},
+		ExpectEvicted:  []string{"c1/device-holder-1", "c1/device-holder-2"},
+		ExpectEvictNum: 2,
+		ExpectPipeLined: map[string][]string{
+			"c1/pg-reclaimer": {"n1"},
+		},
+	}
+	tiers := []conf.Tier{{
+		Plugins: []conf.PluginOption{
+			{Name: conformance.PluginName, EnabledReclaimable: &trueValue},
+			{Name: gang.PluginName, EnabledReclaimable: &trueValue, EnabledJobStarving: &trueValue},
+			{Name: proportion.PluginName, EnabledReclaimable: &trueValue, EnabledQueueOrder: &trueValue, EnablePreemptive: &trueValue},
+			{Name: deviceFitAfterReclaimPluginName, EnabledPredicate: &trueValue},
+		},
+	}}
+
+	test.RegisterSession(tiers, nil)
+	defer test.Close()
+	test.Run([]framework.Action{New()})
+	if err := test.CheckAll(0); err != nil {
+		t.Fatal(err)
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

## What this PR does

Fixes the cross-queue `reclaim` path when aggregate Node resources appear sufficient but a device-aware predicate, such as HAMi Ascend DeviceShare, cannot form a valid concrete allocation.

Reclaim now re-evaluates task feasibility after each tentative victim eviction:

- generic `FutureIdle()` resource availability; and
- scheduler `PredicateFn()` results, including device-backed predicates.

The per-Node `Statement` remains transactional: unsuccessful reclaim attempts are discarded and do not commit victim evictions.

## Why

`reclaim` previously stopped selecting victims based only on aggregate resources. This can be incorrect for device resources where physical-device availability, memory, geometry, or fragmentation cannot be represented by scalar Node totals.

This issue was identified while investigating the HAMi Ascend report in #5828. It is the cross-queue counterpart to the normal-preemption predicate recheck in #5843.

## Tests

Added a regression test where:

1. Generic resources become sufficient after the first reclaim victim.
2. A simulated device predicate remains unschedulable.
3. Reclaim selects the second valid victim.
4. The predicate becomes feasible and the reclaimer is pipelined.

## Validation

- `go test ./pkg/scheduler/actions/reclaim`
- `git diff --check`

Fixes #5852