### PR TITLE
job scheduler: fix topology-aware preemption over-evicting for untracked resources

### DIFF
--- a/pkg/scheduler/actions/preempt/preempt.go
+++ b/pkg/scheduler/actions/preempt/preempt.go
@@ -758,6 +758,22 @@ func SelectVictimsOnNode(
 		return nil
 	}
 
+	// fitsAfterSimulatedEviction reports whether preemptor fits on nodeInfo given the current
+	// simulated eviction state. The generic scalar-resource comparison is only trustworthy for
+	// resources nodeInfo.Allocatable actually carries a capacity number for. A resource a device
+	// plugin tracks entirely through its own ledger instead (like volcano.sh/vgpu-memory-percentage,
+	// a pure request-side modifier with no coherent node-wide total to advertise) can never pass
+	// it, no matter how much room the real predicate would allow, so a shortfall confined to
+	// untracked dimensions is treated as inconclusive rather than a hard no; the caller still
+	// consults SimulatePredicateFn afterward to make the actual determination.
+	fitsAfterSimulatedEviction := func() bool {
+		if !ssn.SimulateAllocatableFn(ctx, state, currentQueue, preemptor) {
+			return false
+		}
+		ok, resources := preemptor.InitResreq.LessEqualWithResourcesName(nodeInfo.FutureIdle(), api.Zero)
+		return ok || api.AllUntrackedByAllocatable(resources, nodeInfo)
+	}
+
 	var preemptees []*api.TaskInfo
 	for _, task := range nodeInfo.Tasks {
 		if filter == nil {
@@ -788,7 +804,7 @@ func SelectVictimsOnNode(
 			return nil, api.AsStatus(err)
 		}
 
-		if ssn.SimulateAllocatableFn(ctx, state, currentQueue, preemptor) && preemptor.InitResreq.LessEqual(nodeInfo.FutureIdle(), api.Zero) {
+		if fitsAfterSimulatedEviction() {
 			if err := ssn.SimulatePredicateFn(ctx, state, preemptor, nodeInfo); err == nil {
 				klog.V(3).Infof("Pod %v/%v can be scheduled on node %v after preempt %v/%v, stop evicting more pods", preemptor.Namespace, preemptor.Name, nodeInfo.Name, task.Namespace, task.Name)
 				break
@@ -824,7 +840,7 @@ func SelectVictimsOnNode(
 		}
 
 		var fits bool
-		if ssn.SimulateAllocatableFn(ctx, state, currentQueue, preemptor) && preemptor.InitResreq.LessEqual(nodeInfo.FutureIdle(), api.Zero) {
+		if fitsAfterSimulatedEviction() {
 			err := ssn.SimulatePredicateFn(ctx, state, preemptor, nodeInfo)
 			fits = err == nil
 		}

--- a/pkg/scheduler/actions/preempt/preempt.go
+++ b/pkg/scheduler/actions/preempt/preempt.go
@@ -429,12 +429,20 @@ func (pmpt *Action) normalPreempt(
 // 2. The cluster has no free resources, and the queue is not allocatable.
 // 3. The cluster has no free resources, but the queue is allocatable.
 // 4. The node has sufficient aggregate resources, but PredicateFn fails because vNPU or vGPU resources are fragmented.
-// Same-queue preemption handles cases 1 and 2. Reclaim handles case 3. For case 4, normal preemption continues until
-// the predicate passes after enough victims are evicted.
+// 5. The preemptor requests a resource dimension no node advertises in Allocatable at all, such as
+// volcano.sh/vgpu-memory-percentage, which a device plugin tracks entirely on its own. The generic
+// resource comparison below can't tell that apart from a genuine shortfall, so it treats a shortfall
+// confined to untracked dimensions as inconclusive and defers to PredicateFn instead of rejecting outright.
+// Same-queue preemption handles cases 1 and 2. Reclaim handles case 3. For cases 4 and 5, normal preemption
+// continues until the predicate passes after enough victims are evicted.
 func preemptorFitsOnNode(ssn *framework.Session, queue *api.QueueInfo, preemptor *api.TaskInfo, node *api.NodeInfo) bool {
-	return ssn.Allocatable(queue, preemptor) &&
-		preemptor.InitResreq.LessEqual(node.FutureIdle(), api.Zero) &&
-		ssn.PredicateFn(preemptor, node) == nil
+	if !ssn.Allocatable(queue, preemptor) {
+		return false
+	}
+	if ok, failing := preemptor.InitResreq.LessEqualWithResourcesName(node.FutureIdle(), api.Zero); !ok && !api.AllUntrackedByAllocatable(failing, node) {
+		return false
+	}
+	return ssn.PredicateFn(preemptor, node) == nil
 }
 
 func (pmpt *Action) taskEligibleToPreempt(preemptor *api.TaskInfo) error {

--- a/pkg/scheduler/actions/preempt/preempt_test.go
+++ b/pkg/scheduler/actions/preempt/preempt_test.go
@@ -993,3 +993,114 @@ func buildPodWithPodAntiAffinity(name, namespace, node string, phase v1.PodPhase
 
 	return pod
 }
+
+const untrackedResourceTopologyPluginName = "device-fit-topology-untracked"
+
+type untrackedResourceTopologyPlugin struct{}
+
+func (p *untrackedResourceTopologyPlugin) Name() string {
+	return untrackedResourceTopologyPluginName
+}
+
+func (p *untrackedResourceTopologyPlugin) OnSessionOpen(ssn *framework.Session) {
+	ssn.AddPredicateFn(p.Name(), func(task *api.TaskInfo, node *api.NodeInfo) error {
+		if task.Name != "preemptor" {
+			return nil
+		}
+		remaining := 0
+		for _, nodeTask := range node.Tasks {
+			if (nodeTask.Name == "preemptee-low" || nodeTask.Name == "preemptee-mid" || nodeTask.Name == "preemptee-high") &&
+				nodeTask.Status != api.Releasing {
+				remaining++
+			}
+		}
+		// Stands in for a device predicate (e.g. deviceshare/HAMi) satisfied once at least one
+		// victim is evicted, independent of node.Status.Allocatable.
+		if remaining > 2 {
+			return api.NewFitErrWithStatus(task, node, &api.Status{
+				Code:   api.Unschedulable,
+				Reason: "hidden device capacity is occupied",
+			})
+		}
+		return nil
+	})
+}
+
+func (p *untrackedResourceTopologyPlugin) OnSessionClose(ssn *framework.Session) {}
+
+// TestTopologyAwarePreemptUntrackedResourceDoesNotOverEvict covers #5858: SelectVictimsOnNode
+// decides when to stop evicting and which evictions to reprieve using the same generic
+// scalar-resource arithmetic as normalPreempt. A preemptor requesting a resource dimension the
+// node never advertises in Allocatable at all (volcano.sh/vgpu-memory-percentage here) must not
+// make that arithmetic permanently unsatisfiable, or SelectVictimsOnNode keeps evicting every
+// remaining candidate instead of stopping once the real predicate is satisfied, causing
+// unnecessary over-eviction. With three evictable victims at increasing priority and a device
+// predicate satisfied after just one eviction, only the lowest-priority victim should be evicted.
+func TestTopologyAwarePreemptUntrackedResourceDoesNotOverEvict(t *testing.T) {
+	trueValue := true
+	falseValue := false
+	plugins := map[string]framework.PluginBuilder{
+		conformance.PluginName: conformance.New,
+		gang.PluginName:        gang.New,
+		priority.PluginName:    priority.New,
+		proportion.PluginName:  proportion.New,
+		untrackedResourceTopologyPluginName: func(framework.Arguments) framework.Plugin {
+			return &untrackedResourceTopologyPlugin{}
+		},
+	}
+	lowPrio := util.BuildPriorityClass("low-priority", 10)
+	midPrio := util.BuildPriorityClass("mid-priority", 500)
+	victimHighPrio := util.BuildPriorityClass("victim-high-priority", 1000)
+	preemptorPrio := util.BuildPriorityClass("preemptor-priority", 100000)
+
+	test := uthelper.TestCommonStruct{
+		Name:    "topology-aware preemption stops after the real predicate is satisfied despite an untracked resource",
+		Plugins: plugins,
+		PodGroups: []*schedulingv1beta1.PodGroup{
+			util.BuildPodGroupWithPrio("pg-low", "c1", "q1", 1, map[string]int32{"": 1}, schedulingv1beta1.PodGroupInqueue, "low-priority"),
+			util.BuildPodGroupWithPrio("pg-mid", "c1", "q1", 1, map[string]int32{"": 1}, schedulingv1beta1.PodGroupInqueue, "mid-priority"),
+			util.BuildPodGroupWithPrio("pg-victim-high", "c1", "q1", 1, map[string]int32{"": 1}, schedulingv1beta1.PodGroupInqueue, "victim-high-priority"),
+			util.BuildPodGroupWithPrio("pg-preemptor", "c1", "q1", 1, map[string]int32{"": 1}, schedulingv1beta1.PodGroupInqueue, "preemptor-priority"),
+		},
+		Pods: []*v1.Pod{
+			util.BuildPod("c1", "preemptee-low", "n1", v1.PodRunning, api.BuildResourceList("1", "1G"), "pg-low", map[string]string{schedulingv1beta1.PodPreemptable: "true"}, make(map[string]string)),
+			util.BuildPod("c1", "preemptee-mid", "n1", v1.PodRunning, api.BuildResourceList("1", "1G"), "pg-mid", map[string]string{schedulingv1beta1.PodPreemptable: "true"}, make(map[string]string)),
+			util.BuildPod("c1", "preemptee-high", "n1", v1.PodRunning, api.BuildResourceList("1", "1G"), "pg-victim-high", map[string]string{schedulingv1beta1.PodPreemptable: "true"}, make(map[string]string)),
+			util.BuildPod("c1", "preemptor", "", v1.PodPending,
+				api.BuildResourceList("1", "1G", api.ScalarResource{Name: "volcano.sh/vgpu-memory-percentage", Value: "50"}),
+				"pg-preemptor", make(map[string]string), make(map[string]string)),
+		},
+		// n1's Allocatable deliberately carries no volcano.sh/vgpu-memory-percentage entry at all.
+		Nodes: []*v1.Node{
+			util.BuildNode("n1", api.BuildResourceList("3", "3G", []api.ScalarResource{{Name: "pods", Value: "10"}}...), make(map[string]string)),
+		},
+		Queues: []*schedulingv1beta1.Queue{
+			util.BuildQueue("q1", 1, nil),
+		},
+		PriClass:       []*schedulingv1.PriorityClass{lowPrio, midPrio, victimHighPrio, preemptorPrio},
+		ExpectEvicted:  []string{"c1/preemptee-low"},
+		ExpectEvictNum: 1,
+	}
+	// proportion's Allocatable reuses queueAllocatable arithmetic with the identical untracked
+	// resource gap independently (a separate, pre-existing bug in that plugin, out of scope
+	// here). Disabled so this test isolates the fix in SelectVictimsOnNode.
+	tiers := []conf.Tier{{
+		Plugins: []conf.PluginOption{
+			{Name: conformance.PluginName, EnabledPreemptable: &trueValue},
+			{Name: gang.PluginName, EnabledPreemptable: &falseValue, EnabledJobPipelined: &trueValue, EnabledJobStarving: &trueValue},
+			{Name: priority.PluginName, EnabledTaskOrder: &trueValue, EnabledJobOrder: &trueValue, EnabledPreemptable: &trueValue, EnabledJobPipelined: &trueValue, EnabledJobStarving: &trueValue},
+			{Name: proportion.PluginName, EnabledOverused: &trueValue, EnabledQueueOrder: &trueValue},
+			{Name: untrackedResourceTopologyPluginName, EnabledPredicate: &trueValue},
+		},
+	}}
+
+	test.RegisterSession(tiers, []conf.Configuration{{
+		Name:      New().Name(),
+		Arguments: map[string]interface{}{EnableTopologyAwarePreemptionKey: true},
+	}})
+	defer test.Close()
+	test.Run([]framework.Action{New()})
+	if err := test.CheckAll(0); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/pkg/scheduler/actions/preempt/preempt_test.go
+++ b/pkg/scheduler/actions/preempt/preempt_test.go
@@ -508,7 +508,14 @@ func newNormalPreemptDeviceFitFixture() (uthelper.TestCommonStruct, []conf.Tier)
 			util.BuildPod("c1", "preemptor", "", v1.PodPending, api.BuildResourceList("1", "1G"), "pg-high", make(map[string]string), make(map[string]string)),
 		},
 		Nodes: []*v1.Node{
-			util.BuildNode("n1", api.BuildResourceList("2", "2G", []api.ScalarResource{{Name: "pods", Value: "10"}}...), make(map[string]string)),
+			util.BuildNode("n1", api.BuildResourceList("2", "2G", []api.ScalarResource{
+				{Name: "pods", Value: "10"},
+				// Tracked like a real HAMi node: vgpu-number is advertised in Allocatable.
+				// vgpu-memory-percentage deliberately is not (see
+				// TestNormalPreemptUntrackedResourceDefersToPredicate) - that's the one
+				// dimension this fixture is actually testing.
+				{Name: "volcano.sh/vgpu-number", Value: "1"},
+			}...), make(map[string]string)),
 		},
 		Queues: []*schedulingv1beta1.Queue{
 			util.BuildQueue("q1", 1, nil),
@@ -544,7 +551,14 @@ func TestNormalPreemptUntrackedResourceDefersToPredicate(t *testing.T) {
 	test.Pods = []*v1.Pod{
 		util.BuildPod("c1", "preemptee", "n1", v1.PodRunning, api.BuildResourceList("1", "1G"), "pg-low", map[string]string{schedulingv1beta1.PodPreemptable: "true"}, make(map[string]string)),
 		util.BuildPod("c1", "preemptor", "", v1.PodPending,
-			api.BuildResourceList("1", "1G", api.ScalarResource{Name: "volcano.sh/vgpu-memory-percentage", Value: "50"}),
+			// vgpu-memory-percentage is never requested on its own in practice - the API
+			// requires vgpu-number (or vgpu-memory) alongside it. Both are requested here;
+			// only vgpu-memory-percentage is untracked in n1's Allocatable (see the fixture
+			// above), which is the one dimension this test is actually exercising.
+			api.BuildResourceList("1", "1G",
+				api.ScalarResource{Name: "volcano.sh/vgpu-number", Value: "1"},
+				api.ScalarResource{Name: "volcano.sh/vgpu-memory-percentage", Value: "50"},
+			),
 			"pg-high", make(map[string]string), make(map[string]string)),
 	}
 	// n1's Allocatable deliberately carries no volcano.sh/vgpu-memory-percentage entry at all,
@@ -1066,13 +1080,24 @@ func TestTopologyAwarePreemptUntrackedResourceDoesNotOverEvict(t *testing.T) {
 			util.BuildPod("c1", "preemptee-low", "n1", v1.PodRunning, api.BuildResourceList("1", "1G"), "pg-low", map[string]string{schedulingv1beta1.PodPreemptable: "true"}, make(map[string]string)),
 			util.BuildPod("c1", "preemptee-mid", "n1", v1.PodRunning, api.BuildResourceList("1", "1G"), "pg-mid", map[string]string{schedulingv1beta1.PodPreemptable: "true"}, make(map[string]string)),
 			util.BuildPod("c1", "preemptee-high", "n1", v1.PodRunning, api.BuildResourceList("1", "1G"), "pg-victim-high", map[string]string{schedulingv1beta1.PodPreemptable: "true"}, make(map[string]string)),
+			// vgpu-memory-percentage is never requested on its own in practice - the API
+			// requires vgpu-number (or vgpu-memory) alongside it. Both are requested here;
+			// only vgpu-memory-percentage is untracked in n1's Allocatable below, which is
+			// the one dimension this test is actually exercising.
 			util.BuildPod("c1", "preemptor", "", v1.PodPending,
-				api.BuildResourceList("1", "1G", api.ScalarResource{Name: "volcano.sh/vgpu-memory-percentage", Value: "50"}),
+				api.BuildResourceList("1", "1G",
+					api.ScalarResource{Name: "volcano.sh/vgpu-number", Value: "1"},
+					api.ScalarResource{Name: "volcano.sh/vgpu-memory-percentage", Value: "50"},
+				),
 				"pg-preemptor", make(map[string]string), make(map[string]string)),
 		},
-		// n1's Allocatable deliberately carries no volcano.sh/vgpu-memory-percentage entry at all.
+		// n1's Allocatable tracks vgpu-number like a real HAMi node, but deliberately carries
+		// no volcano.sh/vgpu-memory-percentage entry at all.
 		Nodes: []*v1.Node{
-			util.BuildNode("n1", api.BuildResourceList("3", "3G", []api.ScalarResource{{Name: "pods", Value: "10"}}...), make(map[string]string)),
+			util.BuildNode("n1", api.BuildResourceList("3", "3G", []api.ScalarResource{
+				{Name: "pods", Value: "10"},
+				{Name: "volcano.sh/vgpu-number", Value: "1"},
+			}...), make(map[string]string)),
 		},
 		Queues: []*schedulingv1beta1.Queue{
 			util.BuildQueue("q1", 1, nil),

--- a/pkg/scheduler/actions/preempt/preempt_test.go
+++ b/pkg/scheduler/actions/preempt/preempt_test.go
@@ -530,6 +530,48 @@ func newNormalPreemptDeviceFitFixture() (uthelper.TestCommonStruct, []conf.Tier)
 	return test, tiers
 }
 
+// TestNormalPreemptUntrackedResourceDefersToPredicate covers #4863: a preemptor requesting
+// a resource dimension the node never advertises in Allocatable at all (volcano.sh/vgpu-memory-percentage
+// here, mirroring HAMi's fractional vGPU resource, which is a pure request-side modifier with no
+// coherent node-wide capacity total to advertise) must not be rejected by the generic scalar-resource
+// arithmetic before the device-aware predicate ever runs. Before the fix, node.FutureIdle() has no entry
+// for that resource name, so the comparison reads it as zero capacity and preemptorFitsOnNode/ValidateVictims
+// reject unconditionally, regardless of what the real predicate would say, and the preemptor never gets
+// scheduled even after the victim is evicted.
+func TestNormalPreemptUntrackedResourceDefersToPredicate(t *testing.T) {
+	test, tiers := newNormalPreemptDeviceFitFixture()
+	test.Name = "normal preemption evicts a victim for a resource untracked in node.Allocatable"
+	test.Pods = []*v1.Pod{
+		util.BuildPod("c1", "preemptee", "n1", v1.PodRunning, api.BuildResourceList("1", "1G"), "pg-low", map[string]string{schedulingv1beta1.PodPreemptable: "true"}, make(map[string]string)),
+		util.BuildPod("c1", "preemptor", "", v1.PodPending,
+			api.BuildResourceList("1", "1G", api.ScalarResource{Name: "volcano.sh/vgpu-memory-percentage", Value: "50"}),
+			"pg-high", make(map[string]string), make(map[string]string)),
+	}
+	// n1's Allocatable deliberately carries no volcano.sh/vgpu-memory-percentage entry at all,
+	// matching a real HAMi node: the resource is tracked by the device plugin's own ledger, not
+	// advertised node-wide.
+	//
+	// proportion's own queue-level Allocatable check has this identical untracked-resource gap
+	// independently (attr.deserved never carries an unconfigured scalar dimension either), which
+	// is a separate bug in a different plugin, out of scope here. Disable it so this test isolates
+	// the node-level fix in preemptorFitsOnNode/ValidateVictims that #4863/#5784 actually covers.
+	falseValue := false
+	for i, plugin := range tiers[0].Plugins {
+		if plugin.Name == proportion.PluginName {
+			tiers[0].Plugins[i].EnabledAllocatable = &falseValue
+		}
+	}
+	test.RegisterSession(tiers, []conf.Configuration{{
+		Name:      New().Name(),
+		Arguments: map[string]interface{}{EnableTopologyAwarePreemptionKey: false},
+	}})
+	defer test.Close()
+	test.Run([]framework.Action{New()})
+	if err := test.CheckAll(0); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func newNormalPreemptBenchmarkFixture() (uthelper.TestCommonStruct, []conf.Tier) {
 	test, tiers := newNormalPreemptDeviceFitFixture()
 	test.Name = "normal preemption benchmark with one required victim"

--- a/pkg/scheduler/actions/reclaim/reclaim.go
+++ b/pkg/scheduler/actions/reclaim/reclaim.go
@@ -262,9 +262,15 @@ func (ra *Action) reclaimForTask(ssn *framework.Session, stmt *framework.Stateme
 }
 
 // reclaimerFitsOnNode verifies available resources and plugin predicates after tentative evictions.
+// The arithmetic check alone can't be trusted when the shortfall is confined to a resource
+// dimension node.Allocatable has no entry for at all, such as volcano.sh/vgpu-memory-percentage,
+// which a device plugin tracks entirely through its own ledger. In that case defer to the real
+// predicate instead of rejecting outright.
 func reclaimerFitsOnNode(ssn *framework.Session, task *api.TaskInfo, node *api.NodeInfo, resreq, availableResources *api.Resource) bool {
-	return resreq.LessEqual(availableResources, api.Zero) &&
-		ssn.PredicateFn(task, node) == nil
+	if ok, failing := resreq.LessEqualWithResourcesName(availableResources, api.Zero); !ok && !api.AllUntrackedByAllocatable(failing, node) {
+		return false
+	}
+	return ssn.PredicateFn(task, node) == nil
 }
 
 func (ra *Action) UnInitialize() {

--- a/pkg/scheduler/actions/reclaim/reclaim_test.go
+++ b/pkg/scheduler/actions/reclaim/reclaim_test.go
@@ -476,3 +476,79 @@ func TestReclaimRechecksPredicateAfterEviction(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+// TestReclaimUntrackedResourceDefersToPredicate covers the same #4863-class bug as
+// TestNormalPreemptUntrackedResourceDefersToPredicate in the preempt package, but for reclaim:
+// a reclaimer requesting a resource dimension the node never advertises in Allocatable at all
+// (volcano.sh/vgpu-memory-percentage here, mirroring HAMi's fractional vGPU resource) must not be
+// rejected by the generic scalar-resource arithmetic in reclaimerFitsOnNode/ValidateVictims before
+// the device-aware predicate ever runs.
+func TestReclaimUntrackedResourceDefersToPredicate(t *testing.T) {
+	plugins := map[string]framework.PluginBuilder{
+		conformance.PluginName: conformance.New,
+		gang.PluginName:        gang.New,
+		proportion.PluginName:  proportion.New,
+		deviceFitAfterReclaimPluginName: func(framework.Arguments) framework.Plugin {
+			return &deviceFitAfterReclaimPlugin{}
+		},
+	}
+	trueValue := true
+	// Same PodGroups/Pods/Queues as TestReclaimRechecksPredicateAfterEviction (including the
+	// unrelated q3/pg-demand job, which affects proportion's deserved-share math), so the only
+	// variable relative to that already-passing baseline is the untracked resource dimension
+	// added to the reclaimer's request below. That isolates this test to the fix in
+	// reclaimerFitsOnNode/ValidateVictims instead of also exercising queue-weight arithmetic.
+	test := uthelper.TestCommonStruct{
+		Name:    "reclaim evicts a victim for a resource untracked in node.Allocatable",
+		Plugins: plugins,
+		PodGroups: []*schedulingv1beta1.PodGroup{
+			util.BuildPodGroupWithPrio("pg-victim", "c1", "q1", 0, nil, schedulingv1beta1.PodGroupRunning, "low-priority"),
+			util.BuildPodGroupWithPrio("pg-reclaimer", "c1", "q2", 1, nil, schedulingv1beta1.PodGroupInqueue, "high-priority"),
+			util.BuildPodGroupWithPrio("pg-demand", "c1", "q3", 0, nil, schedulingv1beta1.PodGroupInqueue, "low-priority"),
+		},
+		Pods: []*v1.Pod{
+			util.BuildPod("c1", "device-holder-1", "n1", v1.PodRunning, api.BuildResourceList("1", "1G"), "pg-victim", map[string]string{schedulingv1beta1.PodPreemptable: "true"}, make(map[string]string)),
+			util.BuildPod("c1", "device-holder-2", "n1", v1.PodRunning, api.BuildResourceList("1", "1G"), "pg-victim", map[string]string{schedulingv1beta1.PodPreemptable: "true"}, make(map[string]string)),
+			util.BuildPod("c1", "device-holder-3", "n1", v1.PodRunning, api.BuildResourceList("1", "1G"), "pg-victim", map[string]string{schedulingv1beta1.PodPreemptable: "false"}, make(map[string]string)),
+			// device-fit-after-reclaim's predicate only special-cases a task named "reclaimer", so
+			// this stays evicted regardless of the untracked resource on the reclaimer's request.
+			util.BuildPod("c1", "reclaimer", "", v1.PodPending,
+				api.BuildResourceList("1", "1G", api.ScalarResource{Name: "volcano.sh/vgpu-memory-percentage", Value: "50"}),
+				"pg-reclaimer", make(map[string]string), make(map[string]string)),
+			util.BuildPod("c1", "other-queue-demand", "", v1.PodPending, api.BuildResourceList("1", "1G"), "pg-demand", make(map[string]string), make(map[string]string)),
+		},
+		// n1's Allocatable deliberately carries no volcano.sh/vgpu-memory-percentage entry at all.
+		Nodes: []*v1.Node{
+			util.BuildNode("n1", api.BuildResourceList("3", "3G", []api.ScalarResource{{Name: "pods", Value: "10"}}...), make(map[string]string)),
+		},
+		Queues: []*schedulingv1beta1.Queue{
+			util.BuildQueue("q1", 1, nil),
+			util.BuildQueue("q2", 9, nil),
+			util.BuildQueue("q3", 1, nil),
+		},
+		ExpectEvicted:  []string{"c1/device-holder-1", "c1/device-holder-2"},
+		ExpectEvictNum: 2,
+		ExpectPipeLined: map[string][]string{
+			"c1/pg-reclaimer": {"n1"},
+		},
+	}
+	// proportion's EnablePreemptive reuses the same queueAllocatable arithmetic as its
+	// Allocatable check and has this identical untracked-resource gap independently (a
+	// separate, pre-existing bug in that plugin, out of scope here). Disabled so this test
+	// isolates the node-level fix in reclaimerFitsOnNode/ValidateVictims.
+	tiers := []conf.Tier{{
+		Plugins: []conf.PluginOption{
+			{Name: conformance.PluginName, EnabledReclaimable: &trueValue},
+			{Name: gang.PluginName, EnabledReclaimable: &trueValue, EnabledJobStarving: &trueValue},
+			{Name: proportion.PluginName, EnabledReclaimable: &trueValue, EnabledQueueOrder: &trueValue},
+			{Name: deviceFitAfterReclaimPluginName, EnabledPredicate: &trueValue},
+		},
+	}}
+
+	test.RegisterSession(tiers, nil)
+	defer test.Close()
+	test.Run([]framework.Action{New()})
+	if err := test.CheckAll(0); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/pkg/scheduler/api/node_info.go
+++ b/pkg/scheduler/api/node_info.go
@@ -464,7 +464,13 @@ func (ni *NodeInfo) AddTask(task *TaskInfo) error {
 			ni.Pipelined.Add(ti.Resreq)
 		case Binding:
 			// When task in Binding status, it will bind to node, we should double-check whether idle resources are enough to put task before bind to apiserver.
-			if ok, resNames := ti.Resreq.LessEqualWithResourcesName(ni.Idle, Zero); !ok {
+			// A shortfall confined to resource dimensions ni.Allocatable has no entry for at all
+			// (like volcano.sh/vgpu-memory-percentage, tracked entirely by a device plugin's own
+			// ledger rather than advertised node-wide) can never pass this arithmetic, no matter
+			// how much room the device plugin's predicate already confirmed earlier in scheduling.
+			// This is the final gate before every bind, real or simulated, across every action, so
+			// treat that case as inconclusive rather than a hard no instead of rejecting outright.
+			if ok, resNames := ti.Resreq.LessEqualWithResourcesName(ni.Idle, Zero); !ok && !AllUntrackedByAllocatable(resNames, ni) {
 				return fmt.Errorf("node %s resources %v are not enough to put task <%s/%s>, idle: %s, req: %s", ni.Name, resNames, ti.Namespace, ti.Name, ni.Idle.String(), ti.Resreq.String())
 			}
 			ni.allocateIdleResource(ti)

--- a/pkg/scheduler/api/node_info_test.go
+++ b/pkg/scheduler/api/node_info_test.go
@@ -504,3 +504,40 @@ func TestNodeInfoClonePreservesUnassignedNumaPods(t *testing.T) {
 		t.Errorf("Clone mutation leaked back into original: %v", ni.UnassignedNumaPods)
 	}
 }
+
+// TestNodeInfo_AddTask_UntrackedResourceDefersToPredicate covers the final, most fundamental
+// occurrence of the #4863-class bug: AddTask's Binding-status check is the last gate every task
+// passes through before actually binding to the API server, across every scheduling action. A
+// task requesting a resource dimension the node never advertises in Allocatable at all (like
+// volcano.sh/vgpu-memory-percentage, tracked entirely by a device plugin's own ledger) must not
+// be rejected here, since nothing downstream double-checks it again.
+func TestNodeInfo_AddTask_UntrackedResourceDefersToPredicate(t *testing.T) {
+	node := buildNode("n1", nil, BuildResourceList("2000m", "2G", []ScalarResource{{Name: "pods", Value: "10"}}...))
+	pod := buildPod("c1", "p1", "", v1.PodPending,
+		BuildResourceList("1000m", "1G", []ScalarResource{{Name: "volcano.sh/vgpu-memory-percentage", Value: "50"}}...),
+		[]metav1.OwnerReference{}, make(map[string]string))
+
+	ni := NewNodeInfo(node)
+	task := NewTaskInfo(pod)
+	task.Status = Binding
+
+	if err := ni.AddTask(task); err != nil {
+		t.Fatalf("expected AddTask to succeed for a resource untracked in node.Allocatable, got error: %v", err)
+	}
+}
+
+// TestNodeInfo_AddTask_GenuineShortfallStillRejected is the companion regression: a real,
+// tracked-resource shortfall (cpu here) must still be rejected at bind time. The fallback above
+// is only for dimensions Allocatable has no entry for at all, not a blanket bypass.
+func TestNodeInfo_AddTask_GenuineShortfallStillRejected(t *testing.T) {
+	node := buildNode("n1", nil, BuildResourceList("1000m", "2G", []ScalarResource{{Name: "pods", Value: "10"}}...))
+	pod := buildPod("c1", "p1", "", v1.PodPending, BuildResourceList("2000m", "1G"), []metav1.OwnerReference{}, make(map[string]string))
+
+	ni := NewNodeInfo(node)
+	task := NewTaskInfo(pod)
+	task.Status = Binding
+
+	if err := ni.AddTask(task); err == nil {
+		t.Fatal("expected AddTask to reject a genuine cpu shortfall, got success")
+	}
+}

--- a/pkg/scheduler/api/resource_info.go
+++ b/pkg/scheduler/api/resource_info.go
@@ -559,6 +559,31 @@ func (r *Resource) LessEqualWithResourcesName(rr *Resource, defaultValue Dimensi
 	return true, resources
 }
 
+// AllUntrackedByAllocatable reports whether every resource name in names has no capacity entry
+// at all in node.Allocatable. cpu and memory always carry a real capacity number, so they are
+// never considered untracked. Used to tell a genuine shortfall (a tracked resource that's really
+// insufficient) apart from a resource dimension a device plugin manages entirely on its own (like
+// volcano.sh/vgpu-memory-percentage, a pure request-side modifier with no coherent node-wide total
+// to advertise), where the generic scalar comparison has nothing to compare against and can't be
+// trusted as "no".
+func AllUntrackedByAllocatable(names []string, node *NodeInfo) bool {
+	if len(names) == 0 {
+		return false
+	}
+	for _, name := range names {
+		if name == string(v1.ResourceCPU) || name == string(v1.ResourceMemory) {
+			return false
+		}
+		if node.Allocatable == nil {
+			return false
+		}
+		if _, tracked := node.Allocatable.ScalarResources[v1.ResourceName(name)]; tracked {
+			return false
+		}
+	}
+	return true
+}
+
 // LessPartly returns true if there exists any dimension whose resource amount in r is less than that in rr.
 // Otherwise returns false.
 // @param defaultValue "default value for resource dimension not defined in ScalarResources. Its value can only be one of 'Zero' and 'Infinity'"

--- a/pkg/scheduler/util/scheduler_helper.go
+++ b/pkg/scheduler/util/scheduler_helper.go
@@ -324,8 +324,15 @@ func ValidateVictims(preemptor *api.TaskInfo, node *api.NodeInfo, victims []*api
 		futureIdle.Add(victim.Resreq)
 	}
 	// Every resource of the preemptor needs to be less or equal than corresponding
-	// idle resource after preemption.
-	if !preemptor.InitResreq.LessEqual(futureIdle, api.Zero) {
+	// idle resource after preemption. This arithmetic check is only authoritative for
+	// resources node.Allocatable actually carries a capacity number for (cpu, memory,
+	// volcano.sh/vgpu-number, ...). A resource a device plugin tracks entirely through its
+	// own ledger instead (like volcano.sh/vgpu-memory-percentage, a pure request-side
+	// modifier with no coherent node-wide total to advertise) can never pass this check,
+	// no matter how much room the device plugin's predicate would actually allow, so treat
+	// a shortfall confined to untracked dimensions as inconclusive rather than a hard no
+	// and let the real predicate decide once eviction is attempted.
+	if ok, failing := preemptor.InitResreq.LessEqualWithResourcesName(futureIdle, api.Zero); !ok && !api.AllUntrackedByAllocatable(failing, node) {
 		return fmt.Errorf("not enough resources: requested <%v>, but future idle <%v>",
 			preemptor.InitResreq, futureIdle)
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Fixes topology-aware preemption's `SelectVictimsOnNode` over-evicting victims when the preemptor requests a resource dimension the node never advertises in `node.Status.Allocatable` at all, such as `volcano.sh/vgpu-memory-percentage` from HAMi's fractional vGPU support.

`SelectVictimsOnNode` decides when to stop evicting candidate victims, and which of the evicted victims to reprieve afterward, using the same generic scalar-resource arithmetic as `normalPreempt`: does the preemptor now fit given `node.FutureIdle()` after the simulated evictions so far. Both of the two call sites gate a real, device-aware predicate call behind that arithmetic. For an untracked resource, the arithmetic can never come back true, no matter how much room the real predicate would actually allow once enough has been evicted, so it keeps evicting every remaining candidate instead of stopping once the real predicate is satisfied, and the reprieve pass that would normally give back unnecessary evictions can't recover any of them either. Net effect: unnecessary over-eviction and disruption of running workloads.

Both call sites get the same fallback already used for the preempt and reclaim actions in #5784: when the arithmetic shortfall is confined to dimensions `node.Allocatable` has no entry for at all, treat that as inconclusive instead of a hard no and let the real predicate decide.

#### Which issue(s) this PR fixes:

Fixes #5858

#### Special notes for your reviewer:

Depends on #5784 — this branch is built on top of it since it needs the `AllUntrackedByAllocatable` helper `#5784` adds to `pkg/scheduler/api`. The diff here will look larger than the actual change until #5784 merges and this rebases down to just this commit.

Used Claude Code (AI assistant) to investigate this issue and draft the fix and test, following the same pattern already reviewed in #5784. The regression test has three evictable victims at increasing priority and a device predicate satisfied after just one eviction; confirmed it fails against the code before this change (evicts an extra victim it didn't need to) and passes after (evicts only the lowest-priority one). Full `pkg/scheduler/...` suite is green.

#### Does this PR introduce a user-facing change?

```release-note
Fix a bug where topology-aware preemption over-evicted running pods when the preempting task requested a resource untracked in node.Status.Allocatable (such as a fractional vGPU request), disrupting more workloads than necessary.
```
