### PR TITLE
Bump cilium/ebpf off the BTF integer-overflow advisory

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.26.0
 require (
 	github.com/AdaLogics/go-fuzz-headers v0.0.0-20240806141605-e8a1dd7889d6
 	github.com/agiledragon/gomonkey/v2 v2.14.1
-	github.com/cilium/ebpf v0.17.3
+	github.com/cilium/ebpf v0.22.0
 	github.com/containernetworking/cni v1.3.0
 	github.com/containernetworking/plugins v1.1.1
 	github.com/elastic/go-elasticsearch/v7 v7.17.10

--- a/go.sum
+++ b/go.sum
@@ -34,8 +34,8 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/chai2010/gettext-go v1.0.2 h1:1Lwwip6Q2QGsAdl/ZKPCwTe9fe0CjlUbqj5bFNSjIRk=
 github.com/chai2010/gettext-go v1.0.2/go.mod h1:y+wnP2cHYaVj19NZhYKAwEMH2CI1gNHeQQ+5AjwawxA=
-github.com/cilium/ebpf v0.17.3 h1:FnP4r16PWYSE4ux6zN+//jMcW4nMVRvuTLVTvCjyyjg=
-github.com/cilium/ebpf v0.17.3/go.mod h1:G5EDHij8yiLzaqn0WjyfJHvRa+3aDlReIaLVRMvOyJk=
+github.com/cilium/ebpf v0.22.0 h1:v2ktp0roffpMOj2MMf3idtCQZOsAoC4BJbAJN+ke2bY=
+github.com/cilium/ebpf v0.22.0/go.mod h1:CDzZbe2hC5JjlDC+CY3KFCzlYwN4gbxppYM+Z10bQt4=
 github.com/container-storage-interface/spec v1.9.0 h1:zKtX4STsq31Knz3gciCYCi1SXtO2HJDecIjDVboYavY=
 github.com/container-storage-interface/spec v1.9.0/go.mod h1:ZfDu+3ZRyeVqxZM0Ds19MVLkN2d1XJ5MAfi1L3VjlT0=
 github.com/containerd/containerd/api v1.10.0 h1:5n0oHYVBwN4VhoX9fFykCV9dF1/BvAXeg2F8W6UYq1o=
@@ -142,8 +142,8 @@ github.com/go-openapi/testify/enable/yaml/v2 v2.4.0 h1:7SgOMTvJkM8yWrQlU8Jm18VeD
 github.com/go-openapi/testify/enable/yaml/v2 v2.4.0/go.mod h1:14iV8jyyQlinc9StD7w1xVPW3CO3q1Gj04Jy//Kw4VM=
 github.com/go-openapi/testify/v2 v2.4.0 h1:8nsPrHVCWkQ4p8h1EsRVymA2XABB4OT40gcvAu+voFM=
 github.com/go-openapi/testify/v2 v2.4.0/go.mod h1:HCPmvFFnheKK2BuwSA0TbbdxJ3I16pjwMkYkP4Ywn54=
-github.com/go-quicktest/qt v1.101.0 h1:O1K29Txy5P2OK0dGo59b7b0LR6wKfIhttaAhHUyn7eI=
-github.com/go-quicktest/qt v1.101.0/go.mod h1:14Bz/f7NwaXPtdYEgzsx46kqSxVwTbzVZsDC26tQJow=
+github.com/go-quicktest/qt v1.101.1-0.20240301121107-c6c8733fa1e6 h1:teYtXy9B7y5lHTp8V9KPxpYRAVA7dozigQcMiBust1s=
+github.com/go-quicktest/qt v1.101.1-0.20240301121107-c6c8733fa1e6/go.mod h1:p4lGIVX+8Wa6ZPNDvqcxq36XpUDLh42FLetFU7odllI=
 github.com/go-task/slim-sprig/v3 v3.0.0 h1:sUs3vkvUymDpBKi3qH1YSqBQk9+9D/8M2mN1vB6EwHI=
 github.com/go-task/slim-sprig/v3 v3.0.0/go.mod h1:W848ghGpv3Qj3dhTPRyJypKRiqCdHZiAzKg9hl15HA8=
 github.com/goccy/go-yaml v1.18.0 h1:8W7wMFS12Pcas7KU+VVkaiCng+kG8QiFeFwzFb+rwuw=

--- a/licenses/github.com/cilium/ebpf/testdata/windows/LICENSE
+++ b/licenses/github.com/cilium/ebpf/testdata/windows/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) eBPF for Windows contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

`govulncheck ./...` reports GO-2026-6238, an integer overflow in BTF parsing, as reachable from production code:

```
Vulnerability #1: GO-2026-6238
    Integer overflow in BTF parsing in github.com/cilium/ebpf
    Found in: github.com/cilium/ebpf@v0.17.3
    Fixed in: github.com/cilium/ebpf@v0.22.0
    Example traces found:
      #1: pkg/networkqos/utils/ebpf/map.go:70:37: ebpf.Map.CreateAndPinArrayMap
          calls ebpf.NewMapWithOptions, which eventually calls btf.Handle.Spec
```

This is the same bump dependabot proposed in #5692, which was closed with:

> This pr contains a license lint error that depedabot can't resolve, may needs to track after

That is the part dependabot structurally cannot do. `v0.22.0` ships `testdata/windows` with its own MIT licence, so `make mirror-licenses` produces `licenses/github.com/cilium/ebpf/testdata/windows/LICENSE`, and it has to be committed alongside `go.mod`. Dependabot only touches `go.mod` and `go.sum`, so `make licenses-check` failed for it every time. That file is included here.

After the bump, `make lint-licenses` reports:

```
Found licenses: 2 reciprocal, 196 unrestricted, 0 restricted, 0 unrecognized, and 0 unlicensed. 10 are allowlisted.
```

`govulncheck` goes from `affected by 3 vulnerabilities from 2 modules` to `affected by 2`. The two that remain are GO-2025-3547 and GO-2025-3521 in `k8s.io/kubernetes`, both listed as `Fixed in: N/A` and both reached only through package `init` from `test/e2e/schedulingbase/volume_binding.go`, so there is nothing to bump for those.

**Which issue(s) this PR fixes**:

N/A. Related to #5692.

**Special notes for your reviewer**:

`go build ./pkg/networkqos/...` and `go vet ./pkg/networkqos/...` are clean, and `go test ./pkg/networkqos/... ./pkg/agent/...` passes.

`go build ./...` reports `example/custom-plugin: function main is undeclared in the main package`, which also happens on an untouched `master` checkout, so it is not from this change.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
