### PR TITLE
queue: rebuild the PodGroup cache of a recreated queue

### DIFF
--- a/pkg/controllers/queue/queue_controller.go
+++ b/pkg/controllers/queue/queue_controller.go
@@ -118,6 +118,9 @@ func (c *queuecontroller) Initialize(opt *framework.ControllerOption) error {
 	c.queueSynced = queueInformer.Informer().HasSynced
 	c.pgLister = pgInformer.Lister()
 	c.pgSynced = pgInformer.Informer().HasSynced
+	if err := c.initPodGroupIndexers(); err != nil {
+		return fmt.Errorf("failed to init PodGroup indexers: %v", err)
+	}
 	c.queue = workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[*apis.Request]())
 	c.commandQueue = workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[*busv1alpha1.Command]())
 	c.podGroups = make(map[string]map[string]struct{})

--- a/pkg/controllers/queue/queue_controller_action.go
+++ b/pkg/controllers/queue/queue_controller_action.go
@@ -55,7 +55,7 @@ func (c *queuecontroller) syncQueue(queue *schedulingv1beta1.Queue, updateStateF
 		return err
 	}
 
-	podGroups := c.getPodGroups(queue.Name)
+	podGroups := c.reconcilePodGroups(queue.Name)
 	queueStatus := schedulingv1beta1.QueueStatus{}
 
 	for _, pgKey := range podGroups {
@@ -152,7 +152,7 @@ func (c *queuecontroller) closeQueue(queue *schedulingv1beta1.Queue, updateState
 		}
 	}
 
