### PR TITLE
Fix nil queueOpts panic for empty queues and orphaned jobs (#5878)

### DIFF
--- a/pkg/scheduler/plugins/capacity/capacity.go
+++ b/pkg/scheduler/plugins/capacity/capacity.go
@@ -1062,49 +1062,52 @@ func (cp *capacityPlugin) buildQueueAttrs(ssn *framework.Session) {
 		cp.totalGuarantee.Add(guarantee)
 	}
 	klog.V(4).Infof("The total guarantee resource is <%v>", cp.totalGuarantee)
-	// Build attributes for Queues.
+	// Build attributes for all Queues.
+	for _, queue := range ssn.Queues {
+		attr := &queueAttr{
+			queueID: queue.UID,
+			name:    queue.Name,
+
+			deserved:          api.NewResource(queue.Queue.Spec.Deserved),
+			allocated:         api.EmptyResource(),
+			request:           api.EmptyResource(),
+			elastic:           api.EmptyResource(),
+			inqueue:           api.EmptyResource(),
+			guarantee:         api.EmptyResource(),
+			resourceClaimRefs: make(map[string]int),
+		}
+		if len(queue.Queue.Spec.Capability) != 0 {
+			attr.capability = api.NewResource(queue.Queue.Spec.Capability)
+			if attr.capability.MilliCPU <= 0 {
+				attr.capability.MilliCPU = math.MaxFloat64
+			}
+			if attr.capability.Memory <= 0 {
+				attr.capability.Memory = math.MaxFloat64
+			}
+		}
+		attr.dra = newDRAQuotaAttr(queue.Queue.Spec.Capability, queue.Queue.Spec.Deserved, queue.Queue.Spec.Guarantee.Resource)
+		if len(queue.Queue.Spec.Guarantee.Resource) != 0 {
+			attr.guarantee = api.NewResource(queue.Queue.Spec.Guarantee.Resource)
+		}
+		realCapability := api.ExceededPart(cp.totalResource, cp.totalGuarantee).Add(attr.guarantee)
+		if attr.capability == nil {
+			attr.capability = api.EmptyResource()
+			attr.realCapability = realCapability
+		} else {
+			realCapability.MinDimensionResource(attr.capability, api.Infinity)
+			attr.realCapability = realCapability
+		}
+		cp.queueOpts[queue.UID] = attr
+		klog.V(4).Infof("Added Queue <%s> attributes.", queue.Name)
+	}
+
 	for _, job := range ssn.Jobs {
 		klog.V(4).Infof("Considering Job <%s/%s>.", job.Namespace, job.Name)
-		if _, found := cp.queueOpts[job.Queue]; !found {
-			queue := ssn.Queues[job.Queue]
-			attr := &queueAttr{
-				queueID: queue.UID,
-				name:    queue.Name,
-
-				deserved:          api.NewResource(queue.Queue.Spec.Deserved),
-				allocated:         api.EmptyResource(),
-				request:           api.EmptyResource(),
-				elastic:           api.EmptyResource(),
-				inqueue:           api.EmptyResource(),
-				guarantee:         api.EmptyResource(),
-				resourceClaimRefs: make(map[string]int),
-			}
-			if len(queue.Queue.Spec.Capability) != 0 {
-				attr.capability = api.NewResource(queue.Queue.Spec.Capability)
-				if attr.capability.MilliCPU <= 0 {
-					attr.capability.MilliCPU = math.MaxFloat64
-				}
-				if attr.capability.Memory <= 0 {
-					attr.capability.Memory = math.MaxFloat64
-				}
-			}
-			attr.dra = newDRAQuotaAttr(queue.Queue.Spec.Capability, queue.Queue.Spec.Deserved, queue.Queue.Spec.Guarantee.Resource)
-			if len(queue.Queue.Spec.Guarantee.Resource) != 0 {
-				attr.guarantee = api.NewResource(queue.Queue.Spec.Guarantee.Resource)
-			}
-			realCapability := api.ExceededPart(cp.totalResource, cp.totalGuarantee).Add(attr.guarantee)
-			if attr.capability == nil {
-				attr.capability = api.EmptyResource()
-				attr.realCapability = realCapability
-			} else {
-				realCapability.MinDimensionResource(attr.capability, api.Infinity)
-				attr.realCapability = realCapability
-			}
-			cp.queueOpts[job.Queue] = attr
-			klog.V(4).Infof("Added Queue <%s> attributes.", job.Queue)
-		}
-
 		attr := cp.queueOpts[job.Queue]
+		if attr == nil {
+			klog.Warningf("[capacity] Skip orphaned job <%s/%s>: queue <%s> not found in session", job.Namespace, job.Name, job.Queue)
+			continue
+		}
 		for status, tasks := range job.TaskStatusIndex {
 			if api.AllocatedStatus(status) {
 				for _, t := range tasks {

--- a/pkg/scheduler/plugins/capacity/capacity_test.go
+++ b/pkg/scheduler/plugins/capacity/capacity_test.go
@@ -2124,12 +2124,10 @@ func TestCapacityEmptyQueueAndOrphanedJob(t *testing.T) {
 		Binder:        &util.FakeBinder{Channel: make(chan string)},
 		Evictor:       &util.FakeEvictor{Channel: make(chan string)},
 		StatusUpdater: &util.FakeStatusUpdater{},
-		VolumeBinder:  &util.FakeVolumeBinder{},
-		Recorder:      record.NewFakeRecorder(100),
 	}
 
-	schedulerCache.AddQueue(queue1)
-	schedulerCache.AddPodGroup(pg1)
+	schedulerCache.AddQueueV1beta1(queue1)
+	schedulerCache.AddPodGroupV1beta1(pg1)
 	schedulerCache.AddPod(w1)
 
 	trueValue := true

--- a/pkg/scheduler/plugins/capacity/capacity_test.go
+++ b/pkg/scheduler/plugins/capacity/capacity_test.go
@@ -2108,3 +2108,43 @@ func TestCheckDRAAllocatable_overflowRejected(t *testing.T) {
 		t.Fatalf("checkDRAAllocatable rejected a valid request (4 <= 8); want admitted")
 	}
 }
+
+func TestCapacityEmptyQueueAndOrphanedJob(t *testing.T) {
+	uthelper.RegisterPlugins(map[string]framework.PluginBuilder{PluginName: New, gang.PluginName: gang.New})
+	defer framework.CleanupPluginBuilders()
+
+	queue1 := util.BuildQueueWithResourcesQuantity("q1", nil, api.BuildResourceList("2", "2Gi"))
+	pg1 := util.BuildPodGroup("pg1", "ns1", "missing-queue", 1, nil, schedulingv1beta1.PodGroupInqueue)
+	w1 := util.BuildPod("ns1", "worker-1", "", corev1.PodPending, api.BuildResourceList("1", "1k"), "pg1", nil, nil)
+
+	schedulerCache := &cache.SchedulerCache{
+		Nodes:         make(map[string]*api.NodeInfo),
+		Jobs:          make(map[api.JobID]*api.JobInfo),
+		Queues:        make(map[api.QueueID]*api.QueueInfo),
+		Binder:        &util.FakeBinder{Channel: make(chan string)},
+		Evictor:       &util.FakeEvictor{Channel: make(chan string)},
+		StatusUpdater: &util.FakeStatusUpdater{},
+		VolumeBinder:  &util.FakeVolumeBinder{},
+		Recorder:      record.NewFakeRecorder(100),
+	}
+
+	schedulerCache.AddQueue(queue1)
+	schedulerCache.AddPodGroup(pg1)
+	schedulerCache.AddPod(w1)
+
+	trueValue := true
+	ssn := framework.OpenSession(schedulerCache, []conf.Tier{
+		{
+			Plugins: []conf.PluginOption{
+				{
+					Name:             PluginName,
+					EnabledPredicate: &trueValue,
+				},
+			},
+		},
+	}, nil)
+	defer framework.CloseSession(ssn)
+
+	allocator := allocate.New()
+	allocator.Execute(ssn)
+}

--- a/pkg/scheduler/plugins/proportion/proportion.go
+++ b/pkg/scheduler/plugins/proportion/proportion.go
@@ -100,48 +100,51 @@ func (pp *proportionPlugin) OnSessionOpen(ssn *framework.Session) {
 		pp.totalGuarantee.Add(guarantee)
 	}
 	klog.V(4).Infof("The total guarantee resource is <%v>", pp.totalGuarantee)
-	// Build attributes for Queues.
+	// Build attributes for all Queues.
+	for _, queue := range ssn.Queues {
+		attr := &queueAttr{
+			queueID: queue.UID,
+			name:    queue.Name,
+			weight:  queue.Weight,
+
+			deserved:  api.EmptyResource(),
+			allocated: api.EmptyResource(),
+			request:   api.EmptyResource(),
+			elastic:   api.EmptyResource(),
+			inqueue:   api.EmptyResource(),
+			guarantee: api.EmptyResource(),
+		}
+		if len(queue.Queue.Spec.Capability) != 0 {
+			attr.capability = api.NewResource(queue.Queue.Spec.Capability)
+			if attr.capability.MilliCPU <= 0 {
+				attr.capability.MilliCPU = math.MaxFloat64
+			}
+			if attr.capability.Memory <= 0 {
+				attr.capability.Memory = math.MaxFloat64
+			}
+		}
+		if len(queue.Queue.Spec.Guarantee.Resource) != 0 {
+			attr.guarantee = api.NewResource(queue.Queue.Spec.Guarantee.Resource)
+		}
+		realCapability := api.ExceededPart(pp.totalResource, pp.totalGuarantee).Add(attr.guarantee)
+		if attr.capability == nil {
+			attr.capability = api.EmptyResource()
+			attr.realCapability = realCapability
+		} else {
+			realCapability.MinDimensionResource(attr.capability, api.Infinity)
+			attr.realCapability = realCapability
+		}
+		pp.queueOpts[queue.UID] = attr
+		klog.V(4).Infof("Added Queue <%s> attributes.", queue.Name)
+	}
+
 	for _, job := range ssn.Jobs {
 		klog.V(4).Infof("Considering Job <%s/%s>.", job.Namespace, job.Name)
-		if _, found := pp.queueOpts[job.Queue]; !found {
-			queue := ssn.Queues[job.Queue]
-			attr := &queueAttr{
-				queueID: queue.UID,
-				name:    queue.Name,
-				weight:  queue.Weight,
-
-				deserved:  api.EmptyResource(),
-				allocated: api.EmptyResource(),
-				request:   api.EmptyResource(),
-				elastic:   api.EmptyResource(),
-				inqueue:   api.EmptyResource(),
-				guarantee: api.EmptyResource(),
-			}
-			if len(queue.Queue.Spec.Capability) != 0 {
-				attr.capability = api.NewResource(queue.Queue.Spec.Capability)
-				if attr.capability.MilliCPU <= 0 {
-					attr.capability.MilliCPU = math.MaxFloat64
-				}
-				if attr.capability.Memory <= 0 {
-					attr.capability.Memory = math.MaxFloat64
-				}
-			}
-			if len(queue.Queue.Spec.Guarantee.Resource) != 0 {
-				attr.guarantee = api.NewResource(queue.Queue.Spec.Guarantee.Resource)
-			}
-			realCapability := api.ExceededPart(pp.totalResource, pp.totalGuarantee).Add(attr.guarantee)
-			if attr.capability == nil {
-				attr.capability = api.EmptyResource()
-				attr.realCapability = realCapability
-			} else {
-				realCapability.MinDimensionResource(attr.capability, api.Infinity)
-				attr.realCapability = realCapability
-			}
-			pp.queueOpts[job.Queue] = attr
-			klog.V(4).Infof("Added Queue <%s> attributes.", job.Queue)
-		}
-
 		attr := pp.queueOpts[job.Queue]
+		if attr == nil {
+			klog.Warningf("[proportion] Skip orphaned job <%s/%s>: queue <%s> not found in session", job.Namespace, job.Name, job.Queue)
+			continue
+		}
 		for status, tasks := range job.TaskStatusIndex {
 			if api.AllocatedStatus(status) {
 				for _, t := range tasks {

--- a/pkg/scheduler/plugins/proportion/proportion_test.go
+++ b/pkg/scheduler/plugins/proportion/proportion_test.go
@@ -685,3 +685,36 @@ func TestJobEnqueuedOnOtherPluginsReject(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestProportionEmptyQueueAndOrphanedJob(t *testing.T) {
+	uthelper.RegisterPlugins(map[string]framework.PluginBuilder{PluginName: New, gang.PluginName: gang.New, priority.PluginName: priority.New})
+	defer framework.CleanupPluginBuilders()
+
+	queue1 := util.BuildQueue("q1", 0, nil)
+	pg1 := util.BuildPodGroupWithPrio("pg1", "ns1", "missing-queue", 1, nil, "", "")
+	w1 := util.BuildPod("ns1", "worker-1", "", apiv1.PodPending, api.BuildResourceList("1", "1k"), "pg1", nil, nil)
+
+	binder := util.NewFakeBinder(0)
+	recorder := record.NewFakeRecorder(100)
+	schedulerCache := cache.NewCustomMockSchedulerCache("mock-test", binder, nil, &util.FakeStatusUpdater{}, nil, recorder)
+
+	schedulerCache.AddQueueV1beta1(queue1)
+	schedulerCache.AddPodGroupV1beta1(pg1)
+	schedulerCache.AddPod(w1)
+
+	trueValue := true
+	ssn := framework.OpenSession(schedulerCache, []conf.Tier{
+		{
+			Plugins: []conf.PluginOption{
+				{
+					Name:             PluginName,
+					EnabledPredicate: &trueValue,
+				},
+			},
+		},
+	}, nil)
+	defer framework.CloseSession(ssn)
+
+	allocator := allocate.New()
+	allocator.Execute(ssn)
+}


### PR DESCRIPTION
### What this PR does / why we need it
This PR resolves the panics encountered in the `proportion` and `capacity` plugins when dealing with empty queues and orphaned jobs. 

Historically, `queueOpts` mapping was initialized via an iteration loop over `ssn.Jobs`. This led to two failure vectors:
1. **Empty Queues**: Queues with no actively running or queued jobs were skipped during the population phase. When metric updates or plugin callbacks fired for these queues, attempting to access `queueOpts[queue.UID]` caused a nil pointer dereference.
2. **Orphaned Jobs**: Jobs referencing a nonexistent or deleted queue assumed `ssn.Queues[job.Queue]` was a valid pointer, resulting in a panic when `queue.UID` was resolved.

### Proposed Changes
- **Decoupled Queue Initialization**: Refactored `proportion.go` and `capacity.go` (non-hierarchical flow) to iterate over `ssn.Queues` explicitly to construct and populate `queueOpts` attributes.
- **Orphaned Job Safety Check**: Implemented safety boundaries within the subsequent `ssn.Jobs` processing loop. Missing queue attributes now trigger a non-fatal `klog.Warningf` skip instead of a runtime crash.

Fixes #5878