### PR TITLE
scheduler: make updater worker counts configurable

### DIFF
--- a/cmd/scheduler/app/options/options.go
+++ b/cmd/scheduler/app/options/options.go
@@ -51,6 +51,8 @@ const (
 	defaultPercentageOfNodesToFind    = 0
 	defaultLockObjectNamespace        = "volcano-system"
 	defaultNodeWorkers                = 20
+	defaultJobUpdaterWorkerNum        = 16
+	defaultTaskUpdaterWorkerNum       = 16
 )
 
 var (
@@ -98,6 +100,10 @@ type ServerOption struct {
 	CacheDumpFileDir  string
 	EnableCacheDumper bool
 	NodeWorkerThreads uint32
+	// JobUpdaterWorkerNum is the number of workers updating jobs concurrently.
+	JobUpdaterWorkerNum int
+	// TaskUpdaterWorkerNum is the number of workers updating tasks concurrently for each job.
+	TaskUpdaterWorkerNum int
 
 	// GateRemovalWorkerNum is the number of async workers for scheduling gate removal.
 	// Only used when SchedulingGatesQueueAdmission feature gate is enabled.
@@ -127,6 +133,22 @@ type DecryptFunc func(c *ServerOption) error
 
 // ServerOpts server options.
 var ServerOpts *ServerOption
+
+// GetJobUpdaterWorkerNum returns the configured job updater worker number.
+func GetJobUpdaterWorkerNum() int {
+	if ServerOpts == nil || ServerOpts.JobUpdaterWorkerNum <= 0 {
+		return defaultJobUpdaterWorkerNum
+	}
+	return ServerOpts.JobUpdaterWorkerNum
+}
+
+// GetTaskUpdaterWorkerNum returns the configured task updater worker number.
+func GetTaskUpdaterWorkerNum() int {
+	if ServerOpts == nil || ServerOpts.TaskUpdaterWorkerNum <= 0 {
+		return defaultTaskUpdaterWorkerNum
+	}
+	return ServerOpts.TaskUpdaterWorkerNum
+}
 
 // NewServerOption creates a new CMServer with a default config.
 func NewServerOption() *ServerOption {
@@ -179,6 +201,8 @@ func (s *ServerOption) AddFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&s.EnableCacheDumper, "cache-dumper", true, "Enable the cache dumper, it's true by default")
 	fs.StringVar(&s.CacheDumpFileDir, "cache-dump-dir", "/tmp", "The target dir where the json file put at when dump cache info to json file")
 	fs.Uint32Var(&s.NodeWorkerThreads, "node-worker-threads", defaultNodeWorkers, "The number of threads syncing node operations.")
+	fs.IntVar(&s.JobUpdaterWorkerNum, "job-updater-worker-num", defaultJobUpdaterWorkerNum, "The number of workers updating jobs concurrently.")
+	fs.IntVar(&s.TaskUpdaterWorkerNum, "task-updater-worker-num", defaultTaskUpdaterWorkerNum, "The number of workers updating tasks concurrently for each job.")
 	fs.IntVar(&s.GateRemovalWorkerNum, "gate-removal-worker-num", 5, "The number of async workers for scheduling gate removal (used when SchedulingGatesQueueAdmission is enabled).")
 	fs.StringSliceVar(&s.IgnoredCSIProvisioners, "ignored-provisioners", nil, "The provisioners that will be ignored during pod pvc request computation and preemption.")
 	fs.DurationVar(&s.ResourceSyncTimeout, "resource-sync-timeout", defaultResourceSyncTimeout, "timeout on waiting for handler handling initial resources synchronization before starting scheduler, default is 60s, 0 skip waiting")
@@ -187,8 +211,14 @@ func (s *ServerOption) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&s.ShardName, "scheduler-sharding-name", defaultShardName, "The name of shard used for this scheduler")
 }
 
