### PR TITLE
feat: support mixed-depth HyperNode topology trees

### DIFF
--- a/docs/user-guide/how_to_use_hypernode_auto_discovery.md
+++ b/docs/user-guide/how_to_use_hypernode_auto_discovery.md
@@ -95,6 +95,77 @@ data:
       * `topologyA3`: The network topology type of A3(Ascend 910C) cluster. 
         * `nodeLabel`: For the labels on a node, when there are multiple labels, hypernodes are constructed from bottom to top. The bottommost label is kubernetes.io/hostname, which is a standard built-in label key in Kubernetes, and the label above it is volcano.sh/hypernode and volcano.sh/hypercluster, volcano.sh/hypernode indicates which hypernode a node belongs to, volcano.sh/hypercluster indicates which hypercluster a node belongs to.
 
+##### Mixed topology profiles
+
+Clusters that contain multiple topology structures should use the profile form of
+`networkTopologyTypes`. A profile separates the node label used to identify a
+physical network domain (`nodeLabel`) from the semantic boundary exposed to the
+scheduler (`tierName`). A node may match at most one explicit profile; multiple
+explicit matches are rejected. If no explicit profile matches, selector-less
+legacy profiles retain the legacy discovery behavior.
+
+The following configuration generates two independent HyperNode trees with
+different depths. It allows `highestTierName: volcano.sh/hypernode` to select
+the local tier carrying that semantic name in either tree, even though the
+numeric tier differs between the trees:
+
+```yaml
+networkTopologyDiscovery:
+  - source: label
+    enabled: true
+    config:
+      networkTopologyTypes:
+        topologyShallow:
+          nodeSelector:
+            matchLabels:
+              volcano.sh/network-topology-profile: shallow
+          levels:
+            - nodeLabel: volcano.sh/shallow-cluster
+              tierName: volcano.sh/hypercluster
+            - nodeLabel: volcano.sh/shallow-hypernode
+              tierName: volcano.sh/hypernode
+            - nodeLabel: kubernetes.io/hostname
+        topologyDeep:
+          nodeSelector:
+            matchLabels:
+              volcano.sh/network-topology-profile: deep
+          levels:
+            - nodeLabel: volcano.sh/deep-cluster
+              tierName: volcano.sh/hypercluster
+            - nodeLabel: volcano.sh/deep-hypernode
+              tierName: volcano.sh/hypernode
+            - nodeLabel: volcano.sh/deep-superpod
+              tierName: volcano.sh/superpod
+            - nodeLabel: kubernetes.io/hostname
+```
+
+`levels` are declared from the highest network domain to the node level. The
+last entry identifies the node leaf and does not create a HyperNode. The other
+entries are converted to HyperNode tiers from bottom to top, starting at tier 1.
+A profile may contain only one real topology level followed by
+`kubernetes.io/hostname`; this represents a valid single-tier tree and covers
+hardware layouts with one schedulable network boundary without requiring a
+hardware-specific profile type in Volcano.
+
+The discoverer adds `volcano.sh/network-topology-profile` to every generated
+HyperNode and scopes domain identity by profile. Two profiles can therefore use
+the same domain label and value without merging their HyperNodes. If selectors
+overlap, a selected node is missing a configured level, or a child domain maps
+to multiple parents, discovery fails without publishing a partial topology.
+
+The legacy list form remains supported. It treats `nodeLabel` as both the domain
+label and `tierName`, and infers profile membership from the lowest topology
+label. Explicit `nodeSelector` profiles are recommended for mixed clusters.
+
+This configuration creates separate real roots for the shallow and deep
+profiles. The scheduler connects those roots through its in-memory cluster
+root; the controller does not create a virtual-root HyperNode resource.
+
+The legacy list form shown for `topologyA2` and `topologyA3` remains supported
+unchanged. The mixed-depth profile form is generic: profile names, selectors,
+label keys, and tier names are user-defined and do not imply support for a
+particular accelerator product.
+
         *       tier2                     s4                                 s5                         
                                   /               \                   /              \                 
                 tier1           s0                s1                 s2              s3              

--- a/pkg/controllers/hypernode/api/types.go
+++ b/pkg/controllers/hypernode/api/types.go
@@ -21,8 +21,9 @@ import (
 )
 
 const (
-	NetworkTopologySourceLabelKey = "volcano.sh/network-topology-source"
-	DefaultDiscoveryInterval      = time.Hour
+	NetworkTopologySourceLabelKey  = "volcano.sh/network-topology-source"
+	NetworkTopologyProfileLabelKey = "volcano.sh/network-topology-profile"
+	DefaultDiscoveryInterval       = time.Hour
 )
 
 // NetworkTopologyConfig represents the configuration for network topology

