### PR TITLE
docs: fix capacity plugin tier configuration and add reclaim regression test

### DIFF
--- a/docs/user-guide/how_to_use_capacity_plugin.md
+++ b/docs/user-guide/how_to_use_capacity_plugin.md
@@ -39,8 +39,8 @@ data:
       - name: priority
       - name: gang
         enablePreemptable: false
-      - name: conformance
     - plugins:
+      - name: conformance
       - name: drf
         enablePreemptable: false
       - name: predicates
@@ -48,6 +48,10 @@ data:
       - name: nodeorder
       - name: binpack
 ```
+
+> [!NOTE]
+> When using eviction actions like `reclaim` or `preempt`, victim eligibility filter plugins such as `conformance` should be placed in the **same tier** as quota plugins (`capacity` or `proportion`).
+> In Volcano, `Session.Reclaimable` and `Session.Preemptable` evaluate plugin tiers in sequence and short-circuit at the first tier that returns a non-nil candidate list. Placing `conformance` in a higher tier by itself causes it to return all non-critical pods, preventing lower-tier plugins like `capacity` from enforcing queue deserved quotas.
 
 ## Configure ancestor reclaim level
 
@@ -74,8 +78,8 @@ data:
       - name: priority
       - name: gang
         enablePreemptable: false
-      - name: conformance
     - plugins:
+      - name: conformance
       - name: drf
         enablePreemptable: false
       - name: predicates

--- a/pkg/scheduler/actions/reclaim/reclaim_test.go
+++ b/pkg/scheduler/actions/reclaim/reclaim_test.go
@@ -476,3 +476,88 @@ func TestReclaimRechecksPredicateAfterEviction(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestReclaimTiers_ConformanceAndCapacity(t *testing.T) {
+	trueValue := true
+	plugins := map[string]framework.PluginBuilder{
+		conformance.PluginName: conformance.New,
+		gang.PluginName:        gang.New,
+		capacity.PluginName:    capacity.New,
+	}
+
+	buildTest := func() uthelper.TestCommonStruct {
+		return uthelper.TestCommonStruct{
+			Plugins: plugins,
+			PodGroups: []*schedulingv1beta1.PodGroup{
+				util.BuildPodGroupWithPrio("pg-victim", "c1", "q2", 0, nil, schedulingv1beta1.PodGroupRunning, "low-priority"),
+				util.BuildPodGroupWithPrio("pg-reclaimer", "c1", "q1", 1, nil, schedulingv1beta1.PodGroupInqueue, "high-priority"),
+				util.BuildPodGroupWithPrio("pg-q1-running", "c1", "q1", 0, nil, schedulingv1beta1.PodGroupRunning, "low-priority"),
+			},
+			Pods: []*v1.Pod{
+				util.BuildPod("c1", "victim1", "n1", v1.PodRunning, api.BuildResourceList("2", "2G"), "pg-victim", map[string]string{schedulingv1beta1.PodPreemptable: "true"}, make(map[string]string)),
+				util.BuildPod("c1", "q1-holder", "n1", v1.PodRunning, api.BuildResourceList("1", "1G"), "pg-q1-running", map[string]string{schedulingv1beta1.PodPreemptable: "false"}, make(map[string]string)),
+				util.BuildPod("c1", "reclaimer", "", v1.PodPending, api.BuildResourceList("1", "1G"), "pg-reclaimer", make(map[string]string), make(map[string]string)),
+			},
+			Nodes: []*v1.Node{
+				util.BuildNode("n1", api.BuildResourceList("3", "3G", []api.ScalarResource{{Name: "pods", Value: "10"}}...), make(map[string]string)),
+			},
+			Queues: []*schedulingv1beta1.Queue{
+				util.BuildQueueWithResourcesQuantity("q1", api.BuildResourceList("2", "2G"), api.BuildResourceList("4", "4G")),
+				util.BuildQueueWithResourcesQuantity("q2", api.BuildResourceList("2", "2G"), api.BuildResourceList("4", "4G")),
+			},
+		}
+	}
+
+	t.Run("conformance and capacity in same tier respects queue deserved capacity", func(t *testing.T) {
+		test := buildTest()
+		test.Name = "same-tier-respects-deserved"
+		test.ExpectEvictNum = 0
+		test.ExpectEvicted = []string{}
+
+		sameTier := []conf.Tier{{
+			Plugins: []conf.PluginOption{
+				{Name: conformance.PluginName, EnabledReclaimable: &trueValue},
+				{Name: gang.PluginName, EnabledReclaimable: &trueValue, EnabledJobStarving: &trueValue},
+				{Name: capacity.PluginName, EnabledReclaimable: &trueValue},
+			},
+		}}
+
+		test.RegisterSession(sameTier, nil)
+		defer test.Close()
+		test.Run([]framework.Action{New()})
+		if err := test.CheckAll(0); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	t.Run("conformance in higher tier than capacity short-circuits and ignores deserved capacity", func(t *testing.T) {
+		test := buildTest()
+		test.Name = "different-tier-short-circuits"
+		test.ExpectEvictNum = 1
+		test.ExpectEvicted = []string{"c1/victim1"}
+		test.ExpectPipeLined = map[string][]string{
+			"c1/pg-reclaimer": {"n1"},
+		}
+
+		diffTiers := []conf.Tier{
+			{
+				Plugins: []conf.PluginOption{
+					{Name: conformance.PluginName, EnabledReclaimable: &trueValue},
+					{Name: gang.PluginName, EnabledReclaimable: &trueValue, EnabledJobStarving: &trueValue},
+				},
+			},
+			{
+				Plugins: []conf.PluginOption{
+					{Name: capacity.PluginName, EnabledReclaimable: &trueValue},
+				},
+			},
+		}
+
+		test.RegisterSession(diffTiers, nil)
+		defer test.Close()
+		test.Run([]framework.Action{New()})
+		if err := test.CheckAll(0); err != nil {
+			t.Fatal(err)
+		}
+	})
+}


### PR DESCRIPTION
#### What type of PR is this?
/kind documentation

#### What this PR does / why we need it:
When `conformance` is placed in an earlier tier than `capacity` or `proportion`, `Session.Reclaimable` and `Session.Preemptable` short-circuit at the first tier that returns non-nil victim candidates (`pkg/scheduler/framework/session_plugins.go`). Because `conformance` considers all non-critical pods as candidates, placing it in a higher tier causes victim selection to halt before `capacity` can filter candidates against queue deserved quotas. As a result, queues can have pods reclaimed even when their allocation is within their deserved capacity.

The examples in `docs/user-guide/how_to_use_capacity_plugin.md` previously configured `conformance` in Tier 1 and `capacity` in Tier 2, exposing users to this behavior.

This PR:
1. Updates `how_to_use_capacity_plugin.md` to place `conformance` in Tier 2 alongside `capacity`.
2. Adds a note explaining why victim filtering plugins (`conformance`) and quota plugins (`capacity`/`proportion`) must be configured in the same tier.
3. Adds a regression unit test `TestReclaimTiers_ConformanceAndCapacity` in `pkg/scheduler/actions/reclaim/reclaim_test.go` covering both the same-tier (desired) and multi-tier (short-circuit) behaviors.

#### Which issue(s) this PR fixes:
Fixes #5896


Volcano rhyme:
> *When workloads surge and clusters strain,*
> *Volcano yields the batch domain.*
> *Keep tiers aligned so quotas stand,*
> *And fair reclaim rules all the land.*

#### Does this PR introduce a user-facing change?
```release-note
Update capacity plugin documentation to place conformance and capacity in the same tier to ensure queue deserved quota is respected during reclaim.