### PR TITLE
feat(metrics): expose queue nodegroup resource allocations

### DIFF
--- a/docs/design/metrics.md
+++ b/docs/design/metrics.md
@@ -38,6 +38,9 @@ This metrics describe internal state of volcano.
 | `queue_allocated_milli_cpu`            | Gauge           | `queue_name`=&lt;queue_name&gt;                                   | Allocated CPU count for one queue             |
 | `queue_allocated_memory_bytes`         | Gauge           | `queue_name`=&lt;queue_name&gt;                                   | Allocated memory for one queue                |
 | `queue_allocated_scalar_resources`     | Gauge           | `queue_name`=&lt;queue_name&gt;, `resource`=&lt;resource_name&gt; | Allocated scalar resource for one queue       |
+| `queue_nodegroup_allocated_milli_cpu`  | Gauge           | `queue_name`=&lt;queue_name&gt;, `nodegroup_name`=&lt;nodegroup_name&gt; | Allocated CPU requests in millicores for one queue on one nodegroup |
+| `queue_nodegroup_allocated_memory_bytes` | Gauge         | `queue_name`=&lt;queue_name&gt;, `nodegroup_name`=&lt;nodegroup_name&gt; | Allocated memory requests in bytes for one queue on one nodegroup |
+| `queue_nodegroup_allocated_scalar_resources` | Gauge   | `queue_name`=&lt;queue_name&gt;, `nodegroup_name`=&lt;nodegroup_name&gt;, `resource`=&lt;resource_name&gt; | Allocated scalar resource requests for one queue on one nodegroup |
 | `queue_request_milli_cpu`              | Gauge           | `queue_name`=&lt;queue_name&gt;                                   | Requested CPU count for one queue             |
 | `queue_request_memory_bytes`           | Gauge           | `queue_name`=&lt;queue_name&gt;                                   | Requested memory for one queue                |
 | `queue_request_scalar_resources`       | Gauge           | `queue_name`=&lt;queue_name&gt;, `resource`=&lt;resource_name&gt; | Requested scalar resource for one queue       |
@@ -67,6 +70,8 @@ This metrics describe internal state of volcano.
 | `job_retry_counts`                     | Counter         | `job_id`=&lt;job_id&gt;                                           | The number of retry counts for one job        |
 | `job_completed_phase_count`            | Counter         | `job_name`=&lt;job_name&gt; `queue_name`=&lt;queue_name&gt;       | The number of job completed phase             |
 | `job_failed_phase_count`               | Counter         | `job_name`=&lt;job_name&gt; `queue_name`=&lt;queue_name&gt;       | The number of job failed phase                |
+
+The `queue_nodegroup_allocated_*` metrics are refreshed by the `nodegroup` plugin at the beginning of each scheduling session. They report Pod resource requests for allocated tasks directly assigned to the queue, grouped by the assigned node's `volcano.sh/nodegroup-name` label; they do not report actual node utilization. Scalar values use the same units as `queue_allocated_scalar_resources`. A previously observed Queue/NodeGroup pair is reset to zero when absent from a later session, and all of its series are removed when the Queue is deleted.
 
 ### volcano agent scheduler related metrics
 

--- a/pkg/scheduler/metrics/queue.go
+++ b/pkg/scheduler/metrics/queue.go
@@ -24,6 +24,20 @@ import (
 	v1 "k8s.io/api/core/v1"
 )
 
