### PR TITLE
webhooks: report all invalid subGroupPolicy entries, not just the first

### DIFF
--- a/pkg/webhooks/admission/podgroups/validate/validate_podgroup.go
+++ b/pkg/webhooks/admission/podgroups/validate/validate_podgroup.go
@@ -129,7 +129,6 @@ func validateNetworkTopology(networkTopology *schedulingv1beta1.NetworkTopologyS
 	for _, policy := range policies {
 		if policy.NetworkTopology != nil && policy.NetworkTopology.HighestTierAllowed != nil && policy.NetworkTopology.HighestTierName != "" {
 			errs = append(errs, fmt.Sprintf("in subGroupPolicy '%s': must not specify 'highestTierAllowed' and 'highestTierName' in networkTopology simultaneously.", policy.Name))
-			break
 		}
 	}
 	return strings.Join(errs, " ")

--- a/pkg/webhooks/admission/podgroups/validate/validate_podgroup_test.go
+++ b/pkg/webhooks/admission/podgroups/validate/validate_podgroup_test.go
@@ -193,6 +193,41 @@ func TestValidatePodGroup(t *testing.T) {
 			expectError: true,
 		},
 		{
+			name: "invalid podgroup with two bad SubGroupPolicy entries reports both",
+			podGroup: &schedulingv1beta1.PodGroup{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "PodGroup",
+					APIVersion: "scheduling.volcano.sh/v1beta1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-podgroup",
+				},
+				Spec: schedulingv1beta1.PodGroupSpec{
+					SubGroupPolicy: []schedulingv1beta1.SubGroupPolicySpec{
+						{
+							Name: "policy-a",
+							NetworkTopology: &schedulingv1beta1.NetworkTopologySpec{
+								Mode:               schedulingv1beta1.HardNetworkTopologyMode,
+								HighestTierAllowed: &highestTierAllowed,
+								HighestTierName:    "volcano.sh/hypernode",
+							},
+						},
+						{
+							Name: "policy-b",
+							NetworkTopology: &schedulingv1beta1.NetworkTopologySpec{
+								Mode:               schedulingv1beta1.HardNetworkTopologyMode,
+								HighestTierAllowed: &highestTierAllowed,
+								HighestTierName:    "volcano.sh/hypernode",
+							},
+						},
+					},
+				},
+			},
+			queue:       &schedulingv1beta1.Queue{},
+			expectError: true,
+			msgContains: []string{"policy-a", "policy-b"},
+		},
+		{
 			name: "invalid podgroup configured with NetworkTopology containing HighestTierAllowed and HighestTierName",
 			podGroup: &schedulingv1beta1.PodGroup{
 				TypeMeta: metav1.TypeMeta{


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
validateNetworkTopology broke out of the policy loop as soon as it found one subGroupPolicy with both highestTierAllowed and highestTierName set. A PodGroup with more than one bad policy still gets rejected either way, but the rejection message only names the first offending policy, so a user fixing it resubmits and gets rejected again for the next one. Removed the break so every bad policy is reported in the same pass.

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:
This PR was prepared with AI assistance (Claude Code), reviewed and tested by me before submitting. Verified with `go test ./pkg/webhooks/admission/podgroups/validate/...`, all cases pass including a new one covering two bad policies reported together.

#### Does this PR introduce a user-facing change?
```release-note
Admission webhook now reports all invalid subGroupPolicy entries in a PodGroup's networkTopology, not just the first one found.
```
