### PR TITLE
docs: fix broken relative links in installer and apis guides

### DIFF
--- a/installer/README.md
+++ b/installer/README.md
@@ -182,4 +182,4 @@ Alternatively, a YAML file that specifies the values for the parameters can be p
 $ helm install --name volcano-release -f values.yaml volcano/volcano
 ```
 
-> **Tip**: You can use the default [values.yaml](chart/volcano/values.yaml)
+> **Tip**: You can use the default [values.yaml](helm/chart/volcano/values.yaml)

--- a/staging/src/volcano.sh/apis/contribute.md
+++ b/staging/src/volcano.sh/apis/contribute.md
@@ -30,8 +30,8 @@ The goal of the community is to develop a volcano system which is useful for run
 
 # Getting started
 
-- Read the [get started](docs/development/prepare-for-development.md) for developing code for Volcano
-- Read the [setup](docs/development/development.md) for build/deploy instructions.
+- Read the [get started](https://github.com/volcano-sh/volcano/blob/master/docs/development/prepare-for-development.md) for developing code for Volcano
+- Read the [setup](https://github.com/volcano-sh/volcano/blob/master/docs/development/development.md) for build/deploy instructions.
 
 
 # Your First Contribution


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

Fixes two broken relative links in the documentation.

**1. `installer/README.md`**

The tip at the end of the Helm section links to `chart/volcano/values.yaml`,
but the chart lives under `helm/`, so the link resolves to
`installer/chart/volcano/values.yaml`, which does not exist. The file is at
`installer/helm/chart/volcano/values.yaml`.

**2. `staging/src/volcano.sh/apis/contribute.md`**

The "Getting started" section links to `docs/development/prepare-for-development.md`
and `docs/development/development.md` as relative paths. Those documents exist in
this repository but not under `staging/src/volcano.sh/apis/`, and this file is
published to `volcano-sh/apis` by the `sync-apis` workflow, where no such directory
exists either. Both links are therefore broken for readers of the apis repo, which
is the audience the file is written for. Changed to absolute URLs into this
repository.

I checked all 155 markdown files in the tree rather than only these two, so this
should be the complete set of broken relative links.

#### Which issue(s) this PR fixes:

None; there is no filed issue for these. The evidence is above: the two link
targets do not exist at the paths given, and the corrected paths do.

#### Special notes for your reviewer:

Documentation only. No Go files are touched, so no behaviour changes.

One further apparent broken link exists, in `docs/design/command-line-enhancement.md`:
the author byline `[@jiangkaihua](jiangkaihua1@huawei.com)` renders as a relative
link rather than a `mailto:`. I left it alone deliberately, since rewriting a
historical attribution line seemed like churn rather than a fix. Happy to include
it if you would prefer it corrected.

Disclosure: I used an AI coding assistant while preparing this change, in line with
the AI guidance in contributing.md. I verified each link target myself and will
respond to review comments directly.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