-// CheckOptionOrDie check leader election flag when LeaderElection is enabled.
+// CheckOptionOrDie validates scheduler options.
 func (s *ServerOption) CheckOptionOrDie() error {
+	if s.JobUpdaterWorkerNum <= 0 {
+		return fmt.Errorf("job-updater-worker-num must be greater than 0")
+	}
+	if s.TaskUpdaterWorkerNum <= 0 {
+		return fmt.Errorf("task-updater-worker-num must be greater than 0")
+	}
 	return componentbaseconfigvalidation.ValidateLeaderElectionConfiguration(&s.LeaderElection, field.NewPath("leaderElection")).ToAggregate()
 }
 

--- a/cmd/scheduler/app/options/options_test.go
+++ b/cmd/scheduler/app/options/options_test.go
@@ -83,6 +83,8 @@ func TestAddFlags(t *testing.T) {
 		MinPercentageOfNodesToFind:    defaultMinPercentageOfNodesToFind,
 		PercentageOfNodesToFind:       defaultPercentageOfNodesToFind,
 		NodeWorkerThreads:             defaultNodeWorkers,
+		JobUpdaterWorkerNum:           defaultJobUpdaterWorkerNum,
+		TaskUpdaterWorkerNum:          defaultTaskUpdaterWorkerNum,
 		GateRemovalWorkerNum:          5,
 		CacheDumpFileDir:              "/tmp",
 		DisableDefaultSchedulerConfig: false,
@@ -100,5 +102,62 @@ func TestAddFlags(t *testing.T) {
 	}
 	for k, v := range expectedFeatureGates {
 		assert.Equal(t, v, utilfeature.DefaultFeatureGate.Enabled(k))
+	}
+}
+
+func TestUpdaterWorkerNumFlags(t *testing.T) {
+	originalOpts := ServerOpts
+	t.Cleanup(func() {
+		ServerOpts = originalOpts
+	})
+	ServerOpts = nil
+	assert.Equal(t, defaultJobUpdaterWorkerNum, GetJobUpdaterWorkerNum())
+	assert.Equal(t, defaultTaskUpdaterWorkerNum, GetTaskUpdaterWorkerNum())
+
+	fs := pflag.NewFlagSet("updater-worker-num-test", pflag.ExitOnError)
+	s := NewServerOption()
+	s.AddFlags(fs)
+
+	err := fs.Parse([]string{
+		"--job-updater-worker-num=8",
+		"--task-updater-worker-num=4",
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, 8, s.JobUpdaterWorkerNum)
+	assert.Equal(t, 4, s.TaskUpdaterWorkerNum)
+	ServerOpts = s
+	assert.Equal(t, 8, GetJobUpdaterWorkerNum())
+	assert.Equal(t, 4, GetTaskUpdaterWorkerNum())
+}
+
+func TestCheckOptionOrDieRejectsNonPositiveUpdaterWorkerNum(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr string
+	}{
+		{
+			name:    "zero job updater workers",
+			args:    []string{"--job-updater-worker-num=0"},
+			wantErr: "job-updater-worker-num must be greater than 0",
+		},
+		{
+			name:    "negative task updater workers",
+			args:    []string{"--task-updater-worker-num=-1"},
+			wantErr: "task-updater-worker-num must be greater than 0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fs := pflag.NewFlagSet("updater-worker-num-validation-test", pflag.ExitOnError)
+			s := NewServerOption()
+			s.AddFlags(fs)
+			s.LeaderElection.LeaderElect = false
+
+			err := fs.Parse(tt.args)
+			assert.NoError(t, err)
+			assert.EqualError(t, s.CheckOptionOrDie(), tt.wantErr)
+		})
 	}
 }

--- a/installer/helm/chart/volcano/templates/scheduler.yaml
+++ b/installer/helm/chart/volcano/templates/scheduler.yaml
@@ -229,6 +229,12 @@ spec:
             {{- if .Values.custom.scheduler_node_worker_threads }}
             - --node-worker-threads={{.Values.custom.scheduler_node_worker_threads}}
             {{- end }}
