### PR TITLE
fix(cronjob): return the status update error from sync

### DIFF
--- a/pkg/controllers/cronjob/cronjob_controller.go
+++ b/pkg/controllers/cronjob/cronjob_controller.go
@@ -210,7 +210,7 @@ func (cc *cronjobcontroller) sync(cronJobKey string) (*time.Duration, error) {
 	if updateStatus {
 		if _, err := cc.vcClient.BatchV1alpha1().CronJobs(ns).UpdateStatus(context.TODO(), cronJob, metav1.UpdateOptions{}); err != nil {
 			klog.Errorf("Failed to update status for CronJob <%s>, err: %v", cronJobKey, err)
-			return nil, syncErr
+			return nil, err
 		}
 	}
 	return requeueAfter, nil

--- a/pkg/controllers/cronjob/cronjob_status_error_test.go
+++ b/pkg/controllers/cronjob/cronjob_status_error_test.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+Copyright 2025 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cronjob
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	k8stesting "k8s.io/client-go/testing"
+
+	volcanofake "volcano.sh/apis/pkg/client/clientset/versioned/fake"
+)
+
+// A failed status update must reach the caller so the key is requeued. syncErr
+// is always nil at that point, because a non-nil one returns earlier.
+func TestSyncReturnsStatusUpdateError(t *testing.T) {
+	cronJob := createTestCronJob(cjSpec{concurrency: "Allow"})
+	controller, _ := setupTestController()
+	setupFakeJobClient(controller, nil, nil)
+	controller.now = func() time.Time { return fiveMinutesAfterTen() }
+
+	if err := controller.cronJobInformer.Informer().GetIndexer().Add(cronJob); err != nil {
+		t.Fatal(err)
+	}
+
+	fakeVC, ok := controller.vcClient.(*volcanofake.Clientset)
+	if !ok {
+		t.Fatalf("vcClient is %T, want the fake clientset", controller.vcClient)
+	}
+	fakeVC.PrependReactor("update", "cronjobs", func(k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, fmt.Errorf("status update rejected")
+	})
+
+	if _, err := controller.sync(cronJob.Namespace + "/" + cronJob.Name); err == nil {
+		t.Fatal("sync returned nil, want the status update error")
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

`sync` returns `syncErr` when the status update fails ([cronjob_controller.go#L203-L215](https://github.com/volcano-sh/volcano/blob/606c628d364db8de18c045e947d5255ef058aa26/pkg/controllers/cronjob/cronjob_controller.go#L203-L215)):

```go
requeueAfter, updateStatus, syncErr := cc.syncCronJob(cronJob, jobsByCronJob)
if syncErr != nil {
    return nil, syncErr          // non-nil syncErr already returned here
}
if updateStatus {
    if _, err := cc.vcClient...UpdateStatus(...); err != nil {
        klog.Errorf("Failed to update status for CronJob <%s>, err: %v", cronJobKey, err)
        return nil, syncErr      // provably nil at this point
    }
}
```

`syncErr` is nil on that line, because a non-nil one returned a few lines earlier. The UpdateStatus error is logged and then discarded, so a failed status write is reported to the caller as success.

#### Which issue(s) this PR fixes:

None filed. Evidence is below.

#### Bug evidence

Affected version: master at 606c628d364db8de18c045e947d5255ef058aa26.

User path: the apiserver rejects or drops the CronJob status update, from a conflict, a webhook rejection, or transient unavailability. The controller logs the failure, returns nil, and the worker treats the key as done. Nothing requeues it, so `lastScheduleTime` and `active` stay stale until some later event happens to re-enqueue the CronJob.

Test driving `sync` with a reactor that fails the status update, on unmodified master:

```
E cronjob_controller.go:212] Failed to update status for CronJob <volcano/vccronjob>, err: status update rejected
--- FAIL: TestSyncReturnsStatusUpdateError
    sync returned nil, want the status update error
```

The controller logs the rejection and reports success in the same breath. With the fix the same test passes.

`go test ./pkg/controllers/cronjob/`, `go vet` and `gofmt` are clean.

#### Special notes for your reviewer:

One line, `return nil, syncErr` to `return nil, err`. Worth a look at whether the sibling `cronjobClient.UpdateStatus` abstraction in `injection.go` was meant to be used here instead of the direct client call, but I kept this change to the error.

#### Does this PR introduce a user-facing change?

```release-note
Fixed a CronJob controller bug where a failed status update was reported as success, so the key was never requeued.
```
