### PR TITLE
Fix command injection via ifName in network-qos tc AddFilter (#5874)

### DIFF
--- a/pkg/agent/utils/exec/exec.go
+++ b/pkg/agent/utils/exec/exec.go
@@ -26,8 +26,10 @@ import (
 
 // ExecInterface is an interface of os/exec API.
 type ExecInterface interface {
-	// CommandContext runs command
+	// CommandContext runs cmd via "sh -c". Do not pass untrusted input.
 	CommandContext(ctx context.Context, cmd string) (string, error)
+	// CommandContextWithArgs runs cmd with explicit arguments (no shell).
+	CommandContextWithArgs(ctx context.Context, cmd string, args ...string) (string, error)
 }
 
 var _ ExecInterface = &Executor{}
@@ -51,12 +53,14 @@ func (e *Executor) CommandContext(ctx context.Context, cmd string) (string, erro
 	if ctx == nil {
 		return "", fmt.Errorf("command failed, nil Context")
 	}
-	var outBytes []byte
-	var err error
-	outBytes, err = exec.CommandContext(ctx, "sh", "-c", cmd).CombinedOutput()
-	outputStr := ""
-	if len(outBytes) != 0 {
-		outputStr = string(outBytes)
+	outBytes, err := exec.CommandContext(ctx, "sh", "-c", cmd).CombinedOutput()
+	return string(outBytes), err
+}
+
+func (e *Executor) CommandContextWithArgs(ctx context.Context, cmd string, args ...string) (string, error) {
+	if ctx == nil {
+		return "", fmt.Errorf("command failed, nil Context")
 	}
-	return outputStr, err
+	outBytes, err := exec.CommandContext(ctx, cmd, args...).CombinedOutput()
+	return string(outBytes), err
 }

--- a/pkg/agent/utils/exec/mocks/mock_exec.go
+++ b/pkg/agent/utils/exec/mocks/mock_exec.go
@@ -64,3 +64,23 @@ func (mr *MockExecInterfaceMockRecorder) CommandContext(ctx, cmd interface{}) *g
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CommandContext", reflect.TypeOf((*MockExecInterface)(nil).CommandContext), ctx, cmd)
 }
+
+// CommandContextWithArgs mocks base method.
+func (m *MockExecInterface) CommandContextWithArgs(ctx context.Context, cmd string, args ...string) (string, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{ctx, cmd}
+	for _, a := range args {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "CommandContextWithArgs", varargs...)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CommandContextWithArgs indicates an expected call of CommandContextWithArgs.
+func (mr *MockExecInterfaceMockRecorder) CommandContextWithArgs(ctx, cmd interface{}, args ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{ctx, cmd}, args...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CommandContextWithArgs", reflect.TypeOf((*MockExecInterface)(nil).CommandContextWithArgs), varargs...)
+}

--- a/pkg/networkqos/tc/tc_linux.go
+++ b/pkg/networkqos/tc/tc_linux.go
@@ -113,12 +113,12 @@ func (t *TCCmd) AddFilter(netns, ifName string) error {
 		}
 		klog.InfoS("Successfully added qdisc", "type", QdiscTypeClsact, "netns", netns, "ifName", ifName)
 
-		filterCmd := fmt.Sprintf("tc filter add dev %s egress bpf direct-action obj %s sec tc", ifName, utils.TCPROGPath)
 		ctx, cancel := context.WithTimeout(context.Background(), CmdTimeout)
 		defer cancel()
-		output, err := exec.GetExecutor().CommandContext(ctx, filterCmd)
+		args := []string{"filter", "add", "dev", ifName, "egress", "bpf", "direct-action", "obj", utils.TCPROGPath, "sec", "tc"}
+		output, err := exec.GetExecutor().CommandContextWithArgs(ctx, "tc", args...)
 		if err != nil {
-			return fmt.Errorf("add dev on ns:ifName(%s:%s) failed : %v, %s, %s", netns, ifName, err, output, filterCmd)
+			return fmt.Errorf("add dev on ns:ifName(%s:%s) failed : %v, %s, args: %v", netns, ifName, err, output, args)
 		}
 		klog.InfoS("Successfully added filter", "ebpf-obj", utils.TCPROGPath, "netns", netns, "ifName", ifName)
 		return nil


### PR DESCRIPTION
## What type of PR is this?
/kind bug
/area security

## What this PR does / why we need it:
This PR mitigates a command injection vulnerability identified in the `tc` component of `network-qos`. 

**Context**: 
Previously, the `AddFilter` function in `tc_linux.go` constructed the `tc filter` command by directly interpolating the `ifName` argument via `fmt.Sprintf`. The resulting formatted string was then passed to `GetExecutor().CommandContext()`, which executes the command using `sh -c`. This execution flow permitted command injection if an attacker could manipulate the `ifName` parameter (e.g., passing an `ifName` containing shell metacharacters like `;`).

**Fix Implementation**:
- Extended the `ExecInterface` in `pkg/agent/utils/exec/exec.go` to include a new method: `CommandContextWithArgs(ctx context.Context, cmd string, args ...string) (string, error)`.
- Implemented `CommandContextWithArgs` to pass the executable and arguments natively to `exec.CommandContext` without the intermediate `sh -c` invocation.
- Refactored `tc_linux.go:AddFilter` to utilize `CommandContextWithArgs`, strictly separating the `tc` executable from its arguments, thereby rendering injection via `ifName` impossible.
- Regenerated and updated the `mock_exec.go` to support testing of the new interface method.

## Which issue(s) this PR fixes:
Fixes #5874