+            {{- if not (kindIs "invalid" .Values.custom.scheduler_job_updater_worker_num) }}
+            - --job-updater-worker-num={{.Values.custom.scheduler_job_updater_worker_num}}
+            {{- end }}
+            {{- if not (kindIs "invalid" .Values.custom.scheduler_task_updater_worker_num) }}
+            - --task-updater-worker-num={{.Values.custom.scheduler_task_updater_worker_num}}
+            {{- end }}
             {{- if ne .Values.custom.scheduler_percentage_nodes_to_find nil }}
             - --percentage-nodes-to-find={{.Values.custom.scheduler_percentage_nodes_to_find}}
             {{- end }}

--- a/installer/helm/chart/volcano/values.yaml
+++ b/installer/helm/chart/volcano/values.yaml
@@ -64,6 +64,8 @@ custom:
   scheduler_kube_api_burst: 2000
   scheduler_schedule_period: 1s
   scheduler_node_worker_threads: 20
+  scheduler_job_updater_worker_num: ~
+  scheduler_task_updater_worker_num: ~
   scheduler_percentage_nodes_to_find: ~
   agent_scheduler_worker_count: 1
   enabled_admissions: "/jobs/mutate,/jobs/validate,/podgroups/validate,/queues/mutate,/queues/validate,/hypernodes/validate,/cronjobs/validate"

--- a/pkg/scheduler/cache/cache.go
+++ b/pkg/scheduler/cache/cache.go
@@ -83,8 +83,6 @@ const (
 	// default interval for sync data from metrics server, the value is 30s
 	defaultMetricsInternal = 30 * time.Second
 
-	taskUpdaterWorker = 16
-
 	handlerSyncPollPeriod = 100 * time.Millisecond
 )
 
@@ -1669,7 +1667,7 @@ func (sc *SchedulerCache) RecordJobStatusEvent(job *schedulingapi.JobInfo, updat
 			taskInfos = append(taskInfos, task)
 		}
 
-		workqueue.ParallelizeUntil(context.TODO(), taskUpdaterWorker, len(taskInfos), func(index int) {
+		workqueue.ParallelizeUntil(context.TODO(), options.GetTaskUpdaterWorkerNum(), len(taskInfos), func(index int) {
 			taskInfo := taskInfos[index]
 
 			// The pod of a scheduling gated task is given

--- a/pkg/scheduler/framework/job_updater.go
+++ b/pkg/scheduler/framework/job_updater.go
@@ -26,11 +26,8 @@ import (
 	"k8s.io/klog/v2"
 
 	"volcano.sh/apis/pkg/apis/scheduling"
+	"volcano.sh/volcano/cmd/scheduler/app/options"
 	"volcano.sh/volcano/pkg/scheduler/api"
-)
-
-const (
-	jobUpdaterWorker = 16
 )
 
 // TimeJitterAfter means: new after old + duration + jitter
@@ -61,7 +58,7 @@ func NewJobUpdater(ssn *Session) *JobUpdater {
 }
 
 func (ju *JobUpdater) UpdateAll() {
-	workqueue.ParallelizeUntil(context.TODO(), jobUpdaterWorker, len(ju.jobQueue), ju.updateJob)
+	workqueue.ParallelizeUntil(context.TODO(), options.GetJobUpdaterWorkerNum(), len(ju.jobQueue), ju.updateJob)
 }
 
 func isPodGroupConditionsUpdated(newCondition, oldCondition []scheduling.PodGroupCondition) bool {


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Makes the scheduler's job and task updater worker counts configurable. Both default to 16, reject non-positive values, and are exposed through Helm.

#### Which issue(s) this PR fixes:

Fixes #5872

#### Special notes for your reviewer:

Validation:

- `go test -count=1 ./cmd/scheduler/... ./pkg/scheduler/framework ./pkg/scheduler/cache ./pkg/scheduler`
- `make verify`
- `helm lint installer/helm/chart/volcano`

Prepared with Codex. Prompt: "Make jobUpdaterWorker and taskUpdaterWorker configurable in vc-scheduler, then create a concise issue and PR."

Volcano workers flow,
Tuned with care from high to low.

#### Does this PR introduce a user-facing change?

```release-note
vc-scheduler supports configurable job and task updater worker counts.
```