-	podGroups := c.getPodGroups(queue.Name)
+	podGroups := c.reconcilePodGroups(queue.Name)
 	newQueue := queue.DeepCopy()
 	if updateStateFn != nil {
 		updateStateFn(&newQueue.Status, podGroups)

--- a/pkg/controllers/queue/queue_controller_handler.go
+++ b/pkg/controllers/queue/queue_controller_handler.go
@@ -30,6 +30,24 @@ func (c *queuecontroller) enqueue(req *apis.Request) {
 	c.queue.Add(req)
 }
 
+// initPodGroupIndexers adds an indexer on the PodGroup informer so that
+// PodGroups can be looked up by queue name.
+func (c *queuecontroller) initPodGroupIndexers() error {
+	if _, exists := c.pgInformer.Informer().GetIndexer().GetIndexers()[podGroupQueueIndex]; exists {
+		return nil
+	}
+
+	return c.pgInformer.Informer().AddIndexers(cache.Indexers{
+		podGroupQueueIndex: func(obj interface{}) ([]string, error) {
+			pg, ok := obj.(*schedulingv1beta1.PodGroup)
+			if !ok || pg.Spec.Queue == "" {
+				return nil, nil
+			}
+			return []string{pg.Spec.Queue}, nil
+		},
+	})
+}
+
 func (c *queuecontroller) addQueue(obj interface{}) {
 	queue := obj.(*schedulingv1beta1.Queue)
 
@@ -158,6 +176,59 @@ func (c *queuecontroller) getPodGroups(key string) []string {
 	podGroups := make([]string, 0, len(c.podGroups[key]))
 	for pgKey := range c.podGroups[key] {
 		podGroups = append(podGroups, pgKey)
+	}
+
+	return podGroups
+}
+
+// reconcilePodGroups makes the PodGroup cache of a queue match the
+// PodGroups known to the informer, and returns the current PodGroup keys of
+// the queue.
+//
+// The cache is maintained by PodGroup informer events. When a queue is deleted
+// its cache entry is dropped, and if the queue is then recreated under the same
+// name no event is emitted for the PodGroups that kept running. Rebuilding the
+// cache from the informer lets the sync and close paths observe the
+// PodGroups that still exist instead of an empty cache.
+func (c *queuecontroller) reconcilePodGroups(queueName string) []string {
+	objs, err := c.pgInformer.Informer().GetIndexer().ByIndex(podGroupQueueIndex, queueName)
+	if err != nil {
+		klog.Errorf("Failed to list PodGroups of queue %s from the indexer: %v", queueName, err)
+		return c.getPodGroups(queueName)
+	}
+
+	expected := make(map[string]struct{}, len(objs))
+	for _, obj := range objs {
+		pg, ok := obj.(*schedulingv1beta1.PodGroup)
+		if !ok {
+			continue
+		}
+		key, err := cache.MetaNamespaceKeyFunc(pg)
+		if err != nil {
+			continue
+		}
+		expected[key] = struct{}{}
+	}
+
+	c.pgMutex.Lock()
+	defer c.pgMutex.Unlock()
+
+	if c.podGroups[queueName] == nil {
+		c.podGroups[queueName] = make(map[string]struct{})
+	}
+	current := c.podGroups[queueName]
+	for key := range expected {
+		current[key] = struct{}{}
+	}
+	for key := range current {
+		if _, ok := expected[key]; !ok {
+			delete(current, key)
+		}
+	}
+
+	podGroups := make([]string, 0, len(current))
+	for key := range current {
+		podGroups = append(podGroups, key)
 	}
 
 	return podGroups

--- a/pkg/controllers/queue/queue_controller_test.go
+++ b/pkg/controllers/queue/queue_controller_test.go
@@ -26,6 +26,7 @@ import (
 	kubeclient "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/tools/cache"
 
+	busv1alpha1 "volcano.sh/apis/pkg/apis/bus/v1alpha1"
 	schedulingv1beta1 "volcano.sh/apis/pkg/apis/scheduling/v1beta1"
 	vcclient "volcano.sh/apis/pkg/client/clientset/versioned/fake"
 	informerfactory "volcano.sh/apis/pkg/client/informers/externalversions"
@@ -305,6 +306,149 @@ func TestSyncQueue(t *testing.T) {
 		item, err := c.vcClient.SchedulingV1beta1().Queues().Get(context.TODO(), testcase.queue.Name, metav1.GetOptions{})
 		assert.NoError(t, err)
 		assert.Equal(t, testcase.ExpectState, item.Status.State)
+	}
+}
+
+func TestCloseQueueAfterQueueRecreate(t *testing.T) {
+	testCases := []struct {
+		Name            string
+		PodGroups       []*schedulingv1beta1.PodGroup
+		ExpectState     schedulingv1beta1.QueueState
+		ExpectPodGroups int
+	}{
+		{
+			Name: "close after recreate observes the running PodGroup",
+			PodGroups: []*schedulingv1beta1.PodGroup{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "pg1",
+						Namespace: "ns1",
+					},
+					Spec: schedulingv1beta1.PodGroupSpec{
+						Queue: "c1",
+					},
+					Status: schedulingv1beta1.PodGroupStatus{
+						Phase: schedulingv1beta1.PodGroupRunning,
+					},
+				},
+			},
+			ExpectState:     schedulingv1beta1.QueueStateClosing,
+			ExpectPodGroups: 1,
+		},
+		{
+			Name:            "close after recreate with no PodGroup reports Closed",
+			ExpectState:     schedulingv1beta1.QueueStateClosed,
+			ExpectPodGroups: 0,
+		},
+	}
+
+	for _, testcase := range testCases {
+		c := newFakeController()
+		queue := &schedulingv1beta1.Queue{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "c1",
+			},
+			Spec: schedulingv1beta1.QueueSpec{
+				Weight: 1,
+			},
+		}
+
+		for _, pg := range testcase.PodGroups {
+			assert.NoError(t, c.pgInformer.Informer().GetStore().Add(pg))
+			c.addPodGroup(pg)
+		}
+
+		// The queue is deleted while its PodGroups are still running and then
+		// recreated under the same name. The recreated queue receives no
+		// PodGroup event for the PodGroups that kept running.
+		c.deleteQueue(queue)
+		assert.Empty(t, c.getPodGroups(queue.Name))
+
+		assert.NoError(t, c.queueInformer.Informer().GetStore().Add(queue))
+		_, err := c.vcClient.SchedulingV1beta1().Queues().Create(context.TODO(), queue, metav1.CreateOptions{})
+		assert.NoError(t, err)
+
+		err = c.handleQueue(&apis.Request{
+			QueueName: queue.Name,
+			Event:     busv1alpha1.OutOfSyncEvent,
+			Action:    busv1alpha1.CloseQueueAction,
+		})
+		assert.NoError(t, err)
+
+		item, err := c.vcClient.SchedulingV1beta1().Queues().Get(context.TODO(), queue.Name, metav1.GetOptions{})
+		assert.NoError(t, err)
+		assert.Equal(t, testcase.ExpectState, item.Status.State)
+		assert.Len(t, c.getPodGroups(queue.Name), testcase.ExpectPodGroups)
+	}
+}
+
+func TestReconcilePodGroups(t *testing.T) {
+	testCases := []struct {
+		Name            string
+		PodGroups       []*schedulingv1beta1.PodGroup
+		Cache           map[string]struct{}
+		ExpectPodGroups []string
+		ExpectCache     map[string]struct{}
+	}{
+		{
+			Name: "adds PodGroups that are missing from the cache",
+			PodGroups: []*schedulingv1beta1.PodGroup{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "pg1",
+						Namespace: "ns1",
+					},
+					Spec: schedulingv1beta1.PodGroupSpec{
+						Queue: "c1",
+					},
+				},
+			},
+			ExpectPodGroups: []string{"ns1/pg1"},
+			ExpectCache:     map[string]struct{}{"ns1/pg1": {}},
+		},
+		{
+			Name:            "drops cache entries that no longer exist",
+			Cache:           map[string]struct{}{"ns1/stale": {}},
+			ExpectPodGroups: []string{},
+			ExpectCache:     map[string]struct{}{},
+		},
+		{
+			Name: "matches the cache to the informer in both directions",
+			PodGroups: []*schedulingv1beta1.PodGroup{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "pg1",
+						Namespace: "ns1",
+					},
+					Spec: schedulingv1beta1.PodGroupSpec{
+						Queue: "c1",
+					},
+				},
+			},
+			Cache:           map[string]struct{}{"ns1/stale": {}},
+			ExpectPodGroups: []string{"ns1/pg1"},
+			ExpectCache:     map[string]struct{}{"ns1/pg1": {}},
+		},
+	}
+
+	for _, testcase := range testCases {
+		c := newFakeController()
+		for _, pg := range testcase.PodGroups {
+			assert.NoError(t, c.pgInformer.Informer().GetStore().Add(pg))
+		}
+
+		if testcase.Cache != nil {
+			current := make(map[string]struct{}, len(testcase.Cache))
+			for key := range testcase.Cache {
+				current[key] = struct{}{}
+			}
+			c.podGroups["c1"] = current
+		}
+
+		podGroups := c.reconcilePodGroups("c1")
+
+		assert.ElementsMatch(t, testcase.ExpectPodGroups, podGroups)
+		assert.Equal(t, testcase.ExpectCache, c.podGroups["c1"])
 	}
 }
 

