### PR TITLE
fix(rescheduling): stop mistyped scheduler config from panicking the plugin

### DIFF
--- a/pkg/scheduler/plugins/rescheduling/low_node_utilization.go
+++ b/pkg/scheduler/plugins/rescheduling/low_node_utilization.go
@@ -65,11 +65,7 @@ func (lnuc *LowNodeUtilizationConf) parse(configs map[string]interface{}) {
 			klog.Warningln("Assert lowThresholdsConfigs to map error, abort the configuration parse.")
 			return
 		}
-		config := make(map[string]int)
-		for k, v := range lowConfigs {
-			config[k.(string)] = v.(int)
-		}
-		parseThreshold(config, lnuc, "Thresholds")
+		parseThreshold(toStringIntMap(lowConfigs, "thresholds"), lnuc, "Thresholds")
 	}
 	targetThresholdsConfigs, ok := configs["targetThresholds"]
 	if ok {
@@ -78,12 +74,31 @@ func (lnuc *LowNodeUtilizationConf) parse(configs map[string]interface{}) {
 			klog.Warningln("Assert targetThresholdsConfigs to map error, abort the configuration parse.")
 			return
 		}
-		config := make(map[string]int)
-		for k, v := range targetConfigs {
-			config[k.(string)] = v.(int)
-		}
-		parseThreshold(config, lnuc, "TargetThresholds")
+		parseThreshold(toStringIntMap(targetConfigs, "targetThresholds"), lnuc, "TargetThresholds")
 	}
