### PR TITLE
ci: run validation workflows on branch pushes

### DIFF
--- a/.github/workflows/code_verify.yaml
+++ b/.github/workflows/code_verify.yaml
@@ -2,9 +2,9 @@ name: Code Verify
 
 on:
   push:
-    branches:
-      - master
-    tags:
+    branches-ignore:
+      - "dependabot/**"
+      - "copilot/**"
   pull_request:
 
 permissions: read-all

--- a/.github/workflows/code_verify.yaml
+++ b/.github/workflows/code_verify.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches-ignore:
       - "dependabot/**"
-      - "copilot/**"
   pull_request:
 
 permissions: read-all

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -8,7 +8,6 @@ on:
   push:
     branches-ignore:
       - "dependabot/**"
-      - "copilot/**"
   pull_request:
 
 permissions: read-all

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -6,9 +6,9 @@ concurrency:
 
 on:
   push:
-    branches:
-      - master
-    tags:
+    branches-ignore:
+      - "dependabot/**"
+      - "copilot/**"
   pull_request:
 
 permissions: read-all

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -6,8 +6,9 @@ concurrency:
 
 on:
   push:
-    branches-ignore:
-      - "dependabot/**"
+    branches:
+      - master
+      - "e2e/**"
   pull_request:
 
 permissions: read-all

--- a/.github/workflows/licenses_lint.yaml
+++ b/.github/workflows/licenses_lint.yaml
@@ -2,9 +2,9 @@ name: Licenses Lint
 
 on:
   push:
-    branches:
-      - master
-    tags:
+    branches-ignore:
+      - "dependabot/**"
+      - "copilot/**"
   pull_request:
 
 permissions: read-all

--- a/.github/workflows/licenses_lint.yaml
+++ b/.github/workflows/licenses_lint.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches-ignore:
       - "dependabot/**"
-      - "copilot/**"
   pull_request:
 
 permissions: read-all


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

`Code Verify` and `Licenses Lint` currently run for pull requests and `master` pushes, so contributors cannot run the repository's lightweight validation on a fork topic branch before opening a PR.

This change runs those lightweight workflows on branch pushes while excluding `dependabot/**`. Full E2E push validation remains enabled for `master` and becomes opt-in for `e2e/**` branches. Pull-request triggers, workflow jobs, permissions, and release, publication, and synchronization workflows are unchanged.

#### Which issue(s) this PR fixes:

None.

#### Special notes for your reviewer:

This follows the branch-push validation pattern from [karmada-io/karmada#4762](https://github.com/karmada-io/karmada/pull/4762). `agent/**` intentionally remains eligible because human contributor branches use that prefix, including [#5826](https://github.com/volcano-sh/volcano/pull/5826). The invalid empty `tags:` filters are removed; tag publishing remains owned by the release workflows.

Contributors can push a candidate commit to an `e2e/**` branch in their fork to run the full suite. Ordinary WIP and experimental branches do not trigger E2E push validation.

Validation:

- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 .github/workflows/code_verify.yaml .github/workflows/e2e.yaml .github/workflows/licenses_lint.yaml`
- `git diff --check`
- Fork push at `86bac2b69`: [Code Verify](https://github.com/ranxi2001/volcano/actions/runs/33059312413), [Licenses Lint](https://github.com/ranxi2001/volcano/actions/runs/33059312419), and [E2E Tests](https://github.com/ranxi2001/volcano/actions/runs/33059312721): passed
- Fork push at `0d9ddc938`: [Licenses Lint](https://github.com/ranxi2001/volcano/actions/runs/33156581849): passed; [Code Verify](https://github.com/ranxi2001/volcano/actions/runs/33156581887): in progress; E2E did not trigger for the ordinary topic branch

AI assistance: OpenAI Codex was used to audit the workflow scope, prepare the initial patch, and draft this PR text. The final three-file diff and validation evidence remain the contributor's responsibility.

Rhyme: Volcano branches rise and glow; checks run before reviews can flow.

Prompt: "Prepare a focused Volcano CI change that runs lightweight validation on topic-branch pushes and keeps full E2E push validation opt-in through `e2e/**` branches, without changing release or secret-bearing workflows."

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
