### PR TITLE
perf(nodeorder): run score plugins in a single node traversal

### DIFF
--- a/pkg/agentscheduler/plugins/predicates/predicates.go
+++ b/pkg/agentscheduler/plugins/predicates/predicates.go
@@ -29,6 +29,7 @@ import (
 	vcache "volcano.sh/volcano/pkg/scheduler/cache"
 	vfwk "volcano.sh/volcano/pkg/scheduler/framework"
 	"volcano.sh/volcano/pkg/scheduler/plugins/predicates"
+	"volcano.sh/volcano/pkg/scheduler/plugins/util/nodescore"
 )
 
 const (
@@ -74,16 +75,16 @@ func (pp *predicatesPlugin) OnPluginInit(fwk *framework.Framework) {
 	})
 
 	fwk.AddBatchNodeOrderFn(PluginName, func(task *api.TaskInfo, nodes []*api.NodeInfo) (map[string]float64, error) {
-		state := fwk.GetCycleState(types.UID(task.UID))
-		nodeInfoList, err := fwk.SnapshotSharedLister().NodeInfos().List()
-		if err != nil {
-			klog.Errorf("Failed to list nodes from snapshot: %v", err)
-			return nil, err
-		}
-		return pp.BatchNodeOrder(task, nodeInfoList, state)
+		return pp.batchNodeOrder(fwk, task, nodes)
 	})
 
 	fwk.Cache.RegisterBinder(pp.Name(), pp)
