### PR TITLE
feat: support optional cert-manager admission TLS

### DIFF
--- a/cmd/webhook-manager/app/options/options.go
+++ b/cmd/webhook-manager/app/options/options.go
@@ -57,6 +57,9 @@ type Config struct {
 	GracefulShutdownTime time.Duration
 
 	EnableHealthz bool
+	// ManageWebhookCABundle controls whether the webhook manager writes CA data
+	// into webhook configurations. cert-manager mode delegates this to cainjector.
+	ManageWebhookCABundle bool
 	// HealthzBindAddress is the IP address and port for the health check server to serve on
 	// defaulting to :11251
 	HealthzBindAddress string
@@ -98,6 +101,7 @@ func (c *Config) AddFlags(fs *pflag.FlagSet) {
 	fs.StringArrayVar(&c.SchedulerNames, "scheduler-name", []string{defaultSchedulerName}, "Volcano will handle pods whose .spec.SchedulerName is same as scheduler-name")
 	fs.StringVar(&c.ConfigPath, "admission-conf", "", "The configmap file of this webhook")
 	fs.BoolVar(&c.EnableHealthz, "enable-healthz", false, "Enable the health check; it is false by default")
+	fs.BoolVar(&c.ManageWebhookCABundle, "manage-webhook-ca-bundle", true, "Update webhook caBundle from the configured CA; disable when cert-manager cainjector manages it.")
 	fs.StringVar(&c.HealthzBindAddress, "healthz-address", defaultHealthzAddress, "The address to listen on for the health check server.")
 	fs.DurationVar(&c.GracefulShutdownTime, "graceful-shutdown-time", defaultGracefulShutdownTime, "The duration to wait during graceful shutdown before forcing termination.")
 	fs.BoolVar(&c.EnableQueueAllocatedPodsCheck, "enable-queue-allocated-pods-check", false, "If true, queue deletion will be rejected when the queue has allocated pods.")

--- a/cmd/webhook-manager/app/options/options_test.go
+++ b/cmd/webhook-manager/app/options/options_test.go
@@ -57,6 +57,7 @@ func TestAddFlags(t *testing.T) {
 		EnabledAdmission:              defaultEnabledAdmission,
 		GracefulShutdownTime:          defaultGracefulShutdownTime,
 		EnableHealthz:                 false,
+		ManageWebhookCABundle:         true,
 		HealthzBindAddress:            defaultHealthzAddress,
 		EnableQueueAllocatedPodsCheck: false,
 		MaxQueueDepth:                 defaultMaxQueueDepth,

--- a/cmd/webhook-manager/app/server.go
+++ b/cmd/webhook-manager/app/server.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/klog/v2"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	"volcano.sh/apis/pkg/apis/helpers"
 	"volcano.sh/apis/pkg/apis/scheduling/scheme"
@@ -42,6 +43,7 @@ import (
 
 // Run start the service of admission controller.
 func Run(config *options.Config) error {
+	logf.SetLogger(klog.NewKlogr())
 	if config.EnableHealthz {
 		if err := helpers.StartHealthz(config.HealthzBindAddress, "volcano-admission", config.CaCertData, config.CertData, config.KeyData); err != nil {
 			return err
@@ -105,9 +107,11 @@ func Run(config *options.Config) error {
 		klog.V(3).Infof("Registered '%s' as webhook.", service.Path)
 		http.HandleFunc(service.Path, service.Handler)
 
-		klog.V(3).Infof("Add CaCert for webhook <%s>", service.Path)
-		if err = addCaCertForWebhook(kubeClient, service, config.CaCertData); err != nil {
-			return fmt.Errorf("failed to add caCert for webhook %v", err)
+		if config.ManageWebhookCABundle {
+			klog.V(3).Infof("Add CaCert for webhook <%s>", service.Path)
+			if err = addCaCertForWebhook(kubeClient, service, config.CaCertData); err != nil {
+				return fmt.Errorf("failed to add caCert for webhook %v", err)
+			}
 		}
 		return nil
 	}); err != nil {
@@ -126,9 +130,21 @@ func Run(config *options.Config) error {
 		}
 	}
 
+	tlsConfig, certWatcher, err := configTLS(config, restConfig)
+	if err != nil {
+		return err
+	}
+	if certWatcher != nil {
+		go func() {
+			if err := certWatcher.Start(ctx); err != nil && !errors.Is(err, context.Canceled) {
+				klog.ErrorS(err, "certificate watcher stopped")
+			}
+		}()
+	}
+
 	server := &http.Server{
 		Addr:              config.ListenAddress + ":" + strconv.Itoa(config.Port),
-		TLSConfig:         configTLS(config, restConfig),
+		TLSConfig:         tlsConfig,
 		ReadHeaderTimeout: helpers.DefaultReadHeaderTimeout,
 		ReadTimeout:       helpers.DefaultReadTimeout,
 		WriteTimeout:      helpers.DefaultWriteTimeout,

--- a/cmd/webhook-manager/app/util.go
+++ b/cmd/webhook-manager/app/util.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/certwatcher"
 
 	"volcano.sh/apis/pkg/client/clientset/versioned"
 	"volcano.sh/volcano/cmd/webhook-manager/app/options"
@@ -131,40 +132,57 @@ func getVolcanoClient(restConfig *rest.Config) *versioned.Clientset {
 // configTLS is a helper function that generate tls certificates from directly defined tls config or kubeconfig
 // These are passed in as command line for cluster certification. If tls config is passed in, we use the directly
 // defined tls config, else use that defined in kubeconfig.
-func configTLS(config *options.Config, restConfig *rest.Config) *tls.Config {
+func configTLS(config *options.Config, restConfig *rest.Config) (*tls.Config, *certwatcher.CertWatcher, error) {
 	if len(config.CertData) != 0 && len(config.KeyData) != 0 {
 		certPool := x509.NewCertPool()
 		certPool.AppendCertsFromPEM(config.CaCertData)
 
-		sCert, err := tls.X509KeyPair(config.CertData, config.KeyData)
+		if config.CertFile == "" || config.KeyFile == "" {
+			sCert, err := tls.X509KeyPair(config.CertData, config.KeyData)
+			if err != nil {
+				return nil, nil, fmt.Errorf("failed to parse TLS certificate: %w", err)
+			}
+			return &tls.Config{
+				Certificates: []tls.Certificate{sCert},
+				RootCAs:      certPool,
+				MinVersion:   tls.VersionTLS12,
+				ClientAuth:   tls.VerifyClientCertIfGiven,
+				CipherSuites: []uint16{
+					tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+					tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+					tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+				},
+			}, nil, nil
+		}
+
+		watcher, err := certwatcher.New(config.CertFile, config.KeyFile)
 		if err != nil {
-			klog.Fatal(err)
+			return nil, nil, fmt.Errorf("failed to create certificate watcher: %w", err)
 		}
 
 		return &tls.Config{
-			Certificates: []tls.Certificate{sCert},
-			RootCAs:      certPool,
-			MinVersion:   tls.VersionTLS12,
-			ClientAuth:   tls.VerifyClientCertIfGiven,
+			GetCertificate: watcher.GetCertificate,
+			RootCAs:        certPool,
+			MinVersion:     tls.VersionTLS12,
+			ClientAuth:     tls.VerifyClientCertIfGiven,
 			CipherSuites: []uint16{
 				tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
 				tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
 				tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
 			},
-		}
+		}, watcher, nil
 	}
 
 	if len(restConfig.CertData) != 0 && len(restConfig.KeyData) != 0 {
 		sCert, err := tls.X509KeyPair(restConfig.CertData, restConfig.KeyData)
 		if err != nil {
-			klog.Fatal(err)
+			return nil, nil, fmt.Errorf("failed to parse TLS certificate: %w", err)
 		}
 
 		return &tls.Config{
 			Certificates: []tls.Certificate{sCert},
-		}
+		}, nil, nil
 	}
 
-	klog.Fatal("tls: failed to find any tls config data")
-	return &tls.Config{}
+	return nil, nil, fmt.Errorf("tls: failed to find any tls config data")
 }

--- a/go.sum
+++ b/go.sum
@@ -470,6 +470,8 @@ golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+gomodules.xyz/jsonpatch/v2 v2.4.0 h1:Ci3iUJyx9UeRx7CeFN8ARgGbkESwJK+KB9lLcWxY/Zw=
+gomodules.xyz/jsonpatch/v2 v2.4.0/go.mod h1:AH3dM2RI6uoBZxn3LVrfvJ3E0/9dG4cSrbuBJT4moAY=
 gonum.org/v1/gonum v0.17.0 h1:VbpOemQlsSMrYmn7T2OUvQ4dqxQXU+ouZFQsZOx50z4=
 gonum.org/v1/gonum v0.17.0/go.mod h1:El3tOrEuMpv2UdMrbNlKEh9vd86bmQ6vqIcDwxEOc1E=
 google.golang.org/genproto/googleapis/api v0.0.0-20260414002931-afd174a4e478 h1:yQugLulqltosq0B/f8l4w9VryjV+N/5gcW0jQ3N8Qec=

--- a/installer/README.md
+++ b/installer/README.md
@@ -94,6 +94,7 @@ The following are the list configurable parameters of Volcano Chart and their de
 |`basic.scheduler_app_name`|Scheduler App Name|`volcano-scheduler`|
 |`custom.metrics_enable`|Whether to Enable Metrics|`false`|
 |`custom.admission_enable`|Whether to Enable Admission|`true`|
+|`custom.certManager.enabled`|Use cert-manager for admission TLS; when false, use the self-signed fallback hook|`false`|
 |`custom.admission_replicas`|The number of Admission pods to run|`1`|
 |`custom.controller_enable`|Whether to Enable Controller|`true`|
 |`custom.controller_replicas`|The number of Controller pods to run|`1`|

--- a/installer/helm/chart/volcano/templates/admission-certmanager.yaml
+++ b/installer/helm/chart/volcano/templates/admission-certmanager.yaml
@@ -1,0 +1,25 @@
+{{- if and .Values.custom.admission_enable .Values.custom.certManager.enabled }}
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: {{ .Release.Name }}-admission-selfsigned
+  namespace: {{ .Release.Namespace }}
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ .Release.Name }}-admission-cert
+  namespace: {{ .Release.Namespace }}
+spec:
+  secretName: {{ .Values.basic.admission_secret_name }}
+  dnsNames:
+    - {{ .Release.Name }}-admission-service
+    - {{ .Release.Name }}-admission-service.{{ .Release.Namespace }}
+    - {{ .Release.Name }}-admission-service.{{ .Release.Namespace }}.svc
+    - {{ .Release.Name }}-admission-service.{{ .Release.Namespace }}.svc.cluster.local
+  issuerRef:
+    name: {{ .Release.Name }}-admission-selfsigned
+    kind: Issuer
+{{- end }}

--- a/installer/helm/chart/volcano/templates/admission-init.yaml
+++ b/installer/helm/chart/volcano/templates/admission-init.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.custom.admission_enable }}
+{{- if and .Values.custom.admission_enable (not .Values.custom.certManager.enabled) }}
 {{ $admission_affinity := or .Values.custom.admission_affinity .Values.custom.default_affinity }}
 {{ $admission_tolerations := or .Values.custom.admission_tolerations .Values.custom.default_tolerations }}
 {{ $admission_sc := or .Values.custom.admission_sc .Values.custom.default_sc }}
@@ -15,8 +15,8 @@ metadata:
     {{- toYaml .Values.custom.common_labels | nindent 4 }}
   {{- end }}
   annotations:
-    "helm.sh/hook": pre-install,pre-upgrade
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-delete-policy": before-hook-creation
     "helm.sh/hook-weight": "0"
 
 ---
@@ -30,8 +30,8 @@ metadata:
     {{- toYaml .Values.custom.common_labels | nindent 4 }}
   {{- end }}
   annotations:
-    "helm.sh/hook": pre-install,pre-upgrade
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-delete-policy": before-hook-creation
     "helm.sh/hook-weight": "0"
 rules:
   - apiGroups: [""]
@@ -49,8 +49,8 @@ metadata:
     {{- toYaml .Values.custom.common_labels | nindent 4 }}
   {{- end }}
   annotations:
-    "helm.sh/hook": pre-install,pre-upgrade
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-delete-policy": before-hook-creation
     "helm.sh/hook-weight": "0"
 subjects:
   - kind: ServiceAccount
@@ -68,7 +68,7 @@ metadata:
   name: {{ .Release.Name }}-admission-init
   namespace: {{ .Release.Namespace }}
   annotations:
-    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook": pre-install
     "helm.sh/hook-delete-policy": before-hook-creation
     "helm.sh/hook-weight": "5" # set a higher weight to reserve buffers.
   labels:

--- a/installer/helm/chart/volcano/templates/admission.yaml
+++ b/installer/helm/chart/volcano/templates/admission.yaml
@@ -142,6 +142,7 @@ spec:
             - --admission-conf=/admission.local.config/configmap/{{base .Values.basic.admission_config_file}}
             - --webhook-namespace={{ .Release.Namespace }}
             - --webhook-service-name={{ .Release.Name }}-admission-service
+            - --manage-webhook-ca-bundle={{ not .Values.custom.certManager.enabled }}
             {{- if $scheduler_name }}
             - --scheduler-name={{- $scheduler_name }}
             {{- end }}

--- a/installer/helm/chart/volcano/templates/webhooks.yaml
+++ b/installer/helm/chart/volcano/templates/webhooks.yaml
@@ -514,6 +514,10 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration  
 metadata:  
   name: volcano-admission-service-cronjobs-validate  
+  {{- if .Values.custom.certManager.enabled }}
+  annotations:
+    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ .Release.Name }}-admission-cert
+  {{- end }}
   {{- if .Values.custom.common_labels }}  
   labels:  
     {{- toYaml .Values.custom.common_labels | nindent 4 }}  

--- a/installer/helm/chart/volcano/templates/webhooks.yaml
+++ b/installer/helm/chart/volcano/templates/webhooks.yaml
@@ -4,6 +4,10 @@
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
+  {{- if .Values.custom.certManager.enabled }}
+  annotations:
+    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ .Release.Name }}-admission-cert
+  {{- end }}
   name: volcano-admission-service-pods-mutate
   {{- if .Values.custom.common_labels }}
   labels:
