### PR TITLE
job scheduler: fix proportion plugin blocking untracked resources on queue checks

### DIFF
--- a/pkg/scheduler/actions/allocate/allocate.go
+++ b/pkg/scheduler/actions/allocate/allocate.go
@@ -947,14 +947,23 @@ func (alloc *Action) prioritizeNodes(ssn *framework.Session, task *api.TaskInfo,
 	var futureIdleCandidateNodes []*api.NodeInfo
 	var idleCandidateNodesInOtherShards []*api.NodeInfo
 	var futureIdleCandidateNodesInOtherShards []*api.NodeInfo
+	// fitsResourcePool reports whether task fits in pool, treating a shortfall confined to
+	// resource dimensions node.Allocatable has no entry for at all as fitting. Every node reaching
+	// this loop already passed alloc.predicate, which applies the identical fallback, so a node
+	// filtered out here purely by an untracked dimension would otherwise be dropped from every
+	// candidate bucket and never scored, even though the real predicate already accepted it.
+	fitsResourcePool := func(pool *api.Resource, node *api.NodeInfo) bool {
+		ok, resources := task.InitResreq.LessEqualWithResourcesName(pool, api.Zero)
+		return ok || api.AllUntrackedByAllocatable(resources, node)
+	}
 	for _, n := range predicateNodes {
-		if task.InitResreq.LessEqual(n.Idle, api.Zero) {
+		if fitsResourcePool(n.Idle, n) {
 			if shardingMode == commonutil.SoftShardingMode && !ssn.NodesInShard.Has(n.Name) {
 				idleCandidateNodesInOtherShards = append(idleCandidateNodesInOtherShards, n)
 			} else {
 				idleCandidateNodes = append(idleCandidateNodes, n)
 			}
-		} else if task.InitResreq.LessEqual(n.FutureIdle(), api.Zero) {
+		} else if fitsResourcePool(n.FutureIdle(), n) {
 			if shardingMode == commonutil.SoftShardingMode && !ssn.NodesInShard.Has(n.Name) {
 				futureIdleCandidateNodesInOtherShards = append(futureIdleCandidateNodesInOtherShards, n)
 			} else {
@@ -1008,7 +1017,12 @@ func (alloc *Action) prioritizeNodes(ssn *framework.Session, task *api.TaskInfo,
 
 func (alloc *Action) allocateResourcesForTask(stmt *framework.Statement, task *api.TaskInfo, node *api.NodeInfo, job *api.JobInfo) (err error) {
 	// Allocate idle resource to the task.
-	if task.InitResreq.LessEqual(node.Idle, api.Zero) {
+	// Same fallback as alloc.predicate: a resource dimension node.Allocatable has no entry for
+	// at all can never pass this arithmetic, no matter how much room the device-aware predicate
+	// (already consulted for this node back in alloc.predicate) actually allows. Without it, a
+	// node that predicate/prioritizeNodes correctly selected would silently fail to bind here,
+	// with neither an error nor any task movement.
+	if ok, resources := task.InitResreq.LessEqualWithResourcesName(node.Idle, api.Zero); ok || api.AllUntrackedByAllocatable(resources, node) {
 		klog.V(3).Infof("Binding Task <%v/%v> to node <%v>", task.Namespace, task.Name, node.Name)
 		if err = stmt.Allocate(task, node); err != nil {
 			klog.Errorf("Failed to bind Task %v on %v in Session %v, err: %v",
@@ -1024,7 +1038,7 @@ func (alloc *Action) allocateResourcesForTask(stmt *framework.Statement, task *a
 		task.Namespace, task.Name, node.Name)
 
 	// Allocate releasing resource to the task if any.
-	if task.InitResreq.LessEqual(node.FutureIdle(), api.Zero) {
+	if ok, resources := task.InitResreq.LessEqualWithResourcesName(node.FutureIdle(), api.Zero); ok || api.AllUntrackedByAllocatable(resources, node) {
 		klog.V(3).Infof("Pipelining Task <%v/%v> to node <%v> for <%v> on <%v>",
 			task.Namespace, task.Name, node.Name, task.InitResreq, node.Releasing)
 		if err = stmt.Pipeline(task, node.Name, false); err != nil {
@@ -1039,9 +1053,16 @@ func (alloc *Action) allocateResourcesForTask(stmt *framework.Statement, task *a
 }
 
 func (alloc *Action) predicate(task *api.TaskInfo, node *api.NodeInfo) error {
-	// Check for Resource Predicate
+	// Check for Resource Predicate. This generic scalar-resource comparison is only trustworthy
+	// for resources node.Allocatable actually carries a capacity number for (cpu, memory,
+	// volcano.sh/vgpu-number, ...). A resource a device plugin tracks entirely through its own
+	// ledger instead (like volcano.sh/vgpu-memory-percentage, a pure request-side modifier with
+	// no coherent node-wide total to advertise) can never pass this check, no matter how much
+	// room the device plugin's own predicate would actually allow. When the shortfall is confined
+	// to dimensions node.Allocatable has no entry for at all, treat that as inconclusive rather
+	// than a hard no and let the real predicate, called right below, decide instead.
 	var statusSets api.StatusSets
-	if ok, resources := task.InitResreq.LessEqualWithResourcesName(node.FutureIdle(), api.Zero); !ok {
+	if ok, resources := task.InitResreq.LessEqualWithResourcesName(node.FutureIdle(), api.Zero); !ok && !api.AllUntrackedByAllocatable(resources, node) {
 		statusSets = append(statusSets, &api.Status{Code: api.Unschedulable, Reason: api.WrapInsufficientResourceReason(resources)})
 		return api.NewFitErrWithStatus(task, node, statusSets...)
 	}

--- a/pkg/scheduler/actions/allocate/allocate_test.go
+++ b/pkg/scheduler/actions/allocate/allocate_test.go
@@ -6318,14 +6318,24 @@ func TestAllocateUntrackedResourceDefersToPredicate(t *testing.T) {
 			util.BuildPodGroup("pg1", "c1", "q1", 1, nil, schedulingv1.PodGroupInqueue),
 		},
 		Pods: []*v1.Pod{
+			// vgpu-memory-percentage is never requested on its own in practice - the API
+			// requires vgpu-number (or vgpu-memory) alongside it. Both are requested here;
+			// only vgpu-memory-percentage is untracked in n1's Allocatable below, which is
+			// the one dimension this test is actually exercising.
 			util.BuildPod("c1", "p1", "", v1.PodPending,
-				api.BuildResourceList("1", "1G", api.ScalarResource{Name: "volcano.sh/vgpu-memory-percentage", Value: "50"}),
+				api.BuildResourceList("1", "1G",
+					api.ScalarResource{Name: "volcano.sh/vgpu-number", Value: "1"},
+					api.ScalarResource{Name: "volcano.sh/vgpu-memory-percentage", Value: "50"},
+				),
 				"pg1", make(map[string]string), make(map[string]string)),
 		},
-		// n1's Allocatable deliberately carries no volcano.sh/vgpu-memory-percentage entry at
-		// all, and the node is otherwise fully idle.
+		// n1's Allocatable tracks vgpu-number like a real HAMi node, but deliberately carries
+		// no volcano.sh/vgpu-memory-percentage entry at all; the node is otherwise fully idle.
 		Nodes: []*v1.Node{
-			util.BuildNode("n1", api.BuildResourceList("2", "2G", []api.ScalarResource{{Name: "pods", Value: "10"}}...), make(map[string]string)),
+			util.BuildNode("n1", api.BuildResourceList("2", "2G", []api.ScalarResource{
+				{Name: "pods", Value: "10"},
+				{Name: "volcano.sh/vgpu-number", Value: "1"},
+			}...), make(map[string]string)),
 		},
 		Queues: []*schedulingv1.Queue{
 			util.BuildQueue("q1", 1, nil),

--- a/pkg/scheduler/actions/allocate/allocate_test.go
+++ b/pkg/scheduler/actions/allocate/allocate_test.go
@@ -6272,3 +6272,85 @@ func TestAllocate_NominatedJobWinsOverRegularJob(t *testing.T) {
 	assert.Equal(t, "", nominatedSubJob.NominatedHyperNode,
 		"flat-path commit must clear subJob.NominatedHyperNode after binding")
 }
+
+const untrackedResourceAllocatePluginName = "device-fit-allocate"
+
+type untrackedResourceAllocatePlugin struct{}
+
+func (p *untrackedResourceAllocatePlugin) Name() string {
+	return untrackedResourceAllocatePluginName
+}
+
+func (p *untrackedResourceAllocatePlugin) OnSessionOpen(ssn *framework.Session) {
+	ssn.AddPredicateFn(p.Name(), func(task *api.TaskInfo, node *api.NodeInfo) error {
+		if task.Name != "p1" {
+			return nil
+		}
+		// Stands in for a device plugin (e.g. deviceshare/HAMi) that tracks
+		// volcano.sh/vgpu-memory-percentage on its own ledger and confirms the
+		// request fits, independent of node.Status.Allocatable.
+		return nil
+	})
+}
+
+func (p *untrackedResourceAllocatePlugin) OnSessionClose(ssn *framework.Session) {}
+
+// TestAllocateUntrackedResourceDefersToPredicate covers the allocate-action counterpart of the
+// #4863-class bug already fixed in preempt/reclaim: a task requesting a resource dimension the
+// node never advertises in Allocatable at all (volcano.sh/vgpu-memory-percentage here, mirroring
+// HAMi's fractional vGPU resource) must not be rejected by the generic scalar-resource arithmetic
+// in alloc.predicate or filtered out of every scoring bucket in prioritizeNodes, before the real
+// device-aware predicate ever gets a say. The node here is otherwise completely idle, so a pass
+// depends entirely on both of those functions falling back correctly.
+func TestAllocateUntrackedResourceDefersToPredicate(t *testing.T) {
+	trueValue := true
+	plugins := map[string]framework.PluginBuilder{
+		gang.PluginName:       gang.New,
+		proportion.PluginName: proportion.New,
+		untrackedResourceAllocatePluginName: func(framework.Arguments) framework.Plugin {
+			return &untrackedResourceAllocatePlugin{}
+		},
+	}
+	test := uthelper.TestCommonStruct{
+		Name:    "allocate binds a task requesting a resource untracked in node.Allocatable",
+		Plugins: plugins,
+		PodGroups: []*schedulingv1.PodGroup{
+			util.BuildPodGroup("pg1", "c1", "q1", 1, nil, schedulingv1.PodGroupInqueue),
+		},
+		Pods: []*v1.Pod{
+			util.BuildPod("c1", "p1", "", v1.PodPending,
+				api.BuildResourceList("1", "1G", api.ScalarResource{Name: "volcano.sh/vgpu-memory-percentage", Value: "50"}),
+				"pg1", make(map[string]string), make(map[string]string)),
+		},
+		// n1's Allocatable deliberately carries no volcano.sh/vgpu-memory-percentage entry at
+		// all, and the node is otherwise fully idle.
+		Nodes: []*v1.Node{
+			util.BuildNode("n1", api.BuildResourceList("2", "2G", []api.ScalarResource{{Name: "pods", Value: "10"}}...), make(map[string]string)),
+		},
+		Queues: []*schedulingv1.Queue{
+			util.BuildQueue("q1", 1, nil),
+		},
+		ExpectBindMap: map[string]string{
+			"c1/p1": "n1",
+		},
+		ExpectBindsNum: 1,
+	}
+	// proportion's Allocatable reuses the same queueAllocatable arithmetic that its Preemptive
+	// and Reclaimable checks do, and has this identical untracked-resource gap independently (a
+	// separate, pre-existing bug in that plugin, out of scope here). Disabled so this test
+	// isolates the fix in alloc.predicate/prioritizeNodes.
+	tiers := []conf.Tier{{
+		Plugins: []conf.PluginOption{
+			{Name: gang.PluginName, EnabledJobStarving: &trueValue, EnabledJobPipelined: &trueValue},
+			{Name: proportion.PluginName, EnabledOverused: &trueValue, EnabledQueueOrder: &trueValue},
+			{Name: untrackedResourceAllocatePluginName, EnabledPredicate: &trueValue},
+		},
+	}}
+
+	test.RegisterSession(tiers, nil)
+	defer test.Close()
+	test.Run([]framework.Action{New()})
+	if err := test.CheckAll(0); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/pkg/scheduler/actions/preempt/preempt.go
+++ b/pkg/scheduler/actions/preempt/preempt.go
@@ -429,12 +429,20 @@ func (pmpt *Action) normalPreempt(
 // 2. The cluster has no free resources, and the queue is not allocatable.
 // 3. The cluster has no free resources, but the queue is allocatable.
 // 4. The node has sufficient aggregate resources, but PredicateFn fails because vNPU or vGPU resources are fragmented.
-// Same-queue preemption handles cases 1 and 2. Reclaim handles case 3. For case 4, normal preemption continues until
-// the predicate passes after enough victims are evicted.
+// 5. The preemptor requests a resource dimension no node advertises in Allocatable at all, such as
+// volcano.sh/vgpu-memory-percentage, which a device plugin tracks entirely on its own. The generic
+// resource comparison below can't tell that apart from a genuine shortfall, so it treats a shortfall
+// confined to untracked dimensions as inconclusive and defers to PredicateFn instead of rejecting outright.
+// Same-queue preemption handles cases 1 and 2. Reclaim handles case 3. For cases 4 and 5, normal preemption
+// continues until the predicate passes after enough victims are evicted.
 func preemptorFitsOnNode(ssn *framework.Session, queue *api.QueueInfo, preemptor *api.TaskInfo, node *api.NodeInfo) bool {
-	return ssn.Allocatable(queue, preemptor) &&
-		preemptor.InitResreq.LessEqual(node.FutureIdle(), api.Zero) &&
-		ssn.PredicateFn(preemptor, node) == nil
+	if !ssn.Allocatable(queue, preemptor) {
+		return false
+	}
+	if ok, failing := preemptor.InitResreq.LessEqualWithResourcesName(node.FutureIdle(), api.Zero); !ok && !api.AllUntrackedByAllocatable(failing, node) {
+		return false
+	}
+	return ssn.PredicateFn(preemptor, node) == nil
 }
 
 func (pmpt *Action) taskEligibleToPreempt(preemptor *api.TaskInfo) error {

--- a/pkg/scheduler/actions/preempt/preempt_test.go
+++ b/pkg/scheduler/actions/preempt/preempt_test.go
@@ -508,7 +508,14 @@ func newNormalPreemptDeviceFitFixture() (uthelper.TestCommonStruct, []conf.Tier)
 			util.BuildPod("c1", "preemptor", "", v1.PodPending, api.BuildResourceList("1", "1G"), "pg-high", make(map[string]string), make(map[string]string)),
 		},
 		Nodes: []*v1.Node{
-			util.BuildNode("n1", api.BuildResourceList("2", "2G", []api.ScalarResource{{Name: "pods", Value: "10"}}...), make(map[string]string)),
+			util.BuildNode("n1", api.BuildResourceList("2", "2G", []api.ScalarResource{
+				{Name: "pods", Value: "10"},
+				// Tracked like a real HAMi node: vgpu-number is advertised in Allocatable.
+				// vgpu-memory-percentage deliberately is not (see
+				// TestNormalPreemptUntrackedResourceDefersToPredicate) - that's the one
+				// dimension this fixture is actually testing.
+				{Name: "volcano.sh/vgpu-number", Value: "1"},
+			}...), make(map[string]string)),
 		},
 		Queues: []*schedulingv1beta1.Queue{
 			util.BuildQueue("q1", 1, nil),
@@ -544,7 +551,14 @@ func TestNormalPreemptUntrackedResourceDefersToPredicate(t *testing.T) {
 	test.Pods = []*v1.Pod{
 		util.BuildPod("c1", "preemptee", "n1", v1.PodRunning, api.BuildResourceList("1", "1G"), "pg-low", map[string]string{schedulingv1beta1.PodPreemptable: "true"}, make(map[string]string)),
 		util.BuildPod("c1", "preemptor", "", v1.PodPending,
-			api.BuildResourceList("1", "1G", api.ScalarResource{Name: "volcano.sh/vgpu-memory-percentage", Value: "50"}),
+			// vgpu-memory-percentage is never requested on its own in practice - the API
+			// requires vgpu-number (or vgpu-memory) alongside it. Both are requested here;
+			// only vgpu-memory-percentage is untracked in n1's Allocatable (see the fixture
+			// above), which is the one dimension this test is actually exercising.
+			api.BuildResourceList("1", "1G",
+				api.ScalarResource{Name: "volcano.sh/vgpu-number", Value: "1"},
+				api.ScalarResource{Name: "volcano.sh/vgpu-memory-percentage", Value: "50"},
+			),
 			"pg-high", make(map[string]string), make(map[string]string)),
 	}
 	// n1's Allocatable deliberately carries no volcano.sh/vgpu-memory-percentage entry at all,

--- a/pkg/scheduler/actions/preempt/preempt_test.go
+++ b/pkg/scheduler/actions/preempt/preempt_test.go
@@ -530,6 +530,48 @@ func newNormalPreemptDeviceFitFixture() (uthelper.TestCommonStruct, []conf.Tier)
 	return test, tiers
 }
 
+// TestNormalPreemptUntrackedResourceDefersToPredicate covers #4863: a preemptor requesting
+// a resource dimension the node never advertises in Allocatable at all (volcano.sh/vgpu-memory-percentage
+// here, mirroring HAMi's fractional vGPU resource, which is a pure request-side modifier with no
+// coherent node-wide capacity total to advertise) must not be rejected by the generic scalar-resource
+// arithmetic before the device-aware predicate ever runs. Before the fix, node.FutureIdle() has no entry
+// for that resource name, so the comparison reads it as zero capacity and preemptorFitsOnNode/ValidateVictims
+// reject unconditionally, regardless of what the real predicate would say, and the preemptor never gets
+// scheduled even after the victim is evicted.
+func TestNormalPreemptUntrackedResourceDefersToPredicate(t *testing.T) {
+	test, tiers := newNormalPreemptDeviceFitFixture()
+	test.Name = "normal preemption evicts a victim for a resource untracked in node.Allocatable"
+	test.Pods = []*v1.Pod{
+		util.BuildPod("c1", "preemptee", "n1", v1.PodRunning, api.BuildResourceList("1", "1G"), "pg-low", map[string]string{schedulingv1beta1.PodPreemptable: "true"}, make(map[string]string)),
+		util.BuildPod("c1", "preemptor", "", v1.PodPending,
+			api.BuildResourceList("1", "1G", api.ScalarResource{Name: "volcano.sh/vgpu-memory-percentage", Value: "50"}),
+			"pg-high", make(map[string]string), make(map[string]string)),
+	}
+	// n1's Allocatable deliberately carries no volcano.sh/vgpu-memory-percentage entry at all,
+	// matching a real HAMi node: the resource is tracked by the device plugin's own ledger, not
+	// advertised node-wide.
+	//
+	// proportion's own queue-level Allocatable check has this identical untracked-resource gap
+	// independently (attr.deserved never carries an unconfigured scalar dimension either), which
+	// is a separate bug in a different plugin, out of scope here. Disable it so this test isolates
+	// the node-level fix in preemptorFitsOnNode/ValidateVictims that #4863/#5784 actually covers.
+	falseValue := false
+	for i, plugin := range tiers[0].Plugins {
+		if plugin.Name == proportion.PluginName {
+			tiers[0].Plugins[i].EnabledAllocatable = &falseValue
+		}
+	}
+	test.RegisterSession(tiers, []conf.Configuration{{
+		Name:      New().Name(),
+		Arguments: map[string]interface{}{EnableTopologyAwarePreemptionKey: false},
+	}})
+	defer test.Close()
+	test.Run([]framework.Action{New()})
+	if err := test.CheckAll(0); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func newNormalPreemptBenchmarkFixture() (uthelper.TestCommonStruct, []conf.Tier) {
 	test, tiers := newNormalPreemptDeviceFitFixture()
 	test.Name = "normal preemption benchmark with one required victim"

--- a/pkg/scheduler/actions/reclaim/reclaim.go
+++ b/pkg/scheduler/actions/reclaim/reclaim.go
@@ -262,9 +262,15 @@ func (ra *Action) reclaimForTask(ssn *framework.Session, stmt *framework.Stateme
 }
 
 // reclaimerFitsOnNode verifies available resources and plugin predicates after tentative evictions.
+// The arithmetic check alone can't be trusted when the shortfall is confined to a resource
+// dimension node.Allocatable has no entry for at all, such as volcano.sh/vgpu-memory-percentage,
+// which a device plugin tracks entirely through its own ledger. In that case defer to the real
+// predicate instead of rejecting outright.
 func reclaimerFitsOnNode(ssn *framework.Session, task *api.TaskInfo, node *api.NodeInfo, resreq, availableResources *api.Resource) bool {
-	return resreq.LessEqual(availableResources, api.Zero) &&
-		ssn.PredicateFn(task, node) == nil
+	if ok, failing := resreq.LessEqualWithResourcesName(availableResources, api.Zero); !ok && !api.AllUntrackedByAllocatable(failing, node) {
+		return false
+	}
+	return ssn.PredicateFn(task, node) == nil
 }
 
 func (ra *Action) UnInitialize() {

--- a/pkg/scheduler/actions/reclaim/reclaim_test.go
+++ b/pkg/scheduler/actions/reclaim/reclaim_test.go
@@ -476,3 +476,79 @@ func TestReclaimRechecksPredicateAfterEviction(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+// TestReclaimUntrackedResourceDefersToPredicate covers the same #4863-class bug as
+// TestNormalPreemptUntrackedResourceDefersToPredicate in the preempt package, but for reclaim:
+// a reclaimer requesting a resource dimension the node never advertises in Allocatable at all
+// (volcano.sh/vgpu-memory-percentage here, mirroring HAMi's fractional vGPU resource) must not be
+// rejected by the generic scalar-resource arithmetic in reclaimerFitsOnNode/ValidateVictims before
+// the device-aware predicate ever runs.
+func TestReclaimUntrackedResourceDefersToPredicate(t *testing.T) {
+	plugins := map[string]framework.PluginBuilder{
+		conformance.PluginName: conformance.New,
+		gang.PluginName:        gang.New,
+		proportion.PluginName:  proportion.New,
+		deviceFitAfterReclaimPluginName: func(framework.Arguments) framework.Plugin {
+			return &deviceFitAfterReclaimPlugin{}
+		},
+	}
+	trueValue := true
+	// Same PodGroups/Pods/Queues as TestReclaimRechecksPredicateAfterEviction (including the
+	// unrelated q3/pg-demand job, which affects proportion's deserved-share math), so the only
+	// variable relative to that already-passing baseline is the untracked resource dimension
+	// added to the reclaimer's request below. That isolates this test to the fix in
+	// reclaimerFitsOnNode/ValidateVictims instead of also exercising queue-weight arithmetic.
+	test := uthelper.TestCommonStruct{
+		Name:    "reclaim evicts a victim for a resource untracked in node.Allocatable",
+		Plugins: plugins,
+		PodGroups: []*schedulingv1beta1.PodGroup{
+			util.BuildPodGroupWithPrio("pg-victim", "c1", "q1", 0, nil, schedulingv1beta1.PodGroupRunning, "low-priority"),
+			util.BuildPodGroupWithPrio("pg-reclaimer", "c1", "q2", 1, nil, schedulingv1beta1.PodGroupInqueue, "high-priority"),
+			util.BuildPodGroupWithPrio("pg-demand", "c1", "q3", 0, nil, schedulingv1beta1.PodGroupInqueue, "low-priority"),
+		},
+		Pods: []*v1.Pod{
+			util.BuildPod("c1", "device-holder-1", "n1", v1.PodRunning, api.BuildResourceList("1", "1G"), "pg-victim", map[string]string{schedulingv1beta1.PodPreemptable: "true"}, make(map[string]string)),
+			util.BuildPod("c1", "device-holder-2", "n1", v1.PodRunning, api.BuildResourceList("1", "1G"), "pg-victim", map[string]string{schedulingv1beta1.PodPreemptable: "true"}, make(map[string]string)),
+			util.BuildPod("c1", "device-holder-3", "n1", v1.PodRunning, api.BuildResourceList("1", "1G"), "pg-victim", map[string]string{schedulingv1beta1.PodPreemptable: "false"}, make(map[string]string)),
+			// device-fit-after-reclaim's predicate only special-cases a task named "reclaimer", so
+			// this stays evicted regardless of the untracked resource on the reclaimer's request.
+			util.BuildPod("c1", "reclaimer", "", v1.PodPending,
+				api.BuildResourceList("1", "1G", api.ScalarResource{Name: "volcano.sh/vgpu-memory-percentage", Value: "50"}),
+				"pg-reclaimer", make(map[string]string), make(map[string]string)),
+			util.BuildPod("c1", "other-queue-demand", "", v1.PodPending, api.BuildResourceList("1", "1G"), "pg-demand", make(map[string]string), make(map[string]string)),
+		},
+		// n1's Allocatable deliberately carries no volcano.sh/vgpu-memory-percentage entry at all.
+		Nodes: []*v1.Node{
+			util.BuildNode("n1", api.BuildResourceList("3", "3G", []api.ScalarResource{{Name: "pods", Value: "10"}}...), make(map[string]string)),
+		},
+		Queues: []*schedulingv1beta1.Queue{
+			util.BuildQueue("q1", 1, nil),
+			util.BuildQueue("q2", 9, nil),
+			util.BuildQueue("q3", 1, nil),
+		},
+		ExpectEvicted:  []string{"c1/device-holder-1", "c1/device-holder-2"},
+		ExpectEvictNum: 2,
+		ExpectPipeLined: map[string][]string{
+			"c1/pg-reclaimer": {"n1"},
+		},
+	}
+	// proportion's EnablePreemptive reuses the same queueAllocatable arithmetic as its
+	// Allocatable check and has this identical untracked-resource gap independently (a
+	// separate, pre-existing bug in that plugin, out of scope here). Disabled so this test
+	// isolates the node-level fix in reclaimerFitsOnNode/ValidateVictims.
+	tiers := []conf.Tier{{
+		Plugins: []conf.PluginOption{
+			{Name: conformance.PluginName, EnabledReclaimable: &trueValue},
+			{Name: gang.PluginName, EnabledReclaimable: &trueValue, EnabledJobStarving: &trueValue},
+			{Name: proportion.PluginName, EnabledReclaimable: &trueValue, EnabledQueueOrder: &trueValue},
+			{Name: deviceFitAfterReclaimPluginName, EnabledPredicate: &trueValue},
+		},
+	}}
+
+	test.RegisterSession(tiers, nil)
+	defer test.Close()
+	test.Run([]framework.Action{New()})
+	if err := test.CheckAll(0); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/pkg/scheduler/actions/reclaim/reclaim_test.go
+++ b/pkg/scheduler/actions/reclaim/reclaim_test.go
@@ -512,14 +512,25 @@ func TestReclaimUntrackedResourceDefersToPredicate(t *testing.T) {
 			util.BuildPod("c1", "device-holder-3", "n1", v1.PodRunning, api.BuildResourceList("1", "1G"), "pg-victim", map[string]string{schedulingv1beta1.PodPreemptable: "false"}, make(map[string]string)),
 			// device-fit-after-reclaim's predicate only special-cases a task named "reclaimer", so
 			// this stays evicted regardless of the untracked resource on the reclaimer's request.
+			// vgpu-memory-percentage is never requested on its own in practice - the API requires
+			// vgpu-number (or vgpu-memory) alongside it. Both are requested here; only
+			// vgpu-memory-percentage is untracked in n1's Allocatable below, which is the one
+			// dimension this test is actually exercising.
 			util.BuildPod("c1", "reclaimer", "", v1.PodPending,
-				api.BuildResourceList("1", "1G", api.ScalarResource{Name: "volcano.sh/vgpu-memory-percentage", Value: "50"}),
+				api.BuildResourceList("1", "1G",
+					api.ScalarResource{Name: "volcano.sh/vgpu-number", Value: "1"},
+					api.ScalarResource{Name: "volcano.sh/vgpu-memory-percentage", Value: "50"},
+				),
 				"pg-reclaimer", make(map[string]string), make(map[string]string)),
 			util.BuildPod("c1", "other-queue-demand", "", v1.PodPending, api.BuildResourceList("1", "1G"), "pg-demand", make(map[string]string), make(map[string]string)),
 		},
-		// n1's Allocatable deliberately carries no volcano.sh/vgpu-memory-percentage entry at all.
+		// n1's Allocatable tracks vgpu-number like a real HAMi node, but deliberately carries no
+		// volcano.sh/vgpu-memory-percentage entry at all.
 		Nodes: []*v1.Node{
-			util.BuildNode("n1", api.BuildResourceList("3", "3G", []api.ScalarResource{{Name: "pods", Value: "10"}}...), make(map[string]string)),
+			util.BuildNode("n1", api.BuildResourceList("3", "3G", []api.ScalarResource{
+				{Name: "pods", Value: "10"},
+				{Name: "volcano.sh/vgpu-number", Value: "1"},
+			}...), make(map[string]string)),
 		},
 		Queues: []*schedulingv1beta1.Queue{
 			util.BuildQueue("q1", 1, nil),

--- a/pkg/scheduler/api/node_info.go
+++ b/pkg/scheduler/api/node_info.go
@@ -464,7 +464,13 @@ func (ni *NodeInfo) AddTask(task *TaskInfo) error {
 			ni.Pipelined.Add(ti.Resreq)
 		case Binding:
 			// When task in Binding status, it will bind to node, we should double-check whether idle resources are enough to put task before bind to apiserver.
-			if ok, resNames := ti.Resreq.LessEqualWithResourcesName(ni.Idle, Zero); !ok {
+			// A shortfall confined to resource dimensions ni.Allocatable has no entry for at all
+			// (like volcano.sh/vgpu-memory-percentage, tracked entirely by a device plugin's own
+			// ledger rather than advertised node-wide) can never pass this arithmetic, no matter
+			// how much room the device plugin's predicate already confirmed earlier in scheduling.
+			// This is the final gate before every bind, real or simulated, across every action, so
+			// treat that case as inconclusive rather than a hard no instead of rejecting outright.
+			if ok, resNames := ti.Resreq.LessEqualWithResourcesName(ni.Idle, Zero); !ok && !AllUntrackedByAllocatable(resNames, ni) {
 				return fmt.Errorf("node %s resources %v are not enough to put task <%s/%s>, idle: %s, req: %s", ni.Name, resNames, ti.Namespace, ti.Name, ni.Idle.String(), ti.Resreq.String())
 			}
 			ni.allocateIdleResource(ti)

--- a/pkg/scheduler/api/node_info_test.go
+++ b/pkg/scheduler/api/node_info_test.go
@@ -504,3 +504,40 @@ func TestNodeInfoClonePreservesUnassignedNumaPods(t *testing.T) {
 		t.Errorf("Clone mutation leaked back into original: %v", ni.UnassignedNumaPods)
 	}
 }
+
+// TestNodeInfo_AddTask_UntrackedResourceDefersToPredicate covers the final, most fundamental
+// occurrence of the #4863-class bug: AddTask's Binding-status check is the last gate every task
+// passes through before actually binding to the API server, across every scheduling action. A
+// task requesting a resource dimension the node never advertises in Allocatable at all (like
+// volcano.sh/vgpu-memory-percentage, tracked entirely by a device plugin's own ledger) must not
+// be rejected here, since nothing downstream double-checks it again.
+func TestNodeInfo_AddTask_UntrackedResourceDefersToPredicate(t *testing.T) {
+	node := buildNode("n1", nil, BuildResourceList("2000m", "2G", []ScalarResource{{Name: "pods", Value: "10"}}...))
+	pod := buildPod("c1", "p1", "", v1.PodPending,
+		BuildResourceList("1000m", "1G", []ScalarResource{{Name: "volcano.sh/vgpu-memory-percentage", Value: "50"}}...),
+		[]metav1.OwnerReference{}, make(map[string]string))
+
+	ni := NewNodeInfo(node)
+	task := NewTaskInfo(pod)
+	task.Status = Binding
+
+	if err := ni.AddTask(task); err != nil {
+		t.Fatalf("expected AddTask to succeed for a resource untracked in node.Allocatable, got error: %v", err)
+	}
+}
+
+// TestNodeInfo_AddTask_GenuineShortfallStillRejected is the companion regression: a real,
+// tracked-resource shortfall (cpu here) must still be rejected at bind time. The fallback above
+// is only for dimensions Allocatable has no entry for at all, not a blanket bypass.
+func TestNodeInfo_AddTask_GenuineShortfallStillRejected(t *testing.T) {
+	node := buildNode("n1", nil, BuildResourceList("1000m", "2G", []ScalarResource{{Name: "pods", Value: "10"}}...))
+	pod := buildPod("c1", "p1", "", v1.PodPending, BuildResourceList("2000m", "1G"), []metav1.OwnerReference{}, make(map[string]string))
+
+	ni := NewNodeInfo(node)
+	task := NewTaskInfo(pod)
+	task.Status = Binding
+
+	if err := ni.AddTask(task); err == nil {
+		t.Fatal("expected AddTask to reject a genuine cpu shortfall, got success")
+	}
+}

--- a/pkg/scheduler/api/resource_info.go
+++ b/pkg/scheduler/api/resource_info.go
@@ -567,6 +567,18 @@ func (r *Resource) LessEqualWithResourcesName(rr *Resource, defaultValue Dimensi
 // to advertise), where the generic scalar comparison has nothing to compare against and can't be
 // trusted as "no".
 func AllUntrackedByAllocatable(names []string, node *NodeInfo) bool {
+	if node.Allocatable == nil {
+		return false
+	}
+	return AllUntrackedByResource(names, node.Allocatable)
+}
+
+// AllUntrackedByResource reports whether every resource name in names has no capacity entry at
+// all in r. cpu and memory always carry a real capacity number, so they are never considered
+// untracked. Same idea as AllUntrackedByAllocatable, generalized to any Resource baseline, such
+// as a queue's deserved or capability share, which a device-tracked resource is just as absent
+// from as it is from node.Allocatable.
+func AllUntrackedByResource(names []string, r *Resource) bool {
 	if len(names) == 0 {
 		return false
 	}
@@ -574,10 +586,10 @@ func AllUntrackedByAllocatable(names []string, node *NodeInfo) bool {
 		if name == string(v1.ResourceCPU) || name == string(v1.ResourceMemory) {
 			return false
 		}
-		if node.Allocatable == nil {
+		if r == nil {
 			return false
 		}
-		if _, tracked := node.Allocatable.ScalarResources[v1.ResourceName(name)]; tracked {
+		if _, tracked := r.ScalarResources[v1.ResourceName(name)]; tracked {
 			return false
 		}
 	}

--- a/pkg/scheduler/api/resource_info.go
+++ b/pkg/scheduler/api/resource_info.go
@@ -559,6 +559,31 @@ func (r *Resource) LessEqualWithResourcesName(rr *Resource, defaultValue Dimensi
 	return true, resources
 }
 
+// AllUntrackedByAllocatable reports whether every resource name in names has no capacity entry
+// at all in node.Allocatable. cpu and memory always carry a real capacity number, so they are
+// never considered untracked. Used to tell a genuine shortfall (a tracked resource that's really
+// insufficient) apart from a resource dimension a device plugin manages entirely on its own (like
+// volcano.sh/vgpu-memory-percentage, a pure request-side modifier with no coherent node-wide total
+// to advertise), where the generic scalar comparison has nothing to compare against and can't be
+// trusted as "no".
+func AllUntrackedByAllocatable(names []string, node *NodeInfo) bool {
+	if len(names) == 0 {
+		return false
+	}
+	for _, name := range names {
+		if name == string(v1.ResourceCPU) || name == string(v1.ResourceMemory) {
+			return false
+		}
+		if node.Allocatable == nil {
+			return false
+		}
+		if _, tracked := node.Allocatable.ScalarResources[v1.ResourceName(name)]; tracked {
+			return false
+		}
+	}
+	return true
+}
+
 // LessPartly returns true if there exists any dimension whose resource amount in r is less than that in rr.
 // Otherwise returns false.
 // @param defaultValue "default value for resource dimension not defined in ScalarResources. Its value can only be one of 'Zero' and 'Infinity'"

--- a/pkg/scheduler/plugins/proportion/proportion.go
+++ b/pkg/scheduler/plugins/proportion/proportion.go
@@ -309,7 +309,15 @@ func (pp *proportionPlugin) OnSessionOpen(ssn *framework.Session) {
 			}
 			allocated := allocations[job.Queue]
 
-			if !allocated.LessEqual(attr.deserved, api.Zero) {
+			// A resource dimension attr.deserved has no entry for at all, such as one tracked
+			// entirely by a device plugin (volcano.sh/vgpu-memory-percentage from HAMi, for
+			// example), always reads as an "over deserved" violation here since deserved defaults
+			// to zero capacity for it. That would make a queue running any amount of an untracked
+			// resource look perpetually over its share on that dimension alone, regardless of its
+			// actual cpu/memory usage, so a shortfall confined to untracked dimensions doesn't
+			// count as a real violation.
+			ok, failing := allocated.LessEqualWithResourcesName(attr.deserved, api.Zero)
+			if !ok && !api.AllUntrackedByResource(failing, attr.deserved) {
 				allocated.Sub(reclaimee.Resreq)
 				victims = append(victims, reclaimee)
 			}
@@ -347,7 +355,14 @@ func (pp *proportionPlugin) OnSessionOpen(ssn *framework.Session) {
 		}
 
 		futureUsed := attr.allocated.Clone().Add(totalReq)
-		allocatable, _ := futureUsed.LessEqualWithDimensionAndResourcesName(attr.deserved, totalReq)
+		// A shortfall confined to dimensions attr.deserved has no entry for at all, such as one
+		// tracked entirely by a device plugin, can never pass this arithmetic no matter how much
+		// room the device plugin's own predicate would allow, so it doesn't count as a real
+		// violation of the queue's share.
+		allocatable, resources := futureUsed.LessEqualWithDimensionAndResourcesName(attr.deserved, totalReq)
+		if !allocatable && api.AllUntrackedByResource(resources, attr.deserved) {
+			allocatable = true
+		}
 		if !allocatable {
 			klog.V(3).Infof("Queue <%v>: deserved <%v>, allocated <%v>; Candidates total request <%v>",
 				queue.Name, attr.deserved, attr.allocated, totalReq)
@@ -373,7 +388,12 @@ func (pp *proportionPlugin) OnSessionOpen(ssn *framework.Session) {
 		}
 
 		futureUsed := attr.allocated.Clone().Add(candidate.Resreq)
-		allocatable, _ := futureUsed.LessEqualWithDimensionAndResourcesName(attr.deserved, candidate.Resreq)
+		// Same fallback as queueAllocatable above: a shortfall confined to dimensions
+		// attr.deserved has no entry for at all doesn't count as a real violation.
+		allocatable, resources := futureUsed.LessEqualWithDimensionAndResourcesName(attr.deserved, candidate.Resreq)
+		if !allocatable && api.AllUntrackedByResource(resources, attr.deserved) {
+			allocatable = true
+		}
 		if !allocatable {
 			klog.V(3).Infof("Queue <%v>: deserved <%v>, allocated <%v>; Candidate <%v>: resource request <%v>",
 				queue.Name, attr.deserved, attr.allocated, candidate.Name, candidate.Resreq)

--- a/pkg/scheduler/plugins/proportion/proportion_test.go
+++ b/pkg/scheduler/plugins/proportion/proportion_test.go
@@ -685,3 +685,154 @@ func TestJobEnqueuedOnOtherPluginsReject(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+// TestAllocatableUntrackedResourceDefersToDeserved covers the allocate-path instance of the
+// #4863-class bug in the proportion plugin: a task requesting a resource dimension the queue's
+// deserved share has no entry for at all (volcano.sh/vgpu-memory-percentage here, mirroring
+// HAMi's fractional vGPU resource) must not be rejected by queueAllocatable's generic arithmetic,
+// which otherwise treats deserved's default zero capacity for that dimension as a hard violation
+// regardless of how much cpu/memory headroom the queue actually has.
+func TestAllocatableUntrackedResourceDefersToDeserved(t *testing.T) {
+	plugins := map[string]framework.PluginBuilder{PluginName: New}
+	trueValue := true
+
+	n1 := util.BuildNode("n1", api.BuildResourceList("2", "4Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), make(map[string]string))
+	p1 := util.BuildPod("ns1", "p1", "", apiv1.PodPending,
+		api.BuildResourceList("1", "1Gi", api.ScalarResource{Name: "volcano.sh/vgpu-memory-percentage", Value: "50"}),
+		"pg1", make(map[string]string), make(map[string]string))
+	pg1 := util.BuildPodGroup("pg1", "ns1", "q1", 1, nil, schedulingv1beta1.PodGroupInqueue)
+	// q1's capability/deserved deliberately carries no volcano.sh/vgpu-memory-percentage entry
+	// at all, and covers the node's full cpu/memory capacity.
+	queue1 := util.BuildQueue("q1", 1, api.BuildResourceList("2", "4Gi"))
+
+	test := uthelper.TestCommonStruct{
+		Name:      "allocatable check does not block a task purely for a resource untracked in queue deserved",
+		Plugins:   plugins,
+		Pods:      []*apiv1.Pod{p1},
+		Nodes:     []*apiv1.Node{n1},
+		PodGroups: []*schedulingv1beta1.PodGroup{pg1},
+		Queues:    []*schedulingv1beta1.Queue{queue1},
+		ExpectBindMap: map[string]string{
+			"ns1/p1": "n1",
+		},
+		ExpectBindsNum: 1,
+	}
+
+	tiers := []conf.Tier{{
+		Plugins: []conf.PluginOption{
+			{Name: PluginName, EnabledAllocatable: &trueValue, EnabledOverused: &trueValue, EnabledQueueOrder: &trueValue},
+		},
+	}}
+	test.RegisterSession(tiers, nil)
+	defer test.Close()
+	test.Run([]framework.Action{allocate.New()})
+	if err := test.CheckAll(0); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestPreemptiveUntrackedResourceDefersToDeserved covers the reclaim-path instance of the same
+// bug via ssn.Preemptive (queueAllocatable is shared between AddAllocatableFn and
+// AddPreemptiveFn): a reclaimer requesting an untracked resource must not be blocked from even
+// attempting to reclaim, purely because its own queue's deserved share has no entry for that
+// dimension.
+func TestPreemptiveUntrackedResourceDefersToDeserved(t *testing.T) {
+	plugins := map[string]framework.PluginBuilder{
+		PluginName:          New,
+		gang.PluginName:     gang.New,
+		priority.PluginName: priority.New,
+	}
+	trueValue := true
+
+	n1 := util.BuildNode("n1", api.BuildResourceList("2", "2Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), make(map[string]string))
+	victim := util.BuildPod("ns1", "victim", "n1", apiv1.PodRunning, api.BuildResourceList("2", "2Gi"), "pg-victim", map[string]string{schedulingv1beta1.PodPreemptable: "true"}, make(map[string]string))
+	reclaimer := util.BuildPod("ns1", "reclaimer", "", apiv1.PodPending,
+		api.BuildResourceList("1", "1Gi", api.ScalarResource{Name: "volcano.sh/vgpu-memory-percentage", Value: "50"}),
+		"pg-reclaimer", make(map[string]string), make(map[string]string))
+	pgVictim := util.BuildPodGroupWithPrio("pg-victim", "ns1", "q1", 0, nil, schedulingv1beta1.PodGroupRunning, "low-priority")
+	pgReclaimer := util.BuildPodGroupWithPrio("pg-reclaimer", "ns1", "q2", 1, nil, schedulingv1beta1.PodGroupInqueue, "high-priority")
+	// q2's capability/deserved deliberately carries no volcano.sh/vgpu-memory-percentage entry.
+	queue1 := util.BuildQueue("q1", 1, nil)
+	queue2 := util.BuildQueue("q2", 9, nil)
+	lowPrio := util.BuildPriorityClass("low-priority", 10)
+	highPrio := util.BuildPriorityClass("high-priority", 100000)
+
+	test := uthelper.TestCommonStruct{
+		Name:           "reclaim's preemptive check does not block a reclaimer purely for a resource untracked in queue deserved",
+		Plugins:        plugins,
+		Pods:           []*apiv1.Pod{victim, reclaimer},
+		Nodes:          []*apiv1.Node{n1},
+		PodGroups:      []*schedulingv1beta1.PodGroup{pgVictim, pgReclaimer},
+		Queues:         []*schedulingv1beta1.Queue{queue1, queue2},
+		PriClass:       []*schedulingv1.PriorityClass{lowPrio, highPrio},
+		ExpectEvicted:  []string{"ns1/victim"},
+		ExpectEvictNum: 1,
+	}
+
+	tiers := []conf.Tier{{
+		Plugins: []conf.PluginOption{
+			{Name: PluginName, EnabledOverused: &trueValue, EnabledQueueOrder: &trueValue, EnablePreemptive: &trueValue, EnabledReclaimable: &trueValue},
+			{Name: gang.PluginName, EnabledJobStarving: &trueValue},
+			{Name: priority.PluginName, EnabledTaskOrder: &trueValue, EnabledJobOrder: &trueValue},
+		},
+	}}
+	test.RegisterSession(tiers, nil)
+	defer test.Close()
+	test.Run([]framework.Action{reclaim.New()})
+	if err := test.CheckAll(0); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestReclaimableUntrackedResourceDoesNotForcePerpetualOverDeserved covers AddReclaimableFn's
+// own, independent instance of the bug: a victim task requesting a resource untracked in its
+// queue's deserved share must not make that queue look permanently "over deserved" on that
+// dimension alone. deserved defaults to zero capacity for a dimension it has no entry for, so
+// without the fix, any positive usage of an untracked resource makes the arithmetic conclude the
+// queue is over-deserved forever, regardless of actual cpu/memory usage, marking every task in it
+// as a reclaim victim indefinitely. Here the victim's queue is well within its cpu/memory
+// deserved share, so it should not be offered as a reclaim victim at all.
+func TestReclaimableUntrackedResourceDoesNotForcePerpetualOverDeserved(t *testing.T) {
+	plugins := map[string]framework.PluginBuilder{PluginName: New}
+	trueValue := true
+
+	n1 := util.BuildNode("n1", api.BuildResourceList("4", "4Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), make(map[string]string))
+	victim := util.BuildPod("ns1", "victim", "n1", apiv1.PodRunning,
+		api.BuildResourceList("1", "1Gi", api.ScalarResource{Name: "volcano.sh/vgpu-memory-percentage", Value: "50"}),
+		"pg-victim", map[string]string{schedulingv1beta1.PodPreemptable: "true"}, make(map[string]string))
+	reclaimer := util.BuildPod("ns1", "reclaimer", "", apiv1.PodPending, api.BuildResourceList("1", "1Gi"), "pg-reclaimer", make(map[string]string), make(map[string]string))
+	pgVictim := util.BuildPodGroup("pg-victim", "ns1", "q1", 0, nil, schedulingv1beta1.PodGroupRunning)
+	pgReclaimer := util.BuildPodGroup("pg-reclaimer", "ns1", "q2", 1, nil, schedulingv1beta1.PodGroupInqueue)
+	// q1's deserved covers its actual cpu/memory usage generously (3 cpu / 3Gi deserved for 1
+	// cpu / 1Gi used), and deliberately has no entry for volcano.sh/vgpu-memory-percentage.
+	queue1 := util.BuildQueueWithPriorityAndResourcesQuantity("q1", 1, api.BuildResourceList("3", "3Gi"), nil)
+	queue2 := util.BuildQueueWithPriorityAndResourcesQuantity("q2", 1, api.BuildResourceList("1", "1Gi"), nil)
+
+	tiers := []conf.Tier{{
+		Plugins: []conf.PluginOption{
+			{Name: PluginName, EnabledReclaimable: &trueValue, EnabledQueueOrder: &trueValue},
+		},
+	}}
+
+	test := uthelper.TestCommonStruct{
+		Name:      "reclaimable does not offer a victim whose queue is within its cpu/memory deserved share",
+		Plugins:   plugins,
+		Pods:      []*apiv1.Pod{victim, reclaimer},
+		Nodes:     []*apiv1.Node{n1},
+		PodGroups: []*schedulingv1beta1.PodGroup{pgVictim, pgReclaimer},
+		Queues:    []*schedulingv1beta1.Queue{queue1, queue2},
+	}
+	ssn := test.RegisterSession(tiers, nil)
+	defer test.Close()
+
+	reclaimerTask := api.NewTaskInfo(reclaimer)
+	victimTask := ssn.Jobs[api.JobID("ns1/pg-victim")].TaskStatusIndex[api.Running][api.TaskID("ns1-victim")]
+	if victimTask == nil {
+		t.Fatalf("victim task not found in session")
+	}
+
+	victims := ssn.Reclaimable(reclaimerTask, []*api.TaskInfo{victimTask})
+	if len(victims) != 0 {
+		t.Fatalf("expected no reclaim victims from a queue within its cpu/memory deserved share, got %v", victims)
+	}
+}

--- a/pkg/scheduler/plugins/proportion/proportion_test.go
+++ b/pkg/scheduler/plugins/proportion/proportion_test.go
@@ -697,8 +697,15 @@ func TestAllocatableUntrackedResourceDefersToDeserved(t *testing.T) {
 	trueValue := true
 
 	n1 := util.BuildNode("n1", api.BuildResourceList("2", "4Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), make(map[string]string))
+	// vgpu-memory-percentage is never requested on its own in practice - the API requires
+	// vgpu-number (or vgpu-memory) alongside it. Both are requested here; only
+	// vgpu-memory-percentage is untracked in q1's deserved below, which is the one dimension
+	// this test is actually exercising.
 	p1 := util.BuildPod("ns1", "p1", "", apiv1.PodPending,
-		api.BuildResourceList("1", "1Gi", api.ScalarResource{Name: "volcano.sh/vgpu-memory-percentage", Value: "50"}),
+		api.BuildResourceList("1", "1Gi",
+			api.ScalarResource{Name: "volcano.sh/vgpu-number", Value: "1"},
+			api.ScalarResource{Name: "volcano.sh/vgpu-memory-percentage", Value: "50"},
+		),
 		"pg1", make(map[string]string), make(map[string]string))
 	pg1 := util.BuildPodGroup("pg1", "ns1", "q1", 1, nil, schedulingv1beta1.PodGroupInqueue)
 	// q1's capability/deserved deliberately carries no volcano.sh/vgpu-memory-percentage entry
@@ -746,8 +753,15 @@ func TestPreemptiveUntrackedResourceDefersToDeserved(t *testing.T) {
 
 	n1 := util.BuildNode("n1", api.BuildResourceList("2", "2Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), make(map[string]string))
 	victim := util.BuildPod("ns1", "victim", "n1", apiv1.PodRunning, api.BuildResourceList("2", "2Gi"), "pg-victim", map[string]string{schedulingv1beta1.PodPreemptable: "true"}, make(map[string]string))
+	// vgpu-memory-percentage is never requested on its own in practice - the API requires
+	// vgpu-number (or vgpu-memory) alongside it. Both are requested here; only
+	// vgpu-memory-percentage is untracked in q2's deserved below, which is the one dimension
+	// this test is actually exercising.
 	reclaimer := util.BuildPod("ns1", "reclaimer", "", apiv1.PodPending,
-		api.BuildResourceList("1", "1Gi", api.ScalarResource{Name: "volcano.sh/vgpu-memory-percentage", Value: "50"}),
+		api.BuildResourceList("1", "1Gi",
+			api.ScalarResource{Name: "volcano.sh/vgpu-number", Value: "1"},
+			api.ScalarResource{Name: "volcano.sh/vgpu-memory-percentage", Value: "50"},
+		),
 		"pg-reclaimer", make(map[string]string), make(map[string]string))
 	pgVictim := util.BuildPodGroupWithPrio("pg-victim", "ns1", "q1", 0, nil, schedulingv1beta1.PodGroupRunning, "low-priority")
 	pgReclaimer := util.BuildPodGroupWithPrio("pg-reclaimer", "ns1", "q2", 1, nil, schedulingv1beta1.PodGroupInqueue, "high-priority")
@@ -797,8 +811,15 @@ func TestReclaimableUntrackedResourceDoesNotForcePerpetualOverDeserved(t *testin
 	trueValue := true
 
 	n1 := util.BuildNode("n1", api.BuildResourceList("4", "4Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), make(map[string]string))
+	// vgpu-memory-percentage is never requested on its own in practice - the API requires
+	// vgpu-number (or vgpu-memory) alongside it. Both are requested here; only
+	// vgpu-memory-percentage is untracked in q1's deserved below, which is the one dimension
+	// this test is actually exercising.
 	victim := util.BuildPod("ns1", "victim", "n1", apiv1.PodRunning,
-		api.BuildResourceList("1", "1Gi", api.ScalarResource{Name: "volcano.sh/vgpu-memory-percentage", Value: "50"}),
+		api.BuildResourceList("1", "1Gi",
+			api.ScalarResource{Name: "volcano.sh/vgpu-number", Value: "1"},
+			api.ScalarResource{Name: "volcano.sh/vgpu-memory-percentage", Value: "50"},
+		),
 		"pg-victim", map[string]string{schedulingv1beta1.PodPreemptable: "true"}, make(map[string]string))
 	reclaimer := util.BuildPod("ns1", "reclaimer", "", apiv1.PodPending, api.BuildResourceList("1", "1Gi"), "pg-reclaimer", make(map[string]string), make(map[string]string))
 	pgVictim := util.BuildPodGroup("pg-victim", "ns1", "q1", 0, nil, schedulingv1beta1.PodGroupRunning)

--- a/pkg/scheduler/util/scheduler_helper.go
+++ b/pkg/scheduler/util/scheduler_helper.go
@@ -324,8 +324,15 @@ func ValidateVictims(preemptor *api.TaskInfo, node *api.NodeInfo, victims []*api
 		futureIdle.Add(victim.Resreq)
 	}
 	// Every resource of the preemptor needs to be less or equal than corresponding
-	// idle resource after preemption.
-	if !preemptor.InitResreq.LessEqual(futureIdle, api.Zero) {
+	// idle resource after preemption. This arithmetic check is only authoritative for
+	// resources node.Allocatable actually carries a capacity number for (cpu, memory,
+	// volcano.sh/vgpu-number, ...). A resource a device plugin tracks entirely through its
+	// own ledger instead (like volcano.sh/vgpu-memory-percentage, a pure request-side
+	// modifier with no coherent node-wide total to advertise) can never pass this check,
+	// no matter how much room the device plugin's predicate would actually allow, so treat
+	// a shortfall confined to untracked dimensions as inconclusive rather than a hard no
+	// and let the real predicate decide once eviction is attempted.
+	if ok, failing := preemptor.InitResreq.LessEqualWithResourcesName(futureIdle, api.Zero); !ok && !api.AllUntrackedByAllocatable(failing, node) {
 		return fmt.Errorf("not enough resources: requested <%v>, but future idle <%v>",
 			preemptor.InitResreq, futureIdle)
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Fixes the default `proportion` plugin (queue fairness/quota enforcement) blocking tasks and misjudging reclaim victims purely because they touch a resource dimension a queue's `deserved` share has no entry for at all, such as `volcano.sh/vgpu-memory-percentage` from HAMi's fractional vGPU support. This is the same class of bug already fixed in the allocate, preempt, and reclaim actions (#5784, #5905, #5906), independently, in three of `proportion`'s own checks:

1. `queueAllocatable` (shared by `AddAllocatableFn` and `AddPreemptiveFn`, used by `ssn.Allocatable` and `ssn.Preemptive`): compares a queue's future usage against its deserved share. A resource dimension `deserved` has no entry for at all always reads as a violation, since `deserved` defaults to zero capacity for it, so a queue with plenty of cpu/memory headroom still gets marked not-allocatable for a task requesting that resource.
2. `AddSimulateAllocatableFn` (used by `ssn.SimulateAllocatableFn`, called from topology-aware preemption's `SelectVictimsOnNode`): the identical arithmetic, duplicated for the simulated dry-run path.
3. `AddReclaimableFn` (used by `ssn.Reclaimable`): the same gap in the other direction. It decides whether a queue is still over its deserved share to keep offering more reclaim victims. A victim task using an untracked resource makes its queue look permanently over-deserved on that dimension alone, regardless of actual cpu/memory usage, so every task in that queue stays reclaimable indefinitely.

All three get the same fallback already used in #5784/#5905/#5906: when the arithmetic violation is confined to dimensions the baseline has no entry for at all, treat that as inconclusive rather than a real violation.

#### Which issue(s) this PR fixes:

Fixes #5907

#### Special notes for your reviewer:

Depends on #5784 and #5905 — this branch is built on top of both since it needs `AllUntrackedByAllocatable`/the allocate-action fix. The diff here will look larger than the actual change until those merge and this rebases down to just this commit.

The fallback helper needed a queue-resource variant, since `deserved`/`capability` are plain `Resource` values, not a `NodeInfo`. Added `AllUntrackedByResource` next to the existing `AllUntrackedByAllocatable` in `pkg/scheduler/api`, with the latter now a thin wrapper over the former so existing callers (already reviewed in #5784/#5905/#5906) are unaffected.

Used Claude Code (AI assistant) to investigate this issue and draft the fix and test, following the pattern already reviewed in #5784. Each of the three regression tests is run through the actual `allocate`/`reclaim` actions rather than just the plugin function in isolation, so they exercise the real end-to-end path; confirmed each fails against the code before this change and passes after. Full `pkg/scheduler/...` suite is green.

Beyond the unit tests, also verified live against a real Kubernetes cluster (OrbStack) running the full Volcano stack (CRDs, controller-manager, admission webhook): built the stock v1.15.1 scheduler and this fix as separate binaries, ran the stock one first against a queue with `deserved` cpu/memory set but no `vgpu-memory-percentage` entry, and confirmed a pod requesting that resource sat Pending indefinitely with the scheduler repeatedly logging the queue as overused. Swapped in the fixed binary against the same queue and pod spec, no other changes, and the pod was scheduled, bound, and ran successfully within seconds.

#### Does this PR introduce a user-facing change?

```release-note
Fix a bug where the proportion plugin's queue fairness checks (Allocatable, Preemptive, Reclaimable) could block or misjudge tasks requesting a resource untracked in the queue's deserved share (such as a fractional vGPU request), even when the queue had ample cpu/memory headroom.
```