+}
+
+func (pp *predicatesPlugin) batchNodeOrder(fwk *framework.Framework, task *api.TaskInfo, nodes []*api.NodeInfo) (map[string]float64, error) {
+	state := fwk.GetCycleState(types.UID(task.UID))
+	nodeInfoList := nodescore.NodeInfosForCandidateNodes(nodes, fwk.GetSnapshot().GetFwkNodeInfoMap())
+	return pp.BatchNodeOrder(task, nodeInfoList, state)
 }
 
 func (pp *predicatesPlugin) PreBind(ctx context.Context, bindCtx *agentapi.BindContext) error {

--- a/pkg/agentscheduler/plugins/predicates/predicates_test.go
+++ b/pkg/agentscheduler/plugins/predicates/predicates_test.go
@@ -1,0 +1,93 @@
+/*
+Copyright 2026 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package predicates
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	fwk "k8s.io/kube-scheduler/framework"
+
+	agentframework "volcano.sh/volcano/pkg/agentscheduler/framework"
+	"volcano.sh/volcano/pkg/scheduler/api"
+	schedulerpredicates "volcano.sh/volcano/pkg/scheduler/plugins/predicates"
+	k8sutil "volcano.sh/volcano/pkg/scheduler/plugins/util/k8s"
+	"volcano.sh/volcano/pkg/scheduler/plugins/util/nodescore"
+)
+
+type candidateRecordingScorePlugin struct {
+	name          string
+	preScoreNodes []string
+	scoreNodes    []string
+}
+
+func (p *candidateRecordingScorePlugin) Name() string {
+	return p.name
+}
+
+func (p *candidateRecordingScorePlugin) PreScore(_ context.Context, _ fwk.CycleState, _ *v1.Pod, nodes []fwk.NodeInfo) *fwk.Status {
+	for _, node := range nodes {
+		p.preScoreNodes = append(p.preScoreNodes, node.Node().Name)
+	}
+	return nil
+}
+
+func (p *candidateRecordingScorePlugin) Score(_ context.Context, _ fwk.CycleState, _ *v1.Pod, node fwk.NodeInfo) (int64, *fwk.Status) {
+	p.scoreNodes = append(p.scoreNodes, node.Node().Name)
+	return 1, nil
+}
+
+func (p *candidateRecordingScorePlugin) ScoreExtensions() fwk.ScoreExtensions {
+	return nil
+}
+
+func TestBatchNodeOrderUsesOnlyCandidateNodes(t *testing.T) {
+	candidate := api.NewNodeInfo(&v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "candidate"}})
+	extra := api.NewNodeInfo(&v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "extra"}})
+	snapshot := k8sutil.NewEmptySnapshot()
+	snapshot.AddOrUpdateNodes([]*api.NodeInfo{candidate, extra})
+
+	agentFwk := &agentframework.Framework{
+		Framework: k8sutil.NewFramework(nil, k8sutil.WithSnapshotSharedLister(snapshot)),
+	}
+	recorder := &candidateRecordingScorePlugin{name: "recording-score"}
+	plugin := &predicatesPlugin{PredicatesPlugin: &schedulerpredicates.PredicatesPlugin{
+		PreScorePlugins: map[string]fwk.PreScorePlugin{recorder.name: recorder},
+		ScorePlugins:    map[string]nodescore.BaseScorePlugin{recorder.name: recorder},
+		ScoreWeights:    map[string]int{recorder.name: 1},
+		PreScoreOrder:   []string{recorder.name},
+		ScoreOrder:      []string{recorder.name},
+	}}
+	task := &api.TaskInfo{UID: "pod", Pod: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod"}}}
+
+	scores, err := plugin.batchNodeOrder(agentFwk, task, []*api.NodeInfo{candidate})
+	if err != nil {
+		t.Fatalf("batchNodeOrder returned an error: %v", err)
+	}
+	if !reflect.DeepEqual(scores, map[string]float64{"candidate": 1}) {
+		t.Fatalf("unexpected scores: %v", scores)
+	}
+	if !reflect.DeepEqual(recorder.preScoreNodes, []string{"candidate"}) {
+		t.Fatalf("PreScore nodes: got %v, want only candidate", recorder.preScoreNodes)
+	}
+	if !reflect.DeepEqual(recorder.scoreNodes, []string{"candidate"}) {
+		t.Fatalf("Score nodes: got %v, want only candidate", recorder.scoreNodes)
+	}
+}

--- a/pkg/scheduler/plugins/nodeorder/nodeorder.go
+++ b/pkg/scheduler/plugins/nodeorder/nodeorder.go
@@ -363,26 +363,25 @@ func (pp *NodeOrderPlugin) NodeOrderFn(task *api.TaskInfo, node *api.NodeInfo, k
 // BatchNodeOrderFn scores all candidate nodes for the given task in one call.
 func (pp *NodeOrderPlugin) BatchNodeOrderFn(task *api.TaskInfo, nodes []*api.NodeInfo, nodeMap map[string]fwk.NodeInfo, state *k8sframework.CycleState) (map[string]float64, error) {
 	nodeInfos := nodescore.NodeInfosForCandidateNodes(nodes, nodeMap)
-	nodeScores := make(map[string]float64, len(nodes))
-
+	preScorePlugins := make([]nodescore.PreScorePluginSpec, 0, len(pp.ScorePlugins))
+	scorePlugins := make([]nodescore.ScorePluginSpec, 0, len(pp.ScorePlugins))
 	for name, entry := range pp.ScorePlugins {
+		scorePlugins = append(scorePlugins, nodescore.ScorePluginSpec{
+			Name:   name,
+			Plugin: entry.plugin,
+			Weight: entry.weight,
+		})
 		if preScorePlugin, ok := entry.plugin.(fwk.PreScorePlugin); ok {
-			skipScore, err := nodescore.RunPreScorePlugin(preScorePlugin, state, task.Pod, nodeInfos)
-			if err != nil {
-				return nil, err
-			}
-			if skipScore {
-				continue
-			}
+			preScorePlugins = append(preScorePlugins, nodescore.PreScorePluginSpec{
+				Name:   name,
+				Plugin: preScorePlugin,
+			})
 		}
+	}
 
-		scores, err := nodescore.CalculatePluginScore(name, entry.plugin, state, task.Pod, nodeInfos, entry.weight)
-		if err != nil {
-			return nil, err
-		}
-		for n, s := range scores {
-			nodeScores[n] += s
-		}
+	nodeScores, err := nodescore.RunScorePlugins(context.TODO(), preScorePlugins, scorePlugins, state, task.Pod, nodeInfos)
+	if err != nil {
+		return nil, err
 	}
 
 	klog.V(4).Infof("Batch Total Score for task %s/%s is: %v", task.Namespace, task.Name, nodeScores)

--- a/pkg/scheduler/plugins/nodeorder/nodeorder_test.go
+++ b/pkg/scheduler/plugins/nodeorder/nodeorder_test.go
@@ -17,7 +17,9 @@ limitations under the License.
 package nodeorder
 
 import (
+	"context"
 	"os"
+	"reflect"
 	"testing"
 
 	v1 "k8s.io/api/core/v1"
@@ -25,6 +27,7 @@ import (
 	"k8s.io/client-go/informers"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
 	k8sframework "k8s.io/kube-scheduler/framework"
+	schedframework "k8s.io/kubernetes/pkg/scheduler/framework"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/imagelocality"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/interpodaffinity"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/nodeaffinity"
@@ -41,6 +44,7 @@ import (
 	"volcano.sh/volcano/pkg/scheduler/framework"
 	"volcano.sh/volcano/pkg/scheduler/plugins/gang"
 	"volcano.sh/volcano/pkg/scheduler/plugins/util/k8s"
+	"volcano.sh/volcano/pkg/scheduler/plugins/util/nodescore"
 	"volcano.sh/volcano/pkg/scheduler/uthelper"
 	"volcano.sh/volcano/pkg/scheduler/util"
 )
@@ -442,4 +446,134 @@ func TestInitPlugin(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestBatchNodeOrderFnWithMultipleScorePlugins(t *testing.T) {
+	nodeA := util.BuildNode("node-a", api.BuildResourceList("4", "8Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), nil)
+	nodeB := util.BuildNode("node-b", api.BuildResourceList("8", "16Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), nil)
+	nodeB.Spec.Taints = []v1.Taint{{Key: "dedicated", Effect: v1.TaintEffectPreferNoSchedule}}
+
+	nodeInfoA := schedframework.NewNodeInfo()
+	nodeInfoA.SetNode(nodeA)
+	nodeInfoB := schedframework.NewNodeInfo()
+	nodeInfoB.SetNode(nodeB)
+	nodeInfos := []k8sframework.NodeInfo{nodeInfoA, nodeInfoB}
+	nodeMap := map[string]k8sframework.NodeInfo{"node-a": nodeInfoA, "node-b": nodeInfoB}
+
+	client := k8sfake.NewSimpleClientset()
+	informerFactory := informers.NewSharedInformerFactory(client, 0)
+	pp := New(nil).(*NodeOrderPlugin)
+	pp.weight = priorityWeight{
+		leastReqWeight:         1,
+		balancedResourceWeight: 1,
+		taintTolerationWeight:  3,
+	}
+	pp.Handle = k8s.NewFramework(
+		nodeMap,
+		k8s.WithClientSet(client),
+		k8s.WithInformerFactory(informerFactory),
+	)
+	pp.InitPlugin()
+	if len(pp.ScorePlugins) != 3 {
+		t.Fatalf("expected LeastAllocated, BalancedAllocation, and TaintToleration plugins, got %d", len(pp.ScorePlugins))
+	}
+	pod := util.BuildPod("ns", "pod", "", v1.PodPending, api.BuildResourceList("1", "1Gi"), "", nil, nil)
+
+	scores, err := pp.BatchNodeOrderFn(
+		&api.TaskInfo{Pod: pod},
+		[]*api.NodeInfo{api.NewNodeInfo(nodeA), api.NewNodeInfo(nodeB)},
+		nodeMap,
+		schedframework.NewCycleState(),
+	)
+	if err != nil {
+		t.Fatalf("BatchNodeOrderFn returned an error: %v", err)
+	}
+
+	legacyScores := runScorePluginsSequentially(t, pp.ScorePlugins, pod, nodeInfos)
+
+	if !reflect.DeepEqual(scores, legacyScores) {
+		t.Fatalf("fused scores differ from sequential scores: fused=%v sequential=%v", scores, legacyScores)
+	}
+	if len(scores) != 2 || scores["node-a"] == scores["node-b"] {
+		t.Fatalf("expected distinct scores for both nodes, got %v", scores)
+	}
+}
+
+func TestBatchNodeOrderFnWithLeastAndMostAllocated(t *testing.T) {
+	nodeA := util.BuildNode("node-a", api.BuildResourceList("4", "8Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), nil)
+	nodeB := util.BuildNode("node-b", api.BuildResourceList("8", "16Gi", []api.ScalarResource{{Name: "pods", Value: "10"}}...), nil)
+	nodeInfoA := schedframework.NewNodeInfo()
+	nodeInfoA.SetNode(nodeA)
+	nodeInfoB := schedframework.NewNodeInfo()
+	nodeInfoB.SetNode(nodeB)
+	nodeInfos := []k8sframework.NodeInfo{nodeInfoA, nodeInfoB}
+	nodeMap := map[string]k8sframework.NodeInfo{"node-a": nodeInfoA, "node-b": nodeInfoB}
+
+	client := k8sfake.NewSimpleClientset()
+	informerFactory := informers.NewSharedInformerFactory(client, 0)
+	pp := New(nil).(*NodeOrderPlugin)
+	pp.weight = priorityWeight{leastReqWeight: 2, mostReqWeight: 1}
+	pp.Handle = k8s.NewFramework(
+		nodeMap,
+		k8s.WithClientSet(client),
+		k8s.WithInformerFactory(informerFactory),
+	)
+	pp.InitPlugin()
+	if len(pp.ScorePlugins) != 2 {
+		t.Fatalf("expected LeastAllocated and MostAllocated plugins, got %d", len(pp.ScorePlugins))
+	}
+	for _, name := range []string{
+		noderesources.Name + "_LeastAllocated",
+		noderesources.Name + "_MostAllocated",
+	} {
+		if _, exists := pp.ScorePlugins[name]; !exists {
+			t.Fatalf("expected score plugin %q to be registered", name)
+		}
+	}
+
+	pod := util.BuildPod("ns", "pod", "", v1.PodPending, api.BuildResourceList("1", "1Gi"), "", nil, nil)
+	fusedScores, err := pp.BatchNodeOrderFn(
+		&api.TaskInfo{Pod: pod},
+		[]*api.NodeInfo{api.NewNodeInfo(nodeA), api.NewNodeInfo(nodeB)},
+		nodeMap,
+		schedframework.NewCycleState(),
+	)
+	if err != nil {
+		t.Fatalf("BatchNodeOrderFn returned an error: %v", err)
+	}
+	legacyScores := runScorePluginsSequentially(t, pp.ScorePlugins, pod, nodeInfos)
+	if !reflect.DeepEqual(fusedScores, legacyScores) {
+		t.Fatalf("Least/Most fused scores differ from sequential scores: fused=%v sequential=%v", fusedScores, legacyScores)
+	}
+	if fusedScores["node-a"] == fusedScores["node-b"] {
+		t.Fatalf("expected asymmetric weights to produce distinct node scores, got %v", fusedScores)
+	}
+}
+
+func runScorePluginsSequentially(t *testing.T, plugins map[string]scorePluginEntry, pod *v1.Pod, nodeInfos []k8sframework.NodeInfo) map[string]float64 {
+	t.Helper()
+
+	scores := make(map[string]float64, len(nodeInfos))
+	state := schedframework.NewCycleState()
+	for name, entry := range plugins {
+		var preScorePlugins []nodescore.PreScorePluginSpec
+		if preScorePlugin, ok := entry.plugin.(k8sframework.PreScorePlugin); ok {
+			preScorePlugins = append(preScorePlugins, nodescore.PreScorePluginSpec{Name: name, Plugin: preScorePlugin})
+		}
+		pluginScores, err := nodescore.RunScorePlugins(
+			context.TODO(),
+			preScorePlugins,
+			[]nodescore.ScorePluginSpec{{Name: name, Plugin: entry.plugin, Weight: entry.weight}},
+			state,
+			pod,
+			nodeInfos,
+		)
+		if err != nil {
+			t.Fatalf("sequential score plugin %s returned an error: %v", name, err)
+		}
+		for node, score := range pluginScores {
+			scores[node] += score
+		}
+	}
+	return scores
 }

--- a/pkg/scheduler/plugins/predicates/predicates.go
+++ b/pkg/scheduler/plugins/predicates/predicates.go
@@ -775,52 +775,32 @@ func (pp *PredicatesPlugin) Predicate(task *api.TaskInfo, node *api.NodeInfo, st
 
 // BatchNodeOrder runs all Score plugins for the given task and nodes.
 func (pp *PredicatesPlugin) BatchNodeOrder(task *api.TaskInfo, nodes []fwk.NodeInfo, state *k8sframework.CycleState) (map[string]float64, error) {
-	nodeScores := make(map[string]float64, len(nodes))
-	skippedScorePlugins := map[string]struct{}{}
-
+	preScorePlugins := make([]nodescore.PreScorePluginSpec, 0, len(pp.PreScoreOrder))
 	for _, name := range pp.PreScoreOrder {
 		plugin, exists := pp.PreScorePlugins[name]
 		if !exists {
 			continue
 		}
-
-		skipScore, err := nodescore.RunPreScorePlugin(plugin, state, task.Pod, nodes)
-		if err != nil {
-			return nil, fmt.Errorf("pre-score plugin %s failed: %w", name, err)
-		}
-		if skipScore {
-			skippedScorePlugins[name] = struct{}{}
-		}
+		preScorePlugins = append(preScorePlugins, nodescore.PreScorePluginSpec{Name: name, Plugin: plugin})
 	}
 
-	// Run all Score plugins
+	scorePlugins := make([]nodescore.ScorePluginSpec, 0, len(pp.ScoreOrder))
 	for _, name := range pp.ScoreOrder {
-		if _, skipped := skippedScorePlugins[name]; skipped {
-			continue
-		}
 		plugin, exists := pp.ScorePlugins[name]
 		if !exists {
 			continue
 		}
-		// Get weight from ScoreWeights map, default to 1 if not set
 		weight := 1
 		if w, exists := pp.ScoreWeights[name]; exists {
 			weight = w
 		}
-
-		// Calculate score using the helper function
-		pluginScores, err := nodescore.CalculatePluginScore(name, plugin, state, task.Pod, nodes, weight)
-		if err != nil {
-			return nil, err
-		}
-
-		// Accumulate scores
-		for _, node := range nodes {
-			nodeName := node.Node().Name
-			nodeScores[nodeName] += pluginScores[nodeName]
-		}
+		scorePlugins = append(scorePlugins, nodescore.ScorePluginSpec{Name: name, Plugin: plugin, Weight: weight})
 	}
 
+	nodeScores, err := nodescore.RunScorePlugins(context.TODO(), preScorePlugins, scorePlugins, state, task.Pod, nodes)
+	if err != nil {
+		return nil, err
+	}
 	klog.V(4).Infof("Batch Total Score for task %s/%s is: %v", task.Namespace, task.Name, nodeScores)
 	return nodeScores, nil
 }

--- a/pkg/scheduler/plugins/predicates/predicates_test.go
+++ b/pkg/scheduler/plugins/predicates/predicates_test.go
@@ -97,6 +97,17 @@ type fakePreScorePlugin struct {
 	preScoreCalls  int
 }
 
+type fakeScoreOnlyPlugin struct {
+	name       string
+	score      int64
+	scoreCalls int
+	extensions *fakeScoreExtensions
+}
+
+type fakeScoreExtensions struct {
+	calls int
+}
+
 func (p *fakePreScorePlugin) Name() string {
 	return p.name
 }
@@ -111,6 +122,25 @@ func (p *fakePreScorePlugin) Score(_ context.Context, _ k8sframework.CycleState,
 }
 
 func (p *fakePreScorePlugin) ScoreExtensions() k8sframework.ScoreExtensions {
+	return nil
+}
+
+func (p *fakeScoreOnlyPlugin) Name() string {
+	return p.name
+}
+
+func (p *fakeScoreOnlyPlugin) Score(_ context.Context, _ k8sframework.CycleState, _ *apiv1.Pod, _ k8sframework.NodeInfo) (int64, *k8sframework.Status) {
+	p.scoreCalls++
+	return p.score, nil
+}
+
+func (p *fakeScoreOnlyPlugin) ScoreExtensions() k8sframework.ScoreExtensions {
+	return p.extensions
+}
+
+func (e *fakeScoreExtensions) NormalizeScore(_ context.Context, _ k8sframework.CycleState, _ *apiv1.Pod, scores k8sframework.NodeScoreList) *k8sframework.Status {
+	e.calls++
+	scores[0].Score = 40
 	return nil
 }
 
@@ -732,7 +762,68 @@ func TestBatchNodeOrderRunsPreScorePlugins(t *testing.T) {
 			if scored != tt.wantScore {
 				t.Errorf("expected node score presence to be %t, got %t", tt.wantScore, scored)
 			}
+			if tt.wantScore && scores["node-a"] != 50 {
+				t.Errorf("expected node score 50, got %v", scores["node-a"])
+			}
 		})
+	}
+}
+
+func TestBatchNodeOrderRunsScoreOnlyPluginsInConfiguredOrder(t *testing.T) {
+	plugin := &fakeScoreOnlyPlugin{
+		name:       "score-only",
+		score:      25,
+		extensions: &fakeScoreExtensions{},
+	}
+	ignored := &fakeScoreOnlyPlugin{name: "ignored", score: 100}
+	pp := &PredicatesPlugin{
+		ScorePlugins: map[string]nodescore.BaseScorePlugin{
+			plugin.Name():  plugin,
+			ignored.Name(): ignored,
+		},
+		ScoreWeights: map[string]int{plugin.Name(): 2},
+		ScoreOrder:   []string{"missing", plugin.Name()},
+	}
+	nodeInfo := schedframework.NewNodeInfo()
+	nodeInfo.SetNode(&apiv1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-a"}})
+
+	scores, err := pp.BatchNodeOrder(
+		&api.TaskInfo{Pod: &apiv1.Pod{}},
+		[]k8sframework.NodeInfo{nodeInfo},
+		schedframework.NewCycleState(),
+	)
+	if err != nil {
+		t.Fatalf("BatchNodeOrder returned an error: %v", err)
+	}
+	if scores["node-a"] != 80 {
+		t.Fatalf("expected normalized weighted score 80, got %v", scores["node-a"])
+	}
+	if plugin.scoreCalls != 1 || plugin.extensions.calls != 1 {
+		t.Fatalf("expected score and normalize once, got Score=%d Normalize=%d", plugin.scoreCalls, plugin.extensions.calls)
+	}
+	if ignored.scoreCalls != 0 {
+		t.Fatalf("plugin absent from ScoreOrder ran %d times", ignored.scoreCalls)
+	}
+
+	defaultWeightPlugin := &fakeScoreOnlyPlugin{
+		name:       "default-weight",
+		score:      25,
+		extensions: &fakeScoreExtensions{},
+	}
+	pp = &PredicatesPlugin{
+		ScorePlugins: map[string]nodescore.BaseScorePlugin{defaultWeightPlugin.Name(): defaultWeightPlugin},
+		ScoreOrder:   []string{defaultWeightPlugin.Name()},
+	}
+	scores, err = pp.BatchNodeOrder(
+		&api.TaskInfo{Pod: &apiv1.Pod{}},
+		[]k8sframework.NodeInfo{nodeInfo},
+		schedframework.NewCycleState(),
+	)
+	if err != nil {
+		t.Fatalf("BatchNodeOrder with default weight returned an error: %v", err)
+	}
+	if scores["node-a"] != 40 {
+		t.Fatalf("expected normalized default-weight score 40, got %v", scores["node-a"])
 	}
 }
 

--- a/pkg/scheduler/plugins/util/nodescore/score_helper.go
+++ b/pkg/scheduler/plugins/util/nodescore/score_helper.go
@@ -22,14 +22,34 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/util/workqueue"
-	"k8s.io/klog/v2"
 	fwk "k8s.io/kube-scheduler/framework"
+	"k8s.io/kubernetes/pkg/scheduler/framework/parallelize"
 
 	"volcano.sh/volcano/pkg/scheduler/api"
 )
 
 type BaseScorePlugin interface {
 	fwk.ScorePlugin
+}
+
+// PreScorePluginSpec identifies a registered PreScore plugin by its logical name.
+type PreScorePluginSpec struct {
+	Name   string
+	Plugin fwk.PreScorePlugin
+}
+
+// ScorePluginSpec identifies a registered Score plugin and its configured weight.
+type ScorePluginSpec struct {
+	Name   string
+	Plugin BaseScorePlugin
+	Weight int
+}
+
+const scoreWorkerNum = parallelize.DefaultParallelism
+
+type activeScorePlugin struct {
+	spec   ScorePluginSpec
+	scores fwk.NodeScoreList
 }
 
 func NodeInfosForCandidateNodes(nodes []*api.NodeInfo, nodeMap map[string]fwk.NodeInfo) []fwk.NodeInfo {
@@ -45,79 +65,129 @@ func NodeInfosForCandidateNodes(nodes []*api.NodeInfo, nodeMap map[string]fwk.No
 	return nodeInfos
 }
 
-// RunPreScorePlugin runs a pre-score plugin.
-// It returns whether the plugin requested its Score phase to be skipped and any error from PreScore.
-func RunPreScorePlugin(plugin fwk.PreScorePlugin, cycleState fwk.CycleState, pod *v1.Pod, nodeInfos []fwk.NodeInfo) (skipScore bool, err error) {
-	status := plugin.PreScore(context.TODO(), cycleState, pod, nodeInfos)
-	if status.IsSkip() {
-		return true, nil
-	}
-	if !status.IsSuccess() {
-		return false, status.AsError()
-	}
-	return false, nil
-}
-
-func CalculatePluginScore(
-	pluginName string,
-	plugin BaseScorePlugin,
+// RunScorePlugins runs PreScore plugins in order, then runs all active Score plugins
+// with a single parallel node traversal.
+func RunScorePlugins(
+	ctx context.Context,
+	preScorePlugins []PreScorePluginSpec,
+	scorePlugins []ScorePluginSpec,
 	cycleState fwk.CycleState,
 	pod *v1.Pod,
 	nodeInfos []fwk.NodeInfo,
-	weight int,
 ) (map[string]float64, error) {
-	nodeScoreList := make(fwk.NodeScoreList, len(nodeInfos))
-	// the default parallelization worker number is 16.
-	// the whole scoring will fail if one of the processes failed.
-	// so just create a parallelizeContext to control the whole ParallelizeUntil process.
-	// if the parallelizeCancel is invoked, the whole "ParallelizeUntil" goes to the end.
-	// this could avoid extra computation, especially in huge cluster.
-	// and the ParallelizeUntil guarantees only "workerNum" goroutines will be working simultaneously.
-	// so it's enough to allocate workerNum size for errCh.
-	// note that, in such case, size of errCh should be no less than parallelization number
-	workerNum := 16
-	errCh := make(chan error, workerNum)
-	parallelizeContext, parallelizeCancel := context.WithCancel(context.TODO())
-	workqueue.ParallelizeUntil(parallelizeContext, workerNum, len(nodeInfos), func(index int) {
-		nodeInfo := nodeInfos[index]
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
-		s, status := plugin.Score(ctx, cycleState, pod, nodeInfo)
-		if !status.IsSuccess() {
-			parallelizeCancel()
-			errCh <- fmt.Errorf("calculate %s priority failed %v", pluginName, status.Message())
-			return
-		}
-		nodeScoreList[index] = fwk.NodeScore{
-			Name:  nodeInfo.Node().Name,
-			Score: s,
-		}
-	})
-
-	select {
-	case err := <-errCh:
+	if err := ctx.Err(); err != nil {
 		return nil, err
-	default:
 	}
 
-	if extensions := plugin.ScoreExtensions(); extensions != nil {
-		normalizeStatus := extensions.NormalizeScore(context.TODO(), cycleState, pod, nodeScoreList)
-		if !normalizeStatus.IsSuccess() {
-			return nil, fmt.Errorf("normalize %s score failed %v", pluginName, normalizeStatus.Message())
+	skippedScorePlugins := make(map[string]struct{}, len(preScorePlugins))
+	for _, spec := range preScorePlugins {
+		status := spec.Plugin.PreScore(ctx, cycleState, pod, nodeInfos)
+		if status.IsSkip() {
+			skippedScorePlugins[spec.Name] = struct{}{}
+			continue
 		}
+		if !status.IsSuccess() {
+			return nil, fmt.Errorf("running PreScore plugin %q failed: %w", spec.Name, status.AsError())
+		}
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	activePlugins := make([]activeScorePlugin, 0, len(scorePlugins))
+	for _, spec := range scorePlugins {
+		if _, skipped := skippedScorePlugins[spec.Name]; skipped {
+			continue
+		}
+		activePlugins = append(activePlugins, activeScorePlugin{
+			spec:   spec,
+			scores: make(fwk.NodeScoreList, len(nodeInfos)),
+		})
+	}
+
+	if len(activePlugins) == 0 {
+		return map[string]float64{}, nil
+	}
+
+	parallelCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	errCh := parallelize.NewResultChannel[error]()
+
+	// Score nodes in parallel. Each worker owns one node index and runs every
+	// active plugin for that node.
+	workqueue.ParallelizeUntil(parallelCtx, scoreWorkerNum, len(nodeInfos), func(index int) {
+		nodeInfo := nodeInfos[index]
+		nodeName := nodeInfo.Node().Name
+		for pluginIndex := range activePlugins {
+			plugin := &activePlugins[pluginIndex]
+			score, status := plugin.spec.Plugin.Score(parallelCtx, cycleState, pod, nodeInfo)
+			if !status.IsSuccess() {
+				errCh.SendWithCancel(
+					fmt.Errorf("running Score plugin %q for node %q failed: %s", plugin.spec.Name, nodeName, status.Message()),
+					cancel,
+				)
+				return
+			}
+			plugin.scores[index] = fwk.NodeScore{Name: nodeName, Score: score}
+		}
+	})
+	if err := errCh.Receive(); err != nil {
+		return nil, err
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	// Each normalizer owns one score list, so plugins can normalize in parallel.
+	workqueue.ParallelizeUntil(parallelCtx, scoreWorkerNum, len(activePlugins), func(index int) {
+		plugin := &activePlugins[index]
+		extensions := plugin.spec.Plugin.ScoreExtensions()
+		if extensions == nil {
+			return
+		}
+		status := extensions.NormalizeScore(parallelCtx, cycleState, pod, plugin.scores)
+		if !status.IsSuccess() {
+			errCh.SendWithCancel(
+				fmt.Errorf("running NormalizeScore plugin %q failed: %s", plugin.spec.Name, status.Message()),
+				cancel,
+			)
+		}
+	})
+	if err := errCh.Receive(); err != nil {
+		return nil, err
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	// Validate normalized scores and aggregate weighted totals by node index.
+	nodeTotalScores := make([]float64, len(nodeInfos))
+	workqueue.ParallelizeUntil(parallelCtx, scoreWorkerNum, len(nodeInfos), func(index int) {
+		var total float64
+		for pluginIndex := range activePlugins {
+			plugin := &activePlugins[pluginIndex]
+			nodeScore := plugin.scores[index]
+			if nodeScore.Score > fwk.MaxNodeScore || nodeScore.Score < fwk.MinNodeScore {
+				errCh.SendWithCancel(
+					fmt.Errorf("plugin %q returns an invalid score %v for node %q", plugin.spec.Name, nodeScore.Score, nodeScore.Name),
+					cancel,
+				)
+				return
+			}
+			total += float64(nodeScore.Score * int64(plugin.spec.Weight))
+		}
+		nodeTotalScores[index] = total
+	})
+	if err := errCh.Receive(); err != nil {
+		return nil, err
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
 	}
 
 	nodeScores := make(map[string]float64, len(nodeInfos))
-	for i, nodeScore := range nodeScoreList {
-		// return error if score plugin returns invalid score.
-		if nodeScore.Score > fwk.MaxNodeScore || nodeScore.Score < fwk.MinNodeScore {
-			return nil, fmt.Errorf("%s returns an invalid score %v for node %s", pluginName, nodeScore.Score, nodeScore.Name)
-		}
-		nodeScore.Score *= int64(weight)
-		nodeScoreList[i] = nodeScore
-		nodeScores[nodeScore.Name] = float64(nodeScore.Score)
+	for index, nodeInfo := range nodeInfos {
+		nodeScores[nodeInfo.Node().Name] = nodeTotalScores[index]
 	}
-
-	klog.V(4).Infof("%s Score for task %s/%s is: %v", pluginName, pod.Namespace, pod.Name, nodeScores)
 	return nodeScores, nil
 }

--- a/pkg/scheduler/plugins/util/nodescore/score_helper_test.go
+++ b/pkg/scheduler/plugins/util/nodescore/score_helper_test.go
@@ -18,7 +18,10 @@ package nodescore
 
 import (
 	"context"
+	"errors"
+	"reflect"
 	"strings"
+	"sync"
 	"testing"
 
 	v1 "k8s.io/api/core/v1"
@@ -29,10 +32,64 @@ import (
 	"volcano.sh/volcano/pkg/scheduler/api"
 )
 
+type scoreCallTracker struct {
+	mu                       sync.Mutex
+	preScoreCalls            map[string]int
+	scoreCalls               map[string]map[string]int
+	normalizeCalls           map[string]int
+	totalPreScoreCalls       int
+	totalScoreCalls          int
+	expectedPreScoreCalls    int
+	expectedTotalScoreCalls  int
+	scoreBeforePreScoreDone  bool
+	normalizeBeforeScoreDone bool
+}
+
+func newScoreCallTracker(expectedPreScoreCalls, expectedTotalScoreCalls int) *scoreCallTracker {
+	return &scoreCallTracker{
+		preScoreCalls:           map[string]int{},
+		scoreCalls:              map[string]map[string]int{},
+		normalizeCalls:          map[string]int{},
+		expectedPreScoreCalls:   expectedPreScoreCalls,
+		expectedTotalScoreCalls: expectedTotalScoreCalls,
+	}
+}
+
+func (t *scoreCallTracker) recordPreScore(plugin string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.preScoreCalls[plugin]++
+	t.totalPreScoreCalls++
+}
+
+func (t *scoreCallTracker) recordScore(plugin, node string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.totalPreScoreCalls != t.expectedPreScoreCalls {
+		t.scoreBeforePreScoreDone = true
+	}
+	if t.scoreCalls[plugin] == nil {
+		t.scoreCalls[plugin] = map[string]int{}
+	}
+	t.scoreCalls[plugin][node]++
+	t.totalScoreCalls++
+}
+
+func (t *scoreCallTracker) recordNormalize(plugin string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.totalScoreCalls != t.expectedTotalScoreCalls {
+		t.normalizeBeforeScoreDone = true
+	}
+	t.normalizeCalls[plugin]++
+}
+
 type fakeScorePlugin struct {
-	name       string
-	scores     map[string]int64
-	extensions *fakeScoreExtensions
+	name        string
+	scores      map[string]int64
+	scoreStatus map[string]*fwk.Status
+	extensions  *fakeScoreExtensions
+	tracker     *scoreCallTracker
 }
 
 func (p *fakeScorePlugin) Name() string {
@@ -40,7 +97,11 @@ func (p *fakeScorePlugin) Name() string {
 }
 
 func (p *fakeScorePlugin) Score(_ context.Context, _ fwk.CycleState, _ *v1.Pod, nodeInfo fwk.NodeInfo) (int64, *fwk.Status) {
-	return p.scores[nodeInfo.Node().Name], nil
+	nodeName := nodeInfo.Node().Name
+	if p.tracker != nil {
+		p.tracker.recordScore(p.name, nodeName)
+	}
+	return p.scores[nodeName], p.scoreStatus[nodeName]
 }
 
 func (p *fakeScorePlugin) ScoreExtensions() fwk.ScoreExtensions {
@@ -50,14 +111,29 @@ func (p *fakeScorePlugin) ScoreExtensions() fwk.ScoreExtensions {
 	return p.extensions
 }
 
+type fakePreScorePlugin struct {
+	*fakeScorePlugin
+	preStatus *fwk.Status
+}
+
+func (p *fakePreScorePlugin) PreScore(_ context.Context, _ fwk.CycleState, _ *v1.Pod, _ []fwk.NodeInfo) *fwk.Status {
+	if p.tracker != nil {
+		p.tracker.recordPreScore(p.name)
+	}
+	return p.preStatus
+}
+
 type fakeScoreExtensions struct {
-	calls     int
+	plugin    string
 	normalize func(fwk.NodeScoreList)
 	status    *fwk.Status
+	tracker   *scoreCallTracker
 }
 
 func (e *fakeScoreExtensions) NormalizeScore(_ context.Context, _ fwk.CycleState, _ *v1.Pod, scores fwk.NodeScoreList) *fwk.Status {
-	e.calls++
+	if e.tracker != nil {
+		e.tracker.recordNormalize(e.plugin)
+	}
 	if e.normalize != nil {
 		e.normalize(scores)
 	}
@@ -97,90 +173,283 @@ func TestNodeInfosForCandidateNodes(t *testing.T) {
 	}
 }
 
-func TestCalculatePluginScore(t *testing.T) {
-	tests := []struct {
-		name           string
-		extensions     *fakeScoreExtensions
-		expectedScores map[string]float64
-		expectedCalls  int
-	}{
-		{
-			name: "skips normalization when score extensions are absent",
-			expectedScores: map[string]float64{
-				"node-a": 20,
-				"node-b": 40,
-			},
-		},
-		{
-			name: "normalizes scores before applying weight",
-			extensions: &fakeScoreExtensions{
-				normalize: func(scores fwk.NodeScoreList) {
-					scores[0].Score = 50
-					scores[1].Score = 75
-				},
-			},
-			expectedScores: map[string]float64{
-				"node-a": 100,
-				"node-b": 150,
-			},
-			expectedCalls: 1,
+func TestRunScorePluginsAggregatesNormalizedWeightedScores(t *testing.T) {
+	tracker := newScoreCallTracker(2, 4)
+	plugin1 := &fakePreScorePlugin{fakeScorePlugin: &fakeScorePlugin{
+		name:    "plugin-1",
+		scores:  map[string]int64{"node-a": 10, "node-b": 20},
+		tracker: tracker,
+	}}
+	plugin2 := &fakePreScorePlugin{fakeScorePlugin: &fakeScorePlugin{
+		name:    "plugin-2",
+		scores:  map[string]int64{"node-a": 80, "node-b": 40},
+		tracker: tracker,
+	}}
+	plugin1.extensions = &fakeScoreExtensions{plugin: plugin1.name, tracker: tracker}
+	plugin2.extensions = &fakeScoreExtensions{
+		plugin:  plugin2.name,
+		tracker: tracker,
+		normalize: func(scores fwk.NodeScoreList) {
+			for i := range scores {
+				switch scores[i].Name {
+				case "node-a":
+					scores[i].Score = 20
+				case "node-b":
+					scores[i].Score = 60
+				}
+			}
 		},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			plugin := &fakeScorePlugin{
-				name:       "test-score-plugin",
-				scores:     map[string]int64{"node-a": 10, "node-b": 20},
-				extensions: tt.extensions,
-			}
+	got, err := RunScorePlugins(
+		context.TODO(),
+		[]PreScorePluginSpec{
+			{Name: plugin1.name, Plugin: plugin1},
+			{Name: plugin2.name, Plugin: plugin2},
+		},
+		[]ScorePluginSpec{
+			{Name: plugin1.name, Plugin: plugin1, Weight: 2},
+			{Name: plugin2.name, Plugin: plugin2, Weight: 3},
+		},
+		k8sframework.NewCycleState(),
+		&v1.Pod{},
+		testNodeInfos("node-a", "node-b"),
+	)
+	if err != nil {
+		t.Fatalf("RunScorePlugins returned an error: %v", err)
+	}
+	want := map[string]float64{"node-a": 80, "node-b": 220}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("unexpected scores: got %v, want %v", got, want)
+	}
 
-			scores, err := CalculatePluginScore(
-				plugin.Name(),
-				plugin,
-				k8sframework.NewCycleState(),
-				&v1.Pod{},
-				testNodeInfos("node-a", "node-b"),
-				2,
-			)
-			if err != nil {
-				t.Fatalf("CalculatePluginScore returned an error: %v", err)
+	tracker.mu.Lock()
+	defer tracker.mu.Unlock()
+	if tracker.scoreBeforePreScoreDone {
+		t.Error("Score ran before all PreScore plugins completed")
+	}
+	if tracker.normalizeBeforeScoreDone {
+		t.Error("NormalizeScore ran before all Score calls completed")
+	}
+	for _, plugin := range []string{plugin1.name, plugin2.name} {
+		if tracker.preScoreCalls[plugin] != 1 {
+			t.Errorf("plugin %s PreScore calls: got %d, want 1", plugin, tracker.preScoreCalls[plugin])
+		}
+		if tracker.normalizeCalls[plugin] != 1 {
+			t.Errorf("plugin %s NormalizeScore calls: got %d, want 1", plugin, tracker.normalizeCalls[plugin])
+		}
+		for _, node := range []string{"node-a", "node-b"} {
+			if tracker.scoreCalls[plugin][node] != 1 {
+				t.Errorf("plugin %s Score calls for %s: got %d, want 1", plugin, node, tracker.scoreCalls[plugin][node])
 			}
-			for nodeName, expectedScore := range tt.expectedScores {
-				if score := scores[nodeName]; score != expectedScore {
-					t.Errorf("expected score %v for %s, got %v", expectedScore, nodeName, score)
-				}
-			}
-			if tt.extensions != nil && tt.extensions.calls != tt.expectedCalls {
-				t.Errorf("expected NormalizeScore to be called %d times, got %d", tt.expectedCalls, tt.extensions.calls)
-			}
-		})
+		}
 	}
 }
 
-func TestCalculatePluginScoreReturnsNormalizeError(t *testing.T) {
-	extensions := &fakeScoreExtensions{
-		status: fwk.NewStatus(fwk.Error, "normalization failed"),
+func TestRunScorePluginsSkipsPlugin(t *testing.T) {
+	tracker := newScoreCallTracker(2, 2)
+	skipped := &fakePreScorePlugin{
+		fakeScorePlugin: &fakeScorePlugin{name: "skipped", tracker: tracker},
+		preStatus:       fwk.NewStatus(fwk.Skip),
 	}
-	plugin := &fakeScorePlugin{
-		name:       "test-score-plugin",
-		scores:     map[string]int64{"node-a": 10},
-		extensions: extensions,
-	}
+	active := &fakePreScorePlugin{fakeScorePlugin: &fakeScorePlugin{
+		name:    "active",
+		scores:  map[string]int64{"node-a": 30, "node-b": 40},
+		tracker: tracker,
+	}}
+	skipped.extensions = &fakeScoreExtensions{plugin: skipped.name, tracker: tracker}
+	active.extensions = &fakeScoreExtensions{plugin: active.name, tracker: tracker}
 
-	_, err := CalculatePluginScore(
-		plugin.Name(),
-		plugin,
+	got, err := RunScorePlugins(
+		context.TODO(),
+		[]PreScorePluginSpec{
+			{Name: skipped.name, Plugin: skipped},
+			{Name: active.name, Plugin: active},
+		},
+		[]ScorePluginSpec{
+			{Name: skipped.name, Plugin: skipped, Weight: 10},
+			{Name: active.name, Plugin: active, Weight: 2},
+		},
 		k8sframework.NewCycleState(),
 		&v1.Pod{},
-		testNodeInfos("node-a"),
-		1,
+		testNodeInfos("node-a", "node-b"),
 	)
-	if err == nil || !strings.Contains(err.Error(), "normalization failed") {
-		t.Fatalf("expected normalization error, got %v", err)
+	if err != nil {
+		t.Fatalf("RunScorePlugins returned an error: %v", err)
 	}
-	if extensions.calls != 1 {
-		t.Errorf("expected NormalizeScore to be called once, got %d", extensions.calls)
+	want := map[string]float64{"node-a": 60, "node-b": 80}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("unexpected scores: got %v, want %v", got, want)
+	}
+
+	tracker.mu.Lock()
+	defer tracker.mu.Unlock()
+	if tracker.preScoreCalls[skipped.name] != 1 || len(tracker.scoreCalls[skipped.name]) != 0 || tracker.normalizeCalls[skipped.name] != 0 {
+		t.Fatalf("skipped plugin calls: PreScore=%d Score=%v NormalizeScore=%d",
+			tracker.preScoreCalls[skipped.name], tracker.scoreCalls[skipped.name], tracker.normalizeCalls[skipped.name])
+	}
+}
+
+func TestRunScorePluginsReturnsErrors(t *testing.T) {
+	t.Run("PreScore error", func(t *testing.T) {
+		preScoreErr := errors.New("pre failed")
+		plugin := &fakePreScorePlugin{
+			fakeScorePlugin: &fakeScorePlugin{name: "pre-error"},
+			preStatus:       fwk.AsStatus(preScoreErr),
+		}
+		got, err := RunScorePlugins(
+			context.TODO(),
+			[]PreScorePluginSpec{{Name: plugin.name, Plugin: plugin}},
+			[]ScorePluginSpec{{Name: plugin.name, Plugin: plugin, Weight: 1}},
+			k8sframework.NewCycleState(), &v1.Pod{}, testNodeInfos("node-a"),
+		)
+		assertRunScoreError(t, got, err, "PreScore plugin \"pre-error\"")
+		if !errors.Is(err, preScoreErr) {
+			t.Fatalf("expected wrapped PreScore error, got %v", err)
+		}
+	})
+
+	t.Run("Score error", func(t *testing.T) {
+		plugin := &fakeScorePlugin{
+			name:        "score-error",
+			scores:      map[string]int64{"node-a": 10},
+			scoreStatus: map[string]*fwk.Status{"node-a": fwk.NewStatus(fwk.Error, "score failed")},
+		}
+		got, err := RunScorePlugins(
+			context.TODO(), nil,
+			[]ScorePluginSpec{{Name: plugin.name, Plugin: plugin, Weight: 1}},
+			k8sframework.NewCycleState(), &v1.Pod{}, testNodeInfos("node-a"),
+		)
+		assertRunScoreError(t, got, err, "Score plugin \"score-error\" for node \"node-a\"")
+	})
+
+	t.Run("NormalizeScore error", func(t *testing.T) {
+		plugin := &fakeScorePlugin{
+			name:   "normalize-error",
+			scores: map[string]int64{"node-a": 10},
+			extensions: &fakeScoreExtensions{
+				status: fwk.NewStatus(fwk.Error, "normalize failed"),
+			},
+		}
+		got, err := RunScorePlugins(
+			context.TODO(), nil,
+			[]ScorePluginSpec{{Name: plugin.name, Plugin: plugin, Weight: 1}},
+			k8sframework.NewCycleState(), &v1.Pod{}, testNodeInfos("node-a"),
+		)
+		assertRunScoreError(t, got, err, "NormalizeScore plugin \"normalize-error\"")
+	})
+
+	t.Run("invalid normalized score", func(t *testing.T) {
+		plugin := &fakeScorePlugin{
+			name:   "invalid-score",
+			scores: map[string]int64{"node-a": 10},
+			extensions: &fakeScoreExtensions{normalize: func(scores fwk.NodeScoreList) {
+				scores[0].Score = fwk.MaxNodeScore + 1
+			}},
+		}
+		got, err := RunScorePlugins(
+			context.TODO(), nil,
+			[]ScorePluginSpec{{Name: plugin.name, Plugin: plugin, Weight: 1}},
+			k8sframework.NewCycleState(), &v1.Pod{}, testNodeInfos("node-a"),
+		)
+		assertRunScoreError(t, got, err, "invalid score")
+	})
+}
+
+func TestRunScorePluginsSupportsScoreOnlyPlugin(t *testing.T) {
+	plugin := &fakeScorePlugin{
+		name:   "score-only",
+		scores: map[string]int64{"node-a": 25},
+		extensions: &fakeScoreExtensions{normalize: func(scores fwk.NodeScoreList) {
+			scores[0].Score = 40
+		}},
+	}
+
+	got, err := RunScorePlugins(
+		context.TODO(), nil,
+		[]ScorePluginSpec{{Name: plugin.name, Plugin: plugin, Weight: 2}},
+		k8sframework.NewCycleState(), &v1.Pod{}, testNodeInfos("node-a"),
+	)
+	if err != nil {
+		t.Fatalf("RunScorePlugins returned an error: %v", err)
+	}
+	want := map[string]float64{"node-a": 80}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("unexpected scores: got %v, want %v", got, want)
+	}
+}
+
+func TestRunScorePluginsEmptyInputs(t *testing.T) {
+	t.Run("no plugins", func(t *testing.T) {
+		got, err := RunScorePlugins(context.TODO(), nil, nil, k8sframework.NewCycleState(), &v1.Pod{}, testNodeInfos("node-a"))
+		if err != nil {
+			t.Fatalf("RunScorePlugins returned an error: %v", err)
+		}
+		if len(got) != 0 {
+			t.Fatalf("expected no scores, got %v", got)
+		}
+	})
+
+	t.Run("no nodes", func(t *testing.T) {
+		tracker := newScoreCallTracker(1, 0)
+		plugin := &fakePreScorePlugin{fakeScorePlugin: &fakeScorePlugin{
+			name:    "plugin",
+			tracker: tracker,
+			extensions: &fakeScoreExtensions{
+				plugin:  "plugin",
+				tracker: tracker,
+			},
+		}}
+		got, err := RunScorePlugins(
+			context.TODO(),
+			[]PreScorePluginSpec{{Name: plugin.name, Plugin: plugin}},
+			[]ScorePluginSpec{{Name: plugin.name, Plugin: plugin, Weight: 1}},
+			k8sframework.NewCycleState(), &v1.Pod{}, nil,
+		)
+		if err != nil {
+			t.Fatalf("RunScorePlugins returned an error: %v", err)
+		}
+		if len(got) != 0 {
+			t.Fatalf("expected no scores, got %v", got)
+		}
+
+		tracker.mu.Lock()
+		defer tracker.mu.Unlock()
+		if tracker.preScoreCalls[plugin.name] != 1 || len(tracker.scoreCalls[plugin.name]) != 0 || tracker.normalizeCalls[plugin.name] != 1 {
+			t.Fatalf("calls with no nodes: PreScore=%d Score=%v NormalizeScore=%d",
+				tracker.preScoreCalls[plugin.name], tracker.scoreCalls[plugin.name], tracker.normalizeCalls[plugin.name])
+		}
+	})
+}
+
+func TestRunScorePluginsReturnsCanceledContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	plugin := &fakeScorePlugin{name: "plugin", scores: map[string]int64{"node-a": 10}}
+
+	scores, err := RunScorePlugins(
+		ctx, nil,
+		[]ScorePluginSpec{{Name: plugin.name, Plugin: plugin, Weight: 1}},
+		k8sframework.NewCycleState(), &v1.Pod{}, testNodeInfos("node-a"),
+	)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got %v", err)
+	}
+	if scores != nil {
+		t.Fatalf("expected no scores, got %v", scores)
+	}
+}
+
+func assertRunScoreError(t *testing.T, scores map[string]float64, err error, wantError string) {
+	t.Helper()
+	if err == nil {
+		t.Fatalf("expected an error containing %q, got scores %v", wantError, scores)
+	}
+	if !strings.Contains(err.Error(), wantError) {
+		t.Fatalf("unexpected error: got %q, want substring %q", err, wantError)
+	}
+	if scores != nil {
+		t.Fatalf("expected partial scores to be discarded, got %v", scores)
 	}
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

/area performance

#### What this PR does / why we need it:

Before this change, `BatchNodeOrderFn` runs the scoring phase roughly as follows:

(Relevant code: `pkg/scheduler/plugins/predicates/predicates.go` and `pkg/scheduler/plugins/nodeorder/nodeorder.go`)

```text
for each registered plugin {
    run PreScore
    if PreScore returns Skip {
        continue
    }

    CalculatePluginScore {
        score all candidate nodes with 16 workers
        store the score of each node in nodeScoreList

        if the plugin implements ScoreExtensions {
            run NormalizeScore to update nodeScoreList in place
        }

        apply the plugin weight to nodeScoreList and return the per-node scores
    }

    add the plugin's scores to the total score of each node
}
```

With `N` score plugins and `M` candidate nodes, the scheduler still needs to execute `N * M` `Score` calls. Using a separate `NodeScoreList` for each plugin is also necessary because each plugin may implement `NormalizeScore`. The main issue is how these calls are organized:

1. Each plugin starts a separate parallel node traversal, repeatedly creating workers, contexts, and error channels.
2. The same set of `NodeInfo` objects is traversed again for every plugin, increasing memory access and reducing CPU cache locality.
3. Although each plugin scores nodes with 16 workers, plugins are processed one at a time. The next plugin cannot start scoring until the current plugin completes `NormalizeScore`.

This PR scores all candidate nodes in a single 16-worker traversal. Each worker runs all active score plugins for its current node:

(`CalculatePluginScore` no longer describes the new multi-plugin behavior, so it is replaced by `RunScorePlugins`.)

```text
build the PreScore and Score plugin lists

RunScorePlugins {
    run PreScore plugins serially and record skipped plugins
    build activePlugins

    score all candidate nodes with 16 workers {
        for each plugin in activePlugins {
            store the plugin's raw score for the current node in
            activePlugins[pluginIndex].scores[nodeIndex]
        }
    }

    run NormalizeScore for active plugins in parallel
    validate scores, apply plugin weights, and aggregate each node's total score in parallel
}
```

Compared with the previous implementation, this PR:

1. Score N*M times as well, but only starts  one parallel node traversal for all score plugins.
2. Processes all plugins for the same `NodeInfo` within one worker, improving CPU cache locality.
3. Normalizes plugins in parallel and aggregates weighted totals across nodes in parallel.

This reduces repeated parallelization and synchronization overhead and improves scheduling performance in large clusters.

#### Which issue(s) this PR fixes:

N/A

#### Special notes for your reviewer:

AI tools were used to assist with the implementation and tests. I reviewed all generated changes and completed the tests and benchmark documented below.

#### Tests

The following unit and race tests passed. They cover the shared scoring helper, the volcano-scheduler `nodeorder` and `predicates` paths, and the agent-scheduler `predicates` adapter:

```bash
go test ./pkg/scheduler/plugins/util/nodescore \
  ./pkg/scheduler/plugins/nodeorder \
  ./pkg/scheduler/plugins/predicates \
  ./pkg/agentscheduler/plugins/predicates

go test -race ./pkg/scheduler/plugins/util/nodescore \
  ./pkg/scheduler/plugins/nodeorder \
  ./pkg/scheduler/plugins/predicates \
  ./pkg/agentscheduler/plugins/predicates
```

The tests cover the following behavior:

- All `PreScore` calls complete before `Score` starts, and all `Score` calls complete before `NormalizeScore` starts.
- When `PreScore` returns `Skip`, only the corresponding plugin's `Score` and `NormalizeScore` phases are skipped.
- Raw scores are normalized, weighted, and aggregated correctly. If any phase fails, no scores are returned and all partially computed results are discarded.
- The fused `nodeorder` and `predicates` paths produce the same results as the previous per-plugin execution, including when `LeastAllocated` and `MostAllocated` are enabled together.
- The agent-scheduler runs `PreScore` and `Score` only for candidate nodes.

#### Performance benchmark

The benchmark compares the original implementation with this PR. Each version was run seven times. The runs with the highest and lowest throughput were excluded, and the remaining five runs were averaged.

- Environment:

  - Machine: one VM with 32 vCPUs and 64 GiB of memory
  - Nodes: 1,000 KWOK nodes
  - Workload: 20 jobs, 500 replicas per job, 10,000 pods in total
  - Scheduler: agent-scheduler with 4 workers
  - Scheduling cycle interval: `0`, to avoid phase effects from a fixed scheduling interval
  - Volcano version: `master`

- Metrics:

  - Pod latency = binding timestamp - creation timestamp
  - P50/P90/P99 are calculated for each run using the nearest-rank method; the table reports the average of the five retained runs
  - Binding window = timestamp of the last binding - timestamp of the first binding
  - Throughput = total number of pods / binding window
  - Pod creation and binding timestamps are read directly from `audit.log` instead of being estimated from Prometheus histograms

| Version | Runs | Raw P50 avg | Raw P90 avg | Raw P99 avg | Throughput avg | Binding window avg |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| master baseline | 5 | 2265.296 ms | 3704.348 ms | 3961.418 ms | 762.772 pods/s | 13.1102 s |
| master with this PR | 5 | 1115.628 ms | 1554.856 ms | 1637.436 ms | 936.232 pods/s | 10.6820 s |
| Improvement | - | 50.75% lower | 58.03% lower | 58.67% lower | 22.74% higher | 18.52% lower |

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
