### PR TITLE
agent: replace deprecated sets.String with generic Set

### DIFF
--- a/pkg/agent/events/handlers/oversubscription/resource_reporter_test.go
+++ b/pkg/agent/events/handlers/oversubscription/resource_reporter_test.go
@@ -71,7 +71,7 @@ func Test_reporter_RefreshCfg(t *testing.T) {
 		cfg               *api.ColocationConfig
 		enable            bool
 		expectNode        func() *v1.Node
-		expectTypes       sets.String
+		expectTypes       sets.Set[string]
 		expectEvictedPods []*v1.Pod
 	}{
 		{
@@ -96,7 +96,7 @@ func Test_reporter_RefreshCfg(t *testing.T) {
 					OverSubscriptionTypes: utilpointer.String("cpu,memory"),
 				}},
 			enable:      true,
-			expectTypes: sets.NewString("cpu", "memory"),
+			expectTypes: sets.New[string]("cpu", "memory"),
 			expectNode: func() *v1.Node {
 				node, err := makeNode()
 				assert.NoError(t, err)
@@ -125,7 +125,7 @@ func Test_reporter_RefreshCfg(t *testing.T) {
 					Enable:                utilpointer.Bool(true),
 					OverSubscriptionTypes: utilpointer.String("cpu,memory"),
 				}},
-			expectTypes: sets.NewString("cpu", "memory"),
+			expectTypes: sets.New[string]("cpu", "memory"),
 			expectNode: func() *v1.Node {
 				node, err := makeNode()
 				assert.NoError(t, err)

--- a/pkg/agent/events/probes/noderesources/resource_calculator.go
+++ b/pkg/agent/events/probes/noderesources/resource_calculator.go
@@ -50,7 +50,7 @@ type historicalUsageCalculator struct {
 	policy.Interface
 	eventQueueFactory *framework.EventQueueFactory
 	queue             *queue.SqQueue
-	resourceTypes     sets.String
+	resourceTypes     sets.Set[string]
 	getNodeFunc       utilnode.ActiveNode
 }
 
@@ -61,7 +61,7 @@ func NewCalculator(config *config.Configuration, mgr *metriccollect.MetricCollec
 		Interface:         policy.GetPolicyFunc(config.GenericConfiguration.OverSubscriptionPolicy)(config, mgr, nil, sqQueue, local.CollectorName),
 		eventQueueFactory: eventQueueFactory,
 		queue:             sqQueue,
-		resourceTypes:     sets.NewString(),
+		resourceTypes:     sets.New[string](),
 		getNodeFunc:       config.GetNode,
 	}
 }
@@ -84,7 +84,7 @@ func (r *historicalUsageCalculator) RefreshCfg(cfg *api.ColocationConfig) error 
 		return fmt.Errorf("nil colocation cfg")
 	}
 	// refresh overSubscription resource types.
-	set := sets.NewString()
+	set := sets.New[string]()
 	typ := strings.Split(*cfg.OverSubscriptionConfig.OverSubscriptionTypes, ",")
 	for _, resType := range typ {
 		if resType == "" {
@@ -148,7 +148,7 @@ func (r *historicalUsageCalculator) getOverSubscriptionTypes(node *v1.Node) map[
 	r.cfgLock.Lock()
 	defer r.cfgLock.Unlock()
 	ret := make(map[v1.ResourceName]bool)
-	for _, item := range r.resourceTypes.List() {
+	for _, item := range sets.List(r.resourceTypes) {
 		ret[v1.ResourceName(item)] = true
 	}
 

--- a/pkg/agent/events/probes/noderesources/resource_calculator_test.go
+++ b/pkg/agent/events/probes/noderesources/resource_calculator_test.go
@@ -166,7 +166,7 @@ func Test_historicalUsageCalculator_preProcess(t *testing.T) {
 		name             string
 		getNodeFunc      utilnode.ActiveNode
 		getPodsFunc      utilpod.ActivePods
-		resourceTypes    sets.String
+		resourceTypes    sets.Set[string]
 		expectedResource framework.NodeResourceEvent
 	}{
 		{
@@ -219,7 +219,7 @@ func Test_historicalUsageCalculator_preProcess(t *testing.T) {
 				queue:             queue,
 				eventQueueFactory: factory,
 				getNodeFunc:       tt.getNodeFunc,
-				resourceTypes:     sets.NewString("cpu", "memory"),
+				resourceTypes:     sets.New[string]("cpu", "memory"),
 			}
 			r.preProcess()
 			eventQueue := factory.EventQueue(string(framework.NodeResourcesEventName)).GetQueue()
@@ -239,37 +239,37 @@ func Test_historicalUsageCalculator_preProcess(t *testing.T) {
 func Test_historicalUsageCalculator_RefreshCfg(t *testing.T) {
 	tests := []struct {
 		name                 string
-		resourceTypes        sets.String
+		resourceTypes        sets.Set[string]
 		cfg                  *api.ColocationConfig
-		expectedResourceType sets.String
+		expectedResourceType sets.Set[string]
 		wantErr              assert.ErrorAssertionFunc
 	}{
 		{
 			name:                 "return err",
 			cfg:                  nil,
-			resourceTypes:        sets.NewString(),
-			expectedResourceType: sets.NewString(),
+			resourceTypes:        sets.New[string](),
+			expectedResourceType: sets.New[string](),
 			wantErr:              assert.Error,
 		},
 		{
 			name:                 "empty config",
 			cfg:                  &api.ColocationConfig{OverSubscriptionConfig: &api.OverSubscription{OverSubscriptionTypes: utilpointer.String("")}},
-			resourceTypes:        sets.NewString(),
-			expectedResourceType: sets.NewString(),
+			resourceTypes:        sets.New[string](),
+			expectedResourceType: sets.New[string](),
 			wantErr:              assert.NoError,
 		},
 		{
 			name:                 "cpu",
 			cfg:                  &api.ColocationConfig{OverSubscriptionConfig: &api.OverSubscription{OverSubscriptionTypes: utilpointer.String("cpu")}},
-			resourceTypes:        sets.NewString(),
-			expectedResourceType: sets.NewString("cpu"),
+			resourceTypes:        sets.New[string](),
+			expectedResourceType: sets.New[string]("cpu"),
 			wantErr:              assert.NoError,
 		},
 		{
 			name:                 "cpu and memory",
 			cfg:                  &api.ColocationConfig{OverSubscriptionConfig: &api.OverSubscription{OverSubscriptionTypes: utilpointer.String("cpu,memory")}},
-			resourceTypes:        sets.NewString(),
-			expectedResourceType: sets.NewString("cpu", "memory"),
+			resourceTypes:        sets.New[string](),
+			expectedResourceType: sets.New[string]("cpu", "memory"),
 			wantErr:              assert.NoError,
 		},
 	}


### PR DESCRIPTION
/kind cleanup

#### What this PR does / why we need it:

Replace deprecated `sets.String` usage with the generic
`sets.Set[string]` API in the agent node resource calculator and
oversubscription tests.

This keeps the existing behavior unchanged while aligning the code
with the current Kubernetes sets API.

#### Which issue(s) this PR fixes:

NONE

#### Special notes for your reviewer:

- This is a focused cleanup change.
- `sets.List(...)` preserves the previous sorted-list behavior.
- AI tools were used to inspect and prepare this patch; all changes were reviewed manually.
- Validation: `gofmt`, `git diff --check`, and Linux-target compilation checks passed.
- Full tests were not run locally because the host is macOS and `opencontainers/cgroups` cannot compile natively.

#### Does this PR introduce a user-facing change?

NONE

```release-note
NONE
