### PR TITLE
[release-1.13] scheduler: skip backfill task when no best node is selected

### DIFF
--- a/pkg/scheduler/actions/backfill/backfill.go
+++ b/pkg/scheduler/actions/backfill/backfill.go
@@ -92,6 +92,10 @@ func (backfill *Action) Execute(ssn *framework.Session) {
 			if node == nil {
 				node, _ = util.SelectBestNodeAndScore(nodeScores)
 			}
+			if node == nil {
+				klog.V(3).Infof("No best node for task <%v/%v>, skip it in backfill", task.Namespace, task.Name)
+				continue
+			}
 		}
 
 		klog.V(3).Infof("Binding Task <%v/%v> to node <%v>", task.Namespace, task.Name, node.Name)

--- a/pkg/scheduler/actions/backfill/backfill_test.go
+++ b/pkg/scheduler/actions/backfill/backfill_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package backfill
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -27,12 +28,14 @@ import (
 	"k8s.io/client-go/tools/record"
 	schedulingv1beta1 "volcano.sh/apis/pkg/apis/scheduling/v1beta1"
 
+	"volcano.sh/volcano/cmd/scheduler/app/options"
 	"volcano.sh/volcano/pkg/scheduler/api"
 	"volcano.sh/volcano/pkg/scheduler/cache"
 	"volcano.sh/volcano/pkg/scheduler/conf"
 	"volcano.sh/volcano/pkg/scheduler/framework"
 	"volcano.sh/volcano/pkg/scheduler/plugins/drf"
 	"volcano.sh/volcano/pkg/scheduler/plugins/priority"
+	"volcano.sh/volcano/pkg/scheduler/uthelper"
 	"volcano.sh/volcano/pkg/scheduler/util"
 )
 
@@ -174,5 +177,70 @@ func TestPickUpPendingTasks(t *testing.T) {
 		if !assert.Equal(t, tc.expectedResult, actualResult) {
 			t.Errorf("unexpected test; name: %s, expected result: %v, actual result: %v", tc.name, tc.expectedResult, actualResult)
 		}
+	}
+}
+
+type batchNodeOrderErrPlugin struct{}
+
+func (p *batchNodeOrderErrPlugin) Name() string { return "batch-node-order-err" }
+
+func (p *batchNodeOrderErrPlugin) OnSessionOpen(ssn *framework.Session) {
+	ssn.AddBatchNodeOrderFn(p.Name(), func(task *api.TaskInfo, nodes []*api.NodeInfo) (map[string]float64, error) {
+		return nil, errors.New("batch node order failed")
+	})
+}
+
+func (p *batchNodeOrderErrPlugin) OnSessionClose(ssn *framework.Session) {}
+
+// TestBackfillSkipsTaskWhenNoBestNode verifies that backfill skips a task
+// instead of panicking when node scoring fails and no best node is selected.
+func TestBackfillSkipsTaskWhenNoBestNode(t *testing.T) {
+	options.ServerOpts = &options.ServerOption{
+		MinNodesToFind:             100,
+		MinPercentageOfNodesToFind: 5,
+		PercentageOfNodesToFind:    100,
+	}
+
+	test := uthelper.TestCommonStruct{
+		Name: "scoring failure leaves task unscheduled without panic",
+		Plugins: map[string]framework.PluginBuilder{
+			"batch-node-order-err": func(arguments framework.Arguments) framework.Plugin {
+				return &batchNodeOrderErrPlugin{}
+			},
+		},
+		PodGroups: []*schedulingv1beta1.PodGroup{
+			util.BuildPodGroup("pg1", "c1", "c1", 0, nil, schedulingv1beta1.PodGroupInqueue),
+		},
+		Pods: []*v1.Pod{
+			util.BuildPod("c1", "p1", "", v1.PodPending, api.BuildResourceList("0", "0"), "pg1", make(map[string]string), make(map[string]string)),
+		},
+		Nodes: []*v1.Node{
+			util.BuildNode("n1", api.BuildResourceList("2", "4Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), make(map[string]string)),
+			util.BuildNode("n2", api.BuildResourceList("2", "4Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), make(map[string]string)),
+		},
+		Queues: []*schedulingv1beta1.Queue{
+			util.BuildQueue("c1", 1, nil),
+		},
+		ExpectBindsNum: 0,
+		ExpectBindMap:  map[string]string{},
+	}
+
+	trueValue := true
+	tiers := []conf.Tier{
+		{
+			Plugins: []conf.PluginOption{
+				{
+					Name:             "batch-node-order-err",
+					EnabledNodeOrder: &trueValue,
+				},
+			},
+		},
+	}
+
+	test.RegisterSession(tiers, nil)
+	defer test.Close()
+	test.Run([]framework.Action{New()})
+	if err := test.CheckBind(0); err != nil {
+		t.Fatal(err)
 	}
 }


### PR DESCRIPTION
Manual cherry-pick of #5901 to release-1.13, requested in #5918.

The automated cherry-pick (#5918) failed because the unit test panics on release-1.13: `util.CalculateNumOfFeasibleNodesToFind` dereferences `options.ServerOpts`, which is nil in the test context on this branch. The test now initializes `options.ServerOpts` the same way the allocate action tests on release-1.13 do.

No changes to the fix itself; `backfill.go` applied cleanly.

```
$ go test ./pkg/scheduler/actions/backfill/ -v
--- PASS: TestPickUpPendingTasks (0.00s)
--- PASS: TestBackfillSkipsTaskWhenNoBestNode (0.41s)
ok      volcano.sh/volcano/pkg/scheduler/actions/backfill
```