### PR TITLE
scheduler: fix nil pointer panic in backfill when node scoring fails

### DIFF
--- a/pkg/scheduler/actions/backfill/backfill.go
+++ b/pkg/scheduler/actions/backfill/backfill.go
@@ -98,6 +98,10 @@ func (backfill *Action) Execute(ssn *framework.Session) {
 					break
 				}
 			}
+			if node == nil {
+				klog.V(3).Infof("No best node for task <%v/%v>, skip it in backfill", task.Namespace, task.Name)
+				continue
+			}
 		}
 
 		klog.V(3).Infof("Binding Task <%v/%v> to node <%v>", task.Namespace, task.Name, node.Name)

--- a/pkg/scheduler/actions/backfill/backfill_test.go
+++ b/pkg/scheduler/actions/backfill/backfill_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package backfill
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -33,6 +34,7 @@ import (
 	"volcano.sh/volcano/pkg/scheduler/framework"
 	"volcano.sh/volcano/pkg/scheduler/plugins/drf"
 	"volcano.sh/volcano/pkg/scheduler/plugins/priority"
+	"volcano.sh/volcano/pkg/scheduler/uthelper"
 	"volcano.sh/volcano/pkg/scheduler/util"
 )
 
@@ -174,5 +176,64 @@ func TestPickUpPendingTasks(t *testing.T) {
 		if !assert.Equal(t, tc.expectedResult, actualResult) {
 			t.Errorf("unexpected test; name: %s, expected result: %v, actual result: %v", tc.name, tc.expectedResult, actualResult)
 		}
+	}
+}
+
+type batchNodeOrderErrPlugin struct{}
+
+func (p *batchNodeOrderErrPlugin) Name() string { return "batch-node-order-err" }
+
+func (p *batchNodeOrderErrPlugin) OnSessionOpen(ssn *framework.Session) {
+	ssn.AddBatchNodeOrderFn(p.Name(), func(task *api.TaskInfo, nodes []*api.NodeInfo) (map[string]float64, error) {
+		return nil, errors.New("batch node order failed")
+	})
+}
+
+func (p *batchNodeOrderErrPlugin) OnSessionClose(ssn *framework.Session) {}
+
+// TestBackfillSkipsTaskWhenNoBestNode verifies that backfill skips a task
+// instead of panicking when node scoring fails and no best node is selected.
+func TestBackfillSkipsTaskWhenNoBestNode(t *testing.T) {
+	test := uthelper.TestCommonStruct{
+		Name: "scoring failure leaves task unscheduled without panic",
+		Plugins: map[string]framework.PluginBuilder{
+			"batch-node-order-err": func(arguments framework.Arguments) framework.Plugin {
+				return &batchNodeOrderErrPlugin{}
+			},
+		},
+		PodGroups: []*schedulingv1beta1.PodGroup{
+			util.BuildPodGroup("pg1", "c1", "c1", 0, nil, schedulingv1beta1.PodGroupInqueue),
+		},
+		Pods: []*v1.Pod{
+			util.BuildPod("c1", "p1", "", v1.PodPending, api.BuildResourceList("0", "0"), "pg1", make(map[string]string), make(map[string]string)),
+		},
+		Nodes: []*v1.Node{
+			util.BuildNode("n1", api.BuildResourceList("2", "4Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), make(map[string]string)),
+			util.BuildNode("n2", api.BuildResourceList("2", "4Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), make(map[string]string)),
+		},
+		Queues: []*schedulingv1beta1.Queue{
+			util.BuildQueue("c1", 1, nil),
+		},
+		ExpectBindsNum: 0,
+		ExpectBindMap:  map[string]string{},
+	}
+
+	trueValue := true
+	tiers := []conf.Tier{
+		{
+			Plugins: []conf.PluginOption{
+				{
+					Name:             "batch-node-order-err",
+					EnabledNodeOrder: &trueValue,
+				},
+			},
+		},
+	}
+
+	test.RegisterSession(tiers, nil)
+	defer test.Close()
+	test.Run([]framework.Action{New()})
+	if err := test.CheckBind(0); err != nil {
+		t.Fatal(err)
 	}
 }


### PR DESCRIPTION
/kind bug

When a backfill task passes predicates on more than one node, the node selection loop overwrites `node` with the result of `ssn.BestNodeFn`, falling back to `util.SelectBestNodeAndScore`. Both return nil when node scoring fails, for example when a batch node order plugin returns an error and `util.PrioritizeNodes` returns an empty score map. The next line then dereferences `node.Name` and the scheduler panics (code path on master: [backfill.go#L88-L103](https://github.com/volcano-sh/volcano/blob/7b1f5c384149050d57d6bf07643bc39745f7b690/pkg/scheduler/actions/backfill/backfill.go#L88-L103)):

```
panic: runtime error: invalid memory address or nil pointer dereference
volcano.sh/volcano/pkg/scheduler/actions/backfill.(*Action).Execute
    pkg/scheduler/actions/backfill/backfill.go:103
```

Reproduced with the unit test in this PR on unpatched master (7b1f5c3). The fix skips the task when no best node is selected, the same guard the allocate action already uses.

AI tooling assisted in preparing this fix. All changes were reviewed and tests were run locally.