### PR TITLE
scheduler: optimize queue status updates

### DIFF
--- a/cmd/scheduler/app/options/options.go
+++ b/cmd/scheduler/app/options/options.go
@@ -53,6 +53,7 @@ const (
 	defaultNodeWorkers                = 20
 	defaultJobUpdaterWorkerNum        = 16
 	defaultTaskUpdaterWorkerNum       = 16
+	defaultQueueUpdaterWorkerNum      = 4
 )
 
 var (
@@ -104,6 +105,8 @@ type ServerOption struct {
 	JobUpdaterWorkerNum int
 	// TaskUpdaterWorkerNum is the number of workers updating tasks concurrently for each job.
 	TaskUpdaterWorkerNum int
+	// QueueUpdaterWorkerNum is the number of workers updating queues concurrently.
+	QueueUpdaterWorkerNum int
 
 	// GateRemovalWorkerNum is the number of async workers for scheduling gate removal.
 	// Only used when SchedulingGatesQueueAdmission feature gate is enabled.
@@ -148,6 +151,14 @@ func GetTaskUpdaterWorkerNum() int {
 		return defaultTaskUpdaterWorkerNum
 	}
 	return ServerOpts.TaskUpdaterWorkerNum
+}
+
+// GetQueueUpdaterWorkerNum returns the configured queue updater worker number.
+func GetQueueUpdaterWorkerNum() int {
+	if ServerOpts == nil || ServerOpts.QueueUpdaterWorkerNum <= 0 {
+		return defaultQueueUpdaterWorkerNum
+	}
+	return ServerOpts.QueueUpdaterWorkerNum
 }
 
 // NewServerOption creates a new CMServer with a default config.
@@ -203,6 +214,7 @@ func (s *ServerOption) AddFlags(fs *pflag.FlagSet) {
 	fs.Uint32Var(&s.NodeWorkerThreads, "node-worker-threads", defaultNodeWorkers, "The number of threads syncing node operations.")
 	fs.IntVar(&s.JobUpdaterWorkerNum, "job-updater-worker-num", defaultJobUpdaterWorkerNum, "The number of workers updating jobs concurrently.")
 	fs.IntVar(&s.TaskUpdaterWorkerNum, "task-updater-worker-num", defaultTaskUpdaterWorkerNum, "The number of workers updating tasks concurrently for each job.")
+	fs.IntVar(&s.QueueUpdaterWorkerNum, "queue-updater-worker-num", defaultQueueUpdaterWorkerNum, "The number of workers updating queues concurrently.")
 	fs.IntVar(&s.GateRemovalWorkerNum, "gate-removal-worker-num", 5, "The number of async workers for scheduling gate removal (used when SchedulingGatesQueueAdmission is enabled).")
 	fs.StringSliceVar(&s.IgnoredCSIProvisioners, "ignored-provisioners", nil, "The provisioners that will be ignored during pod pvc request computation and preemption.")
 	fs.DurationVar(&s.ResourceSyncTimeout, "resource-sync-timeout", defaultResourceSyncTimeout, "timeout on waiting for handler handling initial resources synchronization before starting scheduler, default is 60s, 0 skip waiting")
@@ -218,6 +230,9 @@ func (s *ServerOption) CheckOptionOrDie() error {
 	}
 	if s.TaskUpdaterWorkerNum <= 0 {
 		return fmt.Errorf("task-updater-worker-num must be greater than 0")
+	}
+	if s.QueueUpdaterWorkerNum <= 0 {
+		return fmt.Errorf("queue-updater-worker-num must be greater than 0")
 	}
 	return componentbaseconfigvalidation.ValidateLeaderElectionConfiguration(&s.LeaderElection, field.NewPath("leaderElection")).ToAggregate()
 }

--- a/cmd/scheduler/app/options/options_test.go
+++ b/cmd/scheduler/app/options/options_test.go
@@ -85,6 +85,7 @@ func TestAddFlags(t *testing.T) {
 		NodeWorkerThreads:             defaultNodeWorkers,
 		JobUpdaterWorkerNum:           defaultJobUpdaterWorkerNum,
 		TaskUpdaterWorkerNum:          defaultTaskUpdaterWorkerNum,
+		QueueUpdaterWorkerNum:         defaultQueueUpdaterWorkerNum,
 		GateRemovalWorkerNum:          5,
 		CacheDumpFileDir:              "/tmp",
 		DisableDefaultSchedulerConfig: false,
@@ -113,6 +114,7 @@ func TestUpdaterWorkerNumFlags(t *testing.T) {
 	ServerOpts = nil
 	assert.Equal(t, defaultJobUpdaterWorkerNum, GetJobUpdaterWorkerNum())
 	assert.Equal(t, defaultTaskUpdaterWorkerNum, GetTaskUpdaterWorkerNum())
+	assert.Equal(t, defaultQueueUpdaterWorkerNum, GetQueueUpdaterWorkerNum())
 
 	fs := pflag.NewFlagSet("updater-worker-num-test", pflag.ExitOnError)
 	s := NewServerOption()
@@ -121,13 +123,16 @@ func TestUpdaterWorkerNumFlags(t *testing.T) {
 	err := fs.Parse([]string{
 		"--job-updater-worker-num=8",
 		"--task-updater-worker-num=4",
+		"--queue-updater-worker-num=2",
 	})
 	assert.NoError(t, err)
 	assert.Equal(t, 8, s.JobUpdaterWorkerNum)
 	assert.Equal(t, 4, s.TaskUpdaterWorkerNum)
+	assert.Equal(t, 2, s.QueueUpdaterWorkerNum)
 	ServerOpts = s
 	assert.Equal(t, 8, GetJobUpdaterWorkerNum())
 	assert.Equal(t, 4, GetTaskUpdaterWorkerNum())
+	assert.Equal(t, 2, GetQueueUpdaterWorkerNum())
 }
 
 func TestCheckOptionOrDieRejectsNonPositiveUpdaterWorkerNum(t *testing.T) {
@@ -145,6 +150,16 @@ func TestCheckOptionOrDieRejectsNonPositiveUpdaterWorkerNum(t *testing.T) {
 			name:    "negative task updater workers",
 			args:    []string{"--task-updater-worker-num=-1"},
 			wantErr: "task-updater-worker-num must be greater than 0",
+		},
+		{
+			name:    "zero queue updater workers",
+			args:    []string{"--queue-updater-worker-num=0"},
+			wantErr: "queue-updater-worker-num must be greater than 0",
+		},
+		{
+			name:    "negative queue updater workers",
+			args:    []string{"--queue-updater-worker-num=-1"},
+			wantErr: "queue-updater-worker-num must be greater than 0",
 		},
 	}
 

--- a/installer/helm/chart/volcano/templates/scheduler.yaml
+++ b/installer/helm/chart/volcano/templates/scheduler.yaml
@@ -235,6 +235,9 @@ spec:
             {{- if not (kindIs "invalid" .Values.custom.scheduler_task_updater_worker_num) }}
             - --task-updater-worker-num={{.Values.custom.scheduler_task_updater_worker_num}}
             {{- end }}
+            {{- if not (kindIs "invalid" .Values.custom.scheduler_queue_updater_worker_num) }}
+            - --queue-updater-worker-num={{.Values.custom.scheduler_queue_updater_worker_num}}
+            {{- end }}
             {{- if ne .Values.custom.scheduler_percentage_nodes_to_find nil }}
             - --percentage-nodes-to-find={{.Values.custom.scheduler_percentage_nodes_to_find}}
             {{- end }}

--- a/installer/helm/chart/volcano/values.yaml
+++ b/installer/helm/chart/volcano/values.yaml
@@ -66,6 +66,7 @@ custom:
   scheduler_node_worker_threads: 20
   scheduler_job_updater_worker_num: ~
   scheduler_task_updater_worker_num: ~
+  scheduler_queue_updater_worker_num: ~
   scheduler_percentage_nodes_to_find: ~
   agent_scheduler_worker_count: 1
   enabled_admissions: "/jobs/mutate,/jobs/validate,/podgroups/validate,/queues/mutate,/queues/validate,/hypernodes/validate,/cronjobs/validate"

--- a/pkg/scheduler/framework/session.go
+++ b/pkg/scheduler/framework/session.go
@@ -23,6 +23,7 @@ limitations under the License.
 package framework
 
 import (
+	"context"
 	"fmt"
 	"maps"
 	"sort"
@@ -38,6 +39,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2"
 	fwk "k8s.io/kube-scheduler/framework"
 	k8sframework "k8s.io/kubernetes/pkg/scheduler/framework"
@@ -47,6 +49,7 @@ import (
 	vcv1beta1 "volcano.sh/apis/pkg/apis/scheduling/v1beta1"
 	topologyv1alpha1 "volcano.sh/apis/pkg/apis/topology/v1alpha1"
 	vcclient "volcano.sh/apis/pkg/client/clientset/versioned"
+	"volcano.sh/volcano/cmd/scheduler/app/options"
 	"volcano.sh/volcano/pkg/scheduler/api"
 	"volcano.sh/volcano/pkg/scheduler/cache"
 	"volcano.sh/volcano/pkg/scheduler/conf"
@@ -509,48 +512,161 @@ func addNodeSharableDeviceUsage(ssn *Session, task *api.TaskInfo) {
 	}
 }
 
-// updateQueueStatus updates allocated field in queue status on session close.
-func updateQueueStatus(ssn *Session) {
+// calculateQueueAllocatedResources adds each task to its queue once,
+// then rolls queue totals up from leaves to root.
+func calculateQueueAllocatedResources(ssn *Session) (
+	map[api.QueueID]*api.Resource,
+	map[api.QueueID]map[string]*api.DRAResource,
+	error,
+) {
 	rootQueue := api.QueueID("root")
-	// calculate allocated resources on each queue
-	var allocatedResources = make(map[api.QueueID]*api.Resource, len(ssn.Queues))
-	var allocatedDRAResources = make(map[api.QueueID]map[string]*api.DRAResource, len(ssn.Queues))
-	var allocatedDRAClaimRefs = make(map[api.QueueID]map[string]int, len(ssn.Queues))
+	allocatedResources := make(map[api.QueueID]*api.Resource, len(ssn.Queues))
+	var allocatedDRAResources map[api.QueueID]*queueDRAAllocation
 	for queueID := range ssn.Queues {
-		allocatedResources[queueID] = &api.Resource{}
+		allocatedResources[queueID] = api.EmptyResource()
 	}
-	for _, job := range ssn.Jobs {
-		for status, tasks := range job.TaskStatusIndex {
-			if api.AllocatedStatus(status) {
-				for _, task := range tasks {
-					addNodeSharableDeviceUsage(ssn, task)
-					allocatedResources[job.Queue].Add(task.Resreq)
-					addTaskDRAAllocatedByQueue(allocatedDRAResources, allocatedDRAClaimRefs, job.Queue, task)
-					// recursively updates the allocated resources of parent queues
-					queue := ssn.Queues[job.Queue].Queue
-					// compatibility unit testing
-					for ssn.Queues[rootQueue] != nil {
-						parent := string(rootQueue)
-						if queue.Spec.Parent != "" {
-							parent = queue.Spec.Parent
-						}
-						allocatedResources[api.QueueID(parent)].Add(task.Resreq)
-						addTaskDRAAllocatedByQueue(allocatedDRAResources, allocatedDRAClaimRefs, api.QueueID(parent), task)
+	if len(ssn.Queues) == 0 {
+		return allocatedResources, nil, nil
+	}
 
-						if parent == string(rootQueue) {
-							break
-						}
-						queue = ssn.Queues[api.QueueID(queue.Spec.Parent)].Queue
+	root, found := ssn.Queues[rootQueue]
+	if !found || root == nil || root.Queue == nil {
+		return nil, nil, fmt.Errorf("queue hierarchy root queue <%s> does not exist", rootQueue)
+	}
+	if root.Queue.Spec.Parent != "" {
+		return nil, nil, fmt.Errorf("root queue <%s> must not have parent <%s>", rootQueue, root.Queue.Spec.Parent)
+	}
+
+	parents := make(map[api.QueueID]api.QueueID, len(ssn.Queues)-1)
+	for queueID, queue := range ssn.Queues {
+		if queue == nil || queue.Queue == nil {
+			return nil, nil, fmt.Errorf("queue <%s> has no queue object", queueID)
+		}
+		if queueID == rootQueue {
+			continue
+		}
+
+		parent := rootQueue
+		if queue.Queue.Spec.Parent != "" {
+			parent = api.QueueID(queue.Queue.Spec.Parent)
+		}
+		if _, found := ssn.Queues[parent]; !found {
+			return nil, nil, fmt.Errorf("parent queue <%s> of queue <%s> does not exist", parent, queueID)
+		}
+		parents[queueID] = parent
+	}
+
+	const (
+		queueVisiting uint8 = iota + 1
+		queueVisited
+	)
+	visitState := make(map[api.QueueID]uint8, len(ssn.Queues))
+	parentFirstOrder := make([]api.QueueID, 0, len(ssn.Queues))
+	var visitQueue func(api.QueueID) error
+	visitQueue = func(queueID api.QueueID) error {
+		switch visitState[queueID] {
+		case queueVisiting:
+			return fmt.Errorf("queue hierarchy contains a cycle at queue <%s>", queueID)
+		case queueVisited:
+			return nil
+		}
+
+		visitState[queueID] = queueVisiting
+		if queueID != rootQueue {
+			if err := visitQueue(parents[queueID]); err != nil {
+				return err
+			}
+		}
+		visitState[queueID] = queueVisited
+		parentFirstOrder = append(parentFirstOrder, queueID)
+		return nil
+	}
+	for queueID := range ssn.Queues {
+		if err := visitQueue(queueID); err != nil {
+			return nil, nil, err
+		}
+	}
+
+	for jobID, job := range ssn.Jobs {
+		if job == nil {
+			return nil, nil, fmt.Errorf("job <%s> has no job object", jobID)
+		}
+		queueValidated := false
+		for status, tasks := range job.TaskStatusIndex {
+			if !api.AllocatedStatus(status) {
+				continue
+			}
+			if len(tasks) > 0 && !queueValidated {
+				if _, found := allocatedResources[job.Queue]; !found {
+					return nil, nil, fmt.Errorf("queue <%s> of job <%s> does not exist", job.Queue, jobID)
+				}
+				queueValidated = true
+			}
+			for taskID, task := range tasks {
+				if task == nil || task.Resreq == nil {
+					return nil, nil, fmt.Errorf("allocated task <%s> of job <%s> has no resource request", taskID, jobID)
+				}
+				addNodeSharableDeviceUsage(ssn, task)
+				allocatedResources[job.Queue].Add(task.Resreq)
+				if len(task.DRAResreq) > 0 || len(task.ResourceClaimDRAResreq) > 0 {
+					if allocatedDRAResources == nil {
+						allocatedDRAResources = make(map[api.QueueID]*queueDRAAllocation)
 					}
+					allocated := allocatedDRAResources[job.Queue]
+					if allocated == nil {
+						allocated = newQueueDRAAllocation()
+						allocatedDRAResources[job.Queue] = allocated
+					}
+					allocated.addTask(task)
 				}
 			}
 		}
 	}
 
-	// update queue status
+	for i := len(parentFirstOrder) - 1; i >= 0; i-- {
+		queueID := parentFirstOrder[i]
+		if queueID == rootQueue {
+			continue
+		}
+		parentID := parents[queueID]
+		allocatedResources[parentID].Add(allocatedResources[queueID])
+		childDRA := allocatedDRAResources[queueID]
+		if childDRA == nil || childDRA.empty() {
+			continue
+		}
+		parentDRA := allocatedDRAResources[parentID]
+		if parentDRA == nil {
+			parentDRA = newQueueDRAAllocation()
+			allocatedDRAResources[parentID] = parentDRA
+		}
+		parentDRA.addChild(childDRA)
+	}
+
+	var queueDRAResources map[api.QueueID]map[string]*api.DRAResource
+	for queueID, allocated := range allocatedDRAResources {
+		total := allocated.total()
+		if len(total) == 0 {
+			continue
+		}
+		if queueDRAResources == nil {
+			queueDRAResources = make(map[api.QueueID]map[string]*api.DRAResource, len(allocatedDRAResources))
+		}
+		queueDRAResources[queueID] = total
+	}
+	return allocatedResources, queueDRAResources, nil
+}
+
+// updateQueueStatus updates allocated field in queue status on session close.
+func updateQueueStatus(ssn *Session) {
+	allocatedResources, allocatedDRAResources, err := calculateQueueAllocatedResources(ssn)
+	if err != nil {
+		klog.Errorf("failed to calculate queue allocated resources: %s", err.Error())
+		return
+	}
+
+	updates := make([]*api.QueueInfo, 0, len(ssn.Queues))
 	for queueID := range ssn.Queues {
-		// convert api.Resource to v1.ResourceList
-		var queueStatus = util.ConvertRes2ResList(allocatedResources[queueID]).DeepCopy()
+		queueStatus := util.ConvertRes2ResList(allocatedResources[queueID]).DeepCopy()
 		queueStatus = mergeDRAAllocatedIntoResourceList(queueStatus, allocatedDRAResources[queueID])
 
 		if equality.Semantic.DeepEqual(ssn.Queues[queueID].Queue.Status.Allocated, queueStatus) {
@@ -560,11 +676,15 @@ func updateQueueStatus(ssn *Session) {
 		}
 
 		ssn.Queues[queueID].Queue.Status.Allocated = queueStatus
-
-		if err := ssn.cache.UpdateQueueStatus(ssn.Queues[queueID]); err != nil {
-			klog.Errorf("failed to update queue <%s> status: %s", ssn.Queues[queueID].Name, err.Error())
-		}
+		updates = append(updates, ssn.Queues[queueID])
 	}
+
+	workqueue.ParallelizeUntil(context.TODO(), options.GetQueueUpdaterWorkerNum(), len(updates), func(piece int) {
+		queue := updates[piece]
+		if err := ssn.cache.UpdateQueueStatus(queue); err != nil {
+			klog.Errorf("failed to update queue <%s> status: %s", queue.Name, err.Error())
+		}
+	})
 }
 
 func closeSession(ssn *Session) {

--- a/pkg/scheduler/framework/session_dra_queue_status.go
+++ b/pkg/scheduler/framework/session_dra_queue_status.go
@@ -28,38 +28,81 @@ const (
 	queueDRADeviceClassCapacitySep = ".deviceclass/"
 )
 
-func addTaskDRAAllocatedByQueue(
-	allocated map[api.QueueID]map[string]*api.DRAResource,
-	resourceClaimRefs map[api.QueueID]map[string]int,
-	queueID api.QueueID,
-	task *api.TaskInfo,
-) {
+type queueDRAAllocation struct {
+	// unattributed contains DRA resources that cannot be associated with an
+	// individual ResourceClaim and therefore cannot be deduplicated.
+	unattributed map[string]*api.DRAResource
+	// claims contains DRA resources keyed by ResourceClaim. Keeping the claim
+	// identity allows ancestors to deduplicate claims shared by descendants.
+	claims map[string]map[string]*api.DRAResource
+}
+
+func newQueueDRAAllocation() *queueDRAAllocation {
+	return &queueDRAAllocation{}
+}
+
+func (allocated *queueDRAAllocation) addTask(task *api.TaskInfo) {
 	if task == nil {
 		return
 	}
 
-	if allocated[queueID] == nil {
-		allocated[queueID] = make(map[string]*api.DRAResource)
-	}
-	if resourceClaimRefs[queueID] == nil {
-		resourceClaimRefs[queueID] = make(map[string]int)
-	}
-
 	if len(task.ResourceClaimDRAResreq) == 0 {
-		mergeDRAResourceMap(allocated[queueID], task.DRAResreq)
+		if len(task.DRAResreq) == 0 {
+			return
+		}
+		if allocated.unattributed == nil {
+			allocated.unattributed = make(map[string]*api.DRAResource)
+		}
+		mergeDRAResourceMap(allocated.unattributed, task.DRAResreq)
 		return
 	}
 
 	for _, claimKey := range task.ResourceClaimKeys {
+		if _, found := allocated.claims[claimKey]; found {
+			continue
+		}
 		claimReq := task.ResourceClaimDRAResreq[claimKey]
 		if len(claimReq) == 0 {
 			continue
 		}
-		if resourceClaimRefs[queueID][claimKey] == 0 {
-			mergeDRAResourceMap(allocated[queueID], claimReq)
+		if allocated.claims == nil {
+			allocated.claims = make(map[string]map[string]*api.DRAResource)
 		}
-		resourceClaimRefs[queueID][claimKey]++
+		allocated.claims[claimKey] = claimReq
 	}
+}
+
+func (allocated *queueDRAAllocation) addChild(child *queueDRAAllocation) {
+	if len(child.unattributed) > 0 {
+		if allocated.unattributed == nil {
+			allocated.unattributed = make(map[string]*api.DRAResource)
+		}
+		mergeDRAResourceMap(allocated.unattributed, child.unattributed)
+	}
+	if len(child.claims) > 0 && allocated.claims == nil {
+		allocated.claims = make(map[string]map[string]*api.DRAResource)
+	}
+	for claimKey, claimReq := range child.claims {
+		if _, found := allocated.claims[claimKey]; !found {
+			allocated.claims[claimKey] = claimReq
+		}
+	}
+}
+
+func (allocated *queueDRAAllocation) empty() bool {
+	return allocated == nil || len(allocated.unattributed) == 0 && len(allocated.claims) == 0
+}
+
+func (allocated *queueDRAAllocation) total() map[string]*api.DRAResource {
+	if allocated.empty() {
+		return nil
+	}
+	total := make(map[string]*api.DRAResource)
+	mergeDRAResourceMap(total, allocated.unattributed)
+	for _, claimReq := range allocated.claims {
+		mergeDRAResourceMap(total, claimReq)
+	}
+	return total
 }
 
 func mergeDRAResourceMap(dst map[string]*api.DRAResource, src map[string]*api.DRAResource) {

--- a/pkg/scheduler/framework/session_dra_queue_status_test.go
+++ b/pkg/scheduler/framework/session_dra_queue_status_test.go
@@ -25,10 +25,8 @@ import (
 	"volcano.sh/volcano/pkg/scheduler/api"
 )
 
-func TestAddTaskDRAAllocatedByQueueDeduplicatesSharedClaims(t *testing.T) {
-	queueID := api.QueueID("q1")
-	allocated := make(map[api.QueueID]map[string]*api.DRAResource)
-	resourceClaimRefs := make(map[api.QueueID]map[string]int)
+func TestQueueDRAAllocationDeduplicatesSharedClaims(t *testing.T) {
+	allocated := newQueueDRAAllocation()
 
 	taskA := &api.TaskInfo{
 		ResourceClaimKeys: []string{"ns1/shared"},
@@ -47,12 +45,51 @@ func TestAddTaskDRAAllocatedByQueueDeduplicatesSharedClaims(t *testing.T) {
 		},
 	}
 
-	addTaskDRAAllocatedByQueue(allocated, resourceClaimRefs, queueID, taskA)
-	addTaskDRAAllocatedByQueue(allocated, resourceClaimRefs, queueID, taskB)
+	allocated.addTask(taskA)
+	allocated.addTask(taskB)
 
-	got := allocated[queueID]["gpu.example.com"]
+	got := allocated.total()["gpu.example.com"]
 	if got == nil || got.Count != 1 {
 		t.Fatalf("expected shared claim to be charged once, got %#v", got)
+	}
+}
+
+func TestCalculateQueueAllocatedResourcesDeduplicatesSharedClaimsAcrossSiblingQueues(t *testing.T) {
+	sharedTask := func(uid string) *api.TaskInfo {
+		task := newTaskInfo(uid, api.Running, v1.ResourceList{})
+		task.ResourceClaimKeys = []string{"ns1/shared"}
+		task.ResourceClaimDRAResreq = map[string]map[string]*api.DRAResource{
+			"ns1/shared": {
+				"gpu.example.com": {Count: 1},
+			},
+		}
+		return task
+	}
+
+	ssn := &Session{
+		Jobs: map[api.JobID]*api.JobInfo{
+			"job-a": newJobInfo("job-a", "leaf-a", sharedTask("task-a")),
+			"job-b": newJobInfo("job-b", "leaf-b", sharedTask("task-b")),
+		},
+		Nodes: map[string]*api.NodeInfo{},
+		Queues: map[api.QueueID]*api.QueueInfo{
+			"root":   newQueueInfo("root", ""),
+			"team":   newQueueInfo("team", "root"),
+			"leaf-a": newQueueInfo("leaf-a", "team"),
+			"leaf-b": newQueueInfo("leaf-b", "team"),
+		},
+	}
+
+	_, allocatedDRA, err := calculateQueueAllocatedResources(ssn)
+	if err != nil {
+		t.Fatalf("calculateQueueAllocatedResources returned error: %v", err)
+	}
+
+	for _, queueID := range []api.QueueID{"leaf-a", "leaf-b", "team", "root"} {
+		got := allocatedDRA[queueID]["gpu.example.com"]
+		if got == nil || got.Count != 1 {
+			t.Fatalf("expected queue %q to charge the shared claim once, got %#v", queueID, got)
+		}
 	}
 }
 

--- a/pkg/scheduler/framework/session_queue_test.go
+++ b/pkg/scheduler/framework/session_queue_test.go
@@ -1,0 +1,412 @@
+/*
+Copyright 2026 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package framework
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"volcano.sh/apis/pkg/apis/scheduling"
+	"volcano.sh/volcano/cmd/scheduler/app/options"
+	"volcano.sh/volcano/pkg/scheduler/api"
+	schedcache "volcano.sh/volcano/pkg/scheduler/cache"
+)
+
+const queueUpdateTestTimeout = 2 * time.Second
+
+var benchmarkQueueAllocatedResources map[api.QueueID]*api.Resource
+
+func newQueueInfo(name, parent string) *api.QueueInfo {
+	return api.NewQueueInfo(&scheduling.Queue{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec: scheduling.QueueSpec{
+			Weight: 1,
+			Parent: parent,
+		},
+	})
+}
+
+func newTaskInfo(uid string, status api.TaskStatus, resources v1.ResourceList) *api.TaskInfo {
+	return &api.TaskInfo{
+		UID:                api.TaskID(uid),
+		Resreq:             api.NewResource(resources),
+		TransactionContext: api.TransactionContext{Status: status},
+	}
+}
+
+func newJobInfo(uid, queue string, tasks ...*api.TaskInfo) *api.JobInfo {
+	job := api.NewJobInfo(api.JobID(uid), tasks...)
+	job.Queue = api.QueueID(queue)
+	return job
+}
+
+func queueTestResourceList(cpu, memory, scalar string) v1.ResourceList {
+	resources := v1.ResourceList{
+		v1.ResourceCPU:    resource.MustParse(cpu),
+		v1.ResourceMemory: resource.MustParse(memory),
+	}
+	if scalar != "" {
+		resources[v1.ResourceName("example.com/accelerator")] = resource.MustParse(scalar)
+	}
+	return resources
+}
+
+func assertQueueResource(t *testing.T, got *api.Resource, cpu, memory, scalar float64) {
+	t.Helper()
+	if got == nil {
+		t.Fatal("expected queue resource, got nil")
+	}
+	if got.MilliCPU != cpu || got.Memory != memory || got.ScalarResources[v1.ResourceName("example.com/accelerator")] != scalar {
+		t.Fatalf("unexpected queue resource: got %v, want cpu %.0f, memory %.0f, scalar %.0f", got, cpu, memory, scalar)
+	}
+}
+
+func TestCalculateQueueAllocatedResourcesBottomUp(t *testing.T) {
+	leafTask := newTaskInfo("leaf-running", api.Running, queueTestResourceList("1", "1Gi", "2"))
+	leafPendingTask := newTaskInfo("leaf-pending", api.Pending, queueTestResourceList("4", "4Gi", "4"))
+	teamTask := newTaskInfo("team-allocated", api.Allocated, queueTestResourceList("500m", "512Mi", "1"))
+	topLevelTask := newTaskInfo("top-level-bound", api.Bound, queueTestResourceList("250m", "256Mi", "3"))
+
+	ssn := &Session{
+		Jobs: map[api.JobID]*api.JobInfo{
+			"leaf-job":      newJobInfo("leaf-job", "leaf", leafTask, leafPendingTask),
+			"team-job":      newJobInfo("team-job", "team", teamTask),
+			"top-level-job": newJobInfo("top-level-job", "top-level", topLevelTask),
+		},
+		Nodes: map[string]*api.NodeInfo{},
+		Queues: map[api.QueueID]*api.QueueInfo{
+			"root":      newQueueInfo("root", ""),
+			"team":      newQueueInfo("team", "root"),
+			"leaf":      newQueueInfo("leaf", "team"),
+			"top-level": newQueueInfo("top-level", ""),
+		},
+	}
+
+	allocated, _, err := calculateQueueAllocatedResources(ssn)
+	if err != nil {
+		t.Fatalf("calculateQueueAllocatedResources returned error: %v", err)
+	}
+
+	assertQueueResource(t, allocated["leaf"], 1000, float64(1<<30), 2000)
+	assertQueueResource(t, allocated["team"], 1500, float64(3*(1<<29)), 3000)
+	assertQueueResource(t, allocated["top-level"], 250, float64(1<<28), 3000)
+	assertQueueResource(t, allocated["root"], 1750, float64(7*(1<<28)), 6000)
+}
+
+func TestCalculateQueueAllocatedResourcesDoesNotCreateEmptyDRAResults(t *testing.T) {
+	ssn := &Session{
+		Jobs: map[api.JobID]*api.JobInfo{
+			"job": newJobInfo("job", "leaf", newTaskInfo("task", api.Running, queueTestResourceList("1", "1Gi", ""))),
+		},
+		Nodes: map[string]*api.NodeInfo{},
+		Queues: map[api.QueueID]*api.QueueInfo{
+			"root": newQueueInfo("root", ""),
+			"leaf": newQueueInfo("leaf", "root"),
+		},
+	}
+
+	_, allocatedDRA, err := calculateQueueAllocatedResources(ssn)
+	if err != nil {
+		t.Fatalf("calculateQueueAllocatedResources returned error: %v", err)
+	}
+	if allocatedDRA != nil {
+		t.Fatalf("expected no DRA result for queues without DRA resources, got %v", allocatedDRA)
+	}
+}
+
+func TestCalculateQueueAllocatedResourcesRejectsInvalidHierarchy(t *testing.T) {
+	tests := []struct {
+		name    string
+		queues  map[api.QueueID]*api.QueueInfo
+		wantErr string
+	}{
+		{
+			name: "missing root",
+			queues: map[api.QueueID]*api.QueueInfo{
+				"leaf": newQueueInfo("leaf", ""),
+			},
+			wantErr: "root queue",
+		},
+		{
+			name: "root has parent",
+			queues: map[api.QueueID]*api.QueueInfo{
+				"root": newQueueInfo("root", "parent"),
+			},
+			wantErr: "must not have parent",
+		},
+		{
+			name: "missing parent",
+			queues: map[api.QueueID]*api.QueueInfo{
+				"root": newQueueInfo("root", ""),
+				"leaf": newQueueInfo("leaf", "missing"),
+			},
+			wantErr: "missing",
+		},
+		{
+			name: "cycle",
+			queues: map[api.QueueID]*api.QueueInfo{
+				"root":    newQueueInfo("root", ""),
+				"queue-a": newQueueInfo("queue-a", "queue-b"),
+				"queue-b": newQueueInfo("queue-b", "queue-a"),
+			},
+			wantErr: "cycle",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, err := calculateQueueAllocatedResources(&Session{
+				Jobs:   map[api.JobID]*api.JobInfo{},
+				Nodes:  map[string]*api.NodeInfo{},
+				Queues: tt.queues,
+			})
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("expected error containing %q, got %v", tt.wantErr, err)
+			}
+		})
+	}
+}
+
+type countingQueueUpdateCache struct {
+	schedcache.Cache
+
+	mu      sync.Mutex
+	updates int
+}
+
+func (c *countingQueueUpdateCache) UpdateQueueStatus(_ *api.QueueInfo) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.updates++
+	return nil
+}
+
+func (c *countingQueueUpdateCache) updateCount() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.updates
+}
+
+func TestUpdateQueueStatusDoesNotWriteInvalidHierarchy(t *testing.T) {
+	cache := &countingQueueUpdateCache{}
+	ssn := &Session{
+		cache: cache,
+		Jobs:  map[api.JobID]*api.JobInfo{},
+		Nodes: map[string]*api.NodeInfo{},
+		Queues: map[api.QueueID]*api.QueueInfo{
+			"root": newQueueInfo("root", ""),
+			"leaf": newQueueInfo("leaf", "missing"),
+		},
+	}
+
+	updateQueueStatus(ssn)
+
+	if got := cache.updateCount(); got != 0 {
+		t.Fatalf("expected no queue writes, got %d", got)
+	}
+}
+
+type blockingQueueUpdateTracker struct {
+	entered chan string
+	release <-chan struct{}
+
+	mu      sync.Mutex
+	updates []string
+}
+
+func (t *blockingQueueUpdateTracker) track(name string) {
+	t.mu.Lock()
+	t.updates = append(t.updates, name)
+	t.mu.Unlock()
+	t.entered <- name
+	<-t.release
+}
+
+func (t *blockingQueueUpdateTracker) updateNames() []string {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return append([]string(nil), t.updates...)
+}
+
+type blockingQueueUpdateCache struct {
+	schedcache.Cache
+	tracker *blockingQueueUpdateTracker
+}
+
+func (c *blockingQueueUpdateCache) UpdateQueueStatus(queue *api.QueueInfo) error {
+	c.tracker.track(queue.Name)
+	return nil
+}
+
+func TestUpdateQueueStatusHonorsWorkerLimit(t *testing.T) {
+	const (
+		workerNum    = 4
+		normalQueues = 8
+	)
+
+	release := make(chan struct{})
+	var releaseOnce sync.Once
+	releaseUpdates := func() {
+		releaseOnce.Do(func() { close(release) })
+	}
+	t.Cleanup(releaseUpdates)
+
+	tracker := &blockingQueueUpdateTracker{
+		entered: make(chan string, normalQueues+2),
+		release: release,
+	}
+	cache := &blockingQueueUpdateCache{tracker: tracker}
+
+	queues := map[api.QueueID]*api.QueueInfo{
+		"root": newQueueInfo("root", ""),
+	}
+	for i := 0; i < normalQueues; i++ {
+		name := fmt.Sprintf("queue-%d", i)
+		queues[api.QueueID(name)] = newQueueInfo(name, "root")
+	}
+
+	originalOptions := options.ServerOpts
+	options.ServerOpts = &options.ServerOption{QueueUpdaterWorkerNum: workerNum}
+	t.Cleanup(func() { options.ServerOpts = originalOptions })
+
+	ssn := &Session{
+		cache:  cache,
+		Jobs:   map[api.JobID]*api.JobInfo{},
+		Nodes:  map[string]*api.NodeInfo{},
+		Queues: queues,
+	}
+	done := make(chan struct{})
+	go func() {
+		updateQueueStatus(ssn)
+		close(done)
+	}()
+
+	for i := 0; i < workerNum; i++ {
+		select {
+		case <-tracker.entered:
+		case <-time.After(queueUpdateTestTimeout):
+			t.Fatalf("timed out waiting for %d concurrent queue updates", workerNum)
+		}
+	}
+	select {
+	case name := <-tracker.entered:
+		t.Fatalf("worker limit exceeded: a fifth update for %q started before release", name)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	releaseUpdates()
+	select {
+	case <-done:
+	case <-time.After(queueUpdateTestTimeout):
+		t.Fatal("timed out waiting for queue status updates to finish")
+	}
+
+	updateCounts := make(map[string]int)
+	for _, name := range tracker.updateNames() {
+		updateCounts[name]++
+	}
+	if len(updateCounts) != len(queues) {
+		t.Fatalf("expected %d queues to be updated, got %d: %v", len(queues), len(updateCounts), updateCounts)
+	}
+	for name, count := range updateCounts {
+		if count != 1 {
+			t.Fatalf("expected queue %q to be updated once, got %d", name, count)
+		}
+	}
+}
+
+func legacyQueueAllocatedResources(ssn *Session) map[api.QueueID]*api.Resource {
+	rootQueue := api.QueueID("root")
+	allocatedResources := make(map[api.QueueID]*api.Resource, len(ssn.Queues))
+	for queueID := range ssn.Queues {
+		allocatedResources[queueID] = api.EmptyResource()
+	}
+	for _, job := range ssn.Jobs {
+		for status, tasks := range job.TaskStatusIndex {
+			if !api.AllocatedStatus(status) {
+				continue
+			}
+			for _, task := range tasks {
+				allocatedResources[job.Queue].Add(task.Resreq)
+				queue := ssn.Queues[job.Queue].Queue
+				for ssn.Queues[rootQueue] != nil {
+					parent := string(rootQueue)
+					if queue.Spec.Parent != "" {
+						parent = queue.Spec.Parent
+					}
+					allocatedResources[api.QueueID(parent)].Add(task.Resreq)
+					if parent == string(rootQueue) {
+						break
+					}
+					queue = ssn.Queues[api.QueueID(queue.Spec.Parent)].Queue
+				}
+			}
+		}
+	}
+	return allocatedResources
+}
+
+func BenchmarkCalculateQueueAllocatedResources(b *testing.B) {
+	const (
+		queueDepth = 8
+		taskCount  = 2000
+	)
+
+	queues := map[api.QueueID]*api.QueueInfo{
+		"root": newQueueInfo("root", ""),
+	}
+	parent := "root"
+	for i := 0; i < queueDepth; i++ {
+		name := fmt.Sprintf("queue-%d", i)
+		queues[api.QueueID(name)] = newQueueInfo(name, parent)
+		parent = name
+	}
+	tasks := make([]*api.TaskInfo, 0, taskCount)
+	for i := 0; i < taskCount; i++ {
+		tasks = append(tasks, newTaskInfo(fmt.Sprintf("task-%d", i), api.Running, queueTestResourceList("1m", "1Mi", "")))
+	}
+	job := newJobInfo("benchmark-job", parent, tasks...)
+	ssn := &Session{
+		Jobs:   map[api.JobID]*api.JobInfo{job.UID: job},
+		Nodes:  map[string]*api.NodeInfo{},
+		Queues: queues,
+	}
+
+	b.Run("legacy-per-task-ancestors", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			benchmarkQueueAllocatedResources = legacyQueueAllocatedResources(ssn)
+		}
+	})
+	b.Run("bottom-up", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			var err error
+			benchmarkQueueAllocatedResources, _, err = calculateQueueAllocatedResources(ssn)
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/area performance

#### What this PR does / why we need it:

`CloseSession` currently calculates Queue allocations by walking from every allocated task to the root Queue, then writes changed Queue status objects sequentially. The repeated ancestor walks and serialized API calls increase the `updateQueueStatus` stage latency.

This PR:

- validates the Queue hierarchy once and aggregates regular resources bottom-up, reducing that calculation from approximately `O(A * D)` to `O(A + Q)` for `A` allocated tasks, hierarchy depth `D`, and `Q` queues;
- keeps DRA resources associated with their ResourceClaim while rolling them up, so a claim shared by sibling queues is charged only once to each ancestor;
- collects only changed Queue objects and updates them with a bounded worker pool while keeping `CloseSession` synchronous;
- adds `--queue-updater-worker-num`, defaults it to 4, rejects non-positive values, and exposes it through Helm without overriding the Go default when the Helm value is null; and
- rejects missing parents and hierarchy cycles before issuing any Queue status writes.

Each Queue appears at most once in the worker input, and Session Queue objects remain isolated from scheduler-cache objects through the existing `QueueInfo.Clone` deep copy.

#### Which issue(s) this PR fixes:

Fixes #5921

#### Special notes for your reviewer:

Local calculation benchmark on Apple M4 with 2,000 allocated tasks and an 8-level Queue hierarchy (`-benchtime=1s -count=3`):

- per-task ancestor walk: 1.28-1.43 ms/op
- bottom-up aggregation: 0.177-0.204 ms/op

This microbenchmark covers resource calculation only; the linked issue contains an observational end-to-end `updateQueueStatus` stage comparison.

Validation:

- `go test ./cmd/scheduler/app/options ./pkg/scheduler/api ./pkg/scheduler/framework`
- `go test -race ./cmd/scheduler/app/options ./pkg/scheduler/framework`
- concurrency and aggregation tests repeated 20 times
- `make verify`
- Helm lint plus default, zero, and explicit worker-value rendering

`make unit-test` was also attempted. All scheduler packages passed, but the overall Darwin run fails in unrelated Linux-only agent/cgroup packages with build-constraint and Linux symbol errors. The same failures reproduce on the unchanged `upstream/master` checkout.

AI disclosure: Codex assisted with adapting the reviewed downstream change to current upstream, testing, and PR preparation. I reviewed the final diff and validation results.

Prompt summary: "Optimize CloseSession Queue resource calculation, add configurable bounded Queue update concurrency with a default of 4, review concurrency safety, and submit an upstream PR."

Queues rise through Volcano's glow,
Four steady workers keep updates in flow.

#### Does this PR introduce a user-facing change?

```release-note
vc-scheduler now aggregates hierarchical Queue allocations bottom-up and supports --queue-updater-worker-num to control concurrent Queue status updates (default 4).
```
