### PR TITLE
queue: transition closed queue back to closing on resync if podgroups remain

### DIFF
--- a/pkg/controllers/queue/state/closed.go
+++ b/pkg/controllers/queue/state/closed.go
@@ -44,7 +44,11 @@ func (cs *closedState) Execute(action v1alpha1.Action) error {
 			}
 
 			if specState == v1beta1.QueueStateClosed {
-				status.State = v1beta1.QueueStateClosed
+				if len(podGroupList) == 0 {
+					status.State = v1beta1.QueueStateClosed
+					return
+				}
+				status.State = v1beta1.QueueStateClosing
 				return
 			}
 

--- a/pkg/controllers/queue/state/closed_test.go
+++ b/pkg/controllers/queue/state/closed_test.go
@@ -137,6 +137,15 @@ func TestClosedState_SyncQueueAction(t *testing.T) {
 			expectedState: schedulingv1beta1.QueueStateClosed,
 		},
 		{
+			name: "SyncQueueAction: Spec state closed with remaining podgroups",
+			queue: &schedulingv1beta1.Queue{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-queue"},
+				Status:     schedulingv1beta1.QueueStatus{State: schedulingv1beta1.QueueStateClosed},
+			},
+			podGroups:     []string{"default/pg1"},
+			expectedState: schedulingv1beta1.QueueStateClosing,
+		},
+		{
 			name: "SyncQueueAction: Spec state unknown/garbage",
 			queue: &schedulingv1beta1.Queue{
 				ObjectMeta: metav1.ObjectMeta{Name: "test-queue"},


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The default (resync) branch of closedState.Execute in pkg/controllers/queue/state/closed.go hardcodes status.State back to Closed whenever the queue's spec state is Closed, regardless of whether podgroups still exist for that queue.

The other three state handlers (open, closing, unknown) all check len(podGroupList) in this same situation and transition to Closing when podgroups remain, only reporting Closed once the podgroup list is actually empty. closedState is the only one of the four that skips this check.

There is no filed issue for this; the evidence is the inconsistency between closed.go and the other three state files (open.go, closing.go, unknown.go), which all share the same pattern.

#### Which issue(s) this PR fixes:

None.

#### Special notes for your reviewer:

The fix makes closed.go match the existing len(podGroupList) == 0 check already present in open.go, closing.go, and unknown.go. Added a test case for a closed queue with a remaining podgroup, confirmed it fails on unmodified code and passes with the fix.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```