+}
+
+// toStringIntMap converts a YAML-decoded threshold map into map[string]int.
+// The caller has already asserted the container type; this checks the element
+// types, which YAML does not guarantee. A quoted number such as cpu: "20"
+// decodes to a string, so entries that are not string-keyed integers are
+// logged and skipped rather than panicking the scheduler.
+func toStringIntMap(in map[interface{}]interface{}, name string) map[string]int {
+	out := make(map[string]int, len(in))
+	for k, v := range in {
+		key, ok := k.(string)
+		if !ok {
+			klog.Warningf("Skipping %s entry with non-string key %v, expected a string", name, k)
+			continue
+		}
+		value, ok := v.(int)
+		if !ok {
+			klog.Warningf("Skipping %s entry %q: expected an integer, got %T", name, key, v)
+			continue
+		}
+		out[key] = value
+	}
+	return out
 }
 
 func parseThreshold(thresholdsConfig map[string]int, lnuc *LowNodeUtilizationConf, param string) {

--- a/pkg/scheduler/plugins/rescheduling/rescheduling.go
+++ b/pkg/scheduler/plugins/rescheduling/rescheduling.go
@@ -148,17 +148,13 @@ func NewReschedulingConfigs() *Configs {
 func (rc *Configs) parseArguments(arguments framework.Arguments) {
 	var intervalStr string
 	var err error
-	if intervalArg, ok := arguments["interval"]; ok {
-		intervalStr = intervalArg.(string)
-	}
+	arguments.GetString(&intervalStr, "interval")
 	rc.interval, err = time.ParseDuration(intervalStr)
 	if err != nil {
 		klog.V(4).Infof("Parse rescheduling interval failed. Reset the interval to 5m by default.")
 		rc.interval = DefaultInterval
 	}
-	if metricsPeriodArg, ok := arguments["metricsPeriod"]; ok {
-		MetricsPeriod = metricsPeriodArg.(string)
-	}
+	arguments.GetString(&MetricsPeriod, "metricsPeriod")
 	if MetricsPeriod == "" {
 		MetricsPeriod = DefaultMetricsPeriod
 	}

--- a/pkg/scheduler/plugins/rescheduling/rescheduling_test.go
+++ b/pkg/scheduler/plugins/rescheduling/rescheduling_test.go
@@ -1,0 +1,99 @@
+/*
+Copyright 2026 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rescheduling
+
+import (
+	"testing"
+	"time"
+
+	"volcano.sh/volcano/pkg/scheduler/framework"
+)
+
+// A scheduler config that writes interval as a bare YAML number decodes to an
+// int, not a string. Before this was fixed the assertion panicked and took the
+// scheduler down at config load.
+func TestParseArgumentsNonStringInterval(t *testing.T) {
+	rc := NewReschedulingConfigs()
+	rc.parseArguments(framework.Arguments{"interval": 5})
+
+	if rc.interval != DefaultInterval {
+		t.Errorf("interval = %v, want the default %v", rc.interval, DefaultInterval)
+	}
+}
+
+func TestParseArgumentsNonStringMetricsPeriod(t *testing.T) {
+	MetricsPeriod = ""
+	rc := NewReschedulingConfigs()
+	rc.parseArguments(framework.Arguments{"metricsPeriod": 30})
+
+	if MetricsPeriod != DefaultMetricsPeriod {
+		t.Errorf("MetricsPeriod = %q, want the default %q", MetricsPeriod, DefaultMetricsPeriod)
+	}
+}
+
+func TestParseArgumentsValidValuesStillApply(t *testing.T) {
+	MetricsPeriod = ""
+	rc := NewReschedulingConfigs()
+	rc.parseArguments(framework.Arguments{"interval": "10m", "metricsPeriod": "1m"})
+
+	if rc.interval != 10*time.Minute {
+		t.Errorf("interval = %v, want 10m", rc.interval)
+	}
+	if MetricsPeriod != "1m" {
+		t.Errorf("MetricsPeriod = %q, want 1m", MetricsPeriod)
+	}
+}
+
+// cpu: "20" in the scheduler config decodes to a string, and memory: 20
+// decodes to an int. The container assertion already guarded the map itself,
+// so only the element types were left unchecked.
+func TestLowNodeUtilizationParseMixedThresholdTypes(t *testing.T) {
+	conf := &LowNodeUtilizationConf{
+		Thresholds:       map[string]float64{},
+		TargetThresholds: map[string]float64{},
+	}
+	conf.parse(map[string]interface{}{
+		"thresholds": map[interface{}]interface{}{
+			"cpu":    "20",
+			"memory": 30,
+		},
+	})
+
+	if got, ok := conf.Thresholds["memory"]; !ok || got != 30 {
+		t.Errorf("Thresholds[memory] = %v (present=%v), want 30", got, ok)
+	}
+	if _, ok := conf.Thresholds["cpu"]; ok {
+		t.Error("Thresholds[cpu] was set from a string value, want it skipped")
+	}
+}
+
+func TestLowNodeUtilizationParseNonStringKey(t *testing.T) {
+	conf := &LowNodeUtilizationConf{
+		Thresholds:       map[string]float64{},
+		TargetThresholds: map[string]float64{},
+	}
+	conf.parse(map[string]interface{}{
+		"targetThresholds": map[interface{}]interface{}{
+			1:     40,
+			"cpu": 50,
+		},
+	})
+
+	if got, ok := conf.TargetThresholds["cpu"]; !ok || got != 50 {
+		t.Errorf("TargetThresholds[cpu] = %v (present=%v), want 50", got, ok)
+	}
+}


### PR DESCRIPTION
## What this fixes

The rescheduling plugin reads four values out of its scheduler configuration with unchecked type assertions. YAML does not guarantee the type of a value, so a config that is merely mistyped panics the scheduler rather than being rejected.

**`parseArguments`** asserted `arguments["interval"]` and `arguments["metricsPeriod"]` straight to `string`:

```go
if intervalArg, ok := arguments["interval"]; ok {
    intervalStr = intervalArg.(string)
}
```

The `ok` there checks that the key is present, not that the value is a string. So this config panics:

```yaml
- plugins:
  - name: rescheduling
    arguments:
      interval: 5        # bare number, decodes to int
```

`framework.Arguments` already has `GetString`, which does the comma-ok, logs a warning and leaves the target untouched. Both call sites now use it. `deviceshare.go` (lines 111, 123, 125) and `warmup.go` already read their arguments through these helpers, so this brings rescheduling in line with them.

**`LowNodeUtilizationConf.parse`** had a subtler version of the same thing. It already asserts the container and logs when that fails:

```go
lowConfigs, ok := lowThresholdsConfigs.(map[interface{}]interface{})
if !ok {
    klog.Warningln("Assert lowThresholdsConfigs to map error, abort the configuration parse.")
    return
}
config := make(map[string]int)
for k, v := range lowConfigs {
    config[k.(string)] = v.(int)   // element types never checked
}
```

So the intent to validate is there, it just stops at the container. A quoted number is the easy way to hit it, because `cpu: "20"` decodes to a string:

```yaml
thresholds:
  cpu: "20"
  memory: 30
```

Element conversion moves into `toStringIntMap`, which skips and logs a bad entry instead of panicking, matching what the container check already did. Both threshold loops were identical, so they share it.

## Behaviour

Unchanged for valid config. `interval` and `metricsPeriod` already fell back to their defaults when parsing failed, and that path now actually gets reached instead of being pre-empted by a panic. Bad threshold entries are dropped with a warning naming the key and the type received, and the good entries in the same map still apply.

## Tests

This adds the package's first test file. Five tests covering a non-string `interval`, a non-string `metricsPeriod`, valid values still applying, a threshold map mixing a quoted and an unquoted number, and a non-string key.

I checked that they fail without the change. Reverting just the two source files and keeping the tests gives:

```
--- FAIL: TestParseArgumentsNonStringInterval (0.00s)
panic: interface conversion: interface {} is int, not string [recovered, repanicked]
```

`go build ./pkg/...`, `go vet` and the package tests all pass.

## Not in this PR

`pkg/scheduler/plugins/tdm/tdm.go:71` has the same unchecked element assertion on a label map. Different plugin and a different input path, so I have left it out rather than widening this. Say the word and I will send it separately.

