### PR TITLE
fix: deep copy the pod before evicting to avoid data race with plugins

### DIFF
--- a/pkg/scheduler/cache/cache.go
+++ b/pkg/scheduler/cache/cache.go
@@ -965,7 +965,7 @@ func (sc *SchedulerCache) Evict(taskInfo *schedulingapi.TaskInfo, reason string)
 	// Add new task to node.
 	node.UpdateTask(task)
 
-	p := task.Pod
+	p := task.Pod.DeepCopy()
 
 	go func() {
 		err := sc.Evictor.Evict(p, reason)


### PR DESCRIPTION
<!--
Special notes: AI involvement is disclosed below per contributing.md#ai-guidance.
-->

#### What type of PR is this?

bug-fix

#### What this PR does / why we need it:

SchedulerCache.Evict passes task.Pod directly into an unlocked goroutine, while the same Pod pointer is shared with scheduler plugins via TaskInfo.Clone and may be mutated in place (e.g. SetPodResourceDecision). defaultEvictor.Evict deep-copies the pod while unlocked, so a concurrent plugin mutation can race with the copy and crash the scheduler with fatal error: concurrent map writes.

Pass a private deep copy into the goroutine so the eviction path never operates on the shared cache object. The existing deep copy inside defaultEvictor.Evict is kept to protect the default implementation.

#### Which issue(s) this PR fixes:

Fixes #5932

<!-- issue not created yet — replace with the issue number once opened. The evidence (affected versions, code references) is provided below in Special notes / PR body until then. -->

#### Special notes for your reviewer:

- The single-line change (`p := task.Pod.DeepCopy()` at pkg/scheduler/cache/cache.go) is once per eviction; negligible next to the UpdateStatus/Delete API calls.

#### Does this PR introduce a user-facing change?

```release-note
Fix data race when evicting: pass a deep copy of the pod to the evictor so concurrent in-place mutations from scheduler plugins can no longer race with the eviction goroutine and crash the scheduler.