--- a/pkg/controllers/queue/queue_controller_util.go
+++ b/pkg/controllers/queue/queue_controller_util.go
@@ -24,6 +24,9 @@ import (
 
 const (
 	controllerName = "queue-controller"
+	// podGroupQueueIndex is the name of the PodGroup informer index that maps
+	// a PodGroup to the queue it belongs to.
+	podGroupQueueIndex = "queue"
 )
 
 type patchOperation struct {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The queue controller tracks the PodGroups of each queue in an in-memory map that is built from PodGroup informer events. deleteQueue drops the map entry of a deleted queue, and addQueue does not rebuild it. When a queue is deleted and then recreated under the same name while its PodGroups are still running, no PodGroup event is emitted for them, so the recreated queue starts with an empty map.

syncQueue only removes entries that no longer exist; it never adds missing ones. A close action on such a queue therefore observes an empty PodGroup list and writes Closed directly, skipping Closing, although the queue still has running PodGroups and pods. New jobs are then rejected by the admission webhook while the previous workload keeps running.

This PR adds a queue index on the PodGroup informer and rebuilds the in-memory map from the index before it is read by the sync and close paths: PodGroups that still exist are added back, stale entries are removed. A recreated queue observes its existing PodGroups again: a close action transitions to Closing while they remain, and the queue reports Closed only after they are gone.

#### Which issue(s) this PR fixes:

Fixes #5960

#### Special notes for your reviewer:

The change is small and localized to the queue controller: an informer index, one helper that reconciles the cache against the index, and the two call sites that read the cache. Reconciling on read (instead of only when a queue is added) also covers other cases where the map can drift from the informer.

Verification: TestCloseQueueAfterQueueRecreate covers delete + recreate + close and asserts Closing; TestReconcilePodGroups covers both directions of the reconciliation. The regression test was confirmed to fail without the fix and pass with it. I also reproduced the bug on a live kind cluster (Volcano master, queue real-g): before the fix the queue jumped straight to Closed and stayed there for 90+ seconds while its PodGroup stayed Running; with a controller image built from this branch, close reported Closing, and the queue reported Closed automatically once the workload was deleted. Full reproduction details are in #5960.

Note on #5955 (now merged): it makes the resync path re-check the PodGroup list of a Closed queue, but that list comes from this same in-memory map, so after a delete and recreate it still sees nothing. This fix is what restores the map in that case; the two changes are complementary.

Drafted with AI assistance (analysis and writing support); every change was reviewed, the unit tests for the changed package pass, and the bug was reproduced on master and the fix was verified on a live cluster.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