+// QueueNodeGroupResource contains allocated resources for one queue and nodegroup pair.
+type QueueNodeGroupResource struct {
+	QueueName       string
+	NodeGroupName   string
+	MilliCPU        float64
+	Memory          float64
+	ScalarResources map[v1.ResourceName]float64
+}
+
+type queueNodeGroupKey struct {
+	queueName     string
+	nodeGroupName string
+}
+
 var (
 	queueAllocatedMilliCPU = promauto.NewGaugeVec(
 		prometheus.GaugeOpts{
@@ -47,6 +61,30 @@ var (
 			Name:      "queue_allocated_scalar_resources",
 			Help:      "Allocated scalar resources for one queue",
 		}, []string{"queue_name", "resource"},
+	)
+
+	queueNodeGroupAllocatedMilliCPU = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Subsystem: VolcanoSubSystemName,
+			Name:      "queue_nodegroup_allocated_milli_cpu",
+			Help:      "Allocated CPU requests in millicores for one queue on one nodegroup",
+		}, []string{"queue_name", "nodegroup_name"},
+	)
+
+	queueNodeGroupAllocatedMemory = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Subsystem: VolcanoSubSystemName,
+			Name:      "queue_nodegroup_allocated_memory_bytes",
+			Help:      "Allocated memory requests in bytes for one queue on one nodegroup",
+		}, []string{"queue_name", "nodegroup_name"},
+	)
+
+	queueNodeGroupAllocatedScalarResource = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Subsystem: VolcanoSubSystemName,
+			Name:      "queue_nodegroup_allocated_scalar_resources",
+			Help:      "Allocated scalar resource requests for one queue on one nodegroup",
+		}, []string{"queue_name", "nodegroup_name", "resource"},
 	)
 
 	queueRequestMilliCPU = promauto.NewGaugeVec(
@@ -216,6 +254,9 @@ var (
 	// Track all known scalar resources for each queue
 	knownScalarResources     = make(map[string]map[string]struct{})
 	knownScalarResourcesLock sync.RWMutex
+
+	queueNodeGroupAllocatedMetricsLock sync.Mutex
+	knownQueueNodeGroupScalarResources = make(map[queueNodeGroupKey]map[string]struct{})
 )
 
 // helper to update knownScalarResources and delete metrics for removed resources
@@ -245,6 +286,84 @@ func UpdateQueueAllocated(queueName string, milliCPU, memory float64, scalarReso
 	queueAllocatedMilliCPU.WithLabelValues(queueName).Set(milliCPU)
 	queueAllocatedMemory.WithLabelValues(queueName).Set(memory)
 	updateScalarResourceMetrics(queueAllocatedScalarResource, queueName, scalarResources)
+}
+
+// SyncQueueNodeGroupAllocated refreshes queue/nodegroup allocations from a scheduler session snapshot.
+// Missing pairs for an existing queue are set to zero; metrics for missing queues are deleted.
+func SyncQueueNodeGroupAllocated(queueNames []string, resources []QueueNodeGroupResource) {
+	queueNodeGroupAllocatedMetricsLock.Lock()
+	defer queueNodeGroupAllocatedMetricsLock.Unlock()
+
+	activeQueues := make(map[string]struct{}, len(queueNames))
+	for _, queueName := range queueNames {
+		activeQueues[queueName] = struct{}{}
+	}
+	activePairs := make(map[queueNodeGroupKey]struct{}, len(resources))
+	for _, resource := range resources {
+		if _, found := activeQueues[resource.QueueName]; found {
+			activePairs[queueNodeGroupKey{queueName: resource.QueueName, nodeGroupName: resource.NodeGroupName}] = struct{}{}
+		}
+	}
+	for key, scalarResources := range knownQueueNodeGroupScalarResources {
+		if _, found := activeQueues[key.queueName]; !found {
+			deleteQueueNodeGroupAllocatedLocked(key)
+			continue
+		}
+		if _, found := activePairs[key]; !found {
+			zeroQueueNodeGroupAllocatedLocked(key, scalarResources)
+		}
+	}
+
+	for _, resource := range resources {
+		if _, found := activeQueues[resource.QueueName]; !found {
+			continue
+		}
+		updateQueueNodeGroupAllocatedLocked(resource)
+	}
+}
+
+func zeroQueueNodeGroupAllocatedLocked(key queueNodeGroupKey, scalarResources map[string]struct{}) {
+	queueNodeGroupAllocatedMilliCPU.WithLabelValues(key.queueName, key.nodeGroupName).Set(0)
+	queueNodeGroupAllocatedMemory.WithLabelValues(key.queueName, key.nodeGroupName).Set(0)
+	for name := range scalarResources {
+		queueNodeGroupAllocatedScalarResource.WithLabelValues(key.queueName, key.nodeGroupName, name).Set(0)
+	}
+}
+
+func updateQueueNodeGroupAllocatedLocked(resource QueueNodeGroupResource) {
+	key := queueNodeGroupKey{queueName: resource.QueueName, nodeGroupName: resource.NodeGroupName}
+	knownScalarResourceNames, known := knownQueueNodeGroupScalarResources[key]
+	if !known {
+		knownQueueNodeGroupScalarResources[key] = nil
+	}
+
+	queueNodeGroupAllocatedMilliCPU.WithLabelValues(resource.QueueName, resource.NodeGroupName).Set(resource.MilliCPU)
+	queueNodeGroupAllocatedMemory.WithLabelValues(resource.QueueName, resource.NodeGroupName).Set(resource.Memory)
+
+	for resourceName, value := range resource.ScalarResources {
+		name := string(resourceName)
+		if knownScalarResourceNames == nil {
+			knownScalarResourceNames = make(map[string]struct{})
+			knownQueueNodeGroupScalarResources[key] = knownScalarResourceNames
+		}
+		knownScalarResourceNames[name] = struct{}{}
+		queueNodeGroupAllocatedScalarResource.WithLabelValues(resource.QueueName, resource.NodeGroupName, name).Set(value)
+	}
+	for name := range knownScalarResourceNames {
+		if _, found := resource.ScalarResources[v1.ResourceName(name)]; !found {
+			queueNodeGroupAllocatedScalarResource.WithLabelValues(resource.QueueName, resource.NodeGroupName, name).Set(0)
+		}
+	}
+}
+
+func deleteQueueNodeGroupAllocatedLocked(key queueNodeGroupKey) {
+	queueNodeGroupAllocatedMilliCPU.DeleteLabelValues(key.queueName, key.nodeGroupName)
+	queueNodeGroupAllocatedMemory.DeleteLabelValues(key.queueName, key.nodeGroupName)
+	queueNodeGroupAllocatedScalarResource.DeletePartialMatch(prometheus.Labels{
+		"queue_name":     key.queueName,
+		"nodegroup_name": key.nodeGroupName,
+	})
+	delete(knownQueueNodeGroupScalarResources, key)
 }
 
 // UpdateQueueRequest records request resources for one queue
@@ -335,6 +454,16 @@ func DeleteQueueMetrics(queueName string) {
 	queueRealCapacityScalarResource.DeletePartialMatch(partialLabelMap)
 	queueInqueueScalarResource.DeletePartialMatch(partialLabelMap)
 	queueTaskCount.DeletePartialMatch(partialLabelMap)
+	queueNodeGroupAllocatedMetricsLock.Lock()
+	queueNodeGroupAllocatedMilliCPU.DeletePartialMatch(partialLabelMap)
+	queueNodeGroupAllocatedMemory.DeletePartialMatch(partialLabelMap)
+	queueNodeGroupAllocatedScalarResource.DeletePartialMatch(partialLabelMap)
+	for key := range knownQueueNodeGroupScalarResources {
+		if key.queueName == queueName {
+			delete(knownQueueNodeGroupScalarResources, key)
+		}
+	}
+	queueNodeGroupAllocatedMetricsLock.Unlock()
 	knownScalarResourcesLock.Lock()
 	delete(knownScalarResources, queueName)
 	knownScalarResourcesLock.Unlock()

--- a/pkg/scheduler/metrics/queue_nodegroup_test.go
+++ b/pkg/scheduler/metrics/queue_nodegroup_test.go
@@ -1,0 +1,102 @@
+/*
+Copyright 2026 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	v1 "k8s.io/api/core/v1"
+)
+
+func TestQueueNodeGroupAllocatedMetricsLifecycle(t *testing.T) {
+	resetQueueNodeGroupAllocatedMetricsForTest()
+	t.Cleanup(resetQueueNodeGroupAllocatedMetricsForTest)
+
+	const (
+		queue1 = "queue-nodegroup-metrics-1"
+		queue2 = "queue-nodegroup-metrics-2"
+		group1 = "group-1"
+		group2 = "group-2"
+	)
+	gpu := v1.ResourceName("nvidia.com/gpu")
+
+	SyncQueueNodeGroupAllocated([]string{queue1, queue2}, []QueueNodeGroupResource{
+		{
+			QueueName:       queue1,
+			NodeGroupName:   group1,
+			MilliCPU:        1000,
+			Memory:          1024,
+			ScalarResources: map[v1.ResourceName]float64{gpu: 1},
+		},
+		{QueueName: queue1, NodeGroupName: group2, MilliCPU: 2000, Memory: 2048},
+		{QueueName: queue2, NodeGroupName: group1, MilliCPU: 3000, Memory: 3072},
+	})
+
+	if got := testutil.ToFloat64(queueNodeGroupAllocatedMilliCPU.WithLabelValues(queue1, group1)); got != 1000 {
+		t.Fatalf("expected initial CPU to be 1000, got %v", got)
+	}
+	if got := testutil.ToFloat64(queueNodeGroupAllocatedMemory.WithLabelValues(queue1, group2)); got != 2048 {
+		t.Fatalf("expected initial memory to be 2048, got %v", got)
+	}
+	if got := testutil.ToFloat64(queueNodeGroupAllocatedScalarResource.WithLabelValues(queue1, group1, string(gpu))); got != 1 {
+		t.Fatalf("expected initial GPU to be 1, got %v", got)
+	}
+
+	// A later session keeps known pairs for existing queues and zeros omitted values.
+	SyncQueueNodeGroupAllocated([]string{queue1, queue2}, []QueueNodeGroupResource{
+		{QueueName: queue1, NodeGroupName: group1, MilliCPU: 1600, Memory: 1636},
+		{QueueName: queue2, NodeGroupName: group1, MilliCPU: 3000, Memory: 3072},
+	})
+	if got := testutil.ToFloat64(queueNodeGroupAllocatedScalarResource.WithLabelValues(queue1, group1, string(gpu))); got != 0 {
+		t.Fatalf("expected removed GPU dimension to be reset to zero, got %v", got)
+	}
+	if got := testutil.ToFloat64(queueNodeGroupAllocatedMilliCPU.WithLabelValues(queue1, group2)); got != 0 {
+		t.Fatalf("expected omitted nodegroup pair to be reset to zero, got %v", got)
+	}
+	if got := testutil.CollectAndCount(queueNodeGroupAllocatedMilliCPU); got != 3 {
+		t.Fatalf("expected all three known CPU series to be retained, got %d", got)
+	}
+
+	// A later session removes metrics for queues that no longer exist.
+	SyncQueueNodeGroupAllocated([]string{queue1}, []QueueNodeGroupResource{
+		{QueueName: queue1, NodeGroupName: group1, MilliCPU: 1600, Memory: 1636},
+	})
+	if got := testutil.CollectAndCount(queueNodeGroupAllocatedMilliCPU); got != 2 {
+		t.Fatalf("expected only queue1 CPU series after deleting queue2, got %d", got)
+	}
+
+	DeleteQueueMetrics(queue1)
+	if got := testutil.CollectAndCount(queueNodeGroupAllocatedMilliCPU); got != 0 {
+		t.Fatalf("expected all CPU series to be deleted, got %d", got)
+	}
+	if got := testutil.CollectAndCount(queueNodeGroupAllocatedMemory); got != 0 {
+		t.Fatalf("expected all memory series to be deleted, got %d", got)
+	}
+	if got := testutil.CollectAndCount(queueNodeGroupAllocatedScalarResource); got != 0 {
+		t.Fatalf("expected all scalar series to be deleted, got %d", got)
+	}
+}
+
+func resetQueueNodeGroupAllocatedMetricsForTest() {
+	queueNodeGroupAllocatedMetricsLock.Lock()
+	defer queueNodeGroupAllocatedMetricsLock.Unlock()
+	queueNodeGroupAllocatedMilliCPU.Reset()
+	queueNodeGroupAllocatedMemory.Reset()
+	queueNodeGroupAllocatedScalarResource.Reset()
+	knownQueueNodeGroupScalarResources = make(map[queueNodeGroupKey]map[string]struct{})
+}

--- a/pkg/scheduler/plugins/nodegroup/nodegroup.go
+++ b/pkg/scheduler/plugins/nodegroup/nodegroup.go
@@ -29,6 +29,7 @@ import (
 	schedulingv1 "volcano.sh/apis/pkg/apis/scheduling/v1beta1"
 	"volcano.sh/volcano/pkg/scheduler/api"
 	"volcano.sh/volcano/pkg/scheduler/framework"
+	"volcano.sh/volcano/pkg/scheduler/metrics"
 )
 
 const (
@@ -353,6 +354,34 @@ func (np *nodeGroupPlugin) taskNodeGroup(ssn *framework.Session, task *api.TaskI
 	return group, ok
 }
 
+func (np *nodeGroupPlugin) syncNodeGroupAllocatedMetrics(ssn *framework.Session) {
+	queueNames := make([]string, 0, len(ssn.Queues))
+	resources := make([]metrics.QueueNodeGroupResource, 0)
+	for queueID, queueInfo := range ssn.Queues {
+		if queueInfo == nil {
+			continue
+		}
+		queueNames = append(queueNames, queueInfo.Name)
+		attr := np.queueAttrs[queueID]
+		if attr == nil {
+			continue
+		}
+		for group, allocated := range attr.nodeGroupAllocated {
+			if group == "" || allocated == nil {
+				continue
+			}
+			resources = append(resources, metrics.QueueNodeGroupResource{
+				QueueName:       queueInfo.Name,
+				NodeGroupName:   group,
+				MilliCPU:        allocated.MilliCPU,
+				Memory:          allocated.Memory,
+				ScalarResources: allocated.ScalarResources,
+			})
+		}
+	}
+	metrics.SyncQueueNodeGroupAllocated(queueNames, resources)
+}
+
 func (np *nodeGroupPlugin) checkNodeGroupResourceLimit(task *api.TaskInfo, group string, attr *queueAttr) error {
 	if attr.resourceLimitErr != nil {
 		return attr.resourceLimitErr
@@ -408,6 +437,7 @@ func greaterThanResourceLimit(used, limit float64) bool {
 func (np *nodeGroupPlugin) OnSessionOpen(ssn *framework.Session) {
 	np.initQueueAttrs(ssn)
 	np.initNodeGroupAllocated(ssn)
+	np.syncNodeGroupAllocatedMetrics(ssn)
 	for id, attr := range np.queueAttrs {
 		if attr.affinity != nil {
 			klog.V(4).Infof("queue <%v> affinity: anti-required %v, anti-preferred %v, required %v, preferred %v",

--- a/pkg/scheduler/plugins/nodegroup/nodegroup_test.go
+++ b/pkg/scheduler/plugins/nodegroup/nodegroup_test.go
@@ -21,11 +21,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/prometheus/client_golang/prometheus"
 	v1 "k8s.io/api/core/v1"
 	schedulingv1 "volcano.sh/apis/pkg/apis/scheduling/v1beta1"
 	"volcano.sh/volcano/pkg/scheduler/api"
 	"volcano.sh/volcano/pkg/scheduler/conf"
 	"volcano.sh/volcano/pkg/scheduler/framework"
+	schedmetrics "volcano.sh/volcano/pkg/scheduler/metrics"
 	"volcano.sh/volcano/pkg/scheduler/uthelper"
 	"volcano.sh/volcano/pkg/scheduler/util"
 )
@@ -655,4 +657,134 @@ func TestNodeGroupResourceLimitAllocationEvent(t *testing.T) {
 	if err := ssn.PredicateFn(task2, node); err == nil {
 		t.Fatalf("second task should exceed nodegroup resource limit after allocation event")
 	}
+}
+
+func TestNodeGroupAllocatedMetricsSnapshot(t *testing.T) {
+	const queueName = "queue-nodegroup-allocation-metrics"
+	schedmetrics.DeleteQueueMetrics(queueName)
+	t.Cleanup(func() { schedmetrics.DeleteQueueMetrics(queueName) })
+
+	plugins := map[string]framework.PluginBuilder{PluginName: New}
+	trueValue := true
+	tiers := []conf.Tier{{
+		Plugins: []conf.PluginOption{{
+			Name:             PluginName,
+			EnabledNodeOrder: &trueValue,
+			EnabledPredicate: &trueValue,
+		}},
+	}}
+
+	nodeResource := api.BuildResourceList("16", "64Gi",
+		api.ScalarResource{Name: "nvidia.com/gpu", Value: "8"},
+		api.ScalarResource{Name: string(v1.ResourcePods), Value: "32"})
+	n1 := util.BuildNode("metrics-n1", nodeResource, map[string]string{schedulingv1.NodeGroupNameKey: "group1"})
+	n2 := util.BuildNode("metrics-n2", nodeResource, map[string]string{schedulingv1.NodeGroupNameKey: "group2"})
+	n3 := util.BuildNode("metrics-n3", nodeResource, nil)
+
+	affinity := &schedulingv1.Affinity{
+		NodeGroupAffinity: &schedulingv1.NodeGroupAffinity{
+			RequiredDuringSchedulingIgnoredDuringExecution: []string{"group1", "group2"},
+		},
+	}
+	queue := util.MakeQueue(queueName).Affinity(affinity).Obj()
+
+	group1Pod := util.BuildPod("metrics", "group1-running", "metrics-n1", v1.PodRunning,
+		api.BuildResourceList("2", "4Gi", api.ScalarResource{Name: "nvidia.com/gpu", Value: "1"}), "pg-group1", nil, nil)
+	group2Pod := util.BuildPod("metrics", "group2-running", "metrics-n2", v1.PodRunning,
+		api.BuildResourceList("1", "2Gi"), "pg-group2", nil, nil)
+	unlabeledPod := util.BuildPod("metrics", "unlabeled-running", "metrics-n3", v1.PodRunning,
+		api.BuildResourceList("3", "6Gi"), "pg-unlabeled", nil, nil)
+	pendingPod := util.BuildPod("metrics", "group2-pending", "", v1.PodPending,
+		api.BuildResourceList("500m", "1Gi"), "pg-pending", nil, nil)
+
+	common := uthelper.TestCommonStruct{
+		Name:   "queue nodegroup allocated metrics snapshot",
+		Queues: []*schedulingv1.Queue{queue},
+		PodGroups: []*schedulingv1.PodGroup{
+			util.BuildPodGroup("pg-group1", "metrics", queueName, 0, nil, schedulingv1.PodGroupRunning),
+			util.BuildPodGroup("pg-group2", "metrics", queueName, 0, nil, schedulingv1.PodGroupRunning),
+			util.BuildPodGroup("pg-unlabeled", "metrics", queueName, 0, nil, schedulingv1.PodGroupRunning),
+			util.BuildPodGroup("pg-pending", "metrics", queueName, 0, nil, ""),
+		},
+		Pods:    []*v1.Pod{group1Pod, group2Pod, unlabeledPod, pendingPod},
+		Nodes:   []*v1.Node{n1, n2, n3},
+		Plugins: plugins,
+	}
+	ssn := common.RegisterSession(tiers, nil)
+	defer common.Close()
+
+	group1Task := ssn.Jobs[api.JobID("metrics/pg-group1")].Tasks[api.TaskID("metrics-group1-running")]
+	group2Task := ssn.Jobs[api.JobID("metrics/pg-group2")].Tasks[api.TaskID("metrics-group2-running")]
+	pendingTask := ssn.Jobs[api.JobID("metrics/pg-pending")].Tasks[api.TaskID("metrics-group2-pending")]
+
+	requireNodeGroupGaugeValue(t, "volcano_queue_nodegroup_allocated_milli_cpu", map[string]string{
+		"queue_name": queueName, "nodegroup_name": "group1",
+	}, group1Task.Resreq.MilliCPU)
+	requireNodeGroupGaugeValue(t, "volcano_queue_nodegroup_allocated_memory_bytes", map[string]string{
+		"queue_name": queueName, "nodegroup_name": "group1",
+	}, group1Task.Resreq.Memory)
+	requireNodeGroupGaugeValue(t, "volcano_queue_nodegroup_allocated_scalar_resources", map[string]string{
+		"queue_name": queueName, "nodegroup_name": "group1", "resource": "nvidia.com/gpu",
+	}, group1Task.Resreq.ScalarResources[v1.ResourceName("nvidia.com/gpu")])
+	requireNodeGroupGaugeValue(t, "volcano_queue_nodegroup_allocated_milli_cpu", map[string]string{
+		"queue_name": queueName, "nodegroup_name": "group2",
+	}, group2Task.Resreq.MilliCPU)
+	if _, found := nodeGroupGaugeValue(t, "volcano_queue_nodegroup_allocated_milli_cpu", map[string]string{
+		"queue_name": queueName, "nodegroup_name": "",
+	}); found {
+		t.Fatal("tasks on unlabeled nodes must not be attributed to a nodegroup")
+	}
+
+	statement := framework.NewStatement(ssn)
+	if err := statement.Allocate(pendingTask, ssn.Nodes["metrics-n2"]); err != nil {
+		t.Fatalf("allocate pending task: %v", err)
+	}
+	// Metrics are a session-input snapshot and must not update in the allocation hot path.
+	requireNodeGroupGaugeValue(t, "volcano_queue_nodegroup_allocated_milli_cpu", map[string]string{
+		"queue_name": queueName, "nodegroup_name": "group2",
+	}, group2Task.Resreq.MilliCPU)
+}
+
+func requireNodeGroupGaugeValue(t *testing.T, metricName string, labels map[string]string, expected float64) {
+	t.Helper()
+	actual, found := nodeGroupGaugeValue(t, metricName, labels)
+	if !found {
+		t.Fatalf("metric %s with labels %v was not found", metricName, labels)
+	}
+	if actual != expected {
+		t.Fatalf("metric %s with labels %v: expected %v, got %v", metricName, labels, expected, actual)
+	}
+}
+
+func nodeGroupGaugeValue(t *testing.T, metricName string, labels map[string]string) (float64, bool) {
+	t.Helper()
+	metricFamilies, err := prometheus.DefaultGatherer.Gather()
+	if err != nil {
+		t.Fatalf("gather metrics: %v", err)
+	}
+	for _, metricFamily := range metricFamilies {
+		if metricFamily.GetName() != metricName {
+			continue
+		}
+		for _, metric := range metricFamily.GetMetric() {
+			if len(metric.GetLabel()) != len(labels) {
+				continue
+			}
+			matches := true
+			for _, label := range metric.GetLabel() {
+				expected, found := labels[label.GetName()]
+				if !found || expected != label.GetValue() {
+					matches = false
+					break
+				}
+			}
+			if matches {
+				if metric.GetGauge() == nil {
+					t.Fatalf("metric %s with labels %v is not a gauge", metricName, labels)
+				}
+				return metric.GetGauge().GetValue(), true
+			}
+		}
+	}
+	return 0, false
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

The `nodegroup` plugin already accounts for allocated resources by Queue and NodeGroup, but the scheduler only exposes queue-wide allocation metrics. Operators therefore cannot observe how a queue's requested resources are distributed across nodegroups.

This PR adds the following scheduler gauges:

- `volcano_queue_nodegroup_allocated_milli_cpu{queue_name,nodegroup_name}`
- `volcano_queue_nodegroup_allocated_memory_bytes{queue_name,nodegroup_name}`
- `volcano_queue_nodegroup_allocated_scalar_resources{queue_name,nodegroup_name,resource}`

The gauges are refreshed from allocated tasks at the beginning of each scheduling session. They use Pod resource requests and the assigned node's `volcano.sh/nodegroup-name` label, keep Prometheus writes out of Allocate/Deallocate event handlers, reset missing Queue/NodeGroup pairs to zero, and remove series when a Queue is deleted.

The metrics documentation and lifecycle tests cover CPU, memory, scalar resources, deallocation snapshots, queue deletion, unlabeled nodes, and session-snapshot timing.

#### Which issue(s) this PR fixes:

Fixes #5942

#### Special notes for your reviewer:

AI assistance was used to prepare the implementation and PR text. The change was reviewed against #5942 and validated with focused tests, race detection, scheduler-wide tests, generated-code verification, vet, and golangci-lint.

Volcano queues glow while measured resources flow;  
NodeGroups show clearly where scheduled workloads go.

Prompt used for this PR: `进行开发，并提交PR`, followed by `同意方案1` to select scheduling-session snapshot gauges.

Validation:

- `go test -run 'TestQueueNodeGroupAllocatedMetricsLifecycle|TestNodeGroupAllocatedMetricsSnapshot' -count=20 ./pkg/scheduler/metrics ./pkg/scheduler/plugins/nodegroup`
- `go test -race -count=1 ./pkg/scheduler/metrics ./pkg/scheduler/plugins/nodegroup`
- `go vet ./pkg/scheduler/metrics ./pkg/scheduler/plugins/nodegroup`
- `go test -count=1 ./pkg/scheduler/...`
- `make verify OS=darwin GOOS=darwin GOARCH=arm64 GOPATH=/Users/zyb/go`
- `/Users/zyb/go/bin/golangci-lint run ./pkg/scheduler/metrics/... ./pkg/scheduler/plugins/nodegroup/...`
- `GOOS=linux GOARCH=amd64 CGO_ENABLED=0 /Users/zyb/go/bin/golangci-lint run`

On macOS, the repository-wide default-target lint reaches existing Linux-only cgroup type-check errors under `pkg/agent/utils/cgroup`; the changed packages pass directly, and the repository-wide lint passes with the Linux target shown above.

#### Does this PR introduce a user-facing change?

```release-note
Add per-queue, per-nodegroup allocated CPU, memory, and scalar resource metrics for the nodegroup plugin.
```
