### PR TITLE
fix: propagate hot-reloaded configuration to agent scheduler workers

### DIFF
--- a/pkg/agentscheduler/actions/factory.go
+++ b/pkg/agentscheduler/actions/factory.go
@@ -26,5 +26,8 @@ import (
 )
 
 func init() {
+	framework.RegisterActionBuilder("allocate", func() framework.Action {
+		return allocate.New()
+	})
 	framework.RegisterAction(allocate.New())
 }

--- a/pkg/agentscheduler/framework/plugins.go
+++ b/pkg/agentscheduler/framework/plugins.go
@@ -221,7 +221,12 @@ func (f *Framework) NodeOrderReduceFn(task *api.TaskInfo, pluginNodeScoreMap map
 }
 
 // Action management
-var actionMap = map[string]Action{}
+type ActionBuilder = func() Action
+
+var (
+	actionMap      = map[string]Action{}
+	actionBuilders = map[string]ActionBuilder{}
+)
 
 // RegisterAction register action
 func RegisterAction(act Action) {
@@ -231,10 +236,23 @@ func RegisterAction(act Action) {
 	actionMap[act.Name()] = act
 }
 
-// GetAction get the action by name
+// RegisterActionBuilder registers an action builder for creating fresh action instances
+func RegisterActionBuilder(name string, builder ActionBuilder) {
+	pluginMutex.Lock()
+	defer pluginMutex.Unlock()
+
+	actionBuilders[name] = builder
+}
+
+// GetAction get the action by name. If an ActionBuilder is registered,
+// it returns a new instance of Action; otherwise it returns the registered Action instance.
 func GetAction(name string) (Action, bool) {
 	pluginMutex.RLock()
 	defer pluginMutex.RUnlock()
+
+	if builder, found := actionBuilders[name]; found {
+		return builder(), true
+	}
 
 	act, found := actionMap[name]
 	return act, found

--- a/pkg/agentscheduler/scheduler.go
+++ b/pkg/agentscheduler/scheduler.go
@@ -45,6 +45,13 @@ import (
 	agentmetrics "volcano.sh/volcano/pkg/agentscheduler/metrics"
 )
 
+type configSnapshot struct {
+	actions        []framework.Action
+	tiers          []conf.Tier
+	configurations []conf.Configuration
+	version        uint64
+}
+
 // Scheduler represents a "Volcano Agent Scheduler".
 // Scheduler watches for new unscheduled pods.
 // It attempts to find nodes that can accommodate these pods and writes the binding information back to the API server.
@@ -63,11 +70,34 @@ type Scheduler struct {
 	disableDefaultConf bool
 	workerCount        int
 	shardingMode       string
+	confSnapshot       *configSnapshot
+}
+
+func (sched *Scheduler) getConfSnapshot() *configSnapshot {
+	sched.mutex.Lock()
+	defer sched.mutex.Unlock()
+	return sched.confSnapshot
 }
 
 type Worker struct {
-	framework *framework.Framework
-	index     int
+	framework   *framework.Framework
+	index       int
+	sched       *Scheduler
+	confVersion uint64
+}
+
+func (worker *Worker) updateFrameworkIfNeeded() {
+	if worker.sched == nil {
+		return
+	}
+
+	snap := worker.sched.getConfSnapshot()
+	if snap == nil || snap.version == worker.confVersion {
+		return
+	}
+
+	worker.framework = framework.NewFramework(snap.actions, snap.tiers, worker.sched.cache, snap.configurations)
+	worker.confVersion = snap.version
 }
 
 // NewAgentScheduler returns a Scheduler
@@ -104,14 +134,15 @@ func (sched *Scheduler) Run(stopCh <-chan struct{}) {
 	sched.cache.SetMetricsConf(sched.metricsConf)
 	sched.cache.Run(stopCh)
 
-	for _, action := range sched.actions {
-		action.OnActionInit(sched.configurations)
-	}
-
+	snap := sched.getConfSnapshot()
 	klog.V(2).Infof("Scheduler completes Initialization and start to run %d workers", sched.workerCount)
 	for i := range sched.workerCount {
-		worker := &Worker{index: i}
-		worker.framework = framework.NewFramework(sched.actions, sched.tiers, sched.cache, sched.configurations)
+		worker := &Worker{
+			index:       i,
+			sched:       sched,
+			confVersion: snap.version,
+		}
+		worker.framework = framework.NewFramework(snap.actions, snap.tiers, sched.cache, snap.configurations)
 		go func() {
 			for {
 				select {
@@ -145,6 +176,8 @@ func (worker *Worker) runOnce() {
 		klog.Warningf("No task to schedule")
 		return
 	}
+
+	worker.updateFrameworkIfNeeded()
 
 	scheduleStartTime := time.Now()
 
@@ -228,9 +261,26 @@ func (sched *Scheduler) loadSchedulerConf() {
 	var err error
 	if !sched.disableDefaultConf {
 		sched.once.Do(func() {
-			sched.actions, sched.tiers, sched.configurations, sched.metricsConf, err = UnmarshalSchedulerConf(DefaultSchedulerConf)
+			var dActions []framework.Action
+			var dTiers []conf.Tier
+			var dConfigurations []conf.Configuration
+			var dMetricsConf map[string]string
+			dActions, dTiers, dConfigurations, dMetricsConf, err = UnmarshalSchedulerConf(DefaultSchedulerConf)
 			if err != nil {
 				klog.Fatalf("Invalid default configuration: unmarshal Scheduler config %s failed: %v", DefaultSchedulerConf, err)
+			}
+			for _, action := range dActions {
+				action.OnActionInit(dConfigurations)
+			}
+			sched.actions = dActions
+			sched.tiers = dTiers
+			sched.configurations = dConfigurations
+			sched.metricsConf = dMetricsConf
+			sched.confSnapshot = &configSnapshot{
+				actions:        dActions,
+				tiers:          dTiers,
+				configurations: dConfigurations,
+				version:        1,
 			}
 		})
 	}
@@ -258,12 +308,27 @@ func (sched *Scheduler) loadSchedulerConf() {
 		return
 	}
 
+	for _, action := range actions {
+		action.OnActionInit(configurations)
+	}
+
 	sched.mutex.Lock()
 	sched.actions = actions
 	sched.tiers = tiers
 	sched.configurations = configurations
 	sched.metricsConf = metricsConf
-	defer sched.mutex.Unlock()
+	newVersion := uint64(1)
+	if sched.confSnapshot != nil {
+		newVersion = sched.confSnapshot.version + 1
+	}
+	sched.confSnapshot = &configSnapshot{
+		actions:        actions,
+		tiers:          tiers,
+		configurations: configurations,
+		version:        newVersion,
+	}
+	sched.mutex.Unlock()
+
 }
 
 func (sched *Scheduler) getSchedulerConf() (actions []string, plugins []string) {

--- a/pkg/agentscheduler/scheduler_test.go
+++ b/pkg/agentscheduler/scheduler_test.go
@@ -3,16 +3,20 @@ package agentscheduler
 import (
 	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
 	v1 "k8s.io/api/core/v1"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/features"
-	"sync"
-	"testing"
 
 	"volcano.sh/volcano/cmd/agent-scheduler/app/options"
 	scheduleroptions "volcano.sh/volcano/cmd/scheduler/app/options"
+	_ "volcano.sh/volcano/pkg/agentscheduler/actions"
 	agentapi "volcano.sh/volcano/pkg/agentscheduler/api"
 	agentcache "volcano.sh/volcano/pkg/agentscheduler/cache"
 	"volcano.sh/volcano/pkg/agentscheduler/framework"
@@ -162,4 +166,334 @@ func TestRunOnceRequeuesWhenSnapshotUpdateFails(t *testing.T) {
 	if len(pendingPods) != 1 {
 		t.Fatalf("expected pod to be requeued after snapshot failure, got %d pending pods", len(pendingPods))
 	}
+}
+
+type testCustomAction struct {
+	name           string
+	mu             sync.Mutex
+	configurations []conf.Configuration
+	executedCount  int
+}
+
+func (a *testCustomAction) Name() string {
+	return a.name
+}
+
+func (a *testCustomAction) OnActionInit(configurations []conf.Configuration) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.configurations = configurations
+}
+
+func (a *testCustomAction) Initialize() {}
+
+func (a *testCustomAction) Execute(_ *framework.Framework, _ *agentapi.SchedulingContext) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.executedCount++
+}
+
+func (a *testCustomAction) UnInitialize() {}
+
+func TestWorkerFrameworkHotReload(t *testing.T) {
+	agentuthelper.InitTestEnv(t)
+	options.ServerOpts.ShardingMode = commonutil.NoneShardingMode
+	scheduleroptions.ServerOpts.ShardingMode = commonutil.NoneShardingMode
+
+	var actionAInstances []*testCustomAction
+	var actionBInstances []*testCustomAction
+	var instMu sync.Mutex
+
+	framework.RegisterActionBuilder("test-action-a", func() framework.Action {
+		inst := &testCustomAction{name: "test-action-a"}
+		instMu.Lock()
+		actionAInstances = append(actionAInstances, inst)
+		instMu.Unlock()
+		return inst
+	})
+	framework.RegisterActionBuilder("test-action-b", func() framework.Action {
+		inst := &testCustomAction{name: "test-action-b"}
+		instMu.Lock()
+		actionBInstances = append(actionBInstances, inst)
+		instMu.Unlock()
+		return inst
+	})
+
+	testFwk, err := agentuthelper.NewTestFramework(
+		"test-scheduler",
+		1,
+		[]framework.Action{&noopAction{}},
+		nil,
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("failed to create test framework: %v", err)
+	}
+	defer testFwk.Close()
+
+	confDir := t.TempDir()
+	confFile := filepath.Join(confDir, "agentscheduler.conf")
+
+	confA := `
+actions: "test-action-a"
+tiers:
+- plugins:
+  - name: predicates
+configurations:
+- name: test-action-a
+  arguments:
+    testKey: valueA
+`
+	if err := os.WriteFile(confFile, []byte(confA), 0644); err != nil {
+		t.Fatalf("failed to write confA: %v", err)
+	}
+
+	sched := &Scheduler{
+		schedulerConf: confFile,
+		cache:         testFwk.MockCache,
+		workerCount:   1,
+	}
+	sched.loadSchedulerConf()
+
+	snap := sched.getConfSnapshot()
+	if snap == nil {
+		t.Fatalf("expected initial configSnapshot, got nil")
+	}
+	initialVersion := snap.version
+	if len(snap.actions) != 1 || snap.actions[0].Name() != "test-action-a" {
+		t.Fatalf("expected action 'test-action-a', got %v", snap.actions)
+	}
+
+	worker := &Worker{
+		index:       0,
+		sched:       sched,
+		confVersion: snap.version,
+		framework:   framework.NewFramework(snap.actions, snap.tiers, testFwk.MockCache, snap.configurations),
+	}
+
+	// Verify worker initial framework configuration
+	if len(worker.framework.Actions) != 1 || worker.framework.Actions[0].Name() != "test-action-a" {
+		t.Fatalf("expected initial worker action 'test-action-a', got %v", worker.framework.Actions)
+	}
+	if len(worker.framework.Tiers) != 1 || len(worker.framework.Tiers[0].Plugins) != 1 || worker.framework.Tiers[0].Plugins[0].Name != "predicates" {
+		t.Fatalf("expected initial worker plugin 'predicates', got %v", worker.framework.Tiers)
+	}
+	if len(worker.framework.Configurations) != 1 || worker.framework.Configurations[0].Arguments["testKey"] != "valueA" {
+		t.Fatalf("expected initial argument testKey=valueA, got %v", worker.framework.Configurations)
+	}
+
+	// Schedule first pod under Config A
+	podA := util.BuildPod("default", "pod-a", "", v1.PodPending, v1.ResourceList{}, "", map[string]string{}, map[string]string{})
+	podA.Spec.SchedulerName = "test-scheduler"
+	taskA := schedulingapi.NewTaskInfo(podA)
+	testFwk.MockCache.AddTaskInfo(taskA)
+	testFwk.SchedulingQueue.Add(klog.Background(), podA)
+
+	worker.runOnce()
+
+	instMu.Lock()
+	if len(actionAInstances) == 0 || actionAInstances[len(actionAInstances)-1].executedCount != 1 {
+		t.Fatalf("expected test-action-a executed count 1, got %v", actionAInstances)
+	}
+	if len(actionBInstances) != 0 {
+		t.Fatalf("expected test-action-b not executed, got %d instances", len(actionBInstances))
+	}
+	instMu.Unlock()
+
+	// Hot reload to Config B
+	confB := `
+actions: "test-action-b"
+tiers:
+- plugins:
+  - name: nodeorder
+configurations:
+- name: test-action-b
+  arguments:
+    testKey: valueB
+`
+	if err := os.WriteFile(confFile, []byte(confB), 0644); err != nil {
+		t.Fatalf("failed to write confB: %v", err)
+	}
+
+	sched.loadSchedulerConf()
+
+	snapB := sched.getConfSnapshot()
+	if snapB == nil || snapB.version != initialVersion+1 {
+		t.Fatalf("expected reloaded configSnapshot version %d, got %+v", initialVersion+1, snapB)
+	}
+
+	// Prior to next worker cycle, worker.framework retains Config A (not mutated mid-stream)
+	if worker.framework.Actions[0].Name() != "test-action-a" {
+		t.Fatalf("expected worker framework to retain test-action-a before next cycle, got %v", worker.framework.Actions[0].Name())
+	}
+
+	// Schedule second pod under Config B
+	podB := util.BuildPod("default", "pod-b", "", v1.PodPending, v1.ResourceList{}, "", map[string]string{}, map[string]string{})
+	podB.Spec.SchedulerName = "test-scheduler"
+	taskB := schedulingapi.NewTaskInfo(podB)
+	testFwk.MockCache.AddTaskInfo(taskB)
+	testFwk.SchedulingQueue.Add(klog.Background(), podB)
+
+	worker.runOnce()
+
+	// Verify worker Framework transitioned to Config B at cycle boundary
+	if worker.confVersion != initialVersion+1 {
+		t.Fatalf("expected worker confVersion %d, got %d", initialVersion+1, worker.confVersion)
+	}
+	if len(worker.framework.Actions) != 1 || worker.framework.Actions[0].Name() != "test-action-b" {
+		t.Fatalf("expected worker action 'test-action-b' after reload, got %v", worker.framework.Actions)
+	}
+	if len(worker.framework.Tiers) != 1 || len(worker.framework.Tiers[0].Plugins) != 1 || worker.framework.Tiers[0].Plugins[0].Name != "nodeorder" {
+		t.Fatalf("expected worker plugin 'nodeorder' after reload, got %v", worker.framework.Tiers)
+	}
+	if len(worker.framework.Configurations) != 1 || worker.framework.Configurations[0].Arguments["testKey"] != "valueB" {
+		t.Fatalf("expected reloaded argument testKey=valueB, got %v", worker.framework.Configurations)
+	}
+
+	instMu.Lock()
+	if len(actionBInstances) == 0 || actionBInstances[len(actionBInstances)-1].executedCount != 1 {
+		t.Fatalf("expected test-action-b executed count 1, got %v", actionBInstances)
+	}
+	// Action A count should remain 1 (removed action not executed again)
+	if actionAInstances[len(actionAInstances)-1].executedCount != 1 {
+		t.Fatalf("expected test-action-a executed count to remain 1, got %d", actionAInstances[len(actionAInstances)-1].executedCount)
+	}
+	instMu.Unlock()
+
+	// Test reload failure: invalid config leaves old config active
+	invalidConf := `actions: [invalid`
+	if err := os.WriteFile(confFile, []byte(invalidConf), 0644); err != nil {
+		t.Fatalf("failed to write invalidConf: %v", err)
+	}
+	sched.loadSchedulerConf()
+
+	snapAfterInvalid := sched.getConfSnapshot()
+	if snapAfterInvalid.version != initialVersion+1 {
+		t.Fatalf("expected version to remain %d after failed reload, got %d", initialVersion+1, snapAfterInvalid.version)
+	}
+
+	podC := util.BuildPod("default", "pod-c", "", v1.PodPending, v1.ResourceList{}, "", map[string]string{}, map[string]string{})
+	podC.Spec.SchedulerName = "test-scheduler"
+	taskC := schedulingapi.NewTaskInfo(podC)
+	testFwk.MockCache.AddTaskInfo(taskC)
+	testFwk.SchedulingQueue.Add(klog.Background(), podC)
+
+	worker.runOnce()
+
+	if worker.framework.Actions[0].Name() != "test-action-b" {
+		t.Fatalf("expected worker framework to retain test-action-b after failed reload, got %v", worker.framework.Actions[0].Name())
+	}
+}
+
+func TestWorkerFrameworkHotReloadConcurrent(t *testing.T) {
+	agentuthelper.InitTestEnv(t)
+	options.ServerOpts.ShardingMode = commonutil.NoneShardingMode
+	scheduleroptions.ServerOpts.ShardingMode = commonutil.NoneShardingMode
+
+	const workerCount = 4
+	const podCount = 20
+
+	framework.RegisterActionBuilder("test-concurrent-action-a", func() framework.Action {
+		return &noopAction{}
+	})
+	framework.RegisterActionBuilder("test-concurrent-action-b", func() framework.Action {
+		return &noopAction{}
+	})
+
+	testFwk, err := agentuthelper.NewTestFramework(
+		"test-scheduler",
+		workerCount,
+		[]framework.Action{&noopAction{}},
+		nil,
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("failed to create test framework: %v", err)
+	}
+	defer testFwk.Close()
+
+	confDir := t.TempDir()
+	confFile := filepath.Join(confDir, "agentscheduler.conf")
+
+	confA := `
+actions: "test-concurrent-action-a"
+tiers:
+- plugins:
+  - name: predicates
+`
+	confB := `
+actions: "test-concurrent-action-b"
+tiers:
+- plugins:
+  - name: nodeorder
+`
+	if err := os.WriteFile(confFile, []byte(confA), 0644); err != nil {
+		t.Fatalf("failed to write conf: %v", err)
+	}
+
+	sched := &Scheduler{
+		schedulerConf: confFile,
+		cache:         testFwk.MockCache,
+		workerCount:   workerCount,
+	}
+	sched.loadSchedulerConf()
+
+	snap := sched.getConfSnapshot()
+	workers := make([]*Worker, workerCount)
+	for i := 0; i < workerCount; i++ {
+		workers[i] = &Worker{
+			index:       i,
+			sched:       sched,
+			confVersion: snap.version,
+			framework:   framework.NewFramework(snap.actions, snap.tiers, testFwk.MockCache, snap.configurations),
+		}
+	}
+
+	for i := 0; i < podCount; i++ {
+		pod := util.BuildPod("default", fmt.Sprintf("concurrent-pod-%d", i), "", v1.PodPending, v1.ResourceList{}, "", map[string]string{}, map[string]string{})
+		pod.Spec.SchedulerName = "test-scheduler"
+		task := schedulingapi.NewTaskInfo(pod)
+		testFwk.MockCache.AddTaskInfo(task)
+		testFwk.SchedulingQueue.Add(klog.Background(), pod)
+	}
+
+	stopCh := make(chan struct{})
+	var reloadWg sync.WaitGroup
+	var workerWg sync.WaitGroup
+
+	// Reload goroutine repeatedly reloading config
+	reloadWg.Add(1)
+	go func() {
+		defer reloadWg.Done()
+		toggle := false
+		for {
+			select {
+			case <-stopCh:
+				return
+			default:
+				if toggle {
+					_ = os.WriteFile(confFile, []byte(confA), 0644)
+				} else {
+					_ = os.WriteFile(confFile, []byte(confB), 0644)
+				}
+				toggle = !toggle
+				sched.loadSchedulerConf()
+			}
+		}
+	}()
+
+	// Workers running runOnce concurrently
+	for i := 0; i < workerCount; i++ {
+		workerWg.Add(1)
+		go func(w *Worker) {
+			defer workerWg.Done()
+			for j := 0; j < podCount/workerCount; j++ {
+				w.runOnce()
+			}
+		}(workers[i])
+	}
+
+	workerWg.Wait()
+	close(stopCh)
+	reloadWg.Wait()
 }


### PR DESCRIPTION
## What type of PR is this?

/kind bug

## What this PR does / why we need it:

Fixes a bug in the Agent Scheduler where configuration changes detected by the hot-reload watcher were updated on the scheduler but were not propagated to existing worker Frameworks.

As a result, workers could continue scheduling with stale actions, tiers, and plugin configurations after a successful configuration reload. Newly added actions/configuration were not picked up, while removed actions could remain active.

This PR:

* Introduces an immutable configuration snapshot for atomic publication of scheduler configuration.
* Creates isolated action instances for reloadable configurations.
* Tracks configuration versions so workers can detect changes.
* Refreshes worker Frameworks at scheduling-cycle boundaries, ensuring a cycle always uses one consistent configuration version.
* Preserves the previous valid configuration when a reload fails.
* Adds regression and concurrent hot-reload tests.

## Which issue(s) this PR fixes:

Fixes #5967

## How has this been tested?

The following tests and checks were run successfully:

```text
go test ./pkg/agentscheduler/...
go test -race ./pkg/agentscheduler/...
go vet ./pkg/agentscheduler/...
git diff --check
gofmt -l pkg/agentscheduler
```

Additional regression coverage verifies:

* configuration changes are propagated to existing workers;
* actions can be added and removed through hot-reload;
* action/plugin configuration changes are applied;
* invalid configuration reloads preserve the previous valid configuration;
* concurrent scheduling and configuration reloads do not introduce data races.

## Special notes for your reviewer:

Configuration changes are applied only at scheduling-cycle boundaries. An in-progress scheduling cycle continues using its existing Framework, while the next cycle observes the latest successfully loaded configuration.

The implementation also preserves the existing action registration path for backward compatibility while using fresh action instances for reloadable configurations.
