### PR TITLE
fix(plugins): prevent nil queueOpts panic for empty queues and orphaned jobs

### DIFF
--- a/pkg/scheduler/plugins/capacity/capacity.go
+++ b/pkg/scheduler/plugins/capacity/capacity.go
@@ -1062,49 +1062,30 @@ func (cp *capacityPlugin) buildQueueAttrs(ssn *framework.Session) {
 		cp.totalGuarantee.Add(guarantee)
 	}
 	klog.V(4).Infof("The total guarantee resource is <%v>", cp.totalGuarantee)
+
 	// Build attributes for Queues.
+	for _, queue := range ssn.Queues {
+		attr := cp.newQueueAttr(queue)
+		realCapability := api.ExceededPart(cp.totalResource, cp.totalGuarantee).Add(attr.guarantee)
+		if attr.capability == nil {
+			attr.capability = api.EmptyResource()
+			attr.realCapability = realCapability
+		} else {
+			realCapability.MinDimensionResource(attr.capability, api.Infinity)
+			attr.realCapability = realCapability
+		}
+		cp.queueOpts[queue.UID] = attr
+		klog.V(4).Infof("Added Queue <%s> attributes.", queue.Name)
+	}
+
 	for _, job := range ssn.Jobs {
 		klog.V(4).Infof("Considering Job <%s/%s>.", job.Namespace, job.Name)
-		if _, found := cp.queueOpts[job.Queue]; !found {
-			queue := ssn.Queues[job.Queue]
-			attr := &queueAttr{
-				queueID: queue.UID,
-				name:    queue.Name,
-
-				deserved:          api.NewResource(queue.Queue.Spec.Deserved),
-				allocated:         api.EmptyResource(),
-				request:           api.EmptyResource(),
-				elastic:           api.EmptyResource(),
-				inqueue:           api.EmptyResource(),
-				guarantee:         api.EmptyResource(),
-				resourceClaimRefs: make(map[string]int),
-			}
-			if len(queue.Queue.Spec.Capability) != 0 {
-				attr.capability = api.NewResource(queue.Queue.Spec.Capability)
-				if attr.capability.MilliCPU <= 0 {
-					attr.capability.MilliCPU = math.MaxFloat64
-				}
-				if attr.capability.Memory <= 0 {
-					attr.capability.Memory = math.MaxFloat64
-				}
-			}
-			attr.dra = newDRAQuotaAttr(queue.Queue.Spec.Capability, queue.Queue.Spec.Deserved, queue.Queue.Spec.Guarantee.Resource)
-			if len(queue.Queue.Spec.Guarantee.Resource) != 0 {
-				attr.guarantee = api.NewResource(queue.Queue.Spec.Guarantee.Resource)
-			}
-			realCapability := api.ExceededPart(cp.totalResource, cp.totalGuarantee).Add(attr.guarantee)
-			if attr.capability == nil {
-				attr.capability = api.EmptyResource()
-				attr.realCapability = realCapability
-			} else {
-				realCapability.MinDimensionResource(attr.capability, api.Infinity)
-				attr.realCapability = realCapability
-			}
-			cp.queueOpts[job.Queue] = attr
-			klog.V(4).Infof("Added Queue <%s> attributes.", job.Queue)
+		attr, found := cp.queueOpts[job.Queue]
+		if !found {
+			klog.Warningf("[capacity] Skip Job <%s/%s>: queue <%s> not found in session",
+				job.Namespace, job.Name, job.Queue)
+			continue
 		}
-
-		attr := cp.queueOpts[job.Queue]
 		for status, tasks := range job.TaskStatusIndex {
 			if api.AllocatedStatus(status) {
 				for _, t := range tasks {
@@ -1559,6 +1540,16 @@ func (cp *capacityPlugin) checkHierarchicalQueue(attr *queueAttr) {
 // queues with non-empty deserved are prioritized over best-effort queues.
 // Returns negative if l should come before r.
 func (cp *capacityPlugin) compareShareWithDeserved(lattr, rattr *queueAttr) int {
+	if lattr == nil || rattr == nil {
+		if lattr == nil && rattr == nil {
+			return 0
+		}
+		if lattr == nil {
+			return 1
+		}
+		return -1
+	}
+
 	if lattr.share == rattr.share {
 		lHasDeserved := !lattr.deserved.IsEmpty()
 		rHasDeserved := !rattr.deserved.IsEmpty()
@@ -1644,6 +1635,9 @@ func (cp *capacityPlugin) buildQueueReservedTasksCache(ssn *framework.Session) {
 }
 
 func (cp *capacityPlugin) queueAllocatableWithReserved(attr *queueAttr, candidate *api.TaskInfo, queue *api.QueueInfo, draEnabled bool, consumableCapacityEnabled bool) bool {
+	if attr == nil {
+		return false
+	}
 	if draEnabled && attr.dra != nil {
 		candidateDRA := incrementalTaskDRA(attr, candidate)
 		if candidateDRA != nil {
@@ -1695,7 +1689,13 @@ func (cp *capacityPlugin) checkQueueAllocatableHierarchically(ssn *framework.Ses
 }
 
 func (cp *capacityPlugin) jobEnqueueable(queue *api.QueueInfo, job *api.JobInfo) (bool, []string) {
+	if queue == nil {
+		return false, []string{"queue-is-nil"}
+	}
 	attr := cp.queueOpts[queue.UID]
+	if attr == nil {
+		return false, []string{"queue-not-found"}
+	}
 	minReq := job.GetMinResources()
 
 	klog.V(5).Infof("job %s min resource <%s>, queue %s capability <%s> allocated <%s> inqueue <%s> elastic <%s>",

--- a/pkg/scheduler/plugins/capacity/capacity_test.go
+++ b/pkg/scheduler/plugins/capacity/capacity_test.go
@@ -2108,3 +2108,71 @@ func TestCheckDRAAllocatable_overflowRejected(t *testing.T) {
 		t.Fatalf("checkDRAAllocatable rejected a valid request (4 <= 8); want admitted")
 	}
 }
+
+// TestEmptyQueueAndOrphanedJobSafetyNonHierarchical tests that capacity plugin
+// in non-hierarchical mode handles empty queues and orphaned jobs without panicking.
+func TestEmptyQueueAndOrphanedJobSafetyNonHierarchical(t *testing.T) {
+	trueValue := true
+
+	n1 := util.BuildNode("n1", api.BuildResourceList("10", "10Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), nil)
+
+	res1CPU := api.BuildResourceList("1", "1Gi")
+	pod1 := util.BuildPod("ns1", "pod1", "", corev1.PodPending, res1CPU, "pg1", nil, nil)
+	pg1 := util.BuildPodGroup("pg1", "ns1", "q1", 1, nil, schedulingv1beta1.PodGroupPending)
+	pg1.Spec.MinResources = &res1CPU
+
+	// podOrphan belongs to non-existent queue "q-deleted"
+	podOrphan := util.BuildPod("ns1", "podOrphan", "", corev1.PodPending, res1CPU, "pgOrphan", nil, nil)
+	pgOrphan := util.BuildPodGroup("pgOrphan", "ns1", "q-deleted", 1, nil, schedulingv1beta1.PodGroupPending)
+	pgOrphan.Spec.MinResources = &res1CPU
+
+	// q1 has job pg1, q2 and q3 are empty queues
+	q1 := util.BuildQueue("q1", 1, api.BuildResourceList("4", "4Gi"))
+	q2 := util.BuildQueue("q2", 2, api.BuildResourceList("4", "4Gi"))
+	q3 := util.BuildQueue("q3", 3, api.BuildResourceList("4", "4Gi"))
+
+	plugins := map[string]framework.PluginBuilder{
+		PluginName: New,
+	}
+	tiers := []conf.Tier{
+		{
+			Plugins: []conf.PluginOption{
+				{Name: PluginName, EnabledJobEnqueued: &trueValue, EnabledQueueOrder: &trueValue},
+			},
+		},
+	}
+
+	test := uthelper.TestCommonStruct{
+		Name:      "empty queues and orphaned jobs safety in capacity plugin (non-hierarchical)",
+		Plugins:   plugins,
+		Pods:      []*corev1.Pod{pod1, podOrphan},
+		Nodes:     []*corev1.Node{n1},
+		PodGroups: []*schedulingv1beta1.PodGroup{pg1, pgOrphan},
+		Queues:    []*schedulingv1beta1.Queue{q1, q2, q3},
+		ExpectStatus: map[api.JobID]scheduling.PodGroupPhase{
+			"ns1/pg1": scheduling.PodGroupInqueue,
+		},
+	}
+	ssn := test.RegisterSession(tiers, nil)
+	defer test.Close()
+
+	// Verify QueueOrderFn does not panic when comparing empty and busy queues
+	q1Info := ssn.Queues["q1"]
+	q2Info := ssn.Queues["q2"]
+	q3Info := ssn.Queues["q3"]
+
+	_ = ssn.QueueOrderFn(q1Info, q2Info)
+	_ = ssn.QueueOrderFn(q2Info, q3Info)
+	_ = ssn.QueueOrderFn(q1Info, q3Info)
+
+	// Verify Allocatable on empty queue does not panic
+	task1 := ssn.Jobs["ns1/pg1"].Tasks[api.PodKey(pod1)]
+	if !ssn.Allocatable(q2Info, task1) {
+		t.Errorf("expected task1 to be allocatable on empty queue q2")
+	}
+
+	test.Run([]framework.Action{enqueue.New()})
+	if err := test.CheckAll(0); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/pkg/scheduler/plugins/proportion/proportion.go
+++ b/pkg/scheduler/plugins/proportion/proportion.go
@@ -100,48 +100,52 @@ func (pp *proportionPlugin) OnSessionOpen(ssn *framework.Session) {
 		pp.totalGuarantee.Add(guarantee)
 	}
 	klog.V(4).Infof("The total guarantee resource is <%v>", pp.totalGuarantee)
+	for _, queue := range ssn.Queues {
+		attr := &queueAttr{
+			queueID: queue.UID,
+			name:    queue.Name,
+			weight:  queue.Weight,
+
+			deserved:  api.EmptyResource(),
+			allocated: api.EmptyResource(),
+			request:   api.EmptyResource(),
+			elastic:   api.EmptyResource(),
+			inqueue:   api.EmptyResource(),
+			guarantee: api.EmptyResource(),
+		}
+		if len(queue.Queue.Spec.Capability) != 0 {
+			attr.capability = api.NewResource(queue.Queue.Spec.Capability)
+			if attr.capability.MilliCPU <= 0 {
+				attr.capability.MilliCPU = math.MaxFloat64
+			}
+			if attr.capability.Memory <= 0 {
+				attr.capability.Memory = math.MaxFloat64
+			}
+		}
+		if len(queue.Queue.Spec.Guarantee.Resource) != 0 {
+			attr.guarantee = api.NewResource(queue.Queue.Spec.Guarantee.Resource)
+		}
+		realCapability := api.ExceededPart(pp.totalResource, pp.totalGuarantee).Add(attr.guarantee)
+		if attr.capability == nil {
+			attr.capability = api.EmptyResource()
+			attr.realCapability = realCapability
+		} else {
+			realCapability.MinDimensionResource(attr.capability, api.Infinity)
+			attr.realCapability = realCapability
+		}
+		pp.queueOpts[queue.UID] = attr
+		klog.V(4).Infof("Added Queue <%s> attributes.", queue.Name)
+	}
+
 	// Build attributes for Queues.
 	for _, job := range ssn.Jobs {
 		klog.V(4).Infof("Considering Job <%s/%s>.", job.Namespace, job.Name)
-		if _, found := pp.queueOpts[job.Queue]; !found {
-			queue := ssn.Queues[job.Queue]
-			attr := &queueAttr{
-				queueID: queue.UID,
-				name:    queue.Name,
-				weight:  queue.Weight,
-
-				deserved:  api.EmptyResource(),
-				allocated: api.EmptyResource(),
-				request:   api.EmptyResource(),
-				elastic:   api.EmptyResource(),
-				inqueue:   api.EmptyResource(),
-				guarantee: api.EmptyResource(),
-			}
-			if len(queue.Queue.Spec.Capability) != 0 {
-				attr.capability = api.NewResource(queue.Queue.Spec.Capability)
-				if attr.capability.MilliCPU <= 0 {
-					attr.capability.MilliCPU = math.MaxFloat64
-				}
-				if attr.capability.Memory <= 0 {
-					attr.capability.Memory = math.MaxFloat64
-				}
-			}
-			if len(queue.Queue.Spec.Guarantee.Resource) != 0 {
-				attr.guarantee = api.NewResource(queue.Queue.Spec.Guarantee.Resource)
-			}
-			realCapability := api.ExceededPart(pp.totalResource, pp.totalGuarantee).Add(attr.guarantee)
-			if attr.capability == nil {
-				attr.capability = api.EmptyResource()
-				attr.realCapability = realCapability
-			} else {
-				realCapability.MinDimensionResource(attr.capability, api.Infinity)
-				attr.realCapability = realCapability
-			}
-			pp.queueOpts[job.Queue] = attr
-			klog.V(4).Infof("Added Queue <%s> attributes.", job.Queue)
+		attr, found := pp.queueOpts[job.Queue]
+		if !found {
+			klog.Warningf("[proportion] Skip Job <%s/%s>: queue <%s> not found in session",
+				job.Namespace, job.Name, job.Queue)
+			continue
 		}
-
-		attr := pp.queueOpts[job.Queue]
 		for status, tasks := range job.TaskStatusIndex {
 			if api.AllocatedStatus(status) {
 				for _, t := range tasks {
@@ -274,11 +278,23 @@ func (pp *proportionPlugin) OnSessionOpen(ssn *framework.Session) {
 			return int(rv.Queue.Spec.Priority) - int(lv.Queue.Spec.Priority)
 		}
 
-		if pp.queueOpts[lv.UID].share == pp.queueOpts[rv.UID].share {
+		lAttr := pp.queueOpts[lv.UID]
+		rAttr := pp.queueOpts[rv.UID]
+		if lAttr == nil || rAttr == nil {
+			if lAttr == nil && rAttr == nil {
+				return 0
+			}
+			if lAttr == nil {
+				return 1
+			}
+			return -1
+		}
+
+		if lAttr.share == rAttr.share {
 			return 0
 		}
 
-		if pp.queueOpts[lv.UID].share < pp.queueOpts[rv.UID].share {
+		if lAttr.share < rAttr.share {
 			return -1
 		}
 
@@ -321,6 +337,9 @@ func (pp *proportionPlugin) OnSessionOpen(ssn *framework.Session) {
 	ssn.AddOverusedFn(pp.Name(), func(obj interface{}) bool {
 		queue := obj.(*api.QueueInfo)
 		attr := pp.queueOpts[queue.UID]
+		if attr == nil {
+			return false
+		}
 
 		overused := attr.deserved.LessEqual(attr.allocated, api.Zero)
 		metrics.UpdateQueueOverused(attr.name, overused)
@@ -339,6 +358,9 @@ func (pp *proportionPlugin) OnSessionOpen(ssn *framework.Session) {
 		}
 
 		attr := pp.queueOpts[queue.UID]
+		if attr == nil {
+			return false
+		}
 		totalReq := api.EmptyResource()
 		for _, task := range candidates {
 			if task != nil {
@@ -406,6 +428,10 @@ func (pp *proportionPlugin) OnSessionOpen(ssn *framework.Session) {
 		queueID := job.Queue
 		attr := pp.queueOpts[queueID]
 		queue := ssn.Queues[queueID]
+		if queue == nil || attr == nil {
+			klog.Warningf("[proportion] Queue <%s> not found for Job <%s/%s>, reject", queueID, job.Namespace, job.Name)
+			return util.Reject
+		}
 		// If the queue is not open, do not enqueue
 		if queue.Queue.Status.State != scheduling.QueueStateOpen {
 			klog.V(3).Infof("Queue <%s> current state: %s, is not open state, reject job <%s/%s>.", queue.Name, queue.Queue.Status.State, job.Namespace, job.Name)

--- a/pkg/scheduler/plugins/proportion/proportion_test.go
+++ b/pkg/scheduler/plugins/proportion/proportion_test.go
@@ -685,3 +685,76 @@ func TestJobEnqueuedOnOtherPluginsReject(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+// TestEmptyQueueAndOrphanedJobSafety tests that proportion plugin gracefully handles
+// empty queues in the cluster and jobs referencing non-existent queues without panicking.
+func TestEmptyQueueAndOrphanedJobSafety(t *testing.T) {
+	trueValue := true
+
+	n1 := util.BuildNode("n1", api.BuildResourceList("10", "10Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), nil)
+
+	res1CPU := api.BuildResourceList("1", "1Gi")
+	pod1 := util.BuildPod("ns1", "pod1", "", apiv1.PodPending, res1CPU, "pg1", nil, nil)
+	pg1 := util.BuildPodGroup("pg1", "ns1", "q1", 1, nil, schedulingv1beta1.PodGroupPending)
+	pg1.Spec.MinResources = &res1CPU
+
+	// podOrphan belongs to non-existent queue "q-deleted"
+	podOrphan := util.BuildPod("ns1", "podOrphan", "", apiv1.PodPending, res1CPU, "pgOrphan", nil, nil)
+	pgOrphan := util.BuildPodGroup("pgOrphan", "ns1", "q-deleted", 1, nil, schedulingv1beta1.PodGroupPending)
+	pgOrphan.Spec.MinResources = &res1CPU
+
+	// q1 has job pg1, q2 and q3 are empty queues
+	q1 := util.BuildQueue("q1", 1, api.BuildResourceList("4", "4Gi"))
+	q2 := util.BuildQueue("q2", 2, api.BuildResourceList("4", "4Gi"))
+	q3 := util.BuildQueue("q3", 3, api.BuildResourceList("4", "4Gi"))
+
+	plugins := map[string]framework.PluginBuilder{
+		PluginName: New,
+	}
+	tiers := []conf.Tier{
+		{
+			Plugins: []conf.PluginOption{
+				{Name: PluginName, EnabledJobEnqueued: &trueValue, EnabledQueueOrder: &trueValue},
+			},
+		},
+	}
+
+	test := uthelper.TestCommonStruct{
+		Name:      "empty queues and orphaned jobs safety in proportion plugin",
+		Plugins:   plugins,
+		Pods:      []*apiv1.Pod{pod1, podOrphan},
+		Nodes:     []*apiv1.Node{n1},
+		PodGroups: []*schedulingv1beta1.PodGroup{pg1, pgOrphan},
+		Queues:    []*schedulingv1beta1.Queue{q1, q2, q3},
+		ExpectStatus: map[api.JobID]scheduling.PodGroupPhase{
+			"ns1/pg1": scheduling.PodGroupInqueue,
+		},
+	}
+	ssn := test.RegisterSession(tiers, nil)
+	defer test.Close()
+
+	// Verify QueueOrderFn does not panic when comparing empty and busy queues
+	q1Info := ssn.Queues["q1"]
+	q2Info := ssn.Queues["q2"]
+	q3Info := ssn.Queues["q3"]
+
+	_ = ssn.QueueOrderFn(q1Info, q2Info)
+	_ = ssn.QueueOrderFn(q2Info, q3Info)
+	_ = ssn.QueueOrderFn(q1Info, q3Info)
+
+	// Verify Overused on empty queue does not panic
+	if ssn.Overused(q2Info) {
+		t.Errorf("expected empty queue q2 not to be overused")
+	}
+
+	// Verify Allocatable on empty queue does not panic
+	task1 := ssn.Jobs["ns1/pg1"].Tasks[api.PodKey(pod1)]
+	if !ssn.Allocatable(q2Info, task1) {
+		t.Errorf("expected task1 to be allocatable on empty queue q2")
+	}
+
+	test.Run([]framework.Action{enqueue.New()})
+	if err := test.CheckAll(0); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
Fixes #5878

### What type of PR is this?
/kind bug

### What this PR does / why we need it:
In the `proportion` plugin and non-hierarchical mode of the `capacity` plugin, queue attributes (`queueOpts`) were previously constructed on demand while iterating over `ssn.Jobs` (`for _, job := range ssn.Jobs`) rather than eagerly initializing all active cluster queues present in `ssn.Queues`.

This caused several critical runtime issues:
1. **Nil pointer dereference panics on empty queues**: When sorting queues via `QueueOrderFn` or evaluating `OverusedFn`, `AllocatableFn`, and `PreemptiveFn`, queues without active jobs in `ssn.Jobs` had `nil` entries in `queueOpts`, causing the scheduler to panic.
2. **Nil pointer dereference panics on orphaned jobs**: If a cached job referenced a deleted queue, `queue := ssn.Queues[job.Queue]` returned `nil`, panicking on `queue.UID`.
3. **Fair-share calculation distortion**: Summing queue weights only across queues with active jobs excluded idle queues from `totalWeight` during proportional fair-share distribution.

This PR:
- Eagerly initializes `queueOpts` from `ssn.Queues` before iterating over `ssn.Jobs` in both `proportion` and `capacity` (non-hierarchical) plugins.
- Safely looks up `job.Queue` in `queueOpts` and skips orphaned jobs cleanly with a warning log.
- Adds defensive nil checks in `QueueOrderFn`, `OverusedFn`, `queueAllocatable`, `compareShareWithDeserved`, and `jobEnqueueable`.
- Adds regression unit tests covering empty queue ordering, overused/allocatable checks, and orphaned job safety in both plugins.

### Which issue(s) this PR fixes:
Fixes #5878

### Special notes for your reviewer:
None

### Does this PR introduce a user-facing change?
```release-note
Fix nil pointer dereference panics in proportion and capacity plugins when empty queues or orphaned jobs exist in the cluster.
```
