### PR TITLE
[release-1.15] fix(deviceshare): support HAMi Ascend normal preemption

### DIFF
--- a/pkg/scheduler/actions/preempt/preempt.go
+++ b/pkg/scheduler/actions/preempt/preempt.go
@@ -375,19 +375,10 @@ func (pmpt *Action) normalPreempt(
 		victimsQueue := ssn.BuildVictimsPriorityQueue(victims, preemptor)
 		// Preempt victims for tasks, pick lowest priority task first.
 		preempted := api.EmptyResource()
+		preemptorFits := preemptorFitsOnNode(ssn, currentQueue, preemptor, node)
 
 		for !victimsQueue.Empty() {
-			// If reclaimed enough resources, break loop to avoid Sub panic.
-			// Preempt action is about preempt in same queue, which job is not allocatable in allocate action, due to:
-			// 1. cluster has free resource, but queue not allocatable
-			// 2. cluster has no free resource, but queue not allocatable
-			// 3. cluster has no free resource, but queue allocatable
-			// for case 1 and 2, high priority job/task can preempt low priority job/task in same queue;
-			// for case 3, it need to do reclaim resource from other queue, in reclaim action;
-			// so if current queue is not allocatable(the queue will be overused when consider current preemptor's requests)
-			// or current idle resource is not enough for preemptor, it need to continue preempting
-			// otherwise, break out
-			if ssn.Allocatable(currentQueue, preemptor) && preemptor.InitResreq.LessEqual(node.FutureIdle(), api.Zero) {
+			if preemptorFits {
 				break
 			}
 			preemptee := victimsQueue.Pop().(*api.TaskInfo)
@@ -395,6 +386,7 @@ func (pmpt *Action) normalPreempt(
 				preemptee.Namespace, preemptee.Name, preemptor.Namespace, preemptor.Name)
 			nodeStmt.Evict(preemptee, "preempt")
 			preempted.Add(preemptee.Resreq)
+			preemptorFits = preemptorFitsOnNode(ssn, currentQueue, preemptor, node)
 		}
 
 		evictionOccurred := false
@@ -407,7 +399,7 @@ func (pmpt *Action) normalPreempt(
 			preempted, preemptor.Namespace, preemptor.Name, preemptor.InitResreq)
 
 		// If preemptor's queue is not allocatable, it means preemptor cannot be allocated. So no need care about the node idle resource
-		if ssn.Allocatable(currentQueue, preemptor) && preemptor.InitResreq.LessEqual(node.FutureIdle(), api.Zero) {
+		if preemptorFits {
 			if err := nodeStmt.Pipeline(preemptor, node.Name, evictionOccurred); err != nil {
 				klog.Errorf("Failed to pipeline Task <%s/%s> on Node <%s>",
 					preemptor.Namespace, preemptor.Name, node.Name)
@@ -427,6 +419,20 @@ func (pmpt *Action) normalPreempt(
 	}
 
 	return assigned, nil
+}
+
+// preemptorFitsOnNode checks whether the preemptor fits the node after tentative evictions.
+// A job may not be allocatable because:
+// 1. The cluster has free resources, but the queue is not allocatable.
+// 2. The cluster has no free resources, and the queue is not allocatable.
+// 3. The cluster has no free resources, but the queue is allocatable.
+// 4. The node has sufficient aggregate resources, but PredicateFn fails because vNPU or vGPU resources are fragmented.
+// Same-queue preemption handles cases 1 and 2. Reclaim handles case 3. For case 4, normal preemption continues until
+// the predicate passes after enough victims are evicted.
+func preemptorFitsOnNode(ssn *framework.Session, queue *api.QueueInfo, preemptor *api.TaskInfo, node *api.NodeInfo) bool {
+	return ssn.Allocatable(queue, preemptor) &&
+		preemptor.InitResreq.LessEqual(node.FutureIdle(), api.Zero) &&
+		ssn.PredicateFn(preemptor, node) == nil
 }
 
 func (pmpt *Action) taskEligibleToPreempt(preemptor *api.TaskInfo) error {

--- a/pkg/scheduler/actions/preempt/preempt_test.go
+++ b/pkg/scheduler/actions/preempt/preempt_test.go
@@ -51,6 +51,51 @@ func init() {
 	flag.Set("v", "4")
 }
 
+const deviceFitAfterEvictionPluginName = "device-fit-after-eviction"
+
+const normalPreemptBenchmarkPredicatePluginName = "normal-preempt-benchmark-predicate"
+
+type deviceFitAfterEvictionPlugin struct{}
+
+func (p *deviceFitAfterEvictionPlugin) Name() string {
+	return deviceFitAfterEvictionPluginName
+}
+
+func (p *deviceFitAfterEvictionPlugin) OnSessionOpen(ssn *framework.Session) {
+	ssn.AddPredicateFn(p.Name(), func(task *api.TaskInfo, node *api.NodeInfo) error {
+		if task.Name != "preemptor" {
+			return nil
+		}
+
+		for _, nodeTask := range node.Tasks {
+			if nodeTask.Name == "preemptee" && nodeTask.Status != api.Releasing {
+				return api.NewFitErrWithStatus(task, node, &api.Status{
+					Code:   api.Unschedulable,
+					Reason: "hidden device capacity is occupied",
+				})
+			}
+		}
+
+		return nil
+	})
+}
+
+func (p *deviceFitAfterEvictionPlugin) OnSessionClose(ssn *framework.Session) {}
+
+type normalPreemptBenchmarkPredicatePlugin struct{}
+
+func (p *normalPreemptBenchmarkPredicatePlugin) Name() string {
+	return normalPreemptBenchmarkPredicatePluginName
+}
+
+func (p *normalPreemptBenchmarkPredicatePlugin) OnSessionOpen(ssn *framework.Session) {
+	ssn.AddPredicateFn(p.Name(), func(task *api.TaskInfo, node *api.NodeInfo) error {
+		return nil
+	})
+}
+
+func (p *normalPreemptBenchmarkPredicatePlugin) OnSessionClose(ssn *framework.Session) {}
+
 func TestPreempt(t *testing.T) {
 	plugins := map[string]framework.PluginBuilder{
 		conformance.PluginName: conformance.New,
@@ -422,6 +467,148 @@ func TestPreempt(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestNormalPreemptRechecksPredicateAfterEviction(t *testing.T) {
+	test, tiers := newNormalPreemptDeviceFitFixture()
+	test.RegisterSession(tiers, []conf.Configuration{{
+		Name:      New().Name(),
+		Arguments: map[string]interface{}{EnableTopologyAwarePreemptionKey: false},
+	}})
+	defer test.Close()
+	test.Run([]framework.Action{New()})
+	if err := test.CheckAll(0); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func newNormalPreemptDeviceFitFixture() (uthelper.TestCommonStruct, []conf.Tier) {
+	plugins := map[string]framework.PluginBuilder{
+		conformance.PluginName: conformance.New,
+		gang.PluginName:        gang.New,
+		priority.PluginName:    priority.New,
+		proportion.PluginName:  proportion.New,
+		deviceFitAfterEvictionPluginName: func(framework.Arguments) framework.Plugin {
+			return &deviceFitAfterEvictionPlugin{}
+		},
+	}
+	highPrio := util.BuildPriorityClass("high-priority", 100000)
+	lowPrio := util.BuildPriorityClass("low-priority", 10)
+	trueValue := true
+	falseValue := false
+	test := uthelper.TestCommonStruct{
+		Name:    "normal preemption evicts a victim when hidden device capacity remains unavailable",
+		Plugins: plugins,
+		PodGroups: []*schedulingv1beta1.PodGroup{
+			util.BuildPodGroupWithPrio("pg-low", "c1", "q1", 1, map[string]int32{"": 1}, schedulingv1beta1.PodGroupInqueue, "low-priority"),
+			util.BuildPodGroupWithPrio("pg-high", "c1", "q1", 1, map[string]int32{"": 1}, schedulingv1beta1.PodGroupInqueue, "high-priority"),
+		},
+		Pods: []*v1.Pod{
+			util.BuildPod("c1", "preemptee", "n1", v1.PodRunning, api.BuildResourceList("1", "1G"), "pg-low", map[string]string{schedulingv1beta1.PodPreemptable: "true"}, make(map[string]string)),
+			util.BuildPod("c1", "preemptor", "", v1.PodPending, api.BuildResourceList("1", "1G"), "pg-high", make(map[string]string), make(map[string]string)),
+		},
+		Nodes: []*v1.Node{
+			util.BuildNode("n1", api.BuildResourceList("2", "2G", []api.ScalarResource{{Name: "pods", Value: "10"}}...), make(map[string]string)),
+		},
+		Queues: []*schedulingv1beta1.Queue{
+			util.BuildQueue("q1", 1, nil),
+		},
+		PriClass:       []*schedulingv1.PriorityClass{highPrio, lowPrio},
+		ExpectEvicted:  []string{"c1/preemptee"},
+		ExpectEvictNum: 1,
+	}
+	tiers := []conf.Tier{{
+		Plugins: []conf.PluginOption{
+			{Name: conformance.PluginName, EnabledPreemptable: &trueValue},
+			{Name: gang.PluginName, EnabledPreemptable: &falseValue, EnabledJobPipelined: &trueValue, EnabledJobStarving: &trueValue},
+			{Name: priority.PluginName, EnabledTaskOrder: &trueValue, EnabledJobOrder: &trueValue, EnabledPreemptable: &trueValue, EnabledJobPipelined: &trueValue, EnabledJobStarving: &trueValue},
+			{Name: proportion.PluginName, EnabledOverused: &trueValue, EnabledAllocatable: &trueValue, EnabledQueueOrder: &trueValue},
+			{Name: deviceFitAfterEvictionPluginName, EnabledPredicate: &trueValue},
+		},
+	}}
+
+	return test, tiers
+}
+
+func newNormalPreemptBenchmarkFixture() (uthelper.TestCommonStruct, []conf.Tier) {
+	test, tiers := newNormalPreemptDeviceFitFixture()
+	test.Name = "normal preemption benchmark with one required victim"
+	test.Nodes = []*v1.Node{
+		util.BuildNode("n1", api.BuildResourceList("1", "1G", []api.ScalarResource{{Name: "pods", Value: "10"}}...), make(map[string]string)),
+	}
+	test.Plugins[normalPreemptBenchmarkPredicatePluginName] = func(framework.Arguments) framework.Plugin {
+		return &normalPreemptBenchmarkPredicatePlugin{}
+	}
+
+	benchmarkPlugins := make([]conf.PluginOption, 0, len(tiers[0].Plugins))
+	for _, plugin := range tiers[0].Plugins {
+		if plugin.Name != deviceFitAfterEvictionPluginName {
+			benchmarkPlugins = append(benchmarkPlugins, plugin)
+		}
+	}
+	trueValue := true
+	benchmarkPlugins = append(benchmarkPlugins, conf.PluginOption{
+		Name:             normalPreemptBenchmarkPredicatePluginName,
+		EnabledPredicate: &trueValue,
+	})
+	tiers[0].Plugins = benchmarkPlugins
+
+	return test, tiers
+}
+
+// BenchmarkNormalPreemptPredicateRecheck measures the direct normalPreempt
+// call when both revisions must evict one victim.
+func BenchmarkNormalPreemptPredicateRecheck(b *testing.B) {
+	previousVerbosity := flag.Lookup("v").Value.String()
+	if err := flag.Set("v", "0"); err != nil {
+		b.Fatal(err)
+	}
+	b.Cleanup(func() {
+		_ = flag.Set("v", previousVerbosity)
+	})
+
+	test, tiers := newNormalPreemptBenchmarkFixture()
+	ssn := test.RegisterSession(tiers, []conf.Configuration{{
+		Name:      New().Name(),
+		Arguments: map[string]interface{}{EnableTopologyAwarePreemptionKey: false},
+	}})
+	defer test.Close()
+
+	preemptor := benchmarkPreemptor(ssn)
+	if preemptor == nil {
+		b.Fatal("benchmark preemptor was not found")
+	}
+	node := ssn.Nodes["n1"]
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for iteration := 0; iteration < b.N; iteration++ {
+		stmt := framework.NewStatement(ssn)
+
+		assigned, err := New().normalPreempt(ssn, stmt, preemptor, func(task *api.TaskInfo) bool {
+			return api.PreemptableStatus(task.Status) && task.Preemptable && task.Job != preemptor.Job
+		}, []*api.NodeInfo{node})
+
+		if err != nil {
+			b.Fatal(err)
+		}
+		if !assigned {
+			b.Fatal("normal preemption did not assign the preemptor")
+		}
+		stmt.Discard()
+	}
+}
+
+func benchmarkPreemptor(ssn *framework.Session) *api.TaskInfo {
+	for _, jobInfo := range ssn.Jobs {
+		for _, task := range jobInfo.TaskStatusIndex[api.Pending] {
+			if task.Name == "preemptor" {
+				return task
+			}
+		}
+	}
+
+	return nil
 }
 
 func TestTopologyAwarePreempt(t *testing.T) {

--- a/pkg/scheduler/api/devices/ascend/hami/device_info.go
+++ b/pkg/scheduler/api/devices/ascend/hami/device_info.go
@@ -77,6 +77,8 @@ type RuntimeInfo struct {
 var (
 	AscendHAMiVNPUEnable bool
 	NodeLockEnable       bool
+
+	errInsufficientAscendDeviceCapacity = errors.New("no enough ascend device available")
 )
 
 func NewAscendDevices(name string, node *v1.Node) map[string]*AscendDevices {
@@ -257,6 +259,9 @@ func (ads *AscendDevices) HasDeviceRequest(pod *v1.Pod) bool {
 func (ads *AscendDevices) FilterNode(pod *v1.Pod, policy string) (int, string, error) {
 	_, err := ads.selectDevices(pod, policy)
 	if err != nil {
+		if errors.Is(err, errInsufficientAscendDeviceCapacity) {
+			return devices.Unschedulable, "no ascend device available", err
+		}
 		return devices.Error, "no ascend device available", err
 	}
 	klog.V(4).Infoln("ascend DeviceSharing successfully filters pods. device_type:", ads.Type)
@@ -479,7 +484,7 @@ func (ads *AscendDevices) selectDevices(pod *v1.Pod, schedulePolicy string) (dev
 		}
 		if req_nums > 0 {
 			klog.V(5).Infof("no enough ascend device available! raw req_nums %d cur req_nums %d", req.Nums, req_nums)
-			return nil, errors.Errorf("no enough ascend device available")
+			return nil, errors.WithStack(errInsufficientAscendDeviceCapacity)
 		}
 		if needTopology {
 			selectedDevs = selectDevicesWithTopology(int(req.Nums), selectedDevs)

--- a/pkg/scheduler/api/devices/ascend/hami/device_info_test.go
+++ b/pkg/scheduler/api/devices/ascend/hami/device_info_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/yaml.v2"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/fake"
@@ -339,6 +340,73 @@ func Test_fit(t *testing.T) {
 	}
 }
 
+func TestAscendDevicesFilterNodeErrorClassification(t *testing.T) {
+	newPod := func(deviceCount, deviceMemory string) *v1.Pod {
+		return &v1.Pod{
+			Spec: v1.PodSpec{
+				Containers: []v1.Container{{
+					Name: "worker",
+					Resources: v1.ResourceRequirements{
+						Limits: v1.ResourceList{
+							"huawei.com/Ascend910A":        resource.MustParse(deviceCount),
+							"huawei.com/Ascend910A-memory": resource.MustParse(deviceMemory),
+						},
+					},
+				}},
+			},
+		}
+	}
+
+	tests := []struct {
+		name    string
+		devices map[string]*AscendDevice
+		pod     *v1.Pod
+		status  int
+	}{
+		{
+			name: "insufficient device capacity is retryable",
+			devices: map[string]*AscendDevice{
+				"device-1": func() *AscendDevice {
+					device := createTestAscendAllocateDevice("device-1")
+					device.DeviceUsage.Used = 1
+					device.DeviceUsage.Usedmem = 32768
+					return device
+				}(),
+			},
+			pod:    newPod("1", "32768"),
+			status: devices.Unschedulable,
+		},
+		{
+			name:    "missing device inventory is an error",
+			devices: map[string]*AscendDevice{},
+			pod:     newPod("1", "32768"),
+			status:  devices.Error,
+		},
+		{
+			name: "invalid multi-device partial memory request is an error",
+			devices: map[string]*AscendDevice{
+				"device-1": func() *AscendDevice {
+					device := createTestAscendAllocateDevice("device-1")
+					device.config.Templates = []config.Template{{Name: "vir01", Memory: 4096, AICore: 1}}
+					return device
+				}(),
+			},
+			pod:    newPod("2", "4096"),
+			status: devices.Error,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ascendDevices := createTestAscendDevices("node-a", "Ascend910A", test.devices)
+			status, _, err := ascendDevices.FilterNode(test.pod, binpackPolicy)
+
+			assert.Error(t, err)
+			assert.Equal(t, test.status, status)
+		})
+	}
+}
+
 func Test_verifyReq(t *testing.T) {
 	conf, err := yamlStringToConfig(config_yaml)
 	assert.Nil(t, err)
@@ -605,6 +673,26 @@ func TestAscendDevices_AddResource(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func createTestAscendAllocateDevice(id string) *AscendDevice {
+	return &AscendDevice{
+		DeviceInfo: &devices.DeviceInfo{
+			ID:      id,
+			Devcore: 30,
+			Devmem:  32768,
+			Count:   1,
+		},
+		DeviceUsage: &devices.DeviceUsage{},
+		PodMap:      make(map[string]*devices.DeviceUsage),
+		config: config.VNPUConfig{
+			CommonWord:         "Ascend910A",
+			ResourceName:       "huawei.com/Ascend910A",
+			ResourceMemoryName: "huawei.com/Ascend910A-memory",
+			MemoryCapacity:     32768,
+			MemoryAllocatable:  32768,
+		},
 	}
 }
 


### PR DESCRIPTION
#### What this PR does / why we need it:

This backports the HAMi Ascend normal-preemption fix from #5843 to `release-1.15`.

#### Which issue(s) this PR fixes:

Fixes #5864

#### Special notes for your reviewer:

- This is a manual backport of #5843 because the original commit conflicted on `release-1.15`.
- The release branch lacks the test helper available on `master`, so this PR includes the small local helper required by the HAMi test.
- The production changes are limited to `preempt.go` and HAMi `device_info.go`. The remaining changes are regression coverage.

#### Does this PR introduce a user-facing change?

```release-note
Fixes HAMi Ascend normal preemption when lower-priority workload eviction makes sufficient device capacity available.