@@ -52,6 +56,10 @@ webhooks:
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
+  {{- if .Values.custom.certManager.enabled }}
+  annotations:
+    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ .Release.Name }}-admission-cert
+  {{- end }}
   name: volcano-admission-service-queues-mutate
   {{- if .Values.custom.common_labels }}
   labels:
@@ -101,6 +109,10 @@ webhooks:
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
+  {{- if .Values.custom.certManager.enabled }}
+  annotations:
+    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ .Release.Name }}-admission-cert
+  {{- end }}
   name: volcano-admission-service-podgroups-mutate
   {{- if .Values.custom.common_labels }}
   labels:
@@ -149,6 +161,10 @@ webhooks:
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
+  {{- if .Values.custom.certManager.enabled }}
+  annotations:
+    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ .Release.Name }}-admission-cert
+  {{- end }}
   name: volcano-admission-service-jobs-mutate
   {{- if .Values.custom.common_labels }}
   labels:
@@ -198,6 +214,10 @@ webhooks:
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
+  {{- if .Values.custom.certManager.enabled }}
+  annotations:
+    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ .Release.Name }}-admission-cert
+  {{- end }}
   name: volcano-admission-service-jobs-validate
   {{- if .Values.custom.common_labels }}
   labels:
@@ -246,6 +266,10 @@ webhooks:
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
+  {{- if .Values.custom.certManager.enabled }}
+  annotations:
+    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ .Release.Name }}-admission-cert
+  {{- end }}
   name: volcano-admission-service-jobflows-validate
   {{- if .Values.custom.common_labels }}
   labels:
@@ -295,6 +319,10 @@ webhooks:
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
+  {{- if .Values.custom.certManager.enabled }}
+  annotations:
+    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ .Release.Name }}-admission-cert
+  {{- end }}
   name: volcano-admission-service-pods-validate
   {{- if .Values.custom.common_labels }}
   labels:
@@ -342,6 +370,10 @@ webhooks:
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
+  {{- if .Values.custom.certManager.enabled }}
+  annotations:
+    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ .Release.Name }}-admission-cert
+  {{- end }}
   name: volcano-admission-service-queues-validate
   {{- if .Values.custom.common_labels }}
   labels:
@@ -391,6 +423,10 @@ webhooks:
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
+  {{- if .Values.custom.certManager.enabled }}
+  annotations:
+    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ .Release.Name }}-admission-cert
+  {{- end }}
   name: volcano-admission-service-podgroups-validate
   {{- if .Values.custom.common_labels }}
   labels:
@@ -438,6 +474,10 @@ webhooks:
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
+  {{- if .Values.custom.certManager.enabled }}
+  annotations:
+    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ .Release.Name }}-admission-cert
+  {{- end }}
   name: volcano-admission-service-hypernodes-validate
   {{- if .Values.custom.common_labels }}
   labels:

--- a/installer/helm/chart/volcano/values.yaml
+++ b/installer/helm/chart/volcano/values.yaml
@@ -23,6 +23,10 @@ basic:
   admission_port: 8443
   image_registry: "docker.io"
 custom:
+  # Use cert-manager for admission TLS when available. When disabled, the
+  # admission-init hook provides the self-signed fallback certificate path.
+  certManager:
+    enabled: false
   go_memlimit_enable: false
   metrics_enable: false
   admission_enable: true

--- a/installer/volcano-development.yaml
+++ b/installer/volcano-development.yaml
@@ -149,6 +149,7 @@ spec:
             - --admission-conf=/admission.local.config/configmap/volcano-admission.conf
             - --webhook-namespace=volcano-system
             - --webhook-service-name=volcano-admission-service
+            - --manage-webhook-ca-bundle=true
             - --enable-healthz=true
             - --logtostderr
             - --port=8443
@@ -188,8 +189,8 @@ metadata:
   name: volcano-admission-init
   namespace: volcano-system
   annotations:
-    "helm.sh/hook": pre-install,pre-upgrade
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-delete-policy": before-hook-creation
     "helm.sh/hook-weight": "0"
 ---
 # Source: volcano/templates/admission-init.yaml
@@ -199,8 +200,8 @@ metadata:
   name: volcano-admission-init
   namespace: volcano-system
   annotations:
-    "helm.sh/hook": pre-install,pre-upgrade
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-delete-policy": before-hook-creation
     "helm.sh/hook-weight": "0"
 rules:
   - apiGroups: [""]
