### PR TITLE
webhooks: report all invalid hierarchical weight entries, not just the first

### DIFF
--- a/pkg/webhooks/admission/queues/validate/validate_queue.go
+++ b/pkg/webhooks/admission/queues/validate/validate_queue.go
@@ -164,13 +164,14 @@ func validateHierarchicalAttributes(queue *schedulingv1beta1.Queue, fldPath *fie
 		for _, weight := range weights {
 			weightFloat, err := strconv.ParseFloat(weight, 64)
 			if err != nil {
-				return append(errs, field.Invalid(fldPath, hierarchicalWeights,
+				errs = append(errs, field.Invalid(fldPath, hierarchicalWeights,
 					fmt.Sprintf("%s in the %s is invalid number: %v",
 						weight, hierarchicalWeights, err,
 					)))
+				continue
 			}
 			if weightFloat <= 0 {
-				return append(errs, field.Invalid(fldPath, hierarchicalWeights,
+				errs = append(errs, field.Invalid(fldPath, hierarchicalWeights,
 					fmt.Sprintf("%s in the %s must be larger than 0",
 						weight, hierarchicalWeights,
 					)))
@@ -193,7 +194,7 @@ func validateHierarchicalAttributes(queue *schedulingv1beta1.Queue, fldPath *fie
 			// For example if we have in the cluster queue /root/scidev and wants to create a /root/sci
 			if hierarchyInTree != "" && queue.Name != queueInTree.Name &&
 				strings.HasPrefix(hierarchyInTree, hierarchy+"/") {
-				return append(errs, field.Invalid(fldPath, hierarchy,
+				errs = append(errs, field.Invalid(fldPath, hierarchy,
 					fmt.Sprintf("%s is not allowed to be in the sub path of %s of queue %s",
 						hierarchy, hierarchyInTree, queueInTree.Name)))
 			}

--- a/pkg/webhooks/admission/queues/validate/validate_queue_test.go
+++ b/pkg/webhooks/admission/queues/validate/validate_queue_test.go
@@ -2677,6 +2677,33 @@ func TestValidateChildrenConstraintsForCapability(t *testing.T) {
 	}
 }
 
+func TestValidateHierarchicalAttributesReportsAllBadWeights(t *testing.T) {
+	config.VolcanoClient = fakeclient.NewSimpleClientset()
+	informerFactory := informers.NewSharedInformerFactory(config.VolcanoClient, 0)
+	config.QueueLister = informerFactory.Scheduling().V1beta1().Queues().Lister()
+
+	queue := &schedulingv1beta1.Queue{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "queue-with-bad-weights",
+			Annotations: map[string]string{
+				schedulingv1beta1.KubeHierarchyAnnotationKey:       "root/sci",
+				schedulingv1beta1.KubeHierarchyWeightAnnotationKey: "bad/-1",
+			},
+		},
+	}
+
+	errs := validateHierarchicalAttributes(queue, field.NewPath("metadata", "annotations"))
+	if len(errs) != 2 {
+		t.Fatalf("expected 2 errors, got %d: %v", len(errs), errs)
+	}
+	if !contains(errs[0].Error(), "bad") {
+		t.Errorf("expected first error to mention the invalid weight %q, got %q", "bad", errs[0].Error())
+	}
+	if !contains(errs[1].Error(), "-1") {
+		t.Errorf("expected second error to mention the invalid weight %q, got %q", "-1", errs[1].Error())
+	}
+}
+
 func contains(s, substr string) bool {
 	return len(s) >= len(substr) && (s == substr || len(substr) == 0 ||
 		(len(s) > 0 && len(substr) > 0 && searchSubstring(s, substr)))


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

`validateHierarchicalAttributes` in the queue admission webhook returned as soon as it found one bad weight in the `volcano.sh/hierarchy-weights` annotation, or one queue conflicting in the sub path check. A queue with more than one bad weight still gets rejected either way, but the rejection message only names the first problem, so a user fixing it resubmits and gets rejected again for the next one. This is the same class of bug already fixed for `subGroupPolicy` in the podgroup webhook (PR #5959).

No issue filed, this is self-discovered while reading the same file after that fix. Evidence: creating a Queue with `volcano.sh/hierarchy: root/sci` and `volcano.sh/hierarchy-weights: bad/-1` (two invalid weights, one non-numeric and one non-positive) is rejected with an error naming only the first bad weight (`bad`); after fixing that one and resubmitting, it is rejected again for the second (`-1`).

Collected all bad weights and all sub path conflicts into the same error list instead of returning on the first one.

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:

This PR was written with AI assistance (Claude Code), under my direction and review. I wrote and ran the tests, and reviewed and understand the change.

Added `TestValidateHierarchicalAttributesReportsAllBadWeights`, confirmed it fails against the pre-fix code (reports 1 error instead of 2) and passes against the fix. Full `pkg/webhooks/admission/queues/validate` package test suite still passes, `go vet` and `gofmt` clean.

#### Does this PR introduce a user-facing change?
```release-note
Queue admission now reports every invalid `volcano.sh/hierarchy-weights` entry and sub path conflict at once instead of only the first one.
```
