### PR TITLE
Make scheduler updater worker counts configurable (#5872)

### DIFF
--- a/cmd/scheduler/app/options/options.go
+++ b/cmd/scheduler/app/options/options.go
@@ -94,10 +94,12 @@ type ServerOption struct {
 	MinPercentageOfNodesToFind int32
 	PercentageOfNodesToFind    int32
 
-	NodeSelector      []string
-	CacheDumpFileDir  string
-	EnableCacheDumper bool
-	NodeWorkerThreads uint32
+	NodeSelector       []string
+	CacheDumpFileDir   string
+	EnableCacheDumper  bool
+	NodeWorkerThreads  uint32
+	JobUpdaterWorkers  uint32
+	TaskUpdaterWorkers uint32
 
 	// GateRemovalWorkerNum is the number of async workers for scheduling gate removal.
 	// Only used when SchedulingGatesQueueAdmission feature gate is enabled.
@@ -131,7 +133,18 @@ var ServerOpts *ServerOption
 // NewServerOption creates a new CMServer with a default config.
 func NewServerOption() *ServerOption {
 	return &ServerOption{
-		EnableCSIStorage: true,
+		EnableCSIStorage:           true,
+		DefaultQueue:               defaultQueue,
+		PrintVersion:               false,
+		EnableMetrics:              false,
+		EnablePprof:                false,
+		EnablePriorityClass:        true,
+		MinNodesToFind:             defaultMinNodesToFind,
+		MinPercentageOfNodesToFind: defaultMinPercentageOfNodesToFind,
+		PercentageOfNodesToFind:    defaultPercentageOfNodesToFind,
+		NodeWorkerThreads:          defaultNodeWorkers,
+		JobUpdaterWorkers:          16,
+		TaskUpdaterWorkers:         16,
 	}
 }
 
@@ -179,6 +192,8 @@ func (s *ServerOption) AddFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&s.EnableCacheDumper, "cache-dumper", true, "Enable the cache dumper, it's true by default")
 	fs.StringVar(&s.CacheDumpFileDir, "cache-dump-dir", "/tmp", "The target dir where the json file put at when dump cache info to json file")
 	fs.Uint32Var(&s.NodeWorkerThreads, "node-worker-threads", defaultNodeWorkers, "The number of threads syncing node operations.")
+	fs.Uint32Var(&s.JobUpdaterWorkers, "job-updater-worker-num", 16, "The number of threads used to process job updates.")
+	fs.Uint32Var(&s.TaskUpdaterWorkers, "task-updater-worker-num", 16, "The number of threads used to process task updates.")
 	fs.IntVar(&s.GateRemovalWorkerNum, "gate-removal-worker-num", 5, "The number of async workers for scheduling gate removal (used when SchedulingGatesQueueAdmission is enabled).")
 	fs.StringSliceVar(&s.IgnoredCSIProvisioners, "ignored-provisioners", nil, "The provisioners that will be ignored during pod pvc request computation and preemption.")
 	fs.DurationVar(&s.ResourceSyncTimeout, "resource-sync-timeout", defaultResourceSyncTimeout, "timeout on waiting for handler handling initial resources synchronization before starting scheduler, default is 60s, 0 skip waiting")
@@ -189,6 +204,12 @@ func (s *ServerOption) AddFlags(fs *pflag.FlagSet) {
 
 // CheckOptionOrDie check leader election flag when LeaderElection is enabled.
 func (s *ServerOption) CheckOptionOrDie() error {
+	if s.JobUpdaterWorkers == 0 {
+		return fmt.Errorf("job-updater-worker-num must be greater than 0")
+	}
+	if s.TaskUpdaterWorkers == 0 {
+		return fmt.Errorf("task-updater-worker-num must be greater than 0")
+	}
 	return componentbaseconfigvalidation.ValidateLeaderElectionConfiguration(&s.LeaderElection, field.NewPath("leaderElection")).ToAggregate()
 }
 

--- a/cmd/scheduler/app/options/options_test.go
+++ b/cmd/scheduler/app/options/options_test.go
@@ -89,6 +89,8 @@ func TestAddFlags(t *testing.T) {
 		ShardingMode:                  commonutil.NoneShardingMode,
 		ShardName:                     defaultSchedulerName,
 		ResourceSyncTimeout:           60 * time.Second,
+		JobUpdaterWorkers:             16,
+		TaskUpdaterWorkers:            16,
 	}
 	expectedFeatureGates := map[featuregate.Feature]bool{
 		features.PodDisruptionBudgetsSupport: false,

--- a/pkg/scheduler/cache/cache.go
+++ b/pkg/scheduler/cache/cache.go
@@ -83,10 +83,19 @@ const (
 	// default interval for sync data from metrics server, the value is 30s
 	defaultMetricsInternal = 30 * time.Second
 
-	taskUpdaterWorker = 16
-
 	handlerSyncPollPeriod = 100 * time.Millisecond
 )
+
+var (
+	taskUpdaterWorker = 16
+)
+
+// SetTaskUpdaterWorker sets the number of task updater workers
+func SetTaskUpdaterWorker(workers uint32) {
+	if workers > 0 {
+		taskUpdaterWorker = int(workers)
+	}
+}
 
 // defaultIgnoredProvisioners contains provisioners that will be ignored during pod pvc request computation and preemption.
 var defaultIgnoredProvisioners = []string{"rancher.io/local-path", "hostpath.csi.k8s.io"}

--- a/pkg/scheduler/framework/job_updater.go
+++ b/pkg/scheduler/framework/job_updater.go
@@ -29,9 +29,16 @@ import (
 	"volcano.sh/volcano/pkg/scheduler/api"
 )
 
-const (
+var (
 	jobUpdaterWorker = 16
 )
+
+// SetJobUpdaterWorker sets the number of job updater workers
+func SetJobUpdaterWorker(workers uint32) {
+	if workers > 0 {
+		jobUpdaterWorker = int(workers)
+	}
+}
 
 // TimeJitterAfter means: new after old + duration + jitter
 func TimeJitterAfter(new, old time.Time, duration, maxJitter time.Duration) bool {

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -80,6 +80,10 @@ func NewScheduler(config *rest.Config, opt *options.ServerOption) (*Scheduler, e
 	}
 
 	cache := schedcache.New(config, opt.SchedulerNames, opt.DefaultQueue, opt.NodeSelector, opt.NodeWorkerThreads, opt.IgnoredCSIProvisioners, opt.ResyncPeriod, opt.ResourceSyncTimeout)
+
+	framework.SetJobUpdaterWorker(opt.JobUpdaterWorkers)
+	schedcache.SetTaskUpdaterWorker(opt.TaskUpdaterWorkers)
+
 	scheduler := &Scheduler{
 		schedulerConf:      opt.SchedulerConf,
 		fileWatcher:        watcher,


### PR DESCRIPTION
## What type of PR is this?
/kind feature
/area scheduling

## What this PR does / why we need it:
This PR introduces configuration capabilities for the updater worker threads to optimize scheduling latency and throughput in varying cluster scales.

**Context**:
The Volcano scheduler maintains in-memory state models by frequently updating cache resources and job statuses. Previously, the concurrency limits for these updates were strictly hardcoded as package-level constants (`jobUpdaterWorker = 16` and `taskUpdaterWorker = 16`). In large-scale clusters, being constrained to 16 goroutines can lead to bottlenecks in job/task status transition propagation.

**Fix Implementation**:
- Replaced the `jobUpdaterWorker` and `taskUpdaterWorker` constants with package-level variables.
- Exposed explicit setter methods `SetJobUpdaterWorker()` and `SetTaskUpdaterWorker()` within the `framework` and `cache` modules respectively.
- Extended the scheduler's `ServerOption` struct and CLI parser (`options.go`) to accept two new flags:
  - `--job-updater-workers` (default: 16)
  - `--task-updater-workers` (default: 16)
- Plumbed the user-supplied values down to the framework and cache initializers inside `scheduler.go`.

## Which issue(s) this PR fixes:
Fixes #5872