@@ -214,8 +215,8 @@ metadata:
   name: volcano-admission-init-role
   namespace: volcano-system
   annotations:
-    "helm.sh/hook": pre-install,pre-upgrade
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-delete-policy": before-hook-creation
     "helm.sh/hook-weight": "0"
 subjects:
   - kind: ServiceAccount
@@ -233,7 +234,7 @@ metadata:
   name: volcano-admission-init
   namespace: volcano-system
   annotations:
-    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook": pre-install
     "helm.sh/hook-delete-policy": before-hook-creation
     "helm.sh/hook-weight": "5" # set a higher weight to reserve buffers.
   labels:


### PR DESCRIPTION
## Summary

- Add an opt-in cert-manager path for the admission TLS Secret and CA bundle.
- Reload serving certificates with controller-runtime certwatcher when the mounted certificate files change.
- Keep the existing self-signed certificate path and make its install hook safe for upgrades.

## Details

- `custom.certManager.enabled=false` keeps the existing self-managed certificate generation.
- `custom.certManager.enabled=true` creates a self-signed Issuer and Certificate; cert-manager cainjector owns webhook CA bundles.
- The admission manager only updates webhook CA bundles when `--manage-webhook-ca-bundle=true`.
- The cronjob validating webhook is included in cert-manager CA injection.
- Self-managed admission hook dependencies are retained while the pre-install Job runs, preventing premature ServiceAccount deletion.

## Validation

- `go test ./cmd/webhook-manager/...`
- `helm lint installer/helm/chart/volcano`
- Rendered chart with cert-manager enabled and disabled.
- Helm-installed chart with self-managed certificates: install, upgrade, Queue, PodGroup, CronJob, and Volcano scheduler smoke checks.
- OLM Operator deployment was validated separately with cert-manager-managed certificates.

Fixes the certificate ownership and reload behavior without changing the default self-managed mode.

Closes #5936