### PR TITLE
[release-1.15] dra: scale DRA capacity in O(1) to keep large counts from stalling scheduling

### DIFF
--- a/pkg/scheduler/api/job_info.go
+++ b/pkg/scheduler/api/job_info.go
@@ -1497,10 +1497,9 @@ func (ji *JobInfo) GetMinDRAResources() map[string]*DRAResource {
 
 			result[deviceClass].Count = SaturatingAdd(result[deviceClass].Count, SaturatingMul(request.Count, int64(times)))
 			for dim, cap := range request.Capacity {
+				// Add the capacity contributed by the task instances.
 				totalCap := cap.DeepCopy()
-				for i := int32(0); i < times-1; i++ {
-					totalCap.Add(cap)
-				}
+				totalCap.Mul(int64(times))
 
 				if existing, exists := result[deviceClass].Capacity[dim]; exists {
 					existing.Add(totalCap)

--- a/pkg/scheduler/api/job_info_test.go
+++ b/pkg/scheduler/api/job_info_test.go
@@ -21,7 +21,9 @@ limitations under the License.
 package api
 
 import (
+	"math"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
@@ -813,6 +815,40 @@ func TestGetMinDRAResourcesFallbackWithoutTaskMinAvailable(t *testing.T) {
 			Capacity: map[string]resource.Quantity{},
 		},
 	}, job.GetMinDRAResources())
+}
+
+func TestGetMinDRAResources_constantTimeForHugeTaskMinAvailable(t *testing.T) {
+	job := NewJobInfo("test-job")
+	job.TaskMinAvailable["worker"] = math.MaxInt32
+	job.Tasks[TaskID("worker-0")] = &TaskInfo{
+		UID:      TaskID("worker-0"),
+		Name:     "worker-0",
+		TaskRole: "worker",
+		DRAResreq: map[string]*DRAResource{
+			"gpu.com": {
+				Count:    1,
+				Capacity: map[string]resource.Quantity{"memory": resource.MustParse("2Gi")},
+			},
+		},
+	}
+
+	var result map[string]*DRAResource
+	done := make(chan struct{})
+	go func() {
+		result = job.GetMinDRAResources()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("GetMinDRAResources did not return for TaskMinAvailable=MaxInt32 within 5s; the unbounded capacity loop was reintroduced")
+	}
+
+	// MaxInt32 * 2Gi dwarfs 2Gi, so the multiply ran and was not dropped.
+	got := result["gpu.com"].Capacity["memory"]
+	if got.Cmp(resource.MustParse("1Ei")) <= 0 {
+		t.Fatalf("capacity = %s for TaskMinAvailable=MaxInt32; want much greater than 1Ei", got.String())
+	}
 }
 
 func newTaskWithStatus(uid string, status TaskStatus, nodeName string) *TaskInfo {

--- a/pkg/scheduler/cache/cache.go
+++ b/pkg/scheduler/cache/cache.go
@@ -1903,12 +1903,11 @@ func addDRAResource(dst map[string]*schedulingapi.DRAResource, deviceClass strin
 	}
 	dst[deviceClass].Count += count
 	for dim, reqQty := range capacity {
-		totalQty := reqQty.DeepCopy()
-		for i := int64(1); i < count; i++ {
-			totalQty.Add(reqQty)
-		}
+		// Add the capacity contributed by count devices.
+		total := reqQty.DeepCopy()
+		total.Mul(count)
 		capQty := dst[deviceClass].Capacity[dim]
-		capQty.Add(totalQty)
+		capQty.Add(total)
 		dst[deviceClass].Capacity[dim] = capQty
 	}
 }

--- a/pkg/scheduler/cache/cache_test.go
+++ b/pkg/scheduler/cache/cache_test.go
@@ -23,6 +23,7 @@ package cache
 import (
 	"context"
 	"fmt"
+	"math"
 	"reflect"
 	"sync"
 	"testing"
@@ -31,6 +32,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -44,6 +46,34 @@ import (
 	"volcano.sh/volcano/pkg/scheduler/util"
 	schedulercache "volcano.sh/volcano/pkg/schedulercommon/cache"
 )
+
+// addDRAResource computes reqQty*count in O(1), so it returns immediately even at the
+// maximum count and is safe on its own rather than relying on the caller to bound count.
+// Before the O(1) change it looped ~count times (issue #5627) -- centuries for MaxInt64.
+func TestAddDRAResource_constantTimeForHugeCount(t *testing.T) {
+	const dc = "gpu.example.com"
+	m := make(map[string]*api.DRAResource)
+	capacity := map[string]resource.Quantity{"memory": resource.MustParse("2Gi")}
+
+	done := make(chan struct{})
+	go func() {
+		addDRAResource(m, dc, math.MaxInt64, capacity)
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("addDRAResource did not return for count=MaxInt64 within 5s; the unbounded loop was reintroduced")
+	}
+
+	// The scaled capacity must be exact, not dropped or truncated: 2Gi * MaxInt64
+	// is 19807040628566084396238503936. A String round-trip would cap it near
+	// MaxInt64 instead.
+	got := m[dc].Capacity["memory"]
+	if want := resource.MustParse("19807040628566084396238503936"); got.Cmp(want) != 0 {
+		t.Fatalf("capacity = %s for count=MaxInt64; want exact %s", got.AsDec().String(), want.AsDec().String())
+	}
+}
 
 func buildNode(name string, alloc v1.ResourceList) *v1.Node {
 	return &v1.Node{


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
Manual cherry-pick of the O(1) DRA capacity fix (master commit c7fb3fe) to `release-1.15`, as requested by @JesseStutler in #5627.

release-1.15 carries the same DRA capacity accounting (`addDRAResource` in the scheduler cache and `JobInfo.GetMinDRAResources`), so it has the same O(n) scaling: a per-device capacity was multiplied by a tenant-controlled count in an additive loop, so a large count (the ResourceClaim device count or the job min-available) made scheduling spin. This backport applies the identical fix: both paths use `Quantity.Mul` (O(1), which promotes to `inf.Dec` on overflow), and `addDRAResource` also drops the `ParseQuantity(String())` round-trip that truncated large products. It carries the constant-time regression tests for both paths.

The conflict was limited to `job_info_test.go`, where release-1.15 does not have the unrelated main-only tests that surrounded the added test on `master`; the resolution adds only the `math`/`time` imports and `TestGetMinDRAResources_constantTimeForHugeTaskMinAvailable`, nothing else. `go test ./pkg/scheduler/api/... ./pkg/scheduler/cache/...` passes.

#### Which issue(s) this PR fixes:
Backport for #5627 (not using `Fixes`, since #5627 tracks several PRs).

#### Special notes for your reviewer:
Clean cherry-pick of my own master commit c7fb3fe; the only manual step was resolving the `job_info_test.go` context. I will respond to review comments myself.

#### Does this PR introduce a user-facing change?
```release-note
Fixed DRA capacity accounting that scaled a per-device capacity by a tenant-controlled count with an O(n) loop; a large ResourceClaim device count or job min-available could stall the scheduler. Capacity now scales in O(1).
```
