### PR TITLE
scheduler: terminate tier when plugin intersection is empty

### DIFF
--- a/pkg/scheduler/framework/session_plugins.go
+++ b/pkg/scheduler/framework/session_plugins.go
@@ -260,6 +260,13 @@ func (ssn *Session) Reclaimable(reclaimer *api.TaskInfo, reclaimees []*api.TaskI
 				// Update victims to intersection
 				victims = intersection
 			}
+			// An empty intersection means the plugins in this tier agreed on
+			// nothing. Terminate the tier instead of leaving victims nil, which
+			// a later plugin would read as "no vote yet" and refill.
+			if len(victims) == 0 {
+				victims = nil
+				break
+			}
 		}
 		// Plugins in this tier made decision if victims is not nil
 		if victims != nil {
@@ -310,6 +317,13 @@ func (ssn *Session) Preemptable(preemptor *api.TaskInfo, preemptees []*api.TaskI
 				// Update victims to intersection
 				victims = intersection
 			}
+			// An empty intersection means the plugins in this tier agreed on
+			// nothing. Terminate the tier instead of leaving victims nil, which
+			// a later plugin would read as "no vote yet" and refill.
+			if len(victims) == 0 {
+				victims = nil
+				break
+			}
 		}
 		// Plugins in this tier made decision if victims is not nil
 		if victims != nil {
@@ -351,6 +365,13 @@ func (ssn *Session) UnifiedEvictable(ctx *api.EvictionContext, candidates []*api
 					}
 				}
 				victims = intersection
