### PR TITLE
fix(webhook): remove redundant fmt.Println in patchAffinity

### DIFF
--- a/pkg/webhooks/admission/pods/mutate/mutate_pod.go
+++ b/pkg/webhooks/admission/pods/mutate/mutate_pod.go
@@ -231,7 +231,6 @@ func patchAffinity(pod *v1.Pod, resGroupConfig wkconfig.ResGroupConfig) *patchOp
 	var affinity v1.Affinity
 	err := json.Unmarshal([]byte(resGroupConfig.Affinity), &affinity)
 	if err != nil {
-		fmt.Println("Failed to unmarshal JSON:", err)
 		klog.V(3).Infof("Failed to unmarshal JSON: %s", err)
 		return nil
 	}


### PR DESCRIPTION
`patchAffinity` logged the same JSON unmarshal error twice: once via
`fmt.Println` straight to stdout, and again right after via
`klog.V(3).Infof`. The `fmt.Println` bypasses klog's leveled, structured
logging, and in a webhook-manager deployment stdout isn't guaranteed to
be collected the same way as klog's stderr output, so the line ends up
either missed or duplicated depending on the log aggregation setup. The
klog call right below it already reports the same error, so the
`fmt.Println` is redundant.

This drops the `fmt.Println` and keeps the existing `klog.V(3).Infof`
call. No behavior change — `fmt` stays imported since it's still used
elsewhere in the file (`fmt.Errorf` in `mutatePods`).

Tested with `go build ./pkg/webhooks/...`, `go vet` and
`golangci-lint run` on the changed package, and the existing
`go test ./pkg/webhooks/admission/pods/mutate/...` suite, all passing.

Fixes #5951

Special notes for your reviewer

I used an AI coding assistant (Claude Code) to help investigate, verify,
and draft this fix and its issue. I reviewed the change and the
verification steps myself before submitting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
