### PR TITLE
[release-1.14] fix(reclaim): recheck device feasibility after tentative evictions

### DIFF
--- a/pkg/scheduler/actions/reclaim/reclaim.go
+++ b/pkg/scheduler/actions/reclaim/reclaim.go
@@ -215,12 +215,14 @@ func (ra *Action) reclaimForTask(ssn *framework.Session, stmt *framework.Stateme
 		victimsQueue := ssn.BuildVictimsPriorityQueue(victims, task)
 		resreq := task.InitResreq.Clone()
 		reclaimed := api.EmptyResource()
-
-		// The reclaimed resources should be added to the remaining available resources of the nodes to avoid over-reclaiming.
 		availableResources := n.FutureIdle()
+		reclaimerFits := reclaimerFitsOnNode(ssn, task, n, resreq, availableResources)
 
 		evictionOccurred := false
 		for !victimsQueue.Empty() {
+			if reclaimerFits {
+				break
+			}
 			reclaimee := victimsQueue.Pop().(*api.TaskInfo)
 			klog.V(3).Infof("Try to reclaim Task <%s/%s> for Tasks <%s/%s>",
 				reclaimee.Namespace, reclaimee.Name, task.Namespace, task.Name)
@@ -232,14 +234,12 @@ func (ra *Action) reclaimForTask(ssn *framework.Session, stmt *framework.Stateme
 			reclaimed.Add(reclaimee.Resreq)
 			availableResources.Add(reclaimee.Resreq)
 			evictionOccurred = true
-			if resreq.LessEqual(availableResources, api.Zero) {
-				break
-			}
+			reclaimerFits = reclaimerFitsOnNode(ssn, task, n, resreq, availableResources)
 		}
 
 		klog.V(3).Infof("Reclaimed <%v> for task <%s/%s> requested <%v>, and Node <%s> availableResources <%v>.", reclaimed, task.Namespace, task.Name, task.InitResreq, n.Name, availableResources)
 
-		if task.InitResreq.LessEqual(availableResources, api.Zero) {
+		if reclaimerFits {
 			if err := stmt.Pipeline(task, n.Name, evictionOccurred); err != nil {
 				klog.Errorf("Failed to pipeline Task <%s/%s> on Node <%s>",
 					task.Namespace, task.Name, n.Name)
@@ -251,6 +251,12 @@ func (ra *Action) reclaimForTask(ssn *framework.Session, stmt *framework.Stateme
 			break
 		}
 	}
+}
+
+// reclaimerFitsOnNode verifies available resources and plugin predicates after tentative evictions.
+func reclaimerFitsOnNode(ssn *framework.Session, task *api.TaskInfo, node *api.NodeInfo, resreq, availableResources *api.Resource) bool {
+	return resreq.LessEqual(availableResources, api.Zero) &&
+		ssn.PredicateFn(task, node) == nil
 }
 
 func (ra *Action) UnInitialize() {

--- a/pkg/scheduler/actions/reclaim/reclaim_test.go
+++ b/pkg/scheduler/actions/reclaim/reclaim_test.go
@@ -44,6 +44,40 @@ func init() {
 	options.Default()
 }
 
+const deviceFitAfterReclaimPluginName = "device-fit-after-reclaim"
+
+type deviceFitAfterReclaimPlugin struct{}
+
+func (p *deviceFitAfterReclaimPlugin) Name() string {
+	return deviceFitAfterReclaimPluginName
+}
+
+func (p *deviceFitAfterReclaimPlugin) OnSessionOpen(ssn *framework.Session) {
+	ssn.AddPredicateFn(p.Name(), func(task *api.TaskInfo, node *api.NodeInfo) error {
+		if task.Name != "reclaimer" {
+			return nil
+		}
+
+		remainingDeviceHolders := 0
+		for _, nodeTask := range node.Tasks {
+			if (nodeTask.Name == "device-holder-1" || nodeTask.Name == "device-holder-2" || nodeTask.Name == "device-holder-3") && nodeTask.Status != api.Releasing {
+				remainingDeviceHolders++
+			}
+		}
+
+		if remainingDeviceHolders > 1 {
+			return api.NewFitErrWithStatus(task, node, &api.Status{
+				Code:   api.Unschedulable,
+				Reason: "hidden device capacity is occupied",
+			})
+		}
+
+		return nil
+	})
+}
+
+func (p *deviceFitAfterReclaimPlugin) OnSessionClose(ssn *framework.Session) {}
+
 func TestReclaim(t *testing.T) {
 	tests := []uthelper.TestCommonStruct{
 		{
@@ -337,5 +371,61 @@ func TestReclaim(t *testing.T) {
 				t.Fatal(err)
 			}
 		})
+	}
+}
+
+func TestReclaimRechecksPredicateAfterEviction(t *testing.T) {
+	plugins := map[string]framework.PluginBuilder{
+		conformance.PluginName: conformance.New,
+		gang.PluginName:        gang.New,
+		proportion.PluginName:  proportion.New,
+		deviceFitAfterReclaimPluginName: func(framework.Arguments) framework.Plugin {
+			return &deviceFitAfterReclaimPlugin{}
+		},
+	}
+	trueValue := true
+	test := uthelper.TestCommonStruct{
+		Name:    "reclaim continues until hidden device capacity is available",
+		Plugins: plugins,
+		PodGroups: []*schedulingv1beta1.PodGroup{
+			util.BuildPodGroupWithPrio("pg-victim", "c1", "q1", 0, nil, schedulingv1beta1.PodGroupRunning, "low-priority"),
+			util.BuildPodGroupWithPrio("pg-reclaimer", "c1", "q2", 1, nil, schedulingv1beta1.PodGroupInqueue, "high-priority"),
+			util.BuildPodGroupWithPrio("pg-demand", "c1", "q3", 0, nil, schedulingv1beta1.PodGroupInqueue, "low-priority"),
+		},
+		Pods: []*v1.Pod{
+			util.BuildPod("c1", "device-holder-1", "n1", v1.PodRunning, api.BuildResourceList("1", "1G"), "pg-victim", map[string]string{schedulingv1beta1.PodPreemptable: "true"}, make(map[string]string)),
+			util.BuildPod("c1", "device-holder-2", "n1", v1.PodRunning, api.BuildResourceList("1", "1G"), "pg-victim", map[string]string{schedulingv1beta1.PodPreemptable: "true"}, make(map[string]string)),
+			util.BuildPod("c1", "device-holder-3", "n1", v1.PodRunning, api.BuildResourceList("1", "1G"), "pg-victim", map[string]string{schedulingv1beta1.PodPreemptable: "false"}, make(map[string]string)),
+			util.BuildPod("c1", "reclaimer", "", v1.PodPending, api.BuildResourceList("1", "1G"), "pg-reclaimer", make(map[string]string), make(map[string]string)),
+			util.BuildPod("c1", "other-queue-demand", "", v1.PodPending, api.BuildResourceList("1", "1G"), "pg-demand", make(map[string]string), make(map[string]string)),
+		},
+		Nodes: []*v1.Node{
+			util.BuildNode("n1", api.BuildResourceList("3", "3G", []api.ScalarResource{{Name: "pods", Value: "10"}}...), make(map[string]string)),
+		},
+		Queues: []*schedulingv1beta1.Queue{
+			util.BuildQueue("q1", 1, nil),
+			util.BuildQueue("q2", 9, nil),
+			util.BuildQueue("q3", 1, nil),
+		},
+		ExpectEvicted:  []string{"c1/device-holder-1", "c1/device-holder-2"},
+		ExpectEvictNum: 2,
+		ExpectPipeLined: map[string][]string{
+			"c1/pg-reclaimer": {"n1"},
+		},
+	}
+	tiers := []conf.Tier{{
+		Plugins: []conf.PluginOption{
+			{Name: conformance.PluginName, EnabledReclaimable: &trueValue},
+			{Name: gang.PluginName, EnabledReclaimable: &trueValue, EnabledJobStarving: &trueValue},
+			{Name: proportion.PluginName, EnabledReclaimable: &trueValue, EnabledQueueOrder: &trueValue, EnablePreemptive: &trueValue},
+			{Name: deviceFitAfterReclaimPluginName, EnabledPredicate: &trueValue},
+		},
+	}}
+
+	test.RegisterSession(tiers, nil)
+	defer test.Close()
+	test.Run([]framework.Action{New()})
+	if err := test.CheckAll(0); err != nil {
+		t.Fatal(err)
 	}
 }


### PR DESCRIPTION
#### What this PR does / why we need it:

Backports the reclaim device-feasibility fix from #5855 to `release-1.14`.

The conflict was resolved using the release-1.14 statement lifecycle. Its direct `stmt.Evict` and `stmt.Pipeline` handling remains unchanged.

#### Which issue(s) this PR fixes:

Backport of #5855  
Related to #5852

#### Special notes for your reviewer:

Validated with:

```bash
go test ./pkg/scheduler/actions/reclaim -count=1