+			}
+			// An empty intersection means the plugins in this tier agreed on
+			// nothing. Terminate the tier instead of leaving victims nil, which
+			// a later plugin would read as "no vote yet" and refill.
+			if len(victims) == 0 {
+				victims = nil
+				break
 			}
 		}
 		if victims != nil {

--- a/pkg/scheduler/framework/session_plugins_test.go
+++ b/pkg/scheduler/framework/session_plugins_test.go
@@ -315,3 +315,106 @@ func TestHyperNodeGradientForJobFn_NoPluginKeepsCurrentFallback(t *testing.T) {
 	result := ssn.HyperNodeGradientForJobFn(&api.JobInfo{}, root, api.PurposeEvict)
 	assert.Equal(t, [][]*api.HyperNodeInfo{{root}}, result)
 }
+
+func TestUnifiedEvictable_EmptyIntersectionTerminatesTier(t *testing.T) {
+	taskA := &api.TaskInfo{UID: "a"}
+	taskB := &api.TaskInfo{UID: "b"}
+	candidates := []*api.TaskInfo{taskA, taskB}
+	ctx := &api.EvictionContext{Kind: api.EvictionKindGangReclaim}
+
+	ssn := &Session{
+		Tiers: []conf.Tier{
+			{
+				Plugins: []conf.PluginOption{
+					{Name: "filterA"},
+					{Name: "filterB"},
+					{Name: "permitAll"},
+				},
+			},
+		},
+		unifiedEvictableFns: map[string]api.UnifiedEvictableFn{},
+	}
+
+	ssn.AddUnifiedEvictableFn("filterA", func(_ *api.EvictionContext, c []*api.TaskInfo) ([]*api.TaskInfo, int) {
+		return []*api.TaskInfo{taskA}, 1
+	})
+	ssn.AddUnifiedEvictableFn("filterB", func(_ *api.EvictionContext, c []*api.TaskInfo) ([]*api.TaskInfo, int) {
+		return []*api.TaskInfo{taskB}, 1 // disjoint from filterA => empty intersection
+	})
+	ssn.AddUnifiedEvictableFn("permitAll", func(_ *api.EvictionContext, c []*api.TaskInfo) ([]*api.TaskInfo, int) {
+		return c, 1
+	})
+
+	// filterA and filterB agree on nothing, so the tier must terminate empty
+	// instead of letting permitAll refill victims from its own raw result.
+	result := ssn.UnifiedEvictable(ctx, candidates)
+	assert.Empty(t, result)
+}
+
+func TestPreemptable_EmptyIntersectionTerminatesTier(t *testing.T) {
+	taskA := &api.TaskInfo{UID: "a"}
+	taskB := &api.TaskInfo{UID: "b"}
+	preemptor := &api.TaskInfo{UID: "p"}
+	preemptees := []*api.TaskInfo{taskA, taskB}
+	on := true
+
+	ssn := &Session{
+		Tiers: []conf.Tier{
+			{
+				Plugins: []conf.PluginOption{
+					{Name: "filterA", EnabledPreemptable: &on},
+					{Name: "filterB", EnabledPreemptable: &on},
+					{Name: "permitAll", EnabledPreemptable: &on},
+				},
+			},
+		},
+		preemptableFns: map[string]api.EvictableFn{},
+	}
+
+	ssn.AddPreemptableFn("filterA", func(_ *api.TaskInfo, c []*api.TaskInfo) ([]*api.TaskInfo, int) {
+		return []*api.TaskInfo{taskA}, 1
+	})
+	ssn.AddPreemptableFn("filterB", func(_ *api.TaskInfo, c []*api.TaskInfo) ([]*api.TaskInfo, int) {
+		return []*api.TaskInfo{taskB}, 1 // disjoint from filterA => empty intersection
+	})
+	ssn.AddPreemptableFn("permitAll", func(_ *api.TaskInfo, c []*api.TaskInfo) ([]*api.TaskInfo, int) {
+		return c, 1
+	})
+
+	result := ssn.Preemptable(preemptor, preemptees)
+	assert.Empty(t, result)
+}
+
+func TestReclaimable_EmptyIntersectionTerminatesTier(t *testing.T) {
+	taskA := &api.TaskInfo{UID: "a"}
+	taskB := &api.TaskInfo{UID: "b"}
+	reclaimer := &api.TaskInfo{UID: "r"}
+	reclaimees := []*api.TaskInfo{taskA, taskB}
+	on := true
+
+	ssn := &Session{
+		Tiers: []conf.Tier{
+			{
+				Plugins: []conf.PluginOption{
+					{Name: "filterA", EnabledReclaimable: &on},
+					{Name: "filterB", EnabledReclaimable: &on},
+					{Name: "permitAll", EnabledReclaimable: &on},
+				},
+			},
+		},
+		reclaimableFns: map[string]api.EvictableFn{},
+	}
+
+	ssn.AddReclaimableFn("filterA", func(_ *api.TaskInfo, c []*api.TaskInfo) ([]*api.TaskInfo, int) {
+		return []*api.TaskInfo{taskA}, 1
+	})
+	ssn.AddReclaimableFn("filterB", func(_ *api.TaskInfo, c []*api.TaskInfo) ([]*api.TaskInfo, int) {
+		return []*api.TaskInfo{taskB}, 1 // disjoint from filterA => empty intersection
+	})
+	ssn.AddReclaimableFn("permitAll", func(_ *api.TaskInfo, c []*api.TaskInfo) ([]*api.TaskInfo, int) {
+		return c, 1
+	})
+
+	result := ssn.Reclaimable(reclaimer, reclaimees)
+	assert.Empty(t, result)
+}


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
`Session.Preemptable`, `Session.Reclaimable`, and `Session.UnifiedEvictable` intersect the candidates returned by the plugins in a tier. A nil `victims` slice is used to mean both "no plugin in this tier has voted yet" and "the intersection of the votes so far is empty". When two plugins in a tier agree on nothing, the intersection is written back as nil, so the next plugin reads it as "no vote yet" and repopulates `victims` from its own raw result, discarding every filter applied before it.

This PR terminates the tier when the intersection empties, matching the existing behaviour when a single plugin permits nothing.

#### Which issue(s) this PR fixes:
Fixes #5963

#### Special notes for your reviewer:
Regression tests for all three functions (`UnifiedEvictable`, `Preemptable`, `Reclaimable`) exercise the three-plugin shape from the issue and fail on master.

#### Does this PR introduce a user-facing change?
```release-note
Fix scheduler victim selection: terminate a tier when the plugin intersection is empty instead of letting a permissive plugin refill victims that earlier plugins filtered out.
```
