### PR TITLE
test/e2e: exclude terminating pods from WaitTaskPhase readiness count

### DIFF
--- a/test/e2e/util/job.go
+++ b/test/e2e/util/job.go
@@ -309,6 +309,15 @@ func WaitTaskPhase(ctx *TestContext, job *batchv1alpha1.Job, phase []v1.PodPhase
 			if !metav1.IsControlledBy(&pod, job) {
 				continue
 			}
+			// Terminating pods (e.g. the old pod being replaced after a kill)
+			// can still report a stale matching phase; excluding them avoids
+			// counting them toward readyTaskNum before their replacement has
+			// actually reached the target phase.
+			if pod.DeletionTimestamp != nil {
+				podKey := fmt.Sprintf("%s/%s", pod.Namespace, pod.Name)
+				podNotReadyCache[podKey] = &pod
+				continue
+			}
 
 			podKey := fmt.Sprintf("%s/%s", pod.Namespace, pod.Name)
 			podReady := false


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Fixes intermittent failures in the network topology E2E tests for hypernode-reschedule scenarios.

The scheduler correctly rebinds the replacement task to the same hyperNode after the original Pod is killed. The flakiness was caused by the E2E `WaitTaskPhase` helper, which considered any Pod matching the requested phase.

A killed Pod can temporarily retain its previous phase while its `DeletionTimestamp` is set but before it is fully removed. `WaitTaskPhase` could therefore return successfully based on the stale Pod instead of waiting for the newly created replacement Pod to reach the expected phase.

This change makes the wait logic ignore Pods that are being deleted, ensuring that the phase check is performed against an active Pod. This prevents the following assertions from observing unsettled replacement state.

#### Which issue(s) this PR fixes:

Fixes #5856

#### Special notes for your reviewer:

The scheduler behaviour was verified independently: the replacement task is correctly rebound to the same hyperNode.

The failure was isolated to the E2E polling helper and its handling of Pods with a `DeletionTimestamp`.

The fix is scoped to E2E test synchronization and does not change scheduler or production scheduling behaviour.

#### Does this PR introduce a user-facing change?

NONE

```release-note
```