--- a/pkg/controllers/hypernode/discovery/label/label.go
+++ b/pkg/controllers/hypernode/discovery/label/label.go
@@ -18,8 +18,10 @@ package label
 
 import (
 	"context"
+	"crypto/sha256"
 	"errors"
 	"fmt"
+	"reflect"
 	"sort"
 	"strings"
 	"time"
@@ -30,7 +32,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/util/rand"
+	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/client-go/informers"
 	infov1 "k8s.io/client-go/informers/core/v1"
 	clientset "k8s.io/client-go/kubernetes"
@@ -50,7 +52,6 @@ import (
 
 const (
 	networkTopologyTypeLength = 20
-	loopCount                 = 20
 )
 
 func init() {
@@ -60,11 +61,28 @@ func init() {
 // NodeLabel represents a label associated with a node in the network topology.
 type NodeLabel struct {
 	NodeLabel string `mapstructure:"nodeLabel"`
+	TierName  string `mapstructure:"tierName"`
 }
 
 // NetworkTopologyType defines the structure that holds different types of network topologies.
 type NetworkTopologyType struct {
-	NetworkTopologyTypes map[string][]NodeLabel `mapstructure:"networkTopologyTypes"`
+	NetworkTopologyTypes map[string]interface{} `mapstructure:"networkTopologyTypes"`
+}
+
+// NetworkTopologyProfile is the extended topology configuration. Levels use
+// node labels to identify domains and tierName to expose a shared semantic
+// boundary to the scheduler.
+type NetworkTopologyProfile struct {
+	NodeSelector *metav1.LabelSelector `mapstructure:"nodeSelector"`
+	Levels       []NodeLabel           `mapstructure:"levels"`
+}
+
+type topologyProfile struct {
+	name               string
+	labelValue         string
+	nodeSelector       labels.Selector
+	selectorConfigured bool
+	levels             []NodeLabel
 }
 
 // HyperNodeInfo contains detailed information about a HyperNode, which is used to describe the hypernode's tier, members, and label attributes.
@@ -77,21 +95,23 @@ type HyperNodeInfo struct {
 
 // labelDiscoverer implements the Discoverer interface for label
 type labelDiscoverer struct {
-	informerFactory       informers.SharedInformerFactory
-	vcInformerFactory     vcinformer.SharedInformerFactory
-	nodeInformer          infov1.NodeInformer
-	hyperNodeInformer     topologyinformerv1alpha1.HyperNodeInformer
-	networkTopologyRecord map[string][]string
-	outputCh              chan []*topologyv1alpha1.HyperNode
-	stopCh                chan struct{}
-	completedCh           chan struct{}
-	queue                 workqueue.TypedRateLimitingInterface[string]
-	hyperNodeLister       topologylisterv1alpha1.HyperNodeLister
-	vcClient              vcclientset.Interface
-	nodeHandler           cache.ResourceEventHandlerRegistration
-	hyperNodeHandler      cache.ResourceEventHandlerRegistration
-	workerDone            chan struct{}
-	started               bool
+	informerFactory      informers.SharedInformerFactory
+	vcInformerFactory    vcinformer.SharedInformerFactory
+	nodeInformer         infov1.NodeInformer
+	hyperNodeInformer    topologyinformerv1alpha1.HyperNodeInformer
+	topologyProfiles     []topologyProfile
+	watchedNodeLabelKeys map[string]struct{}
+	configErr            error
+	outputCh             chan []*topologyv1alpha1.HyperNode
+	stopCh               chan struct{}
+	completedCh          chan struct{}
+	queue                workqueue.TypedRateLimitingInterface[string]
+	hyperNodeLister      topologylisterv1alpha1.HyperNodeLister
+	vcClient             vcclientset.Interface
+	nodeHandler          cache.ResourceEventHandlerRegistration
+	hyperNodeHandler     cache.ResourceEventHandlerRegistration
+	workerDone           chan struct{}
+	started              bool
 }
 
 // hyperNodeNameResolver resolves and reuses HyperNode names within one complete
@@ -118,6 +138,10 @@ func newHyperNodeNameResolver(hyperNodeLister topologylisterv1alpha1.HyperNodeLi
 
 // Start begins the topology discovery process and returns the channel for receiving discovered topology
 func (l *labelDiscoverer) Start() (chan []*topologyv1alpha1.HyperNode, error) {
+	if l.configErr != nil {
+		return nil, l.configErr
+	}
+
 	var err error
 	l.nodeHandler, err = l.nodeInformer.Informer().AddEventHandler(
 		cache.ResourceEventHandlerFuncs{
@@ -201,11 +225,14 @@ func (l *labelDiscoverer) Name() string {
 func NewLabelDiscoverer(cfg api.DiscoveryConfig, kubeClient clientset.Interface, vcClient vcclientset.Interface) api.Discoverer {
 	informerFactory := informers.NewSharedInformerFactory(kubeClient, 0)
 	vcInformerFactory := vcinformer.NewSharedInformerFactory(vcClient, 0)
-	discoverer, _ := newLabelDiscoverer(cfg, api.DiscovererOptions{
+	discoverer, err := newLabelDiscoverer(cfg, api.DiscovererOptions{
 		KubeClient: kubeClient, VolcanoClient: vcClient,
 		NodeInformer:      informerFactory.Core().V1().Nodes(),
 		HyperNodeInformer: vcInformerFactory.Topology().V1alpha1().HyperNodes(),
 	}, informerFactory, vcInformerFactory)
+	if err != nil {
+		return &labelDiscoverer{configErr: err}
+	}
 	return discoverer
 }
 
@@ -215,13 +242,17 @@ func NewLabelDiscovererWithOptions(cfg api.DiscoveryConfig, options api.Discover
 		if options.KubeClient == nil || options.VolcanoClient == nil {
 			return nil, errors.New("label discoverer requires Node and HyperNode informers or Kubernetes and Volcano clients")
 		}
-		return NewLabelDiscoverer(cfg, options.KubeClient, options.VolcanoClient), nil
+		informerFactory := informers.NewSharedInformerFactory(options.KubeClient, 0)
+		vcInformerFactory := vcinformer.NewSharedInformerFactory(options.VolcanoClient, 0)
+		options.NodeInformer = informerFactory.Core().V1().Nodes()
+		options.HyperNodeInformer = vcInformerFactory.Topology().V1alpha1().HyperNodes()
+		return newLabelDiscoverer(cfg, options, informerFactory, vcInformerFactory)
 	}
 	return newLabelDiscoverer(cfg, options, nil, nil)
 }
 
 func newLabelDiscoverer(cfg api.DiscoveryConfig, options api.DiscovererOptions, informerFactory informers.SharedInformerFactory,
-	vcInformerFactory vcinformer.SharedInformerFactory) (api.Discoverer, error) {
+	vcInformerFactory vcinformer.SharedInformerFactory) (*labelDiscoverer, error) {
 	if options.NodeInformer == nil || options.HyperNodeInformer == nil {
 		return nil, errors.New("label discoverer requires Node and HyperNode informers")
 	}
@@ -229,7 +260,10 @@ func newLabelDiscoverer(cfg api.DiscoveryConfig, options api.DiscovererOptions, 
 		return nil, errors.New("label discoverer requires a Volcano client")
 	}
 	// parse config
-	networkTopologyRecord := parseCfg(cfg)
+	topologyProfiles, watchedNodeLabelKeys, err := parseCfg(cfg)
+	if err != nil {
+		return nil, err
+	}
 
 	// Create the output channel that this discoverer will manage
 	outputCh := make(chan []*topologyv1alpha1.HyperNode)
@@ -241,58 +275,150 @@ func newLabelDiscoverer(cfg api.DiscoveryConfig, options api.DiscovererOptions, 
 	queue := workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[string]())
 
 	return &labelDiscoverer{
-		informerFactory:       informerFactory,
-		vcInformerFactory:     vcInformerFactory,
-		nodeInformer:          nodeInformer,
-		hyperNodeInformer:     hyperNodeInformer,
-		networkTopologyRecord: networkTopologyRecord,
-		outputCh:              outputCh,
-		stopCh:                stopCh,
-		completedCh:           completedCh,
-		workerDone:            make(chan struct{}),
-		queue:                 queue,
-		hyperNodeLister:       hyperNodeInformer.Lister(),
-		vcClient:              options.VolcanoClient,
+		informerFactory:      informerFactory,
+		nodeInformer:         nodeInformer,
+		vcInformerFactory:    vcInformerFactory,
+		hyperNodeInformer:    hyperNodeInformer,
+		topologyProfiles:     topologyProfiles,
+		watchedNodeLabelKeys: watchedNodeLabelKeys,
+		outputCh:             outputCh,
+		stopCh:               stopCh,
+		completedCh:          completedCh,
+		workerDone:           make(chan struct{}),
+		queue:                queue,
+		hyperNodeLister:      hyperNodeInformer.Lister(),
+		vcClient:             options.VolcanoClient,
 	}, nil
 }
 
-// parseCfg Parse the ConfigMap and read the topology information.
-func parseCfg(cfg api.DiscoveryConfig) map[string][]string {
+// parseCfg parses legacy topology lists and extended topology profiles.
+func parseCfg(cfg api.DiscoveryConfig) ([]topologyProfile, map[string]struct{}, error) {
 	klog.InfoS("Start parse label based hyperNode auto discovery config")
 
-	networkTopologyRecord := make(map[string][]string)
-
 	var config NetworkTopologyType
-
-	if err := mapstructure.WeakDecode(cfg.Config, &config); err != nil {
-		klog.Errorf("Cannot get networkTopologyTypes, %s %T, error is %v", cfg.Config, cfg.Config, err)
-		return networkTopologyRecord
+	if err := strictWeakDecode(cfg.Config, &config); err != nil {
+		return nil, nil, fmt.Errorf("decode networkTopologyTypes: %w", err)
+	}
+	if len(config.NetworkTopologyTypes) == 0 {
+		return nil, nil, errors.New("networkTopologyTypes must contain at least one topology profile")
 	}
 
-	for name, labels := range config.NetworkTopologyTypes {
+	names := make([]string, 0, len(config.NetworkTopologyTypes))
+	for name := range config.NetworkTopologyTypes {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	profiles := make([]topologyProfile, 0, len(names))
+	watchedNodeLabelKeys := make(map[string]struct{})
+	profileByLabelValue := make(map[string]string)
+	for _, name := range names {
 		if len(name) > networkTopologyTypeLength {
-			klog.Errorf("The length of topologyTypeName exceeds 20. topologyTypeName is %s", name)
-			continue
+			return nil, nil, fmt.Errorf("topology profile name %q exceeds %d characters", name, networkTopologyTypeLength)
 		}
 
-		if err := checkLabels(labels); err != nil {
-			klog.Errorf("The configMap format is incorrect, label is %v, error is %v", labels, err)
-			continue
+		rawProfile := config.NetworkTopologyTypes[name]
+		profileConfig := NetworkTopologyProfile{}
+		legacyConfig := reflect.ValueOf(rawProfile).IsValid() && reflect.ValueOf(rawProfile).Kind() == reflect.Slice
+		if legacyConfig {
+			if err := strictWeakDecode(rawProfile, &profileConfig.Levels); err != nil {
+				return nil, nil, fmt.Errorf("decode legacy topology profile %q: %w", name, err)
+			}
+		} else if err := strictWeakDecode(rawProfile, &profileConfig); err != nil {
+			return nil, nil, fmt.Errorf("decode topology profile %q: %w", name, err)
 		}
-		networkTopologyRecord[name] = make([]string, 0)
+
+		if err := checkLabels(profileConfig.Levels); err != nil {
+			return nil, nil, fmt.Errorf("invalid topology profile %q: %w", name, err)
+		}
+		if len(profileConfig.Levels) < 2 {
+			return nil, nil, fmt.Errorf("invalid topology profile %q: at least one topology level and one node level are required", name)
+		}
+		leafLevel := profileConfig.Levels[len(profileConfig.Levels)-1]
+		if leafLevel.NodeLabel != v1.LabelHostname {
+			return nil, nil, fmt.Errorf("invalid topology profile %q: last level must use nodeLabel %q", name, v1.LabelHostname)
+		}
+		if leafLevel.TierName != "" {
+			return nil, nil, fmt.Errorf("invalid topology profile %q: node leaf level must not set tierName", name)
+		}
+
+		selector := labels.Everything()
+		if profileConfig.NodeSelector != nil {
+			var err error
+			selector, err = metav1.LabelSelectorAsSelector(profileConfig.NodeSelector)
+			if err != nil {
+				return nil, nil, fmt.Errorf("invalid nodeSelector for topology profile %q: %w", name, err)
+			}
+			for key := range profileConfig.NodeSelector.MatchLabels {
+				watchedNodeLabelKeys[key] = struct{}{}
+			}
+			for _, expression := range profileConfig.NodeSelector.MatchExpressions {
+				watchedNodeLabelKeys[expression.Key] = struct{}{}
+			}
+		}
+
+		levels := make([]NodeLabel, 0, len(profileConfig.Levels)-1)
+		seenTierNames := make(map[string]struct{})
 		// kubernetes.io/hostname refers to a node label, not a hypernode label. This level of label needs to be removed during traversal.
-		for i := len(labels) - 2; i >= 0; i-- {
-			networkTopologyRecord[name] = append(networkTopologyRecord[name], labels[i].NodeLabel)
+		for i := len(profileConfig.Levels) - 2; i >= 0; i-- {
+			level := profileConfig.Levels[i]
+			if level.TierName == "" {
+				level.TierName = level.NodeLabel
+			}
+			if _, exists := seenTierNames[level.TierName]; exists {
+				return nil, nil, fmt.Errorf("invalid topology profile %q: duplicate tierName %q", name, level.TierName)
+			}
+			seenTierNames[level.TierName] = struct{}{}
+			levels = append(levels, level)
+			watchedNodeLabelKeys[level.NodeLabel] = struct{}{}
 		}
-	}
-	klog.InfoS("Successfully parsed label based hyperNode auto discovery config", "networkTopologyRecord", networkTopologyRecord)
 
-	return networkTopologyRecord
+		labelValue := strings.Trim(cleanString(name), ".-")
+		if labelValue == "" {
+			return nil, nil, fmt.Errorf("topology profile name %q cannot be normalized to a label value", name)
+		}
+		if validationErrors := validation.IsValidLabelValue(labelValue); len(validationErrors) > 0 {
+			return nil, nil, fmt.Errorf("topology profile name %q has invalid normalized label value %q: %s", name, labelValue, strings.Join(validationErrors, "; "))
+		}
+		if existingName, exists := profileByLabelValue[labelValue]; exists {
+			return nil, nil, fmt.Errorf("topology profile names %q and %q normalize to the same label value %q", existingName, name, labelValue)
+		}
+		profileByLabelValue[labelValue] = name
+		profiles = append(profiles, topologyProfile{
+			name:               name,
+			labelValue:         labelValue,
+			nodeSelector:       selector,
+			selectorConfigured: profileConfig.NodeSelector != nil,
+			levels:             levels,
+		})
+	}
+	klog.InfoS("Successfully parsed label based hyperNode auto discovery config", "profileCount", len(profiles))
+
+	return profiles, watchedNodeLabelKeys, nil
+}
+
+func strictWeakDecode(input, output interface{}) error {
+	decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
+		ErrorUnused:      true,
+		WeaklyTypedInput: true,
+		ZeroFields:       true,
+		Result:           output,
+	})
+	if err != nil {
+		return err
+	}
+	return decoder.Decode(input)
 }
 
 func checkLabels(labels []NodeLabel) error {
 	seen := make(map[string]bool)
 	for _, label := range labels {
+		if label.NodeLabel == "" {
+			return errors.New("nodeLabel cannot be empty")
+		}
+		if validationErrors := validation.IsQualifiedName(label.NodeLabel); len(validationErrors) > 0 {
+			return fmt.Errorf("nodeLabel %q is not a valid qualified name: %s", label.NodeLabel, strings.Join(validationErrors, "; "))
+		}
 		if _, exist := seen[label.NodeLabel]; !exist {
 			seen[label.NodeLabel] = true
 			continue
@@ -311,6 +437,7 @@ func (l *labelDiscoverer) work() {
 			return
 		}
 
+		discoverySucceeded := false
 		func() {
 			defer l.queue.Done(key)
 			if err := l.discovery(); err != nil {
@@ -320,7 +447,11 @@ func (l *labelDiscoverer) work() {
 			}
 
 			l.queue.Forget(key)
+			discoverySucceeded = true
 		}()
+		if !discoverySucceeded {
+			continue
+		}
 		select {
 		case <-l.completedCh:
 		case <-l.stopCh:
@@ -347,7 +478,7 @@ func (l *labelDiscoverer) discovery() error {
 	// create HyperNodes
 	hyperNodes := l.buildHyperNodes(hyperNodeInfoMap)
 
-	// Send discovered nodes through the channel
+	// Send discovered nodes through the channel unless shutdown has started.
 	select {
 	case l.outputCh <- hyperNodes:
 	case <-l.stopCh:
@@ -438,12 +569,10 @@ func (l *labelDiscoverer) getNodeNetworkTopologyLabels(obj interface{}) map[stri
 		return tempMap
 	}
 	labelMap := node.Labels
-	for _, labelKey := range l.networkTopologyRecord {
-		for _, key := range labelKey {
-			value, exist := labelMap[key]
-			if exist {
-				tempMap[key] = value
-			}
+	for key := range l.watchedNodeLabelKeys {
+		value, exist := labelMap[key]
+		if exist {
+			tempMap[key] = value
 		}
 	}
 	return tempMap
@@ -466,8 +595,15 @@ func (l *labelDiscoverer) generateHyperNodeInfo() (map[string]HyperNodeInfo, err
 	// Record the hyperNode and its info.
 	hyperNodeInfoMap := make(map[string]HyperNodeInfo)
 
-	// Record the label and hyperNodeName.
-	labelHyperNodeMap := make(map[string]map[string]string)
+	// Domain identity is profile-scoped. Two profiles may intentionally use
+	// the same node label and value while representing independent networks.
+	type domainKey struct {
+		profile   string
+		nodeLabel string
+		value     string
+	}
+	domainHyperNodeMap := make(map[domainKey]string)
+	parentByHyperNode := make(map[string]string)
 	nameResolver := newHyperNodeNameResolver(l.hyperNodeLister, l.vcClient)
 
 	// Get all node
@@ -477,57 +613,113 @@ func (l *labelDiscoverer) generateHyperNodeInfo() (map[string]HyperNodeInfo, err
 		return hyperNodeInfoMap, err
 	}
 
+	sort.Slice(list, func(i, j int) bool {
+		return list[i].Name < list[j].Name
+	})
 	for _, node := range list {
 		labelMap := node.Labels
-		for topologyTypeName, labelKey := range l.networkTopologyRecord {
+		profiles, err := l.profilesForNode(node)
+		if err != nil {
+			return hyperNodeInfoMap, err
+		}
+		if len(profiles) == 0 {
+			continue
+		}
+
+		for _, profile := range profiles {
 			memberName := node.Name
-			for i, key := range labelKey {
-				value, exists := labelMap[key]
+			for i, level := range profile.levels {
+				value, exists := labelMap[level.NodeLabel]
 				if !exists {
-					klog.V(5).Info("The label does not exist in the node")
+					if profile.selectorConfigured {
+						return hyperNodeInfoMap, fmt.Errorf("node %s selected by topology profile %s is missing level label %s", node.Name, profile.name, level.NodeLabel)
+					}
+					klog.V(5).InfoS("Topology level label does not exist on node", "node", node.Name, "profile", profile.name, "label", level.NodeLabel)
 					break
 				}
+
 				tier := i + 1
-				hyperNodeName, exists := getHyperNodeCached(labelHyperNodeMap, key, value)
+				cacheKey := domainKey{profile: profile.name, nodeLabel: level.NodeLabel, value: value}
+				hyperNodeName, exists := domainHyperNodeMap[cacheKey]
 				if !exists {
-					// Construct hyperNodeName
-					hyperNodeName, err = nameResolver.buildHyperNodeName(topologyTypeName, key, value, tier, hyperNodeInfoMap)
+					hyperNodeName, err = nameResolver.buildHyperNodeName(*profile, level.NodeLabel, value, tier, hyperNodeInfoMap)
 					if err != nil {
-						klog.Errorf("Failed to build hyperNode resources, error is %v", err.Error())
-						return hyperNodeInfoMap, err
+						return hyperNodeInfoMap, fmt.Errorf("build HyperNode for profile %s: %w", profile.name, err)
 					}
+					domainHyperNodeMap[cacheKey] = hyperNodeName
 				}
 
-				// Record the members of the hyperNode
-				_, exists = hyperNodeInfoMap[hyperNodeName]
+				hyperNodeInfo, exists := hyperNodeInfoMap[hyperNodeName]
 				if !exists {
-					hyperNodeInfoMap[hyperNodeName] = HyperNodeInfo{
+					hyperNodeInfo = HyperNodeInfo{
 						tier:     tier,
-						tierName: key,
+						tierName: level.TierName,
 						members:  make([]string, 0),
-						labels:   map[string]string{key: value},
+						labels: map[string]string{
+							api.NetworkTopologyProfileLabelKey: profile.labelValue,
+							level.NodeLabel:                    value,
+						},
 					}
 				}
-				hyperNodeInfo := hyperNodeInfoMap[hyperNodeName]
+				if tier > 1 {
+					if existingParent, exists := parentByHyperNode[memberName]; exists && existingParent != hyperNodeName {
+						return hyperNodeInfoMap, fmt.Errorf("HyperNode %s in profile %s belongs to multiple parents: %s and %s", memberName, profile.name, existingParent, hyperNodeName)
+					}
+					parentByHyperNode[memberName] = hyperNodeName
+				}
 				hyperNodeInfo.members = append(hyperNodeInfo.members, memberName)
 				hyperNodeInfoMap[hyperNodeName] = hyperNodeInfo
-
-				// Record the label and hyperNodeName.
-				if _, exists := labelHyperNodeMap[key]; exists {
-					labelHyperNodeMap[key][value] = hyperNodeName
-				} else {
-					labelHyperNodeMap[key] = map[string]string{
-						value: hyperNodeName,
-					}
-				}
 				memberName = hyperNodeName
 			}
 		}
 	}
-	return hyperNodeInfoMap, err
+	return hyperNodeInfoMap, nil
 }
 
-func (r *hyperNodeNameResolver) buildHyperNodeName(topologyTypeName, key, value string, tier int, hyperNodeInfoMap map[string]HyperNodeInfo) (string, error) {
+// profilesForNode gives explicit selectors ownership of a Node. If no
+// explicit selector matches, every matching selector-less legacy topology is
+// returned so the pre-profile multi-topology traversal remains compatible.
+func (l *labelDiscoverer) profilesForNode(node *v1.Node) ([]*topologyProfile, error) {
+	var explicitMatch *topologyProfile
+	legacyMatches := make([]*topologyProfile, 0)
+	for i := range l.topologyProfiles {
+		profile := &l.topologyProfiles[i]
+		if !profile.nodeSelector.Matches(labels.Set(node.Labels)) {
+			continue
+		}
+		if profile.selectorConfigured {
+			if explicitMatch != nil {
+				return nil, fmt.Errorf("node %s matches multiple topology profiles: %s and %s", node.Name, explicitMatch.name, profile.name)
+			}
+			explicitMatch = profile
+			continue
+		}
+
+		// Legacy profiles have no selector. Preserve their partial-level
+		// behavior while requiring at least the first topology label before
+		// treating the node as a profile member.
+		if len(profile.levels) == 0 {
+			continue
+		}
+		if _, exists := node.Labels[profile.levels[0].NodeLabel]; !exists {
+			continue
+		}
+		legacyMatches = append(legacyMatches, profile)
+	}
+	if explicitMatch != nil {
+		return []*topologyProfile{explicitMatch}, nil
+	}
+	return legacyMatches, nil
+}
+
+func (l *labelDiscoverer) buildHyperNodeName(profile topologyProfile, key, value string, tier int,
+	hyperNodeInfoMap map[string]HyperNodeInfo) (string, error) {
+	return newHyperNodeNameResolver(l.hyperNodeLister, l.vcClient).
+		buildHyperNodeName(profile, key, value, tier, hyperNodeInfoMap)
+}
+
+func (r *hyperNodeNameResolver) buildHyperNodeName(profile topologyProfile, key, value string, tier int,
+	hyperNodeInfoMap map[string]HyperNodeInfo) (string, error) {
 	selector := labels.SelectorFromSet(labels.Set{
 		key:                               value,
 		api.NetworkTopologySourceLabelKey: "label",
@@ -537,16 +729,16 @@ func (r *hyperNodeNameResolver) buildHyperNodeName(topologyTypeName, key, value 
 		klog.Errorf("Failed to list existing hyperNode resources, error is %v", err.Error())
 		return "", err
 	}
-	topologyTypeName = cleanString(topologyTypeName)
+	topologyTypeName := cleanString(profile.name)
 	targetName := fmt.Sprintf("hypernode-%s-tier%d", topologyTypeName, tier)
-	if name, found := findExistingHyperNodeName(list, targetName); found {
+	if name, found := findExistingHyperNodeName(list, profile, targetName); found {
 		return name, nil
 	}
 
 	// An API write can complete before the shared informer observes it. Confirm
-	// the cache miss against the API before generating another random name for
-	// the same logical topology. A resolver loads at most one live snapshot per
-	// discovery round, even when the topology contains many HyperNodes.
+	// the cache miss against the API before generating the deterministic name.
+	// This is also required to reuse a legacy random-suffix object during an
+	// upgrade instead of publishing a second object for the same Profile domain.
 	liveHyperNodes, err := r.getLiveHyperNodes()
 	if err != nil {
 		return "", err
@@ -557,30 +749,26 @@ func (r *hyperNodeNameResolver) buildHyperNodeName(topologyTypeName, key, value 
 			matchingLiveHyperNodes = append(matchingLiveHyperNodes, hyperNode)
 		}
 	}
-	if name, found := findExistingHyperNodeName(matchingLiveHyperNodes, targetName); found {
+	if name, found := findExistingHyperNodeName(matchingLiveHyperNodes, profile, targetName); found {
 		return name, nil
 	}
 
-	for i := 0; i < loopCount; i++ {
-		randomSuffix := rand.String(5)
-		hyperNodeName := fmt.Sprintf("hypernode-%s-tier%d-%s", topologyTypeName, tier, randomSuffix)
-		_, err := r.hyperNodeLister.Get(hyperNodeName)
-		if err == nil {
-			continue
-		}
-		if !apierrors.IsNotFound(err) {
-			return "", err
-		}
-		if _, exists := r.liveHyperNodeNames[hyperNodeName]; exists {
-			continue
-		}
-		_, exists := hyperNodeInfoMap[hyperNodeName]
-		if !exists {
-			return hyperNodeName, nil
-		}
+	domainHash := sha256.Sum256([]byte(profile.name + "\x00" + key + "\x00" + value))
+	hyperNodeName := fmt.Sprintf("hypernode-%s-tier%d-%x", topologyTypeName, tier, domainHash[:6])
+	_, err = r.hyperNodeLister.Get(hyperNodeName)
+	if err == nil {
+		return "", fmt.Errorf("deterministic HyperNode name %s is already used by a different topology domain", hyperNodeName)
 	}
-	klog.Errorf("unable to get unique hyperNodeName after %d attempts", loopCount)
-	return "", fmt.Errorf("unable to get unique hyperNodeName after %d attempts", loopCount)
+	if !apierrors.IsNotFound(err) {
+		return "", err
+	}
+	if _, exists := r.liveHyperNodeNames[hyperNodeName]; exists {
+		return "", fmt.Errorf("deterministic HyperNode name %s is already used by a different topology domain", hyperNodeName)
+	}
+	if _, exists := hyperNodeInfoMap[hyperNodeName]; exists {
+		return "", fmt.Errorf("deterministic HyperNode name collision for %s", hyperNodeName)
+	}
+	return hyperNodeName, nil
 }
 
 func (r *hyperNodeNameResolver) getLiveHyperNodes() ([]*topologyv1alpha1.HyperNode, error) {
@@ -603,9 +791,13 @@ func (r *hyperNodeNameResolver) getLiveHyperNodes() ([]*topologyv1alpha1.HyperNo
 	return r.liveHyperNodes, nil
 }
 
-func findExistingHyperNodeName(hyperNodes []*topologyv1alpha1.HyperNode, targetName string) (string, bool) {
+func findExistingHyperNodeName(hyperNodes []*topologyv1alpha1.HyperNode, profile topologyProfile,
+	targetName string) (string, bool) {
 	matchingNames := make([]string, 0, len(hyperNodes))
 	for _, hyperNode := range hyperNodes {
+		if existingProfile, exists := hyperNode.Labels[api.NetworkTopologyProfileLabelKey]; exists && existingProfile != profile.labelValue {
+			continue
+		}
 		if strings.HasPrefix(hyperNode.Name, targetName) {
 			matchingNames = append(matchingNames, hyperNode.Name)
 		}
@@ -650,13 +842,4 @@ func removeDuplicates(memberList []string) []string {
 		result = append(result, k)
 	}
 	return result
-}
-
-func getHyperNodeCached(labelHyperNodeMap map[string]map[string]string, key, value string) (string, bool) {
-	if valueMap, exists := labelHyperNodeMap[key]; exists {
-		if name, exists := valueMap[value]; exists {
-			return name, true
-		}
-	}
-	return "", false
 }

--- a/pkg/controllers/hypernode/discovery/label/label_test.go
+++ b/pkg/controllers/hypernode/discovery/label/label_test.go
@@ -19,10 +19,13 @@ package label
 import (
 	"context"
 	"errors"
+	"sort"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v2"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -141,7 +144,6 @@ func TestNewLabelDiscovererWithOptionsFallsBackToDedicatedInformers(t *testing.T
 
 func TestBuildHyperNodeNameFallsBackToAPIWhenInformerCacheIsStale(t *testing.T) {
 	const (
-		topologyType  = "e2e-rack-topology"
 		topologyLabel = "volcano.sh/e2e-hypernode-rack"
 		topologyValue = "rack-a"
 		existingName  = "hypernode-e2e-rack-topology-tier1-abcde"
@@ -150,29 +152,40 @@ func TestBuildHyperNodeNameFallsBackToAPIWhenInformerCacheIsStale(t *testing.T) 
 		api.NetworkTopologySourceLabelKey: "label",
 		topologyLabel:                     topologyValue,
 	})
+	cfg := api.DiscoveryConfig{Source: "label", Config: map[string]interface{}{
+		"networkTopologyTypes": map[string]interface{}{
+			"e2e-rack-topology": map[string]interface{}{
+				"levels": []interface{}{
+					map[string]interface{}{"nodeLabel": topologyLabel, "tierName": "volcano.sh/hypernode"},
+					map[string]interface{}{"nodeLabel": corev1.LabelHostname},
+				},
+			},
+		},
+	}}
 	kubeClient := fake.NewSimpleClientset()
 	fakeVcClient := vcclientset.NewSimpleClientset(existing)
 	informerFactory := informers.NewSharedInformerFactory(kubeClient, 0)
 	vcInformerFactory := vcinformer.NewSharedInformerFactory(fakeVcClient, 0)
 	hyperNodeInformer := vcInformerFactory.Topology().V1alpha1().HyperNodes()
 
-	discoverer, err := NewLabelDiscovererWithOptions(getCfg(), api.DiscovererOptions{
+	discoverer, err := NewLabelDiscovererWithOptions(cfg, api.DiscovererOptions{
 		KubeClient:        kubeClient,
 		VolcanoClient:     fakeVcClient,
 		NodeInformer:      informerFactory.Core().V1().Nodes(),
 		HyperNodeInformer: hyperNodeInformer,
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	labelDiscoverer := discoverer.(*labelDiscoverer)
 	resolver := newHyperNodeNameResolver(labelDiscoverer.hyperNodeLister, labelDiscoverer.vcClient)
 
 	// Keep the informer stopped so its cache does not contain the API object.
 	cached, err := hyperNodeInformer.Lister().List(labels.Everything())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Empty(t, cached)
 
-	name, err := resolver.buildHyperNodeName(topologyType, topologyLabel, topologyValue, 1, map[string]HyperNodeInfo{})
-	assert.NoError(t, err)
+	name, err := resolver.buildHyperNodeName(
+		labelDiscoverer.topologyProfiles[0], topologyLabel, topologyValue, 1, map[string]HyperNodeInfo{})
+	require.NoError(t, err)
 	assert.Equal(t, existingName, name)
 }
 
@@ -187,14 +200,15 @@ func TestHyperNodeNameResolverLoadsLiveSnapshotOnceWithoutPerNameGets(t *testing
 		NodeInformer:      informerFactory.Core().V1().Nodes(),
 		HyperNodeInformer: vcInformerFactory.Topology().V1alpha1().HyperNodes(),
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	labelDiscoverer := discoverer.(*labelDiscoverer)
 	resolver := newHyperNodeNameResolver(labelDiscoverer.hyperNodeLister, labelDiscoverer.vcClient)
+	profile := labelDiscoverer.topologyProfiles[0]
 
-	_, err = resolver.buildHyperNodeName("topology-a", "volcano.sh/rack", "rack-a", 1, map[string]HyperNodeInfo{})
-	assert.NoError(t, err)
-	_, err = resolver.buildHyperNodeName("topology-a", "volcano.sh/rack", "rack-b", 1, map[string]HyperNodeInfo{})
-	assert.NoError(t, err)
+	_, err = resolver.buildHyperNodeName(profile, "volcano.sh/rack", "rack-a", 1, map[string]HyperNodeInfo{})
+	require.NoError(t, err)
+	_, err = resolver.buildHyperNodeName(profile, "volcano.sh/rack", "rack-b", 1, map[string]HyperNodeInfo{})
+	require.NoError(t, err)
 
 	listCount := 0
 	getCount := 0
@@ -224,13 +238,99 @@ func TestBuildHyperNodeNameReturnsLiveLookupError(t *testing.T) {
 		NodeInformer:      informerFactory.Core().V1().Nodes(),
 		HyperNodeInformer: vcInformerFactory.Topology().V1alpha1().HyperNodes(),
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	labelDiscoverer := discoverer.(*labelDiscoverer)
 	resolver := newHyperNodeNameResolver(labelDiscoverer.hyperNodeLister, labelDiscoverer.vcClient)
 	_, err = resolver.buildHyperNodeName(
-		"topology-a", "volcano.sh/rack", "rack-a", 1, map[string]HyperNodeInfo{})
+		labelDiscoverer.topologyProfiles[0], "volcano.sh/rack", "rack-a", 1, map[string]HyperNodeInfo{})
 	assert.ErrorContains(t, err, "failed to confirm existing HyperNodes from API")
+}
+
+func TestBuildHyperNodeNameLiveSnapshotPreservesProfileIsolation(t *testing.T) {
+	const (
+		domainKey      = "example.com/hypernode-domain"
+		domainValue    = "hn-0"
+		existingName   = "hypernode-topology-b-tier1-abcde"
+		foreignProfile = "topology-a"
+	)
+	cfg := api.DiscoveryConfig{Source: "label", Config: map[string]interface{}{
+		"networkTopologyTypes": map[string]interface{}{
+			"topology-b": map[string]interface{}{
+				"levels": []interface{}{
+					map[string]interface{}{"nodeLabel": domainKey, "tierName": "volcano.sh/hypernode"},
+					map[string]interface{}{"nodeLabel": corev1.LabelHostname},
+				},
+			},
+		},
+	}}
+	existing := utils.BuildHyperNodeWithTierName(existingName, 1, domainKey, nil, map[string]string{
+		api.NetworkTopologySourceLabelKey:  "label",
+		api.NetworkTopologyProfileLabelKey: foreignProfile,
+		domainKey:                          domainValue,
+	})
+	kubeClient := fake.NewSimpleClientset()
+	fakeVcClient := vcclientset.NewSimpleClientset(existing)
+	informerFactory := informers.NewSharedInformerFactory(kubeClient, 0)
+	vcInformerFactory := vcinformer.NewSharedInformerFactory(fakeVcClient, 0)
+	discoverer, err := NewLabelDiscovererWithOptions(cfg, api.DiscovererOptions{
+		KubeClient:        kubeClient,
+		VolcanoClient:     fakeVcClient,
+		NodeInformer:      informerFactory.Core().V1().Nodes(),
+		HyperNodeInformer: vcInformerFactory.Topology().V1alpha1().HyperNodes(),
+	})
+	require.NoError(t, err)
+	labelDiscoverer := discoverer.(*labelDiscoverer)
+	resolver := newHyperNodeNameResolver(labelDiscoverer.hyperNodeLister, labelDiscoverer.vcClient)
+
+	name, err := resolver.buildHyperNodeName(
+		labelDiscoverer.topologyProfiles[0], domainKey, domainValue, 1, map[string]HyperNodeInfo{})
+	require.NoError(t, err)
+	assert.NotEqual(t, existingName, name)
+	assert.Contains(t, name, "hypernode-topology-b-tier1-")
+}
+
+func TestBuildHyperNodeNameRejectsLiveDeterministicNameConflict(t *testing.T) {
+	const domainKey = "example.com/hypernode-domain"
+	cfg := api.DiscoveryConfig{Source: "label", Config: map[string]interface{}{
+		"networkTopologyTypes": map[string]interface{}{
+			"topologyshallow": map[string]interface{}{
+				"levels": []interface{}{
+					map[string]interface{}{"nodeLabel": domainKey, "tierName": "volcano.sh/hypernode"},
+					map[string]interface{}{"nodeLabel": corev1.LabelHostname},
+				},
+			},
+		},
+	}}
+	kubeClient := fake.NewSimpleClientset()
+	fakeVcClient := vcclientset.NewSimpleClientset()
+	informerFactory := informers.NewSharedInformerFactory(kubeClient, 0)
+	vcInformerFactory := vcinformer.NewSharedInformerFactory(fakeVcClient, 0)
+	discoverer, err := NewLabelDiscovererWithOptions(cfg, api.DiscovererOptions{
+		KubeClient:        kubeClient,
+		VolcanoClient:     fakeVcClient,
+		NodeInformer:      informerFactory.Core().V1().Nodes(),
+		HyperNodeInformer: vcInformerFactory.Topology().V1alpha1().HyperNodes(),
+	})
+	require.NoError(t, err)
+	labelDiscoverer := discoverer.(*labelDiscoverer)
+	profile := labelDiscoverer.topologyProfiles[0]
+
+	name, err := newHyperNodeNameResolver(labelDiscoverer.hyperNodeLister, labelDiscoverer.vcClient).
+		buildHyperNodeName(profile, domainKey, "hn-0", 1, map[string]HyperNodeInfo{})
+	require.NoError(t, err)
+	_, err = fakeVcClient.TopologyV1alpha1().HyperNodes().Create(context.Background(), &topologyv1alpha1.HyperNode{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Labels: map[string]string{
+			api.NetworkTopologySourceLabelKey:  "label",
+			api.NetworkTopologyProfileLabelKey: "different-profile",
+			domainKey:                          "different-domain",
+		}},
+	}, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	_, err = newHyperNodeNameResolver(labelDiscoverer.hyperNodeLister, labelDiscoverer.vcClient).
+		buildHyperNodeName(profile, domainKey, "hn-0", 1, map[string]HyperNodeInfo{})
+	require.ErrorContains(t, err, "is already used by a different topology domain")
 }
 
 func getCfg() api.DiscoveryConfig {
@@ -260,12 +360,12 @@ func getCfg() api.DiscoveryConfig {
 						"nodeLabel": "kubernetes.io/hostname",
 					},
 				},
-				"topologyA5": []interface{}{
+				"topologydeep": []interface{}{
 					map[interface{}]interface{}{
-						"nodeLabel": "volcano.sh/torA5-2",
+						"nodeLabel": "volcano.sh/tordeep-2",
 					},
 					map[interface{}]interface{}{
-						"nodeLabel": "volcano.sh/torA5-1",
+						"nodeLabel": "volcano.sh/tordeep-1",
 					},
 					map[interface{}]interface{}{
 						"nodeLabel": "kubernetes.io/hostname",
@@ -636,6 +736,661 @@ func expectedNodeForTest5() map[string]*corev1.Node {
 			},
 		},
 	}
+}
+
+func TestGenerateHyperNodesWithMixedTopologyProfiles(t *testing.T) {
+	const (
+		profileLabel    = "example.com/topology-profile"
+		hyperCluster    = "volcano.sh/hypercluster"
+		hyperNode       = "volcano.sh/hypernode"
+		superPod        = "volcano.sh/superpod"
+		hyperNodeKey    = "example.com/hypernode-domain"
+		hyperClusterKey = "example.com/hypercluster-domain"
+	)
+
+	cfg := api.DiscoveryConfig{
+		Source: "label",
+		Config: map[string]interface{}{
+			"networkTopologyTypes": map[string]interface{}{
+				"topologyshallow": map[string]interface{}{
+					"nodeSelector": map[string]interface{}{
+						"matchLabels": map[string]interface{}{profileLabel: "shallow"},
+					},
+					"levels": []interface{}{
+						map[string]interface{}{"nodeLabel": hyperClusterKey, "tierName": hyperCluster},
+						map[string]interface{}{"nodeLabel": hyperNodeKey, "tierName": hyperNode},
+						map[string]interface{}{"nodeLabel": "kubernetes.io/hostname"},
+					},
+				},
+				"topologydeep": map[string]interface{}{
+					"nodeSelector": map[string]interface{}{
+						"matchLabels": map[string]interface{}{profileLabel: "deep"},
+					},
+					"levels": []interface{}{
+						map[string]interface{}{"nodeLabel": hyperClusterKey, "tierName": hyperCluster},
+						map[string]interface{}{"nodeLabel": hyperNodeKey, "tierName": hyperNode},
+						map[string]interface{}{"nodeLabel": "example.com/superpod-domain", "tierName": superPod},
+						map[string]interface{}{"nodeLabel": "kubernetes.io/hostname"},
+					},
+				},
+			},
+		},
+	}
+	nodes := []*corev1.Node{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "shallow-node", Labels: map[string]string{
+				profileLabel: "shallow", hyperNodeKey: "hn-0", hyperClusterKey: "hc-0",
+			}},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "deep-node", Labels: map[string]string{
+				profileLabel: "deep", hyperNodeKey: "hn-0", hyperClusterKey: "hc-0",
+				"example.com/superpod-domain": "sp-0",
+			}},
+		},
+	}
+
+	discoverer := newDiscovererForGenerationTest(t, cfg, nodes)
+	infoMap, err := discoverer.generateHyperNodeInfo()
+	require.NoError(t, err)
+	require.Len(t, infoMap, 5)
+
+	// Rebuilding from the same desired state must produce stable names and
+	// graph content even though networkTopologyTypes is backed by a Go map.
+	secondInfoMap, err := discoverer.generateHyperNodeInfo()
+	require.NoError(t, err)
+	assert.Equal(t, infoMap, secondInfoMap)
+
+	byProfileTier := make(map[string]map[int]*topologyv1alpha1.HyperNode)
+	for _, hn := range discoverer.buildHyperNodes(infoMap) {
+		profile := hn.Labels[api.NetworkTopologyProfileLabelKey]
+		if byProfileTier[profile] == nil {
+			byProfileTier[profile] = make(map[int]*topologyv1alpha1.HyperNode)
+		}
+		require.Nil(t, byProfileTier[profile][hn.Spec.Tier], "fixture expects one domain per profile tier")
+		byProfileTier[profile][hn.Spec.Tier] = hn
+	}
+
+	require.Len(t, byProfileTier["topologyshallow"], 2)
+	require.Len(t, byProfileTier["topologydeep"], 3)
+	assert.Equal(t, hyperNode, byProfileTier["topologyshallow"][1].Spec.TierName)
+	assert.Equal(t, hyperCluster, byProfileTier["topologyshallow"][2].Spec.TierName)
+	assert.Equal(t, superPod, byProfileTier["topologydeep"][1].Spec.TierName)
+	assert.Equal(t, hyperNode, byProfileTier["topologydeep"][2].Spec.TierName)
+	assert.Equal(t, hyperCluster, byProfileTier["topologydeep"][3].Spec.TierName)
+
+	// shallow and deep intentionally reuse the same domain key/value. Profile-scoped
+	// identity must still create independent HyperNodes at different tiers.
+	shallowHyperNode := byProfileTier["topologyshallow"][1]
+	deepHyperNode := byProfileTier["topologydeep"][2]
+	assert.Equal(t, "hn-0", shallowHyperNode.Labels[hyperNodeKey])
+	assert.Equal(t, "hn-0", deepHyperNode.Labels[hyperNodeKey])
+	assert.NotEqual(t, shallowHyperNode.Name, deepHyperNode.Name)
+	assert.Equal(t, []string{"shallow-node"}, exactMemberNames(shallowHyperNode))
+	assert.Equal(t, []string{"deep-node"}, exactMemberNames(byProfileTier["topologydeep"][1]))
+	assert.Equal(t, []string{deepHyperNode.Name}, exactMemberNames(byProfileTier["topologydeep"][3]))
+}
+
+func TestGenerateHyperNodesWithSingleTopologyLevelProfile(t *testing.T) {
+	const (
+		profileLabel = "example.com/topology-profile"
+		domainLabel  = "example.com/compute-domain"
+		tierName     = "volcano.sh/compute-domain"
+	)
+	cfg := api.DiscoveryConfig{Source: "label", Config: map[string]interface{}{
+		"networkTopologyTypes": map[string]interface{}{
+			"topologyflat": map[string]interface{}{
+				"nodeSelector": map[string]interface{}{
+					"matchLabels": map[string]interface{}{profileLabel: "flat"},
+				},
+				"levels": []interface{}{
+					map[string]interface{}{"nodeLabel": domainLabel, "tierName": tierName},
+					map[string]interface{}{"nodeLabel": corev1.LabelHostname},
+				},
+			},
+		},
+	}}
+	node := func(name, domain string) *corev1.Node {
+		return &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: name, Labels: map[string]string{
+			profileLabel: "flat", domainLabel: domain,
+		}}}
+	}
+	discoverer := newDiscovererForGenerationTest(t, cfg, []*corev1.Node{
+		node("flat-node-0", "domain-a"),
+		node("flat-node-1", "domain-a"),
+		node("flat-node-2", "domain-b"),
+	})
+
+	infoMap, err := discoverer.generateHyperNodeInfo()
+	require.NoError(t, err)
+	assert.Len(t, infoMap, 2, "one real topology level should produce one HyperNode per domain")
+
+	byDomain := make(map[string]*topologyv1alpha1.HyperNode)
+	for _, hyperNode := range discoverer.buildHyperNodes(infoMap) {
+		assert.Equal(t, 1, hyperNode.Spec.Tier)
+		assert.Equal(t, tierName, hyperNode.Spec.TierName)
+		assert.Equal(t, "topologyflat", hyperNode.Labels[api.NetworkTopologyProfileLabelKey])
+		byDomain[hyperNode.Labels[domainLabel]] = hyperNode
+	}
+	assert.Equal(t, []string{"flat-node-0", "flat-node-1"}, exactMemberNames(byDomain["domain-a"]))
+	assert.Equal(t, []string{"flat-node-2"}, exactMemberNames(byDomain["domain-b"]))
+}
+
+func TestGenerateHyperNodesWithMultipleDomains(t *testing.T) {
+	const (
+		profileKey      = "example.com/topology-profile"
+		hyperNodeKey    = "example.com/hypernode-domain"
+		hyperClusterKey = "example.com/hypercluster-domain"
+	)
+	cfg := api.DiscoveryConfig{Source: "label", Config: map[string]interface{}{
+		"networkTopologyTypes": map[string]interface{}{
+			"topologyshallow": map[string]interface{}{
+				"nodeSelector": map[string]interface{}{
+					"matchLabels": map[string]interface{}{profileKey: "shallow"},
+				},
+				"levels": []interface{}{
+					map[string]interface{}{"nodeLabel": hyperClusterKey, "tierName": "volcano.sh/hypercluster"},
+					map[string]interface{}{"nodeLabel": hyperNodeKey, "tierName": "volcano.sh/hypernode"},
+					map[string]interface{}{"nodeLabel": corev1.LabelHostname},
+				},
+			},
+		},
+	}}
+	node := func(name, hyperNodeDomain, hyperClusterDomain string) *corev1.Node {
+		return &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: name, Labels: map[string]string{
+			profileKey: "shallow", hyperNodeKey: hyperNodeDomain, hyperClusterKey: hyperClusterDomain,
+		}}}
+	}
+	discoverer := newDiscovererForGenerationTest(t, cfg, []*corev1.Node{
+		node("node-a1", "hn-a", "hc-a"),
+		node("node-a2", "hn-a", "hc-a"),
+		node("node-b1", "hn-b", "hc-a"),
+		node("node-c1", "hn-c", "hc-b"),
+	})
+
+	infoMap, err := discoverer.generateHyperNodeInfo()
+	require.NoError(t, err)
+	require.Len(t, infoMap, 5)
+
+	hyperNodesByDomain := make(map[string]*topologyv1alpha1.HyperNode)
+	hyperClustersByDomain := make(map[string]*topologyv1alpha1.HyperNode)
+	for _, hyperNode := range discoverer.buildHyperNodes(infoMap) {
+		switch hyperNode.Spec.Tier {
+		case 1:
+			hyperNodesByDomain[hyperNode.Labels[hyperNodeKey]] = hyperNode
+		case 2:
+			hyperClustersByDomain[hyperNode.Labels[hyperClusterKey]] = hyperNode
+		default:
+			t.Fatalf("unexpected tier %d", hyperNode.Spec.Tier)
+		}
+	}
+
+	require.Len(t, hyperNodesByDomain, 3)
+	require.Len(t, hyperClustersByDomain, 2)
+	assert.Equal(t, []string{"node-a1", "node-a2"}, exactMemberNames(hyperNodesByDomain["hn-a"]))
+	assert.Equal(t, []string{"node-b1"}, exactMemberNames(hyperNodesByDomain["hn-b"]))
+	assert.Equal(t, []string{"node-c1"}, exactMemberNames(hyperNodesByDomain["hn-c"]))
+	assert.ElementsMatch(t, []string{hyperNodesByDomain["hn-a"].Name, hyperNodesByDomain["hn-b"].Name}, exactMemberNames(hyperClustersByDomain["hc-a"]))
+	assert.Equal(t, []string{hyperNodesByDomain["hn-c"].Name}, exactMemberNames(hyperClustersByDomain["hc-b"]))
+}
+
+func TestBuildHyperNodeNameRejectsDeterministicNameConflict(t *testing.T) {
+	const domainKey = "example.com/hypernode-domain"
+	cfg := api.DiscoveryConfig{Source: "label", Config: map[string]interface{}{
+		"networkTopologyTypes": map[string]interface{}{
+			"topologyshallow": map[string]interface{}{
+				"levels": []interface{}{
+					map[string]interface{}{"nodeLabel": domainKey, "tierName": "volcano.sh/hypernode"},
+					map[string]interface{}{"nodeLabel": corev1.LabelHostname},
+				},
+			},
+		},
+	}}
+	discoverer := newDiscovererForGenerationTest(t, cfg, nil)
+	profile := discoverer.topologyProfiles[0]
+
+	deterministicName, err := discoverer.buildHyperNodeName(profile, domainKey, "hn-0", 1, nil)
+	require.NoError(t, err)
+	require.NoError(t, discoverer.hyperNodeInformer.Informer().GetIndexer().Add(&topologyv1alpha1.HyperNode{
+		ObjectMeta: metav1.ObjectMeta{Name: deterministicName, Labels: map[string]string{
+			api.NetworkTopologySourceLabelKey:  "label",
+			api.NetworkTopologyProfileLabelKey: "different-profile",
+			domainKey:                          "different-domain",
+		}},
+	}))
+
+	_, err = discoverer.buildHyperNodeName(profile, domainKey, "hn-0", 1, nil)
+	require.ErrorContains(t, err, "is already used by a different topology domain")
+}
+
+func TestNodeLabelChangesTriggerDiscovery(t *testing.T) {
+	const (
+		profileKey = "example.com/topology-profile"
+		domainKey  = "example.com/hypernode-domain"
+	)
+	cfg := api.DiscoveryConfig{Source: "label", Config: map[string]interface{}{
+		"networkTopologyTypes": map[string]interface{}{
+			"topologyshallow": map[string]interface{}{
+				"nodeSelector": map[string]interface{}{
+					"matchExpressions": []interface{}{
+						map[string]interface{}{"key": profileKey, "operator": "In", "values": []interface{}{"shallow"}},
+					},
+				},
+				"levels": []interface{}{
+					map[string]interface{}{"nodeLabel": domainKey, "tierName": "volcano.sh/hypernode"},
+					map[string]interface{}{"nodeLabel": corev1.LabelHostname},
+				},
+			},
+		},
+	}}
+	discoverer, ok := NewLabelDiscoverer(cfg, fake.NewSimpleClientset(), vcclientset.NewSimpleClientset()).(*labelDiscoverer)
+	require.True(t, ok)
+	require.NoError(t, discoverer.configErr)
+	t.Cleanup(func() {
+		discoverer.queue.ShutDown()
+	})
+
+	oldNode := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-a", Labels: map[string]string{
+		profileKey: "shallow",
+		domainKey:  "hn-0",
+	}}}
+	unrelatedUpdate := oldNode.DeepCopy()
+	unrelatedUpdate.Labels["example.com/unrelated"] = "changed"
+	discoverer.UpdateNode(oldNode, unrelatedUpdate)
+	time.Sleep(20 * time.Millisecond)
+	assert.Zero(t, discoverer.queue.Len(), "unwatched labels must not trigger a full discovery")
+
+	selectorUpdate := oldNode.DeepCopy()
+	selectorUpdate.Labels[profileKey] = "deep"
+	discoverer.UpdateNode(oldNode, selectorUpdate)
+	require.Eventually(t, func() bool {
+		return discoverer.queue.Len() == 1
+	}, time.Second, 10*time.Millisecond)
+	key, shutdown := discoverer.queue.Get()
+	require.False(t, shutdown)
+	discoverer.queue.Done(key)
+	discoverer.queue.Forget(key)
+
+	domainUpdate := oldNode.DeepCopy()
+	domainUpdate.Labels[domainKey] = "hn-1"
+	discoverer.UpdateNode(oldNode, domainUpdate)
+	require.Eventually(t, func() bool {
+		return discoverer.queue.Len() == 1
+	}, time.Second, 10*time.Millisecond)
+}
+
+func TestGenerateHyperNodesRejectsMultipleProfileMatches(t *testing.T) {
+	profile := func(levelLabel string) map[string]interface{} {
+		return map[string]interface{}{
+			"nodeSelector": map[string]interface{}{
+				"matchLabels": map[string]interface{}{"example.com/role": "compute"},
+			},
+			"levels": []interface{}{
+				map[string]interface{}{"nodeLabel": levelLabel, "tierName": "volcano.sh/hypernode"},
+				map[string]interface{}{"nodeLabel": "kubernetes.io/hostname"},
+			},
+		}
+	}
+	cfg := api.DiscoveryConfig{
+		Source: "label",
+		Config: map[string]interface{}{
+			"networkTopologyTypes": map[string]interface{}{
+				"topologyshallow": profile("example.com/shallow-hypernode"),
+				"topologydeep":    profile("example.com/deep-hypernode"),
+			},
+		},
+	}
+	node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "ambiguous-node", Labels: map[string]string{
+		"example.com/role":              "compute",
+		"example.com/shallow-hypernode": "shallow-hn",
+		"example.com/deep-hypernode":    "deep-hn",
+	}}}
+
+	discoverer := newDiscovererForGenerationTest(t, cfg, []*corev1.Node{node})
+	infoMap, err := discoverer.generateHyperNodeInfo()
+	require.ErrorContains(t, err, "matches multiple topology profiles")
+	assert.Empty(t, infoMap, "an ambiguous node must not publish a partial topology")
+}
+
+func TestGenerateHyperNodesPreservesLegacyMultiTopologyTraversal(t *testing.T) {
+	const (
+		fabricDomain  = "example.com/fabric-domain"
+		storageDomain = "example.com/storage-domain"
+	)
+	cfg := api.DiscoveryConfig{Source: "label", Config: map[string]interface{}{
+		"networkTopologyTypes": map[string]interface{}{
+			"topologyfabric": []interface{}{
+				map[string]interface{}{"nodeLabel": fabricDomain, "tierName": "volcano.sh/fabric"},
+				map[string]interface{}{"nodeLabel": corev1.LabelHostname},
+			},
+			"topologystorage": []interface{}{
+				map[string]interface{}{"nodeLabel": storageDomain, "tierName": "volcano.sh/storage"},
+				map[string]interface{}{"nodeLabel": corev1.LabelHostname},
+			},
+		},
+	}}
+	node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "multi-network-node", Labels: map[string]string{
+		fabricDomain:  "fabric-a",
+		storageDomain: "storage-a",
+	}}}
+
+	discoverer := newDiscovererForGenerationTest(t, cfg, []*corev1.Node{node})
+	infoMap, err := discoverer.generateHyperNodeInfo()
+	require.NoError(t, err)
+	require.Len(t, infoMap, 2)
+
+	byProfile := make(map[string]*topologyv1alpha1.HyperNode)
+	for _, hyperNode := range discoverer.buildHyperNodes(infoMap) {
+		byProfile[hyperNode.Labels[api.NetworkTopologyProfileLabelKey]] = hyperNode
+		assert.Equal(t, []string{node.Name}, exactMemberNames(hyperNode))
+	}
+	require.Contains(t, byProfile, "topologyfabric")
+	require.Contains(t, byProfile, "topologystorage")
+	assert.Equal(t, "volcano.sh/fabric", byProfile["topologyfabric"].Spec.TierName)
+	assert.Equal(t, "volcano.sh/storage", byProfile["topologystorage"].Spec.TierName)
+}
+
+func TestGenerateHyperNodesExplicitProfileTakesOwnershipOverLegacyFallback(t *testing.T) {
+	const (
+		profileLabel = "example.com/profile"
+		explicitTier = "example.com/explicit-domain"
+		legacyTier   = "example.com/legacy-domain"
+	)
+	cfg := api.DiscoveryConfig{Source: "label", Config: map[string]interface{}{
+		"networkTopologyTypes": map[string]interface{}{
+			"topologyexplicit": map[string]interface{}{
+				"nodeSelector": map[string]interface{}{
+					"matchLabels": map[string]interface{}{profileLabel: "explicit"},
+				},
+				"levels": []interface{}{
+					map[string]interface{}{"nodeLabel": explicitTier, "tierName": "volcano.sh/explicit"},
+					map[string]interface{}{"nodeLabel": corev1.LabelHostname},
+				},
+			},
+			"topologylegacy": []interface{}{
+				map[string]interface{}{"nodeLabel": legacyTier, "tierName": "volcano.sh/legacy"},
+				map[string]interface{}{"nodeLabel": corev1.LabelHostname},
+			},
+		},
+	}}
+	node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "explicit-node", Labels: map[string]string{
+		profileLabel: "explicit",
+		explicitTier: "explicit-a",
+		legacyTier:   "legacy-a",
+	}}}
+
+	discoverer := newDiscovererForGenerationTest(t, cfg, []*corev1.Node{node})
+	infoMap, err := discoverer.generateHyperNodeInfo()
+	require.NoError(t, err)
+	require.Len(t, infoMap, 1)
+	hyperNodes := discoverer.buildHyperNodes(infoMap)
+	require.Len(t, hyperNodes, 1)
+	assert.Equal(t, "topologyexplicit", hyperNodes[0].Labels[api.NetworkTopologyProfileLabelKey])
+}
+
+func TestGenerateHyperNodesRejectsMultipleParents(t *testing.T) {
+	cfg := api.DiscoveryConfig{Config: map[string]interface{}{
+		"networkTopologyTypes": map[string]interface{}{
+			"topologyshallow": map[string]interface{}{
+				"nodeSelector": map[string]interface{}{
+					"matchLabels": map[string]interface{}{"example.com/profile": "shallow"},
+				},
+				"levels": []interface{}{
+					map[string]interface{}{"nodeLabel": "example.com/hypercluster", "tierName": "volcano.sh/hypercluster"},
+					map[string]interface{}{"nodeLabel": "example.com/hypernode", "tierName": "volcano.sh/hypernode"},
+					map[string]interface{}{"nodeLabel": "kubernetes.io/hostname"},
+				},
+			},
+		},
+	}}
+	nodes := []*corev1.Node{
+		{ObjectMeta: metav1.ObjectMeta{Name: "node-a", Labels: map[string]string{
+			"example.com/profile": "shallow", "example.com/hypernode": "hn-0", "example.com/hypercluster": "hc-0",
+		}}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "node-b", Labels: map[string]string{
+			"example.com/profile": "shallow", "example.com/hypernode": "hn-0", "example.com/hypercluster": "hc-1",
+		}}},
+	}
+
+	discoverer := newDiscovererForGenerationTest(t, cfg, nodes)
+	_, err := discoverer.generateHyperNodeInfo()
+	require.ErrorContains(t, err, "belongs to multiple parents")
+}
+
+func TestParseCfgRejectsDuplicateSemanticTierName(t *testing.T) {
+	cfg := api.DiscoveryConfig{Config: map[string]interface{}{
+		"networkTopologyTypes": map[string]interface{}{
+			"topologydeep": map[string]interface{}{
+				"levels": []interface{}{
+					map[string]interface{}{"nodeLabel": "example.com/cluster", "tierName": "volcano.sh/hypernode"},
+					map[string]interface{}{"nodeLabel": "example.com/hypernode", "tierName": "volcano.sh/hypernode"},
+					map[string]interface{}{"nodeLabel": "kubernetes.io/hostname"},
+				},
+			},
+		},
+	}}
+
+	_, _, err := parseCfg(cfg)
+	require.ErrorContains(t, err, "duplicate tierName")
+}
+
+func TestParseCfgRejectsUnsafeConfiguration(t *testing.T) {
+	validProfile := func() map[string]interface{} {
+		return map[string]interface{}{
+			"levels": []interface{}{
+				map[string]interface{}{"nodeLabel": "example.com/hypernode", "tierName": "volcano.sh/hypernode"},
+				map[string]interface{}{"nodeLabel": corev1.LabelHostname},
+			},
+		}
+	}
+
+	tests := []struct {
+		name          string
+		config        map[string]interface{}
+		errorContains string
+	}{
+		{
+			name: "missing network topology types",
+			config: map[string]interface{}{
+				"networkTopologyType": map[string]interface{}{"topologyshallow": validProfile()},
+			},
+			errorContains: "networkTopologyType",
+		},
+		{
+			name: "empty network topology types",
+			config: map[string]interface{}{
+				"networkTopologyTypes": map[string]interface{}{},
+			},
+			errorContains: "at least one topology profile",
+		},
+		{
+			name: "unknown profile field",
+			config: map[string]interface{}{
+				"networkTopologyTypes": map[string]interface{}{
+					"topologyshallow": map[string]interface{}{
+						"nodeSelecter": map[string]interface{}{},
+						"levels":       validProfile()["levels"],
+					},
+				},
+			},
+			errorContains: "nodeSelecter",
+		},
+		{
+			name: "unknown level field",
+			config: map[string]interface{}{
+				"networkTopologyTypes": map[string]interface{}{
+					"topologyshallow": map[string]interface{}{
+						"levels": []interface{}{
+							map[string]interface{}{"nodeLabel": "example.com/hypernode", "tierNmae": "volcano.sh/hypernode"},
+							map[string]interface{}{"nodeLabel": corev1.LabelHostname},
+						},
+					},
+				},
+			},
+			errorContains: "tierNmae",
+		},
+		{
+			name: "leaf level is not hostname",
+			config: map[string]interface{}{
+				"networkTopologyTypes": map[string]interface{}{
+					"topologyshallow": map[string]interface{}{
+						"levels": []interface{}{
+							map[string]interface{}{"nodeLabel": "example.com/hypernode", "tierName": "volcano.sh/hypernode"},
+							map[string]interface{}{"nodeLabel": "example.com/node-id"},
+						},
+					},
+				},
+			},
+			errorContains: "last level must use nodeLabel",
+		},
+		{
+			name: "leaf level has tier name",
+			config: map[string]interface{}{
+				"networkTopologyTypes": map[string]interface{}{
+					"topologyshallow": map[string]interface{}{
+						"levels": []interface{}{
+							map[string]interface{}{"nodeLabel": "example.com/hypernode", "tierName": "volcano.sh/hypernode"},
+							map[string]interface{}{"nodeLabel": corev1.LabelHostname, "tierName": "volcano.sh/node"},
+						},
+					},
+				},
+			},
+			errorContains: "node leaf level must not set tierName",
+		},
+		{
+			name: "invalid qualified node label",
+			config: map[string]interface{}{
+				"networkTopologyTypes": map[string]interface{}{
+					"topologyshallow": map[string]interface{}{
+						"levels": []interface{}{
+							map[string]interface{}{"nodeLabel": "bad/key/extra", "tierName": "volcano.sh/hypernode"},
+							map[string]interface{}{"nodeLabel": corev1.LabelHostname},
+						},
+					},
+				},
+			},
+			errorContains: "not a valid qualified name",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, _, err := parseCfg(api.DiscoveryConfig{Source: "label", Config: tc.config})
+			require.ErrorContains(t, err, tc.errorContains)
+		})
+	}
+}
+
+func TestParseCfgAcceptsLabelSelectorExpressions(t *testing.T) {
+	cfg := api.DiscoveryConfig{Source: "label", Config: map[string]interface{}{
+		"networkTopologyTypes": map[string]interface{}{
+			"topologydeep": map[string]interface{}{
+				"nodeSelector": map[string]interface{}{
+					"matchExpressions": []interface{}{
+						map[string]interface{}{"key": "example.com/region", "operator": "In", "values": []interface{}{"east", "west"}},
+						map[string]interface{}{"key": "example.com/environment", "operator": "NotIn", "values": []interface{}{"development"}},
+						map[string]interface{}{"key": "example.com/accelerator", "operator": "Exists"},
+						map[string]interface{}{"key": "example.com/retired", "operator": "DoesNotExist"},
+					},
+				},
+				"levels": []interface{}{
+					map[string]interface{}{"nodeLabel": "example.com/hypernode", "tierName": "volcano.sh/hypernode"},
+					map[string]interface{}{"nodeLabel": corev1.LabelHostname},
+				},
+			},
+		},
+	}}
+
+	profiles, watchedKeys, err := parseCfg(cfg)
+	require.NoError(t, err)
+	require.Len(t, profiles, 1)
+	assert.True(t, profiles[0].nodeSelector.Matches(labels.Set{
+		"example.com/region":      "east",
+		"example.com/environment": "production",
+		"example.com/accelerator": "gpu",
+	}))
+	assert.False(t, profiles[0].nodeSelector.Matches(labels.Set{
+		"example.com/region":      "east",
+		"example.com/environment": "development",
+		"example.com/accelerator": "gpu",
+	}))
+	for _, key := range []string{
+		"example.com/region",
+		"example.com/environment",
+		"example.com/accelerator",
+		"example.com/retired",
+	} {
+		assert.Contains(t, watchedKeys, key)
+	}
+}
+
+func TestParseMixedTopologyProfilesFromYAML(t *testing.T) {
+	const configYAML = `
+networkTopologyDiscovery:
+  - source: label
+    enabled: true
+    config:
+      networkTopologyTypes:
+        topologyshallow:
+          nodeSelector:
+            matchLabels:
+              volcano.sh/network-topology-profile: shallow
+          levels:
+            - nodeLabel: volcano.sh/shallow-hypercluster
+              tierName: volcano.sh/hypercluster
+            - nodeLabel: volcano.sh/shallow-hypernode
+              tierName: volcano.sh/hypernode
+            - nodeLabel: kubernetes.io/hostname
+        topologydeep:
+          nodeSelector:
+            matchLabels:
+              volcano.sh/network-topology-profile: deep
+          levels:
+            - nodeLabel: volcano.sh/deep-hypercluster
+              tierName: volcano.sh/hypercluster
+            - nodeLabel: volcano.sh/deep-hypernode
+              tierName: volcano.sh/hypernode
+            - nodeLabel: volcano.sh/deep-superpod
+              tierName: volcano.sh/superpod
+            - nodeLabel: kubernetes.io/hostname
+`
+	config := &api.NetworkTopologyConfig{}
+	require.NoError(t, yaml.Unmarshal([]byte(configYAML), config))
+	require.Len(t, config.NetworkTopologyDiscovery, 1)
+
+	profiles, watchedKeys, err := parseCfg(config.NetworkTopologyDiscovery[0])
+	require.NoError(t, err)
+	require.Len(t, profiles, 2)
+	assert.Equal(t, "topologydeep", profiles[0].name)
+	assert.Equal(t, []NodeLabel{
+		{NodeLabel: "volcano.sh/deep-superpod", TierName: "volcano.sh/superpod"},
+		{NodeLabel: "volcano.sh/deep-hypernode", TierName: "volcano.sh/hypernode"},
+		{NodeLabel: "volcano.sh/deep-hypercluster", TierName: "volcano.sh/hypercluster"},
+	}, profiles[0].levels)
+	assert.Contains(t, watchedKeys, "volcano.sh/network-topology-profile")
+	assert.Contains(t, watchedKeys, "volcano.sh/deep-superpod")
+}
+
+func newDiscovererForGenerationTest(t *testing.T, cfg api.DiscoveryConfig, nodes []*corev1.Node) *labelDiscoverer {
+	t.Helper()
+	discoverer, ok := NewLabelDiscoverer(cfg, fake.NewSimpleClientset(), vcclientset.NewSimpleClientset()).(*labelDiscoverer)
+	require.True(t, ok)
+	require.NoError(t, discoverer.configErr)
+	for _, node := range nodes {
+		require.NoError(t, discoverer.nodeInformer.Informer().GetIndexer().Add(node))
+	}
+	return discoverer
+}
+
+func exactMemberNames(hyperNode *topologyv1alpha1.HyperNode) []string {
+	names := make([]string, 0, len(hyperNode.Spec.Members))
+	for _, member := range hyperNode.Spec.Members {
+		if member.Selector.ExactMatch != nil {
+			names = append(names, member.Selector.ExactMatch.Name)
+		}
+	}
+	sort.Strings(names)
+	return names
 }
 
 func createHyperNode(vcClient vcclient.Interface, nodeMap map[string]*topologyv1alpha1.HyperNode) {

--- a/pkg/scheduler/actions/allocate/allocate.go
+++ b/pkg/scheduler/actions/allocate/allocate.go
@@ -866,9 +866,9 @@ func (alloc *Action) allocateResourcesForTasks(subJob *api.SubJobInfo, tasks *ut
 	return nil
 }
 
-// getNewAllocatedHyperNode Obtain the newly allocated hyperNode for the job in soft topology mode
+// getNewAllocatedHyperNode updates the allocated HyperNode after placing a topology-aware task on a Node.
 func getNewAllocatedHyperNode(ssn *framework.Session, bestNode string, jobAllocatedHyperNode string) string {
-	hyperNode := util.FindHyperNodeForNode(bestNode, ssn.RealNodesList, ssn.HyperNodesTiers, ssn.HyperNodesSetByTier)
+	hyperNode := ssn.FindHyperNodeForNode(bestNode)
 	if hyperNode != "" {
 		if jobAllocatedHyperNode == "" {
 			return hyperNode

--- a/pkg/scheduler/actions/allocate/allocate_test.go
+++ b/pkg/scheduler/actions/allocate/allocate_test.go
@@ -1492,7 +1492,7 @@ func TestAllocateWithNetWorkTopologies(t *testing.T) {
 			MinimalBindCheck: true,
 		},
 		{
-			Name: "hard network topology constrain and tasks in job rescheduled, can allocate job when LCAHyperNode is empty",
+			Name: "hard network topology constrain and tasks in job rescheduled, cannot escape the allocated real tree when it is full",
 			PodGroups: []*schedulingv1.PodGroup{
 				util.BuildPodGroupWithNetWorkTopologies("pg1", "c1", "s0", "q1", 2, nil, schedulingv1.PodGroupInqueue, "hard", 2),
 			},
@@ -1542,7 +1542,7 @@ func TestAllocateWithNetWorkTopologies(t *testing.T) {
 			Queues: []*schedulingv1.Queue{
 				util.BuildQueue("q1", 1, nil),
 			},
-			ExpectBindsNum:   1,
+			ExpectBindsNum:   0,
 			MinimalBindCheck: true,
 		},
 		{
@@ -2080,7 +2080,7 @@ func TestAllocateWithNetWorkTopologies(t *testing.T) {
 			MinimalBindCheck: true,
 		},
 		{
-			Name: "hard network topology with highestTierName constrain and tasks in job rescheduled, can allocate job when here is no corresponding highestTierAllowed for highestTierName",
+			Name: "hard network topology with missing highestTierName remains pending",
 			PodGroups: []*schedulingv1.PodGroup{
 				util.BuildPodGroupUsingNetWorkTopologiesWithTierName("pg1", "c1", "s0", "q1", 2, nil, schedulingv1.PodGroupInqueue, "hard", "volcano.sh/hypercluster"),
 			},
@@ -2131,7 +2131,7 @@ func TestAllocateWithNetWorkTopologies(t *testing.T) {
 			Queues: []*schedulingv1.Queue{
 				util.BuildQueue("q1", 1, nil),
 			},
-			ExpectBindsNum:   1,
+			ExpectBindsNum:   0,
 			MinimalBindCheck: true,
 		},
 	}
@@ -4415,7 +4415,7 @@ func TestAllocateWithPartitionPolicyNetworkTopology(t *testing.T) {
 			MinimalBindCheck: true,
 		},
 		{
-			Name: "podgroup hard network topology constrain and subGroup hard network topology constrain and tasks in job rescheduled, can allocate job when LCAHyperNode is empty",
+			Name: "podgroup and subgroup hard network topology constrain and tasks rescheduled, cannot escape the allocated real tree when it is full",
 			PodGroups: []*schedulingv1.PodGroup{
 				util.BuildPodGroupWithSubGroupPolicy("pg1", "c1", "s0", "q1", 2, nil, schedulingv1.PodGroupInqueue, "hard", 3,
 					[]schedulingv1.SubGroupPolicySpec{
@@ -4468,7 +4468,7 @@ func TestAllocateWithPartitionPolicyNetworkTopology(t *testing.T) {
 			Queues: []*schedulingv1.Queue{
 				util.BuildQueue("q1", 1, nil),
 			},
-			ExpectBindsNum:   1,
+			ExpectBindsNum:   0,
 			MinimalBindCheck: true,
 		},
 		{

--- a/pkg/scheduler/api/hyper_node_info.go
+++ b/pkg/scheduler/api/hyper_node_info.go
@@ -56,6 +56,8 @@ type HyperNodesInfo struct {
 
 type HyperNodeInfoMap map[string]*HyperNodeInfo
 
+// HyperNodeTierNameMap is kept for compatibility and diagnostics. Tree-aware Hard
+// scheduling must resolve tier names against each HyperNode branch instead.
 type HyperNodeTierNameMap map[string]int
 
 // NewHyperNodesInfo initializes a new HyperNodesInfo instance.
@@ -160,6 +162,11 @@ func (hni *HyperNodeInfo) Tier() int {
 	return hni.tier
 }
 
+// TierName returns the semantic tier name of the HyperNode.
+func (hni *HyperNodeInfo) TierName() string {
+	return hni.tierName
+}
+
 func (hni *HyperNodeInfo) DeepCopy() *HyperNodeInfo {
 	if hni == nil {
 		return nil
@@ -189,15 +196,33 @@ func (hni *HyperNodesInfo) HyperNodes() HyperNodeInfoMap {
 	return copiedHyperNodes
 }
 
-// HyperNodeTierNameMap returns the mapping of tierName and tier.
+// HyperNodeTierNameMap returns the mapping of unambiguous tierName and tier.
+// A semantic tier name can legitimately have different local numeric tiers in
+// different topology trees. Such names are omitted because a single global
+// numeric value cannot represent them safely; tree-aware scheduling resolves
+// the name on the candidate branch instead.
 func (hni *HyperNodesInfo) HyperNodeTierNameMap() HyperNodeTierNameMap {
-	hyperNodeTierNameMap := make(map[string]int, len(hni.hyperNodes))
+	tiersByName := make(map[string]sets.Set[int])
 	for _, info := range hni.hyperNodes {
-		if info.tierName != "" {
-			if existingTier, ok := hyperNodeTierNameMap[info.tierName]; ok && existingTier != info.tier {
-				klog.Warningf("Conflicting tiers for tierName %s: existing %d, new %d. Using %d.", info.tierName, existingTier, info.tier, info.tier)
-			}
-			hyperNodeTierNameMap[info.tierName] = info.tier
+		if info.tierName == "" {
+			continue
+		}
+		if tiersByName[info.tierName] == nil {
+			tiersByName[info.tierName] = sets.New[int]()
+		}
+		tiersByName[info.tierName].Insert(info.tier)
+	}
+
+	hyperNodeTierNameMap := make(map[string]int, len(tiersByName))
+	for tierName, tiers := range tiersByName {
+		if len(tiers) != 1 {
+			conflictingTiers := tiers.UnsortedList()
+			slices.Sort(conflictingTiers)
+			klog.Warningf("Conflicting tiers for tierName %s: %v. Omitting ambiguous global mapping.", tierName, conflictingTiers)
+			continue
+		}
+		for tier := range tiers {
+			hyperNodeTierNameMap[tierName] = tier
 		}
 	}
 

--- a/pkg/scheduler/api/hyper_node_info_test.go
+++ b/pkg/scheduler/api/hyper_node_info_test.go
@@ -96,6 +96,33 @@ func TestHyperNodesInfo_UpdateHyperNode_Normal(t *testing.T) {
 	}
 }
 
+func TestHyperNodesInfoTierNameMapOmitsAmbiguousLocalTiers(t *testing.T) {
+	makeHyperNodeInfo := func(name string, tier int, tierName string) *HyperNodeInfo {
+		hyperNode := BuildHyperNode(name, tier, nil)
+		hyperNode.Spec.TierName = tierName
+		return NewHyperNodeInfo(hyperNode)
+	}
+
+	hni := NewHyperNodesInfoWithCache(
+		HyperNodeInfoMap{
+			"shallow-hypernode": makeHyperNodeInfo("shallow-hypernode", 1, "volcano.sh/hypernode"),
+			"deep-hypernode":    makeHyperNodeInfo("deep-hypernode", 2, "volcano.sh/hypernode"),
+			"hypercluster":      makeHyperNodeInfo("hypercluster", 3, "volcano.sh/hypercluster"),
+		},
+		map[int]sets.Set[string]{
+			1: sets.New[string]("shallow-hypernode"),
+			2: sets.New[string]("deep-hypernode"),
+			3: sets.New[string]("hypercluster"),
+		},
+		map[string]sets.Set[string]{},
+		new(atomic.Bool),
+	)
+
+	assert.Equal(t, HyperNodeTierNameMap{
+		"volcano.sh/hypercluster": 3,
+	}, hni.HyperNodeTierNameMap())
+}
+
 func TestHyperNodesInfo_UpdateHyperNode_NoSpecChange(t *testing.T) {
 	// Exact-match HyperNode: realNodesSet is purely spec-driven, so an unchanged
 	// spec (only metadata changed) must NOT trigger a rebuild.

--- a/pkg/scheduler/api/job_info.go
+++ b/pkg/scheduler/api/job_info.go
@@ -416,9 +416,12 @@ type JobInfo struct {
 
 	AllocatedHyperNode string
 	NetworkTopology    *scheduling.NetworkTopologySpec
-	SubJobs            map[SubJobID]*SubJobInfo
-	TaskToSubJob       map[TaskID]SubJobID
-	MinSubJobs         map[SubJobGID]int32 // key is name of "PodGroup.Spec.SubGroupPolicy", value is minSubGroups
+	// softTopologyConverted records scheduler-internal Soft-to-Hard conversion
+	// provenance. It is intentionally not part of the Kubernetes-facing API.
+	softTopologyConverted bool
+	SubJobs               map[SubJobID]*SubJobInfo
+	TaskToSubJob          map[TaskID]SubJobID
+	MinSubJobs            map[SubJobGID]int32 // key is name of "PodGroup.Spec.SubGroupPolicy", value is minSubGroups
 
 	// All tasks of the Job.
 	TaskStatusIndex       map[TaskStatus]TasksMap
@@ -791,11 +794,12 @@ func (ji *JobInfo) Clone() *JobInfo {
 			return nil
 		}(),
 
-		AllocatedHyperNode: ji.AllocatedHyperNode,
-		NetworkTopology:    cloneNetworkTopology(ji.NetworkTopology),
-		SubJobs:            map[SubJobID]*SubJobInfo{},
-		TaskToSubJob:       map[TaskID]SubJobID{},
-		MinSubJobs:         maps.Clone(ji.MinSubJobs),
+		AllocatedHyperNode:    ji.AllocatedHyperNode,
+		NetworkTopology:       cloneNetworkTopology(ji.NetworkTopology),
+		softTopologyConverted: ji.softTopologyConverted,
+		SubJobs:               map[SubJobID]*SubJobInfo{},
+		TaskToSubJob:          map[TaskID]SubJobID{},
+		MinSubJobs:            maps.Clone(ji.MinSubJobs),
 	}
 
 	ji.CreationTimestamp.DeepCopyInto(&info.CreationTimestamp)
@@ -1297,7 +1301,8 @@ func (ji *JobInfo) HasPendingTasks() bool {
 	return len(ji.TaskStatusIndex[Pending]) != 0
 }
 
-// IsHardTopologyMode return whether the job's network topology mode is hard and also return the highest allowed tier
+// IsHardTopologyMode reports a numeric hard topology constraint and returns its
+// tier. Use HardTopologyConstraint when tier names are supported by the caller.
 func (ji *JobInfo) IsHardTopologyMode() (bool, int) {
 	if ji.NetworkTopology == nil || ji.NetworkTopology.HighestTierAllowed == nil {
 		return false, 0
@@ -1306,12 +1311,34 @@ func (ji *JobInfo) IsHardTopologyMode() (bool, int) {
 	return ji.NetworkTopology.Mode == scheduling.HardNetworkTopologyMode, *ji.NetworkTopology.HighestTierAllowed
 }
 
+// HardTopologyConstraint returns the configured hard topology constraint without
+// validating its boundary. Tier names are intentionally preserved because their
+// numeric tier can differ between topology branches.
+func (ji *JobInfo) HardTopologyConstraint() *scheduling.NetworkTopologySpec {
+	if ji.NetworkTopology == nil || ji.NetworkTopology.Mode != scheduling.HardNetworkTopologyMode {
+		return nil
+	}
+	return ji.NetworkTopology
+}
+
 // IsSoftTopologyMode returns whether the job has configured network topologies with soft mode.
 func (ji *JobInfo) IsSoftTopologyMode() bool {
 	if ji.NetworkTopology == nil {
 		return false
 	}
 	return ji.NetworkTopology.Mode == scheduling.SoftNetworkTopologyMode
+}
+
+// SetSoftTopologyConverted records that the scheduler converted this job's
+// Soft topology constraint to Hard for the upstream compatibility path.
+func (ji *JobInfo) SetSoftTopologyConverted() {
+	ji.softTopologyConverted = true
+}
+
+// IsSoftTopologyConverted reports whether this job's Hard constraint originated
+// from scheduler Soft-to-Hard conversion.
+func (ji *JobInfo) IsSoftTopologyConverted() bool {
+	return ji.softTopologyConverted
 }
 
 // WithNetworkTopology returns whether the job has configured network topologies
@@ -1402,7 +1429,7 @@ func (ji *JobInfo) ContainsSubJobPolicy() bool {
 // ContainsHardTopologyInSubJob returns whether the subJobs in the job contain hard network topology
 func (ji *JobInfo) ContainsHardTopologyInSubJob() bool {
 	for _, subJob := range ji.SubJobs {
-		if hard, _ := subJob.IsHardTopologyMode(); hard {
+		if subJob.HardTopologyConstraint() != nil {
 			return true
 		}
 	}
@@ -1411,7 +1438,7 @@ func (ji *JobInfo) ContainsHardTopologyInSubJob() bool {
 
 // ContainsHardTopology returns whether the job and the subJobs in the job contain hard network topology
 func (ji *JobInfo) ContainsHardTopology() bool {
-	if hard, _ := ji.IsHardTopologyMode(); hard || ji.ContainsHardTopologyInSubJob() {
+	if ji.HardTopologyConstraint() != nil || ji.ContainsHardTopologyInSubJob() {
 		return true
 	}
 	return false

--- a/pkg/scheduler/api/job_info_test.go
+++ b/pkg/scheduler/api/job_info_test.go
@@ -31,6 +31,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/utils/ptr"
 
 	"volcano.sh/apis/pkg/apis/scheduling"
 	schedulingv2 "volcano.sh/apis/pkg/apis/scheduling/v1beta1"
@@ -618,6 +619,54 @@ func TestHasTopologyHardConstrain(t *testing.T) {
 			hasHard, tier := tt.jobInfo.IsHardTopologyMode()
 			assert.Equal(t, tt.expectedHasHard, hasHard)
 			assert.Equal(t, tt.expectedTier, tier)
+		})
+	}
+}
+
+func TestJobInfo_HardTopologyConstraint(t *testing.T) {
+	tests := []struct {
+		name       string
+		topology   *scheduling.NetworkTopologySpec
+		constraint bool
+	}{
+		{
+			name: "hard numeric boundary",
+			topology: &scheduling.NetworkTopologySpec{
+				Mode:               scheduling.HardNetworkTopologyMode,
+				HighestTierAllowed: ptr.To(1),
+			},
+			constraint: true,
+		},
+		{
+			name: "hard name boundary",
+			topology: &scheduling.NetworkTopologySpec{
+				Mode:            scheduling.HardNetworkTopologyMode,
+				HighestTierName: "volcano.sh/hypernode",
+			},
+			constraint: true,
+		},
+		{
+			name: "soft boundary",
+			topology: &scheduling.NetworkTopologySpec{
+				Mode:            scheduling.SoftNetworkTopologyMode,
+				HighestTierName: "volcano.sh/hypernode",
+			},
+		},
+		{
+			name:       "hard mode without boundary",
+			topology:   &scheduling.NetworkTopologySpec{Mode: scheduling.HardNetworkTopologyMode},
+			constraint: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			job := &JobInfo{NetworkTopology: tt.topology}
+			if tt.constraint {
+				assert.Same(t, tt.topology, job.HardTopologyConstraint())
+				return
+			}
+			assert.Nil(t, job.HardTopologyConstraint())
 		})
 	}
 }

--- a/pkg/scheduler/api/sub_job_info.go
+++ b/pkg/scheduler/api/sub_job_info.go
@@ -57,6 +57,9 @@ type SubJobInfo struct {
 	NominatedHyperNode string
 
 	NetworkTopology *scheduling.NetworkTopologySpec
+	// softTopologyConverted records scheduler-internal Soft-to-Hard conversion
+	// provenance. It is intentionally not part of the Kubernetes-facing API.
+	softTopologyConverted bool
 }
 
 func NewSubJobInfo(gid SubJobGID, uid SubJobID, job JobID, policy *scheduling.SubGroupPolicySpec, matchValues []string) *SubJobInfo {
@@ -85,7 +88,8 @@ func NewSubJobInfo(gid SubJobGID, uid SubJobID, job JobID, policy *scheduling.Su
 	return sji
 }
 
-// IsHardTopologyMode return whether the subJob's network topology mode is hard and also return the highest allowed tier
+// IsHardTopologyMode reports a numeric hard topology constraint and returns its
+// tier. Use HardTopologyConstraint when tier names are supported by the caller.
 func (sji *SubJobInfo) IsHardTopologyMode() (bool, int) {
 	if sji.NetworkTopology == nil || sji.NetworkTopology.HighestTierAllowed == nil {
 		return false, 0
@@ -94,12 +98,28 @@ func (sji *SubJobInfo) IsHardTopologyMode() (bool, int) {
 	return sji.NetworkTopology.Mode == scheduling.HardNetworkTopologyMode, *sji.NetworkTopology.HighestTierAllowed
 }
 
+// HardTopologyConstraint returns the configured hard topology constraint without
+// validating its boundary. Tier names are resolved within the candidate topology
+// branch by the scheduler.
+func (sji *SubJobInfo) HardTopologyConstraint() *scheduling.NetworkTopologySpec {
+	if sji.NetworkTopology == nil || sji.NetworkTopology.Mode != scheduling.HardNetworkTopologyMode {
+		return nil
+	}
+	return sji.NetworkTopology
+}
+
 // IsSoftTopologyMode returns whether the subJob has configured network topologies with soft mode.
 func (sji *SubJobInfo) IsSoftTopologyMode() bool {
 	if sji.NetworkTopology == nil {
 		return false
 	}
 	return sji.NetworkTopology.Mode == scheduling.SoftNetworkTopologyMode
+}
+
+// IsSoftTopologyConverted reports whether this subJob's Hard constraint
+// originated from scheduler Soft-to-Hard conversion.
+func (sji *SubJobInfo) IsSoftTopologyConverted() bool {
+	return sji.softTopologyConverted
 }
 
 // WithNetworkTopology returns whether the subJob has configured network topologies
@@ -117,6 +137,7 @@ func (sji *SubJobInfo) ConvertToHardTopology(maxTier int) {
 	sji.NetworkTopology.Mode = scheduling.HardNetworkTopologyMode
 	sji.NetworkTopology.HighestTierAllowed = &maxTier
 	sji.NetworkTopology.HighestTierName = ""
+	sji.softTopologyConverted = true
 }
 
 func (sji *SubJobInfo) addTask(ti *TaskInfo) {
@@ -277,6 +298,7 @@ func (sji *SubJobInfo) AllocatedTaskNum() int32 {
 func (sji *SubJobInfo) CloneStatusFrom(source *SubJobInfo) {
 	sji.AllocatedHyperNode = source.AllocatedHyperNode
 	sji.NominatedHyperNode = source.NominatedHyperNode
+	sji.softTopologyConverted = source.softTopologyConverted
 }
 
 // GetMinResources The current sub job is constrained to gang scheduling,

--- a/pkg/scheduler/api/sub_job_info_test.go
+++ b/pkg/scheduler/api/sub_job_info_test.go
@@ -232,6 +232,54 @@ func TestSubJobInfo_IsHardTopologyMode(t *testing.T) {
 	}
 }
 
+func TestSubJobInfo_HardTopologyConstraint(t *testing.T) {
+	tests := []struct {
+		name       string
+		topology   *scheduling.NetworkTopologySpec
+		constraint bool
+	}{
+		{
+			name: "hard numeric boundary",
+			topology: &scheduling.NetworkTopologySpec{
+				Mode:               scheduling.HardNetworkTopologyMode,
+				HighestTierAllowed: ptr.To(1),
+			},
+			constraint: true,
+		},
+		{
+			name: "hard name boundary",
+			topology: &scheduling.NetworkTopologySpec{
+				Mode:            scheduling.HardNetworkTopologyMode,
+				HighestTierName: "volcano.sh/hypernode",
+			},
+			constraint: true,
+		},
+		{
+			name: "soft boundary",
+			topology: &scheduling.NetworkTopologySpec{
+				Mode:            scheduling.SoftNetworkTopologyMode,
+				HighestTierName: "volcano.sh/hypernode",
+			},
+		},
+		{
+			name:       "hard mode without boundary",
+			topology:   &scheduling.NetworkTopologySpec{Mode: scheduling.HardNetworkTopologyMode},
+			constraint: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			subJob := &SubJobInfo{NetworkTopology: tt.topology}
+			if tt.constraint {
+				assert.Same(t, tt.topology, subJob.HardTopologyConstraint())
+				return
+			}
+			assert.Nil(t, subJob.HardTopologyConstraint())
+		})
+	}
+}
+
 func TestSubJobInfo_IsSoftTopologyMode(t *testing.T) {
 	type fields struct {
 		UID               SubJobID

--- a/pkg/scheduler/framework/session.go
+++ b/pkg/scheduler/framework/session.go
@@ -63,6 +63,17 @@ const (
 	ClusterTopHyperNode = "<cluster-top-hypernode>"
 )
 
+// TopologyTree describes one real, connected HyperNode tree below the virtual
+// ClusterTopHyperNode. Tier indexes are scoped to the tree and must not be used
+// to merge scheduling candidates from different trees.
+type TopologyTree struct {
+	Root       string
+	HyperNodes sets.Set[string]
+	ByTier     map[int]sets.Set[string]
+	Tiers      []int
+	RealNodes  sets.Set[string]
+}
+
 // Session information for the current session
 type Session struct {
 	UID types.UID
@@ -108,6 +119,10 @@ type Session struct {
 	// hyperNode can gain a better performance, the lower the tier of hyperNode, the better performance.
 	HyperNodesSetByTier map[int]sets.Set[string]
 	HyperNodesTiers     []int
+	// TopologyTrees and HyperNodeToTopologyTree preserve the real tree boundary
+	// hidden by ClusterTopHyperNode.
+	TopologyTrees           map[string]*TopologyTree
+	HyperNodeToTopologyTree map[string]string
 	// RealNodesList maps hyperNode Name -> nodes under the hyperNode.
 	RealNodesList             map[string][]*api.NodeInfo
 	RealNodesSet              map[string]sets.Set[string]
@@ -255,6 +270,7 @@ func openSession(cache cache.Cache) *Session {
 	ssn.RealNodesList, ssn.RealNodesSet = util.GetRealNodesByHyperNode(snapshot.RealNodesSet, snapshot.Nodes)
 	ssn.HyperNodesReadyToSchedule = snapshot.HyperNodesReadyToSchedule
 	ssn.addClusterTopHyperNode(ssn.NodeList)
+	ssn.buildTopologyTrees()
 	ssn.parseHyperNodesTiers()
 	ssn.adjustNetworkTopologySpec()
 
@@ -323,6 +339,177 @@ func (ssn *Session) addClusterTopHyperNode(nodes []*api.NodeInfo) {
 	for _, node := range nodes {
 		ssn.RealNodesSet[topHni.Name].Insert(node.Name)
 	}
+}
+
+// EnsureTopologyTrees lazily builds the real topology tree view for tests and
+// callers that construct a Session without going through openSession.
+func (ssn *Session) EnsureTopologyTrees() {
+	if ssn.topologyTreesCurrent() {
+		return
+	}
+	ssn.buildTopologyTrees()
+}
+
+// FindHyperNodeForNode returns the lowest local-tier HyperNode containing the
+// Node. The virtual cluster root is intentionally excluded.
+func (ssn *Session) FindHyperNodeForNode(nodeName string) string {
+	ssn.EnsureTopologyTrees()
+
+	var matchedTree *TopologyTree
+	for _, tree := range ssn.TopologyTrees {
+		if !tree.RealNodes.Has(nodeName) {
+			continue
+		}
+		if matchedTree != nil {
+			klog.Warningf("node %s belongs to multiple real HyperNode trees", nodeName)
+			return ""
+		}
+		matchedTree = tree
+	}
+	if matchedTree == nil {
+		return ""
+	}
+
+	for _, tier := range matchedTree.Tiers {
+		hyperNodes := matchedTree.ByTier[tier].UnsortedList()
+		sort.Strings(hyperNodes)
+		for _, hyperNode := range hyperNodes {
+			if ssn.RealNodesSet[hyperNode].Has(nodeName) {
+				return hyperNode
+			}
+		}
+	}
+	return ""
+}
+
+func (ssn *Session) topologyTreesCurrent() bool {
+	if ssn.TopologyTrees == nil || ssn.HyperNodeToTopologyTree == nil {
+		return false
+	}
+
+	realHyperNodeCount := 0
+	for name := range ssn.HyperNodes {
+		if name == ClusterTopHyperNode {
+			continue
+		}
+		realHyperNodeCount++
+		root, found := ssn.HyperNodeToTopologyTree[name]
+		if !found {
+			return false
+		}
+		tree, found := ssn.TopologyTrees[root]
+		if !found || !tree.HyperNodes.Has(name) {
+			return false
+		}
+	}
+
+	return len(ssn.HyperNodeToTopologyTree) == realHyperNodeCount
+}
+
+func (ssn *Session) buildTopologyTrees() {
+	ssn.TopologyTrees = make(map[string]*TopologyTree)
+	ssn.HyperNodeToTopologyTree = make(map[string]string)
+	if len(ssn.HyperNodes) == 0 {
+		return
+	}
+
+	rootSet := sets.New[string]()
+	if clusterRoot, found := ssn.HyperNodes[ClusterTopHyperNode]; found {
+		for child := range clusterRoot.Children {
+			if child != ClusterTopHyperNode {
+				rootSet.Insert(child)
+			}
+		}
+		for name, hyperNode := range ssn.HyperNodes {
+			if name != ClusterTopHyperNode && hyperNode.Parent == ClusterTopHyperNode {
+				rootSet.Insert(name)
+			}
+		}
+	} else {
+		children := sets.New[string]()
+		for _, hyperNode := range ssn.HyperNodes {
+			children.Insert(hyperNode.Children.UnsortedList()...)
+		}
+		for name, hyperNode := range ssn.HyperNodes {
+			if hyperNode.Parent == "" && !children.Has(name) {
+				rootSet.Insert(name)
+			}
+		}
+	}
+
+	roots := rootSet.UnsortedList()
+	sort.Strings(roots)
+	for _, root := range roots {
+		ssn.addTopologyTree(root)
+	}
+
+	// Keep malformed or temporarily disconnected components visible. The
+	// gradient builder still reports missing children when traversing a tree.
+	remaining := make([]string, 0)
+	for name := range ssn.HyperNodes {
+		if name != ClusterTopHyperNode {
+			if _, found := ssn.HyperNodeToTopologyTree[name]; !found {
+				remaining = append(remaining, name)
+			}
+		}
+	}
+	sort.Strings(remaining)
+	for _, root := range remaining {
+		if _, found := ssn.HyperNodeToTopologyTree[root]; !found {
+			ssn.addTopologyTree(root)
+		}
+	}
+}
+
+func (ssn *Session) addTopologyTree(root string) {
+	if root == ClusterTopHyperNode {
+		return
+	}
+	if _, found := ssn.HyperNodes[root]; !found {
+		return
+	}
+
+	tree := &TopologyTree{
+		Root:       root,
+		HyperNodes: sets.New[string](),
+		ByTier:     make(map[int]sets.Set[string]),
+		RealNodes:  sets.New[string](),
+	}
+	queue := []string{root}
+	for len(queue) > 0 {
+		name := queue[0]
+		queue = queue[1:]
+		if name == ClusterTopHyperNode || tree.HyperNodes.Has(name) {
+			continue
+		}
+		if _, assigned := ssn.HyperNodeToTopologyTree[name]; assigned {
+			continue
+		}
+
+		hyperNode, found := ssn.HyperNodes[name]
+		if !found {
+			continue
+		}
+		tree.HyperNodes.Insert(name)
+		ssn.HyperNodeToTopologyTree[name] = root
+		if tree.ByTier[hyperNode.Tier()] == nil {
+			tree.ByTier[hyperNode.Tier()] = sets.New[string]()
+		}
+		tree.ByTier[hyperNode.Tier()].Insert(name)
+		for nodeName := range ssn.RealNodesSet[name] {
+			tree.RealNodes.Insert(nodeName)
+		}
+
+		children := hyperNode.Children.UnsortedList()
+		sort.Strings(children)
+		queue = append(queue, children...)
+	}
+
+	for tier := range tree.ByTier {
+		tree.Tiers = append(tree.Tiers, tier)
+	}
+	sort.Ints(tree.Tiers)
+	ssn.TopologyTrees[root] = tree
 }
 
 // removeInvalidAllocatedHyperNode removes the non-existent allocated hyperNode for job and subJobs in the job.
@@ -1050,9 +1237,11 @@ func (ssn *Session) IsJobTerminated(jobId api.JobID) bool {
 	return ssn.cache.IsJobTerminated(jobId)
 }
 
-// adjustNetworkTopologySpec translates highestTierName in scheduler-internal network topology copies into highestTierAllowed,
-// and converts soft topology mode to hard mode with ClusterTopHyperNode tier as maxTier.
-// As a result, once adjustNetworkTopologySpec is invoked, it is no need to consider highestTierName or soft mode anymore.
+// adjustNetworkTopologySpec converts Soft topology mode to Hard mode
+// with ClusterTopHyperNode tier as maxTier. Hard highestTierName constraints
+// stay intact so plugins can resolve them independently in each topology
+// branch. Soft constraints keep the upstream name translation and conversion
+// flow; #5732 does not add mixed-topology Soft semantics.
 func (ssn *Session) adjustNetworkTopologySpec() {
 	klog.V(3).Infof("Start adjusting jobs' network topology spec according to hyperNodeTierNameMap %v", ssn.HyperNodeTierNameMap)
 	defer klog.V(3).Infof("Finish adjusting jobs' network topology spec according to hyperNodeTierNameMap %v", ssn.HyperNodeTierNameMap)
@@ -1062,23 +1251,27 @@ func (ssn *Session) adjustNetworkTopologySpec() {
 			continue
 		}
 
-		translated, err := translateHighestTierNameToAllowed(job.NetworkTopology, ssn.HyperNodeTierNameMap)
-		if err != nil {
-			klog.Warningf("Failed to translate highestTierName for job %s/%s: %v, skip translation", job.Namespace, job.Name, err)
-		} else if translated {
-			klog.V(4).Infof("Translated highestTierName for job %s/%s, new highestTierAllowed is %d",
-				job.Namespace, job.Name, *job.NetworkTopology.HighestTierAllowed)
+		if job.NetworkTopology != nil && job.NetworkTopology.Mode == scheduling.SoftNetworkTopologyMode {
+			translated, err := translateHighestTierNameToAllowed(job.NetworkTopology, ssn.HyperNodeTierNameMap)
+			if err != nil {
+				klog.Warningf("Failed to translate highestTierName for job %s/%s: %v, skip translation", job.Namespace, job.Name, err)
+			} else if translated {
+				klog.V(4).Infof("Translated Soft highestTierName for job %s/%s, new highestTierAllowed is %d",
+					job.Namespace, job.Name, *job.NetworkTopology.HighestTierAllowed)
+			}
 		}
 
-		// NetworkTopology of SubJob is derived from the original job or SubGroupPolicy NetworkTopology,
-		// and will be used by plugins like network-topology-aware.
+		// Hard tier names remain semantic and are resolved in each topology tree.
 		for _, subJob := range job.SubJobs {
-			translated, err = translateHighestTierNameToAllowed(subJob.NetworkTopology, ssn.HyperNodeTierNameMap)
+			if subJob.NetworkTopology == nil || subJob.NetworkTopology.Mode != scheduling.SoftNetworkTopologyMode {
+				continue
+			}
+			translated, err := translateHighestTierNameToAllowed(subJob.NetworkTopology, ssn.HyperNodeTierNameMap)
 			if err != nil {
 				klog.Warningf("Failed to translate highestTierName for subJob %s of job %s/%s: %v, skip translation",
 					subJob.UID, job.Namespace, job.Name, err)
 			} else if translated {
-				klog.V(4).Infof("Translated highestTierName for subJob %s of job %s/%s, new highestTierAllowed is %d",
+				klog.V(4).Infof("Translated Soft highestTierName for subJob %s of job %s/%s, new highestTierAllowed is %d",
 					subJob.UID, job.Namespace, job.Name, *subJob.NetworkTopology.HighestTierAllowed)
 			}
 		}
@@ -1121,6 +1314,7 @@ func convertSoftToHardTopology(job *api.JobInfo, maxTier int) {
 		job.NetworkTopology.Mode = scheduling.HardNetworkTopologyMode
 		job.NetworkTopology.HighestTierAllowed = &maxTier
 		job.NetworkTopology.HighestTierName = ""
+		job.SetSoftTopologyConverted()
 	}
 
 	// Determine the effective maxTier for SubJob conversion.
@@ -1144,9 +1338,8 @@ func translateHighestTierNameToAllowed(spec *scheduling.NetworkTopologySpec, nam
 			spec.HighestTierAllowed = &tier
 			spec.HighestTierName = ""
 			return true, nil
-		} else {
-			return false, fmt.Errorf("failed to find hypernode tier name %s", spec.HighestTierName)
 		}
+		return false, fmt.Errorf("failed to find hypernode tier name %s", spec.HighestTierName)
 	}
 	return false, nil
 }

--- a/pkg/scheduler/framework/session_test.go
+++ b/pkg/scheduler/framework/session_test.go
@@ -5,12 +5,223 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/utils/ptr"
 
+	batchv1alpha1 "volcano.sh/apis/pkg/apis/batch/v1alpha1"
 	"volcano.sh/apis/pkg/apis/scheduling"
+	schedulingv1beta1 "volcano.sh/apis/pkg/apis/scheduling/v1beta1"
 	topologyv1alpha1 "volcano.sh/apis/pkg/apis/topology/v1alpha1"
 	"volcano.sh/volcano/pkg/scheduler/api"
 )
+
+func TestSessionEnsureTopologyTrees(t *testing.T) {
+	newHyperNode := func(name string, tier int, children ...string) *api.HyperNodeInfo {
+		info := api.NewHyperNodeInfo(api.BuildHyperNode(name, tier, nil))
+		info.Children.Insert(children...)
+		return info
+	}
+
+	hyperNodes := api.HyperNodeInfoMap{
+		"shallow-leaf":      newHyperNode("shallow-leaf", 1),
+		"shallow-root":      newHyperNode("shallow-root", 2, "shallow-leaf"),
+		"deep-leaf":         newHyperNode("deep-leaf", 1),
+		"deep-middle":       newHyperNode("deep-middle", 2, "deep-leaf"),
+		"deep-root":         newHyperNode("deep-root", 3, "deep-middle"),
+		"single-tier":       newHyperNode("single-tier", 1),
+		ClusterTopHyperNode: newHyperNode(ClusterTopHyperNode, 4, "shallow-root", "deep-root", "single-tier"),
+	}
+	for _, parent := range hyperNodes {
+		for child := range parent.Children {
+			hyperNodes[child].Parent = parent.Name
+		}
+	}
+
+	ssn := &Session{
+		HyperNodes: hyperNodes,
+		RealNodesSet: map[string]sets.Set[string]{
+			"shallow-leaf": sets.New("shallow-node"),
+			"shallow-root": sets.New("shallow-node"),
+			"deep-leaf":    sets.New("deep-node"),
+			"deep-middle":  sets.New("deep-node"),
+			"deep-root":    sets.New("deep-node"),
+			"single-tier":  sets.New("single-tier-node"),
+		},
+	}
+	ssn.EnsureTopologyTrees()
+
+	assert.Equal(t, sets.New("shallow-root", "deep-root", "single-tier"), sets.KeySet(ssn.TopologyTrees))
+	assert.Equal(t, []int{1, 2}, ssn.TopologyTrees["shallow-root"].Tiers)
+	assert.Equal(t, []int{1, 2, 3}, ssn.TopologyTrees["deep-root"].Tiers)
+	assert.Equal(t, []int{1}, ssn.TopologyTrees["single-tier"].Tiers)
+	assert.Equal(t, sets.New("shallow-root", "shallow-leaf"), ssn.TopologyTrees["shallow-root"].HyperNodes)
+	assert.Equal(t, sets.New("deep-root", "deep-middle", "deep-leaf"), ssn.TopologyTrees["deep-root"].HyperNodes)
+	assert.Equal(t, sets.New("single-tier"), ssn.TopologyTrees["single-tier"].HyperNodes)
+	assert.Equal(t, sets.New("shallow-node"), ssn.TopologyTrees["shallow-root"].RealNodes)
+	assert.Equal(t, sets.New("deep-node"), ssn.TopologyTrees["deep-root"].RealNodes)
+	assert.Equal(t, sets.New("single-tier-node"), ssn.TopologyTrees["single-tier"].RealNodes)
+	assert.Equal(t, "shallow-root", ssn.HyperNodeToTopologyTree["shallow-leaf"])
+	assert.Equal(t, "deep-root", ssn.HyperNodeToTopologyTree["deep-middle"])
+	assert.Equal(t, "single-tier", ssn.HyperNodeToTopologyTree["single-tier"])
+	_, clusterRootIndexed := ssn.HyperNodeToTopologyTree[ClusterTopHyperNode]
+	assert.False(t, clusterRootIndexed)
+	assert.Equal(t, "shallow-leaf", ssn.FindHyperNodeForNode("shallow-node"))
+	assert.Equal(t, "deep-leaf", ssn.FindHyperNodeForNode("deep-node"))
+	assert.Equal(t, "single-tier", ssn.FindHyperNodeForNode("single-tier-node"))
+	assert.Empty(t, ssn.FindHyperNodeForNode("outside-node"))
+}
+
+func TestSessionAddClusterTopHyperNodeUsesNumericBoundary(t *testing.T) {
+	newHyperNode := func(name string, tier int) *api.HyperNodeInfo {
+		return api.NewHyperNodeInfo(api.BuildHyperNode(name, tier, nil))
+	}
+
+	ssn := &Session{
+		HyperNodes: api.HyperNodeInfoMap{
+			"root-a": newHyperNode("root-a", 1),
+			"root-b": newHyperNode("root-b", 3),
+		},
+		HyperNodesSetByTier: map[int]sets.Set[string]{
+			1: sets.New[string]("root-a"),
+			3: sets.New[string]("root-b"),
+		},
+		RealNodesList: map[string][]*api.NodeInfo{},
+		RealNodesSet:  map[string]sets.Set[string]{},
+	}
+	nodes := []*api.NodeInfo{{Name: "node-a"}}
+
+	ssn.addClusterTopHyperNode(nodes)
+
+	topHn := ssn.HyperNodes[ClusterTopHyperNode]
+	if assert.NotNil(t, topHn) {
+		assert.Equal(t, 4, topHn.Tier(), "virtual root must be one tier above the highest real tier")
+		assert.Equal(t, sets.New[string]("root-a", "root-b"), topHn.Children)
+	}
+	assert.Equal(t, ClusterTopHyperNode, ssn.HyperNodes["root-a"].Parent)
+	assert.Equal(t, ClusterTopHyperNode, ssn.HyperNodes["root-b"].Parent)
+	assert.Equal(t, sets.New[string](ClusterTopHyperNode), ssn.HyperNodesSetByTier[4])
+	assert.Equal(t, nodes, ssn.RealNodesList[ClusterTopHyperNode])
+	assert.Equal(t, sets.New[string]("node-a"), ssn.RealNodesSet[ClusterTopHyperNode])
+}
+
+func TestSessionRecoverAllocatedHyperNodeAcrossMixedTopology(t *testing.T) {
+	newHyperNode := func(name string, tier int, children ...string) *api.HyperNodeInfo {
+		info := api.NewHyperNodeInfo(api.BuildHyperNode(name, tier, nil))
+		info.Children.Insert(children...)
+		return info
+	}
+
+	hyperNodes := api.HyperNodeInfoMap{
+		"shallow-hypernode-0": newHyperNode("shallow-hypernode-0", 1),
+		"shallow-hypernode-1": newHyperNode("shallow-hypernode-1", 1),
+		"shallow-hypercluster": newHyperNode(
+			"shallow-hypercluster", 2, "shallow-hypernode-0", "shallow-hypernode-1"),
+		"deep-superpod-0": newHyperNode("deep-superpod-0", 1),
+		"deep-superpod-1": newHyperNode("deep-superpod-1", 1),
+		"deep-hypernode": newHyperNode(
+			"deep-hypernode", 2, "deep-superpod-0", "deep-superpod-1"),
+		"deep-hypercluster": newHyperNode("deep-hypercluster", 3, "deep-hypernode"),
+		ClusterTopHyperNode: newHyperNode(
+			ClusterTopHyperNode, 4, "shallow-hypercluster", "deep-hypercluster"),
+	}
+	for _, parent := range hyperNodes {
+		for child := range parent.Children {
+			hyperNodes[child].Parent = parent.Name
+		}
+	}
+
+	realNodes := map[string]sets.Set[string]{
+		"shallow-hypernode-0": sets.New("shallow-node-0", "shallow-node-1"),
+		"shallow-hypernode-1": sets.New("shallow-node-2", "shallow-node-3"),
+		"shallow-hypercluster": sets.New(
+			"shallow-node-0", "shallow-node-1", "shallow-node-2", "shallow-node-3"),
+		"deep-superpod-0": sets.New("deep-node-0", "deep-node-1"),
+		"deep-superpod-1": sets.New("deep-node-2", "deep-node-3"),
+		"deep-hypernode": sets.New(
+			"deep-node-0", "deep-node-1", "deep-node-2", "deep-node-3"),
+		"deep-hypercluster": sets.New(
+			"deep-node-0", "deep-node-1", "deep-node-2", "deep-node-3"),
+		ClusterTopHyperNode: sets.New(
+			"shallow-node-0", "shallow-node-1", "shallow-node-2", "shallow-node-3",
+			"deep-node-0", "deep-node-1", "deep-node-2", "deep-node-3"),
+	}
+
+	const (
+		namespace    = "test"
+		podGroupName = "mixed-recovery"
+		taskName     = "worker"
+	)
+	jobID := api.JobID(namespace + "/" + podGroupName)
+	subGroupSize := int32(2)
+	minSubGroups := int32(2)
+	job := api.NewJobInfo(jobID)
+	job.SetPodGroup(&api.PodGroup{PodGroup: scheduling.PodGroup{
+		ObjectMeta: metav1.ObjectMeta{Name: podGroupName, Namespace: namespace},
+		Spec: scheduling.PodGroupSpec{
+			MinMember: 4,
+			NetworkTopology: &scheduling.NetworkTopologySpec{
+				Mode:            scheduling.HardNetworkTopologyMode,
+				HighestTierName: "volcano.sh/hypercluster",
+			},
+			SubGroupPolicy: []scheduling.SubGroupPolicySpec{{
+				Name:         taskName,
+				SubGroupSize: &subGroupSize,
+				MinSubGroups: &minSubGroups,
+				LabelSelector: &metav1.LabelSelector{MatchLabels: map[string]string{
+					batchv1alpha1.TaskSpecKey: taskName,
+				}},
+				MatchLabelKeys: []string{batchv1alpha1.TaskPartitionID},
+				NetworkTopology: &scheduling.NetworkTopologySpec{
+					Mode:            scheduling.HardNetworkTopologyMode,
+					HighestTierName: "volcano.sh/superpod",
+				},
+			}},
+		},
+	}})
+
+	for partition, nodes := range [][]string{
+		{"deep-node-0", "deep-node-1"},
+		{"deep-node-2", "deep-node-3"},
+	} {
+		for index, nodeName := range nodes {
+			podName := fmt.Sprintf("worker-%d-%d", partition, index)
+			pod := &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      podName,
+					Namespace: namespace,
+					UID:       types.UID(podName),
+					Labels: map[string]string{
+						batchv1alpha1.TaskSpecKey:     taskName,
+						batchv1alpha1.TaskPartitionID: fmt.Sprint(partition),
+					},
+					Annotations: map[string]string{
+						schedulingv1beta1.KubeGroupNameAnnotationKey: podGroupName,
+					},
+				},
+				Spec:   v1.PodSpec{NodeName: nodeName},
+				Status: v1.PodStatus{Phase: v1.PodRunning},
+			}
+			job.AddTaskInfo(api.NewTaskInfo(pod))
+		}
+	}
+
+	ssn := &Session{DirtyJobs: sets.New[api.JobID]()}
+	ssn.recoverAllocatedHyperNode(job, sets.KeySet(hyperNodes), hyperNodes, realNodes)
+
+	assert.Equal(t, "deep-hypernode", job.AllocatedHyperNode)
+	assert.Len(t, job.SubJobs, 2)
+	expectedSubGroupHyperNodes := map[int]string{
+		0: "deep-superpod-0",
+		1: "deep-superpod-1",
+	}
+	for _, subJob := range job.SubJobs {
+		assert.Equal(t, expectedSubGroupHyperNodes[subJob.MatchIndex], subJob.AllocatedHyperNode)
+	}
+	assert.True(t, ssn.DirtyJobs.Has(jobID))
+}
 
 func TestSession_adjustNetworkTopologySpec(t *testing.T) {
 	tests := []struct {
@@ -87,7 +298,7 @@ func TestSession_adjustNetworkTopologySpec(t *testing.T) {
 			},
 		},
 		{
-			name: "job with highestTierName, need translation",
+			name: "job with highestTierName is preserved for branch resolution",
 			jobs: map[api.JobID]*api.JobInfo{
 				"test-uid": {
 					PodGroup: &api.PodGroup{
@@ -128,14 +339,14 @@ func TestSession_adjustNetworkTopologySpec(t *testing.T) {
 						PodGroup: scheduling.PodGroup{
 							Spec: scheduling.PodGroupSpec{
 								NetworkTopology: &scheduling.NetworkTopologySpec{
-									HighestTierName:    "",
-									HighestTierAllowed: ptr.To(2),
+									HighestTierName:    "volcano.sh/hypercluster",
+									HighestTierAllowed: nil,
 								},
 								SubGroupPolicy: []scheduling.SubGroupPolicySpec{
 									{
 										NetworkTopology: &scheduling.NetworkTopologySpec{
-											HighestTierName:    "",
-											HighestTierAllowed: ptr.To(1),
+											HighestTierName:    "volcano.sh/hypernode",
+											HighestTierAllowed: nil,
 										},
 									},
 								},
@@ -145,8 +356,8 @@ func TestSession_adjustNetworkTopologySpec(t *testing.T) {
 					SubJobs: map[api.SubJobID]*api.SubJobInfo{
 						"test-uid": {
 							NetworkTopology: &scheduling.NetworkTopologySpec{
-								HighestTierName:    "",
-								HighestTierAllowed: ptr.To(1),
+								HighestTierName:    "volcano.sh/hypernode",
+								HighestTierAllowed: nil,
 							},
 						},
 					},
@@ -579,8 +790,8 @@ func TestConvertSoftToHardTopology_NilPodGroup(t *testing.T) {
 }
 
 func TestAdjustNetworkTopologySpec_SoftToHardConversion(t *testing.T) {
-	// This test verifies that adjustNetworkTopologySpec performs both tier name translation
-	// and soft→hard conversion in the same place.
+	// This test verifies that adjustNetworkTopologySpec converts soft mode while
+	// preserving hard tier names for branch-local resolution.
 	maxTier := 4 // ClusterTopHyperNode tier will be max(existing tiers) + 1 = 3 + 1 = 4
 
 	topHn := &topologyv1alpha1.HyperNode{}
@@ -594,9 +805,10 @@ func TestAdjustNetworkTopologySpec_SoftToHardConversion(t *testing.T) {
 		hyperNodes  api.HyperNodeInfoMap
 		wantJobMode scheduling.NetworkTopologyMode
 		wantJobTier *int
+		wantJobName string
 	}{
 		{
-			name: "soft topology with tierName: both translated and converted",
+			name: "soft topology with tierName is converted to an unrestricted numeric boundary",
 			jobs: map[api.JobID]*api.JobInfo{
 				"test-uid": {
 					PodGroup: &api.PodGroup{
@@ -619,7 +831,6 @@ func TestAdjustNetworkTopologySpec_SoftToHardConversion(t *testing.T) {
 			hyperNodes: api.HyperNodeInfoMap{
 				ClusterTopHyperNode: api.NewHyperNodeInfo(topHn),
 			},
-			// tierName is translated first (HighestTierAllowed=2), then soft→hard uses that tier
 			wantJobMode: scheduling.HardNetworkTopologyMode,
 			wantJobTier: ptr.To(maxTier),
 		},
@@ -647,7 +858,7 @@ func TestAdjustNetworkTopologySpec_SoftToHardConversion(t *testing.T) {
 			wantJobTier: ptr.To(maxTier),
 		},
 		{
-			name: "hard topology with tierName: only translated, not re-converted",
+			name: "hard topology with tierName is preserved",
 			jobs: map[api.JobID]*api.JobInfo{
 				"test-uid": {
 					PodGroup: &api.PodGroup{
@@ -671,7 +882,8 @@ func TestAdjustNetworkTopologySpec_SoftToHardConversion(t *testing.T) {
 				ClusterTopHyperNode: api.NewHyperNodeInfo(topHn),
 			},
 			wantJobMode: scheduling.HardNetworkTopologyMode,
-			wantJobTier: ptr.To(1), // translated from tierName, not overwritten by maxTier
+			wantJobTier: nil,
+			wantJobName: "volcano.sh/hypernode",
 		},
 	}
 
@@ -692,8 +904,37 @@ func TestAdjustNetworkTopologySpec_SoftToHardConversion(t *testing.T) {
 			gotJob := ssn.Jobs["test-uid"]
 			assert.Equal(t, tt.wantJobMode, gotJob.NetworkTopology.Mode, "job mode mismatch")
 			assert.Equal(t, tt.wantJobTier, gotJob.NetworkTopology.HighestTierAllowed, "job tier mismatch")
+			assert.Equal(t, tt.wantJobName, gotJob.NetworkTopology.HighestTierName, "job tier name mismatch")
 		})
 	}
+}
+
+func TestAdjustNetworkTopologySpecRecordsSoftConversionProvenance(t *testing.T) {
+	maxTier := 2
+	topHn := &topologyv1alpha1.HyperNode{}
+	topHn.Name = ClusterTopHyperNode
+	topHn.Spec.Tier = maxTier
+
+	job := api.NewJobInfo("soft-provenance")
+	job.PodGroup = &api.PodGroup{PodGroup: scheduling.PodGroup{Spec: scheduling.PodGroupSpec{
+		NetworkTopology: &scheduling.NetworkTopologySpec{Mode: scheduling.SoftNetworkTopologyMode},
+	}}}
+	job.NetworkTopology = job.PodGroup.Spec.NetworkTopology.DeepCopy()
+	job.SubJobs[api.SubJobID("soft-provenance/default")] = &api.SubJobInfo{
+		UID:             api.SubJobID("soft-provenance/default"),
+		NetworkTopology: &scheduling.NetworkTopologySpec{Mode: scheduling.SoftNetworkTopologyMode},
+	}
+
+	ssn := &Session{
+		Jobs: map[api.JobID]*api.JobInfo{job.UID: job},
+		HyperNodes: api.HyperNodeInfoMap{
+			ClusterTopHyperNode: api.NewHyperNodeInfo(topHn),
+		},
+	}
+	ssn.adjustNetworkTopologySpec()
+
+	assert.True(t, job.IsSoftTopologyConverted())
+	assert.True(t, job.SubJobs[api.SubJobID("soft-provenance/default")].IsSoftTopologyConverted())
 }
 
 func TestGetPodGroupPhase(t *testing.T) {

--- a/pkg/scheduler/plugins/network-topology-aware/network_topology_aware.go
+++ b/pkg/scheduler/plugins/network-topology-aware/network_topology_aware.go
@@ -27,6 +27,7 @@ import (
 	fwk "k8s.io/kube-scheduler/framework"
 	"k8s.io/utils/set"
 
+	"volcano.sh/apis/pkg/apis/scheduling"
 	"volcano.sh/volcano/pkg/scheduler/api"
 	"volcano.sh/volcano/pkg/scheduler/framework"
 	"volcano.sh/volcano/pkg/scheduler/util"
@@ -291,12 +292,12 @@ func (nta *networkTopologyAwarePlugin) OnSessionOpen(ssn *framework.Session) {
 	})
 
 	ssn.AddHyperNodeGradientForJobFn(nta.Name(), func(job *api.JobInfo, hyperNode *api.HyperNodeInfo, purpose api.SearchPurpose) [][]*api.HyperNodeInfo {
-		if hardMode, highestAllowedTier := job.IsHardTopologyMode(); hardMode {
+		if topology := job.HardTopologyConstraint(); topology != nil {
 			jobMinResource := job.GetMinResources()
-			result, err := nta.hyperNodeGradientFn(ssn, hyperNode, highestAllowedTier, job.AllocatedHyperNode, jobMinResource, purpose)
+			result, err := nta.hyperNodeGradientFn(ssn, hyperNode, topology, job.AllocatedHyperNode, jobMinResource, purpose, job.IsSoftTopologyConverted())
 			if err != nil {
 				klog.ErrorS(err, "build hyperNode gradient fail", "job", job.UID, "hyperNode", hyperNode.Name,
-					"highestAllowedTier", highestAllowedTier, "allocatedHyperNode", job.AllocatedHyperNode)
+					"topology", topology, "allocatedHyperNode", job.AllocatedHyperNode)
 				return nil
 			}
 			if purpose != api.PurposeEvict {
@@ -308,12 +309,12 @@ func (nta *networkTopologyAwarePlugin) OnSessionOpen(ssn *framework.Session) {
 	})
 
 	ssn.AddHyperNodeGradientForSubJobFn(nta.Name(), func(subJob *api.SubJobInfo, hyperNode *api.HyperNodeInfo, purpose api.SearchPurpose) [][]*api.HyperNodeInfo {
-		if hardMode, highestAllowedTier := subJob.IsHardTopologyMode(); hardMode {
+		if topology := subJob.HardTopologyConstraint(); topology != nil {
 			subJobMinResource := subJob.GetMinResources()
-			result, err := nta.hyperNodeGradientFn(ssn, hyperNode, highestAllowedTier, subJob.AllocatedHyperNode, subJobMinResource, purpose)
+			result, err := nta.hyperNodeGradientFn(ssn, hyperNode, topology, subJob.AllocatedHyperNode, subJobMinResource, purpose, subJob.IsSoftTopologyConverted())
 			if err != nil {
 				klog.ErrorS(err, "build hyperNode gradient fail", "subJob", subJob.UID, "hyperNode", hyperNode.Name,
-					"highestAllowedTier", highestAllowedTier, "allocatedHyperNode", subJob.AllocatedHyperNode)
+					"topology", topology, "allocatedHyperNode", subJob.AllocatedHyperNode)
 				return nil
 			}
 			if purpose != api.PurposeEvict {
@@ -483,33 +484,89 @@ func (nta *networkTopologyAwarePlugin) batchNodeOrderFnForNormalPods(ssn *framew
 		return nodeScores, nil
 	}
 
-	totalTierWeight := 0.0
-	tierWeights := make(map[int]float64)
+	// Keep the global weights for malformed topologies where one Node belongs
+	// to multiple real trees. Valid topologies are scored by their local tree
+	// depth below, so tiers that only exist in a sibling tree cannot add score.
+	globalTierWeight := 0.0
+	globalTierWeights := make(map[int]float64)
 	for tier := nta.hyperNodesTier.minTier; tier <= nta.hyperNodesTier.maxTier; tier++ {
 		// Note: math.Pow(0, 0) = 1
 		tierWeight := math.Pow(nta.hyperNodeBinPackingFading, float64(tier-1))
-		totalTierWeight += tierWeight
-		tierWeights[tier] = tierWeight
+		globalTierWeight += tierWeight
+		globalTierWeights[tier] = tierWeight
 	}
-	if totalTierWeight <= 0 {
+	if globalTierWeight <= 0 {
 		// This should not happen, since there are at least one tier and its weight is one
-		klog.Warningf("the total tier weight of plugin %s should be greater than zero, but got %g", PluginName, totalTierWeight)
+		klog.Warningf("the total tier weight of plugin %s should be greater than zero, but got %g", PluginName, globalTierWeight)
 		return nodeScores, nil
 	}
 
-	for _, node := range nodes {
+	ssn.EnsureTopologyTrees()
+	nodeTopologyTrees := make(map[string]*framework.TopologyTree)
+	ambiguousNodes := set.New[string]()
+	for _, tree := range ssn.TopologyTrees {
+		for nodeName := range tree.RealNodes {
+			if previous, found := nodeTopologyTrees[nodeName]; found && previous.Root != tree.Root {
+				ambiguousNodes.Insert(nodeName)
+				continue
+			}
+			nodeTopologyTrees[nodeName] = tree
+		}
+	}
+
+	globalScore := func(nodeName string) float64 {
 		totalScore := 0.0
 		for tier := nta.hyperNodesTier.minTier; tier <= nta.hyperNodesTier.maxTier; tier++ {
-			// If no hypernode is found at this tier, this tierScore is FullScore finally, because we prefer to schedule pods to nodes that do not belong to any hypernode.
 			tierScore := FullScore
 			for hyperNodeName := range ssn.HyperNodesSetByTier[tier] {
+				if ssn.RealNodesSet[hyperNodeName].Has(nodeName) {
+					tierScore = nta.getPodHyperNodeBinPackingScore(task, hyperNodeName)
+					break
+				}
+			}
+			totalScore += globalTierWeights[tier] * tierScore
+		}
+		return totalScore / globalTierWeight
+	}
+
+	for _, node := range nodes {
+		tree, found := nodeTopologyTrees[node.Name]
+		if !found {
+			// Preserve the preference for Nodes outside any HyperNode topology.
+			nodeScores[node.Name] = FullScore
+			continue
+		}
+		if ambiguousNodes.Has(node.Name) {
+			nodeScores[node.Name] = globalScore(node.Name)
+			continue
+		}
+
+		totalScore := 0.0
+		totalTierWeight := 0.0
+		for localTier, tier := range tree.Tiers {
+			tierWeight := math.Pow(nta.hyperNodeBinPackingFading, float64(localTier))
+			totalTierWeight += tierWeight
+			// If no hypernode is found at this tier, this tierScore is FullScore finally, because we prefer to schedule pods to nodes that do not belong to any hypernode.
+			tierScore := FullScore
+			for hyperNodeName := range tree.ByTier[tier] {
 				if ssn.RealNodesSet[hyperNodeName].Has(node.Name) {
 					tierScore = nta.getPodHyperNodeBinPackingScore(task, hyperNodeName)
 					break
 				}
 			}
-			totalScore += tierWeights[tier] * tierScore
+			totalScore += tierWeight * tierScore
 		}
+
+		if _, hasClusterRoot := ssn.HyperNodes[framework.ClusterTopHyperNode]; hasClusterRoot {
+			rootWeight := math.Pow(nta.hyperNodeBinPackingFading, float64(len(tree.Tiers)))
+			totalTierWeight += rootWeight
+			rootScore := FullScore
+			if ssn.RealNodesSet[framework.ClusterTopHyperNode].Has(node.Name) {
+				rootScore = nta.getPodHyperNodeBinPackingScore(task, framework.ClusterTopHyperNode)
+			}
+			totalScore += rootWeight * rootScore
+		}
+
 		nodeScores[node.Name] = totalScore / totalTierWeight
 	}
 	return nodeScores, nil
@@ -567,8 +624,8 @@ func (nta *networkTopologyAwarePlugin) batchNodeOrderFnForNetworkAwarePods(ssn *
 	var maxScore float64 = -1
 	scoreToNodes := map[float64][]string{}
 	for _, node := range nodes {
-		hyperNode := util.FindHyperNodeForNode(node.Name, ssn.RealNodesList, ssn.HyperNodesTiers, ssn.HyperNodesSetByTier)
-		score := nta.networkTopologyAwareScore(hyperNode, allocatedHyperNode, ssn.HyperNodes)
+		hyperNode := ssn.FindHyperNodeForNode(node.Name)
+		score := nta.networkTopologyAwareScore(hyperNode, allocatedHyperNode, ssn)
 		nodeScores[node.Name] = score
 		if score >= maxScore {
 			maxScore = score
@@ -579,7 +636,7 @@ func (nta *networkTopologyAwarePlugin) batchNodeOrderFnForNetworkAwarePods(ssn *
 	if len(scoreToNodes[maxScore]) > 1 {
 		candidateNodes := scoreToNodes[maxScore]
 		for _, node := range candidateNodes {
-			hyperNode := util.FindHyperNodeForNode(node, ssn.RealNodesList, ssn.HyperNodesTiers, ssn.HyperNodesSetByTier)
+			hyperNode := ssn.FindHyperNodeForNode(node)
 			taskNumScore := nta.scoreWithTaskNum(hyperNode, subJob.Tasks, ssn.RealNodesList)
 			nodeScores[node] += taskNumScore
 		}
@@ -590,47 +647,153 @@ func (nta *networkTopologyAwarePlugin) batchNodeOrderFnForNetworkAwarePods(ssn *
 
 // hyperNodeGradientFn computes network topology gradients by performing BFS traversal from the given HyperNode,
 // filtering and grouping HyperNodes by tier based on resource availability and topology constraints.
-// It returns HyperNodes organized in ascending tier order (lower tiers represent closer network proximity).
+// Each real tree is returned as a contiguous sequence of ascending local-tier gradients; real trees are ordered
+// by root name. Only constraints converted from Soft mode and the legacy aggregate-only test fixture retain the
+// upstream cluster-wide virtual-root traversal; native Hard constraints remain tree-local.
 //
 // Parameters:
 //   - ssn: scheduling session containing all HyperNode information and cluster state
 //   - hyperNode: starting HyperNode for the search, typically the root of available HyperNode subtree
-//   - highestAllowedTier: maximum allowed topology tier to limit search scope
+//   - topology: hard topology boundary expressed as either a numeric tier or a semantic tier name
 //   - allocatedHyperNode: previously allocated HyperNode name for partially running scenarios (empty for initial scheduling)
 //   - minResource: minimum resource requirements for resource pre-filtering (nil to skip resource checks)
 //   - purpose: indicates whether this gradient is used for allocation or eviction
-func (nta *networkTopologyAwarePlugin) hyperNodeGradientFn(ssn *framework.Session, hyperNode *api.HyperNodeInfo, highestAllowedTier int, allocatedHyperNode string, minResource *api.Resource, purpose api.SearchPurpose) ([][]*api.HyperNodeInfo, error) {
-	enqueued := set.New[string]()
-	var processQueue []*api.HyperNodeInfo
+func (nta *networkTopologyAwarePlugin) hyperNodeGradientFn(ssn *framework.Session, hyperNode *api.HyperNodeInfo, topology *scheduling.NetworkTopologySpec, allocatedHyperNode string, minResource *api.Resource, purpose api.SearchPurpose, softConverted ...bool) ([][]*api.HyperNodeInfo, error) {
+	if err := validateTopologyConstraint(topology); err != nil {
+		return nil, err
+	}
 
-	searchRoot, err := getSearchRoot(ssn.HyperNodes, hyperNode, highestAllowedTier, allocatedHyperNode)
+	// Only a constraint converted from upstream Soft mode may recover through
+	// the synthetic cluster root. Native Hard constraints must stay in the real
+	// topology tree that already contains the Job/SubJob allocation.
+	convertedFromSoft := len(softConverted) > 0 && softConverted[0]
+	searchRoot, err := getSearchRoot(ssn.HyperNodes, hyperNode, topology, allocatedHyperNode, convertedFromSoft)
 	if err != nil {
 		return nil, fmt.Errorf("getSearchRoot failed: %w", err)
 	}
+	ssn.EnsureTopologyTrees()
+	// Some upstream unit-test fixtures model HyperNodes only as aggregate
+	// resource sets and do not provide real HyperNodeInfo roots. Preserve the
+	// legacy virtual-root traversal for that neutral shape; real topology trees
+	// always take the tree-local path below.
+	if searchRoot.Name == framework.ClusterTopHyperNode && topology.HighestTierAllowed != nil &&
+		*topology.HighestTierAllowed >= searchRoot.Tier() && len(ssn.TopologyTrees) == 0 {
+		result, _, err := nta.hyperNodeGradientsForSubtree(
+			ssn, searchRoot, topology, allocatedHyperNode, minResource, purpose)
+		return result, err
+	}
 
-	processQueue = append(processQueue, searchRoot)
+	// Preserve the upstream cluster-wide traversal for the virtual root. Soft
+	// topology is converted to this numeric boundary before plugin execution.
+	if convertedFromSoft && searchRoot.Name == framework.ClusterTopHyperNode && topology.HighestTierAllowed != nil &&
+		*topology.HighestTierAllowed >= searchRoot.Tier() {
+		result, _, err := nta.hyperNodeGradientsForSubtree(
+			ssn, searchRoot, topology, allocatedHyperNode, minResource, purpose)
+		return result, err
+	}
+
+	searchRoots := []*api.HyperNodeInfo{searchRoot}
+	if searchRoot.Name == framework.ClusterTopHyperNode {
+		searchRoots = searchRoots[:0]
+		for child := range searchRoot.Children {
+			if _, found := ssn.HyperNodes[child]; !found {
+				return nil, fmt.Errorf("child HyperNode %s of %s not found", child, searchRoot.Name)
+			}
+		}
+		roots := make([]string, 0, len(ssn.TopologyTrees))
+		for root := range ssn.TopologyTrees {
+			roots = append(roots, root)
+		}
+		sort.Strings(roots)
+		for _, root := range roots {
+			rootInfo, found := ssn.HyperNodes[root]
+			if !found {
+				return nil, fmt.Errorf("topology tree root HyperNode %s not found", root)
+			}
+			searchRoots = append(searchRoots, rootInfo)
+		}
+	}
+
+	matchedTierName := topology.HighestTierName == ""
+	var result [][]*api.HyperNodeInfo
+	for _, root := range searchRoots {
+		treeGradients, matched, err := nta.hyperNodeGradientsForSubtree(
+			ssn, root, topology, allocatedHyperNode, minResource, purpose)
+		if err != nil {
+			return nil, err
+		}
+		if matched {
+			matchedTierName = true
+		}
+		result = append(result, treeGradients...)
+	}
+
+	if topology.HighestTierName != "" && !matchedTierName {
+		return nil, fmt.Errorf("tier name %s not found in available HyperNode subtree %s", topology.HighestTierName, searchRoot.Name)
+	}
+	return result, nil
+}
+
+// hyperNodeGradientsForSubtree builds gradients for one search subtree. The
+// caller invokes it separately for each real tree in tree-aware hard mode.
+func (nta *networkTopologyAwarePlugin) hyperNodeGradientsForSubtree(ssn *framework.Session, searchRoot *api.HyperNodeInfo, topology *scheduling.NetworkTopologySpec, allocatedHyperNode string, minResource *api.Resource, purpose api.SearchPurpose) ([][]*api.HyperNodeInfo, bool, error) {
+	enqueued := set.New[string]()
+
+	type searchItem struct {
+		hyperNode         *api.HyperNodeInfo
+		nameBoundaryFound bool
+	}
+
+	nameBoundaryFound := false
+	if topology.HighestTierName != "" {
+		var err error
+		nameBoundaryFound, err = hasUniqueTierNameOnAncestorChain(ssn.HyperNodes, searchRoot.Name, topology.HighestTierName)
+		if err != nil {
+			return nil, false, err
+		}
+	}
+	processQueue := []searchItem{{hyperNode: searchRoot, nameBoundaryFound: nameBoundaryFound}}
 	enqueued.Insert(searchRoot.Name)
+	matchedTierName := nameBoundaryFound
 
 	eligibleHyperNodes := make(map[int][]*api.HyperNodeInfo)
 	for len(processQueue) > 0 {
 		// pop one hyperNode from queue
-		current := processQueue[0]
+		item := processQueue[0]
 		processQueue = processQueue[1:]
+		current := item.hyperNode
 
-		if nta.isEligibleHyperNode(current, highestAllowedTier, allocatedHyperNode, minResource, purpose) {
+		withinBoundary := item.nameBoundaryFound
+		if topology.HighestTierAllowed != nil {
+			withinBoundary = current.Tier() <= *topology.HighestTierAllowed
+		}
+		if withinBoundary && nta.isEligibleHyperNode(current, allocatedHyperNode, minResource, purpose) {
 			eligibleHyperNodes[current.Tier()] = append(eligibleHyperNodes[current.Tier()], current)
 		}
 
 		// push children hyperNode into queue
-		for child := range current.Children {
+		children := current.Children.UnsortedList()
+		sort.Strings(children)
+		for _, child := range children {
 			if enqueued.Has(child) {
 				continue
 			}
-			processQueue = append(processQueue, ssn.HyperNodes[child])
+			childInfo, found := ssn.HyperNodes[child]
+			if !found {
+				return nil, false, fmt.Errorf("child HyperNode %s of %s not found", child, current.Name)
+			}
+			childBoundaryFound := item.nameBoundaryFound
+			if topology.HighestTierName != "" && childInfo.TierName() == topology.HighestTierName {
+				if childBoundaryFound {
+					return nil, false, fmt.Errorf("tier name %s appears more than once in the ancestor chain of HyperNode %s", topology.HighestTierName, child)
+				}
+				childBoundaryFound = true
+				matchedTierName = true
+			}
+			processQueue = append(processQueue, searchItem{hyperNode: childInfo, nameBoundaryFound: childBoundaryFound})
 			enqueued.Insert(child)
 		}
 	}
-
 	// organize hyperNode gradients by tiers in ascending order
 	var tiers []int
 	for tier := range eligibleHyperNodes {
@@ -640,17 +803,16 @@ func (nta *networkTopologyAwarePlugin) hyperNodeGradientFn(ssn *framework.Sessio
 
 	var result [][]*api.HyperNodeInfo
 	for _, tier := range tiers {
+		sort.Slice(eligibleHyperNodes[tier], func(i, j int) bool {
+			return eligibleHyperNodes[tier][i].Name < eligibleHyperNodes[tier][j].Name
+		})
 		result = append(result, eligibleHyperNodes[tier])
 	}
 
-	return result, nil
+	return result, matchedTierName, nil
 }
 
-func (nta *networkTopologyAwarePlugin) isEligibleHyperNode(hn *api.HyperNodeInfo, highestAllowedTier int, allocatedHyperNode string, minResource *api.Resource, purpose api.SearchPurpose) bool {
-	if hn.Tier() > highestAllowedTier {
-		return false // the tier should not exceed the highest allowed
-	}
-
+func (nta *networkTopologyAwarePlugin) isEligibleHyperNode(hn *api.HyperNodeInfo, allocatedHyperNode string, minResource *api.Resource, purpose api.SearchPurpose) bool {
 	if allocatedHyperNode != "" {
 		return true // skip pre-filtering in partially running scenarios
 	}
@@ -674,12 +836,12 @@ func (nta *networkTopologyAwarePlugin) isEligibleHyperNode(hn *api.HyperNodeInfo
 // then **intersects** it with the HyperNode subtree constrained by the external caller(`hyperNodeAvailable`),
 // ensuring that the returned HyperNode subtree satisfies both the Job's(/SubJob's) network topology constraints
 // and the caller's constraints.
-func getSearchRoot(hyperNodes api.HyperNodeInfoMap, hyperNodeAvailable *api.HyperNodeInfo, highestAllowedTier int, allocatedHyperNode string) (*api.HyperNodeInfo, error) {
+func getSearchRoot(hyperNodes api.HyperNodeInfoMap, hyperNodeAvailable *api.HyperNodeInfo, topology *scheduling.NetworkTopologySpec, allocatedHyperNode string, allowClusterTop bool) (*api.HyperNodeInfo, error) {
 	if allocatedHyperNode == "" {
 		return hyperNodeAvailable, nil
 	}
 
-	hyperNodeHighestAllowed, err := getHighestAllowedHyperNode(hyperNodes, highestAllowedTier, allocatedHyperNode)
+	hyperNodeHighestAllowed, err := getHighestAllowedHyperNode(hyperNodes, topology, allocatedHyperNode, allowClusterTop)
 	if err != nil {
 		return nil, fmt.Errorf("get highest allowed hyperNode failed: %w", err)
 	}
@@ -701,11 +863,40 @@ func getSearchRoot(hyperNodes api.HyperNodeInfoMap, hyperNodeAvailable *api.Hype
 		hyperNodeAvailable.Name, hyperNodeHighestAllowed)
 }
 
-func getHighestAllowedHyperNode(hyperNodes api.HyperNodeInfoMap, highestAllowedTier int, allocatedHyperNode string) (string, error) {
+func getHighestAllowedHyperNode(hyperNodes api.HyperNodeInfoMap, topology *scheduling.NetworkTopologySpec, allocatedHyperNode string, allowClusterTop bool) (string, error) {
+	if err := validateTopologyConstraint(topology); err != nil {
+		return "", err
+	}
+
+	if topology.HighestTierName != "" {
+		var matched string
+		for _, ancestor := range hyperNodes.GetAncestors(allocatedHyperNode) {
+			hni, ok := hyperNodes[ancestor]
+			if !ok {
+				return "", fmt.Errorf("allocated HyperNode %s ancestor %s not found", allocatedHyperNode, ancestor)
+			}
+			if hni.TierName() != topology.HighestTierName {
+				continue
+			}
+			if matched != "" {
+				return "", fmt.Errorf("tier name %s appears more than once in the ancestor chain of allocated HyperNode %s", topology.HighestTierName, allocatedHyperNode)
+			}
+			matched = ancestor
+		}
+		if matched == "" {
+			return "", fmt.Errorf("allocated HyperNode %s has no ancestor with tier name %s", allocatedHyperNode, topology.HighestTierName)
+		}
+		return matched, nil
+	}
+
+	highestAllowedTier := *topology.HighestTierAllowed
 	var highestAllowedHyperNode string
 
 	ancestors := hyperNodes.GetAncestors(allocatedHyperNode)
 	for _, ancestor := range ancestors {
+		if ancestor == framework.ClusterTopHyperNode && !allowClusterTop {
+			break
+		}
 		hni, ok := hyperNodes[ancestor]
 		if !ok {
 			return "", fmt.Errorf("allocated hyperNode %s ancestor %s not found", allocatedHyperNode, ancestor)
@@ -721,6 +912,37 @@ func getHighestAllowedHyperNode(hyperNodes api.HyperNodeInfoMap, highestAllowedT
 	}
 
 	return highestAllowedHyperNode, nil
+}
+
+func validateTopologyConstraint(topology *scheduling.NetworkTopologySpec) error {
+	if topology == nil {
+		return fmt.Errorf("network topology constraint is nil")
+	}
+	if topology.HighestTierAllowed != nil && topology.HighestTierName != "" {
+		return fmt.Errorf("highestTierAllowed and highestTierName cannot be set simultaneously")
+	}
+	if topology.HighestTierAllowed == nil && topology.HighestTierName == "" {
+		return fmt.Errorf("network topology constraint has no tier boundary")
+	}
+	return nil
+}
+
+func hasUniqueTierNameOnAncestorChain(hyperNodes api.HyperNodeInfoMap, hyperNodeName, tierName string) (bool, error) {
+	matched := false
+	for _, ancestor := range hyperNodes.GetAncestors(hyperNodeName) {
+		hni, ok := hyperNodes[ancestor]
+		if !ok {
+			return false, fmt.Errorf("HyperNode %s ancestor %s not found", hyperNodeName, ancestor)
+		}
+		if hni.TierName() != tierName {
+			continue
+		}
+		if matched {
+			return false, fmt.Errorf("tier name %s appears more than once in the ancestor chain of HyperNode %s", tierName, hyperNodeName)
+		}
+		matched = true
+	}
+	return matched, nil
 }
 
 func (nta *networkTopologyAwarePlugin) OnSessionClose(ssn *framework.Session) {
@@ -757,20 +979,33 @@ func (nta *networkTopologyAwarePlugin) reverseAndCapEvictionGradients(gradients 
 
 // Goals:
 // - The tier of LCAHyperNode of the hyperNode and the job allocatedHyperNode should be as low as possible.
-func (nta *networkTopologyAwarePlugin) networkTopologyAwareScore(hyperNodeName, jobAllocatedHyperNode string, hyperNodeMap api.HyperNodeInfoMap) float64 {
+func (nta *networkTopologyAwarePlugin) networkTopologyAwareScore(hyperNodeName, jobAllocatedHyperNode string, ssn *framework.Session) float64 {
 	if hyperNodeName == "" || jobAllocatedHyperNode == "" {
 		return ZeroScore
 	}
 	if hyperNodeName == jobAllocatedHyperNode {
 		return FullScore
 	}
+	hyperNodeMap := ssn.HyperNodes
 	LCAHyperNode := hyperNodeMap.GetLCAHyperNode(hyperNodeName, jobAllocatedHyperNode)
 	hyperNodeInfo, ok := hyperNodeMap[LCAHyperNode]
 	if !ok {
 		return ZeroScore
 	}
+
+	minTier, maxTier := nta.minTier, nta.maxTier
+	ssn.EnsureTopologyTrees()
+	if root, found := ssn.HyperNodeToTopologyTree[jobAllocatedHyperNode]; found {
+		if tree, found := ssn.TopologyTrees[root]; found && len(tree.Tiers) > 0 {
+			minTier = tree.Tiers[0]
+			// Use a virtual boundary immediately above this real root. This
+			// preserves the legacy single-tree scale without allowing a deeper
+			// sibling tree to inflate scores in a shallower tree.
+			maxTier = tree.Tiers[len(tree.Tiers)-1] + 1
+		}
+	}
 	// Calculate score: (maxTier - LCAhyperNode.tier)/(maxTier - minTier)
-	hyperNodeTierScore := nta.scoreHyperNodeWithTier(hyperNodeInfo.Tier())
+	hyperNodeTierScore := scoreHyperNodeWithTierRange(hyperNodeInfo.Tier(), minTier, maxTier)
 	return hyperNodeTierScore
 }
 
@@ -786,13 +1021,13 @@ func (nta *networkTopologyAwarePlugin) scoreWithTaskNum(hyperNodeName string, ta
 	return taskNumScore
 }
 
-func (nta *networkTopologyAwarePlugin) scoreHyperNodeWithTier(tier int) float64 {
+func scoreHyperNodeWithTierRange(tier, minTier, maxTier int) float64 {
 	// Use tier to calculate scores and map the original score to the range between 0 and 1.
-	if nta.minTier == nta.maxTier {
+	if minTier == maxTier {
 		return FullScore
 	}
-	if nta.minTier <= tier && tier <= nta.maxTier {
-		return float64(nta.maxTier-tier) / float64(nta.maxTier-nta.minTier)
+	if minTier <= tier && tier <= maxTier {
+		return float64(maxTier-tier) / float64(maxTier-minTier)
 	}
 	return ZeroScore
 }

--- a/pkg/scheduler/plugins/network-topology-aware/network_topology_aware_test.go
+++ b/pkg/scheduler/plugins/network-topology-aware/network_topology_aware_test.go
@@ -19,10 +19,12 @@ package networktopologyaware
 import (
 	"fmt"
 	"math"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/record"
@@ -149,6 +151,48 @@ func TestNew(t *testing.T) {
 			assert.Equal(t, tt.expectedPlugin.hyperNodeResourceCache, nta.hyperNodeResourceCache)
 		})
 	}
+}
+
+func TestValidateTopologyConstraintRejectsMissingBoundary(t *testing.T) {
+	topology := &scheduling.NetworkTopologySpec{Mode: scheduling.HardNetworkTopologyMode}
+	require.EqualError(t, validateTopologyConstraint(topology), "network topology constraint has no tier boundary")
+}
+
+func TestEmptyHardTopologyConstraintFailsClosedAtHooks(t *testing.T) {
+	schedulerCache := &cache.SchedulerCache{
+		Nodes:             map[string]*api.NodeInfo{},
+		Jobs:              map[api.JobID]*api.JobInfo{},
+		Queues:            map[api.QueueID]*api.QueueInfo{},
+		HyperNodesInfo:    api.NewHyperNodesInfo(nil),
+		InUseNodesInShard: sets.Set[string]{},
+		StatusUpdater:     &util.FakeStatusUpdater{},
+		Recorder:          record.NewFakeRecorder(100),
+	}
+	ssn := framework.OpenSession(schedulerCache, nil, nil)
+	defer framework.CloseSession(ssn)
+
+	root := api.NewHyperNodeInfo(api.BuildHyperNode("root", 1, nil))
+	ssn.HyperNodes = api.HyperNodeInfoMap{root.Name: root}
+	enabled := true
+	ssn.Tiers = []conf.Tier{{Plugins: []conf.PluginOption{{
+		Name:                     PluginName,
+		EnabledHyperNodeGradient: &enabled,
+	}}}}
+
+	plugin, ok := New(framework.Arguments{}).(*networkTopologyAwarePlugin)
+	require.True(t, ok)
+	plugin.OnSessionOpen(ssn)
+
+	emptyHard := &scheduling.NetworkTopologySpec{Mode: scheduling.HardNetworkTopologyMode}
+	job := api.NewJobInfo(api.JobID("empty-hard-job"))
+	job.NetworkTopology = emptyHard.DeepCopy()
+	assert.Nil(t, ssn.HyperNodeGradientForJobFn(job, root, api.PurposeAllocate),
+		"invalid Hard Job topology must not fall back to an unconstrained gradient")
+
+	policy := &scheduling.SubGroupPolicySpec{NetworkTopology: emptyHard.DeepCopy()}
+	subJob := api.NewSubJobInfo("group", "empty-hard-subjob", job.UID, policy, nil)
+	assert.Nil(t, ssn.HyperNodeGradientForSubJobFn(subJob, root, api.PurposeAllocate),
+		"invalid Hard SubJob topology must not fall back to an unconstrained gradient")
 }
 
 func TestReverseAndCapEvictionGradients(t *testing.T) {
@@ -3404,6 +3448,602 @@ func Test_batchNodeOrderFnForNormalPods(t *testing.T) {
 	}
 }
 
+func TestBatchNodeOrderFnForNormalPodsUsesTreeLocalTiers(t *testing.T) {
+	newHyperNode := func(name string, tier int, children ...string) *api.HyperNodeInfo {
+		info := api.NewHyperNodeInfo(api.BuildHyperNode(name, tier, nil))
+		info.Children.Insert(children...)
+		return info
+	}
+
+	hyperNodes := api.HyperNodeInfoMap{
+		"shallow-leaf": newHyperNode("shallow-leaf", 1),
+		"shallow-root": newHyperNode("shallow-root", 2, "shallow-leaf"),
+		"deep-leaf":    newHyperNode("deep-leaf", 1),
+		"deep-mid":     newHyperNode("deep-mid", 2, "deep-leaf"),
+		"deep-root":    newHyperNode("deep-root", 3, "deep-mid"),
+		framework.ClusterTopHyperNode: newHyperNode(
+			framework.ClusterTopHyperNode, 4, "shallow-root", "deep-root"),
+	}
+	for _, parent := range hyperNodes {
+		for child := range parent.Children {
+			hyperNodes[child].Parent = parent.Name
+		}
+	}
+
+	ssn := &framework.Session{
+		HyperNodes: hyperNodes,
+		HyperNodesSetByTier: map[int]sets.Set[string]{
+			1: sets.New[string]("shallow-leaf", "deep-leaf"),
+			2: sets.New[string]("shallow-root", "deep-mid"),
+			3: sets.New[string]("deep-root"),
+			4: sets.New[string](framework.ClusterTopHyperNode),
+		},
+		RealNodesSet: map[string]sets.Set[string]{
+			"shallow-leaf":                sets.New[string]("shallow-node"),
+			"shallow-root":                sets.New[string]("shallow-node"),
+			"deep-leaf":                   sets.New[string]("deep-node"),
+			"deep-mid":                    sets.New[string]("deep-node"),
+			"deep-root":                   sets.New[string]("deep-node"),
+			framework.ClusterTopHyperNode: sets.New[string]("shallow-node", "deep-node", "outside-node"),
+		},
+	}
+
+	plugin := &networkTopologyAwarePlugin{
+		weight: &priorityWeight{
+			HyperNodeBinPackingCPU: 1,
+		},
+		normalPodConfig: &normalPodConfig{
+			hyperNodeBinPackingEnable: true,
+			hyperNodeBinPackingFading: 0.5,
+		},
+		hyperNodesTier:         &hyperNodesTier{minTier: 1, maxTier: 4},
+		hyperNodeResourceCache: map[string]*resourceStatus{},
+	}
+	for name := range hyperNodes {
+		plugin.hyperNodeResourceCache[name] = &resourceStatus{
+			allocatable: &api.Resource{MilliCPU: 100},
+			used:        &api.Resource{MilliCPU: 40},
+		}
+	}
+
+	task := &api.TaskInfo{
+		Name:   "normal-pod",
+		Resreq: &api.Resource{MilliCPU: 10},
+	}
+	nodes := []*api.NodeInfo{{Name: "shallow-node"}, {Name: "deep-node"}, {Name: "outside-node"}}
+
+	scores, err := plugin.batchNodeOrderFnForNormalPods(ssn, task, nodes)
+	assert.NoError(t, err)
+	assert.InDelta(t, 0.5, scores["shallow-node"], 1e-9)
+	assert.InDelta(t, 0.5, scores["deep-node"], 1e-9)
+	assert.InDelta(t, scores["shallow-node"], scores["deep-node"], 1e-9,
+		"equivalent local topology utilization must not favor the shallower tree")
+	assert.Equal(t, FullScore, scores["outside-node"],
+		"a Node outside all real topology trees should retain the preferred fallback score")
+
+	plugin.hyperNodeResourceCache["shallow-leaf"].used.MilliCPU = 10
+	plugin.hyperNodeResourceCache["shallow-root"].used.MilliCPU = 30
+	plugin.hyperNodeResourceCache[framework.ClusterTopHyperNode].used.MilliCPU = 70
+	scores, err = plugin.batchNodeOrderFnForNormalPods(ssn, task, nodes[:1])
+	assert.NoError(t, err)
+	assert.InDelta(t, (0.2+0.4*0.5+0.8*0.25)/(1+0.5+0.25), scores["shallow-node"], 1e-9,
+		"the virtual cluster root should remain the final fading level of a real tree")
+}
+
+func TestBatchNodeOrderFnForNetworkAwarePodsUsesTreeLocalLeaf(t *testing.T) {
+	newHyperNode := func(name string, tier int, children ...string) *api.HyperNodeInfo {
+		info := api.NewHyperNodeInfo(api.BuildHyperNode(name, tier, nil))
+		info.Children.Insert(children...)
+		return info
+	}
+
+	shallowNode := &api.NodeInfo{Name: "shallow-node"}
+	deepNode := &api.NodeInfo{Name: "deep-node"}
+	hyperNodes := api.HyperNodeInfoMap{
+		"shallow-leaf": newHyperNode("shallow-leaf", 1),
+		"shallow-root": newHyperNode("shallow-root", 2, "shallow-leaf"),
+		"deep-leaf":    newHyperNode("deep-leaf", 0),
+		"deep-mid":     newHyperNode("deep-mid", 1, "deep-leaf"),
+		"deep-root":    newHyperNode("deep-root", 2, "deep-mid"),
+		framework.ClusterTopHyperNode: newHyperNode(
+			framework.ClusterTopHyperNode, 3, "shallow-root", "deep-root"),
+	}
+	for _, parent := range hyperNodes {
+		for child := range parent.Children {
+			hyperNodes[child].Parent = parent.Name
+		}
+	}
+
+	ssn := &framework.Session{
+		HyperNodes:      hyperNodes,
+		HyperNodesTiers: []int{0, 1, 2, 3},
+		HyperNodesSetByTier: map[int]sets.Set[string]{
+			0: sets.New[string]("deep-leaf"),
+			1: sets.New[string]("shallow-leaf", "deep-mid"),
+			2: sets.New[string]("shallow-root", "deep-root"),
+			3: sets.New[string](framework.ClusterTopHyperNode),
+		},
+		RealNodesList: map[string][]*api.NodeInfo{
+			"shallow-leaf":                {shallowNode},
+			"shallow-root":                {shallowNode},
+			"deep-leaf":                   {deepNode},
+			"deep-mid":                    {deepNode},
+			"deep-root":                   {deepNode},
+			framework.ClusterTopHyperNode: {shallowNode, deepNode},
+		},
+		RealNodesSet: map[string]sets.Set[string]{
+			"shallow-leaf":                sets.New[string](shallowNode.Name),
+			"shallow-root":                sets.New[string](shallowNode.Name),
+			"deep-leaf":                   sets.New[string](deepNode.Name),
+			"deep-mid":                    sets.New[string](deepNode.Name),
+			"deep-root":                   sets.New[string](deepNode.Name),
+			framework.ClusterTopHyperNode: sets.New[string](shallowNode.Name, deepNode.Name),
+		},
+	}
+	plugin := &networkTopologyAwarePlugin{}
+	task := &api.TaskInfo{
+		TransactionContext: api.TransactionContext{JobAllocatedHyperNode: "shallow-leaf"},
+	}
+
+	scores, err := plugin.batchNodeOrderFnForNetworkAwarePods(ssn, task, &api.SubJobInfo{}, []*api.NodeInfo{shallowNode})
+	assert.NoError(t, err)
+	assert.Equal(t, FullScore, scores[shallowNode.Name],
+		"the shallow Node must resolve its own leaf even when another tree has a lower numeric tier")
+}
+
+func TestHyperNodeGradientWithMixedDepthTopologies(t *testing.T) {
+	const (
+		hyperNodeTierName    = "volcano.sh/hypernode"
+		hyperClusterTierName = "volcano.sh/hypercluster"
+		superPodTierName     = "volcano.sh/superpod"
+	)
+
+	newHyperNodeInfo := func(name string, tier int, tierName string, children ...string) *api.HyperNodeInfo {
+		members := make([]api.MemberConfig, 0, len(children))
+		for _, child := range children {
+			members = append(members, api.MemberConfig{
+				Name:     child,
+				Type:     topologyv1alpha1.MemberTypeHyperNode,
+				Selector: "exact",
+			})
+		}
+
+		hyperNode := api.BuildHyperNode(name, tier, members)
+		hyperNode.Spec.TierName = tierName
+		info := api.NewHyperNodeInfo(hyperNode)
+		info.Children.Insert(children...)
+		return info
+	}
+
+	hyperNodes := api.HyperNodeInfoMap{
+		// shallow has two topology tiers: hypernode -> hypercluster.
+		"shallow-hypernode-0": newHyperNodeInfo("shallow-hypernode-0", 1, hyperNodeTierName),
+		"shallow-hypernode-1": newHyperNodeInfo("shallow-hypernode-1", 1, hyperNodeTierName),
+		"shallow-hypercluster": newHyperNodeInfo(
+			"shallow-hypercluster", 2, hyperClusterTierName, "shallow-hypernode-0", "shallow-hypernode-1"),
+
+		// deep inserts superpod below hypernode, shifting the same semantic tiers up by one.
+		"deep-superpod-0": newHyperNodeInfo("deep-superpod-0", 1, superPodTierName),
+		"deep-superpod-1": newHyperNodeInfo("deep-superpod-1", 1, superPodTierName),
+		"deep-hypernode": newHyperNodeInfo(
+			"deep-hypernode", 2, hyperNodeTierName, "deep-superpod-0", "deep-superpod-1"),
+		"deep-hypercluster": newHyperNodeInfo(
+			"deep-hypercluster", 3, hyperClusterTierName, "deep-hypernode"),
+		framework.ClusterTopHyperNode: newHyperNodeInfo(
+			framework.ClusterTopHyperNode, 4, "", "shallow-hypercluster", "deep-hypercluster"),
+	}
+	for _, parent := range hyperNodes {
+		for child := range parent.Children {
+			hyperNodes[child].Parent = parent.Name
+		}
+	}
+
+	networkTopology := &scheduling.NetworkTopologySpec{
+		Mode:            scheduling.HardNetworkTopologyMode,
+		HighestTierName: hyperNodeTierName,
+	}
+
+	plugin := &networkTopologyAwarePlugin{
+		hyperNodeResourceCache: make(map[string]*resourceStatus),
+	}
+	ssn := &framework.Session{HyperNodes: hyperNodes}
+
+	collectNames := func(gradients [][]*api.HyperNodeInfo) sets.Set[string] {
+		names := sets.New[string]()
+		for _, gradient := range gradients {
+			for _, hyperNode := range gradient {
+				names.Insert(hyperNode.Name)
+			}
+		}
+		return names
+	}
+	gradientNames := func(gradients [][]*api.HyperNodeInfo) [][]string {
+		result := make([][]string, 0, len(gradients))
+		for _, gradient := range gradients {
+			names := make([]string, 0, len(gradient))
+			for _, hyperNode := range gradient {
+				names = append(names, hyperNode.Name)
+			}
+			result = append(result, names)
+		}
+		return result
+	}
+
+	gradients, err := plugin.hyperNodeGradientFn(
+		ssn, hyperNodes[framework.ClusterTopHyperNode], networkTopology, "", nil, api.PurposeAllocate)
+	assert.NoError(t, err)
+	candidates := collectNames(gradients)
+
+	// highestTierName=hypernode has a different numeric tier in each topology.
+	// Correct behavior must honor the semantic boundary independently per subtree.
+	assert.True(t, candidates.Has("shallow-hypernode-0"), "shallow hypernode tier should remain eligible")
+	assert.False(t, candidates.Has("shallow-hypercluster"),
+		"shallow must not cross the hypernode boundary into hypercluster")
+	assert.True(t, candidates.Has("deep-hypernode"),
+		"deep must allow its tier-2 hypernode even though shallow uses tier 1 for the same tier name")
+	assert.True(t, candidates.Has("deep-superpod-0"), "deep descendants below the boundary should remain eligible")
+	assert.False(t, candidates.Has("deep-hypercluster"),
+		"deep must not cross the hypernode boundary into hypercluster")
+	assert.Equal(t, [][]string{
+		{"deep-superpod-0", "deep-superpod-1"},
+		{"deep-hypernode"},
+		{"shallow-hypernode-0", "shallow-hypernode-1"},
+	}, gradientNames(gradients), "each tree should contribute its own ascending local-tier gradients")
+
+	t.Run("numeric tiers remain isolated by real tree", func(t *testing.T) {
+		highestTierAllowed := 2
+		topology := &scheduling.NetworkTopologySpec{
+			Mode:               scheduling.HardNetworkTopologyMode,
+			HighestTierAllowed: &highestTierAllowed,
+		}
+		gradients, err := plugin.hyperNodeGradientFn(
+			ssn, hyperNodes[framework.ClusterTopHyperNode], topology, "", nil, api.PurposeAllocate)
+		assert.NoError(t, err)
+		assert.Equal(t, [][]string{
+			{"deep-superpod-0", "deep-superpod-1"},
+			{"deep-hypernode"},
+			{"shallow-hypernode-0", "shallow-hypernode-1"},
+			{"shallow-hypercluster"},
+		}, gradientNames(gradients))
+	})
+
+	t.Run("eviction keeps each real tree in wider-to-narrower order", func(t *testing.T) {
+		originalLimit := plugin.maxHyperNodesForEviction
+		plugin.maxHyperNodesForEviction = len(hyperNodes)
+		defer func() {
+			plugin.maxHyperNodesForEviction = originalLimit
+		}()
+
+		topology := &scheduling.NetworkTopologySpec{
+			Mode:            scheduling.HardNetworkTopologyMode,
+			HighestTierName: hyperClusterTierName,
+		}
+		gradients, err := plugin.hyperNodeGradientFn(
+			ssn, hyperNodes[framework.ClusterTopHyperNode], topology, "", nil, api.PurposeEvict)
+		assert.NoError(t, err)
+		gradients = plugin.reverseAndCapEvictionGradients(gradients)
+
+		positions := map[string]int{}
+		position := 0
+		for _, gradient := range gradients {
+			containsShallow := false
+			containsDeep := false
+			for _, hyperNode := range gradient {
+				containsShallow = containsShallow || strings.HasPrefix(hyperNode.Name, "shallow-")
+				containsDeep = containsDeep || strings.HasPrefix(hyperNode.Name, "deep-")
+				positions[hyperNode.Name] = position
+				position++
+			}
+			assert.False(t, containsShallow && containsDeep, "local tiers from separate real trees must not be merged")
+		}
+		assert.Len(t, positions, len(hyperNodes)-1, "the virtual root is outside the hard boundary")
+		assert.Less(t, positions["shallow-hypercluster"], positions["shallow-hypernode-0"])
+		assert.Less(t, positions["shallow-hypercluster"], positions["shallow-hypernode-1"])
+		assert.Less(t, positions["deep-hypercluster"], positions["deep-hypernode"])
+		assert.Less(t, positions["deep-hypernode"], positions["deep-superpod-0"])
+		assert.Less(t, positions["deep-hypernode"], positions["deep-superpod-1"])
+	})
+
+	t.Run("branch without requested tier name is excluded", func(t *testing.T) {
+		topology := &scheduling.NetworkTopologySpec{
+			Mode:            scheduling.HardNetworkTopologyMode,
+			HighestTierName: superPodTierName,
+		}
+		gradients, err := plugin.hyperNodeGradientFn(
+			ssn, hyperNodes[framework.ClusterTopHyperNode], topology, "", nil, api.PurposeAllocate)
+		assert.NoError(t, err)
+		candidates := collectNames(gradients)
+		assert.True(t, candidates.Has("deep-superpod-0"))
+		assert.False(t, candidates.Has("shallow-hypernode-0"))
+		assert.False(t, candidates.Has("shallow-hypercluster"))
+	})
+
+	t.Run("partially running job resolves boundary from allocated branch", func(t *testing.T) {
+		gradients, err := plugin.hyperNodeGradientFn(
+			ssn, hyperNodes[framework.ClusterTopHyperNode], networkTopology, "deep-superpod-0", nil, api.PurposeAllocate)
+		assert.NoError(t, err)
+		assert.Equal(t, [][]string{
+			{"deep-superpod-0", "deep-superpod-1"},
+			{"deep-hypernode"},
+		}, gradientNames(gradients), "a partially running job must remain in the allocated tree")
+		candidates := collectNames(gradients)
+		assert.True(t, candidates.Has("deep-hypernode"))
+		assert.True(t, candidates.Has("deep-superpod-1"))
+		assert.False(t, candidates.Has("deep-hypercluster"))
+		assert.False(t, candidates.Has("shallow-hypernode-0"))
+	})
+
+	t.Run("real shared root keeps branch-local boundaries", func(t *testing.T) {
+		originalTop := hyperNodes[framework.ClusterTopHyperNode]
+		originalShallowParent := hyperNodes["shallow-hypercluster"].Parent
+		originalDeepParent := hyperNodes["deep-hypercluster"].Parent
+		hyperNodes["fabric-root"] = newHyperNodeInfo(
+			"fabric-root", 4, "volcano.sh/fabric", "shallow-hypercluster", "deep-hypercluster")
+		hyperNodes[framework.ClusterTopHyperNode] = newHyperNodeInfo(
+			framework.ClusterTopHyperNode, 5, "", "fabric-root")
+		hyperNodes["fabric-root"].Parent = framework.ClusterTopHyperNode
+		hyperNodes["shallow-hypercluster"].Parent = "fabric-root"
+		hyperNodes["deep-hypercluster"].Parent = "fabric-root"
+		defer func() {
+			hyperNodes[framework.ClusterTopHyperNode] = originalTop
+			hyperNodes["shallow-hypercluster"].Parent = originalShallowParent
+			hyperNodes["deep-hypercluster"].Parent = originalDeepParent
+			delete(hyperNodes, "fabric-root")
+		}()
+
+		gradients, err := plugin.hyperNodeGradientFn(
+			ssn, hyperNodes[framework.ClusterTopHyperNode], networkTopology, "", nil, api.PurposeAllocate)
+		assert.NoError(t, err)
+		candidates := collectNames(gradients)
+		assert.True(t, candidates.Has("shallow-hypernode-0"))
+		assert.True(t, candidates.Has("deep-hypernode"))
+		assert.False(t, candidates.Has("fabric-root"))
+		assert.False(t, candidates.Has("shallow-hypercluster"))
+		assert.False(t, candidates.Has("deep-hypercluster"))
+	})
+
+	t.Run("missing tier name fails closed", func(t *testing.T) {
+		topology := &scheduling.NetworkTopologySpec{
+			Mode:            scheduling.HardNetworkTopologyMode,
+			HighestTierName: "volcano.sh/not-found",
+		}
+		gradients, err := plugin.hyperNodeGradientFn(
+			ssn, hyperNodes[framework.ClusterTopHyperNode], topology, "", nil, api.PurposeAllocate)
+		assert.Error(t, err)
+		assert.Nil(t, gradients)
+	})
+
+	t.Run("duplicate tier name in one ancestor chain is rejected", func(t *testing.T) {
+		originalName := hyperNodes["deep-superpod-0"].HyperNode.Spec.TierName
+		hyperNodes["deep-superpod-0"].HyperNode.Spec.TierName = hyperNodeTierName
+		duplicate := api.NewHyperNodeInfo(hyperNodes["deep-superpod-0"].HyperNode, api.ParentOpt("deep-hypernode"))
+		hyperNodes["deep-superpod-0"] = duplicate
+		defer func() {
+			hyperNodes["deep-superpod-0"].HyperNode.Spec.TierName = originalName
+		}()
+
+		gradients, err := plugin.hyperNodeGradientFn(
+			ssn, hyperNodes[framework.ClusterTopHyperNode], networkTopology, "", nil, api.PurposeAllocate)
+		assert.Error(t, err)
+		assert.Nil(t, gradients)
+	})
+}
+
+func TestHyperNodeGradientHardNumericClusterBoundaryIsTreeLocal(t *testing.T) {
+	newHyperNode := func(name string, tier int, children ...string) *api.HyperNodeInfo {
+		info := api.NewHyperNodeInfo(api.BuildHyperNode(name, tier, nil))
+		info.Children.Insert(children...)
+		return info
+	}
+
+	const (
+		shallowRoot = "shallow-root"
+		deepRoot    = "deep-root"
+	)
+	clusterRoot := framework.ClusterTopHyperNode
+	hyperNodes := api.HyperNodeInfoMap{
+		shallowRoot: newHyperNode(shallowRoot, 1),
+		deepRoot:    newHyperNode(deepRoot, 1),
+		clusterRoot: newHyperNode(clusterRoot, 2, shallowRoot, deepRoot),
+	}
+	for _, parent := range hyperNodes {
+		for child := range parent.Children {
+			hyperNodes[child].Parent = parent.Name
+		}
+	}
+
+	ssn := &framework.Session{
+		HyperNodes: hyperNodes,
+		RealNodesSet: map[string]sets.Set[string]{
+			shallowRoot: sets.New[string]("shallow-node"),
+			deepRoot:    sets.New[string]("deep-node"),
+			clusterRoot: sets.New[string]("shallow-node", "deep-node"),
+		},
+	}
+	plugin := &networkTopologyAwarePlugin{
+		hyperNodeResourceCache: map[string]*resourceStatus{
+			shallowRoot: {idle: &api.Resource{MilliCPU: 2000}, futureIdle: &api.Resource{MilliCPU: 2000}},
+			deepRoot:    {idle: &api.Resource{MilliCPU: 2000}, futureIdle: &api.Resource{MilliCPU: 2000}},
+			clusterRoot: {idle: &api.Resource{MilliCPU: 4000}, futureIdle: &api.Resource{MilliCPU: 4000}},
+		},
+	}
+	required := &api.Resource{MilliCPU: 4000}
+	highestTierAllowed := 2
+	topology := &scheduling.NetworkTopologySpec{
+		Mode:               scheduling.HardNetworkTopologyMode,
+		HighestTierAllowed: &highestTierAllowed,
+	}
+
+	gradients, err := plugin.hyperNodeGradientFn(ssn, hyperNodes[clusterRoot], topology, "", required, api.PurposeAllocate)
+	require.NoError(t, err)
+	assert.Empty(t, gradients,
+		"native Hard at the virtual-root numeric boundary must not aggregate sibling tree capacity")
+
+	hardSubJob := &api.SubJobInfo{
+		UID: "hard-subjob",
+		NetworkTopology: &scheduling.NetworkTopologySpec{
+			Mode:               scheduling.HardNetworkTopologyMode,
+			HighestTierAllowed: &highestTierAllowed,
+		},
+	}
+	subJobGradients, err := plugin.hyperNodeGradientFn(
+		ssn, hyperNodes[clusterRoot], hardSubJob.HardTopologyConstraint(), "", required, api.PurposeAllocate, hardSubJob.IsSoftTopologyConverted())
+	require.NoError(t, err)
+	assert.Empty(t, subJobGradients,
+		"native Hard SubJob at the virtual-root numeric boundary must not aggregate sibling tree capacity")
+
+	plugin.hyperNodeResourceCache[deepRoot].idle = &api.Resource{MilliCPU: 4000}
+	plugin.hyperNodeResourceCache[deepRoot].futureIdle = &api.Resource{MilliCPU: 4000}
+	gradients, err = plugin.hyperNodeGradientFn(ssn, hyperNodes[clusterRoot], topology, "", required, api.PurposeAllocate)
+	require.NoError(t, err)
+	assert.Equal(t, [][]*api.HyperNodeInfo{{hyperNodes[deepRoot]}}, gradients,
+		"native Hard must select only the single feasible real topology tree")
+	subJobGradients, err = plugin.hyperNodeGradientFn(
+		ssn, hyperNodes[clusterRoot], hardSubJob.HardTopologyConstraint(), "", required, api.PurposeAllocate, hardSubJob.IsSoftTopologyConverted())
+	require.NoError(t, err)
+	assert.Equal(t, [][]*api.HyperNodeInfo{{hyperNodes[deepRoot]}}, subJobGradients,
+		"native Hard SubJob must select only the single feasible real topology tree")
+
+	gradients, err = plugin.hyperNodeGradientFn(
+		ssn, hyperNodes[clusterRoot], topology, deepRoot, required, api.PurposeAllocate)
+	require.NoError(t, err)
+	assert.Equal(t, [][]*api.HyperNodeInfo{{hyperNodes[deepRoot]}}, gradients,
+		"a partially allocated native Hard Job must remain in its original real topology tree")
+
+	subJobGradients, err = plugin.hyperNodeGradientFn(
+		ssn, hyperNodes[clusterRoot], hardSubJob.HardTopologyConstraint(), deepRoot, required, api.PurposeAllocate, hardSubJob.IsSoftTopologyConverted())
+	require.NoError(t, err)
+	assert.Equal(t, [][]*api.HyperNodeInfo{{hyperNodes[deepRoot]}}, subJobGradients,
+		"a partially allocated native Hard SubJob must remain in its original real topology tree")
+}
+
+func TestHyperNodeGradientConvertedSoftKeepsVirtualRootCompatibility(t *testing.T) {
+	newHyperNode := func(name string, tier int, children ...string) *api.HyperNodeInfo {
+		info := api.NewHyperNodeInfo(api.BuildHyperNode(name, tier, nil))
+		info.Children.Insert(children...)
+		return info
+	}
+	clusterRoot := framework.ClusterTopHyperNode
+	hyperNodes := api.HyperNodeInfoMap{
+		"tree-a":    newHyperNode("tree-a", 1),
+		"tree-b":    newHyperNode("tree-b", 1),
+		clusterRoot: newHyperNode(clusterRoot, 2, "tree-a", "tree-b"),
+	}
+	for _, parent := range hyperNodes {
+		for child := range parent.Children {
+			hyperNodes[child].Parent = parent.Name
+		}
+	}
+	ssn := &framework.Session{
+		HyperNodes: hyperNodes,
+		RealNodesSet: map[string]sets.Set[string]{
+			"tree-a":    sets.New[string]("node-a"),
+			"tree-b":    sets.New[string]("node-b"),
+			clusterRoot: sets.New[string]("node-a", "node-b"),
+		},
+	}
+	plugin := &networkTopologyAwarePlugin{
+		hyperNodeResourceCache: map[string]*resourceStatus{
+			"tree-a":    {idle: &api.Resource{MilliCPU: 2000}, futureIdle: &api.Resource{MilliCPU: 2000}},
+			"tree-b":    {idle: &api.Resource{MilliCPU: 2000}, futureIdle: &api.Resource{MilliCPU: 2000}},
+			clusterRoot: {idle: &api.Resource{MilliCPU: 4000}, futureIdle: &api.Resource{MilliCPU: 4000}},
+		},
+	}
+	required := &api.Resource{MilliCPU: 4000}
+	subJob := &api.SubJobInfo{
+		UID:             "soft-subjob",
+		NetworkTopology: &scheduling.NetworkTopologySpec{Mode: scheduling.SoftNetworkTopologyMode},
+	}
+	subJob.ConvertToHardTopology(hyperNodes[clusterRoot].Tier())
+	require.True(t, subJob.IsSoftTopologyConverted())
+	require.NotNil(t, subJob.HardTopologyConstraint())
+
+	gradients, err := plugin.hyperNodeGradientFn(ssn, hyperNodes[clusterRoot], subJob.HardTopologyConstraint(), "", required, api.PurposeAllocate, subJob.IsSoftTopologyConverted())
+	require.NoError(t, err)
+	candidates := sets.New[string]()
+	for _, gradient := range gradients {
+		for _, hyperNode := range gradient {
+			candidates.Insert(hyperNode.Name)
+		}
+	}
+	assert.Contains(t, candidates, clusterRoot,
+		"a Soft constraint converted by the framework keeps the legacy virtual-root candidate")
+}
+
+func TestHyperNodeGradientWithSingleTierTopology(t *testing.T) {
+	const (
+		hyperNodeTierName = "volcano.sh/hypernode"
+		superPodTierName  = "volcano.sh/superpod"
+	)
+	newHyperNodeInfo := func(name string, tier int, tierName string, children ...string) *api.HyperNodeInfo {
+		members := make([]api.MemberConfig, 0, len(children))
+		for _, child := range children {
+			members = append(members, api.MemberConfig{
+				Name:     child,
+				Type:     topologyv1alpha1.MemberTypeHyperNode,
+				Selector: "exact",
+			})
+		}
+		hyperNode := api.BuildHyperNode(name, tier, members)
+		hyperNode.Spec.TierName = tierName
+		info := api.NewHyperNodeInfo(hyperNode)
+		info.Children.Insert(children...)
+		return info
+	}
+
+	hyperNodes := api.HyperNodeInfoMap{
+		"single-tier":    newHyperNodeInfo("single-tier", 1, hyperNodeTierName),
+		"deep-leaf":      newHyperNodeInfo("deep-leaf", 1, superPodTierName),
+		"deep-hypernode": newHyperNodeInfo("deep-hypernode", 2, hyperNodeTierName, "deep-leaf"),
+		"deep-root":      newHyperNodeInfo("deep-root", 3, "volcano.sh/hypercluster", "deep-hypernode"),
+		framework.ClusterTopHyperNode: newHyperNodeInfo(
+			framework.ClusterTopHyperNode, 4, "", "single-tier", "deep-root"),
+	}
+	for _, parent := range hyperNodes {
+		for child := range parent.Children {
+			hyperNodes[child].Parent = parent.Name
+		}
+	}
+
+	plugin := &networkTopologyAwarePlugin{}
+	ssn := &framework.Session{HyperNodes: hyperNodes}
+	topology := &scheduling.NetworkTopologySpec{
+		Mode:            scheduling.HardNetworkTopologyMode,
+		HighestTierName: hyperNodeTierName,
+	}
+	gradientNames := func(gradients [][]*api.HyperNodeInfo) [][]string {
+		result := make([][]string, 0, len(gradients))
+		for _, gradient := range gradients {
+			names := make([]string, 0, len(gradient))
+			for _, hyperNode := range gradient {
+				names = append(names, hyperNode.Name)
+			}
+			result = append(result, names)
+		}
+		return result
+	}
+
+	gradients, err := plugin.hyperNodeGradientFn(
+		ssn, hyperNodes[framework.ClusterTopHyperNode], topology, "", nil, api.PurposeAllocate)
+	require.NoError(t, err)
+	assert.Equal(t, [][]string{
+		{"deep-leaf"},
+		{"deep-hypernode"},
+		{"single-tier"},
+	}, gradientNames(gradients),
+		"a one-level tree must contribute its tier-1 candidate without inheriting a sibling tree's depth")
+
+	highestTierAllowed := 1
+	gradients, err = plugin.hyperNodeGradientFn(
+		ssn, hyperNodes[framework.ClusterTopHyperNode], &scheduling.NetworkTopologySpec{
+			Mode:               scheduling.HardNetworkTopologyMode,
+			HighestTierAllowed: &highestTierAllowed,
+		}, "", nil, api.PurposeAllocate)
+	require.NoError(t, err)
+	assert.Equal(t, [][]string{{"deep-leaf"}, {"single-tier"}}, gradientNames(gradients),
+		"numeric tier 1 must be evaluated independently in each real tree")
+}
+
 // TestHyperNodeGradientPreFiltering tests the pre-filtering logic in hyperNodeGradientFn.
 // It verifies HyperNodes are correctly filtered for allocation and eviction purposes.
 func TestHyperNodeGradientPreFiltering(t *testing.T) {
@@ -3720,7 +4360,7 @@ func TestHyperNodeGradientPreFiltering(t *testing.T) {
 			result, err := plugin.hyperNodeGradientFn(
 				ssn,
 				hyperNodesMap[tier2HNName],
-				tt.highestAllowedTier,
+				&scheduling.NetworkTopologySpec{HighestTierAllowed: &tt.highestAllowedTier},
 				"",
 				tt.minResource,
 				tt.purpose,
@@ -3887,4 +4527,44 @@ func TestHyperNodeGradientForSubJobFn_NoSubJobPolicyRespectsHardTopology(t *test
 
 	gradients := ssn.HyperNodeGradientForSubJobFn(subJob, ssn.HyperNodes[rootName], api.PurposeEvict)
 	assert.Empty(t, gradients, "hard topology without feasible tier-1 domain should not fallback to root")
+}
+
+func TestNetworkTopologyAwareScoreMixedTreeUsesLocalDepth(t *testing.T) {
+	newHyperNode := func(name string, tier int, children ...string) *api.HyperNodeInfo {
+		info := api.NewHyperNodeInfo(api.BuildHyperNode(name, tier, nil))
+		info.Children.Insert(children...)
+		return info
+	}
+
+	hyperNodes := api.HyperNodeInfoMap{
+		"shallow-leaf-0": newHyperNode("shallow-leaf-0", 1),
+		"shallow-leaf-1": newHyperNode("shallow-leaf-1", 1),
+		"shallow-root":   newHyperNode("shallow-root", 2, "shallow-leaf-0", "shallow-leaf-1"),
+		"deep-leaf-0":    newHyperNode("deep-leaf-0", 1),
+		"deep-leaf-1":    newHyperNode("deep-leaf-1", 1),
+		"deep-middle":    newHyperNode("deep-middle", 2, "deep-leaf-0", "deep-leaf-1"),
+		"deep-root":      newHyperNode("deep-root", 3, "deep-middle"),
+		framework.ClusterTopHyperNode: newHyperNode(
+			framework.ClusterTopHyperNode, 4, "shallow-root", "deep-root"),
+	}
+	for _, parent := range hyperNodes {
+		for child := range parent.Children {
+			hyperNodes[child].Parent = parent.Name
+		}
+	}
+
+	plugin := &networkTopologyAwarePlugin{
+		hyperNodesTier: &hyperNodesTier{minTier: 1, maxTier: 4},
+	}
+	ssn := &framework.Session{HyperNodes: hyperNodes}
+
+	assert.InDelta(t, 0.5,
+		plugin.networkTopologyAwareScore("shallow-leaf-1", "shallow-leaf-0", ssn), 1e-9,
+		"the deeper deep tree must not inflate a shallow-local LCA score")
+	assert.InDelta(t, 2.0/3.0,
+		plugin.networkTopologyAwareScore("deep-leaf-1", "deep-leaf-0", ssn), 1e-9,
+		"deep should retain its own three-level distance scale")
+	assert.Equal(t, ZeroScore,
+		plugin.networkTopologyAwareScore("deep-leaf-0", "shallow-leaf-0", ssn),
+		"nodes in another connected tree must not receive an affinity score")
 }

--- a/pkg/scheduler/uthelper/helper.go
+++ b/pkg/scheduler/uthelper/helper.go
@@ -420,7 +420,7 @@ func (test *TestCommonStruct) CheckBindInHyperNode(caseIndex int) error {
 
 	realHyperNode := make(map[string]int, 0)
 	for _, node := range binds {
-		hyperNode := util.FindHyperNodeForNode(node, test.ssn.RealNodesList, test.ssn.HyperNodesTiers, test.ssn.HyperNodesSetByTier)
+		hyperNode := test.ssn.FindHyperNodeForNode(node)
 		realHyperNode[hyperNode] += 1
 	}
 

--- a/pkg/webhooks/admission/jobs/validate/admit_job.go
+++ b/pkg/webhooks/admission/jobs/validate/admit_job.go
@@ -265,8 +265,8 @@ func validateJobUpdate(old, new *v1alpha1.Job) error {
 		return fmt.Errorf("job 'minAvailable' must be >= 0")
 	}
 	networkTopology := new.Spec.NetworkTopology
-	if networkTopology != nil && networkTopology.HighestTierAllowed != nil && networkTopology.HighestTierName != "" {
-		return fmt.Errorf("must not specify 'highestTierAllowed' and 'highestTierName' in networkTopology simultaneously")
+	if msg := validateNetworkTopology(networkTopology); msg != "" {
+		return fmt.Errorf("%s", msg)
 	}
 
 	if len(old.Spec.Tasks) != len(new.Spec.Tasks) {
@@ -325,8 +325,15 @@ func validatePartitionPolicy(task v1alpha1.TaskSpec, job *v1alpha1.Job) string {
 }
 
 func validateNetworkTopology(networkTopology *v1alpha1.NetworkTopologySpec) string {
-	if networkTopology != nil && networkTopology.HighestTierAllowed != nil && networkTopology.HighestTierName != "" {
+	if networkTopology == nil {
+		return ""
+	}
+	if networkTopology.HighestTierAllowed != nil && networkTopology.HighestTierName != "" {
 		return "must not specify 'highestTierAllowed' and 'highestTierName' in networkTopology simultaneously"
+	}
+	if (networkTopology.Mode == "" || networkTopology.Mode == v1alpha1.HardNetworkTopologyMode) &&
+		networkTopology.HighestTierAllowed == nil && networkTopology.HighestTierName == "" {
+		return "must specify either 'highestTierAllowed' or 'highestTierName' in hard networkTopology"
 	}
 	return ""
 }

--- a/pkg/webhooks/admission/jobs/validate/admit_job_test.go
+++ b/pkg/webhooks/admission/jobs/validate/admit_job_test.go
@@ -2487,3 +2487,52 @@ func TestValidateTaskTopoPolicy(t *testing.T) {
 		}
 	}
 }
+
+func TestValidateNetworkTopology(t *testing.T) {
+	highestTierAllowed := 1
+	tests := []struct {
+		name     string
+		topology *v1alpha1.NetworkTopologySpec
+		want     string
+	}{
+		{name: "nil topology"},
+		{
+			name:     "hard topology without boundary",
+			topology: &v1alpha1.NetworkTopologySpec{Mode: v1alpha1.HardNetworkTopologyMode},
+			want:     "must specify either 'highestTierAllowed' or 'highestTierName' in hard networkTopology",
+		},
+		{
+			name:     "default hard topology without boundary",
+			topology: &v1alpha1.NetworkTopologySpec{},
+			want:     "must specify either 'highestTierAllowed' or 'highestTierName' in hard networkTopology",
+		},
+		{
+			name:     "soft topology without boundary",
+			topology: &v1alpha1.NetworkTopologySpec{Mode: v1alpha1.SoftNetworkTopologyMode},
+		},
+		{
+			name: "hard topology with numeric boundary",
+			topology: &v1alpha1.NetworkTopologySpec{
+				Mode:               v1alpha1.HardNetworkTopologyMode,
+				HighestTierAllowed: &highestTierAllowed,
+			},
+		},
+		{
+			name: "topology with both boundaries",
+			topology: &v1alpha1.NetworkTopologySpec{
+				Mode:               v1alpha1.HardNetworkTopologyMode,
+				HighestTierAllowed: &highestTierAllowed,
+				HighestTierName:    "volcano.sh/hypernode",
+			},
+			want: "must not specify 'highestTierAllowed' and 'highestTierName' in networkTopology simultaneously",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := validateNetworkTopology(tt.topology); got != tt.want {
+				t.Fatalf("validateNetworkTopology() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/webhooks/admission/podgroups/validate/validate_podgroup.go
+++ b/pkg/webhooks/admission/podgroups/validate/validate_podgroup.go
@@ -123,13 +123,25 @@ func checkQueueState(queueName string) string {
 
 func validateNetworkTopology(networkTopology *schedulingv1beta1.NetworkTopologySpec, policies []schedulingv1beta1.SubGroupPolicySpec) string {
 	var errs []string
-	if networkTopology != nil && networkTopology.HighestTierAllowed != nil && networkTopology.HighestTierName != "" {
-		errs = append(errs, "must not specify 'highestTierAllowed' and 'highestTierName' in networkTopology simultaneously.")
+	if networkTopology != nil {
+		if networkTopology.HighestTierAllowed != nil && networkTopology.HighestTierName != "" {
+			errs = append(errs, "must not specify 'highestTierAllowed' and 'highestTierName' in networkTopology simultaneously.")
+		} else if (networkTopology.Mode == "" || networkTopology.Mode == schedulingv1beta1.HardNetworkTopologyMode) &&
+			networkTopology.HighestTierAllowed == nil && networkTopology.HighestTierName == "" {
+			errs = append(errs, "must specify either 'highestTierAllowed' or 'highestTierName' in hard networkTopology.")
+		}
 	}
 	for _, policy := range policies {
-		if policy.NetworkTopology != nil && policy.NetworkTopology.HighestTierAllowed != nil && policy.NetworkTopology.HighestTierName != "" {
-			errs = append(errs, fmt.Sprintf("in subGroupPolicy '%s': must not specify 'highestTierAllowed' and 'highestTierName' in networkTopology simultaneously.", policy.Name))
-			break
+		if policy.NetworkTopology != nil {
+			if policy.NetworkTopology.HighestTierAllowed != nil && policy.NetworkTopology.HighestTierName != "" {
+				errs = append(errs, fmt.Sprintf("in subGroupPolicy '%s': must not specify 'highestTierAllowed' and 'highestTierName' in networkTopology simultaneously.", policy.Name))
+				break
+			}
+			if (policy.NetworkTopology.Mode == "" || policy.NetworkTopology.Mode == schedulingv1beta1.HardNetworkTopologyMode) &&
+				policy.NetworkTopology.HighestTierAllowed == nil && policy.NetworkTopology.HighestTierName == "" {
+				errs = append(errs, fmt.Sprintf("in subGroupPolicy '%s': must specify either 'highestTierAllowed' or 'highestTierName' in hard networkTopology.", policy.Name))
+				break
+			}
 		}
 	}
 	return strings.Join(errs, " ")

--- a/pkg/webhooks/admission/podgroups/validate/validate_podgroup_test.go
+++ b/pkg/webhooks/admission/podgroups/validate/validate_podgroup_test.go
@@ -288,3 +288,30 @@ func TestValidatePodGroup(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateNetworkTopology(t *testing.T) {
+	t.Run("rejects empty hard podgroup topology", func(t *testing.T) {
+		msg := validateNetworkTopology(
+			&schedulingv1beta1.NetworkTopologySpec{Mode: schedulingv1beta1.HardNetworkTopologyMode}, nil)
+		assert.Contains(t, msg, "must specify either 'highestTierAllowed' or 'highestTierName'")
+	})
+
+	t.Run("allows empty soft podgroup topology", func(t *testing.T) {
+		msg := validateNetworkTopology(
+			&schedulingv1beta1.NetworkTopologySpec{Mode: schedulingv1beta1.SoftNetworkTopologyMode}, nil)
+		assert.Empty(t, msg)
+	})
+
+	t.Run("rejects empty hard subgroup topology", func(t *testing.T) {
+		msg := validateNetworkTopology(nil, []schedulingv1beta1.SubGroupPolicySpec{
+			{
+				Name: "workers",
+				NetworkTopology: &schedulingv1beta1.NetworkTopologySpec{
+					Mode: schedulingv1beta1.HardNetworkTopologyMode,
+				},
+			},
+		})
+		assert.Contains(t, msg, "in subGroupPolicy 'workers'")
+		assert.Contains(t, msg, "must specify either 'highestTierAllowed' or 'highestTierName'")
+	})
+}

--- a/test/e2e/hypernode/mixed_topology_test.go
+++ b/test/e2e/hypernode/mixed_topology_test.go
@@ -1,0 +1,1186 @@
+/*
+Copyright 2026 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hypernode
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/util/retry"
+	"k8s.io/utils/ptr"
+
+	batchv1alpha1 "volcano.sh/apis/pkg/apis/batch/v1alpha1"
+	topologyv1alpha1 "volcano.sh/apis/pkg/apis/topology/v1alpha1"
+	e2eutil "volcano.sh/volcano/test/e2e/util"
+)
+
+const (
+	mixedProfileLabel        = "volcano.sh/e2e-topology-profile"
+	mixedShallowDomainLabel  = "volcano.sh/e2e-shallow-domain"
+	mixedCompactClusterLabel = "volcano.sh/e2e-compact-hypercluster"
+	mixedWideHyperNodeLabel  = "volcano.sh/e2e-wide-hypernode"
+	mixedDeepSuperPodLabel   = "volcano.sh/e2e-deep-superpod"
+	mixedDeepHyperNodeLabel  = "volcano.sh/e2e-deep-hypernode"
+	mixedClusterLabel        = "volcano.sh/e2e-hypercluster"
+	mixedTopologySourceKey   = "volcano.sh/network-topology-source"
+	mixedTopologyProfileKey  = "volcano.sh/network-topology-profile"
+)
+
+type mixedTopologyHyperNodeSnapshot struct {
+	UID  string
+	Spec topologyv1alpha1.HyperNodeSpec
+}
+
+var mixedTopologyTolerations = []v1.Toleration{{
+	Key:      "kwok.x-k8s.io/node",
+	Operator: v1.TolerationOpEqual,
+	Value:    "fake",
+	Effect:   v1.TaintEffectNoSchedule,
+}}
+
+var _ = Describe("Mixed shallow and deep topology", Serial, func() {
+	var testCtx *e2eutil.TestContext
+
+	BeforeEach(func() {
+		testCtx = e2eutil.InitTestContext(e2eutil.Options{NodesNumLimit: 8})
+	})
+
+	AfterEach(func() {
+		e2eutil.CleanupTestContext(testCtx)
+	})
+
+	It("discovers mixed profiles and isolates their update and deletion lifecycles", func() {
+		controllerConfigMap, err := findControllerConfigMap(testCtx.Kubeclient)
+		Expect(err).NotTo(HaveOccurred())
+		originalControllerConfig := controllerConfigMap.Data["volcano-controller.conf"]
+
+		originalNodes, err := labelMixedTopologyNodes(testCtx.Kubeclient)
+		Expect(err).NotTo(HaveOccurred())
+		defer func() {
+			Expect(setControllerConfig(testCtx.Kubeclient, controllerConfigMap, originalControllerConfig)).To(Succeed())
+			Expect(restoreNodeLabels(testCtx.Kubeclient, originalNodes)).To(Succeed())
+		}()
+
+		validConfig := mixedTopologyDiscoveryConfig()
+		By("enabling single-tier shallow and three-tier deep label discovery profiles")
+		Expect(setControllerConfig(testCtx.Kubeclient, controllerConfigMap, validConfig)).To(Succeed())
+		Eventually(func() (bool, error) {
+			return mixedTopologyHasExpectedTiers(testCtx, 6, "", 2)
+		}, 60*time.Second, time.Second).Should(BeTrue())
+		Eventually(func() (bool, error) {
+			return mixedTopologyHasExpectedGraph(testCtx)
+		}, 60*time.Second, time.Second).Should(BeTrue(),
+			"shallow and deep should remain separate complete trees while using the same semantic root tier name")
+		deepSnapshot, err := mixedTopologyProfileSnapshot(testCtx, "topologydeep")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(deepSnapshot).To(HaveLen(4))
+
+		By("scheduling a job whose semantic hypercluster tier is tier 1 in shallow and tier 3 in deep")
+		job := e2eutil.CreateJob(testCtx, &e2eutil.JobSpec{
+			Name: "mixed-tier-name-job",
+			NetworkTopology: &batchv1alpha1.NetworkTopologySpec{
+				Mode:            batchv1alpha1.HardNetworkTopologyMode,
+				HighestTierName: "volcano.sh/hypercluster",
+			},
+			Tasks: []e2eutil.TaskSpec{{
+				Name:        "worker",
+				Img:         e2eutil.DefaultNginxImage,
+				Req:         e2eutil.CPU5Mem5,
+				Min:         4,
+				Rep:         4,
+				Tolerations: mixedTopologyTolerations,
+			}},
+		})
+		defer e2eutil.DeleteJob(testCtx, job)
+		Expect(e2eutil.WaitJobReady(testCtx, job)).NotTo(HaveOccurred())
+		Expect(e2eutil.VerifyPodScheduling(testCtx, job,
+			[]string{"kwok-node-4", "kwok-node-5", "kwok-node-6", "kwok-node-7"})).NotTo(HaveOccurred())
+
+		By("changing a shallow Node without changing deep")
+		Expect(setNodeLabel(testCtx.Kubeclient, "kwok-node-0", mixedShallowDomainLabel, "hn-shallow-new")).To(Succeed())
+		Eventually(func() (bool, error) {
+			return mixedTopologyHasExpectedTiers(testCtx, 7, "hn-shallow-new", 3)
+		}, 60*time.Second, time.Second).Should(BeTrue())
+		currentDeep, err := mixedTopologyProfileSnapshot(testCtx, "topologydeep")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(currentDeep).To(Equal(deepSnapshot), "a shallow-only domain change must not recreate or mutate deep")
+
+		By("restoring the shallow domain without changing deep")
+		Expect(setNodeLabel(testCtx.Kubeclient, "kwok-node-0", mixedShallowDomainLabel, "hn-shallow-0")).To(Succeed())
+		Eventually(func() (bool, error) {
+			return mixedTopologyHasExpectedTiers(testCtx, 6, "", 2)
+		}, 60*time.Second, time.Second).Should(BeTrue())
+		Eventually(func() (bool, error) {
+			return mixedTopologyHasExpectedGraph(testCtx)
+		}, 60*time.Second, time.Second).Should(BeTrue())
+		currentDeep, err = mixedTopologyProfileSnapshot(testCtx, "topologydeep")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(currentDeep).To(Equal(deepSnapshot), "restoring shallow must preserve the independent deep tree")
+
+		By("removing every shallow Node from its profile without changing deep")
+		for i := 0; i < 4; i++ {
+			Expect(setNodeLabel(testCtx.Kubeclient, fmt.Sprintf("kwok-node-%d", i), mixedProfileLabel, "disabled")).To(Succeed())
+		}
+		Eventually(func() (bool, error) {
+			shallowSnapshot, err := mixedTopologyProfileSnapshot(testCtx, "topologyshallow")
+			return len(shallowSnapshot) == 0, err
+		}, 60*time.Second, time.Second).Should(BeTrue(), "all shallow HyperNodes should be deleted")
+		Consistently(func() (map[string]mixedTopologyHyperNodeSnapshot, error) {
+			return mixedTopologyProfileSnapshot(testCtx, "topologydeep")
+		}, 2*time.Second, 200*time.Millisecond).Should(Equal(deepSnapshot),
+			"deleting the shallow tree must not recreate or mutate deep")
+
+		By("restoring shallow after its independent tree was deleted")
+		for i := 0; i < 4; i++ {
+			Expect(setNodeLabel(testCtx.Kubeclient, fmt.Sprintf("kwok-node-%d", i), mixedProfileLabel, "shallow")).To(Succeed())
+		}
+		Eventually(func() (bool, error) {
+			return mixedTopologyHasExpectedGraph(testCtx)
+		}, 60*time.Second, time.Second).Should(BeTrue())
+		currentDeep, err = mixedTopologyProfileSnapshot(testCtx, "topologydeep")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(currentDeep).To(Equal(deepSnapshot), "recreating shallow must preserve the independent deep tree")
+	})
+
+	It("selects feasible hard topology trees without crossing semantic boundaries", func() {
+		controllerConfigMap, err := findControllerConfigMap(testCtx.Kubeclient)
+		Expect(err).NotTo(HaveOccurred())
+		originalControllerConfig := controllerConfigMap.Data["volcano-controller.conf"]
+
+		originalNodes, err := labelMixedTopologyNodes(testCtx.Kubeclient)
+		Expect(err).NotTo(HaveOccurred())
+		defer func() {
+			Expect(setControllerConfig(testCtx.Kubeclient, controllerConfigMap, originalControllerConfig)).To(Succeed())
+			Expect(restoreNodeLabels(testCtx.Kubeclient, originalNodes)).To(Succeed())
+		}()
+
+		By("enabling single-tier shallow and three-tier deep label discovery profiles")
+		Expect(setControllerConfig(testCtx.Kubeclient, controllerConfigMap, mixedTopologyDiscoveryConfig())).To(Succeed())
+		Eventually(func() (bool, error) {
+			return mixedTopologyHasExpectedTiers(testCtx, 6, "", 2)
+		}, 60*time.Second, time.Second).Should(BeTrue())
+
+		By("selecting shallow when deep is the only resource-infeasible tree")
+		deepBlockers := createMixedTopologyBlockers(testCtx, "mixed-deep-blocker", []int{4, 5, 6, 7})
+		shallowOnlyJob := createMixedTopologyHardJob(testCtx, "mixed-hard-shallow-only", "volcano.sh/hypercluster", 2)
+		Expect(e2eutil.WaitJobReady(testCtx, shallowOnlyJob)).NotTo(HaveOccurred())
+		hasShallow, hasDeep, err := mixedTopologyJobUsesProfiles(testCtx, shallowOnlyJob)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(hasShallow).To(BeTrue())
+		Expect(hasDeep).To(BeFalse())
+		shallowDomains, err := mixedTopologyJobDomains(testCtx, shallowOnlyJob, mixedShallowDomainLabel)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(shallowDomains).To(HaveLen(1), "the hard gang must fit within one shallow domain")
+		e2eutil.DeleteJob(testCtx, shallowOnlyJob)
+		Expect(e2eutil.WaitJobCleanedUp(testCtx, shallowOnlyJob)).NotTo(HaveOccurred())
+		deleteMixedTopologyBlockers(testCtx, deepBlockers)
+
+		By("selecting deep when only its semantic hypernode domain can contain the gang")
+		deepOnlyJob := createMixedTopologyHardJob(testCtx, "mixed-hard-deep-only", "volcano.sh/hypernode", 2)
+		Expect(e2eutil.WaitJobReady(testCtx, deepOnlyJob)).NotTo(HaveOccurred())
+		Expect(e2eutil.VerifyPodScheduling(testCtx, deepOnlyJob,
+			[]string{"kwok-node-4", "kwok-node-5", "kwok-node-6", "kwok-node-7"})).NotTo(HaveOccurred())
+		e2eutil.DeleteJob(testCtx, deepOnlyJob)
+		Expect(e2eutil.WaitJobCleanedUp(testCtx, deepOnlyJob)).NotTo(HaveOccurred())
+
+		By("keeping a hard gang in one real tree when both trees are feasible")
+		bothFeasibleJob := createMixedTopologyHardJob(testCtx, "mixed-hard-both-feasible", "volcano.sh/hypercluster", 2)
+		Expect(e2eutil.WaitJobReady(testCtx, bothFeasibleJob)).NotTo(HaveOccurred())
+		hasShallow, hasDeep, err = mixedTopologyJobUsesProfiles(testCtx, bothFeasibleJob)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(hasShallow != hasDeep).To(BeTrue(), "a hard gang must select exactly one feasible real tree")
+		e2eutil.DeleteJob(testCtx, bothFeasibleJob)
+		Expect(e2eutil.WaitJobCleanedUp(testCtx, bothFeasibleJob)).NotTo(HaveOccurred())
+
+		By("excluding shallow when the requested semantic superpod tier exists only in deep")
+		deepTierOnlyJob := createMixedTopologyHardJob(testCtx, "mixed-hard-deep-tier-only", "volcano.sh/superpod", 2)
+		Expect(e2eutil.WaitJobReady(testCtx, deepTierOnlyJob)).NotTo(HaveOccurred())
+		Expect(e2eutil.VerifyPodScheduling(testCtx, deepTierOnlyJob,
+			[]string{"kwok-node-4", "kwok-node-5", "kwok-node-6", "kwok-node-7"})).NotTo(HaveOccurred())
+		domains, err := mixedTopologyJobDomains(testCtx, deepTierOnlyJob, mixedDeepSuperPodLabel)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(domains).To(HaveLen(1), "the hard gang must fit within one deep superpod")
+		e2eutil.DeleteJob(testCtx, deepTierOnlyJob)
+		Expect(e2eutil.WaitJobCleanedUp(testCtx, deepTierOnlyJob)).NotTo(HaveOccurred())
+
+		By("keeping the complete hard gang pending when neither tree is feasible")
+		allBlockers := createMixedTopologyBlockers(testCtx, "mixed-all-blocker", []int{0, 1, 2, 3, 4, 5, 6, 7})
+		defer deleteMixedTopologyBlockers(testCtx, allBlockers)
+		neitherFeasibleJob := createMixedTopologyHardJob(testCtx, "mixed-hard-neither-feasible", "volcano.sh/hypercluster", 4)
+		defer e2eutil.DeleteJob(testCtx, neitherFeasibleJob)
+		Expect(e2eutil.WaitTaskPhase(testCtx, neitherFeasibleJob, []v1.PodPhase{v1.PodPending}, 4)).NotTo(HaveOccurred())
+		Consistently(func() (bool, error) {
+			return mixedTopologyJobPodsUnbound(testCtx, neitherFeasibleJob, 4)
+		}, 10*time.Second, 250*time.Millisecond).Should(BeTrue(),
+			"an infeasible hard gang must not partially bind or cross shallow and deep")
+	})
+
+	It("keeps hard subgroups in their semantic domains across pod and scheduler restarts", func() {
+		controllerConfigMap, err := findControllerConfigMap(testCtx.Kubeclient)
+		Expect(err).NotTo(HaveOccurred())
+		originalControllerConfig := controllerConfigMap.Data["volcano-controller.conf"]
+
+		originalNodes, err := labelMixedTopologyNodes(testCtx.Kubeclient)
+		Expect(err).NotTo(HaveOccurred())
+		defer func() {
+			Expect(setControllerConfig(testCtx.Kubeclient, controllerConfigMap, originalControllerConfig)).To(Succeed())
+			Expect(restoreNodeLabels(testCtx.Kubeclient, originalNodes)).To(Succeed())
+		}()
+
+		By("enabling single-tier shallow and three-tier deep label discovery profiles")
+		Expect(setControllerConfig(testCtx.Kubeclient, controllerConfigMap, mixedTopologyDiscoveryConfig())).To(Succeed())
+		Eventually(func() (bool, error) {
+			return mixedTopologyHasExpectedTiers(testCtx, 6, "", 2)
+		}, 60*time.Second, time.Second).Should(BeTrue())
+
+		By("scheduling two hard subgroups on the deep-only superpod tier")
+		job := e2eutil.CreateJob(testCtx, &e2eutil.JobSpec{
+			Name: "mixed-hard-subgroup-job",
+			NetworkTopology: &batchv1alpha1.NetworkTopologySpec{
+				Mode:            batchv1alpha1.HardNetworkTopologyMode,
+				HighestTierName: "volcano.sh/hypercluster",
+			},
+			Tasks: []e2eutil.TaskSpec{{
+				Name:        "worker",
+				Img:         e2eutil.DefaultNginxImage,
+				Req:         e2eutil.CPU5Mem5,
+				Min:         4,
+				Rep:         4,
+				Tolerations: mixedTopologyTolerations,
+				PartitionPolicy: &batchv1alpha1.PartitionPolicySpec{
+					TotalPartitions: 2,
+					PartitionSize:   2,
+					MinPartitions:   2,
+					NetworkTopology: &batchv1alpha1.NetworkTopologySpec{
+						Mode:            batchv1alpha1.HardNetworkTopologyMode,
+						HighestTierName: "volcano.sh/superpod",
+					},
+				},
+			}},
+		})
+		defer e2eutil.DeleteJob(testCtx, job)
+		Expect(e2eutil.WaitJobReady(testCtx, job)).NotTo(HaveOccurred())
+
+		domainsBefore, err := mixedTopologySubGroupDomains(testCtx, job, "deep", mixedDeepSuperPodLabel, 2, 2)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(sets.New(domainsBefore["0"], domainsBefore["1"])).To(HaveLen(2),
+			"the two CPU-saturated subgroups must occupy different deep superpods")
+
+		By("deleting one subgroup pod and waiting for a different pod instance")
+		Expect(replaceMixedTopologyJobPod(testCtx, job, "0", 4)).To(Succeed())
+		Expect(e2eutil.WaitJobReady(testCtx, job)).NotTo(HaveOccurred())
+
+		By("verifying the replacement remains in the original subgroup superpod")
+		domainsAfter, err := mixedTopologySubGroupDomains(testCtx, job, "deep", mixedDeepSuperPodLabel, 2, 2)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(domainsAfter).To(Equal(domainsBefore))
+
+		By("restarting every Volcano Scheduler process and waiting for new ready instances")
+		Expect(restartVolcanoScheduler(testCtx.Kubeclient)).To(Succeed())
+
+		By("replacing a pod after the scheduler has lost its in-memory allocation state")
+		Expect(replaceMixedTopologyJobPod(testCtx, job, "1", 4)).To(Succeed())
+		Expect(e2eutil.WaitJobReady(testCtx, job)).NotTo(HaveOccurred())
+
+		By("verifying scheduler recovery keeps every subgroup in its original superpod")
+		domainsAfterRestart, err := mixedTopologySubGroupDomains(testCtx, job, "deep", mixedDeepSuperPodLabel, 2, 2)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(domainsAfterRestart).To(Equal(domainsBefore))
+	})
+
+	It("keeps a native hard numeric boundary in its real tree across scheduler recovery", func() {
+		controllerConfigMap, err := findControllerConfigMap(testCtx.Kubeclient)
+		Expect(err).NotTo(HaveOccurred())
+		originalControllerConfig := controllerConfigMap.Data["volcano-controller.conf"]
+
+		originalNodes, err := labelMixedTopologyNodes(testCtx.Kubeclient)
+		Expect(err).NotTo(HaveOccurred())
+		defer func() {
+			Expect(setControllerConfig(testCtx.Kubeclient, controllerConfigMap, originalControllerConfig)).To(Succeed())
+			Expect(restoreNodeLabels(testCtx.Kubeclient, originalNodes)).To(Succeed())
+		}()
+
+		By("enabling shallow and deep topology trees below the numeric cluster boundary")
+		Expect(setControllerConfig(testCtx.Kubeclient, controllerConfigMap, mixedTopologyDiscoveryConfig())).To(Succeed())
+		Eventually(func() (bool, error) {
+			return mixedTopologyHasExpectedTiers(testCtx, 6, "", 2)
+		}, 60*time.Second, time.Second).Should(BeTrue())
+
+		By("forcing the initial native Hard allocation into the shallow real tree")
+		deepBlockers := createMixedTopologyBlockers(testCtx, "mixed-numeric-recovery-blocker", []int{4, 5, 6, 7})
+		defer func() {
+			if len(deepBlockers) > 0 {
+				deleteMixedTopologyBlockers(testCtx, deepBlockers)
+			}
+		}()
+		job := createMixedTopologyNumericHardJob(testCtx, "mixed-hard-numeric-recovery", 4, 2)
+		defer e2eutil.DeleteJob(testCtx, job)
+		Expect(e2eutil.WaitJobReady(testCtx, job)).NotTo(HaveOccurred())
+		hasShallow, hasDeep, err := mixedTopologyJobUsesProfiles(testCtx, job)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(hasShallow).To(BeTrue())
+		Expect(hasDeep).To(BeFalse())
+		domainsBefore, err := mixedTopologyJobDomains(testCtx, job, mixedShallowDomainLabel)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(domainsBefore).To(HaveLen(1))
+
+		By("making the sibling deep tree feasible before restarting the scheduler")
+		deleteMixedTopologyBlockers(testCtx, deepBlockers)
+		deepBlockers = nil
+		Expect(restartVolcanoScheduler(testCtx.Kubeclient)).To(Succeed())
+
+		By("replacing a pod after in-memory allocation state has been reconstructed")
+		Expect(replaceMixedTopologyJobPod(testCtx, job, "", 2)).To(Succeed())
+		Expect(e2eutil.WaitJobReady(testCtx, job)).NotTo(HaveOccurred())
+
+		By("verifying the replacement cannot escape to the now-feasible sibling tree")
+		hasShallow, hasDeep, err = mixedTopologyJobUsesProfiles(testCtx, job)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(hasShallow).To(BeTrue())
+		Expect(hasDeep).To(BeFalse())
+		domainsAfter, err := mixedTopologyJobDomains(testCtx, job, mixedShallowDomainLabel)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(domainsAfter).To(Equal(domainsBefore))
+	})
+
+})
+
+var _ = Describe("Mixed topology profile combinations", Serial, func() {
+	var testCtx *e2eutil.TestContext
+
+	BeforeEach(func() {
+		testCtx = e2eutil.InitTestContext(e2eutil.Options{NodesNumLimit: 8})
+	})
+
+	AfterEach(func() {
+		e2eutil.CleanupTestContext(testCtx)
+	})
+
+	It("keeps three arbitrary topology depths independent", func() {
+		controllerConfigMap, err := findControllerConfigMap(testCtx.Kubeclient)
+		Expect(err).NotTo(HaveOccurred())
+		originalConfig := controllerConfigMap.Data["volcano-controller.conf"]
+		originalNodes, err := labelThreeMixedTopologyNodes(testCtx.Kubeclient)
+		Expect(err).NotTo(HaveOccurred())
+		defer func() {
+			Expect(setControllerConfig(testCtx.Kubeclient, controllerConfigMap, originalConfig)).To(Succeed())
+			Expect(restoreNodeLabels(testCtx.Kubeclient, originalNodes)).To(Succeed())
+		}()
+
+		Expect(setControllerConfig(testCtx.Kubeclient, controllerConfigMap, threeMixedTopologyDiscoveryConfig())).To(Succeed())
+		Eventually(func() (bool, error) {
+			return threeMixedTopologyHasExpectedGraph(testCtx)
+		}, 60*time.Second, time.Second).Should(BeTrue())
+
+		By("selecting the only three-tier tree that can contain a four-pod hard gang")
+		job := createMixedTopologyHardJob(testCtx, "three-profile-hard-job", "volcano.sh/hypercluster", 4)
+		defer e2eutil.DeleteJob(testCtx, job)
+		Expect(e2eutil.WaitJobReady(testCtx, job)).NotTo(HaveOccurred())
+		Expect(e2eutil.VerifyPodScheduling(testCtx, job,
+			[]string{"kwok-node-4", "kwok-node-5", "kwok-node-6", "kwok-node-7"})).NotTo(HaveOccurred())
+	})
+})
+
+func labelThreeMixedTopologyNodes(client kubernetes.Interface) (map[string]*v1.Node, error) {
+	originals := make(map[string]*v1.Node, 8)
+	for i := 0; i < 8; i++ {
+		name := fmt.Sprintf("kwok-node-%d", i)
+		node, err := client.CoreV1().Nodes().Get(context.Background(), name, metav1.GetOptions{})
+		if err != nil {
+			return nil, err
+		}
+		originals[name] = node.DeepCopy()
+		if err := updateNodeLabels(client, name, func(labels map[string]string) {
+			labels[mixedClusterLabel] = "hc-shared"
+			switch {
+			case i < 2:
+				labels[mixedProfileLabel] = "compact"
+				labels[mixedCompactClusterLabel] = "compact-0"
+			case i < 4:
+				labels[mixedProfileLabel] = "wide"
+				labels[mixedWideHyperNodeLabel] = "wide-0"
+			case i < 6:
+				labels[mixedProfileLabel] = "deep"
+				labels[mixedDeepHyperNodeLabel] = "deep-0"
+				labels[mixedDeepSuperPodLabel] = "deep-sp-0"
+			default:
+				labels[mixedProfileLabel] = "deep"
+				labels[mixedDeepHyperNodeLabel] = "deep-0"
+				labels[mixedDeepSuperPodLabel] = "deep-sp-1"
+			}
+		}); err != nil {
+			return nil, err
+		}
+	}
+	return originals, nil
+}
+
+func threeMixedTopologyDiscoveryConfig() string {
+	return `networkTopologyDiscovery:
+  - source: label
+    enabled: true
+    config:
+      networkTopologyTypes:
+        topologycompact:
+          nodeSelector:
+            matchLabels:
+              volcano.sh/e2e-topology-profile: compact
+          levels:
+            - nodeLabel: volcano.sh/e2e-compact-hypercluster
+              tierName: volcano.sh/hypercluster
+            - nodeLabel: kubernetes.io/hostname
+        topologywide:
+          nodeSelector:
+            matchLabels:
+              volcano.sh/e2e-topology-profile: wide
+          levels:
+            - nodeLabel: volcano.sh/e2e-hypercluster
+              tierName: volcano.sh/hypercluster
+            - nodeLabel: volcano.sh/e2e-wide-hypernode
+              tierName: volcano.sh/hypernode
+            - nodeLabel: kubernetes.io/hostname
+        topologydeep:
+          nodeSelector:
+            matchLabels:
+              volcano.sh/e2e-topology-profile: deep
+          levels:
+            - nodeLabel: volcano.sh/e2e-hypercluster
+              tierName: volcano.sh/hypercluster
+            - nodeLabel: volcano.sh/e2e-deep-hypernode
+              tierName: volcano.sh/hypernode
+            - nodeLabel: volcano.sh/e2e-deep-superpod
+              tierName: volcano.sh/superpod
+            - nodeLabel: kubernetes.io/hostname
+`
+}
+
+func threeMixedTopologyHasExpectedGraph(testCtx *e2eutil.TestContext) (bool, error) {
+	hyperNodes, err := testCtx.Vcclient.TopologyV1alpha1().HyperNodes().List(context.Background(), metav1.ListOptions{
+		LabelSelector: labels.Set{mixedTopologySourceKey: "label"}.AsSelector().String(),
+	})
+	if err != nil {
+		return false, err
+	}
+	if len(hyperNodes.Items) != 7 {
+		return false, nil
+	}
+	byProfile := map[string]map[int][]*topologyv1alpha1.HyperNode{}
+	for i := range hyperNodes.Items {
+		hn := &hyperNodes.Items[i]
+		profile := hn.Labels[mixedTopologyProfileKey]
+		if byProfile[profile] == nil {
+			byProfile[profile] = map[int][]*topologyv1alpha1.HyperNode{}
+		}
+		byProfile[profile][hn.Spec.Tier] = append(byProfile[profile][hn.Spec.Tier], hn)
+	}
+	check := func(profile string, tierNames map[int]string, expectedLeafNodes sets.Set[string]) bool {
+		byTier := byProfile[profile]
+		if len(byTier) != len(tierNames) {
+			return false
+		}
+		for tier, name := range tierNames {
+			items := byTier[tier]
+			if len(items) == 0 {
+				return false
+			}
+			for _, hn := range items {
+				if hn.Spec.TierName != name || hn.Labels[mixedTopologyProfileKey] != profile {
+					return false
+				}
+			}
+		}
+		leafNodes := sets.New[string]()
+		for _, leaf := range byTier[1] {
+			for _, member := range leaf.Spec.Members {
+				if member.Type != topologyv1alpha1.MemberTypeNode || member.Selector.ExactMatch == nil {
+					return false
+				}
+				leafNodes.Insert(member.Selector.ExactMatch.Name)
+			}
+		}
+		if !leafNodes.Equal(expectedLeafNodes) {
+			return false
+		}
+		previousTier := byTier[1]
+		maxTier := len(tierNames)
+		for tier := 2; tier <= maxTier; tier++ {
+			if len(byTier[tier]) != 1 {
+				return false
+			}
+			expectedChildren := sets.New[string]()
+			for _, child := range previousTier {
+				expectedChildren.Insert(child.Name)
+			}
+			actualChildren := sets.New[string]()
+			for _, member := range byTier[tier][0].Spec.Members {
+				if member.Type != topologyv1alpha1.MemberTypeHyperNode || member.Selector.ExactMatch == nil {
+					return false
+				}
+				actualChildren.Insert(member.Selector.ExactMatch.Name)
+			}
+			if !actualChildren.Equal(expectedChildren) {
+				return false
+			}
+			previousTier = byTier[tier]
+		}
+		return true
+	}
+	return check("topologycompact", map[int]string{1: "volcano.sh/hypercluster"}, sets.New("kwok-node-0", "kwok-node-1")) &&
+		check("topologywide", map[int]string{1: "volcano.sh/hypernode", 2: "volcano.sh/hypercluster"}, sets.New("kwok-node-2", "kwok-node-3")) &&
+		check("topologydeep", map[int]string{1: "volcano.sh/superpod", 2: "volcano.sh/hypernode", 3: "volcano.sh/hypercluster"}, sets.New("kwok-node-4", "kwok-node-5", "kwok-node-6", "kwok-node-7")), nil
+}
+
+func findControllerConfigMap(client kubernetes.Interface) (*v1.ConfigMap, error) {
+	configMaps, err := client.CoreV1().ConfigMaps(v1.NamespaceAll).List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+	var matched *v1.ConfigMap
+	for i := range configMaps.Items {
+		configMap := &configMaps.Items[i]
+		if !strings.HasSuffix(configMap.Name, "-controller-configmap") {
+			continue
+		}
+		if _, exists := configMap.Data["volcano-controller.conf"]; !exists {
+			continue
+		}
+		if matched != nil {
+			return nil, fmt.Errorf("multiple Volcano controller ConfigMaps found: %s/%s and %s/%s",
+				matched.Namespace, matched.Name, configMap.Namespace, configMap.Name)
+		}
+		matched = configMap.DeepCopy()
+	}
+	if matched == nil {
+		return nil, fmt.Errorf("Volcano controller ConfigMap not found")
+	}
+	return matched, nil
+}
+
+func setControllerConfig(client kubernetes.Interface, configMap *v1.ConfigMap, value string) error {
+	current, err := client.CoreV1().ConfigMaps(configMap.Namespace).Get(
+		context.Background(), configMap.Name, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+	current = current.DeepCopy()
+	if current.Data == nil {
+		current.Data = make(map[string]string)
+	}
+	current.Data["volcano-controller.conf"] = value
+	_, err = client.CoreV1().ConfigMaps(configMap.Namespace).Update(
+		context.Background(), current, metav1.UpdateOptions{})
+	return err
+}
+
+func labelMixedTopologyNodes(client kubernetes.Interface) (map[string]*v1.Node, error) {
+	originals := make(map[string]*v1.Node, 8)
+	for i := 0; i < 8; i++ {
+		name := fmt.Sprintf("kwok-node-%d", i)
+		node, err := client.CoreV1().Nodes().Get(context.Background(), name, metav1.GetOptions{})
+		if err != nil {
+			return nil, err
+		}
+		originals[name] = node.DeepCopy()
+		if err := updateNodeLabels(client, name, func(labels map[string]string) {
+			labels[mixedClusterLabel] = "hc-shared"
+			if i < 4 {
+				labels[mixedProfileLabel] = "shallow"
+				labels[mixedShallowDomainLabel] = fmt.Sprintf("hn-shallow-%d", i/2)
+			} else {
+				labels[mixedProfileLabel] = "deep"
+				labels[mixedDeepHyperNodeLabel] = "hn-deep"
+				labels[mixedDeepSuperPodLabel] = fmt.Sprintf("sp-deep-%d", (i-4)/2)
+			}
+		}); err != nil {
+			return nil, err
+		}
+	}
+	return originals, nil
+}
+
+func restoreNodeLabels(client kubernetes.Interface, originals map[string]*v1.Node) error {
+	for name, original := range originals {
+		if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			current, err := client.CoreV1().Nodes().Get(context.Background(), name, metav1.GetOptions{})
+			if err != nil {
+				return err
+			}
+			current = current.DeepCopy()
+			current.Labels = original.Labels
+			_, err = client.CoreV1().Nodes().Update(context.Background(), current, metav1.UpdateOptions{})
+			return err
+		}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func setNodeLabel(client kubernetes.Interface, nodeName, key, value string) error {
+	return updateNodeLabels(client, nodeName, func(labels map[string]string) {
+		labels[key] = value
+	})
+}
+
+func updateNodeLabels(client kubernetes.Interface, nodeName string, update func(map[string]string)) error {
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		node, err := client.CoreV1().Nodes().Get(context.Background(), nodeName, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		node = node.DeepCopy()
+		if node.Labels == nil {
+			node.Labels = make(map[string]string)
+		}
+		update(node.Labels)
+		_, err = client.CoreV1().Nodes().Update(context.Background(), node, metav1.UpdateOptions{})
+		return err
+	})
+}
+
+func mixedTopologyHasExpectedTiers(testCtx *e2eutil.TestContext, expectedCount int, expectedDomain string, expectedShallowTier1 int) (bool, error) {
+	hyperNodes, err := testCtx.Vcclient.TopologyV1alpha1().HyperNodes().List(context.Background(), metav1.ListOptions{
+		LabelSelector: labels.Set{mixedTopologySourceKey: "label"}.AsSelector().String(),
+	})
+	if err != nil {
+		return false, err
+	}
+	if len(hyperNodes.Items) != expectedCount {
+		return false, nil
+	}
+
+	tiersByName := map[string]map[int]int{}
+	domainFound := expectedDomain == ""
+	for i := range hyperNodes.Items {
+		hyperNode := &hyperNodes.Items[i]
+		if tiersByName[hyperNode.Spec.TierName] == nil {
+			tiersByName[hyperNode.Spec.TierName] = make(map[int]int)
+		}
+		tiersByName[hyperNode.Spec.TierName][hyperNode.Spec.Tier]++
+		if hyperNode.Labels[mixedShallowDomainLabel] == expectedDomain {
+			domainFound = true
+		}
+	}
+
+	return domainFound &&
+		tiersByName["volcano.sh/hypercluster"][1] == expectedShallowTier1 &&
+		tiersByName["volcano.sh/superpod"][1] == 2 &&
+		tiersByName["volcano.sh/hypernode"][2] == 1 &&
+		tiersByName["volcano.sh/hypercluster"][3] == 1, nil
+}
+
+func mixedTopologyHasExpectedGraph(testCtx *e2eutil.TestContext) (bool, error) {
+	hyperNodes, err := testCtx.Vcclient.TopologyV1alpha1().HyperNodes().List(context.Background(), metav1.ListOptions{
+		LabelSelector: labels.Set{mixedTopologySourceKey: "label"}.AsSelector().String(),
+	})
+	if err != nil {
+		return false, err
+	}
+	if len(hyperNodes.Items) != 6 {
+		return false, nil
+	}
+
+	byProfile := map[string][]*topologyv1alpha1.HyperNode{}
+	for i := range hyperNodes.Items {
+		hyperNode := &hyperNodes.Items[i]
+		profile := hyperNode.Labels[mixedTopologyProfileKey]
+		byProfile[profile] = append(byProfile[profile], hyperNode)
+	}
+
+	validateProfile := func(profile string, expectedNodes sets.Set[string], expectedTierNames map[int]string) (sets.Set[string], bool) {
+		byTier := map[int][]*topologyv1alpha1.HyperNode{}
+		for _, hyperNode := range byProfile[profile] {
+			if hyperNode.Spec.TierName != expectedTierNames[hyperNode.Spec.Tier] {
+				return nil, false
+			}
+			byTier[hyperNode.Spec.Tier] = append(byTier[hyperNode.Spec.Tier], hyperNode)
+		}
+		if len(byTier[1]) != 2 || len(byProfile[profile]) != len(expectedTierNames)+1 {
+			return nil, false
+		}
+
+		leafNodes := sets.New[string]()
+		for _, leaf := range byTier[1] {
+			if len(leaf.Spec.Members) != 2 {
+				return nil, false
+			}
+			for _, member := range leaf.Spec.Members {
+				if member.Type != topologyv1alpha1.MemberTypeNode || member.Selector.ExactMatch == nil {
+					return nil, false
+				}
+				leafNodes.Insert(member.Selector.ExactMatch.Name)
+			}
+		}
+		if !leafNodes.Equal(expectedNodes) {
+			return nil, false
+		}
+
+		previousTier := byTier[1]
+		topLevel := sets.New[string]()
+		for tier := 2; tier <= len(expectedTierNames); tier++ {
+			if len(byTier[tier]) != 1 {
+				return nil, false
+			}
+			expectedMembers := sets.New[string]()
+			for _, child := range previousTier {
+				expectedMembers.Insert(child.Name)
+			}
+			actualMembers := sets.New[string]()
+			for _, member := range byTier[tier][0].Spec.Members {
+				if member.Type != topologyv1alpha1.MemberTypeHyperNode || member.Selector.ExactMatch == nil {
+					return nil, false
+				}
+				actualMembers.Insert(member.Selector.ExactMatch.Name)
+			}
+			if !actualMembers.Equal(expectedMembers) {
+				return nil, false
+			}
+			topLevel.Insert(byTier[tier][0].Name)
+			previousTier = byTier[tier]
+		}
+		if len(expectedTierNames) == 1 {
+			for _, leaf := range byTier[1] {
+				topLevel.Insert(leaf.Name)
+			}
+		}
+		return topLevel, true
+	}
+
+	shallowRoots, shallowValid := validateProfile("topologyshallow", sets.New[string](
+		"kwok-node-0", "kwok-node-1", "kwok-node-2", "kwok-node-3"), map[int]string{
+		1: "volcano.sh/hypercluster",
+	})
+	deepRoots, deepValid := validateProfile("topologydeep", sets.New[string](
+		"kwok-node-4", "kwok-node-5", "kwok-node-6", "kwok-node-7"), map[int]string{
+		1: "volcano.sh/superpod",
+		2: "volcano.sh/hypernode",
+		3: "volcano.sh/hypercluster",
+	})
+	for root := range shallowRoots {
+		if deepRoots.Has(root) {
+			return false, nil
+		}
+	}
+	return shallowValid && deepValid, nil
+}
+
+func mixedTopologyProfileSnapshot(testCtx *e2eutil.TestContext, profile string) (map[string]mixedTopologyHyperNodeSnapshot, error) {
+	hyperNodes, err := testCtx.Vcclient.TopologyV1alpha1().HyperNodes().List(context.Background(), metav1.ListOptions{
+		LabelSelector: labels.Set{
+			mixedTopologySourceKey:  "label",
+			mixedTopologyProfileKey: profile,
+		}.AsSelector().String(),
+	})
+	if err != nil {
+		return nil, err
+	}
+	snapshot := make(map[string]mixedTopologyHyperNodeSnapshot, len(hyperNodes.Items))
+	for i := range hyperNodes.Items {
+		hyperNode := hyperNodes.Items[i].DeepCopy()
+		snapshot[hyperNode.Name] = mixedTopologyHyperNodeSnapshot{
+			UID:  string(hyperNode.UID),
+			Spec: hyperNode.Spec,
+		}
+	}
+	return snapshot, nil
+}
+
+func mixedTopologyJobUsesProfiles(testCtx *e2eutil.TestContext, job *batchv1alpha1.Job) (bool, bool, error) {
+	hasShallow := false
+	hasDeep := false
+	for _, pod := range e2eutil.GetTasksOfJob(testCtx, job) {
+		if pod.Spec.NodeName == "" {
+			return false, false, fmt.Errorf("pod %s/%s is not scheduled", pod.Namespace, pod.Name)
+		}
+		node, err := testCtx.Kubeclient.CoreV1().Nodes().Get(context.Background(), pod.Spec.NodeName, metav1.GetOptions{})
+		if err != nil {
+			return false, false, err
+		}
+		switch node.Labels[mixedProfileLabel] {
+		case "shallow":
+			hasShallow = true
+		case "deep":
+			hasDeep = true
+		default:
+			return false, false, fmt.Errorf("pod %s/%s scheduled to node %s without a mixed topology profile", pod.Namespace, pod.Name, pod.Spec.NodeName)
+		}
+	}
+	return hasShallow, hasDeep, nil
+}
+
+func createMixedTopologyHardJob(
+	testCtx *e2eutil.TestContext,
+	name, highestTierName string,
+	replicas int32,
+) *batchv1alpha1.Job {
+	return e2eutil.CreateJob(testCtx, &e2eutil.JobSpec{
+		Name: name,
+		NetworkTopology: &batchv1alpha1.NetworkTopologySpec{
+			Mode:            batchv1alpha1.HardNetworkTopologyMode,
+			HighestTierName: highestTierName,
+		},
+		Tasks: []e2eutil.TaskSpec{{
+			Name:        "worker",
+			Img:         e2eutil.DefaultNginxImage,
+			Req:         e2eutil.CPU5Mem5,
+			Min:         replicas,
+			Rep:         replicas,
+			Tolerations: mixedTopologyTolerations,
+		}},
+	})
+}
+
+func createMixedTopologyNumericHardJob(
+	testCtx *e2eutil.TestContext,
+	name string,
+	highestTierAllowed int,
+	replicas int32,
+) *batchv1alpha1.Job {
+	return e2eutil.CreateJob(testCtx, &e2eutil.JobSpec{
+		Name: name,
+		NetworkTopology: &batchv1alpha1.NetworkTopologySpec{
+			Mode:               batchv1alpha1.HardNetworkTopologyMode,
+			HighestTierAllowed: ptr.To(highestTierAllowed),
+		},
+		Tasks: []e2eutil.TaskSpec{{
+			Name:        "worker",
+			Img:         e2eutil.DefaultNginxImage,
+			Req:         e2eutil.CPU5Mem5,
+			Min:         replicas,
+			Rep:         replicas,
+			Tolerations: mixedTopologyTolerations,
+		}},
+	})
+}
+
+func createMixedTopologyBlockers(testCtx *e2eutil.TestContext, prefix string, nodeIndexes []int) []*v1.Pod {
+	pods := make([]*v1.Pod, 0, len(nodeIndexes))
+	for _, nodeIndex := range nodeIndexes {
+		pod := e2eutil.CreatePod(testCtx, e2eutil.PodSpec{
+			Name:        fmt.Sprintf("%s-%d", prefix, nodeIndex),
+			Node:        fmt.Sprintf("kwok-node-%d", nodeIndex),
+			Req:         e2eutil.CPU4Mem4,
+			Tolerations: mixedTopologyTolerations,
+		})
+		Expect(e2eutil.WaitPodReady(testCtx, pod)).NotTo(HaveOccurred())
+		pods = append(pods, pod)
+	}
+	return pods
+}
+
+func deleteMixedTopologyBlockers(testCtx *e2eutil.TestContext, pods []*v1.Pod) {
+	for _, pod := range pods {
+		e2eutil.DeletePod(testCtx, pod)
+	}
+	for _, pod := range pods {
+		Expect(e2eutil.WaitPodGone(testCtx, pod.Name, pod.Namespace)).NotTo(HaveOccurred())
+	}
+}
+
+func mixedTopologyJobDomains(
+	testCtx *e2eutil.TestContext,
+	job *batchv1alpha1.Job,
+	domainLabel string,
+) (sets.Set[string], error) {
+	domains := sets.New[string]()
+	for _, pod := range e2eutil.GetTasksOfJob(testCtx, job) {
+		if pod.Spec.NodeName == "" {
+			return nil, fmt.Errorf("pod %s/%s is not scheduled", pod.Namespace, pod.Name)
+		}
+		node, err := testCtx.Kubeclient.CoreV1().Nodes().Get(
+			context.Background(), pod.Spec.NodeName, metav1.GetOptions{})
+		if err != nil {
+			return nil, err
+		}
+		domain := node.Labels[domainLabel]
+		if domain == "" {
+			return nil, fmt.Errorf("node %s has no topology domain label %s", node.Name, domainLabel)
+		}
+		domains.Insert(domain)
+	}
+	return domains, nil
+}
+
+func mixedTopologyJobPodsUnbound(
+	testCtx *e2eutil.TestContext,
+	job *batchv1alpha1.Job,
+	expectedPods int,
+) (bool, error) {
+	pods, err := testCtx.Kubeclient.CoreV1().Pods(job.Namespace).List(
+		context.Background(), metav1.ListOptions{})
+	if err != nil {
+		return false, err
+	}
+	controlledPods := 0
+	for i := range pods.Items {
+		pod := &pods.Items[i]
+		if !metav1.IsControlledBy(pod, job) {
+			continue
+		}
+		controlledPods++
+		if pod.Spec.NodeName != "" || pod.Status.Phase != v1.PodPending {
+			return false, nil
+		}
+	}
+	return controlledPods == expectedPods, nil
+}
+
+func mixedTopologySubGroupDomains(
+	testCtx *e2eutil.TestContext,
+	job *batchv1alpha1.Job,
+	expectedProfile, domainLabel string,
+	expectedPartitions, expectedPartitionSize int,
+) (map[string]string, error) {
+	pods := e2eutil.GetTasksOfJob(testCtx, job)
+	expectedPods := expectedPartitions * expectedPartitionSize
+	if len(pods) != expectedPods {
+		return nil, fmt.Errorf("expected %d pods for job %s, got %d", expectedPods, job.Name, len(pods))
+	}
+
+	podCounts := make(map[string]int, expectedPartitions)
+	domainsByPartition := make(map[string]sets.Set[string], expectedPartitions)
+	for _, pod := range pods {
+		partition, found := pod.Labels[batchv1alpha1.TaskPartitionID]
+		if !found || partition == "" {
+			return nil, fmt.Errorf("pod %s/%s has no partition label", pod.Namespace, pod.Name)
+		}
+		if pod.Spec.NodeName == "" {
+			return nil, fmt.Errorf("pod %s/%s is not scheduled", pod.Namespace, pod.Name)
+		}
+
+		node, err := testCtx.Kubeclient.CoreV1().Nodes().Get(
+			context.Background(), pod.Spec.NodeName, metav1.GetOptions{})
+		if err != nil {
+			return nil, err
+		}
+		if profile := node.Labels[mixedProfileLabel]; profile != expectedProfile {
+			return nil, fmt.Errorf("pod %s/%s is on profile %q, expected %q",
+				pod.Namespace, pod.Name, profile, expectedProfile)
+		}
+		domain := node.Labels[domainLabel]
+		if domain == "" {
+			return nil, fmt.Errorf("node %s has no topology domain label %s", node.Name, domainLabel)
+		}
+
+		if domainsByPartition[partition] == nil {
+			domainsByPartition[partition] = sets.New[string]()
+		}
+		domainsByPartition[partition].Insert(domain)
+		podCounts[partition]++
+	}
+
+	result := make(map[string]string, expectedPartitions)
+	for partitionIndex := 0; partitionIndex < expectedPartitions; partitionIndex++ {
+		partition := fmt.Sprint(partitionIndex)
+		if podCounts[partition] != expectedPartitionSize {
+			return nil, fmt.Errorf("partition %s has %d pods, expected %d",
+				partition, podCounts[partition], expectedPartitionSize)
+		}
+		domains := domainsByPartition[partition]
+		if domains.Len() != 1 {
+			return nil, fmt.Errorf("partition %s spans topology domains %v", partition, domains.UnsortedList())
+		}
+		result[partition] = domains.UnsortedList()[0]
+	}
+	if len(domainsByPartition) != expectedPartitions {
+		return nil, fmt.Errorf("found unexpected partitions: %v", sets.KeySet(domainsByPartition).UnsortedList())
+	}
+	return result, nil
+}
+
+func replaceMixedTopologyJobPod(
+	testCtx *e2eutil.TestContext,
+	job *batchv1alpha1.Job,
+	partition string,
+	expectedPods int,
+) error {
+	pods, err := testCtx.Kubeclient.CoreV1().Pods(job.Namespace).List(
+		context.Background(), metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+
+	initialUIDs := sets.New[string]()
+	var victim *v1.Pod
+	for i := range pods.Items {
+		pod := &pods.Items[i]
+		if !metav1.IsControlledBy(pod, job) {
+			continue
+		}
+		initialUIDs.Insert(string(pod.UID))
+		if victim == nil && (partition == "" || pod.Labels[batchv1alpha1.TaskPartitionID] == partition) {
+			victim = pod.DeepCopy()
+		}
+	}
+	if victim == nil {
+		if partition == "" {
+			return fmt.Errorf("job %s has no controlled pod", job.Name)
+		}
+		return fmt.Errorf("job %s has no pod in partition %s", job.Name, partition)
+	}
+	if len(initialUIDs) != expectedPods {
+		return fmt.Errorf("job %s has %d pods before replacement, expected %d",
+			job.Name, len(initialUIDs), expectedPods)
+	}
+	if err := testCtx.Kubeclient.CoreV1().Pods(victim.Namespace).Delete(
+		context.Background(), victim.Name, metav1.DeleteOptions{}); err != nil {
+		return err
+	}
+
+	lastState := "replacement not observed"
+	err = wait.PollUntilContextTimeout(context.Background(), 250*time.Millisecond, 2*time.Minute, true,
+		func(ctx context.Context) (bool, error) {
+			currentPods, err := testCtx.Kubeclient.CoreV1().Pods(job.Namespace).List(ctx, metav1.ListOptions{})
+			if err != nil {
+				return false, err
+			}
+
+			controlledPods := 0
+			readyPods := 0
+			replacementFound := false
+			victimStillExists := false
+			for i := range currentPods.Items {
+				pod := &currentPods.Items[i]
+				if !metav1.IsControlledBy(pod, job) {
+					continue
+				}
+				controlledPods++
+				if pod.UID == victim.UID {
+					victimStillExists = true
+				}
+				if !initialUIDs.Has(string(pod.UID)) {
+					replacementFound = true
+				}
+				if pod.Status.Phase == v1.PodRunning && mixedTopologyPodReady(pod) {
+					readyPods++
+				}
+			}
+			lastState = fmt.Sprintf("controlled=%d ready=%d replacement=%t victimPresent=%t",
+				controlledPods, readyPods, replacementFound, victimStillExists)
+			return controlledPods == expectedPods && readyPods == expectedPods &&
+				replacementFound && !victimStillExists, nil
+		})
+	if err != nil {
+		return fmt.Errorf("wait for replacement of pod %s/%s: %w (%s)",
+			victim.Namespace, victim.Name, err, lastState)
+	}
+	return nil
+}
+
+func restartVolcanoScheduler(client kubernetes.Interface) error {
+	const schedulerSelector = "app=volcano-scheduler"
+
+	pods, err := client.CoreV1().Pods(v1.NamespaceAll).List(
+		context.Background(), metav1.ListOptions{LabelSelector: schedulerSelector})
+	if err != nil {
+		return err
+	}
+	if len(pods.Items) == 0 {
+		return fmt.Errorf("no Volcano Scheduler pods found")
+	}
+
+	oldUIDs := sets.New[string]()
+	for i := range pods.Items {
+		pod := &pods.Items[i]
+		if !mixedTopologyPodReady(pod) {
+			return fmt.Errorf("Volcano Scheduler pod %s/%s is not ready before restart", pod.Namespace, pod.Name)
+		}
+		oldUIDs.Insert(string(pod.UID))
+		if err := client.CoreV1().Pods(pod.Namespace).Delete(
+			context.Background(), pod.Name, metav1.DeleteOptions{}); err != nil {
+			return err
+		}
+	}
+
+	lastState := "new scheduler pod not observed"
+	err = wait.PollUntilContextTimeout(context.Background(), 500*time.Millisecond, 2*time.Minute, true,
+		func(ctx context.Context) (bool, error) {
+			currentPods, err := client.CoreV1().Pods(v1.NamespaceAll).List(
+				ctx, metav1.ListOptions{LabelSelector: schedulerSelector})
+			if err != nil {
+				return false, err
+			}
+
+			readyNewPods := 0
+			oldPodPresent := false
+			for i := range currentPods.Items {
+				pod := &currentPods.Items[i]
+				if oldUIDs.Has(string(pod.UID)) {
+					oldPodPresent = true
+					continue
+				}
+				if pod.DeletionTimestamp == nil && mixedTopologyPodReady(pod) {
+					readyNewPods++
+				}
+			}
+			lastState = fmt.Sprintf("readyNew=%d expected=%d oldPresent=%t",
+				readyNewPods, len(oldUIDs), oldPodPresent)
+			return readyNewPods >= len(oldUIDs) && !oldPodPresent, nil
+		})
+	if err != nil {
+		return fmt.Errorf("wait for Volcano Scheduler restart: %w (%s)", err, lastState)
+	}
+	return nil
+}
+
+func mixedTopologyPodReady(pod *v1.Pod) bool {
+	for _, condition := range pod.Status.Conditions {
+		if condition.Type == v1.PodReady {
+			return condition.Status == v1.ConditionTrue
+		}
+	}
+	return false
+}
+
+func mixedTopologyDiscoveryConfig() string {
+	return `networkTopologyDiscovery:
+  - source: label
+    enabled: true
+    config:
+      networkTopologyTypes:
+        topologyshallow:
+          nodeSelector:
+            matchLabels:
+              volcano.sh/e2e-topology-profile: shallow
+          levels:
+            - nodeLabel: volcano.sh/e2e-shallow-domain
+              tierName: volcano.sh/hypercluster
+            - nodeLabel: kubernetes.io/hostname
+        topologydeep:
+          nodeSelector:
+            matchLabels:
+              volcano.sh/e2e-topology-profile: deep
+          levels:
+            - nodeLabel: volcano.sh/e2e-hypercluster
+              tierName: volcano.sh/hypercluster
+            - nodeLabel: volcano.sh/e2e-deep-hypernode
+              tierName: volcano.sh/hypernode
+            - nodeLabel: volcano.sh/e2e-deep-superpod
+              tierName: volcano.sh/superpod
+            - nodeLabel: kubernetes.io/hostname
+`
+}


### PR DESCRIPTION
#### What type of PR is this?
feature

#### What this PR does / why we need it:

This PR implements support for multiple independent HyperNode topology trees with different depths and local tier semantics in one Kubernetes cluster.

Existing HyperNode discovery and scheduling paths rely on cluster-global tier indexes and tier-name mappings. These assumptions are insufficient when the same semantic topology level appears at different numeric tiers in different topology trees.

The implementation introduces:

1. topology Profiles based on `nodeSelector` and ordered `levels`;
2. Profile-local topology domain isolation and deterministic HyperNode generation;
3. one Session-local `TopologyTree` view for each connected real HyperNode root;
4. preservation of the complete native Hard topology constraint until the candidate tree is known;
5. BFS-based, tree-local resolution of `highestTierName` against semantic `tierName` values in each candidate tree;
6. tree-separated Hard Job/SubGroup candidate generation;
7. tree-local Node lookup and topology scoring;
8. mixed-depth allocation-state updates and restart-recovery handling; and
9. compatibility with legacy discovery configuration, numeric `highestTierAllowed`, and existing workload APIs.

Legacy discovery configuration, numeric `highestTierAllowed`, existing workload APIs, and CRD schemas remain supported. Mixed-topology Soft scheduling semantics are not changed in this PR.

#### Which issue(s) this PR fixes:

Related to [#5732](https://github.com/volcano-sh/volcano/issues/5732)

#### Special notes for your reviewer:

This PR implements the Core Hard scheduling scope described in the mixed-depth HyperNode topology design proposal.

AI tools were used to assist with development, documentation, and wording. I reviewed the final changes and take responsibility for their content.

#### Does this PR introduce a user-facing change?

```release-note
Add profile-based HyperNode discovery and tree-local Hard topology scheduling for clusters containing topology trees with different depths.
```