### PR TITLE
networkqos: fix command injection via ifName in tc AddFilter

### DIFF
--- a/pkg/agent/utils/exec/exec.go
+++ b/pkg/agent/utils/exec/exec.go
@@ -28,6 +28,8 @@ import (
 type ExecInterface interface {
 	// CommandContext runs command
 	CommandContext(ctx context.Context, cmd string) (string, error)
+	// CommandContextWithArgs runs command with given name and args without shell
+	CommandContextWithArgs(ctx context.Context, name string, args ...string) (string, error)
 }
 
 var _ ExecInterface = &Executor{}
@@ -54,6 +56,18 @@ func (e *Executor) CommandContext(ctx context.Context, cmd string) (string, erro
 	var outBytes []byte
 	var err error
 	outBytes, err = exec.CommandContext(ctx, "sh", "-c", cmd).CombinedOutput()
+	outputStr := ""
+	if len(outBytes) != 0 {
+		outputStr = string(outBytes)
+	}
+	return outputStr, err
+}
+
+func (e *Executor) CommandContextWithArgs(ctx context.Context, name string, args ...string) (string, error) {
+	if ctx == nil {
+		return "", fmt.Errorf("command failed, nil Context")
+	}
+	outBytes, err := exec.CommandContext(ctx, name, args...).CombinedOutput()
 	outputStr := ""
 	if len(outBytes) != 0 {
 		outputStr = string(outBytes)

--- a/pkg/agent/utils/exec/exec_test.go
+++ b/pkg/agent/utils/exec/exec_test.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2024 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package exec
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// TestCommandContextWithArgs_NoShellInjection ensures CommandContextWithArgs runs
+// the program directly (no "sh -c"), so any shell metacharacters in arguments are
+// treated as literal data and never executed. This is the regression guard for the
+// command-injection sink that previously existed in pkg/networkqos/tc/tc_linux.go
+// where ifName was concatenated into a "sh -c" command string.
+func TestCommandContextWithArgs_NoShellInjection(t *testing.T) {
+	proofDir := t.TempDir()
+	proofFile := filepath.Join(proofDir, "pwned")
+
+	malicious := "eth0;printf PWNED > " + proofFile
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	e := &Executor{}
+	// printf with %s prints the next arg verbatim. Under the old "sh -c" sink the
+	// ";" would terminate the first command and create proofFile. With argv-based
+	// execution the whole malicious string is a single literal argument.
+	out, err := e.CommandContextWithArgs(ctx, "printf", "%s", malicious)
+	if err != nil {
+		t.Fatalf("CommandContextWithArgs failed: %v, output: %s", err, out)
+	}
+	if out != malicious {
+		t.Fatalf("expected literal arg %q in output, got %q", malicious, out)
+	}
+
+	if _, statErr := os.Stat(proofFile); statErr == nil {
+		t.Fatalf("injection regression: proof file %s was created, argv execution was bypassed", proofFile)
+	}
+}

--- a/pkg/agent/utils/exec/mocks/mock_exec.go
+++ b/pkg/agent/utils/exec/mocks/mock_exec.go
@@ -64,3 +64,23 @@ func (mr *MockExecInterfaceMockRecorder) CommandContext(ctx, cmd interface{}) *g
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CommandContext", reflect.TypeOf((*MockExecInterface)(nil).CommandContext), ctx, cmd)
 }
+
+// CommandContextWithArgs mocks base method.
+func (m *MockExecInterface) CommandContextWithArgs(ctx context.Context, name string, args ...string) (string, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{ctx, name}
+	for _, a := range args {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "CommandContextWithArgs", varargs...)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CommandContextWithArgs indicates an expected call of CommandContextWithArgs.
+func (mr *MockExecInterfaceMockRecorder) CommandContextWithArgs(ctx, name interface{}, args ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{ctx, name}, args...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CommandContextWithArgs", reflect.TypeOf((*MockExecInterface)(nil).CommandContextWithArgs), varargs...)
+}

--- a/pkg/networkqos/tc/tc.go
+++ b/pkg/networkqos/tc/tc.go
@@ -18,6 +18,8 @@ package tc
 
 import (
 	"time"
+
+	"volcano.sh/volcano/pkg/networkqos/utils"
 )
 
 const (
@@ -49,4 +51,15 @@ func GetTCCmd() TC {
 
 func SetTcCmd(tc TC) {
 	tcCmd = tc
+}
+
+// buildFilterArgs constructs the argv slice passed to the `tc` binary for
+// attaching the egress bpf filter to ifName. ifName is placed verbatim as a
+// single argv element so that shell metacharacters (when ifName is attacker-
+// controlled via the CNI ifname annotation) are treated as literal characters
+// and never interpreted by a shell. This is the security-critical construction
+// for the command-injection fix at tc_linux.go AddFilter; do NOT replace it
+// with fmt.Sprintf + sh -c.
+func buildFilterArgs(ifName string) []string {
+	return []string{"filter", "add", "dev", ifName, "egress", "bpf", "direct-action", "obj", utils.TCPROGPath, "sec", "tc"}
 }

--- a/pkg/networkqos/tc/tc_linux.go
+++ b/pkg/networkqos/tc/tc_linux.go
@@ -113,12 +113,12 @@ func (t *TCCmd) AddFilter(netns, ifName string) error {
 		}
 		klog.InfoS("Successfully added qdisc", "type", QdiscTypeClsact, "netns", netns, "ifName", ifName)
 
-		filterCmd := fmt.Sprintf("tc filter add dev %s egress bpf direct-action obj %s sec tc", ifName, utils.TCPROGPath)
+		filterArgs := buildFilterArgs(ifName)
 		ctx, cancel := context.WithTimeout(context.Background(), CmdTimeout)
 		defer cancel()
-		output, err := exec.GetExecutor().CommandContext(ctx, filterCmd)
+		output, err := exec.GetExecutor().CommandContextWithArgs(ctx, "tc", filterArgs...)
 		if err != nil {
-			return fmt.Errorf("add dev on ns:ifName(%s:%s) failed : %v, %s, %s", netns, ifName, err, output, filterCmd)
+			return fmt.Errorf("add dev on ns:ifName(%s:%s) failed : %v, %s, %v", netns, ifName, err, output, filterArgs)
 		}
 		klog.InfoS("Successfully added filter", "ebpf-obj", utils.TCPROGPath, "netns", netns, "ifName", ifName)
 		return nil

--- a/pkg/networkqos/tc/tc_test.go
+++ b/pkg/networkqos/tc/tc_test.go
@@ -1,0 +1,100 @@
+/*
+Copyright 2024 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tc
+
+import (
+	"strings"
+	"testing"
+
+	"volcano.sh/volcano/pkg/networkqos/utils"
+)
+
+// TestBuildFilterArgs_IfNamePassedVerbatim is the revert-detection guard for
+// the command-injection fix at tc_linux.go AddFilter. The CVE sink previously
+// concatenated ifName into a "sh -c" string, letting shell metacharacters in an
+// attacker-controlled ifName (via the Multus k8s.v1.cni.cncf.io/ifname
+// annotation) execute arbitrary commands on the node as root. buildFilterArgs
+// must keep ifName as a single literal argv element so no shell ever sees it.
+//
+// If someone reverts the fix back to fmt.Sprintf + CommandContext (sh -c), this
+// test will not by itself fail (it only exercises the pure constructor); but
+// any revert that inlines/drops buildFilterArgs will force deleting this test,
+// making the regression visible at review time.
+func TestBuildFilterArgs_IfNamePassedVerbatim(t *testing.T) {
+	cases := []struct {
+		name   string
+		ifName string
+	}{
+		{"benign", "eth0"},
+		{"semicolon_injection", "eth0;touch /tmp/pwned"},
+		{"short_semicolon", "a;id"},
+		{"command_substitution", "a$(id)"},
+		{"backticks", "a`id`"},
+		{"pipe", "a|cat /etc/shadow"},
+		{"ampersand", "a&rm -rf /"},
+		{"newline", "a\nid"},
+		{"redirect", "a>evil"},
+	}
+
+	wantPrefix := []string{"filter", "add", "dev"}
+	wantSuffix := []string{"egress", "bpf", "direct-action", "obj", utils.TCPROGPath, "sec", "tc"}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			args := buildFilterArgs(tc.ifName)
+
+			// ifName MUST be a single argv element at index 3, byte-identical to input.
+			if len(args) < 4 || args[3] != tc.ifName {
+				t.Fatalf("ifName must be a single literal argv element at index 3: got args=%v", args)
+			}
+
+			// ifName must not be split across multiple argv elements by any shell logic.
+			joined := strings.Join(args, "\x00")
+			if got := strings.Count(joined, tc.ifName); got != 1 {
+				t.Fatalf("ifName should appear exactly once in argv, got %d occurrences in %v", got, args)
+			}
+
+			// Structural shape: prefix + [ifName] + suffix.
+			if len(args) != len(wantPrefix)+1+len(wantSuffix) {
+				t.Fatalf("argv length = %d, want %d: args=%v", len(args), len(wantPrefix)+1+len(wantSuffix), args)
+			}
+			for i, w := range wantPrefix {
+				if args[i] != w {
+					t.Fatalf("args[%d] = %q, want %q", i, args[i], w)
+				}
+			}
+			for i, w := range wantSuffix {
+				if args[len(wantPrefix)+1+i] != w {
+					t.Fatalf("suffix args[%d] = %q, want %q", len(wantPrefix)+1+i, args[len(wantPrefix)+1+i], w)
+				}
+			}
+		})
+	}
+}
+
+// TestBuildFilterArgs_NoShellMetacharInterpolation is a negative proof: the
+// returned argv, when joined with spaces to mimic what a shell would have seen
+// under the OLD sink, must still contain the metacharacters as inert data. This
+// documents that the safety property is "no shell", not "strip metacharacters".
+func TestBuildFilterArgs_NoShellMetacharInterpolation(t *testing.T) {
+	malicious := "eth0;touch /tmp/pwned"
+	args := buildFilterArgs(malicious)
+	// The semicolon must be present as literal data inside args[3], not parsed.
+	if !strings.Contains(args[3], ";") {
+		t.Fatalf("expected ';' to be preserved as literal data in ifName argv element, got %q", args[3])
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

bug

#### What this PR does / why we need it:

`AddFilter` at `pkg/networkqos/tc/tc_linux.go:116` built the `tc filter` command with `fmt.Sprintf` and ran it through `exec.CommandContext`, which dispatches via `sh -c`. `ifName` is attacker-controlled: it flows from CNI `CmdArgs.IfName` (influenceable through the Multus `k8s.v1.cni.cncf.io/ifname` annotation) into `cmdAdd`/`cmdDel`, then into `AddFilter`. A pod setting `ifName` such as `a;id>z` (a valid Linux interface name: ≤15 bytes, no `/` or whitespace) causes the node-side CNI plugin, running as root, to execute arbitrary commands via the injected shell metacharacters.

This PR passes the `tc` invocation as an argv slice to a new `ExecInterface.CommandContextWithArgs`, which calls `exec.CommandContext(ctx, name, args...)` directly with no shell, so `ifName` is always a single literal argv element and shell metacharacters are inert.

#### Which issue(s) this PR fixes:

Fixes #5874

#### Special notes for your reviewer:

- `buildFilterArgs` is extracted as a platform-independent pure function in `tc.go` (no netlink/ns dependency) with a table-driven test (`tc_test.go`) asserting `ifName` is preserved verbatim at argv index 3 across benign and malicious inputs (`;`, `$()`, backticks, pipe, `&`, newline, redirect). This gives the sink a revert guard: any change that inlines the constructor back into `fmt.Sprintf`+`sh -c` forces deleting the pure function and its test, making the regression visible at review. It does not depend on netns/netlink and does not require refactoring the call chain.
- `exec_test.go::TestCommandContextWithArgs_NoShellInjection` is a helper-level regression that asserts `eth0;printf PWNED > <proof>` is echoed verbatim and creates no file.
- `mock_exec.go` is hand-patched for the new variadic method following the gomock v1.6.0 pattern; `mockgen` was unavailable in the dev environment. Please rerun `go generate ./pkg/agent/utils/exec/...` and reconcile if needed.
- The old `CommandContext` (sh -c) interface is retained for other callers; only the CVE sink and the new helper are introduced here.
- Scope is intentionally tight: two adjacent `sh -c` call sites (`pkg/networkqos/networkqos.go` bandwidth values, `cmd/network-qos/tools/prepare.go` check-interval) are NOT changed here because their interpolated values are derived from `strconv.ParseInt`/`strconv.Itoa` with `>0` validation and are always numeric (not remotely injectable). They may be cleaned up in a separate follow-up.

Verified: `go build`, `go vet`, `gofmt -d -s`, `bash hack/verify-gofmt.sh`, and `go test -count=1 ./pkg/agent/utils/exec/... ./pkg/networkqos/tc/...` all pass.

#### Does this PR introduce a user-facing change?

```release-note
Fix command injection via ifName in the network-qos CNI plugin's tc AddFilter by passing the tc invocation as an argv slice without a shell.
```