### PR TITLE
scheduler: fix slices.SortFunc comparator contract violation in SubJob ordering

### DIFF
--- a/pkg/scheduler/actions/allocate/allocate.go
+++ b/pkg/scheduler/actions/allocate/allocate.go
@@ -219,12 +219,7 @@ func (alloc *Action) organizeJobWorksheet(job *api.JobInfo) *JobWorksheet {
 			subJobs = append(subJobs, subJob)
 		}
 	}
-	slices.SortFunc(subJobs, func(l, r *api.SubJobInfo) int {
-		if !ssn.SubJobOrderFn(l, r) {
-			return 1
-		}
-		return -1
-	})
+	slices.SortFunc(subJobs, ssn.SubJobCompareFn)
 	// Find the smallest set of subJobs that meets the requirements for job execution.
 	requireSubJobs := sets.Set[api.SubJobID]{}
 	for _, subJob := range subJobs {

--- a/pkg/scheduler/actions/utils/simulate.go
+++ b/pkg/scheduler/actions/utils/simulate.go
@@ -165,12 +165,7 @@ func organizeEvictionWorksheet(ssn *framework.Session, job *api.JobInfo) *evicti
 			subJobs = append(subJobs, subJob)
 		}
 	}
-	slices.SortFunc(subJobs, func(l, r *api.SubJobInfo) int {
-		if !ssn.SubJobOrderFn(l, r) {
-			return 1
-		}
-		return -1
-	})
+	slices.SortFunc(subJobs, ssn.SubJobCompareFn)
 	requireSubJobs := sets.Set[api.SubJobID]{}
 	for _, subJob := range subJobs {
 		if subJobCountMap[subJob.GID] < job.MinSubJobs[subJob.GID] {

--- a/pkg/scheduler/framework/session_plugins.go
+++ b/pkg/scheduler/framework/session_plugins.go
@@ -21,6 +21,7 @@ limitations under the License.
 package framework
 
 import (
+	"cmp"
 	"context"
 
 	fwk "k8s.io/kube-scheduler/framework"
@@ -686,7 +687,10 @@ func (ssn *Session) ReservedNodes() {
 	}
 }
 
-func (ssn *Session) SubJobOrderFn(l, r interface{}) bool {
+// SubJobOrderCompareFn compares l and r by running enabled SubJobOrder plugins in
+// order and returning the first non-zero comparison result. It returns 0 if
+// all plugins consider l and r equal.
+func (ssn *Session) SubJobOrderCompareFn(l, r interface{}) int {
 	for _, tier := range ssn.Tiers {
 		for _, plugin := range tier.Plugins {
 			if !isEnabled(plugin.EnabledSubJobOrder) {
@@ -697,18 +701,34 @@ func (ssn *Session) SubJobOrderFn(l, r interface{}) bool {
 				continue
 			}
 			if j := fn(l, r); j != 0 {
-				return j < 0
+				return j
 			}
 		}
 	}
 
-	// If no subJob order funcs, order subJob by MatchIndex and UID.
-	lv := l.(*api.SubJobInfo)
-	rv := r.(*api.SubJobInfo)
-	if lv.MatchIndex != rv.MatchIndex {
-		return lv.MatchIndex < rv.MatchIndex
+	return 0
+}
+
+// SubJobCompareFn compares l and r SubJobInfo by running SubJobOrder plugins first,
+// and falling back to MatchIndex and UID as tie-breakers. It returns <0 if l < r,
+// >0 if l > r, and 0 if l == r.
+func (ssn *Session) SubJobCompareFn(l, r *api.SubJobInfo) int {
+	if res := ssn.SubJobOrderCompareFn(l, r); res != 0 {
+		return res
 	}
-	return lv.UID < rv.UID
+	if l.MatchIndex != r.MatchIndex {
+		return cmp.Compare(l.MatchIndex, r.MatchIndex)
+	}
+	return cmp.Compare(l.UID, r.UID)
+}
+
+func (ssn *Session) SubJobOrderFn(l, r interface{}) bool {
+	lv, lok := l.(*api.SubJobInfo)
+	rv, rok := r.(*api.SubJobInfo)
+	if !lok || !rok {
+		return false
+	}
+	return ssn.SubJobCompareFn(lv, rv) < 0
 }
 
 // JobOrderCompareFn compares l and r by running enabled JobOrder plugins in

--- a/pkg/scheduler/framework/session_plugins_test.go
+++ b/pkg/scheduler/framework/session_plugins_test.go
@@ -18,6 +18,7 @@ package framework
 
 import (
 	"fmt"
+	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -315,3 +316,109 @@ func TestHyperNodeGradientForJobFn_NoPluginKeepsCurrentFallback(t *testing.T) {
 	result := ssn.HyperNodeGradientForJobFn(&api.JobInfo{}, root, api.PurposeEvict)
 	assert.Equal(t, [][]*api.HyperNodeInfo{{root}}, result)
 }
+
+func TestSubJobOrderCompareFn_PluginOrder(t *testing.T) {
+	enabled := true
+	ssn := &Session{
+		Tiers: []conf.Tier{
+			{
+				Plugins: []conf.PluginOption{
+					{Name: "p1", EnabledSubJobOrder: &enabled},
+					{Name: "p2", EnabledSubJobOrder: &enabled},
+				},
+			},
+		},
+		subJobOrderFns: map[string]api.CompareFn{},
+	}
+
+	sj1 := &api.SubJobInfo{UID: "sj1"}
+	sj2 := &api.SubJobInfo{UID: "sj2"}
+
+	// When no plugins are registered, returns 0.
+	assert.Equal(t, 0, ssn.SubJobOrderCompareFn(sj1, sj2))
+
+	// Register p1 returning 0, p2 returning -1 (sj1 < sj2).
+	ssn.AddSubJobOrderFn("p1", func(l, r interface{}) int { return 0 })
+	ssn.AddSubJobOrderFn("p2", func(l, r interface{}) int { return -1 })
+	assert.Equal(t, -1, ssn.SubJobOrderCompareFn(sj1, sj2))
+	assert.True(t, ssn.SubJobOrderFn(sj1, sj2))
+}
+
+func TestSubJobCompareFn_ReflexivityAndAntiSymmetry(t *testing.T) {
+	ssn := &Session{
+		subJobOrderFns: map[string]api.CompareFn{},
+	}
+
+	sj1 := &api.SubJobInfo{UID: "sj-1", MatchIndex: 0}
+	sj2 := &api.SubJobInfo{UID: "sj-2", MatchIndex: 1}
+	sj3 := &api.SubJobInfo{UID: "sj-1", MatchIndex: 0} // equivalent to sj1
+
+	// Reflexivity: cmp(a, a) == 0
+	assert.Equal(t, 0, ssn.SubJobCompareFn(sj1, sj1))
+	assert.Equal(t, 0, ssn.SubJobCompareFn(sj2, sj2))
+	assert.Equal(t, 0, ssn.SubJobCompareFn(sj1, sj3))
+
+	// Anti-symmetry: cmp(a, b) == -cmp(b, a)
+	cmp12 := ssn.SubJobCompareFn(sj1, sj2)
+	cmp21 := ssn.SubJobCompareFn(sj2, sj1)
+	assert.Equal(t, -1, cmp12)
+	assert.Equal(t, 1, cmp21)
+	assert.Equal(t, cmp12, -cmp21)
+
+	// Boolean helper
+	assert.False(t, ssn.SubJobOrderFn(sj1, sj1))
+	assert.True(t, ssn.SubJobOrderFn(sj1, sj2))
+	assert.False(t, ssn.SubJobOrderFn(sj2, sj1))
+}
+
+func TestSubJobCompareFn_TieBreaking(t *testing.T) {
+	ssn := &Session{
+		subJobOrderFns: map[string]api.CompareFn{},
+	}
+
+	// Case 1: different MatchIndex, same UID
+	sjA := &api.SubJobInfo{UID: "same", MatchIndex: 1}
+	sjB := &api.SubJobInfo{UID: "same", MatchIndex: 2}
+	assert.Equal(t, -1, ssn.SubJobCompareFn(sjA, sjB))
+	assert.Equal(t, 1, ssn.SubJobCompareFn(sjB, sjA))
+
+	// Case 2: same MatchIndex, different UID
+	sjC := &api.SubJobInfo{UID: "alpha", MatchIndex: 1}
+	sjD := &api.SubJobInfo{UID: "beta", MatchIndex: 1}
+	assert.Equal(t, -1, ssn.SubJobCompareFn(sjC, sjD))
+	assert.Equal(t, 1, ssn.SubJobCompareFn(sjD, sjC))
+}
+
+func TestSubJobSorting_SlicesSortFunc(t *testing.T) {
+	ssn := &Session{
+		subJobOrderFns: map[string]api.CompareFn{},
+	}
+
+	subJobs := []*api.SubJobInfo{
+		{UID: "sj-3", MatchIndex: 2},
+		{UID: "sj-1", MatchIndex: 1},
+		{UID: "sj-2", MatchIndex: 1},
+		{UID: "sj-1", MatchIndex: 1}, // duplicate entry to test reflexivity under sorting
+		{UID: "sj-0", MatchIndex: 0},
+	}
+
+	// slices.SortFunc must sort stably and without panic/undefined behavior
+	slices.SortFunc(subJobs, ssn.SubJobCompareFn)
+
+	expectedOrder := []struct {
+		uid        api.SubJobID
+		matchIndex int
+	}{
+		{uid: "sj-0", matchIndex: 0},
+		{uid: "sj-1", matchIndex: 1},
+		{uid: "sj-1", matchIndex: 1},
+		{uid: "sj-2", matchIndex: 1},
+		{uid: "sj-3", matchIndex: 2},
+	}
+
+	for i, exp := range expectedOrder {
+		assert.Equal(t, exp.uid, subJobs[i].UID)
+		assert.Equal(t, exp.matchIndex, subJobs[i].MatchIndex)
+	}
+}
+


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
In `allocate` (`pkg/scheduler/actions/allocate/allocate.go`) and `simulate` (`pkg/scheduler/actions/utils/simulate.go`) actions, `subJobs` are sorted using `slices.SortFunc` before populating `requireSubJobs` (the minimal set of sub-jobs needed to satisfy `job.MinSubJobs`).

Previously, the comparator passed to `slices.SortFunc` was:
```go
slices.SortFunc(subJobs, func(l, r *api.SubJobInfo) int {
	if !ssn.SubJobOrderFn(l, r) {
		return 1
	}
	return -1
})
```
Because `SubJobOrderFn(l, l)` returns `false` (identical keys return false for `<`), `!SubJobOrderFn(l, l)` evaluates to `true` and returned `1` (claiming an element is strictly greater than itself). This violated reflexivity (`cmp(a, a) == 0`) and anti-symmetry (`cmp(a, b) == -cmp(b, a)`), breaking the strict weak ordering contract required by Go's `pdqsort` in `slices.SortFunc`. Under sorting, this caused non-deterministic/unstable sub-job order and could lead to `requireSubJobs` selecting wrong sub-jobs.

This PR fixes the issue by:
1. Adding `SubJobOrderCompareFn(l, r interface{}) int` to `pkg/scheduler/framework/session_plugins.go` (mirroring `JobOrderCompareFn`) to return 3-way `int` comparison results (`-1`, `0`, `1`) across plugin tiers.
2. Adding `SubJobCompareFn(l, r *api.SubJobInfo) int` which executes `SubJobOrderCompareFn` and falls back to `MatchIndex` and `UID` comparison using `cmp.Compare`.
3. Refactoring `SubJobOrderFn(l, r interface{}) bool` to call `ssn.SubJobCompareFn(lv, rv) < 0`.
4. Updating `allocate.go` and `simulate.go` to pass `ssn.SubJobCompareFn` directly to `slices.SortFunc`.
5. Adding unit tests in `pkg/scheduler/framework/session_plugins_test.go` covering plugin ordering, reflexivity, anti-symmetry, tie-breaking, and stable sorting with `slices.SortFunc`.

#### Which issue(s) this PR fixes:
Fixes #5860

#### Special notes for your reviewer:
The change is scoped to `SubJob` comparison and sorting in the scheduler framework and `allocate`/`simulate` actions.

#### Does this PR introduce a user-facing change?
```release-note
Fix a comparator contract violation in SubJob sorting within scheduler allocate and simulate actions that could cause incorrect sub-job priority ordering.
```
